### PR TITLE
Integrate Claude Code hook event system for session activity tracking

### DIFF
--- a/Packages/RmCore/Sources/RmCore/AppState.swift
+++ b/Packages/RmCore/Sources/RmCore/AppState.swift
@@ -56,6 +56,17 @@ public final class AppState {
     /// Terminal readiness state per terminal ID.
     public var terminalReadiness: [UUID: TerminalReadiness] = [:]
 
+    // MARK: - Hook Events
+
+    /// Recent hook events per session (ring buffer, last 50 events).
+    public var hookEvents: [UUID: [HookEvent]] = [:]
+
+    /// Pending notification requiring user attention, per session.
+    public var pendingNotification: [UUID: HookNotification] = [:]
+
+    /// Last tool activity per session (what Claude is currently doing).
+    public var lastToolActivity: [UUID: ToolActivity] = [:]
+
     /// Called when user clicks "Work on" for an assigned issue.
     public var onWorkOnIssue: ((String) -> Void)?  // receives issue URL
 

--- a/Packages/RmCore/Sources/RmCore/Models/HookEvent.swift
+++ b/Packages/RmCore/Sources/RmCore/Models/HookEvent.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A Claude Code hook event received from a session's Claude Code instance.
+public struct HookEvent: Identifiable, Sendable {
+    public let id: UUID
+    public let sessionID: UUID
+    public let eventName: String
+    public let summary: String
+    public let timestamp: Date
+
+    public init(
+        id: UUID = UUID(),
+        sessionID: UUID,
+        eventName: String,
+        summary: String,
+        timestamp: Date = Date()
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.eventName = eventName
+        self.summary = summary
+        self.timestamp = timestamp
+    }
+}

--- a/Packages/RmCore/Sources/RmCore/Models/HookNotification.swift
+++ b/Packages/RmCore/Sources/RmCore/Models/HookNotification.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A pending notification from Claude Code that needs user attention.
+public struct HookNotification: Sendable {
+    public let message: String
+    public let notificationType: String
+    public let timestamp: Date
+
+    public init(message: String, notificationType: String, timestamp: Date = Date()) {
+        self.message = message
+        self.notificationType = notificationType
+        self.timestamp = timestamp
+    }
+}

--- a/Packages/RmCore/Sources/RmCore/Models/ToolActivity.swift
+++ b/Packages/RmCore/Sources/RmCore/Models/ToolActivity.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Tracks the current tool being used by Claude Code in a session.
+public struct ToolActivity: Sendable {
+    public let toolName: String
+    public let timestamp: Date
+    public let isActive: Bool
+
+    public init(toolName: String, timestamp: Date = Date(), isActive: Bool = true) {
+        self.toolName = toolName
+        self.timestamp = timestamp
+        self.isActive = isActive
+    }
+}

--- a/Packages/RmIPC/Sources/RmIPC/SocketClient.swift
+++ b/Packages/RmIPC/Sources/RmIPC/SocketClient.swift
@@ -11,6 +11,11 @@ public struct SocketClient: Sendable {
 
     public init(socketPath: String? = nil) {
         self.socketPath = socketPath ?? {
+            // RIDE_SOCKET is set by hook commands to override the default path,
+            // since Claude Code hooks run with a different $TMPDIR than the app.
+            if let override = ProcessInfo.processInfo.environment["RIDE_SOCKET"] {
+                return override
+            }
             let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
             return (tmpDir as NSString).appendingPathComponent("ride.sock")
         }()

--- a/Packages/RmIPC/Sources/RmIPC/SocketClient.swift
+++ b/Packages/RmIPC/Sources/RmIPC/SocketClient.swift
@@ -11,13 +11,11 @@ public struct SocketClient: Sendable {
 
     public init(socketPath: String? = nil) {
         self.socketPath = socketPath ?? {
-            // RIDE_SOCKET is set by hook commands to override the default path,
-            // since Claude Code hooks run with a different $TMPDIR than the app.
+            // RIDE_SOCKET overrides for hook subprocesses (legacy support)
             if let override = ProcessInfo.processInfo.environment["RIDE_SOCKET"] {
                 return override
             }
-            let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
-            return (tmpDir as NSString).appendingPathComponent("ride.sock")
+            return SocketServer.defaultSocketPath()
         }()
     }
 

--- a/Packages/RmIPC/Sources/RmIPC/SocketServer.swift
+++ b/Packages/RmIPC/Sources/RmIPC/SocketServer.swift
@@ -83,7 +83,9 @@ public final class SocketServer: @unchecked Sendable {
             close(serverFD)
             serverFD = -1
         }
-        unlink(socketPath)
+        // Don't unlink here — a newer instance may have already bound
+        // to the same path. Cleanup is handled by start() which unlinks
+        // before binding.
     }
 
     // MARK: - Accept Loop

--- a/Packages/RmIPC/Sources/RmIPC/SocketServer.swift
+++ b/Packages/RmIPC/Sources/RmIPC/SocketServer.swift
@@ -14,14 +14,21 @@ public final class SocketServer: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.radiusmethod.ride.socket", qos: .userInitiated)
 
     public init(socketPath: String? = nil, router: CommandRouter) {
-        self.socketPath = socketPath ?? {
-            let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
-            return (tmpDir as NSString).appendingPathComponent("ride.sock")
-        }()
+        self.socketPath = socketPath ?? Self.defaultSocketPath()
         self.router = router
     }
 
     public var path: String { socketPath }
+
+    /// Well-known socket path shared by server and client.
+    /// Uses ~/.local/share/rm-ai-ide/ride.sock instead of $TMPDIR
+    /// because $TMPDIR varies across processes (app, CLI, Claude Code hooks).
+    public static func defaultSocketPath() -> String {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/rm-ai-ide").path
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return (dir as NSString).appendingPathComponent("ride.sock")
+    }
 
     // MARK: - Start / Stop
 

--- a/Packages/RmUI/Sources/RmUI/SessionListView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionListView.swift
@@ -264,7 +264,12 @@ struct SessionRow: View {
                 .fill(CorveilTheme.bgCard)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
+                        .strokeBorder(
+                            appState.pendingNotification[session.id] != nil
+                                ? Color.orange.opacity(0.6)
+                                : CorveilTheme.borderSubtle,
+                            lineWidth: appState.pendingNotification[session.id] != nil ? 1.5 : 1
+                        )
                 )
         )
         .padding(.vertical, 1)
@@ -289,9 +294,35 @@ struct SessionRow: View {
                     .fill(.blue)
                     .frame(width: 8, height: 8)
             case .claudeLaunched:
-                Circle()
-                    .fill(.green)
-                    .frame(width: 8, height: 8)
+                // Show Claude-state-aware indicator
+                switch claudeState {
+                case .working:
+                    Circle()
+                        .fill(.green)
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(.green.opacity(0.4), lineWidth: 2)
+                                .scaleEffect(1.6)
+                        )
+                case .waiting:
+                    Circle()
+                        .fill(.orange)
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(.orange.opacity(0.4), lineWidth: 2)
+                                .scaleEffect(1.6)
+                        )
+                case .done:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(CorveilTheme.gold)
+                        .font(.system(size: 10))
+                case .idle:
+                    Circle()
+                        .fill(.green)
+                        .frame(width: 8, height: 8)
+                }
             }
         case .paused:
             Circle()
