### PR TITLE
Audit and update documentation for open source release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Environment
+
+- **macOS version:**
+- **Hardware:** Apple Silicon / Intel
+- **Xcode version:**
+- **Zig version:**
+- **Crow version/commit:**
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Logs
+
+Run Crow from the terminal to capture stderr output:
+
+```bash
+.build/debug/CrowApp 2>&1 | tee crow-debug.log
+```
+
+Paste relevant log lines here (filter with `grep "\[TerminalManager\]\|\[SessionService\]\|\[IssueTracker\]"`).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Use Case
+
+Describe the problem or workflow this feature would address.
+
+## Proposed Solution
+
+Describe what you'd like to happen.
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Additional Context
+
+Screenshots, mockups, or references to similar features in other tools.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+Brief description of what this PR does and why.
+
+## Related Issue
+
+Closes #
+
+## Changes
+
+-
+-
+
+## Testing
+
+- [ ] `swift test` passes
+- [ ] Manually tested the affected workflow
+- [ ] Screenshots attached (for UI changes)
+
+## Checklist
+
+- [ ] Code follows existing patterns in the codebase
+- [ ] No unrelated changes included

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,13 @@
+<!-- This file is both repo documentation and Manager tab context.
+     Crow scaffolds it into {devRoot}/.claude/CLAUDE.md on launch (see Scaffolder.swift). -->
+
 # Crow — Manager Context
 
 This is the development root managed by Crow. The Manager tab runs Claude Code here to orchestrate work sessions via the `crow` CLI.
 
 ## crow CLI Reference
 
-The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. **All `crow` commands require `dangerouslyDisableSandbox: true`** and return JSON.
+The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. **All `crow`, `gh`, and `glab` commands require `dangerouslyDisableSandbox: true`** and return JSON.
 
 ### Session Commands
 ```
@@ -13,7 +16,7 @@ crow rename-session --session <uuid> "new-name" → {"session_id":"...","name":"
 crow select-session --session <uuid>            → {"session_id":"..."}
 crow list-sessions                              → {"sessions":[...]}
 crow get-session --session <uuid>               → {id, name, status, ticket_url, ...}
-crow set-status --session <uuid> active|completed|archived
+crow set-status --session <uuid> active|paused|inReview|completed|archived
 crow delete-session --session <uuid>            → {"deleted":true}
 ```
 
@@ -47,48 +50,7 @@ The `crow send` command writes text to the terminal. Newlines in the text are co
 - Use `/crow-workspace` skill for full workspace setup (worktrees + session + Claude Code)
 - **Worktree paths go DIRECTLY under the workspace folder**: `{devRoot}/{workspace}/{repo}-{number}-{slug}` — NOT in a subfolder
 - The prompt for new Claude Code sessions must start with `/plan` to enter plan mode
-
-## Sandbox & Network — CRITICAL
-
-### All `crow` and `gh`/`glab` commands MUST use `dangerouslyDisableSandbox: true`
-
-The sandbox blocks:
-- Unix socket communication (`crow` commands)
-- Network/TLS access (`gh`, `glab`, `curl`)
-- Writing to `/tmp` (use `$TMPDIR` instead, which is sandbox-writable)
-
-**ALWAYS use `dangerouslyDisableSandbox: true` for these commands. Do NOT attempt them sandboxed first — they will always fail.**
-
-### GitHub CLI (gh) — TLS Certificate Errors
-
-The `gh` CLI fails with TLS certificate errors in sandbox mode:
-```
-Post "https://api.github.com/graphql": tls: failed to verify certificate: x509: OSStatus -26276
-```
-
-**Fix:** Always use `dangerouslyDisableSandbox: true` for ALL `gh` commands. There is no workaround.
-
-If `gh` still fails or returns empty output:
-1. Use `--repo owner/repo` explicitly instead of relying on git remote detection
-2. Use full URL: `gh issue view https://github.com/owner/repo/issues/123` not just the number
-
-### GitLab CLI (glab)
-
-Same TLS issue. Always use `dangerouslyDisableSandbox: true` and set `GITLAB_HOST`:
-```bash
-GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo}
-```
-
-## File System Rules
-
-### Temporary Files
-- **DO NOT** write to `/tmp` — it's blocked by sandbox
-- **USE** `$TMPDIR` for temporary files (e.g., prompt files)
-- Example: `cat > $TMPDIR/crow-prompt-feature.md << 'EOF' ... EOF`
-
-### Write-Before-Read Rule
-- You must Read a file before you can Write/Edit it (Claude Code requirement)
-- If creating a new file, just use Write directly
+- Use `$TMPDIR` (not `/tmp`) for temporary files
 
 ## Git Worktree Best Practices
 
