### PR TITLE
CHECK

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -28,6 +28,8 @@ public final class GhosttySurfaceView: NSView {
 
         wantsLayer = true
         layer?.isOpaque = true
+
+        registerForDraggedTypes([.fileURL])
     }
 
     @available(*, unavailable)
@@ -321,6 +323,48 @@ public final class GhosttySurfaceView: NSView {
             }
         }
         NSLog("writeText: sent \(text.count) chars, \(parts.count - 1) newlines")
+    }
+
+    // MARK: - Drag & Drop
+
+    public override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.canReadObject(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) else { return [] }
+        return .copy
+    }
+
+    public override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        .copy
+    }
+
+    public override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        true
+    }
+
+    public override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let surface else { return false }
+        guard let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL], !urls.isEmpty else { return false }
+
+        let escapedPaths = urls.map { Self.shellEscapePath($0.path) }
+        let text = escapedPaths.joined(separator: " ")
+
+        text.withCString { ptr in
+            ghostty_surface_text(surface, ptr, UInt(text.utf8.count))
+        }
+        return true
+    }
+
+    private static func shellEscapePath(_ path: String) -> String {
+        let needsEscaping = path.contains { c in
+            " \t'\"\\()&|;!$`#*?[]{}~<>".contains(c)
+        }
+        guard needsEscaping else { return path }
+        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Register `GhosttySurfaceView` for `.fileURL` drag types and implement `NSDraggingDestination`
- Dragging files from Finder onto the terminal now types their shell-escaped paths at the cursor
- Paths with spaces/special characters are single-quote wrapped; clean paths are left bare

Closes #51

## Test plan
- [x] Drag a single file from Finder onto a terminal — path appears at cursor
- [x] Drag a file with spaces in its name — path is single-quoted
- [x] Drag multiple files — space-separated escaped paths
- [x] Drag non-file content (e.g., image data from browser) — drop is rejected
- [x] Cmd+V paste still works
- [x] Mouse text selection in terminal still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)