### PR TITLE
Add setting to hide subtitle lines in session sidebar rows

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -10,6 +10,9 @@ public final class AppState {
     /// Whether notification sounds are muted (toggled via sidebar speaker icon).
     public var soundMuted: Bool = false
 
+    /// Whether subtitle rows (ticket title, repo/branch) are hidden in sidebar session rows.
+    public var hideSessionDetails: Bool = false
+
     /// Worktrees keyed by session ID.
     public var worktrees: [UUID: [SessionWorktree]] = [:]
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -5,15 +5,18 @@ public struct AppConfig: Codable, Sendable {
     public var workspaces: [WorkspaceInfo]
     public var defaults: ConfigDefaults
     public var notifications: NotificationSettings
+    public var sidebar: SidebarSettings
 
     public init(
         workspaces: [WorkspaceInfo] = [],
         defaults: ConfigDefaults = ConfigDefaults(),
-        notifications: NotificationSettings = NotificationSettings()
+        notifications: NotificationSettings = NotificationSettings(),
+        sidebar: SidebarSettings = SidebarSettings()
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
         self.notifications = notifications
+        self.sidebar = sidebar
     }
 
     public init(from decoder: Decoder) throws {
@@ -21,10 +24,11 @@ public struct AppConfig: Codable, Sendable {
         workspaces = try container.decodeIfPresent([WorkspaceInfo].self, forKey: .workspaces) ?? []
         defaults = try container.decodeIfPresent(ConfigDefaults.self, forKey: .defaults) ?? ConfigDefaults()
         notifications = try container.decodeIfPresent(NotificationSettings.self, forKey: .notifications) ?? NotificationSettings()
+        sidebar = try container.decodeIfPresent(SidebarSettings.self, forKey: .sidebar) ?? SidebarSettings()
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications
+        case workspaces, defaults, notifications, sidebar
     }
 }
 
@@ -71,5 +75,14 @@ public struct ConfigDefaults: Codable, Sendable {
         self.cli = cli
         self.branchPrefix = branchPrefix
         self.excludeDirs = excludeDirs
+    }
+}
+
+/// Sidebar display preferences.
+public struct SidebarSettings: Codable, Sendable {
+    public var hideSessionDetails: Bool
+
+    public init(hideSessionDetails: Bool = false) {
+        self.hideSessionDetails = hideSessionDetails
     }
 }

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -260,7 +260,7 @@ struct SessionRow: View {
             }
 
             // Row 2: Ticket title (if any)
-            if let title = session.ticketTitle {
+            if !appState.hideSessionDetails, let title = session.ticketTitle {
                 Text(title)
                     .font(.caption)
                     .foregroundStyle(CorveilTheme.textSecondary)
@@ -268,7 +268,7 @@ struct SessionRow: View {
             }
 
             // Row 3: Repo + branch
-            if let wt = primaryWorktree {
+            if !appState.hideSessionDetails, let wt = primaryWorktree {
                 Text("\(wt.repoName) / \(shortenBranch(wt.branch))")
                     .font(.caption2)
                     .foregroundStyle(CorveilTheme.textMuted)
@@ -313,6 +313,7 @@ struct SessionRow: View {
                 )
         )
         .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: needsAttention)
+        .animation(.easeInOut(duration: 0.2), value: appState.hideSessionDetails)
         .padding(.vertical, 1)
     }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -83,6 +83,14 @@ public struct SettingsView: View {
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { save() }
             }
+
+            Section("Sidebar") {
+                Toggle("Hide session details", isOn: $config.sidebar.hideSessionDetails)
+                    .onChange(of: config.sidebar.hideSessionDetails) { _, _ in save() }
+                Text("Hides ticket title and repo/branch lines in sidebar rows.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -203,6 +203,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Hydrate mute state from config and wire toggle
         appState.soundMuted = config.notifications.globalMute
+        appState.hideSessionDetails = config.sidebar.hideSessionDetails
         appState.onSoundMutedChanged = { [weak self] muted in
             self?.appConfig?.notifications.globalMute = muted
             if let settings = self?.appConfig?.notifications {
@@ -334,6 +335,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         try? ConfigStore.saveDevRoot(devRoot)
         try? ConfigStore.saveConfig(config, devRoot: devRoot)
         notificationManager?.updateSettings(config.notifications)
+        appState.hideSessionDetails = config.sidebar.hideSessionDetails
     }
 
     // MARK: - Socket Server


### PR DESCRIPTION
## Summary
- Adds a "Hide session details" toggle in Settings > General > Sidebar section
- When enabled, hides the ticket title and repo/branch lines from sidebar session rows, making the list more compact
- Badges (Issue #, PR status, Claude state) remain visible regardless of setting
- Setting persists across app restarts via `config.json`
- Row height transitions are smoothly animated

Closes #41

## Test plan
- [x] Open Settings (Cmd+,) → General tab → verify "Sidebar" section with toggle appears
- [x] Toggle on → sidebar rows collapse to name + badges only
- [x] Toggle off → rows expand back with smooth animation
- [x] Quit and relaunch → setting persists
- [x] Verify backward compat: delete `sidebar` key from config.json → app starts without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)