@@ -310,19 +341,42 @@ struct SessionRow: View {
 
     @ViewBuilder
     private var claudeStateBadge: some View {
-        let (icon, color, label): (String, Color, String) = switch claudeState {
-        case .working: ("bolt.fill", .orange, "Working")
-        case .waiting: ("ellipsis.circle.fill", .blue, "Waiting")
-        case .done: ("checkmark.circle.fill", CorveilTheme.gold, "Done")
-        case .idle: ("circle", CorveilTheme.textMuted, "Idle")
+        let activity = appState.lastToolActivity[session.id]
+        let notification = appState.pendingNotification[session.id]
+
+        switch claudeState {
+        case .working:
+            HStack(spacing: 3) {
+                Image(systemName: "bolt.fill")
+                    .font(.caption2)
+                if let activity, activity.isActive {
+                    Text(activity.toolName)
+                        .font(.caption2)
+                } else {
+                    Text("Working")
+                        .font(.caption2)
+                }
+            }
+            .foregroundStyle(.orange)
+        case .waiting:
+            HStack(spacing: 3) {
+                Image(systemName: "ellipsis.circle.fill")
+                    .font(.caption2)
+                Text(notification?.notificationType == "permission_prompt" ? "Permission" : "Waiting")
+                    .font(.caption2)
+            }
+            .foregroundStyle(.blue)
+        case .done:
+            HStack(spacing: 3) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.caption2)
+                Text("Done")
+                    .font(.caption2)
+            }
+            .foregroundStyle(CorveilTheme.gold)
+        case .idle:
+            EmptyView()
         }
-        HStack(spacing: 3) {
-            Image(systemName: icon)
-                .font(.caption2)
-            Text(label)
-                .font(.caption2)
-        }
-        .foregroundStyle(color)
     }
 
     private func shortenBranch(_ branch: String) -> String {

--- a/Packages/RmUI/Sources/RmUI/SessionListView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionListView.swift
@@ -251,7 +251,7 @@ struct SessionRow: View {
                     if let pr = prLink {
                         PRBadge(label: pr.label, status: prStatus)
                     }
-                    if claudeState != .idle {
+                    if claudeState != .idle || appState.pendingNotification[session.id] != nil {
                         claudeStateBadge
                     }
                 }
@@ -261,17 +261,13 @@ struct SessionRow: View {
         .padding(.vertical, 6)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(CorveilTheme.bgCard)
+                .fill(rowBackgroundColor)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(
-                            appState.pendingNotification[session.id] != nil
-                                ? Color.orange.opacity(0.6)
-                                : CorveilTheme.borderSubtle,
-                            lineWidth: appState.pendingNotification[session.id] != nil ? 1.5 : 1
-                        )
+                        .strokeBorder(rowBorderColor, lineWidth: 1)
                 )
         )
+        .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: needsAttention)
         .padding(.vertical, 1)
     }
 