@@ -117,22 +79,6 @@ Prevents accidental push to main:
 git worktree add /path -b feature/name --no-track origin/main
 ```
 
-## Claude Binary Path
-
-The CMUX app installs a `claude` wrapper at `/Applications/cmux.app/Contents/Resources/bin/claude` that breaks when called from outside CMUX. Always use the real binary:
-
-```bash
-# Find the real claude binary:
-which -a claude | grep -v cmux | head -1
-# Common location: ~/.local/bin/claude
-```
-
-When using `crow new-terminal --command`, the app automatically resolves `claude` to the full path. But for `crow send`, use the full path explicitly.
-
 ## Known Issues / Corrections
 
-- Worktree path must be at `{devRoot}/{workspace}/{repo}-{feature}`, NOT in a subdirectory
-- Use full claude binary path (find with `which -a claude | grep -v cmux | head -1`), not just `claude`
-- All `gh`/`glab` commands fail without `dangerouslyDisableSandbox: true` — never try sandboxed first
-- Write temp files to `$TMPDIR`, not `/tmp`
-- When `gh issue view` returns empty, add `--repo owner/repo` explicitly
+<!-- Auto-maintained by Claude Code during workspace setup -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Crow
+
+Thank you for your interest in contributing to Crow! This guide will help you get started.
+
+## Reporting Bugs
+
+Open a [GitHub Issue](https://github.com/radiusmethod/crow/issues/new?template=bug_report.md) with:
+
+- macOS version and hardware (Intel/Apple Silicon)
+- Xcode and Zig versions
+- Steps to reproduce
+- Expected vs actual behavior
+- Relevant stderr logs (see [Debugging](README.md#debugging))
+
+## Suggesting Features
+
+Open a [GitHub Issue](https://github.com/radiusmethod/crow/issues/new?template=feature_request.md) describing the use case and proposed solution.
+
+## Development Setup
+
+See [README.md](README.md#detailed-setup) for full build instructions. The short version:
+
+```bash
+git clone --recurse-submodules https://github.com/radiusmethod/crow.git
+cd crow
+make build
+```
+
+### Running Tests
+
+```bash
+swift test        # or: mise test
+```
+
+Tests use the Swift Testing framework (`@Test` macros).
+
+## Code Style
+
+- **Swift 6.0** with strict concurrency enabled
+- **SwiftUI** for all views
+- Follow existing patterns in the codebase
+- Keep packages focused — each package under `Packages/` has a single responsibility
+
+## Package Structure
+
+New functionality should go in the appropriate existing package:
+
+| Package | Scope |
+|---------|-------|
+| `CrowCore` | Data models, observable app state |
+| `CrowUI` | SwiftUI views, theme |
+| `CrowTerminal` | Ghostty terminal surface management |
+| `CrowGit` | Git operations |
+| `CrowProvider` | GitHub/GitLab provider abstraction |
+| `CrowPersistence` | JSON store, config I/O |
+| `CrowClaude` | Claude binary resolution |
+| `CrowIPC` | Unix socket RPC protocol |
+
+If a new package is needed, create it under `Packages/` and add it to the root `Package.swift`.
+
+## Pull Requests
+
+1. Fork the repo and create a feature branch from `main`
+2. Make your changes with clear, focused commits
+3. Include tests for new functionality where applicable
+4. Ensure `swift test` passes
+5. Open a PR with:
+   - A description of what changed and why
+   - A link to the related issue
+   - Screenshots for UI changes
+
+## Auto-Scaffolded Files
+
+Crow auto-generates certain files into `{devRoot}/.claude/` on launch (see `Scaffolder.swift`):
+
+- `CLAUDE.md` — scaffolded from the root `CLAUDE.md`
+- `skills/crow-workspace/SKILL.md` — scaffolded from `Resources/crow-workspace-SKILL.md.template`
+- `settings.json` — always overwritten with pre-approved permissions
+
+**Do not edit the scaffolded copies.** Instead, modify the source files in the repository root or `Resources/` directory.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build setup ghostty app release clean clean-all help
+.PHONY: build setup ghostty app release clean clean-all check help
 
 FRAMEWORKS_DIR := Frameworks
 XCFW := $(FRAMEWORKS_DIR)/GhosttyKit.xcframework
@@ -12,7 +12,8 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  build      Full build: submodules + ghostty + swift build (default)"
-	@echo "  setup      Init submodules and check prerequisites"
+	@echo "  setup      Init submodules and check build prerequisites"
+	@echo "  check      Verify all build and runtime prerequisites"
 	@echo "  ghostty    Build GhosttyKit framework"
 	@echo "  app        Swift build only (debug)"
 	@echo "  release    Release build + .app bundle"
@@ -59,3 +60,10 @@ clean:
 
 clean-all: clean
 	rm -rf $(FRAMEWORKS_DIR)
+
+# --- Check ---
+
+check: setup
+	@command -v gh >/dev/null 2>&1 || echo "WARNING: gh (GitHub CLI) not found. Install with: brew install gh"
+	@command -v claude >/dev/null 2>&1 || echo "WARNING: claude (Claude Code) not found. Install from: https://claude.ai/download"
+	@echo "All checks complete."

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ gh auth refresh -s read:project   # Required for project board status
 
 On first launch, a setup wizard guides you through choosing your development root directory and configuring workspaces.
 
+Alternatively, configure via the CLI without launching the GUI:
+
+```bash
+.build/debug/crow setup
+```
+
 ## Detailed Setup
 
 ### 1. Clone the Repository
@@ -274,6 +280,14 @@ The app expects repos organized under workspace folders:
 
 Worktrees are created at the same level as the main repo, **not** in subdirectories.
 
+## Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `CROW_SOCKET` | Override the Unix socket path for CLI ↔ App IPC | `~/.local/share/crow/crow.sock` |
+| `TMPDIR` | Temporary file directory (used by the terminal subsystem) | System default |
+| `GITLAB_HOST` | GitLab instance hostname (set automatically per workspace config) | — |
+
 ## Usage
 
 ### The Sidebar
@@ -333,7 +347,7 @@ crow rename-session --session <uuid> "new-name"
 crow select-session --session <uuid>
 crow list-sessions
 crow get-session --session <uuid>
-crow set-status --session <uuid> active|completed|archived
+crow set-status --session <uuid> active|paused|inReview|completed|archived
 crow delete-session --session <uuid>
 ```
 
