### PR TITLE
Add 'Open in VS Code' button for session worktrees

### DIFF
--- a/Packages/RmCore/Sources/RmCore/AppState.swift
+++ b/Packages/RmCore/Sources/RmCore/AppState.swift
@@ -50,6 +50,9 @@ public final class AppState {
     /// PR status per session (pipeline, review, merge readiness).
     public var prStatus: [UUID: PRStatus] = [:]
 
+    /// Whether the VS Code `code` CLI is available on this system.
+    public var vsCodeAvailable: Bool = false
+
     /// Terminal readiness state per terminal ID.
     public var terminalReadiness: [UUID: TerminalReadiness] = [:]
 
@@ -66,6 +69,9 @@ public final class AppState {
 
     /// Called to mark a session as completed.
     public var onCompleteSession: ((UUID) -> Void)?
+
+    /// Called to open a session's primary worktree in VS Code.
+    public var onOpenInVSCode: ((UUID) -> Void)?
 
     // MARK: - Computed Properties
 

--- a/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
@@ -109,6 +109,18 @@ public struct SessionDetailView: View {
 
                 // Action buttons (not for Manager)
                 if session.id != AppState.managerSessionID {
+                    if appState.vsCodeAvailable, primaryWorktree != nil {
+                        Button {
+                            appState.onOpenInVSCode?(session.id)
+                        } label: {
+                            Label("Open in VS Code", systemImage: "chevron.left.forwardslash.chevron.right")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .tint(CorveilTheme.gold)
+                    }
+
                     if session.status == .active {
                         Button {
                             appState.onCompleteSession?(session.id)

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -119,6 +119,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.launchClaude(terminalID: terminalID)
         }
 
+        // Detect VS Code CLI and wire open action
+        service.detectVSCode()
+        appState.onOpenInVSCode = { [weak service] sessionID in
+            service?.openInVSCode(sessionID: sessionID)
+        }
+
         // Wire "Work on" issue action — sends issue URL to Manager terminal
         appState.onWorkOnIssue = { [weak self] issueURL in
             guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],

--- a/Sources/RmAiIde/App/SessionService.swift
+++ b/Sources/RmAiIde/App/SessionService.swift
@@ -508,4 +508,37 @@ final class SessionService {
         }
         return nil
     }
+
+    // MARK: - VS Code Integration
+
+    /// Find the VS Code `code` CLI binary.
+    static func findVSCodeBinary() -> String? {
+        let candidates = [
+            "/usr/local/bin/code",
+            "/opt/homebrew/bin/code",
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin/code").path,
+        ]
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    /// Check if VS Code CLI is available and cache the result in AppState.
+    func detectVSCode() {
+        appState.vsCodeAvailable = Self.findVSCodeBinary() != nil
+    }
+
+    /// Open the primary worktree for a session in VS Code.
+    func openInVSCode(sessionID: UUID) {
+        guard let codePath = Self.findVSCodeBinary() else { return }
+        guard let wt = appState.primaryWorktree(for: sessionID) else { return }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: codePath)
+        process.arguments = [wt.worktreePath]
+        try? process.run()
+    }
 }


### PR DESCRIPTION
## Summary
- Detects `code` CLI availability at app launch and caches the result
- Adds an "Open in VS Code" button in session header (Row 3) next to "Mark as Completed"
- Button only visible when `code` CLI is found and session has a primary worktree
- Opens the primary worktree directory in VS Code via a background `Process`

Closes #6

## Test plan
- [x] With `code` CLI installed: verify button appears for sessions with worktrees
- [x] Without `code` CLI: verify button is hidden
- [x] Click button: VS Code opens to the worktree directory
- [x] Manager session: verify button is hidden (no worktree)
- [x] Verify clicking the button does not freeze the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)