### PR TITLE
Add In Review button to update GitHub Project status

### DIFF
--- a/Packages/RmCore/Sources/RmCore/AppState.swift
+++ b/Packages/RmCore/Sources/RmCore/AppState.swift
@@ -81,6 +81,12 @@ public final class AppState {
     /// Called to mark a session as completed.
     public var onCompleteSession: ((UUID) -> Void)?
 
+    /// Called to mark a session's ticket as "In Review" on the GitHub Project board.
+    public var onMarkInReview: ((UUID) -> Void)?
+
+    /// Whether a given session is currently being marked as "In Review" (loading state).
+    public var isMarkingInReview: [UUID: Bool] = [:]
+
     /// Called to open a session's primary worktree in VS Code.
     public var onOpenInVSCode: ((UUID) -> Void)?
 

--- a/Packages/RmCore/Sources/RmCore/AppState.swift
+++ b/Packages/RmCore/Sources/RmCore/AppState.swift
@@ -84,6 +84,9 @@ public final class AppState {
     /// Called to mark a session's ticket as "In Review" on the GitHub Project board.
     public var onMarkInReview: ((UUID) -> Void)?
 
+    /// Called to update session status to .inReview (persists to store).
+    public var onSetSessionInReview: ((UUID) -> Void)?
+
     /// Whether a given session is currently being marked as "In Review" (loading state).
     public var isMarkingInReview: [UUID: Bool] = [:]
 
@@ -99,6 +102,10 @@ public final class AppState {
 
     public var activeSessions: [Session] {
         sessions.filter { $0.status == .active && $0.id != Self.managerSessionID }
+    }
+
+    public var inReviewSessions: [Session] {
+        sessions.filter { $0.status == .inReview && $0.id != Self.managerSessionID }
     }
 
     public var completedSessions: [Session] {

--- a/Packages/RmCore/Sources/RmCore/Models/Enums.swift
+++ b/Packages/RmCore/Sources/RmCore/Models/Enums.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum SessionStatus: String, Codable, Sendable {
     case active
     case paused
+    case inReview
     case completed
     case archived
 }

--- a/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
@@ -141,7 +141,7 @@ public struct SessionDetailView: View {
                         }
                     }
 
-                    if session.status == .active {
+                    if session.status == .active || session.status == .inReview {
                         Button {
                             appState.onCompleteSession?(session.id)
                         } label: {
@@ -295,6 +295,7 @@ struct StatusBadge: View {
         switch status {
         case .active: .green
         case .paused: .yellow
+        case .inReview: CorveilTheme.gold
         case .completed: CorveilTheme.gold
         case .archived: CorveilTheme.textMuted
         }

--- a/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
@@ -121,6 +121,26 @@ public struct SessionDetailView: View {
                         .tint(CorveilTheme.gold)
                     }
 
+                    if session.status == .active,
+                       session.ticketURL != nil,
+                       session.provider == .github {
+                        if appState.isMarkingInReview[session.id] == true {
+                            ProgressView()
+                                .controlSize(.small)
+                                .padding(.horizontal, 8)
+                        } else {
+                            Button {
+                                appState.onMarkInReview?(session.id)
+                            } label: {
+                                Label("In Review", systemImage: "eye.circle")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .tint(CorveilTheme.gold)
+                        }
+                    }
+
                     if session.status == .active {
                         Button {
                             appState.onCompleteSession?(session.id)

--- a/Packages/RmUI/Sources/RmUI/SessionListView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionListView.swift
@@ -83,6 +83,17 @@ public struct SessionListView: View {
 
     @ViewBuilder
     private func sessionContextMenu(_ session: Session) -> some View {
+        if session.status == .active,
+           session.ticketURL != nil,
+           session.provider == .github {
+            Button {
+                appState.onMarkInReview?(session.id)
+            } label: {
+                Label("Mark as In Review", systemImage: "eye.circle")
+            }
+            .disabled(appState.isMarkingInReview[session.id] == true)
+        }
+
         if session.status == .active {
             Button {
                 appState.onCompleteSession?(session.id)

--- a/Packages/RmUI/Sources/RmUI/SessionListView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionListView.swift
@@ -46,6 +46,20 @@ public struct SessionListView: View {
                 }
             }
 
+            // In Review sessions
+            if !appState.inReviewSessions.isEmpty {
+                SectionDivider(title: "In Review")
+                ForEach(filteredSessions(appState.inReviewSessions)) { session in
+                    SessionRow(session: session, appState: appState)
+                        .tag(session.id)
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
+                        .contextMenu {
+                            sessionContextMenu(session)
+                        }
+                }
+            }
+
             // Completed sessions
             if !appState.completedSessions.isEmpty {
                 SectionDivider(title: "Completed")
@@ -94,7 +108,7 @@ public struct SessionListView: View {
             .disabled(appState.isMarkingInReview[session.id] == true)
         }
 
-        if session.status == .active {
+        if session.status == .active || session.status == .inReview {
             Button {
                 appState.onCompleteSession?(session.id)
             } label: {
@@ -326,6 +340,10 @@ struct SessionRow: View {
                         .frame(width: 8, height: 8)
                 }
             }
+        case .inReview:
+            Image(systemName: "eye.circle.fill")
+                .foregroundStyle(CorveilTheme.gold)
+                .font(.caption)
         case .paused:
             Circle()
                 .fill(.yellow)

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -114,6 +114,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onCompleteSession = { [weak service] id in
             service?.completeSession(id: id)
         }
+        appState.onSetSessionInReview = { [weak service] id in
+            service?.setSessionInReview(id: id)
+        }
 
         appState.onLaunchClaude = { [weak service] terminalID in
             service?.launchClaude(terminalID: terminalID)

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -143,6 +143,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         tracker.start()
         self.issueTracker = tracker
 
+        appState.onMarkInReview = { [weak tracker] id in
+            Task { await tracker?.markInReview(sessionID: id) }
+        }
+
         // Start socket server
         startSocketServer(store: store, devRoot: devRoot)
 

--- a/Sources/RmAiIde/App/IssueTracker.swift
+++ b/Sources/RmAiIde/App/IssueTracker.swift
@@ -659,6 +659,9 @@ final class IssueTracker {
         }
 
         print("[IssueTracker] Marked \(owner)/\(repoName)#\(number) as In Review")
+
+        // Update local session status to .inReview
+        appState.onSetSessionInReview?(sessionID)
     }
 
     // MARK: - Shell

--- a/Sources/RmAiIde/App/IssueTracker.swift
+++ b/Sources/RmAiIde/App/IssueTracker.swift
@@ -510,6 +510,157 @@ final class IssueTracker {
         }
     }
 
+    // MARK: - Mark In Review
+
+    func markInReview(sessionID: UUID) async {
+        guard let session = appState.sessions.first(where: { $0.id == sessionID }),
+              let ticketURL = session.ticketURL,
+              session.provider == .github else { return }
+
+        // Parse owner/repo/number from URL like "https://github.com/org/repo/issues/123"
+        let components = ticketURL.split(separator: "/")
+        guard components.count >= 5,
+              let number = Int(components.last ?? "") else {
+            print("[IssueTracker] Could not parse ticket URL: \(ticketURL)")
+            return
+        }
+        let owner = String(components[components.count - 4])
+        let repoName = String(components[components.count - 3])
+
+        appState.isMarkingInReview[sessionID] = true
+        defer { appState.isMarkingInReview[sessionID] = false }
+
+        // Step 1: Query for project item ID, project ID, field ID, and "In Review" option ID
+        let query = """
+        query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              projectItems(first: 10) {
+                nodes {
+                  id
+                  project { id }
+                  fieldValueByName(name: "Status") {
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                      field {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+
+        let queryResult = await shellWithStatus(
+            "gh", "api", "graphql",
+            "-f", "query=\(query)",
+            "-F", "owner=\(owner)",
+            "-F", "repo=\(repoName)",
+            "-F", "number=\(number)"
+        )
+
+        if queryResult.exitCode != 0 {
+            if queryResult.stderr.contains("INSUFFICIENT_SCOPES") || queryResult.stderr.contains("read:project") || queryResult.stderr.contains("project") {
+                print("[IssueTracker] GitHub token missing 'project' scope — run 'gh auth refresh -s project'")
+            } else {
+                print("[IssueTracker] GraphQL query failed: \(queryResult.stderr.prefix(200))")
+            }
+            return
+        }
+
+        // Parse the query response
+        guard let data = queryResult.stdout.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any],
+              let repository = dataObj["repository"] as? [String: Any],
+              let issueObj = repository["issue"] as? [String: Any],
+              let projectItems = issueObj["projectItems"] as? [String: Any],
+              let nodes = projectItems["nodes"] as? [[String: Any]],
+              !nodes.isEmpty else {
+            print("[IssueTracker] Issue \(owner)/\(repoName)#\(number) is not in any GitHub Project")
+            return
+        }
+
+        // Find a project item that has a Status field with an "In Review" option
+        var itemID: String?
+        var projectID: String?
+        var fieldID: String?
+        var optionID: String?
+
+        for node in nodes {
+            guard let nodeID = node["id"] as? String,
+                  let project = node["project"] as? [String: Any],
+                  let projID = project["id"] as? String,
+                  let fieldValue = node["fieldValueByName"] as? [String: Any],
+                  let field = fieldValue["field"] as? [String: Any],
+                  let fID = field["id"] as? String,
+                  let options = field["options"] as? [[String: Any]] else { continue }
+
+            // Find the "In Review" option (case-insensitive)
+            for option in options {
+                guard let optName = option["name"] as? String,
+                      let optID = option["id"] as? String else { continue }
+                let normalized = optName.lowercased().trimmingCharacters(in: .whitespaces)
+                if normalized == "in review" || normalized == "review" {
+                    itemID = nodeID
+                    projectID = projID
+                    fieldID = fID
+                    optionID = optID
+                    break
+                }
+            }
+            if optionID != nil { break }
+        }
+
+        guard let itemID, let projectID, let fieldID, let optionID else {
+            print("[IssueTracker] No 'In Review' status option found in project for \(owner)/\(repoName)#\(number)")
+            return
+        }
+
+        // Step 2: Mutation to update the status
+        let mutation = """
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+            value: { singleSelectOptionId: $optionId }
+          }) { projectV2Item { id } }
+        }
+        """
+
+        let mutationResult = await shellWithStatus(
+            "gh", "api", "graphql",
+            "-f", "query=\(mutation)",
+            "-F", "projectId=\(projectID)",
+            "-F", "itemId=\(itemID)",
+            "-F", "fieldId=\(fieldID)",
+            "-F", "optionId=\(optionID)"
+        )
+
+        if mutationResult.exitCode != 0 {
+            if mutationResult.stderr.contains("INSUFFICIENT_SCOPES") {
+                print("[IssueTracker] GitHub token missing 'project' scope — run 'gh auth refresh -s project'")
+            } else {
+                print("[IssueTracker] Failed to update project status: \(mutationResult.stderr.prefix(200))")
+            }
+            return
+        }
+
+        // Update local state
+        if let idx = appState.assignedIssues.firstIndex(where: {
+            $0.repo == "\(owner)/\(repoName)" && $0.number == number
+        }) {
+            appState.assignedIssues[idx].projectStatus = .inReview
+        }
+
+        print("[IssueTracker] Marked \(owner)/\(repoName)#\(number) as In Review")
+    }
+
     // MARK: - Shell
 
     private func shell(env: [String: String] = [:], _ args: String...) async throws -> String {

--- a/Sources/RmAiIde/App/IssueTracker.swift
+++ b/Sources/RmAiIde/App/IssueTracker.swift
@@ -79,6 +79,9 @@ final class IssueTracker {
 
         appState.assignedIssues = allIssues
 
+        // Sync session status for tickets that are "In Review" on the project board
+        syncInReviewSessions(issues: allIssues)
+
         // Fetch count of issues closed in last 24h
         if checkedGitHub {
             appState.doneIssuesLast24h = await fetchDoneIssuesLast24h()
@@ -354,6 +357,19 @@ final class IssueTracker {
     }
 
     // MARK: - Auto-Complete Finished Sessions
+
+    /// Sync active sessions whose linked ticket has "In Review" project status to .inReview session status.
+    private func syncInReviewSessions(issues: [AssignedIssue]) {
+        let inReviewURLs = Set(issues.filter { $0.projectStatus == .inReview }.map(\.url))
+
+        for session in appState.activeSessions {
+            guard let ticketURL = session.ticketURL else { continue }
+            if inReviewURLs.contains(ticketURL) {
+                print("[IssueTracker] Session '\(session.name)' — ticket is In Review on project board, updating session status")
+                appState.onSetSessionInReview?(session.id)
+            }
+        }
+    }
 
     /// Check active sessions whose linked ticket is no longer in the open issues list.
     /// If the session has a PR link and that PR was merged, mark the session as completed.

--- a/Sources/RmAiIde/App/SessionService.swift
+++ b/Sources/RmAiIde/App/SessionService.swift
@@ -501,6 +501,22 @@ final class SessionService {
         }
     }
 
+    func setSessionInReview(id: UUID) {
+        guard id != AppState.managerSessionID else { return }
+
+        if let idx = appState.sessions.firstIndex(where: { $0.id == id }) {
+            appState.sessions[idx].status = .inReview
+            appState.sessions[idx].updatedAt = Date()
+        }
+
+        store.mutate { data in
+            if let idx = data.sessions.firstIndex(where: { $0.id == id }) {
+                data.sessions[idx].status = .inReview
+                data.sessions[idx].updatedAt = Date()
+            }
+        }
+    }
+
     // MARK: - Persist Current State
 
     func persistState() {

--- a/Sources/RmIdeCLI/RmIdeCLI.swift
+++ b/Sources/RmIdeCLI/RmIdeCLI.swift
@@ -104,7 +104,7 @@ struct GetSession: ParsableCommand {
 struct SetStatus: ParsableCommand {
     static let configuration = CommandConfiguration(commandName: "set-status", abstract: "Set session status")
     @Option(name: .long, help: "Session UUID") var session: String
-    @Argument(help: "Status: active, paused, completed, archived") var status: String
+    @Argument(help: "Status: active, paused, inReview, completed, archived") var status: String
 
     func run() throws {
         let result = try rpc("set-status", params: ["session_id": .string(session), "status": .string(status)])


### PR DESCRIPTION
## Summary
- Adds an "In Review" button next to "Mark as Completed" in the session detail header and context menu
- Uses GitHub GraphQL API (`updateProjectV2ItemFieldValue` mutation) to set the linked ticket's Project V2 board status to "In Review"
- Shows a loading spinner while the API call is in progress
- Only visible for active sessions with a linked GitHub ticket

Closes #16

## Test plan
- [x] Link a session to a GitHub issue that's in a Project V2 board
- [x] Click "In Review" → verify the project board column updates
- [x] Verify button is hidden for sessions without a linked ticket
- [x] Verify right-click context menu also shows "Mark as In Review"
- [x] Test error path: ticket not in any project → should no-op with console log

🤖 Generated with [Claude Code](https://claude.com/claude-code)