### PR TITLE
Surface Jira tickets in their mapped Done status in the Done section (read-back; #536)

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -405,6 +405,11 @@ final class IssueTracker {
         }
 
         var allIssues: [AssignedIssue] = []
+        // Recently-done count, accumulated across every provider this refresh.
+        // Each provider contributes its 24h closed/Done window; assigned once
+        // at the end so a non-GitHub (e.g. Jira-only) workspace updates it too
+        // instead of leaving a stale value from a prior GitHub-backed refresh.
+        var doneCount = 0
 
         // GitHub — one consolidated GraphQL query
         let ghResult: ConsolidatedGitHubResponse? = hasGitHub ? await runConsolidatedGitHubQuery() : nil
@@ -428,7 +433,7 @@ final class IssueTracker {
             let openIDs = Set(openIssues.map(\.id))
             let uniqueDone = ghResult.closedIssues.filter { !openIDs.contains($0.id) }
             allIssues.append(contentsOf: uniqueDone)
-            appState.doneIssuesLast24h = ghResult.closedIssues.count
+            doneCount += ghResult.closedIssues.count
         }
 
         // GitLab — unchanged fan-out (one call per host)
@@ -437,10 +442,16 @@ final class IssueTracker {
             allIssues.append(contentsOf: issues)
         }
 
-        // Jira — one search per distinct config (best-effort, like GitLab)
+        // Jira — one search per distinct config (best-effort, like GitLab).
+        // Include the recently-Done half (#536): a Jira ticket in its mapped
+        // Done status is a workflow status, not a closed issue, so it only lands
+        // in the board's Done section once its `.done`-mapped issue reaches
+        // `assignedIssues`. Mirror GitHub's open + deduped-closed merge.
         for cfg in jiraConfigs {
-            let issues = await fetchJiraIssues(config: cfg)
-            allIssues.append(contentsOf: issues)
+            let listing = await fetchJiraIssues(config: cfg)
+            let merged = Self.mergeJiraListing(listing)
+            allIssues.append(contentsOf: merged.issues)
+            doneCount += merged.doneCount
         }
 
         // Corveil — one list per distinct config (best-effort).
@@ -450,6 +461,7 @@ final class IssueTracker {
         }
 
         appState.assignedIssues = allIssues
+        appState.doneIssuesLast24h = doneCount
 
         let ticketExcludePatterns = config.defaults.excludeTicketRepos
         let autoCreateCandidates = ticketExcludePatterns.isEmpty
@@ -2463,15 +2475,29 @@ final class IssueTracker {
         )
     }
 