@@ -294,18 +290,7 @@ struct SessionRow: View {
                     .fill(.blue)
                     .frame(width: 8, height: 8)
             case .claudeLaunched:
-                // Show Claude-state-aware indicator
-                switch claudeState {
-                case .working:
-                    Circle()
-                        .fill(.green)
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(.green.opacity(0.4), lineWidth: 2)
-                                .scaleEffect(1.6)
-                        )
-                case .waiting:
+                if needsAttention {
                     Circle()
                         .fill(.orange)
                         .frame(width: 8, height: 8)
@@ -314,11 +299,17 @@ struct SessionRow: View {
                                 .stroke(.orange.opacity(0.4), lineWidth: 2)
                                 .scaleEffect(1.6)
                         )
-                case .done:
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(CorveilTheme.gold)
-                        .font(.system(size: 10))
-                case .idle:
+                } else if claudeState == .working {
+                    Circle()
+                        .fill(.green)
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(.green.opacity(0.4), lineWidth: 2)
+                                .scaleEffect(1.6)
+                        )
+                } else {
+                    // done or idle — solid green
                     Circle()
                         .fill(.green)
                         .frame(width: 8, height: 8)
@@ -344,39 +335,72 @@ struct SessionRow: View {
         let activity = appState.lastToolActivity[session.id]
         let notification = appState.pendingNotification[session.id]
 
-        switch claudeState {
-        case .working:
-            HStack(spacing: 3) {
-                Image(systemName: "bolt.fill")
-                    .font(.caption2)
-                if let activity, activity.isActive {
-                    Text(activity.toolName)
+        if let notification {
+            // Attention badges
+            if notification.notificationType == "permission_prompt" {
+                HStack(spacing: 3) {
+                    Image(systemName: "lock.fill")
                         .font(.caption2)
-                } else {
-                    Text("Working")
+                    Text("Permission")
                         .font(.caption2)
                 }
+                .foregroundStyle(.orange)
+            } else if notification.notificationType == "question" {
+                HStack(spacing: 3) {
+                    Image(systemName: "questionmark.bubble.fill")
+                        .font(.caption2)
+                    Text("Question")
+                        .font(.caption2)
+                }
+                .foregroundStyle(.orange)
             }
-            .foregroundStyle(.orange)
-        case .waiting:
-            HStack(spacing: 3) {
-                Image(systemName: "ellipsis.circle.fill")
-                    .font(.caption2)
-                Text(notification?.notificationType == "permission_prompt" ? "Permission" : "Waiting")
-                    .font(.caption2)
+        } else {
+            switch claudeState {
+            case .working:
+                HStack(spacing: 3) {
+                    Image(systemName: "bolt.fill")
+                        .font(.caption2)
+                    if let activity, activity.isActive {
+                        Text(activity.toolName)
+                            .font(.caption2)
+                    } else {
+                        Text("Working")
+                            .font(.caption2)
+                    }
+                }
+                .foregroundStyle(.orange)
+            case .done:
+                HStack(spacing: 3) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                    Text("Done")
+                        .font(.caption2)
+                }
+                .foregroundStyle(CorveilTheme.gold)
+            case .waiting, .idle:
+                EmptyView()
             }
-            .foregroundStyle(.blue)
-        case .done:
-            HStack(spacing: 3) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.caption2)
-                Text("Done")
-                    .font(.caption2)
-            }
-            .foregroundStyle(CorveilTheme.gold)
-        case .idle:
-            EmptyView()
         }
+    }
+
+    private var needsAttention: Bool {
+        appState.pendingNotification[session.id] != nil
+    }
+
+    private var rowBackgroundColor: Color {
+        if needsAttention {
+            return Color.orange.opacity(0.12)
+        } else if claudeState == .done && terminalReadiness == .claudeLaunched {
+            return Color.green.opacity(0.06)
+        }
+        return CorveilTheme.bgCard
+    }
+
+    private var rowBorderColor: Color {
+        if needsAttention {
+            return Color.orange.opacity(0.4)
+        }
+        return CorveilTheme.borderSubtle
     }
 
     private func shortenBranch(_ branch: String) -> String {

--- a/Packages/RmUI/Sources/RmUI/SessionListView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionListView.swift
@@ -391,7 +391,7 @@ struct SessionRow: View {
         if needsAttention {
             return Color.orange.opacity(0.12)
         } else if claudeState == .done && terminalReadiness == .claudeLaunched {
-            return Color.green.opacity(0.06)
+            return Color(red: 0.15, green: 0.22, blue: 0.16)
         }
         return CorveilTheme.bgCard
     }

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -401,6 +401,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if sessionID != AppState.managerSessionID {
                         capturedAppState.terminalReadiness[terminal.id] = .uninitialized
                         TerminalManager.shared.trackReadiness(for: terminal.id)
+
+                        // Write hook config for the session's worktree
+                        if let worktree = capturedAppState.primaryWorktree(for: sessionID),
+                           let ridePath = HookConfigGenerator.findRideBinary() {
+                            try? HookConfigGenerator.writeHookConfig(
+                                worktreePath: worktree.worktreePath,
+                                sessionID: sessionID,
+                                ridePath: ridePath
+                            )
+                        }
                     }
                     return ["terminal_id": .string(terminal.id.uuidString), "session_id": .string(idStr)]
                 }
@@ -465,6 +475,143 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     .object(["id": .string(l.id.uuidString), "label": .string(l.label), "url": .string(l.url), "type": .string(l.linkType.rawValue)])
                 }
                 return ["links": .array(items)]
+            },
+            "hook-event": { @Sendable params in
+                guard let sessionIDStr = params["session_id"]?.stringValue,
+                      let sessionID = UUID(uuidString: sessionIDStr),
+                      let eventName = params["event_name"]?.stringValue else {
+                    throw RPCError.invalidParams("session_id and event_name required")
+                }
+                let payload = params["payload"]?.objectValue ?? [:]
+
+                // Build a human-readable summary from the event
+                let summary: String = {
+                    switch eventName {
+                    case "PreToolUse", "PostToolUse", "PostToolUseFailure":
+                        let tool = payload["tool_name"]?.stringValue ?? "unknown"
+                        return "\(eventName): \(tool)"
+                    case "Notification":
+                        let msg = payload["message"]?.stringValue ?? ""
+                        return "Notification: \(msg.prefix(80))"
+                    case "Stop":
+                        return "Claude finished responding"
+                    case "StopFailure":
+                        return "Claude stopped with error"
+                    case "SessionStart":
+                        return "Session started"
+                    case "SessionEnd":
+                        return "Session ended"
+                    case "PermissionRequest":
+                        return "Permission requested"
+                    case "PermissionDenied":
+                        return "Permission denied"
+                    case "UserPromptSubmit":
+                        return "User submitted prompt"
+                    case "TaskCreated":
+                        return "Task created"
+                    case "TaskCompleted":
+                        return "Task completed"
+                    case "SubagentStart":
+                        let agentType = payload["agent_type"]?.stringValue ?? "agent"
+                        return "Subagent started: \(agentType)"
+                    case "SubagentStop":
+                        return "Subagent stopped"
+                    case "PreCompact":
+                        return "Context compaction starting"
+                    case "PostCompact":
+                        return "Context compaction finished"
+                    default:
+                        return eventName
+                    }
+                }()
+
+                let event = HookEvent(
+                    sessionID: sessionID,
+                    eventName: eventName,
+                    summary: summary
+                )
+
+                return await MainActor.run {
+                    // Append to ring buffer (keep last 50 events per session)
+                    var events = capturedAppState.hookEvents[sessionID, default: []]
+                    events.append(event)
+                    if events.count > 50 { events.removeFirst(events.count - 50) }
+                    capturedAppState.hookEvents[sessionID] = events
+
+                    // Update derived state based on event type
+                    switch eventName {
+                    case "PreToolUse":
+                        let toolName = payload["tool_name"]?.stringValue ?? "unknown"
+                        capturedAppState.lastToolActivity[sessionID] = ToolActivity(
+                            toolName: toolName, isActive: true
+                        )
+                        capturedAppState.claudeState[sessionID] = .working
+
+                    case "PostToolUse":
+                        let toolName = payload["tool_name"]?.stringValue ?? "unknown"
+                        capturedAppState.lastToolActivity[sessionID] = ToolActivity(
+                            toolName: toolName, isActive: false
+                        )
+
+                    case "PostToolUseFailure":
+                        let toolName = payload["tool_name"]?.stringValue ?? "unknown"
+                        capturedAppState.lastToolActivity[sessionID] = ToolActivity(
+                            toolName: toolName, isActive: false
+                        )
+
+                    case "Notification":
+                        let message = payload["message"]?.stringValue ?? ""
+                        let notifType = payload["notification_type"]?.stringValue ?? ""
+                        capturedAppState.pendingNotification[sessionID] = HookNotification(
+                            message: message, notificationType: notifType
+                        )
+                        if notifType == "permission_prompt" || notifType == "idle_prompt" {
+                            capturedAppState.claudeState[sessionID] = .waiting
+                        }
+
+                    case "PermissionRequest":
+                        capturedAppState.claudeState[sessionID] = .waiting
+
+                    case "UserPromptSubmit":
+                        capturedAppState.claudeState[sessionID] = .working
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+
+                    case "Stop":
+                        capturedAppState.claudeState[sessionID] = .done
+                        capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+
+                    case "StopFailure":
+                        capturedAppState.claudeState[sessionID] = .waiting
+
+                    case "SessionStart":
+                        capturedAppState.claudeState[sessionID] = .idle
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+
+                    case "SessionEnd":
+                        capturedAppState.claudeState[sessionID] = .idle
+                        capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+
+                    case "SubagentStart":
+                        capturedAppState.claudeState[sessionID] = .working
+
+                    case "TaskCreated", "TaskCompleted", "SubagentStop":
+                        // Stay in working state
+                        if capturedAppState.claudeState[sessionID] != .waiting {
+                            capturedAppState.claudeState[sessionID] = .working
+                        }
+
+                    default:
+                        break // PermissionDenied, PreCompact, PostCompact — log only
+                    }
+
+                    return [
+                        "received": .bool(true),
+                        "session_id": .string(sessionIDStr),
+                        "event_name": .string(eventName),
+                    ]
+                }
             },
         ])
 

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -563,10 +563,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case "Notification":
                         let message = payload["message"]?.stringValue ?? ""
                         let notifType = payload["notification_type"]?.stringValue ?? ""
