### PR TITLE
Fix merged PR status not detected on app restart

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -207,6 +207,7 @@ final class IssueTracker {
 
             if let output = try? await shell(
                 "gh", "pr", "list", "--repo", repoSlug, "--head", branch,
+                "--state", "all",
                 "--json", "number,url,state", "--limit", "1"
             ), let data = output.data(using: .utf8),
                let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],


### PR DESCRIPTION
## Summary
- Fix `checkSessionPRs()` to search all PR states (open, merged, closed) instead of only open PRs
- Sessions whose PRs were merged before a link was ever created now correctly show the merged badge on app restart

## Root Cause
`gh pr list` defaults to `--state open`. If a PR was merged while the app was closed (or before a link was created), the command returned nothing, no `SessionLink` was created, and `fetchPRStatuses()` had nothing to query.

## Fix
Add `--state all` to the `gh pr list` call in `checkSessionPRs()` so merged and closed PRs are also discovered.

Closes #43

## Test plan
- [x] `make build` passes
- [x] Have a session with a worktree branch that has a merged PR but no existing PR link
- [x] Restart the app and verify the merged badge appears after the first poll cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)