### PR TITLE
Manager cards: dots-only activity indicator, drop the throb/glow (#539)

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -378,10 +378,10 @@ public struct ManagerReviewsAllowListRow: View {
         appState.hookState(for: AppState.managerSessionID).activityState
     }
 
-    /// Leading status dot for the Manager pill (#539): orange pulse when the
-    /// Manager needs attention, else a green pulse while it's working, else
-    /// nothing — mirroring the worker card's `agentLaunched` indicator. The pill
-    /// is too narrow for inline state text, so the dot is the whole signal.
+    /// Leading status dot for the Manager pill (#539): amber when the Manager
+    /// needs attention, else green while it's working, else nothing — the same
+    /// static `AttentionDot` worker cards use for their status dot. The pill is
+    /// too narrow for inline state text, so the dot is the whole signal.
     private var managerLeadingDot: AnyView? {
         if managerNeedsAttention {
             return AnyView(AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention"))
@@ -392,10 +392,14 @@ public struct ManagerReviewsAllowListRow: View {
     }
 
     private var managerButton: some View {
+        // Dots-only signalling for the Manager (#539): a leading status dot
+        // (amber = needs attention, green = working) rather than the amber
+        // background pulse — pass needsAttention: false so the pill keeps its
+        // neutral fill and never throbs.
         sidebarButton(
             title: "Manager",
             isActive: appState.selectedSessionID == AppState.managerSessionID,
-            needsAttention: managerNeedsAttention,
+            needsAttention: false,
             leading: managerLeadingDot
         ) {
             appState.selectedSessionID = AppState.managerSessionID

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -463,21 +463,16 @@ struct ManagerSessionRow: View {
         appState.hookState(for: session.id).activityState
     }
 
+    // Manager cards signal activity with a leading status dot only (#539) —
+    // amber for needs-attention, green while working — rather than the amber/
+    // green card-background glow worker cards use, which reads as heavy on the
+    // always-visible Manager surface. Background/border stay neutral gold.
     private var backgroundFill: Color {
-        if needsAttention {
-            return Color.orange.opacity(0.12)
-        }
-        if activityState == .done {
-            return CorveilTheme.bgDone
-        }
-        return isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface
+        isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface
     }
 
     private var borderStroke: Color {
-        if needsAttention {
-            return Color.orange.opacity(0.4)
-        }
-        return isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3)
+        isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3)
     }
 
     var body: some View {
@@ -510,8 +505,6 @@ struct ManagerSessionRow: View {
                 Spacer()
                 if isDeleting {
                     ProgressView().controlSize(.small)
-                } else {
-                    AgentActivityBadge(appState: appState, sessionID: session.id)
                 }
             }
             .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
@@ -526,7 +519,6 @@ struct ManagerSessionRow: View {
                             .strokeBorder(borderStroke, lineWidth: 1)
                     )
             )
-            .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: needsAttention)
             .overlay(alignment: .topTrailing) {
                 if appState.isRemoteControlActive(sessionID: session.id) {
                     RemoteControlBadge(compact: true)
@@ -555,74 +547,6 @@ struct ManagerSessionRow: View {
             appState.onRenameSession?(session.id, trimmed)
         }
         editingSessionID = nil
-    }
-}
-
-// MARK: - Agent Activity Badge
-
-/// Compact inline badge reflecting a session's agent activity, driven by its
-/// `SessionHookState`. Shared by worker `SessionRow` and the Manager card
-/// surfaces (#539) so they stay in lockstep: permission/question attention
-/// badges take precedence, then working (with the active tool name) and done.
-struct AgentActivityBadge: View {
-    let appState: AppState
-    let sessionID: UUID
-
-    private var activityState: AgentActivityState {
-        appState.hookState(for: sessionID).activityState
-    }
-
-    @ViewBuilder
-    var body: some View {
-        let activity = appState.hookState(for: sessionID).lastToolActivity
-        let notification = appState.hookState(for: sessionID).pendingNotification
-
-        if let notification {
-            // Attention badges
-            if notification.notificationType == "permission_prompt" {
-                HStack(spacing: 3) {
-                    Image(systemName: "lock.fill")
-                        .font(.caption2)
-                    Text("Permission")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.orange)
-            } else if notification.notificationType == "question" {
-                HStack(spacing: 3) {
-                    Image(systemName: "questionmark.bubble.fill")
-                        .font(.caption2)
-                    Text("Question")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.orange)
-            }
-        } else {
-            switch activityState {
-            case .working:
-                HStack(spacing: 3) {
-                    Image(systemName: "bolt.fill")
-                        .font(.caption2)
-                    if let activity, activity.isActive {
-                        Text(activity.toolName)
-                            .font(.caption2)
-                    } else {
-                        Text("Working")
-                            .font(.caption2)
-                    }
-                }
-                .foregroundStyle(.orange)
-            case .done:
-                HStack(spacing: 3) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.caption2)
-                    Text("Done")
-                        .font(.caption2)
-                }
-                .foregroundStyle(CorveilTheme.gold)
-            case .waiting, .idle:
-                EmptyView()
-            }
-        }
     }
 }
 
@@ -873,8 +797,57 @@ struct SessionRow: View {
         }
     }
 
