### PR TITLE
Add Open Terminal button to session detail view

### DIFF
--- a/Packages/RmCore/Sources/RmCore/AppState.swift
+++ b/Packages/RmCore/Sources/RmCore/AppState.swift
@@ -93,6 +93,9 @@ public final class AppState {
     /// Called to open a session's primary worktree in VS Code.
     public var onOpenInVSCode: ((UUID) -> Void)?
 
+    /// Called to open a terminal at a session's primary worktree path.
+    public var onOpenTerminal: ((UUID) -> Void)?
+
     // MARK: - Computed Properties
 
     public var selectedSession: Session? {

--- a/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
+++ b/Packages/RmUI/Sources/RmUI/SessionDetailView.swift
@@ -121,6 +121,18 @@ public struct SessionDetailView: View {
                         .tint(CorveilTheme.gold)
                     }
 
+                    if primaryWorktree != nil {
+                        Button {
+                            appState.onOpenTerminal?(session.id)
+                        } label: {
+                            Label("Open Terminal", systemImage: "terminal")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .tint(CorveilTheme.gold)
+                    }
+
                     if session.status == .active,
                        session.ticketURL != nil,
                        session.provider == .github {

--- a/Sources/RmAiIde/App/AppDelegate.swift
+++ b/Sources/RmAiIde/App/AppDelegate.swift
@@ -128,6 +128,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.openInVSCode(sessionID: sessionID)
         }
 
+        // Wire open terminal action
+        appState.onOpenTerminal = { [weak service] sessionID in
+            service?.openTerminal(sessionID: sessionID)
+        }
+
         // Wire "Work on" issue action — sends issue URL to Manager terminal
         appState.onWorkOnIssue = { [weak self] issueURL in
             guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],

--- a/Sources/RmAiIde/App/SessionService.swift
+++ b/Sources/RmAiIde/App/SessionService.swift
@@ -578,4 +578,14 @@ final class SessionService {
         process.arguments = [wt.worktreePath]
         try? process.run()
     }
+
+    /// Open a terminal window at the primary worktree path for a session.
+    func openTerminal(sessionID: UUID) {
+        guard let wt = appState.primaryWorktree(for: sessionID) else { return }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", "Terminal", wt.worktreePath]
+        try? process.run()
+    }
 }


### PR DESCRIPTION
## Summary
- Adds an "Open Terminal" button in the session detail header that launches Terminal.app at the session's primary worktree path
- Button appears alongside "Open in VS Code" when a worktree is associated with the session
- Uses the same callback wiring pattern (`AppState` closure → `AppDelegate` → `SessionService`)

Closes #21

## Test plan
- [x] Select a session with a worktree — verify "Open Terminal" button appears
- [x] Click "Open Terminal" — verify Terminal.app opens at the worktree directory
- [x] Select a session without a worktree (e.g., Manager) — verify button is hidden
- [x] Verify button styling matches existing action buttons (bordered, small, gold tint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)