### PR TITLE
Scrub host-terminal env from tmux server

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -348,7 +348,65 @@ public final class TmuxBackend {
             command: "/usr/bin/tail -f /dev/null"
         )
         controller = ctrl
+        scrubInheritedHostTerminalEnv(ctrl: ctrl)
         return ctrl
+    }
+
+    /// Host-terminal env-var families that must not propagate from the
+    /// CrowApp process into the tmux server's global env. When inherited,
+    /// these trigger oh-my-zsh integration code paths (notably
+    /// `CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION`) whose `$(...)` subshell
+    /// deadlocks the shell that backs each tmux window — the readiness
+    /// sentinel never fires and the watch reports `.timedOut`. See #259.
+    private static let hostTerminalEnvPrefixes: [String] = [
+        "CMUX_",
+        "GHOSTTY_",
+        "ITERM_",
+        "KITTY_",
+        "WEZTERM_",
+        "ALACRITTY_",
+    ]
+
+    /// Single-key host-terminal markers. `TERMINFO`/`TERMINFO_DIRS` are
+    /// scrubbed unconditionally if present — tmux falls back to the
+    /// system terminfo, which is what the cockpit shells expect.
+    private static let hostTerminalEnvExact: Set<String> = [
+        "TERM_PROGRAM",
+        "TERM_PROGRAM_VERSION",
+        "TERMINFO",
+        "TERMINFO_DIRS",
+    ]
+
+    /// Remove host-terminal contamination from the freshly-started tmux
+    /// server's global env. Runs once per server launch from
+    /// `ensureRunningServer` immediately after `newSessionDetached`. The
+    /// session anchor (`tail -f /dev/null`) doesn't care about env, and
+    /// no user-visible window has been created yet, so scrubbing here is
+    /// safe and affects every subsequent `new-window`.
+    private func scrubInheritedHostTerminalEnv(ctrl: TmuxController) {
+        let env = ProcessInfo.processInfo.environment
+        var toScrub: [String] = []
+        for key in env.keys {
+            if Self.hostTerminalEnvExact.contains(key) {
+                toScrub.append(key)
+                continue
+            }
+            if Self.hostTerminalEnvPrefixes.contains(where: { key.hasPrefix($0) }) {
+                toScrub.append(key)
+            }
+        }
+        guard !toScrub.isEmpty else { return }
+        toScrub.sort()
+        for name in toScrub {
+            do {
+                try ctrl.unsetGlobalEnv(name)
+            } catch {
+                // Best-effort: a single var we can't unset shouldn't wedge
+                // server startup. Log and keep going.
+                NSLog("[CrowTelemetry tmux:env_scrub_failed var=\(name) error=\"\(error)\"]")
+            }
+        }
+        NSLog("[CrowTelemetry tmux:env_scrubbed vars=\(toScrub.joined(separator: ","))]")
     }
 
     private func sentinelPath(for id: UUID) -> String {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -104,6 +104,19 @@ public struct TmuxController: Sendable {
         return out.split(separator: "\n").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
     }
 
+    /// Mark `name` as removed in the server's global environment so new
+    /// windows do not inherit it from the env tmux was launched with
+    /// (issue #259).
+    public func unsetGlobalEnv(_ name: String) throws {
+        try run(["set-environment", "-g", "-u", name])
+    }
+
+    /// `tmux show-environment -g`. Returns the global env one entry per
+    /// line (`NAME=value` for set vars, `-NAME` for vars marked removed).
+    public func showGlobalEnv() throws -> String {
+        try run(["show-environment", "-g"])
+    }
+
     // MARK: - Windows
 
     public func newWindow(

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -161,4 +161,33 @@ struct TmuxBackendTests {
         #expect(received.contains(.timedOut))
         #expect(!received.contains(.shellReady))
     }
+
+    @Test func ensureRunningServerScrubsContaminatingEnvVars() throws {
+        // Plant a synthetic CMUX_* var in the parent process before the
+        // backend starts the server. The scrub runs in
+        // `ensureRunningServer`, which `registerTerminal` triggers via
+        // its first call.
+        setenv("CMUX_FOO", "1", 1)
+        defer { unsetenv("CMUX_FOO") }
+
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        _ = try backend.registerTerminal(
+            id: UUID(), name: "scrub-test", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+
+        // Talk to the same server the backend just launched.
+        let ctrl = TmuxController(
+            tmuxBinary: discoveredTmuxBinary!,
+            socketPath: backend.socketPath,
+            sessionName: TmuxBackend.cockpitSessionName
+        )
+        let env = try ctrl.showGlobalEnv()
+        // After `set-environment -g -u CMUX_FOO`, tmux either omits the
+        // var entirely or lists it as `-CMUX_FOO` (marked for removal).
+        // The unscrubbed assignment must not appear.
+        #expect(!env.contains("CMUX_FOO=1"))
+    }
 }


### PR DESCRIPTION
Closes #259

## Summary
- Crow's tmux server inherits `CMUX_*`, `GHOSTTY_*`, `TERM_PROGRAM`, `TERMINFO` and similar host-terminal markers from CrowApp's process env. These vars propagate to every child tmux window. In oh-my-zsh, `CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION` triggers a `$(...)` command substitution whose child blocks; the parent zsh deadlocks on the pipe and the readiness sentinel never fires (timeout from #253).
- Fix: in `TmuxBackend.ensureRunningServer`, immediately after `newSessionDetached`, intersect `ProcessInfo.processInfo.environment.keys` with a known set of host-terminal var families and call `tmux set-environment -g -u <name>` for each match. The session anchor (`tail -f /dev/null`) is unaffected and no user-visible window has been created yet, so the global scrub is safe.
- Adds two thin wrappers (`unsetGlobalEnv`, `showGlobalEnv`) on `TmuxController` so the backend doesn't poke at raw arg arrays and tests have a typed entry point. One telemetry NSLog records the scrubbed list.

Var families scrubbed (prefix match): `CMUX_`, `GHOSTTY_`, `ITERM_`, `KITTY_`, `WEZTERM_`, `ALACRITTY_`
Exact keys: `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `TERMINFO`, `TERMINFO_DIRS`

## Test plan
- [x] `swift test --package-path Packages/CrowTerminal` — new `ensureRunningServerScrubsContaminatingEnvVars` plants `CMUX_FOO=1` via `setenv`, starts the backend, and asserts the unscrubbed assignment doesn't appear in `tmux show-environment -g`.
- [ ] Manual: launch Crow from a Ghostty/cmux terminal that exports `CMUX_*`. Confirm in `Console.app` that `[CrowTelemetry tmux:env_scrubbed vars=…]` lists the `CMUX_*` family and the shell prompt appears within the readiness budget.
- [ ] Reporter (@danny) re-runs the original repro on a build with this fix.

## Out of scope
- Per-window env scrub — `newWindow(env:)` already only passes through `CROW_SENTINEL`, `CROW_WRAPPER_LOG`, `PWD`. Leak is at the server level.
- Rosetta investigation — separate ticket if env scrub doesn't fully resolve the deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)