@@ -353,7 +367,6 @@ crow add-worktree --session <uuid> \
   --repo-path "/path/to/main/repo" \
   --path "/path/to/worktree" \
   --branch "feature/name" \
-  [--workspace "WorkspaceName"] \
   [--primary]
 crow list-worktrees --session <uuid>
 ```
@@ -403,6 +416,14 @@ All commands return JSON. The `crow send` command converts `\n` in the text to E
 2. Add it to the root `Package.swift` dependencies and target
 3. Import in the targets that need it
 
+### Testing
+
+```bash
+swift test        # or: mise test
+```
+
+Tests use the [Swift Testing](https://developer.apple.com/documentation/testing/) framework (`@Test` macros). Test files are under `Packages/*/Tests/`.
+
 ### Debugging
 
 The app logs diagnostic information to stderr:
@@ -417,6 +438,31 @@ Run with log filtering:
 .build/debug/CrowApp 2>&1 | grep "\[TerminalManager\]\|\[SessionService\]"
 ```
 
+## Troubleshooting
+
+### Build Issues
+
+| Problem | Solution |
+|---------|----------|
+| `zig` not found | Install with `brew install zig` or from [ziglang.org](https://ziglang.org/download/) |
+| Zig version mismatch | Version 0.15.2 is required. Check with `zig version` |
+| Metal toolchain not found | Run `xcodebuild -downloadComponent MetalToolchain` |
+| Ghostty submodule missing | Run `git submodule update --init vendor/ghostty` |
+| Swift build fails with linker errors | Ensure GhosttyKit is built first: `./scripts/build-ghostty.sh` |
+
+### Runtime Issues
+
+| Problem | Solution |
+|---------|----------|
+| `crow` CLI: "Connection refused" | The Crow app must be running — the CLI communicates via Unix socket |
+| GitHub API errors / empty responses | Check auth: `gh auth status`. Add project scope: `gh auth refresh -s read:project` |
+| Terminal not starting | Check stderr logs for `[TerminalManager]` or `[Ghostty]` messages |
+| Issue tracker shows no tickets | Verify `gh auth status` shows `repo`, `read:org`, `read:project` scopes |
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggesting features, and submitting pull requests.
+
 ## License
 
-Proprietary — Radius Method, Inc.
+Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -4,11 +4,9 @@
 
 Orchestrates work sessions in **Crow** by setting up git worktrees and creating a crow session with auto-launched Claude Code and ticket metadata. Supports multiple organizations/workspaces with different Git providers.
 
-This skill targets Crow's `crow` CLI. The original `/workspace` skill targeting CMUX remains unchanged and both can run in parallel.
-
 ## Important: Sandbox Bypass
 
-All `crow` CLI commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket at `~/.local/share/crow/crow.sock`.
+All `crow`, `gh`, and `glab` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket or need network/TLS access.
 
 ## Activation
 
@@ -18,7 +16,7 @@ This skill activates when:
 
 ## Configuration
 
-Configuration in `~/.claude/workspace-repos.json` (shared with the CMUX workspace skill):
+Configuration is at `{devRoot}/.claude/config.json` (managed by the Crow app). The format is:
 
 ```json
 {

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -106,6 +106,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Detect orphaned worktrees (runs async, updates UI when done)
         Task { await service.detectOrphanedWorktrees() }
 
+        // Check for runtime dependencies (non-blocking)
+        Task.detached {
+            let tools = ["gh", "git", "claude"]
+            for tool in tools {
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+                proc.arguments = [tool]
+                proc.standardOutput = FileHandle.nullDevice
+                proc.standardError = FileHandle.nullDevice
+                do {
+                    try proc.run()
+                    proc.waitUntilExit()
+                    if proc.terminationStatus != 0 {
+                        NSLog("[Crow] Runtime dependency not found: %@", tool)
+                    }
+                } catch {
+                    NSLog("[Crow] Could not check for %@: %@", tool, error.localizedDescription)
+                }
+            }
+        }
+
         // Ensure manager session exists
         service.ensureManagerSession(devRoot: devRoot)
 

--- a/Sources/CrowCLI/CrowCLI.swift
+++ b/Sources/CrowCLI/CrowCLI.swift
@@ -296,6 +296,26 @@ struct Setup: ParsableCommand {
     func run() throws {
         print("Welcome to Crow setup.\n")
 
+        // Check for runtime dependencies
+        let tools: [(name: String, install: String)] = [
+            ("git", "xcode-select --install"),
+            ("gh", "brew install gh"),
+            ("claude", "https://claude.ai/download"),
+        ]
+        for tool in tools {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+            proc.arguments = [tool.name]
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = FileHandle.nullDevice
+            try? proc.run()
+            proc.waitUntilExit()
+            if proc.terminationStatus != 0 {
+                print("  WARNING: \(tool.name) not found. Install: \(tool.install)")
+            }
+        }
+        print()
+
         // Determine devRoot
         let root: String
         if let devRoot {
@@ -387,7 +407,11 @@ struct Setup: ParsableCommand {
 
         print("Configuration saved to: \(configPath)")
         print("Workspace scaffolded at: \(claudeDir)/")
-        print("\nLaunch Crow to get started.")
+        print()
+        print("Next steps:")
+        print("  1. Build:  make build")
+        print("  2. Launch: .build/debug/CrowApp")
+        print("  3. CLI:    crow --help")
     }
 }
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -4,11 +4,9 @@
 
 Orchestrates work sessions in **Crow** by setting up git worktrees and creating a crow session with auto-launched Claude Code and ticket metadata. Supports multiple organizations/workspaces with different Git providers.
 
-This skill targets Crow's `crow` CLI. The original `/workspace` skill targeting CMUX remains unchanged and both can run in parallel.
-
 ## Important: Sandbox Bypass
 
-All `crow` CLI commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket at `~/.local/share/crow/crow.sock`.
+All `crow`, `gh`, and `glab` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket or need network/TLS access.
 
 ## Activation
 
@@ -282,7 +280,7 @@ sleep 3
 #    CRITICAL: End the text with literal \n — the app converts \n to Enter.
 #    Use single quotes so the shell doesn't expand $(cat ...).
 #    Use --permission-mode plan to start Claude in plan mode.
-#    Use full path to claude binary (avoid CMUX wrapper).
+#    Use full path to claude binary.
 crow send --session {session_id} --terminal {terminal_id} 'cd {primary_worktree_path} && {claude_binary_path} --permission-mode plan "$(cat {devRoot}/.claude/prompts/crow-prompt-{feature_name}.md)"\n'
 ```
 


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md, GitHub issue/PR templates for community contributions
- Clean up CLAUDE.md: remove internal sandbox/CMUX sections, consolidate to a single `dangerouslyDisableSandbox` note
- Update README with environment variables, troubleshooting, testing, and contributing sections
- Promote `crow setup` CLI command in quick start
- Fix CLI doc discrepancies (`set-status` missing values, undocumented `--workspace` flag)
- Remove CMUX references from skill templates, fix stale config path
- Add `make check` target and startup validation for missing runtime dependencies
- Improve `crow setup` with prerequisite checks and next-steps output

## Test plan

- [ ] `make build` compiles successfully
- [ ] `make check` reports missing tools correctly
- [ ] `grep -r "CMUX\|cmux\|rm-ai-ide" --include="*.md"` returns no matches (excluding vendor/)
- [ ] README sections render correctly on GitHub
- [ ] `crow setup` shows dependency warnings and next-steps

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)