### PR TITLE
Security audit and open-source readiness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ Frameworks/ghostty-resources/
 .idea/
 *.xcuserstate
 
+# Claude Code local settings (may contain absolute paths and session IDs)
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,15 +69,14 @@ Post "https://api.github.com/graphql": tls: failed to verify certificate: x509: 
 **Fix:** Always use `dangerouslyDisableSandbox: true` for ALL `gh` commands. There is no workaround.
 
 If `gh` still fails or returns empty output:
-1. Try with `GIT_SSL_NO_VERIFY=1 gh issue view ...`
-2. Use `--repo owner/repo` explicitly instead of relying on git remote detection
-3. Use full URL: `gh issue view https://github.com/owner/repo/issues/123` not just the number
+1. Use `--repo owner/repo` explicitly instead of relying on git remote detection
+2. Use full URL: `gh issue view https://github.com/owner/repo/issues/123` not just the number
 
 ### GitLab CLI (glab)
 
 Same TLS issue. Always use `dangerouslyDisableSandbox: true` and set `GITLAB_HOST`:
 ```bash
-GITLAB_HOST=repo1.dso.mil glab issue view {number} --repo {org/repo}
+GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo}
 ```
 
 ## File System Rules

--- a/Packages/RmClaude/Sources/RmClaude/ClaudeLauncher.swift
+++ b/Packages/RmClaude/Sources/RmClaude/ClaudeLauncher.swift
@@ -55,15 +55,20 @@ public actor ClaudeLauncher {
         let tmpDir = FileManager.default.temporaryDirectory
         let promptPath = tmpDir.appendingPathComponent("rmide-\(sessionID.uuidString)-prompt.md")
         try prompt.write(to: promptPath, atomically: true, encoding: .utf8)
-        return "cd \(worktreePath) && claude \"$(cat \(promptPath.path))\"\n"
+        // Restrict prompt file to owner-only access
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
+        return "cd \(Self.shellEscape(worktreePath)) && claude \"$(cat \(Self.shellEscape(promptPath.path)))\"\n"
+    }
+
+    /// Escape a string for safe inclusion in a shell command by wrapping in single quotes.
+    private static func shellEscape(_ str: String) -> String {
+        // Replace each single quote with: end-quote, escaped-quote, start-quote
+        let escaped = str.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
     }
 
     private func descriptionFor(_ repoName: String) -> String {
-        switch repoName {
-        case "bigbang": "Umbrella Helm chart that loads in specific product packages"
-        case "overrides": "Helm install overrides used for testing; create overrides here when testing changes"
-        case "codename-spotlight": "Infrastructure monorepo containing Citadel, SocketZero, and related services"
-        default: ""
-        }
+        ""
     }
 }

