### PR TITLE
Fix disconnected hooks for CLI-created sessions

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -525,16 +525,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if isManaged && sessionID != AppState.managerSessionID {
                         capturedAppState.terminalReadiness[terminal.id] = .uninitialized
                         TerminalManager.shared.trackReadiness(for: terminal.id)
-
-                        // Write hook config for the session's worktree
-                        if let worktree = capturedAppState.primaryWorktree(for: sessionID),
-                           let crowPath = HookConfigGenerator.findCrowBinary() {
-                            try? HookConfigGenerator.writeHookConfig(
-                                worktreePath: worktree.worktreePath,
-                                sessionID: sessionID,
-                                crowPath: crowPath
-                            )
-                        }
                     }
                     return ["terminal_id": .string(terminal.id.uuidString), "session_id": .string(idStr)]
                 }
@@ -598,6 +588,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             )
                         }
                     }
+
+                    // For managed terminals receiving a claude command, write hook config
+                    // before sending so Claude picks up the hooks on startup.
+                    if let terminals = capturedAppState.terminals[sessionID],
+                       let terminal = terminals.first(where: { $0.id == terminalID }),
+                       terminal.isManaged,
+                       text.contains("claude") {
+                        if let worktree = capturedAppState.primaryWorktree(for: sessionID),
+                           let crowPath = HookConfigGenerator.findCrowBinary() {
+                            try? HookConfigGenerator.writeHookConfig(
+                                worktreePath: worktree.worktreePath,
+                                sessionID: sessionID,
+                                crowPath: crowPath
+                            )
+                        }
+                        capturedAppState.terminalReadiness[terminalID] = .claudeLaunched
+                    }
+
                     TerminalManager.shared.send(id: terminalID, text: text)
                 }
                 return ["sent": .bool(true)]

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -266,7 +266,8 @@ PROMPT
 # 6. Create a shell terminal in the primary worktree (NO command — just a shell)
 crow new-terminal --session {session_id} \
   --cwd "{primary_worktree_path}" \
-  --name "Claude Code"
+  --name "Claude Code" \
+  --managed
 # Output: {"terminal_id":"<uuid>","session_id":"..."}
 # IMPORTANT: Capture the terminal_id from the output!
 


### PR DESCRIPTION
## Summary
- Sessions created via the `crow-workspace` skill had no working hooks — gray dot, no events, no notifications
- Root cause: the skill didn't pass `--managed` to `crow new-terminal`, and the `send` RPC handler didn't write hook config before launching Claude
- Moves hook config writing from `new-terminal` (too early, before shell exists) to `send` (right before Claude reads `.claude/settings.local.json`)

Closes #35

## Test plan
- [x] Run `/crow-workspace` from Manager tab with a ticket URL
- [x] Verify session dot reflects Claude's state (not stuck on gray)
- [x] Verify tool call events appear in Crow UI
- [x] Verify sound/notification fires on permission prompts
- [x] Verify UI-created sessions still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)