-    private func fetchJiraIssues(config: JiraConfig) async -> [AssignedIssue] {
+    /// Fetch assigned Jira issues for one workspace config, including the
+    /// recently-Done half (#536) so tickets in their mapped Done status surface
+    /// in the board's Done section. Best-effort: degrades to an empty listing on
+    /// failure, mirroring the GitLab / Corveil paths.
+    private func fetchJiraIssues(config: JiraConfig) async -> AssignedListing {
         let backend = providerManager.taskBackend(for: .jira, jira: config)
         do {
-            let listing = try await backend.listAssigned(includeClosed: false)
-            return listing.open
+            return try await backend.listAssigned(includeClosed: true)
         } catch {
             print("[IssueTracker] fetchJiraIssues(project: \(config.projectKey ?? "—")) failed: \(error)")
-            return []
+            return AssignedListing(open: [], closed: [])
         }
+    }
+
+    /// Merge a Jira `AssignedListing` into the board's flat issue list: open
+    /// issues plus the closed (Done) issues deduped by `id` against the open
+    /// set, mirroring the GitHub closed-issue merge. `doneCount` is the full
+    /// closed count (the 24h Done window), matching GitHub's `doneIssuesLast24h`
+    /// semantics — it counts the window, not just the post-dedup remainder.
+    nonisolated static func mergeJiraListing(_ listing: AssignedListing) -> (issues: [AssignedIssue], doneCount: Int) {
+        let openIDs = Set(listing.open.map(\.id))
+        let uniqueDone = listing.closed.filter { !openIDs.contains($0.id) }
+        return (listing.open + uniqueDone, listing.closed.count)
     }
 
     /// Fetch open Corveil tasks assigned to the user for one workspace config.

--- a/Tests/CrowTests/IssueTrackerJiraDoneTests.swift
+++ b/Tests/CrowTests/IssueTrackerJiraDoneTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowProvider
+@testable import Crow
+
+/// CROW-536: Jira tickets in their mapped Done status must reach the board's
+/// Done section. The mapping itself (status name → `.done`) is covered by
+/// `JiraTaskBackendTests`; these cover IssueTracker's merge of a Jira
+/// `AssignedListing` into the flat issue list + the recently-Done count.
+@Suite("IssueTracker Jira Done merge")
+struct IssueTrackerJiraDoneTests {
+
+    private func issue(_ key: String, status: TicketStatus, state: String) -> AssignedIssue {
+        AssignedIssue(
+            id: "jira:\(key)",
+            number: 1,
+            title: key,
+            state: state,
+            url: "https://acme.atlassian.net/browse/\(key)",
+            repo: "PROJ",
+            provider: .jira,
+            projectStatus: status
+        )
+    }
+
+    @Test func includesClosedDoneIssuesAndCountsTheWindow() {
+        let listing = AssignedListing(
+            open: [issue("PROJ-1", status: .inProgress, state: "open")],
+            closed: [
+                issue("PROJ-2", status: .done, state: "closed"),
+                issue("PROJ-3", status: .done, state: "closed"),
+            ]
+        )
+
+        let merged = IssueTracker.mergeJiraListing(listing)
+
+        // Both Done issues land in the flat list so the board can group them.
+        #expect(merged.issues.count == 3)
+        #expect(merged.issues.filter { $0.projectStatus == .done }.map(\.id).sorted()
+            == ["jira:PROJ-2", "jira:PROJ-3"])
+        // Done count tracks the full 24h window (mirrors GitHub semantics).
+        #expect(merged.doneCount == 2)
+    }
+
+    @Test func dedupesClosedAgainstOpenButStillCountsTheWindow() {
+        // A ticket present in both halves (defensive: open JQL excludes Done
+        // category, so this shouldn't happen, but mirror GitHub's id dedup).
+        let shared = issue("PROJ-1", status: .inProgress, state: "open")
+        let listing = AssignedListing(
+            open: [shared],
+            closed: [issue("PROJ-1", status: .done, state: "closed")]
+        )
+
+        let merged = IssueTracker.mergeJiraListing(listing)
+
+        // Not double-counted in the issue list...
+        #expect(merged.issues.count == 1)
+        #expect(merged.issues[0].id == "jira:PROJ-1")
+        // ...but the Done window count still reflects the closed result.
+        #expect(merged.doneCount == 1)
+    }
+
+    @Test func emptyListingYieldsNothing() {
+        let merged = IssueTracker.mergeJiraListing(AssignedListing(open: [], closed: []))
+        #expect(merged.issues.isEmpty)
+        #expect(merged.doneCount == 0)
+    }
+}


### PR DESCRIPTION
Closes #536

## Problem

Jira tickets that reach their mapped **Done** status never appeared in Crow's **Done / Completed** ticket section. Crow's Done detection was GitHub-shaped (closed-issue based) with no Jira equivalent surfacing on the board.

## Root cause

CROW-533 (already merged, #535) landed the entire Jira Done substrate in `JiraTaskBackend`:
- `closedJQL` (`statusCategory = Done AND updated >= -1d`) — the 24h recently-Done window
- `listAssigned(includeClosed: true)` parses that closed half with `statusOverride: .done`
- the inverse `jiraStatusMap` (CROW-523) via `ticketStatus(forJiraName:statusMap:)`

The only gap was one line of app-layer wiring: `IssueTracker.fetchJiraIssues` requested `includeClosed: false` and returned only `listing.open`, discarding the already-computed `.done` issues. They never reached `appState.assignedIssues`, so the board never grouped them into Done, and `doneIssuesLast24h` was fed only by GitHub's closed count.

## Changes (`IssueTracker.swift` only)

- `fetchJiraIssues` now requests `includeClosed: true` and returns the full `AssignedListing`.
- New `mergeJiraListing` helper merges open + closed (Done) issues, deduping closed against open by `id` — mirroring the GitHub closed-issue merge at the same site.
- `doneIssuesLast24h` is now a per-refresh accumulator across providers (GitHub contribution unchanged), so Jira's Done window feeds the count and non-GitHub workspaces no longer leave a stale value.

No new backend logic — purely reuses #533's machinery. GitHub/GitLab closed-issue Done behavior is unchanged.

## Acceptance criteria

- ✅ A Jira ticket transitioned to its mapped **Done** status now appears in the Done/Completed section.
- ✅ Done detection keys off the mapped Done status name (inverse `jiraStatusMap`), not a closed-issue concept — already handled by #533's `parseAssigned`.
- ✅ GitHub/GitLab Done behavior unchanged.

## Tests

- Added `Tests/CrowTests/IssueTrackerJiraDoneTests.swift` — covers the merge (Done issues included), id dedup, and Done-count semantics (counts the 24h window, matching GitHub).
- The Done-status mapping itself is already covered by `JiraTaskBackendTests` (`listing.closed[0].projectStatus == .done`, inverse-map cases).
- Full suite green: 31 `JiraTaskBackendTests` + all `IssueTracker` suites + 3 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)