+    @ViewBuilder
     private var activityStateBadge: some View {
-        AgentActivityBadge(appState: appState, sessionID: session.id)
+        let activity = appState.hookState(for: session.id).lastToolActivity
+        let notification = appState.hookState(for: session.id).pendingNotification
+
+        if let notification {
+            // Attention badges
+            if notification.notificationType == "permission_prompt" {
+                HStack(spacing: 3) {
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
+                    Text("Permission")
+                        .font(.caption2)
+                }
+                .foregroundStyle(.orange)
+            } else if notification.notificationType == "question" {
+                HStack(spacing: 3) {
+                    Image(systemName: "questionmark.bubble.fill")
+                        .font(.caption2)
+                    Text("Question")
+                        .font(.caption2)
+                }
+                .foregroundStyle(.orange)
+            }
+        } else {
+            switch activityState {
+            case .working:
+                HStack(spacing: 3) {
+                    Image(systemName: "bolt.fill")
+                        .font(.caption2)
+                    if let activity, activity.isActive {
+                        Text(activity.toolName)
+                            .font(.caption2)
+                    } else {
+                        Text("Working")
+                            .font(.caption2)
+                    }
+                }
+                .foregroundStyle(.orange)
+            case .done:
+                HStack(spacing: 3) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                    Text("Done")
+                        .font(.caption2)
+                }
+                .foregroundStyle(CorveilTheme.gold)
+            case .waiting, .idle:
+                EmptyView()
+            }
+        }
     }
 
     private var needsAttention: Bool {


### PR DESCRIPTION
Follow-up to #540 (already merged via auto-merge). Refs #539.

## What & why

#540 lit up the Manager cards by feeding them Claude Code hook events — but reused worker cards' **full** treatment: the amber/green card-background glow plus a `repeatForever` "needs attention" pulse. On the always-visible Manager surface (the sidebar pill + any additional-Manager cards) that reads as heavy and distracting — a throbbing/glowing card.

This pares the Manager down to a **leading status dot only**:
- **amber** when waiting on you (permission prompt / AskUserQuestion),
- **green** while working,
- **nothing** when idle,

…the same static `AttentionDot` worker cards already use for their status dot. No card-background tint, no throb.

**Worker cards are reverted to exactly how they were** — the shared-badge extraction (`AgentActivityBadge`) from #540 is undone; `SessionRow` keeps its original inline badge and amber/green background treatment, unchanged.

## Scope

UI-only. The hook plumbing from #540 — `createManagerTerminal` installing hook config so `crow hook-event` fires for the Manager, plus `ManagerHookConfigTests` — is already on `main` and untouched here.

## Changes
- `ReviewBoardView.swift` — primary Manager pill: leading dot (amber/green), `needsAttention: false` so the pill never throbs.
- `SessionListView.swift` — `ManagerSessionRow`: neutral gold background/border, leading amber/green dot, throb animation removed; `SessionRow` + `AgentActivityBadge` extraction reverted.

## Verification
- `swift build --arch arm64` — clean off `main`.
- Manual: Manager shows a steady amber dot when blocked on a prompt, green while working, clears when idle — no glow, no throb. Worker cards unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)