### PR TITLE
Fix crash when reopening About or Settings window

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -260,7 +260,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func showAbout() {
-        if let existing = aboutWindow, existing.isVisible {
+        if let existing = aboutWindow {
             existing.makeKeyAndOrderFront(nil)
             return
         }
@@ -274,6 +274,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         win.title = "About Crow"
         win.appearance = NSAppearance(named: .darkAqua)
+        win.isReleasedWhenClosed = false
         win.contentView = hostingView
         win.center()
         win.makeKeyAndOrderFront(nil)
@@ -283,7 +284,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func showSettings() {
         guard let devRoot, let appConfig else { return }
 
-        if let existing = settingsWindow, existing.isVisible {
+        if let existing = settingsWindow {
             existing.makeKeyAndOrderFront(nil)
             return
         }
@@ -309,6 +310,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         win.title = "Settings"
         win.appearance = NSAppearance(named: .darkAqua)
+        win.isReleasedWhenClosed = false
         win.contentView = hostingView
         win.center()
         win.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## Summary
- Fix app crash when opening the About screen after closing it (also applied to Settings window)
- Set `isReleasedWhenClosed = false` on singleton windows so they survive being closed
- Reuse existing window instance instead of recreating on each open

Closes #42

## Test plan
- [ ] Open About screen, close it, reopen it — no crash
- [ ] Repeat open/close cycle 5+ times
- [ ] Same test for Settings window
- [ ] Verify window content displays correctly after reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)