-                        capturedAppState.pendingNotification[sessionID] = HookNotification(
-                            message: message, notificationType: notifType
-                        )
-                        if notifType == "permission_prompt" || notifType == "idle_prompt" {
+                        // Only treat permission_prompt as needing attention.
+                        // idle_prompt just means Claude is at the prompt (same as "done").
+                        if notifType == "permission_prompt" {
+                            capturedAppState.pendingNotification[sessionID] = HookNotification(
+                                message: message, notificationType: notifType
+                            )
                             capturedAppState.claudeState[sessionID] = .waiting
                         }
 

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -617,6 +617,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         // PermissionDenied, PreCompact, PostCompact — clear notification if present
                         if eventName == "PermissionDenied" {
                             capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+                            capturedAppState.claudeState[sessionID] = .working
+                            capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
                         }
                     }
 

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -546,6 +546,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             toolName: toolName, isActive: true
                         )
                         capturedAppState.claudeState[sessionID] = .working
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "PostToolUse":
                         let toolName = payload["tool_name"]?.stringValue ?? "unknown"
@@ -595,6 +596,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                     case "SubagentStart":
                         capturedAppState.claudeState[sessionID] = .working
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "TaskCreated", "TaskCompleted", "SubagentStop":
                         // Stay in working state
@@ -603,7 +605,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         }
 
                     default:
