### PR TITLE
Add Makefile for build automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+.PHONY: build setup ghostty app release clean clean-all help
+
+FRAMEWORKS_DIR := Frameworks
+XCFW := $(FRAMEWORKS_DIR)/GhosttyKit.xcframework
+SUBMODULE_MARKER := vendor/ghostty/build.zig
+
+# Default target
+build: setup ghostty app
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  build      Full build: submodules + ghostty + swift build (default)"
+	@echo "  setup      Init submodules and check prerequisites"
+	@echo "  ghostty    Build GhosttyKit framework"
+	@echo "  app        Swift build only (debug)"
+	@echo "  release    Release build + .app bundle"
+	@echo "  clean      Remove .build/ (keeps ghostty framework)"
+	@echo "  clean-all  Remove .build/ and Frameworks/ (full rebuild)"
+	@echo ""
+	@echo "Prerequisites: Zig 0.15.2, Xcode with Metal Toolchain"
+
+# --- Setup ---
+
+$(SUBMODULE_MARKER):
+	git submodule update --init --recursive
+
+setup: $(SUBMODULE_MARKER)
+	@command -v zig >/dev/null 2>&1 || { echo "ERROR: zig not found. Install with: brew install zig"; exit 1; }
+	@ZIG_VER=$$(zig version); \
+	if [ "$$ZIG_VER" != "0.15.2" ]; then \
+		echo "WARNING: Zig 0.15.2 required, found: $$ZIG_VER"; \
+	fi
+	@xcrun -sdk macosx metal --version >/dev/null 2>&1 || { echo "ERROR: Metal Toolchain not installed. Run: xcodebuild -downloadComponent MetalToolchain"; exit 1; }
+	@echo "Prerequisites OK"
+
+# --- Ghostty ---
+
+$(XCFW): $(SUBMODULE_MARKER)
+	bash scripts/build-ghostty.sh
+
+ghostty: setup $(XCFW)
+
+# --- App ---
+
+app: $(XCFW)
+	swift build
+
+release: $(XCFW)
+	bash scripts/bundle.sh
+
+# --- Clean ---
+
+clean:
+	rm -rf .build
+
+clean-all: clean
+	rm -rf $(FRAMEWORKS_DIR)


### PR DESCRIPTION
## Summary
- Adds a `Makefile` at the project root so the full build is a single `make` command
- Wraps existing `scripts/build-ghostty.sh` and `scripts/bundle.sh` with file-based prerequisites to skip already-completed steps
- Targets: `setup`, `ghostty`, `app`, `release`, `clean`, `clean-all`, `help`

## Test plan
- [ ] `make clean-all && make` runs full build from scratch
- [ ] `make` again is near-instant (skips ghostty, swift build is no-op)
- [ ] `make release` produces `RmAiIde.app`
- [ ] `make help` prints target descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)