--- a/Packages/RmCore/Sources/RmCore/Models/AppConfig.swift
+++ b/Packages/RmCore/Sources/RmCore/Models/AppConfig.swift
@@ -20,7 +20,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable {
     public var name: String
     public var provider: String       // "github" or "gitlab"
     public var cli: String            // "gh" or "glab"
-    public var host: String?          // GitLab host (e.g., "repo1.dso.mil")
+    public var host: String?          // GitLab host (e.g., "gitlab.example.com")
     public var alwaysInclude: [String] // repos to always list in prompt table
 
     public init(

--- a/Packages/RmIPC/Sources/RmIPC/SocketServer.swift
+++ b/Packages/RmIPC/Sources/RmIPC/SocketServer.swift
@@ -13,6 +13,9 @@ public final class SocketServer: @unchecked Sendable {
     private var running = false
     private let queue = DispatchQueue(label: "com.radiusmethod.ride.socket", qos: .userInitiated)
 
+    /// Maximum size of a single JSON-RPC message (1 MB).
+    private static let maxMessageSize = 1_048_576
+
     public init(socketPath: String? = nil, router: CommandRouter) {
         self.socketPath = socketPath ?? Self.defaultSocketPath()
         self.router = router
@@ -27,6 +30,8 @@ public final class SocketServer: @unchecked Sendable {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/rm-ai-ide").path
         try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        // Restrict directory to owner-only access
+        try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir)
         return (dir as NSString).appendingPathComponent("ride.sock")
     }
 
@@ -62,6 +67,9 @@ public final class SocketServer: @unchecked Sendable {
             close(serverFD)
             throw SocketError.bindFailed(errno)
         }
+
+        // Restrict socket to owner-only access
+        chmod(socketPath, 0o600)
 
         // Listen
         guard listen(serverFD, 5) == 0 else {
@@ -108,7 +116,7 @@ public final class SocketServer: @unchecked Sendable {
     private func handleClient(fd: Int32) {
         defer { close(fd) }
 
-        // Read until newline
+        // Read until newline (with size limit to prevent memory exhaustion)
         var buffer = Data()
         var byte: UInt8 = 0
 
@@ -117,6 +125,11 @@ public final class SocketServer: @unchecked Sendable {
             if bytesRead <= 0 { return }
             if byte == UInt8(ascii: "\n") { break }
             buffer.append(byte)
+            if buffer.count >= Self.maxMessageSize {
+                let errorResponse = JSONRPCResponse.error(id: 0, code: RPCErrorCode.parseError, message: "Message too large")
+                writeResponse(errorResponse, to: fd)
+                return
+            }
         }
 
         guard !buffer.isEmpty else { return }

--- a/Packages/RmPersistence/Sources/RmPersistence/ConfigStore.swift
+++ b/Packages/RmPersistence/Sources/RmPersistence/ConfigStore.swift
@@ -25,7 +25,12 @@ public final class ConfigStore: Sendable {
     /// Write the devRoot path.
     public static func saveDevRoot(_ path: String) throws {
         try FileManager.default.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
+        // Restrict app support directory to owner-only access
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: appSupportDir.path)
         try path.write(to: devRootPointerPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: devRootPointerPath.path)
     }
 
     // MARK: - App Config
@@ -49,6 +54,8 @@ public final class ConfigStore: Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(config)
         try data.write(to: configURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: configURL.path)
     }
 
     // MARK: - Import from CMUX workspace-repos.json

--- a/Packages/RmPersistence/Sources/RmPersistence/JSONStore.swift
+++ b/Packages/RmPersistence/Sources/RmPersistence/JSONStore.swift
@@ -77,6 +77,9 @@ public final class JSONStore: Sendable {
         }
         do {
             try jsonData.write(to: url, options: .atomic)
+            // Restrict store file to owner-only access
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: url.path)
         } catch {
             NSLog("[JSONStore] ERROR: Failed to write store.json: \(error.localizedDescription)")
         }

--- a/Packages/RmProvider/Sources/RmProvider/ProviderManager.swift
+++ b/Packages/RmProvider/Sources/RmProvider/ProviderManager.swift
@@ -3,18 +3,25 @@ import RmCore
 
 /// Detects provider from URL and fetches ticket details.
 public actor ProviderManager {
-    public init() {}
+    /// Additional GitLab hosts beyond gitlab.com (user-configurable).
+    private let additionalGitLabHosts: [String]
+
+    public init(additionalGitLabHosts: [String] = []) {
+        self.additionalGitLabHosts = additionalGitLabHosts
+    }
 
     /// Detect provider from a URL string.
     public func detectProvider(from url: String) -> (provider: Provider, cli: String, host: String?) {
         if url.contains("github.com") {
             return (.github, "gh", nil)
-        } else if url.contains("repo1.dso.mil") {
-            return (.gitlab, "glab", "repo1.dso.mil")
-        } else if url.contains("code.il2.dso.mil") {
-            return (.gitlab, "glab", "code.il2.dso.mil")
         } else if url.contains("gitlab.com") {
             return (.gitlab, "glab", "gitlab.com")
+        }
+        // Check user-configured GitLab hosts
+        for host in additionalGitLabHosts {
+            if url.contains(host) {
+                return (.gitlab, "glab", host)
+            }
         }
         return (.github, "gh", nil)
     }

--- a/Packages/RmUI/Sources/RmUI/SettingsView.swift
+++ b/Packages/RmUI/Sources/RmUI/SettingsView.swift
@@ -187,7 +187,7 @@ public struct WorkspaceEditorView: View {
             .pickerStyle(.segmented)
 
             if provider == "gitlab" {
-                TextField("GitLab host (e.g., repo1.dso.mil)", text: $host)
+                TextField("GitLab host (e.g., gitlab.example.com)", text: $host)
                     .textFieldStyle(.roundedBorder)
             }
 

--- a/Packages/RmUI/Sources/RmUI/SetupWizardView.swift
+++ b/Packages/RmUI/Sources/RmUI/SetupWizardView.swift
@@ -126,7 +126,7 @@ public struct SetupWizardView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
 
-            Text("Each workspace is a folder under your dev root containing git repos.\nFor example: RadiusMethod (GitHub), PlatformOne (GitLab).")
+            Text("Each workspace is a folder under your dev root containing git repos.\nFor example: MyOrg (GitHub), MyGitLab (GitLab).")
                 .font(.body)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -235,7 +235,7 @@ struct WorkspaceFormSheet: View {
             .pickerStyle(.segmented)
 
             if provider == "gitlab" {
-                TextField("GitLab host (e.g., repo1.dso.mil)", text: $host)
+                TextField("GitLab host (e.g., gitlab.example.com)", text: $host)
                     .textFieldStyle(.roundedBorder)
             }
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ Verify with: `gh auth status`
 
 ### 5. GitLab Authentication (Optional)
 
-For GitLab repositories (e.g., Platform One):
+For self-hosted GitLab instances:
 
 ```bash
-glab auth login --hostname repo1.dso.mil
+glab auth login --hostname gitlab.example.com
 ```
 
 ### 6. First Launch
@@ -242,10 +242,10 @@ User invokes /ride-workspace in Manager tab
     },
     {
       "id": "uuid",
-      "name": "PlatformOne",
+      "name": "MyGitLab",
       "provider": "gitlab",
       "cli": "glab",
-      "host": "repo1.dso.mil"
+      "host": "gitlab.example.com"
     }
   ],
   "defaults": {
@@ -267,8 +267,8 @@ The app expects repos organized under workspace folders:
 │   ├── citadel/                # Main repo checkout
 │   ├── citadel-134-sensor/     # Worktree for issue #134
 │   └── citadel-209-review/     # Worktree for issue #209
-└── PlatformOne/                # Workspace (GitLab)
-    ├── bigbang/
+└── MyGitLab/                # Workspace (GitLab)
+    ├── my-project/
     └── overrides/
 ```
 

--- a/Resources/ride-workspace-SKILL.md.template
+++ b/Resources/ride-workspace-SKILL.md.template
@@ -28,11 +28,11 @@ Configuration in `~/.claude/workspace-repos.json` (shared with the CMUX workspac
       "provider": "github",
       "cli": "gh"
     },
-    "PlatformOne": {
+    "MyGitLab": {
       "provider": "gitlab",
       "cli": "glab",
-      "host": "repo1.dso.mil",
-      "alwaysInclude": ["bigbang", "overrides"]
+      "host": "gitlab.example.com",
+      "alwaysInclude": []
     }
   },
   "defaults": {
@@ -80,8 +80,8 @@ gh pr view {url} --json title,body,labels
 
 ### GitLab (glab)
 ```bash
-GITLAB_HOST=repo1.dso.mil glab issue view {number} --repo {org/repo} --comments
-GITLAB_HOST=repo1.dso.mil glab mr view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comments
 ```
 
 ### Provider Detection from URL
@@ -89,9 +89,9 @@ GITLAB_HOST=repo1.dso.mil glab mr view {number} --repo {org/repo} --comments
 | URL Contains | Provider | CLI | GITLAB_HOST |
 |---|---|---|---|
 | `github.com` | github | gh | - |
-| `repo1.dso.mil` | gitlab | glab | repo1.dso.mil |
+| `gitlab.example.com` | gitlab | glab | gitlab.example.com |
 | `gitlab.com` | gitlab | glab | gitlab.com |
-| `code.il2.dso.mil` | gitlab | glab | code.il2.dso.mil |
+| `gitlab-il2.example.com` | gitlab | glab | gitlab-il2.example.com |
 
 ## PR Detection
 
@@ -237,12 +237,7 @@ The prompt is written to a temp file at `/tmp/ride-prompt-{feature_name}.md`. It
 
 **Repo descriptions for the prompt table:**
 
-Hardcoded descriptions:
-- `bigbang` → "Umbrella Helm chart that loads in specific product packages"
-- `overrides` → "Helm install overrides used for testing; create overrides here when testing changes"
-- `codename-spotlight` → "Infrastructure monorepo containing Citadel, SocketZero, and related services"
-
-For all other repos, extract dynamically from first non-heading line of CLAUDE.md or README.md.
+Extract dynamically from first non-heading line of CLAUDE.md or README.md. If no description is found, leave the Description column empty.
 
 ~~~markdown
 /plan
@@ -251,9 +246,9 @@ For all other repos, extract dynamically from first non-heading line of CLAUDE.m
 
 | Repository | Path | Branch | Description |
 |------------|------|--------|-------------|
-| citadel | /Users/name/Dev/RadiusMethod/citadel-45-jwt | feature/citadel-45-jwt-validation | Auth gateway service |
-| bigbang | /Users/name/Dev/PlatformOne/bigbang | main | Umbrella Helm chart that loads in specific product packages |
-| overrides | /Users/name/Dev/PlatformOne/overrides | - | Helm install overrides used for testing; create overrides here when testing changes |
+| my-app | /Users/name/Dev/MyOrg/my-app-45-jwt | feature/my-app-45-jwt-validation | Auth gateway service |
+| my-project | /Users/name/Dev/MyGitLab/my-project | main | Infrastructure chart |
+| my-config | /Users/name/Dev/MyGitLab/my-config | - | Configuration overrides |
 
 ## Ticket
 ```bash
@@ -288,7 +283,7 @@ And update the Instructions section to:
 3. Create an implementation plan that builds on the existing work
 ~~~
 
-For PlatformOne, add: `4. If any changes to bigbang are required, create a new worktree with a feature branch before making modifications`
+For MyGitLab, add: `4. If any changes to my-project are required, create a new worktree with a feature branch before making modifications`
 
 ### CLI Commands for Fetching Issues
 
@@ -298,10 +293,10 @@ gh issue view {url} --comments
 gh pr view {url} --comments
 ```
 
-**GitLab (non-default host like repo1.dso.mil):**
+**GitLab (non-default host like gitlab.example.com):**
 ```bash
-GITLAB_HOST=repo1.dso.mil glab issue view {number} --repo {org/repo} --comments
-GITLAB_HOST=repo1.dso.mil glab mr view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comments
 ```
 
 ## Error Handling and Self-Correction
@@ -362,8 +357,8 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 
 ### Cross-Workspace
 ```
-/ride-workspace "integrate bigbang with citadel gateway"
+/ride-workspace "integrate my-project with citadel gateway"
 ```
-→ Matches bigbang (PlatformOne) + citadel (RadiusMethod)
+→ Matches my-project (MyGitLab) + citadel (RadiusMethod)
 → Creates worktrees for both, one ride session
 → Claude launches in highest-scoring repo

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -240,6 +240,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Socket Server
 
+    /// Maximum allowed length for session names.
+    private nonisolated static let maxSessionNameLength = 256
+
+    /// Validate that a path is within the configured devRoot to prevent path traversal.
+    private nonisolated static func isPathWithinDevRoot(_ path: String, devRoot: String) -> Bool {
+        let realPath = (path as NSString).standardizingPath
+        let realRoot = (devRoot as NSString).standardizingPath
+        return realPath.hasPrefix(realRoot + "/") || realPath == realRoot
+    }
+
+    /// Validate a session name contains no control characters and is within length limits.
+    private nonisolated static func isValidSessionName(_ name: String) -> Bool {
+        !name.isEmpty
+            && name.count <= maxSessionNameLength
+            && !name.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) })
+    }
+
     private func startSocketServer(store: JSONStore, devRoot: String) {
         let capturedAppState = appState
         let capturedStore = store
@@ -247,6 +264,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let router = CommandRouter(handlers: [
             "new-session": { @Sendable params in
                 let name = params["name"]?.stringValue ?? "untitled"
+                guard AppDelegate.isValidSessionName(name) else {
+                    throw RPCError.invalidParams("Invalid session name (max \(AppDelegate.maxSessionNameLength) chars, no control characters)")
+                }
                 return await MainActor.run {
                     let session = Session(name: name)
                     capturedAppState.sessions.append(session)
@@ -350,11 +370,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             capturedAppState.sessions[idx].ticketURL = url
                             // Auto-detect provider from URL
                             if capturedAppState.sessions[idx].provider == nil {
-                                if url.contains("github.com") {
-                                    capturedAppState.sessions[idx].provider = .github
-                                } else if url.contains("gitlab.com") || url.contains("repo1.dso.mil") || url.contains("code.il2.dso.mil") {
-                                    capturedAppState.sessions[idx].provider = .gitlab
-                                }
+                                capturedAppState.sessions[idx].provider = SessionService.detectProviderFromURL(url)
                             }
                         }
                         if let title = params["title"]?.stringValue { capturedAppState.sessions[idx].ticketTitle = title }
@@ -371,6 +387,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                       let repo = params["repo"]?.stringValue, let path = params["path"]?.stringValue,
                       let branch = params["branch"]?.stringValue else {
                     throw RPCError.invalidParams("session_id, repo, path, branch required")
+                }
+                // Validate path is within devRoot to prevent path traversal
+                guard AppDelegate.isPathWithinDevRoot(path, devRoot: devRoot) else {
+                    throw RPCError.invalidParams("Worktree path must be within the configured devRoot")
                 }
                 // repo_path is the main repo (for git commands). Defaults to path if not provided.
                 let repoPath = params["repo_path"]?.stringValue ?? path
@@ -398,6 +418,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let idStr = params["session_id"]?.stringValue, let sessionID = UUID(uuidString: idStr),
                       let cwd = params["cwd"]?.stringValue else {
                     throw RPCError.invalidParams("session_id and cwd required")
+                }
+                // Validate cwd is within devRoot to prevent path traversal
+                guard AppDelegate.isPathWithinDevRoot(cwd, devRoot: devRoot) else {
+                    throw RPCError.invalidParams("Terminal cwd must be within the configured devRoot")
                 }
                 // Resolve claude binary path if command references claude
                 var command = params["command"]?.stringValue

--- a/Sources/RmAiIde/App/SessionService.swift
+++ b/Sources/RmAiIde/App/SessionService.swift
@@ -24,11 +24,7 @@ final class SessionService {
         // Backfill provider from ticketURL for sessions that predate provider tracking
         for i in appState.sessions.indices {
             if appState.sessions[i].provider == nil, let url = appState.sessions[i].ticketURL {
-                if url.contains("github.com") {
-                    appState.sessions[i].provider = .github
-                } else if url.contains("gitlab.com") || url.contains("repo1.dso.mil") || url.contains("code.il2.dso.mil") {
-                    appState.sessions[i].provider = .gitlab
-                }
+                appState.sessions[i].provider = Self.detectProviderFromURL(url)
             }
         }
 
@@ -214,6 +210,18 @@ final class SessionService {
         if appState.selectedSessionID == id {
             appState.selectedSessionID = appState.sessions.first?.id
         }
+    }
+
+    // MARK: - Provider Detection
+
+    /// Detect provider from a ticket URL without hardcoding specific hosts.
+    static func detectProviderFromURL(_ url: String) -> Provider? {
+        if url.contains("github.com") {
+            return .github
+        } else if url.contains("gitlab.com") || url.contains("gitlab") || url.contains("/-/issues") || url.contains("/-/merge_requests") {
+            return .gitlab
+        }
+        return nil
     }
 
     // MARK: - Worktree Safety Checks

--- a/Sources/RmIdeCLI/RmIdeCLI.swift
+++ b/Sources/RmIdeCLI/RmIdeCLI.swift
@@ -331,7 +331,7 @@ struct Setup: ParsableCommand {
 
             var host: String? = nil
             if provider == "gitlab" {
-                print("  GitLab host (e.g., repo1.dso.mil): ", terminator: "")
+                print("  GitLab host (e.g., gitlab.example.com): ", terminator: "")
                 let hostInput = readLine()?.trimmingCharacters(in: .whitespaces) ?? ""
                 if !hostInput.isEmpty { host = hostInput }
             }

--- a/settings.json
+++ b/settings.json
@@ -22,7 +22,7 @@
       "Bash(gh pr list:*)",
       "Bash(gh repo view:*)",
       "Bash(gh auth:*)",
-      "Bash(GIT_SSL_NO_VERIFY=1 gh:*)",
+
       "Bash(GITLAB_HOST=* glab issue view:*)",
       "Bash(GITLAB_HOST=* glab mr view:*)",
       "Bash(GITLAB_HOST=* glab mr list:*)",

--- a/skills/ride-workspace/SKILL.md
+++ b/skills/ride-workspace/SKILL.md
@@ -28,11 +28,11 @@ Configuration is at `{devRoot}/.claude/config.json` (managed by the rm-ai-ide ap
       "provider": "github",
       "cli": "gh"
     },
-    "PlatformOne": {
+    "MyGitLab": {
       "provider": "gitlab",
       "cli": "glab",
-      "host": "repo1.dso.mil",
-      "alwaysInclude": ["bigbang", "overrides"]
+      "host": "gitlab.example.com",
+      "alwaysInclude": []
     }
   },
   "defaults": {
@@ -80,8 +80,8 @@ gh pr view {url} --json title,body,labels
 
 ### GitLab (glab)
 ```bash
-GITLAB_HOST=repo1.dso.mil glab issue view {number} --repo {org/repo} --comments
-GITLAB_HOST=repo1.dso.mil glab mr view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comments
 ```
 
 ### Provider Detection from URL
@@ -89,9 +89,9 @@ GITLAB_HOST=repo1.dso.mil glab mr view {number} --repo {org/repo} --comments
 | URL Contains | Provider | CLI | GITLAB_HOST |
 |---|---|---|---|
 | `github.com` | github | gh | - |
-| `repo1.dso.mil` | gitlab | glab | repo1.dso.mil |
+| `gitlab.example.com` | gitlab | glab | gitlab.example.com |
 | `gitlab.com` | gitlab | glab | gitlab.com |
-| `code.il2.dso.mil` | gitlab | glab | code.il2.dso.mil |
+| `gitlab-il2.example.com` | gitlab | glab | gitlab-il2.example.com |
 
 ## PR Detection
 
@@ -144,7 +144,7 @@ Git command:   git -C /Users/jane/Dev/RadiusMethod/citadel worktree add /Users/j
 
 More examples:
 ```
-loki #252 "Update grafana-enterprise.md"    → {devRoot}/PlatformOne/loki-252-update-grafana-docs
+loki #252 "Update grafana-enterprise.md"    → {devRoot}/MyGitLab/loki-252-update-grafana-docs
 citadel #45 "Add JWT validation endpoint"   → {devRoot}/RadiusMethod/citadel-45-jwt-validation
 ```
 
@@ -215,7 +215,7 @@ ride set-ticket --session {session_id} \
 # 3. Register each worktree (after creating with git)
 #    IMPORTANT: --repo-path is the MAIN repo path (e.g., .../citadel)
 #    --path is the WORKTREE path (e.g., .../citadel-197-slug)
-#    --workspace is the workspace folder name (e.g., "RadiusMethod", "PlatformOne")
+#    --workspace is the workspace folder name (e.g., "RadiusMethod", "MyGitLab")
 ride add-worktree --session {session_id} \
   --repo "{repo_name}" \
   --repo-path "{main_repo_path}" \
@@ -294,21 +294,16 @@ The prompt is written to `{devRoot}/.claude/prompts/ride-prompt-{feature_name}.m
 
 **Repo descriptions for the prompt table:**
 
-Hardcoded descriptions:
-- `bigbang` → "Umbrella Helm chart that loads in specific product packages"
-- `overrides` → "Helm install overrides used for testing; create overrides here when testing changes"
-- `codename-spotlight` → "Infrastructure monorepo containing Citadel, SocketZero, and related services"
-
-For all other repos, extract dynamically from first non-heading line of CLAUDE.md or README.md.
+Extract dynamically from first non-heading line of CLAUDE.md or README.md. If no description is found, leave the Description column empty.
 
 ~~~markdown
 # Workspace Context
 
 | Repository | Path | Branch | Description |
 |------------|------|--------|-------------|
-| citadel | /Users/name/Dev/RadiusMethod/citadel-45-jwt | feature/citadel-45-jwt-validation | Auth gateway service |
-| bigbang | /Users/name/Dev/PlatformOne/bigbang | main | Umbrella Helm chart that loads in specific product packages |
-| overrides | /Users/name/Dev/PlatformOne/overrides | - | Helm install overrides used for testing; create overrides here when testing changes |
+| my-app | /Users/name/Dev/MyOrg/my-app-45-jwt | feature/my-app-45-jwt-validation | Auth gateway service |
+| my-project | /Users/name/Dev/MyGitLab/my-project | main | Infrastructure chart |
+| my-config | /Users/name/Dev/MyGitLab/my-config | - | Configuration overrides |
 
 ## Ticket
 
@@ -346,7 +341,7 @@ And update the Instructions section to:
 3. Create an implementation plan that builds on the existing work
 ~~~
 
-For PlatformOne, add: `4. If any changes to bigbang are required, create a new worktree with a feature branch before making modifications`
+For MyGitLab, add: `4. If any changes to my-project are required, create a new worktree with a feature branch before making modifications`
 
 ### CLI Commands for Fetching Issues
 
@@ -356,10 +351,10 @@ gh issue view {url} --comments
 gh pr view {url} --comments
 ```
 
-**GitLab (non-default host like repo1.dso.mil):**
+**GitLab (non-default host like gitlab.example.com):**
 ```bash
-GITLAB_HOST=repo1.dso.mil glab issue view {number} --repo {org/repo} --comments
-GITLAB_HOST=repo1.dso.mil glab mr view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo} --comments
+GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comments
 ```
 
 ## Error Handling and Self-Correction
@@ -420,8 +415,8 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 
 ### Cross-Workspace
 ```
-/ride-workspace "integrate bigbang with citadel gateway"
+/ride-workspace "integrate my-project with citadel gateway"
 ```
-→ Matches bigbang (PlatformOne) + citadel (RadiusMethod)
+→ Matches my-project (MyGitLab) + citadel (RadiusMethod)
 → Creates worktrees for both, one ride session
 → Claude launches in highest-scoring repo


### PR DESCRIPTION
## Summary

Closes #13

Comprehensive security audit and codebase hardening for open-sourcing:

- **Fix shell command injection** in `ClaudeLauncher` — paths are now shell-escaped before interpolation into launch commands
- **Add IPC socket DoS protection** — 1 MB message size limit on the socket server read loop
- **Set restrictive file permissions** — socket (0600), socket dir (0700), store.json (0600), config files (0600), temp prompt files (0600)
- **Add RPC input validation** — path traversal protection on `add-worktree` and `new-terminal` handlers (must be within devRoot), session name length/character validation
- **Remove SSL verification bypass** — removed `GIT_SSL_NO_VERIFY` permission pattern from settings.json and CLAUDE.md
- **Gitignore settings.local.json** — prevents leaking absolute paths and session UUIDs
- **Remove hardcoded government hosts** — replaced `repo1.dso.mil` and `code.il2.dso.mil` with configurable GitLab hosts via `ProviderManager` constructor
- **Genericize documentation** — replaced internal project names (PlatformOne, bigbang, codename-spotlight) with generic examples across README, SKILL.md, templates, and UI

## Test plan

- [x] `swift build` succeeds with 0 errors
- [x] Launch app and verify socket server starts (check `ls -la ~/.local/share/rm-ai-ide/ride.sock` for 0600 permissions)
- [x] Create a session via `ride new-session` and verify store.json has 0600 permissions
- [x] Test `ride add-worktree` with a path outside devRoot — should reject with error
- [x] Test `ride new-session --name` with >256 char name — should reject
- [x] Verify `ride new-terminal --cwd /etc` rejects path traversal
- [x] Connect to socket and send >1MB payload — should disconnect cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)