-                        break // PermissionDenied, PreCompact, PostCompact — log only
+                        // PermissionDenied, PreCompact, PostCompact — clear notification if present
+                        if eventName == "PermissionDenied" {
+                            capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+                        }
                     }
 
                     return [

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -538,7 +538,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if events.count > 50 { events.removeFirst(events.count - 50) }
                     capturedAppState.hookEvents[sessionID] = events
 
-                    // Update derived state based on event type
+                    // Update derived state based on event type.
+                    // Clear pending notification on ANY event that indicates
+                    // Claude moved past the waiting state (except Notification
+                    // itself, which may SET the pending state).
+                    if eventName != "Notification" && eventName != "PermissionRequest" {
+                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
+                    }
+
                     switch eventName {
                     case "PreToolUse":
                         let toolName = payload["tool_name"]?.stringValue ?? "unknown"
@@ -546,7 +553,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             toolName: toolName, isActive: true
                         )
                         capturedAppState.claudeState[sessionID] = .working
-                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "PostToolUse":
                         let toolName = payload["tool_name"]?.stringValue ?? "unknown"
@@ -582,12 +588,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                     case "UserPromptSubmit":
                         capturedAppState.claudeState[sessionID] = .working
-                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "Stop":
                         capturedAppState.claudeState[sessionID] = .done
                         capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
-                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "StopFailure":
                         capturedAppState.claudeState[sessionID] = .waiting
@@ -595,22 +599,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case "SessionStart":
                         let source = payload["source"]?.stringValue ?? "startup"
                         if source == "resume" {
-                            // Resuming a previous session — Claude is at the prompt
-                            // waiting for input, so show as "done" (previous turn finished)
                             capturedAppState.claudeState[sessionID] = .done
                         } else {
                             capturedAppState.claudeState[sessionID] = .idle
                         }
-                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "SessionEnd":
                         capturedAppState.claudeState[sessionID] = .idle
                         capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
-                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "SubagentStart":
                         capturedAppState.claudeState[sessionID] = .working
-                        capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "TaskCreated", "TaskCompleted", "SubagentStop":
                         // Stay in working state
@@ -619,9 +618,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         }
 
                     default:
-                        // PermissionDenied, PreCompact, PostCompact — clear notification if present
+                        // PermissionDenied, PreCompact, PostCompact — state change
+                        // handled by blanket notification clear above
                         if eventName == "PermissionDenied" {
-                            capturedAppState.pendingNotification.removeValue(forKey: sessionID)
                             capturedAppState.claudeState[sessionID] = .working
                             capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
                         }

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -563,13 +563,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case "Notification":
                         let message = payload["message"]?.stringValue ?? ""
                         let notifType = payload["notification_type"]?.stringValue ?? ""
-                        // Only treat permission_prompt as needing attention.
-                        // idle_prompt just means Claude is at the prompt (same as "done").
                         if notifType == "permission_prompt" {
+                            // Permission needed — show attention state
                             capturedAppState.pendingNotification[sessionID] = HookNotification(
                                 message: message, notificationType: notifType
                             )
                             capturedAppState.claudeState[sessionID] = .waiting
+                        } else if notifType == "idle_prompt" {
+                            // Claude is at the prompt — clear any stale permission notification
+                            // but don't change claudeState (Stop already set it to .done)
+                            capturedAppState.pendingNotification.removeValue(forKey: sessionID)
                         }
 
                     case "PermissionRequest":

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -549,10 +549,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     switch eventName {
                     case "PreToolUse":
                         let toolName = payload["tool_name"]?.stringValue ?? "unknown"
-                        capturedAppState.lastToolActivity[sessionID] = ToolActivity(
-                            toolName: toolName, isActive: true
-                        )
-                        capturedAppState.claudeState[sessionID] = .working
+                        if toolName == "AskUserQuestion" {
+                            // Question for the user — set attention state
+                            capturedAppState.pendingNotification[sessionID] = HookNotification(
+                                message: "Claude has a question",
+                                notificationType: "question"
+                            )
+                            capturedAppState.claudeState[sessionID] = .waiting
+                            capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
+                        } else {
+                            capturedAppState.lastToolActivity[sessionID] = ToolActivity(
+                                toolName: toolName, isActive: true
+                            )
+                            capturedAppState.claudeState[sessionID] = .working
+                        }
 
                     case "PostToolUse":
                         let toolName = payload["tool_name"]?.stringValue ?? "unknown"
@@ -582,8 +592,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         }
 
                     case "PermissionRequest":
+                        capturedAppState.pendingNotification[sessionID] = HookNotification(
+                            message: "Permission requested",
+                            notificationType: "permission_prompt"
+                        )
                         capturedAppState.claudeState[sessionID] = .waiting
-                        // Clear tool activity so badge shows "Permission" not tool name
                         capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
 
                     case "UserPromptSubmit":

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -572,6 +572,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                     case "PermissionRequest":
                         capturedAppState.claudeState[sessionID] = .waiting
+                        // Clear tool activity so badge shows "Permission" not tool name
+                        capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
 
                     case "UserPromptSubmit":
                         capturedAppState.claudeState[sessionID] = .working
@@ -586,7 +588,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         capturedAppState.claudeState[sessionID] = .waiting
 
                     case "SessionStart":
