### PR TITLE
Give Manager session cards the same activity indicators as worker cards (#539)

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -374,14 +374,29 @@ public struct ManagerReviewsAllowListRow: View {
         appState.hookState(for: AppState.managerSessionID).pendingNotification != nil
     }
 
+    private var managerActivityState: AgentActivityState {
+        appState.hookState(for: AppState.managerSessionID).activityState
+    }
+
+    /// Leading status dot for the Manager pill (#539): orange pulse when the
+    /// Manager needs attention, else a green pulse while it's working, else
+    /// nothing — mirroring the worker card's `agentLaunched` indicator. The pill
+    /// is too narrow for inline state text, so the dot is the whole signal.
+    private var managerLeadingDot: AnyView? {
+        if managerNeedsAttention {
+            return AnyView(AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention"))
+        } else if managerActivityState == .working {
+            return AnyView(AttentionDot(color: Color.green, accessibilityLabel: "Claude working"))
+        }
+        return nil
+    }
+
     private var managerButton: some View {
         sidebarButton(
             title: "Manager",
             isActive: appState.selectedSessionID == AppState.managerSessionID,
             needsAttention: managerNeedsAttention,
-            leading: managerNeedsAttention
-                ? AnyView(AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention"))
-                : nil
+            leading: managerLeadingDot
         ) {
             appState.selectedSessionID = AppState.managerSessionID
         }

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -459,10 +459,16 @@ struct ManagerSessionRow: View {
     private var needsAttention: Bool {
         appState.hookState(for: session.id).pendingNotification != nil
     }
+    private var activityState: AgentActivityState {
+        appState.hookState(for: session.id).activityState
+    }
 
     private var backgroundFill: Color {
         if needsAttention {
             return Color.orange.opacity(0.12)
+        }
+        if activityState == .done {
+            return CorveilTheme.bgDone
         }
         return isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface
     }
@@ -481,6 +487,8 @@ struct ManagerSessionRow: View {
             HStack(spacing: 6) {
                 if needsAttention {
                     AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention")
+                } else if activityState == .working {
+                    AttentionDot(color: Color.green, accessibilityLabel: "Claude working")
                 }
                 Image(systemName: "person.2.fill")
                     .font(.system(size: 11))
@@ -502,6 +510,8 @@ struct ManagerSessionRow: View {
                 Spacer()
                 if isDeleting {
                     ProgressView().controlSize(.small)
+                } else {
+                    AgentActivityBadge(appState: appState, sessionID: session.id)
                 }
             }
             .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
@@ -545,6 +555,74 @@ struct ManagerSessionRow: View {
             appState.onRenameSession?(session.id, trimmed)
         }
         editingSessionID = nil
+    }
+}
+
+// MARK: - Agent Activity Badge
+
+/// Compact inline badge reflecting a session's agent activity, driven by its
+/// `SessionHookState`. Shared by worker `SessionRow` and the Manager card
+/// surfaces (#539) so they stay in lockstep: permission/question attention
+/// badges take precedence, then working (with the active tool name) and done.
+struct AgentActivityBadge: View {
+    let appState: AppState
+    let sessionID: UUID
+
+    private var activityState: AgentActivityState {
+        appState.hookState(for: sessionID).activityState
+    }
+
+    @ViewBuilder
+    var body: some View {
+        let activity = appState.hookState(for: sessionID).lastToolActivity
+        let notification = appState.hookState(for: sessionID).pendingNotification
+
+        if let notification {
+            // Attention badges
+            if notification.notificationType == "permission_prompt" {
+                HStack(spacing: 3) {
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
+                    Text("Permission")
+                        .font(.caption2)
+                }
+                .foregroundStyle(.orange)
+            } else if notification.notificationType == "question" {
+                HStack(spacing: 3) {
+                    Image(systemName: "questionmark.bubble.fill")
+                        .font(.caption2)
+                    Text("Question")
+                        .font(.caption2)
+                }
+                .foregroundStyle(.orange)
+            }
+        } else {
+            switch activityState {
+            case .working:
+                HStack(spacing: 3) {
+                    Image(systemName: "bolt.fill")
+                        .font(.caption2)
+                    if let activity, activity.isActive {
+                        Text(activity.toolName)
+                            .font(.caption2)
+                    } else {
+                        Text("Working")
+                            .font(.caption2)
+                    }
+                }
+                .foregroundStyle(.orange)
+            case .done:
+                HStack(spacing: 3) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                    Text("Done")
+                        .font(.caption2)
+                }
+                .foregroundStyle(CorveilTheme.gold)
+            case .waiting, .idle:
+                EmptyView()
+            }
+        }
     }
 }
 
@@ -795,57 +873,8 @@ struct SessionRow: View {
         }
     }
 
-    @ViewBuilder
     private var activityStateBadge: some View {
-        let activity = appState.hookState(for: session.id).lastToolActivity
-        let notification = appState.hookState(for: session.id).pendingNotification
-
-        if let notification {
-            // Attention badges
-            if notification.notificationType == "permission_prompt" {
-                HStack(spacing: 3) {
-                    Image(systemName: "lock.fill")
-                        .font(.caption2)
-                    Text("Permission")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.orange)
-            } else if notification.notificationType == "question" {
-                HStack(spacing: 3) {
-                    Image(systemName: "questionmark.bubble.fill")
-                        .font(.caption2)
-                    Text("Question")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.orange)
-            }
-        } else {
-            switch activityState {
-            case .working:
-                HStack(spacing: 3) {
-                    Image(systemName: "bolt.fill")
-                        .font(.caption2)
-                    if let activity, activity.isActive {
-                        Text(activity.toolName)
-                            .font(.caption2)
-                    } else {
-                        Text("Working")
-                            .font(.caption2)
-                    }
-                }
-                .foregroundStyle(.orange)
-            case .done:
-                HStack(spacing: 3) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.caption2)
-                    Text("Done")
-                        .font(.caption2)
-                }
-                .foregroundStyle(CorveilTheme.gold)
-            case .waiting, .idle:
-                EmptyView()
-            }
-        }
+        AgentActivityBadge(appState: appState, sessionID: session.id)
     }
 
     private var needsAttention: Bool {

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -852,6 +852,27 @@ final class SessionService {
     @discardableResult
     private func createManagerTerminal(session: Session, cwd: String) -> SessionTerminal {
         let command = managerCommand(for: session)
+        // CROW-539: install hook config so `crow hook-event` fires for the
+        // Manager, driving the same activity indicators worker cards get. The
+        // Manager has no worktree and runs at the dev root, so hooks carry the
+        // explicit `--session <managerID>` (writeHookConfig bakes it in) — the
+        // cwd-fallback resolver can't route to the Manager. Written before the
+        // gateway-env block below so writeGatewayEnv's 0o600 re-apply (the env
+        // can carry a bearer token) is the final write; both merge into the same
+        // {devRoot}/.claude/settings.local.json without clobbering each other.
+        if let agent = AgentRegistry.shared.agent(for: session.agentKind),
+           let crowPath = ClaudeHookConfigWriter.findCrowBinary() {
+            do {
+                try agent.hookConfigWriter.writeHookConfig(
+                    worktreePath: cwd,
+                    sessionID: session.id,
+                    crowPath: crowPath
+                )
+            } catch {
+                NSLog("[SessionService] Failed to write Manager hook config for session %@: %@",
+                      session.id.uuidString, error.localizedDescription)
+            }
+        }
         // CROW-402: write the Manager gateway env block to {devRoot}/.claude so
         // manual `claude` re-runs in this terminal inherit the same routing. The
         // Manager's cwd is the devRoot.

--- a/Tests/CrowTests/ManagerHookConfigTests.swift
+++ b/Tests/CrowTests/ManagerHookConfigTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowClaude
+
+/// Locks in the invariant the Manager activity-indicator wiring depends on
+/// (#539): `createManagerTerminal` writes hook config *and* the gateway env
+/// block into the same `{devRoot}/.claude/settings.local.json`. Neither writer
+/// may clobber the other, hooks must carry the explicit `--session <managerID>`
+/// (the Manager has no worktree, so cwd-fallback routing can't resolve it), and
+/// gateway-env's owner-only (0600) restriction must survive the pair.
+@Suite("Manager hook-config + gateway-env coexistence")
+struct ManagerHookConfigTests {
+
+    private func makeDir() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crow-mgr-hooks-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func readSettings(_ dir: String) -> [String: Any] {
+        let path = (dir as NSString).appendingPathComponent(".claude/settings.local.json")
+        guard let data = FileManager.default.contents(atPath: path),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return parsed
+    }
+
+    /// Hooks first, then gateway env — the order `createManagerTerminal` uses —
+    /// leaves both blocks present, with hook commands bound to the Manager UUID.
+    @Test
+    func hooksAndGatewayEnvCoexist() throws {
+        let dir = makeDir()
+        try ClaudeHookConfigWriter().writeHookConfig(
+            worktreePath: dir,
+            sessionID: AppState.managerSessionID,
+            crowPath: "/usr/local/bin/crow")
+        ClaudeHookConfigWriter.writeGatewayEnv(
+            dirPath: dir,
+            resolved: .init(baseURL: "https://gw.example", customHeaders: "X-Token: secret"))
+
+        let settings = readSettings(dir)
+        let hooks = try #require(settings["hooks"] as? [String: Any])
+        let env = try #require(settings["env"] as? [String: Any])
+
+        // Every registered event survived the gateway-env write.
+        for event in ["SessionStart", "Stop", "PreToolUse", "PostToolUse"] {
+            #expect(hooks[event] != nil, "missing hook for \(event)")
+        }
+        // Hook commands carry the explicit Manager UUID.
+        let serialized = String(
+            data: try JSONSerialization.data(withJSONObject: hooks), encoding: .utf8) ?? ""
+        #expect(serialized.contains(AppState.managerSessionID.uuidString))
+        #expect(serialized.contains("hook-event --session"))
+        // Gateway env block is intact.
+        #expect(env["ANTHROPIC_BASE_URL"] as? String == "https://gw.example")
+    }
+
+    /// The gateway-env write applies owner-only (0600) perms last — the env can
+    /// carry a bearer token — and that restriction holds with hooks present.
+    @Test
+    func gatewayEnvKeepsOwnerOnlyPermissionsWithHooks() throws {
+        let dir = makeDir()
+        try ClaudeHookConfigWriter().writeHookConfig(
+            worktreePath: dir,
+            sessionID: AppState.managerSessionID,
+            crowPath: "/usr/local/bin/crow")
+        ClaudeHookConfigWriter.writeGatewayEnv(
+            dirPath: dir,
+            resolved: .init(baseURL: "https://gw.example", customHeaders: "X-Token: secret"))
+
+        let path = (dir as NSString).appendingPathComponent(".claude/settings.local.json")
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms == 0o600)
+    }
+
+    /// A Manager with no gateway (resolved == nil) clears env keys but must keep
+    /// its hooks — the file is not emptied/removed out from under them.
+    @Test
+    func hooksSurviveWhenGatewayCleared() throws {
+        let dir = makeDir()
+        try ClaudeHookConfigWriter().writeHookConfig(
+            worktreePath: dir,
+            sessionID: AppState.managerSessionID,
+            crowPath: "/usr/local/bin/crow")
+        ClaudeHookConfigWriter.writeGatewayEnv(dirPath: dir, resolved: nil)
+
+        let settings = readSettings(dir)
+        #expect(settings["hooks"] as? [String: Any] != nil)
+        #expect(settings["env"] == nil)
+    }
+}


### PR DESCRIPTION
Closes #539

## Problem

Worker session cards show activity cues (working / done / attention badge) driven by Claude Code hook events. **Manager** session cards got none of it — tabbed away, there was no peripheral signal that the Manager was mid-tool-call, waiting on a `gh` permission prompt, or idle.

The ingestion/routing/state layers (the `hook-event` RPC handler, `ClaudeHookSignalSource`, `SessionHookState`) are already generic by session UUID, so this is **purely additive** — route the Manager session through the same paths workers use. (Note: the real Manager UUID is the all-zeros `AppState.managerSessionID`; the `1EA19F17…` value in the ticket is just the session footer and appears nowhere in the repo.)

## Two gaps closed

**A — No hooks installed for the Manager.** `createManagerTerminal` wrote only the gateway env block, never the hook config, so `crow hook-event` never fired for the Manager and its `activityState` stayed `.idle`. Now it installs hook config too, mirroring the worker `launchAgent` path. Hooks are written **before** the gateway env so `writeGatewayEnv`'s `0600` re-apply (the env can carry a bearer token) is the final write; both merge into the same `{devRoot}/.claude/settings.local.json` without clobbering each other. The Manager has no worktree, so hooks carry the explicit `--session <managerID>` (cwd-fallback routing can't resolve it).

**B — Manager cards ignored `activityState`.** Both surfaces read only `pendingNotification`. Extracted `SessionRow`'s badge into a shared `AgentActivityBadge` (worker behavior byte-for-byte unchanged), then wired `activityState` into:
- `ManagerSessionRow` (additional managers) — leading working/attention dot, inline Working/Done badge, done-state tint.
- The primary "Manager" pill (`ManagerReviewsAllowListRow`) — leading working/attention dot (the pill is too narrow for inline text).

## Known limitation

A non-Claude Manager (Codex) still won't light up — its no-op hook writer relies on cwd→worktree resolution the Manager lacks. The default Manager is Claude, the ticket's target.

## Tests

`ManagerHookConfigTests` locks in the new, subtle invariant my ordering depends on: hook config and gateway env **coexist** in the same settings file, hook commands are bound to the Manager UUID, the `0600` restriction survives, and hooks aren't nuked when the Manager has no gateway. All 3 pass.

## Verification

- `swift build --arch arm64` — clean.
- `arch -arm64 swift test --arch arm64 --filter ManagerHookConfigTests` — 3/3 pass.
- Manual: on next Manager terminal creation, `{devRoot}/.claude/settings.local.json` gains a `hooks` block with `crow hook-event --session 00000000-… --event …` for all 17 events; the Manager card then shows green-pulse Working / Done / orange Permission|Question in lockstep with worker cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)