### PR TITLE
Stylize About page with Corveil branding

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/CorveilTheme.swift
+++ b/Packages/CrowUI/Sources/CrowUI/CorveilTheme.swift
@@ -1,28 +1,28 @@
 import SwiftUI
 
 /// Corveil design tokens translated from corveil.com/styles.css
-enum CorveilTheme {
+public enum CorveilTheme {
     // Backgrounds
-    static let bgDeep = Color(hex: 0x121416)
-    static let bgSurface = Color(hex: 0x1A1D20)
-    static let bgCard = Color(hex: 0x22262A)
+    public static let bgDeep = Color(hex: 0x121416)
+    public static let bgSurface = Color(hex: 0x1A1D20)
+    public static let bgCard = Color(hex: 0x22262A)
 
     // Gold palette
-    static let gold = Color(hex: 0xDDC482)
-    static let goldDark = Color(hex: 0xB38E46)
+    public static let gold = Color(hex: 0xDDC482)
+    public static let goldDark = Color(hex: 0xB38E46)
 
     // Borders
-    static let borderSubtle = Color(hex: 0xDDC482, opacity: 0.12)
-    static let borderStrong = Color(hex: 0xDDC482, opacity: 0.25)
+    public static let borderSubtle = Color(hex: 0xDDC482, opacity: 0.12)
+    public static let borderStrong = Color(hex: 0xDDC482, opacity: 0.25)
 
     // Text
-    static let textPrimary = Color.white
-    static let textSecondary = Color(hex: 0xA8A9AE)
-    static let textMuted = Color(hex: 0x6B6D72)
+    public static let textPrimary = Color.white
+    public static let textSecondary = Color(hex: 0xA8A9AE)
+    public static let textMuted = Color(hex: 0x6B6D72)
 }
 
 extension Color {
-    init(hex: UInt, opacity: Double = 1.0) {
+    public init(hex: UInt, opacity: Double = 1.0) {
         self.init(
             red: Double((hex >> 16) & 0xFF) / 255,
             green: Double((hex >> 8) & 0xFF) / 255,

--- a/Sources/Crow/App/AboutView.swift
+++ b/Sources/Crow/App/AboutView.swift
@@ -1,3 +1,4 @@
+import CrowUI
 import SwiftUI
 
 struct AboutView: View {
@@ -5,20 +6,21 @@ struct AboutView: View {
 
     var body: some View {
         VStack(spacing: 12) {
-            // App icon
-            if let iconImage = NSImage(named: "AppIcon") ?? NSImage(named: NSImage.applicationIconName) {
-                Image(nsImage: iconImage)
+            // Corveil brandmark
+            if let image = loadBrandmark() {
+                Image(nsImage: image)
                     .resizable()
-                    .frame(width: 96, height: 96)
+                    .scaledToFit()
+                    .frame(width: 140)
             }
 
             Text("Crow")
-                .font(.title2)
-                .fontWeight(.bold)
+                .font(.system(size: 28, weight: .bold, design: .serif))
+                .foregroundStyle(CorveilTheme.gold)
 
             Text("Version \(appVersion)")
                 .font(.callout)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(CorveilTheme.textSecondary)
 
             // Git SHA — click to copy full hash
             Button(action: copyGitSHA) {
@@ -28,28 +30,43 @@ struct AboutView: View {
                     Image(systemName: copied ? "checkmark" : "doc.on.doc")
                         .font(.caption)
                 }
-                .foregroundStyle(copied ? .green : .secondary)
+                .foregroundStyle(copied ? .green : CorveilTheme.textMuted)
             }
             .buttonStyle(.plain)
             .help("Click to copy full commit SHA: \(BuildInfo.gitCommitSHA)")
 
             Text("Built \(BuildInfo.buildDate)")
                 .font(.caption)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(CorveilTheme.textMuted)
 
-            Spacer().frame(height: 4)
+            // Gold accent divider
+            CorveilTheme.borderSubtle
+                .frame(height: 1)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 4)
 
             Text("© \(Calendar.current.component(.year, from: Date())) Radius Method")
                 .font(.caption)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(CorveilTheme.textMuted)
         }
         .padding(.horizontal, 32)
         .padding(.vertical, 24)
-        .frame(width: 300)
+        .frame(width: 320)
+        .background(CorveilTheme.bgDeep)
     }
 
     private var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.0"
+    }
+
+    private func loadBrandmark() -> NSImage? {
+        for bundle in Bundle.allBundles {
+            if let url = bundle.url(forResource: "CorveilBrandmark", withExtension: "png"),
+               let image = NSImage(contentsOf: url) {
+                return image
+            }
+        }
+        return nil
     }
 
     private func copyGitSHA() {

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -267,7 +267,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let hostingView = NSHostingView(rootView: AboutView())
         let win = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 300, height: 340),
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 380),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false


### PR DESCRIPTION
## Summary
- Replace the default system-styled About page with Corveil brand identity: dark background (`#121416`), gold serif title, CorveilBrandmark, and themed text colors
- Make `CorveilTheme` and its design tokens `public` so they're accessible from the main `Crow` target
- Adjust About window size from 300×340 to 320×380 to accommodate the brandmark

Closes #40

## Test plan
- [x] `make build` compiles cleanly
- [x] Open About Crow — verify brandmark, gold serif title, dark background, themed text colors
- [x] Click git SHA — verify copy-to-clipboard with green checkmark feedback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)