-                        capturedAppState.claudeState[sessionID] = .idle
+                        let source = payload["source"]?.stringValue ?? "startup"
+                        if source == "resume" {
+                            // Resuming a previous session — Claude is at the prompt
+                            // waiting for input, so show as "done" (previous turn finished)
+                            capturedAppState.claudeState[sessionID] = .done
+                        } else {
+                            capturedAppState.claudeState[sessionID] = .idle
+                        }
                         capturedAppState.pendingNotification.removeValue(forKey: sessionID)
 
                     case "SessionEnd":

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -592,10 +592,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         }
 
                     case "PermissionRequest":
-                        capturedAppState.pendingNotification[sessionID] = HookNotification(
-                            message: "Permission requested",
-                            notificationType: "permission_prompt"
-                        )
+                        // Don't override a "question" notification — AskUserQuestion
+                        // triggers both PreToolUse and PermissionRequest, and the
+                        // question badge is more specific than generic "Permission"
+                        if capturedAppState.pendingNotification[sessionID]?.notificationType != "question" {
+                            capturedAppState.pendingNotification[sessionID] = HookNotification(
+                                message: "Permission requested",
+                                notificationType: "permission_prompt"
+                            )
+                        }
                         capturedAppState.claudeState[sessionID] = .waiting
                         capturedAppState.lastToolActivity.removeValue(forKey: sessionID)
 

--- a/Sources/RmAiIde/App/HookConfigGenerator.swift
+++ b/Sources/RmAiIde/App/HookConfigGenerator.swift
@@ -12,9 +12,11 @@ struct HookConfigGenerator {
         "PreCompact", "PostCompact",
     ]
 
-    /// High-frequency events that should use async: true to avoid any latency.
+    /// Post-execution events that can safely run async (fire-and-forget).
+    /// PreToolUse is intentionally NOT async — it must arrive before
+    /// PermissionRequest so the state machine ordering is reliable.
     private static let asyncEvents: Set<String> = [
-        "PreToolUse", "PostToolUse", "PostToolUseFailure",
+        "PostToolUse", "PostToolUseFailure",
     ]
 
     /// Marker key to identify our hooks vs user hooks.

