### PR TITLE
Add terminal tabs support for sessions

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -82,6 +82,12 @@ public final class AppState {
     /// Called to launch Claude in a terminal that just became ready.
     public var onLaunchClaude: ((UUID) -> Void)?  // receives terminal ID
 
+    /// Called to add a new plain-shell terminal tab to a session.
+    public var onAddTerminal: ((UUID) -> Void)?  // receives session ID
+
+    /// Called to close a non-managed terminal tab.
+    public var onCloseTerminal: ((UUID, UUID) -> Void)?  // receives (sessionID, terminalID)
+
     // MARK: - Closures wired by AppDelegate
 
     /// Called to delete a session and clean up its worktrees.

--- a/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
@@ -7,6 +7,7 @@ public struct SessionTerminal: Identifiable, Codable, Sendable {
     public var name: String
     public var cwd: String
     public var command: String?
+    public var isManaged: Bool
     public var createdAt: Date
 
     public init(
@@ -15,6 +16,7 @@ public struct SessionTerminal: Identifiable, Codable, Sendable {
         name: String = "Shell",
         cwd: String,
         command: String? = nil,
+        isManaged: Bool = false,
         createdAt: Date = Date()
     ) {
         self.id = id
@@ -22,6 +24,19 @@ public struct SessionTerminal: Identifiable, Codable, Sendable {
         self.name = name
         self.cwd = cwd
         self.command = command
+        self.isManaged = isManaged
         self.createdAt = createdAt
+    }
+
+    // Custom decoder for backward compatibility — existing data lacks isManaged.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        sessionID = try container.decode(UUID.self, forKey: .sessionID)
+        name = try container.decode(String.self, forKey: .name)
+        cwd = try container.decode(String.self, forKey: .cwd)
+        command = try container.decodeIfPresent(String.self, forKey: .command)
+        isManaged = try container.decodeIfPresent(Bool.self, forKey: .isManaged) ?? false
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
     }
 }

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -209,20 +209,28 @@ public struct SessionDetailView: View {
                 workingDirectory: FileManager.default.homeDirectoryForCurrentUser.path
             )
             .id(session.id)
-        } else if sessionTerminals.count == 1 {
-            let terminal = sessionTerminals[0]
-            ReadinessAwareTerminal(terminal: terminal, appState: appState)
         } else {
             VStack(spacing: 0) {
                 TerminalTabBar(
                     terminals: sessionTerminals,
                     activeID: appState.activeTerminalID[session.id] ?? sessionTerminals[0].id,
-                    onSelect: { id in appState.activeTerminalID[session.id] = id }
+                    onSelect: { id in appState.activeTerminalID[session.id] = id },
+                    onClose: { id in appState.onCloseTerminal?(session.id, id) },
+                    onAdd: { appState.onAddTerminal?(session.id) }
                 )
                 Divider().overlay(CorveilTheme.borderSubtle)
                 let activeID = appState.activeTerminalID[session.id] ?? sessionTerminals[0].id
                 if let terminal = sessionTerminals.first(where: { $0.id == activeID }) {
-                    ReadinessAwareTerminal(terminal: terminal, appState: appState)
+                    if terminal.isManaged {
+                        ReadinessAwareTerminal(terminal: terminal, appState: appState)
+                    } else {
+                        TerminalSurfaceView(
+                            terminalID: terminal.id,
+                            workingDirectory: terminal.cwd,
+                            command: terminal.command
+                        )
+                        .id(terminal.id)
+                    }
                 }
             }
         }
@@ -269,20 +277,47 @@ public struct TerminalTabBar: View {
     let terminals: [SessionTerminal]
     let activeID: UUID
     let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onAdd: () -> Void
 
     public var body: some View {
         HStack(spacing: 0) {
             ForEach(terminals) { terminal in
                 Button { onSelect(terminal.id) } label: {
-                    Text(terminal.name)
-                        .font(.caption)
-                        .foregroundStyle(terminal.id == activeID ? CorveilTheme.gold : CorveilTheme.textSecondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(terminal.id == activeID ? CorveilTheme.gold.opacity(0.12) : Color.clear)
+                    HStack(spacing: 4) {
+                        Image(systemName: terminal.isManaged ? "sparkles" : "terminal")
+                            .font(.system(size: 9))
+                        Text(terminal.name)
+                            .font(.caption)
+                        if !terminal.isManaged {
+                            Button {
+                                onClose(terminal.id)
+                            } label: {
+                                Image(systemName: "xmark")
+                                    .font(.system(size: 8, weight: .semibold))
+                                    .foregroundStyle(CorveilTheme.textMuted)
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.leading, 2)
+                        }
+                    }
+                    .foregroundStyle(terminal.id == activeID ? CorveilTheme.gold : CorveilTheme.textSecondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(terminal.id == activeID ? CorveilTheme.gold.opacity(0.12) : Color.clear)
                 }
                 .buttonStyle(.plain)
             }
+
+            Button { onAdd() } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(CorveilTheme.textMuted)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.plain)
+
             Spacer()
         }
         .background(CorveilTheme.bgSurface)

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -203,12 +203,22 @@ public struct SessionDetailView: View {
     @ViewBuilder
     private var terminalArea: some View {
         let sessionTerminals = appState.terminals(for: session.id)
+        let isManager = session.id == AppState.managerSessionID
         if sessionTerminals.isEmpty {
             TerminalSurfaceView(
                 terminalID: session.id,
                 workingDirectory: FileManager.default.homeDirectoryForCurrentUser.path
             )
             .id(session.id)
+        } else if isManager {
+            // Manager session: single terminal, no tab bar
+            let terminal = sessionTerminals[0]
+            TerminalSurfaceView(
+                terminalID: terminal.id,
+                workingDirectory: terminal.cwd,
+                command: terminal.command
+            )
+            .id(terminal.id)
         } else {
             VStack(spacing: 0) {
                 TerminalTabBar(

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -124,6 +124,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.launchClaude(terminalID: terminalID)
         }
 
+        // Wire terminal tab management
+        appState.onAddTerminal = { [weak service] sessionID in
+            service?.addTerminal(sessionID: sessionID)
+        }
+        appState.onCloseTerminal = { [weak service] sessionID, terminalID in
+            service?.closeTerminal(sessionID: sessionID, terminalID: terminalID)
+        }
+
         // Detect VS Code CLI and wire open action
         service.detectVSCode()
         appState.onOpenInVSCode = { [weak service] sessionID in
@@ -485,13 +493,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if let cmd = command, cmd.contains("claude") {
                     command = AppDelegate.resolveClaudeInCommand(cmd)
                 }
-                let terminal = SessionTerminal(sessionID: sessionID, name: params["name"]?.stringValue ?? "Shell",
-                                               cwd: cwd, command: command)
+                let isManaged = params["managed"]?.boolValue ?? false
+                let defaultName = isManaged ? "Claude Code" : "Shell"
+                let terminal = SessionTerminal(sessionID: sessionID, name: params["name"]?.stringValue ?? defaultName,
+                                               cwd: cwd, command: command, isManaged: isManaged)
                 return await MainActor.run {
                     capturedAppState.terminals[sessionID, default: []].append(terminal)
                     capturedStore.mutate { $0.terminals.append(terminal) }
-                    // Track readiness for work session terminals (not Manager)
-                    if sessionID != AppState.managerSessionID {
+                    // Track readiness only for managed work session terminals
+                    if isManaged && sessionID != AppState.managerSessionID {
                         capturedAppState.terminalReadiness[terminal.id] = .uninitialized
                         TerminalManager.shared.trackReadiness(for: terminal.id)
 
@@ -514,9 +524,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 let terms = await MainActor.run { capturedAppState.terminals(for: id) }
                 let items: [JSONValue] = terms.map { t in
-                    .object(["id": .string(t.id.uuidString), "name": .string(t.name), "session_id": .string(t.sessionID.uuidString)])
+                    .object(["id": .string(t.id.uuidString), "name": .string(t.name), "session_id": .string(t.sessionID.uuidString), "managed": .bool(t.isManaged)])
                 }
                 return ["terminals": .array(items)]
+            },
+            "close-terminal": { @Sendable params in
+                guard let sessionIDStr = params["session_id"]?.stringValue,
+                      let sessionID = UUID(uuidString: sessionIDStr),
+                      let terminalIDStr = params["terminal_id"]?.stringValue,
+                      let terminalID = UUID(uuidString: terminalIDStr) else {
+                    throw RPCError.invalidParams("session_id and terminal_id required")
+                }
+                return await MainActor.run {
+                    guard let terminals = capturedAppState.terminals[sessionID],
+                          let terminal = terminals.first(where: { $0.id == terminalID }) else {
+                        return ["error": .string("Terminal not found")]
+                    }
+                    guard !terminal.isManaged else {
+                        return ["error": .string("Cannot close managed terminal")]
+                    }
+                    TerminalManager.shared.destroy(id: terminalID)
+                    capturedAppState.terminals[sessionID]?.removeAll { $0.id == terminalID }
+                    capturedAppState.terminalReadiness.removeValue(forKey: terminalID)
+                    if capturedAppState.activeTerminalID[sessionID] == terminalID {
+                        capturedAppState.activeTerminalID[sessionID] = capturedAppState.terminals[sessionID]?.first?.id
+                    }
+                    capturedStore.mutate { data in data.terminals.removeAll { $0.id == terminalID } }
+                    return ["deleted": .bool(true)]
+                }
             },
             "send": { @Sendable params in
                 guard let sessionIDStr = params["session_id"]?.stringValue,

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -32,18 +32,31 @@ final class SessionService {
             appState.worktrees[session.id] = data.worktrees.filter { $0.sessionID == session.id }
             appState.links[session.id] = data.links.filter { $0.sessionID == session.id }
 
-            // For work session terminals, clear the command so they start as plain shells.
-            // We'll send `claude --continue` after the surfaces are created.
             var terminals = data.terminals.filter { $0.sessionID == session.id }
             if session.id != AppState.managerSessionID {
+                // Backward-compat migration: if no terminal is marked managed,
+                // heuristically mark the first "Claude Code" terminal.
+                let hasManagedTerminal = terminals.contains { $0.isManaged }
+                if !hasManagedTerminal, let idx = terminals.firstIndex(where: {
+                    $0.name == "Claude Code" || ($0.command?.contains("claude") ?? false)
+                }) {
+                    terminals[idx] = SessionTerminal(
+                        id: terminals[idx].id, sessionID: terminals[idx].sessionID,
+                        name: terminals[idx].name, cwd: terminals[idx].cwd,
+                        command: terminals[idx].command, isManaged: true,
+                        createdAt: terminals[idx].createdAt
+                    )
+                }
+
+                // For managed terminals, clear the claude command so they start as plain shells.
+                // We'll send `claude --continue` after the surfaces are created.
                 for i in terminals.indices {
-                    if let cmd = terminals[i].command, cmd.contains("claude") {
+                    if terminals[i].isManaged,
+                       let cmd = terminals[i].command, cmd.contains("claude") {
                         terminals[i] = SessionTerminal(
-                            id: terminals[i].id,
-                            sessionID: terminals[i].sessionID,
-                            name: terminals[i].name,
-                            cwd: terminals[i].cwd,
-                            command: nil,  // Plain shell — claude --continue sent later
+                            id: terminals[i].id, sessionID: terminals[i].sessionID,
+                            name: terminals[i].name, cwd: terminals[i].cwd,
+                            command: nil, isManaged: true,
                             createdAt: terminals[i].createdAt
                         )
                     }
@@ -51,9 +64,9 @@ final class SessionService {
             }
             appState.terminals[session.id] = terminals
 
-            // Initialize readiness tracking for work session terminals
+            // Initialize readiness tracking for managed work session terminals only
             if session.id != AppState.managerSessionID {
-                for terminal in terminals {
+                for terminal in terminals where terminal.isManaged {
                     appState.terminalReadiness[terminal.id] = .uninitialized
                     TerminalManager.shared.trackReadiness(for: terminal.id)
                 }
@@ -453,7 +466,8 @@ final class SessionService {
         let terminal = SessionTerminal(
             sessionID: session.id,
             name: "Claude Code",
-            cwd: worktreePath
+            cwd: worktreePath,
+            isManaged: true
         )
 
         // Add to state and store
@@ -497,6 +511,37 @@ final class SessionService {
         }
 
         NSLog("[SessionService] Recovered session '\(dirName)' — ticket=#\(ticketNumber ?? 0) title=\(ticketTitle ?? "unknown")")
+    }
+
+    // MARK: - Terminal Tab Management
+
+    /// Add a new plain-shell terminal tab to a session.
+    func addTerminal(sessionID: UUID) {
+        let cwd = appState.primaryWorktree(for: sessionID)?.worktreePath
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let terminal = SessionTerminal(
+            sessionID: sessionID, name: "Shell", cwd: cwd, isManaged: false
+        )
+        appState.terminals[sessionID, default: []].append(terminal)
+        appState.activeTerminalID[sessionID] = terminal.id
+        store.mutate { data in data.terminals.append(terminal) }
+    }
+
+    /// Close a non-managed terminal tab.
+    func closeTerminal(sessionID: UUID, terminalID: UUID) {
+        guard let terminals = appState.terminals[sessionID],
+              let terminal = terminals.first(where: { $0.id == terminalID }),
+              !terminal.isManaged else { return }
+
+        TerminalManager.shared.destroy(id: terminalID)
+        appState.terminals[sessionID]?.removeAll { $0.id == terminalID }
+        appState.terminalReadiness.removeValue(forKey: terminalID)
+
+        if appState.activeTerminalID[sessionID] == terminalID {
+            appState.activeTerminalID[sessionID] = appState.terminals[sessionID]?.first?.id
+        }
+
+        store.mutate { data in data.terminals.removeAll { $0.id == terminalID } }
     }
 
     // MARK: - Complete Session

--- a/Sources/CrowCLI/CrowCLI.swift
+++ b/Sources/CrowCLI/CrowCLI.swift
@@ -22,6 +22,7 @@ struct Crow: ParsableCommand {
             ListWorktrees.self,
             NewTerminal.self,
             ListTerminals.self,
+            CloseTerminal.self,
             Send.self,
             AddLink.self,
             ListLinks.self,
@@ -184,6 +185,7 @@ struct NewTerminal: ParsableCommand {
     @Option(name: .long, help: "Working directory") var cwd: String
     @Option(name: .long, help: "Terminal name") var name: String?
     @Option(name: .long, help: "Command to run") var command: String?
+    @Flag(name: .long, help: "Mark as managed Claude Code terminal") var managed: Bool = false
 
     func run() throws {
         var params: [String: JSONValue] = [
@@ -192,6 +194,7 @@ struct NewTerminal: ParsableCommand {
         ]
         if let name { params["name"] = .string(name) }
         if let command { params["command"] = .string(command) }
+        if managed { params["managed"] = .bool(true) }
         let result = try rpc("new-terminal", params: params)
         printJSON(result)
     }
@@ -203,6 +206,20 @@ struct ListTerminals: ParsableCommand {
 
     func run() throws {
         let result = try rpc("list-terminals", params: ["session_id": .string(session)])
+        printJSON(result)
+    }
+}
+
+struct CloseTerminal: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "close-terminal", abstract: "Close a terminal tab in a session")
+    @Option(name: .long, help: "Session UUID") var session: String
+    @Option(name: .long, help: "Terminal UUID") var terminal: String
+
+    func run() throws {
+        let result = try rpc("close-terminal", params: [
+            "session_id": .string(session),
+            "terminal_id": .string(terminal),
+        ])
         printJSON(result)
     }
 }


### PR DESCRIPTION
## Summary
- Add `isManaged` field to `SessionTerminal` to distinguish the primary Claude Code terminal from additional plain shell tabs
- Tab bar always visible (even with 1 terminal) with "+" button to add tabs and "x" to close non-managed tabs
- Managed terminals show sparkles icon, plain tabs show terminal icon
- Readiness tracking and auto-launch of `claude --continue` scoped to managed terminals only
- New `close-terminal` IPC handler and CLI command
- Backward-compatible migration: existing sessions auto-detect their Claude Code terminal as managed

## Test plan
- [ ] Launch app and verify existing sessions show their Claude Code terminal with managed styling
- [ ] Verify readiness overlay and `claude --continue` auto-launch still work for managed terminals
- [ ] Click "+" on a session's tab bar — verify new "Shell" tab opens at worktree directory
- [ ] Click "x" on the new tab — verify it's removed and active tab switches back
- [ ] Verify the managed Claude Code tab has no close button
- [ ] Quit and relaunch — verify added tabs persist
- [ ] Test `crow new-terminal --session <uuid> --cwd /path --managed` via CLI
- [ ] Test `crow close-terminal --session <uuid> --terminal <uuid>` via CLI

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)