--- a/Sources/RmAiIde/App/HookConfigGenerator.swift
+++ b/Sources/RmAiIde/App/HookConfigGenerator.swift
@@ -23,12 +23,14 @@ struct HookConfigGenerator {
     // MARK: - Generate Hook Configuration
 
     /// Generate the hooks dictionary for a session.
-    static func generateHooks(sessionID: UUID, ridePath: String) -> [String: Any] {
+    /// The socketPath is embedded in the command so hooks connect to the correct socket
+    /// regardless of the subprocess's $TMPDIR (Claude Code overrides it).
+    static func generateHooks(sessionID: UUID, ridePath: String, socketPath: String) -> [String: Any] {
         let sid = sessionID.uuidString
         var hooks: [String: Any] = [:]
 
         for event in allEvents {
-            let command = "\(ridePath) hook-event --session \(sid) --event \(event)"
+            let command = "RIDE_SOCKET=\(socketPath) \(ridePath) hook-event --session \(sid) --event \(event)"
             var hookEntry: [String: Any] = [
                 "type": "command",
                 "command": command,
@@ -37,9 +39,9 @@ struct HookConfigGenerator {
             if asyncEvents.contains(event) {
                 hookEntry["async"] = true
             }
+            // Omit matcher to match all occurrences (avoids invalid regex "*")
             hooks[event] = [
                 [
-                    "matcher": "*",
                     "hooks": [hookEntry],
                 ] as [String: Any]
             ]
@@ -72,8 +74,11 @@ struct HookConfigGenerator {
         // Get existing hooks and preserve any non-ride-managed entries
         var existingHooks = settings["hooks"] as? [String: Any] ?? [:]
 
-        // Generate our hooks
-        let ourHooks = generateHooks(sessionID: sessionID, ridePath: ridePath)
+        // Resolve the socket path from the app's actual TMPDIR (not the hook subprocess's)
+        let socketPath = resolveSocketPath()
+
+        // Generate our hooks with the embedded socket path
+        let ourHooks = generateHooks(sessionID: sessionID, ridePath: ridePath, socketPath: socketPath)
 
         // Merge: our hooks overwrite matching event names, user hooks for other events are preserved
         for (eventName, hookConfig) in ourHooks {
@@ -140,5 +145,15 @@ struct HookConfigGenerator {
             }
         }
         return nil
+    }
+
+    /// Resolve the socket path using the app's real TMPDIR.
+    /// This is needed because Claude Code hooks run in a subprocess where
+    /// $TMPDIR is overridden (e.g., /tmp/claude), but the app's socket
+    /// is at the real macOS $TMPDIR (e.g., /var/folders/.../T/).
+    private static func resolveSocketPath() -> String {
+        let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"]
+            ?? NSTemporaryDirectory()
+        return (tmpDir as NSString).appendingPathComponent("ride.sock")
     }
 }

--- a/Sources/RmAiIde/App/HookConfigGenerator.swift
+++ b/Sources/RmAiIde/App/HookConfigGenerator.swift
@@ -23,14 +23,12 @@ struct HookConfigGenerator {
     // MARK: - Generate Hook Configuration
 
     /// Generate the hooks dictionary for a session.
-    /// The socketPath is embedded in the command so hooks connect to the correct socket
-    /// regardless of the subprocess's $TMPDIR (Claude Code overrides it).
-    static func generateHooks(sessionID: UUID, ridePath: String, socketPath: String) -> [String: Any] {
+    static func generateHooks(sessionID: UUID, ridePath: String) -> [String: Any] {
         let sid = sessionID.uuidString
         var hooks: [String: Any] = [:]
 
         for event in allEvents {
-            let command = "RIDE_SOCKET=\(socketPath) \(ridePath) hook-event --session \(sid) --event \(event)"
+            let command = "\(ridePath) hook-event --session \(sid) --event \(event)"
             var hookEntry: [String: Any] = [
                 "type": "command",
                 "command": command,
@@ -74,11 +72,8 @@ struct HookConfigGenerator {
         // Get existing hooks and preserve any non-ride-managed entries
         var existingHooks = settings["hooks"] as? [String: Any] ?? [:]
 
-        // Resolve the socket path from the app's actual TMPDIR (not the hook subprocess's)
-        let socketPath = resolveSocketPath()
-
-        // Generate our hooks with the embedded socket path
-        let ourHooks = generateHooks(sessionID: sessionID, ridePath: ridePath, socketPath: socketPath)
+        // Generate our hooks
+        let ourHooks = generateHooks(sessionID: sessionID, ridePath: ridePath)
 
         // Merge: our hooks overwrite matching event names, user hooks for other events are preserved
         for (eventName, hookConfig) in ourHooks {
@@ -145,15 +140,5 @@ struct HookConfigGenerator {
             }
         }
         return nil
-    }
-
-    /// Resolve the socket path using the app's real TMPDIR.
-    /// This is needed because Claude Code hooks run in a subprocess where
-    /// $TMPDIR is overridden (e.g., /tmp/claude), but the app's socket
-    /// is at the real macOS $TMPDIR (e.g., /var/folders/.../T/).
-    private static func resolveSocketPath() -> String {
-        let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"]
-            ?? NSTemporaryDirectory()
-        return (tmpDir as NSString).appendingPathComponent("ride.sock")
     }
 }

--- a/Sources/RmAiIde/App/HookConfigGenerator.swift
+++ b/Sources/RmAiIde/App/HookConfigGenerator.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Generates and manages Claude Code hook configuration for session worktrees.
+struct HookConfigGenerator {
+
+    /// All hook event names we register.
+    private static let allEvents = [
+        "SessionStart", "SessionEnd", "Stop", "StopFailure",
+        "Notification", "PreToolUse", "PostToolUse", "PostToolUseFailure",
+        "PermissionRequest", "PermissionDenied", "UserPromptSubmit",
+        "TaskCreated", "TaskCompleted", "SubagentStart", "SubagentStop",
+        "PreCompact", "PostCompact",
+    ]
+
+    /// High-frequency events that should use async: true to avoid any latency.
+    private static let asyncEvents: Set<String> = [
+        "PreToolUse", "PostToolUse", "PostToolUseFailure",
+    ]
+
+    /// Marker key to identify our hooks vs user hooks.
+    private static let markerComment = "ride-managed"
+
+    // MARK: - Generate Hook Configuration
+
+    /// Generate the hooks dictionary for a session.
+    static func generateHooks(sessionID: UUID, ridePath: String) -> [String: Any] {
+        let sid = sessionID.uuidString
+        var hooks: [String: Any] = [:]
+
+        for event in allEvents {
+            let command = "\(ridePath) hook-event --session \(sid) --event \(event)"
+            var hookEntry: [String: Any] = [
+                "type": "command",
+                "command": command,
+                "timeout": 5,
+            ]
+            if asyncEvents.contains(event) {
+                hookEntry["async"] = true
+            }
+            hooks[event] = [
+                [
+                    "matcher": "*",
+                    "hooks": [hookEntry],
+                ] as [String: Any]
+            ]
+        }
+
+        return hooks
+    }
+
+    // MARK: - Write / Merge Configuration
+
+    /// Write hook configuration to a worktree's .claude/settings.local.json.
+    /// Uses a merge strategy: preserves user settings, only updates our hook entries.
+    static func writeHookConfig(
+        worktreePath: String,
+        sessionID: UUID,
+        ridePath: String
+    ) throws {
+        let claudeDir = (worktreePath as NSString).appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(atPath: claudeDir, withIntermediateDirectories: true)
+
+        let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.local.json")
+
+        // Read existing settings if present
+        var settings: [String: Any] = [:]
+        if let data = FileManager.default.contents(atPath: settingsPath),
+           let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            settings = parsed
+        }
+
+        // Get existing hooks and preserve any non-ride-managed entries
+        var existingHooks = settings["hooks"] as? [String: Any] ?? [:]
+
+        // Generate our hooks
+        let ourHooks = generateHooks(sessionID: sessionID, ridePath: ridePath)
+
+        // Merge: our hooks overwrite matching event names, user hooks for other events are preserved
+        for (eventName, hookConfig) in ourHooks {
+            existingHooks[eventName] = hookConfig
+        }
+
+        settings["hooks"] = existingHooks
+
+        // Write back
+        let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+    }
+
+    /// Remove our hook entries from a worktree's settings.local.json, preserving user settings.
+    static func removeHookConfig(worktreePath: String) {
+        let settingsPath = (worktreePath as NSString)
+            .appendingPathComponent(".claude/settings.local.json")
+
+        guard let data = FileManager.default.contents(atPath: settingsPath),
+              var settings = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var hooks = settings["hooks"] as? [String: Any] else {
+            return
+        }
+
+        // Remove our managed event entries
+        for event in allEvents {
+            hooks.removeValue(forKey: event)
+        }
+
+        if hooks.isEmpty {
+            settings.removeValue(forKey: "hooks")
+        } else {
+            settings["hooks"] = hooks
+        }
+
+        // If settings is now empty, remove the file
+        if settings.isEmpty {
+            try? FileManager.default.removeItem(atPath: settingsPath)
+        } else if let updatedData = try? JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys]) {
+            try? updatedData.write(to: URL(fileURLWithPath: settingsPath))
+        }
+    }
+
+    // MARK: - Find ride Binary
+
+    /// Find the ride binary, checking common install locations.
+    static func findRideBinary() -> String? {
+        // Check same directory as running executable first (development builds)
+        let execURL = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
+        let buildDir = execURL.deletingLastPathComponent()
+        let devPath = buildDir.appendingPathComponent("ride").path
+        if FileManager.default.isExecutableFile(atPath: devPath) {
+            return devPath
+        }
+
+        let candidates = [
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin/ride").path,
+            "/usr/local/bin/ride",
+            "/opt/homebrew/bin/ride",
+        ]
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/RmAiIde/App/SessionService.swift
+++ b/Sources/RmAiIde/App/SessionService.swift
@@ -85,6 +85,20 @@ final class SessionService {
     /// Send `claude --continue` to a terminal and mark it as launched.
     func launchClaude(terminalID: UUID) {
         guard appState.terminalReadiness[terminalID] == .shellReady else { return }
+
+        // Write/refresh hook config for the session's worktree
+        if let sessionID = appState.terminals.first(where: { _, terminals in
+            terminals.contains(where: { $0.id == terminalID })
+        })?.key,
+           let worktree = appState.primaryWorktree(for: sessionID),
+           let ridePath = HookConfigGenerator.findRideBinary() {
+            try? HookConfigGenerator.writeHookConfig(
+                worktreePath: worktree.worktreePath,
+                sessionID: sessionID,
+                ridePath: ridePath
+            )
+        }
+
         let claudePath = Self.findClaudeBinary() ?? "claude"
         TerminalManager.shared.send(id: terminalID, text: "\(claudePath) --continue\n")
         appState.terminalReadiness[terminalID] = .claudeLaunched
@@ -154,6 +168,9 @@ final class SessionService {
                 continue
             }
 
+            // Remove our hook config from settings.local.json before deleting the worktree
+            HookConfigGenerator.removeHookConfig(worktreePath: wt.worktreePath)
+
             do {
                 // Remove the worktree
                 let removeResult = try await shell("git", "-C", wt.repoPath, "worktree", "remove", "--force", wt.worktreePath)
@@ -182,6 +199,10 @@ final class SessionService {
         appState.links.removeValue(forKey: id)
         appState.terminals.removeValue(forKey: id)
         appState.activeTerminalID.removeValue(forKey: id)
+        appState.hookEvents.removeValue(forKey: id)
+        appState.pendingNotification.removeValue(forKey: id)
+        appState.lastToolActivity.removeValue(forKey: id)
+        appState.claudeState.removeValue(forKey: id)
 
         store.mutate { data in
             data.sessions.removeAll { $0.id == id }

--- a/Sources/RmIdeCLI/RmIdeCLI.swift
+++ b/Sources/RmIdeCLI/RmIdeCLI.swift
@@ -25,6 +25,7 @@ struct Ride: ParsableCommand {
             Send.self,
             AddLink.self,
             ListLinks.self,
+            HookEventCmd.self,
         ]
     )
 }
@@ -249,6 +250,39 @@ struct ListLinks: ParsableCommand {
     func run() throws {
         let result = try rpc("list-links", params: ["session_id": .string(session)])
         printJSON(result)
+    }
+}
+
+// MARK: - Hook Event Command
+
+struct HookEventCmd: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "hook-event",
+        abstract: "Forward a Claude Code hook event to the app (reads JSON from stdin)"
+    )
+    @Option(name: .long, help: "Session UUID") var session: String
+    @Option(name: .long, help: "Event name (e.g., Stop, Notification, PreToolUse)") var event: String
+
+    func run() throws {
+        // Read JSON payload from stdin (Claude Code pipes event data here)
+        var payload: [String: JSONValue] = [:]
+        let stdinData = FileHandle.standardInput.readDataToEndOfFile()
+        if !stdinData.isEmpty {
+            if let parsed = try? JSONDecoder().decode([String: JSONValue].self, from: stdinData) {
+                payload = parsed
+            }
+        }
+
+        let result = try rpc("hook-event", params: [
+            "session_id": .string(session),
+            "event_name": .string(event),
+            "payload": .object(payload),
+        ])
+
+        // Silent on success — only print on error
+        if result["error"] != nil {
+            printJSON(result)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `ride hook-event` CLI command and RPC handler to receive real-time events from Claude Code sessions via the hook system (17 event types)
- Add `HookConfigGenerator` that merges hook config into each worktree's `.claude/settings.local.json`, preserving user settings
- Enhance sidebar status dots to reflect Claude's activity state (working, waiting, done, idle) with tool name badges and attention borders

## Test plan

- [x] Build project: `swift build` — verify zero errors on both `RmAiIde` and `ride` targets
- [x] CLI test: pipe JSON to `ride hook-event --session <uuid> --event PreToolUse` and verify sidebar updates
- [x] Hook config test: create a session with worktree, verify `.claude/settings.local.json` contains all 17 hook entries
- [x] Integration test: launch Claude in a session, verify status dot transitions (green → orange → gold) as Claude works
- [x] Multi-session test: two active sessions, verify events route to correct sessions
- [x] Cleanup test: delete a session, verify hook entries removed from `settings.local.json` and state cleaned up

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)