### PR TITLE
setup.sh: generic per-session env injection (--session-env + sessionEnv). CROW-543

### DIFF
--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -54,6 +54,28 @@ The worktree's settings.local.json is added to that worktree's per-worktree git 
 
 **When authoring commits by hand** (`git commit -m "…"`, heredoc, `git commit --amend`), include both `Crow-Session: <session-uuid>` and `Co-Authored-By: Claude <noreply@anthropic.com>` as trailers at the end of the message. `attribution.commit` only fires for Claude Code's built-in commit flow; hand-rolled commits bypass it. `setup.sh` also installs a per-worktree `prepare-commit-msg` hook (CROW-518) that idempotently appends both trailers when missing — treat that hook as a safety net, not the primary path. Both trailers must be line-anchored at the end of the message; the `crow:merge` auto-merge gate parses `^Crow-Session:\s*<uuid>\s*$` (see `IssueTracker.crowSessionTrailerPattern`).
 
+### Per-Session Environment Injection (CROW-543)
+
+A workspace can bake arbitrary environment variables into every new session's per-worktree `.claude/settings.local.json .env`. Crow stays domain-agnostic: each workspace declares what it needs. Variables land in the same `.env` block that carries the AI gateway settings, so a session's `claude` (and its hooks) inherit them.
+
+Declare a `sessionEnv` map on the workspace's `config.json` entry (peer of `gateway` / `taskProvider` / `customInstructions`). Values may use template tokens (see below):
+
+```jsonc
+{
+  "name": "SecurityScorecard",
+  "provider": "github",
+  "sessionEnv": { "COORD_SESSION_NAME": "{{session_name}}" }
+}
+```
+
+The example above lets the SecurityScorecard coordination layer's SessionStart `session-namer` hook read `COORD_SESSION_NAME` to auto-name the session — a workspace-only concern, expressed in one config line.
+
+`setup.sh` also accepts a repeatable `--session-env KEY=VALUE` flag. Flag pairs are merged **on top of** the config map, so a flag wins for a key that also appears in `sessionEnv`. Flag values support the same template tokens.
+
+**Template tokens** (resolved from setup.sh's per-session vars): `{{session_name}}`, `{{slug}}`, `{{branch}}`, `{{ticket_number}}`, `{{repo}}`, `{{workspace}}`, `{{worktree_path}}`, `{{ticket_url}}`. Unknown tokens are left untouched.
+
+Backward-compatible: with no `sessionEnv` map and no `--session-env` flag, `setup.sh` writes no `.env` block beyond what attribution/gateway already require. The file is `chmod 600` (a session-env value may carry a secret) and stays in the worktree's git exclude list. Gateway and attribution keys are never clobbered by a same-named session-env key.
+
 ## Multi-Workspace Discovery
 
 ### Step 1: Enumerate Workspaces

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -59,6 +59,16 @@ WS_GATEWAY_RESOLVED=false
 TASK_PROVIDER=""
 TASK_PROVIDER_RESOLVED=false
 
+# Resolved per-session env injection for this workspace (CROW-543). Mirrors the
+# gateway block above: resolve_session_env reads .sessionEnv from the workspace
+# config, substitutes template tokens, and overlays any --session-env flags
+# (flag wins). Stored as a newline-separated KEY=VALUE list; write_settings_local
+# folds it into settings.local.json .env. CLI_SESSION_ENV holds the raw flag
+# pairs collected during arg parse (templated later, alongside the config map).
+WS_SESSION_ENV=""
+WS_SESSION_ENV_RESOLVED=false
+CLI_SESSION_ENV=""
+
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
 log() { echo "[setup.sh] $*" >&2; }
@@ -219,6 +229,77 @@ resolve_task_provider() {
   [[ -n "$tp" && "$tp" != "null" ]] && TASK_PROVIDER="$tp"
 }
 
+# Substitute the small whitelist of {{token}} placeholders in a session-env value
+# against the resolved setup.sh vars (CROW-543). Unknown tokens are left
+# untouched. Uses bash parameter-expansion replacement (bash 3.2 safe); the
+# result is later baked into JSON via `jq --arg`, so embedded quotes/specials are
+# never a shell or JSON injection risk. Usage: substitute_session_env_tokens VALUE
+substitute_session_env_tokens() {
+  local v="$1"
+  v="${v//\{\{session_name\}\}/$SESSION_NAME}"
+  v="${v//\{\{slug\}\}/$SLUG}"
+  v="${v//\{\{branch\}\}/$BRANCH}"
+  v="${v//\{\{ticket_number\}\}/$TICKET_NUMBER}"
+  v="${v//\{\{repo\}\}/$REPO}"
+  v="${v//\{\{workspace\}\}/$WORKSPACE}"
+  v="${v//\{\{worktree_path\}\}/$WORKTREE_PATH}"
+  v="${v//\{\{ticket_url\}\}/$TICKET_URL}"
+  printf '%s' "$v"
+}
+
+# Resolve this workspace's generic per-session env injection (CROW-543). Sibling
+# of resolve_gateway_env: reads the optional `.sessionEnv` map from this
+# workspace's config.json entry, substitutes template tokens, then overlays any
+# repeatable --session-env KEY=VALUE flags (CLI_SESSION_ENV). Config pairs are
+# emitted first and flag pairs last, so the last-write-wins jq merge in
+# write_settings_local makes the flag value win for a duplicate key. Result is a
+# newline-separated KEY=VALUE list in WS_SESSION_ENV. Fail-open: missing config /
+# no jq → only the flags (if any). Idempotent. Never logs values (a session-env
+# value may carry a secret) — only the injected key names.
+resolve_session_env() {
+  [[ "$WS_SESSION_ENV_RESOLVED" == true ]] && return 0
+  WS_SESSION_ENV_RESOLVED=true
+
+  local pairs="" kv key value
+
+  # 1. Per-workspace config map (.workspaces[].sessionEnv), if present.
+  local config_path="$DEV_ROOT/.claude/config.json"
+  if [[ -f "$config_path" ]] && command -v jq >/dev/null 2>&1; then
+    while IFS= read -r kv; do
+      [[ -n "$kv" ]] || continue
+      key="${kv%%=*}"
+      value="${kv#*=}"
+      value=$(substitute_session_env_tokens "$value")
+      [[ -n "$pairs" ]] && pairs+=$'\n'
+      pairs+="$key=$value"
+    done < <(jq -r --arg name "$WORKSPACE" \
+      '.workspaces[]? | select(.name == $name) | .sessionEnv // {} | to_entries[] | "\(.key)=\(.value)"' \
+      "$config_path" 2>/dev/null)
+  fi
+
+  # 2. --session-env flags overlaid on top (flag wins via later jq write).
+  while IFS= read -r kv; do
+    [[ -n "$kv" ]] || continue
+    key="${kv%%=*}"
+    value="${kv#*=}"
+    value=$(substitute_session_env_tokens "$value")
+    [[ -n "$pairs" ]] && pairs+=$'\n'
+    pairs+="$key=$value"
+  done <<< "$CLI_SESSION_ENV"
+
+  WS_SESSION_ENV="$pairs"
+  if [[ -n "$WS_SESSION_ENV" ]]; then
+    # Log key names only — never the values.
+    local names=""
+    while IFS= read -r kv; do
+      [[ -n "$kv" ]] || continue
+      [[ -n "$names" ]] && names+=", "
+      names+="${kv%%=*}"
+    done <<< "$WS_SESSION_ENV"
+    log "Session env: injecting into settings.local.json .env: $names"
+  fi
+}
+
 # Build the shell prefix that applies (or clears) the gateway env vars on the
 # `claude` launch line — mirrors ClaudeLaunchArgs.gatewayEnvPrefix in Swift.
 # Gateway absent → `unset … && ` so a no-gateway workspace doesn't inherit a
@@ -288,6 +369,13 @@ Optional:
   --claude-binary <path>     [deprecated alias] Same as --agent-binary; only
                              honored when the resolved agent is claude-code.
   --session-id <uuid>        Existing session ID (for secondary repos)
+  --session-env KEY=VALUE    Inject KEY=VALUE into the new session's per-worktree
+                             .claude/settings.local.json .env (repeatable).
+                             Merged on top of this workspace's sessionEnv config
+                             map (flag wins for a duplicate key). VALUE may use
+                             template tokens: {{session_name}} {{slug}} {{branch}}
+                             {{ticket_number}} {{repo}} {{workspace}}
+                             {{worktree_path}} {{ticket_url}}.
   --base-branch <branch>     Default base branch (auto-detected from origin/HEAD if omitted)
   --primary                  Mark worktree as primary
   --skip-launch              Skip agent launch
@@ -323,6 +411,10 @@ parse_args() {
       --agent-binary)      AGENT_BINARY="$2"; shift 2 ;;
       --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
       --session-id)        SESSION_ID="$2"; shift 2 ;;
+      --session-env)
+        [[ "$2" == *=* ]] || die "parse_args" "--session-env expects KEY=VALUE, got: $2"
+        [[ -n "$CLI_SESSION_ENV" ]] && CLI_SESSION_ENV+=$'\n'
+        CLI_SESSION_ENV+="$2"; shift 2 ;;
       --base-branch)       BASE_BRANCH="$2"; shift 2 ;;
       --primary)           PRIMARY=true; shift ;;
       --skip-launch)       SKIP_LAUNCH=true; shift ;;
@@ -533,9 +625,10 @@ create_session() {
 # regardless of --skip-launch, so any worktree the user later opens with Claude
 # Code picks up both overrides.
 write_settings_local() {
-  # Resolve the gateway first so its block is written even when attribution
-  # trailers are disabled.
+  # Resolve the gateway and session env first so their blocks are written even
+  # when attribution trailers are disabled.
   resolve_gateway_env
+  resolve_session_env
 
   local want_attribution=false
   if is_attribution_trailers_enabled && [[ -n "$SESSION_ID" ]]; then
@@ -546,8 +639,8 @@ write_settings_local() {
     log "Attribution trailers disabled via config"
   fi
 
-  if [[ "$want_attribution" != true && "$WS_HAS_GATEWAY" != true ]]; then
-    log "No attribution trailer or gateway to write; skipping settings.local.json"
+  if [[ "$want_attribution" != true && "$WS_HAS_GATEWAY" != true && -z "$WS_SESSION_ENV" ]]; then
+    log "No attribution trailer, gateway, or session env to write; skipping settings.local.json"
     return
   fi
 
@@ -582,6 +675,22 @@ write_settings_local() {
 Co-Authored-By: Claude <noreply@anthropic.com>
 Crow-Session: $SESSION_ID"
 
+  # Build a JSON object from the resolved KEY=VALUE session-env pairs (CROW-543).
+  # Values are baked via `jq --arg` so quotes/specials are safe; the iterative
+  # .[$k]=$v overwrite makes flag pairs (emitted last by resolve_session_env)
+  # win over a same-named config key.
+  local session_env_json="{}" pair key value
+  if [[ -n "$WS_SESSION_ENV" ]]; then
+    while IFS= read -r pair; do
+      [[ -n "$pair" ]] || continue
+      key="${pair%%=*}"
+      value="${pair#*=}"
+      if ! session_env_json=$(jq --arg k "$key" --arg v "$value" '.[$k] = $v' <<< "$session_env_json"); then
+        die "settings_local" "jq failed to build session env object"
+      fi
+    done <<< "$WS_SESSION_ENV"
+  fi
+
   local merged
   if ! merged=$(jq \
     --argjson want_attr "$want_attribution" \
@@ -589,7 +698,9 @@ Crow-Session: $SESSION_ID"
     --argjson want_gw "$WS_HAS_GATEWAY" \
     --arg base_url "$WS_BASE_URL" \
     --arg headers "$WS_CUSTOM_HEADERS" \
+    --argjson session_env "$session_env_json" \
     '(if $want_attr then .attribution.commit = $commit else . end)
+     | (if ($session_env | length) > 0 then .env = (.env // {}) + $session_env else . end)
      | (if $want_gw then .env.ANTHROPIC_BASE_URL = $base_url
                        | .env.ANTHROPIC_CUSTOM_HEADERS = $headers else . end)' \
     <<< "$base"); then
@@ -600,11 +711,11 @@ Crow-Session: $SESSION_ID"
   # owner-only — matching ConfigStore's 0600 on config.json.
   chmod 600 "$settings_path" 2>/dev/null || true
 
-  if [[ "$WS_HAS_GATEWAY" == true ]]; then
-    log "Wrote settings.local.json (attribution + gateway env) to $settings_path (agent: $display_name)"
-  else
-    log "Wrote attribution settings to $settings_path (agent: $display_name)"
-  fi
+  local wrote=""
+  [[ "$want_attribution" == true ]] && wrote="attribution"
+  [[ "$WS_HAS_GATEWAY" == true ]] && wrote="${wrote:+$wrote + }gateway env"
+  [[ -n "$WS_SESSION_ENV" ]] && wrote="${wrote:+$wrote + }session env"
+  log "Wrote settings.local.json ($wrote) to $settings_path (agent: $display_name)"
 
   # Belt-and-suspenders: add the file to the per-worktree git exclude so it
   # is never accidentally committed even if the repo's .gitignore does not

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -54,6 +54,28 @@ The worktree's settings.local.json is added to that worktree's per-worktree git 
 
 **When authoring commits by hand** (`git commit -m "…"`, heredoc, `git commit --amend`), include both `Crow-Session: <session-uuid>` and `Co-Authored-By: Claude <noreply@anthropic.com>` as trailers at the end of the message. `attribution.commit` only fires for Claude Code's built-in commit flow; hand-rolled commits bypass it. `setup.sh` also installs a per-worktree `prepare-commit-msg` hook (CROW-518) that idempotently appends both trailers when missing — treat that hook as a safety net, not the primary path. Both trailers must be line-anchored at the end of the message; the `crow:merge` auto-merge gate parses `^Crow-Session:\s*<uuid>\s*$` (see `IssueTracker.crowSessionTrailerPattern`).
 
+### Per-Session Environment Injection (CROW-543)
+
+A workspace can bake arbitrary environment variables into every new session's per-worktree `.claude/settings.local.json .env`. Crow stays domain-agnostic: each workspace declares what it needs. Variables land in the same `.env` block that carries the AI gateway settings, so a session's `claude` (and its hooks) inherit them.
+
+Declare a `sessionEnv` map on the workspace's `config.json` entry (peer of `gateway` / `taskProvider` / `customInstructions`). Values may use template tokens (see below):
+
+```jsonc
+{
+  "name": "SecurityScorecard",
+  "provider": "github",
+  "sessionEnv": { "COORD_SESSION_NAME": "{{session_name}}" }
+}
+```
+
+The example above lets the SecurityScorecard coordination layer's SessionStart `session-namer` hook read `COORD_SESSION_NAME` to auto-name the session — a workspace-only concern, expressed in one config line.
+
+`setup.sh` also accepts a repeatable `--session-env KEY=VALUE` flag. Flag pairs are merged **on top of** the config map, so a flag wins for a key that also appears in `sessionEnv`. Flag values support the same template tokens.
+
+**Template tokens** (resolved from setup.sh's per-session vars): `{{session_name}}`, `{{slug}}`, `{{branch}}`, `{{ticket_number}}`, `{{repo}}`, `{{workspace}}`, `{{worktree_path}}`, `{{ticket_url}}`. Unknown tokens are left untouched.
+
+Backward-compatible: with no `sessionEnv` map and no `--session-env` flag, `setup.sh` writes no `.env` block beyond what attribution/gateway already require. The file is `chmod 600` (a session-env value may carry a secret) and stays in the worktree's git exclude list. Gateway and attribution keys are never clobbered by a same-named session-env key.
+
 ## Multi-Workspace Discovery
 
 ### Step 1: Enumerate Workspaces

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -59,6 +59,16 @@ WS_GATEWAY_RESOLVED=false
 TASK_PROVIDER=""
 TASK_PROVIDER_RESOLVED=false
 
+# Resolved per-session env injection for this workspace (CROW-543). Mirrors the
+# gateway block above: resolve_session_env reads .sessionEnv from the workspace
+# config, substitutes template tokens, and overlays any --session-env flags
+# (flag wins). Stored as a newline-separated KEY=VALUE list; write_settings_local
+# folds it into settings.local.json .env. CLI_SESSION_ENV holds the raw flag
+# pairs collected during arg parse (templated later, alongside the config map).
+WS_SESSION_ENV=""
+WS_SESSION_ENV_RESOLVED=false
+CLI_SESSION_ENV=""
+
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
 log() { echo "[setup.sh] $*" >&2; }
@@ -219,6 +229,77 @@ resolve_task_provider() {
   [[ -n "$tp" && "$tp" != "null" ]] && TASK_PROVIDER="$tp"
 }
 
+# Substitute the small whitelist of {{token}} placeholders in a session-env value
+# against the resolved setup.sh vars (CROW-543). Unknown tokens are left
+# untouched. Uses bash parameter-expansion replacement (bash 3.2 safe); the
+# result is later baked into JSON via `jq --arg`, so embedded quotes/specials are
+# never a shell or JSON injection risk. Usage: substitute_session_env_tokens VALUE
+substitute_session_env_tokens() {
+  local v="$1"
+  v="${v//\{\{session_name\}\}/$SESSION_NAME}"
+  v="${v//\{\{slug\}\}/$SLUG}"
+  v="${v//\{\{branch\}\}/$BRANCH}"
+  v="${v//\{\{ticket_number\}\}/$TICKET_NUMBER}"
+  v="${v//\{\{repo\}\}/$REPO}"
+  v="${v//\{\{workspace\}\}/$WORKSPACE}"
+  v="${v//\{\{worktree_path\}\}/$WORKTREE_PATH}"
+  v="${v//\{\{ticket_url\}\}/$TICKET_URL}"
+  printf '%s' "$v"
+}
+
+# Resolve this workspace's generic per-session env injection (CROW-543). Sibling
+# of resolve_gateway_env: reads the optional `.sessionEnv` map from this
+# workspace's config.json entry, substitutes template tokens, then overlays any
+# repeatable --session-env KEY=VALUE flags (CLI_SESSION_ENV). Config pairs are
+# emitted first and flag pairs last, so the last-write-wins jq merge in
+# write_settings_local makes the flag value win for a duplicate key. Result is a
+# newline-separated KEY=VALUE list in WS_SESSION_ENV. Fail-open: missing config /
+# no jq → only the flags (if any). Idempotent. Never logs values (a session-env
+# value may carry a secret) — only the injected key names.
+resolve_session_env() {
+  [[ "$WS_SESSION_ENV_RESOLVED" == true ]] && return 0
+  WS_SESSION_ENV_RESOLVED=true
+
+  local pairs="" kv key value
+
+  # 1. Per-workspace config map (.workspaces[].sessionEnv), if present.
+  local config_path="$DEV_ROOT/.claude/config.json"
+  if [[ -f "$config_path" ]] && command -v jq >/dev/null 2>&1; then
+    while IFS= read -r kv; do
+      [[ -n "$kv" ]] || continue
+      key="${kv%%=*}"
+      value="${kv#*=}"
+      value=$(substitute_session_env_tokens "$value")
+      [[ -n "$pairs" ]] && pairs+=$'\n'
+      pairs+="$key=$value"
+    done < <(jq -r --arg name "$WORKSPACE" \
+      '.workspaces[]? | select(.name == $name) | .sessionEnv // {} | to_entries[] | "\(.key)=\(.value)"' \
+      "$config_path" 2>/dev/null)
+  fi
+
+  # 2. --session-env flags overlaid on top (flag wins via later jq write).
+  while IFS= read -r kv; do
+    [[ -n "$kv" ]] || continue
+    key="${kv%%=*}"
+    value="${kv#*=}"
+    value=$(substitute_session_env_tokens "$value")
+    [[ -n "$pairs" ]] && pairs+=$'\n'
+    pairs+="$key=$value"
+  done <<< "$CLI_SESSION_ENV"
+
+  WS_SESSION_ENV="$pairs"
+  if [[ -n "$WS_SESSION_ENV" ]]; then
+    # Log key names only — never the values.
+    local names=""
+    while IFS= read -r kv; do
+      [[ -n "$kv" ]] || continue
+      [[ -n "$names" ]] && names+=", "
+      names+="${kv%%=*}"
+    done <<< "$WS_SESSION_ENV"
+    log "Session env: injecting into settings.local.json .env: $names"
+  fi
+}
+
 # Build the shell prefix that applies (or clears) the gateway env vars on the
 # `claude` launch line — mirrors ClaudeLaunchArgs.gatewayEnvPrefix in Swift.
 # Gateway absent → `unset … && ` so a no-gateway workspace doesn't inherit a
@@ -288,6 +369,13 @@ Optional:
   --claude-binary <path>     [deprecated alias] Same as --agent-binary; only
                              honored when the resolved agent is claude-code.
   --session-id <uuid>        Existing session ID (for secondary repos)
+  --session-env KEY=VALUE    Inject KEY=VALUE into the new session's per-worktree
+                             .claude/settings.local.json .env (repeatable).
+                             Merged on top of this workspace's sessionEnv config
+                             map (flag wins for a duplicate key). VALUE may use
+                             template tokens: {{session_name}} {{slug}} {{branch}}
+                             {{ticket_number}} {{repo}} {{workspace}}
+                             {{worktree_path}} {{ticket_url}}.
   --base-branch <branch>     Default base branch (auto-detected from origin/HEAD if omitted)
   --primary                  Mark worktree as primary
   --skip-launch              Skip agent launch
@@ -323,6 +411,10 @@ parse_args() {
       --agent-binary)      AGENT_BINARY="$2"; shift 2 ;;
       --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
       --session-id)        SESSION_ID="$2"; shift 2 ;;
+      --session-env)
+        [[ "$2" == *=* ]] || die "parse_args" "--session-env expects KEY=VALUE, got: $2"
+        [[ -n "$CLI_SESSION_ENV" ]] && CLI_SESSION_ENV+=$'\n'
+        CLI_SESSION_ENV+="$2"; shift 2 ;;
       --base-branch)       BASE_BRANCH="$2"; shift 2 ;;
       --primary)           PRIMARY=true; shift ;;
       --skip-launch)       SKIP_LAUNCH=true; shift ;;
@@ -533,9 +625,10 @@ create_session() {
 # regardless of --skip-launch, so any worktree the user later opens with Claude
 # Code picks up both overrides.
 write_settings_local() {
-  # Resolve the gateway first so its block is written even when attribution
-  # trailers are disabled.
+  # Resolve the gateway and session env first so their blocks are written even
+  # when attribution trailers are disabled.
   resolve_gateway_env
+  resolve_session_env
 
   local want_attribution=false
   if is_attribution_trailers_enabled && [[ -n "$SESSION_ID" ]]; then
@@ -546,8 +639,8 @@ write_settings_local() {
     log "Attribution trailers disabled via config"
   fi
 
-  if [[ "$want_attribution" != true && "$WS_HAS_GATEWAY" != true ]]; then
-    log "No attribution trailer or gateway to write; skipping settings.local.json"
+  if [[ "$want_attribution" != true && "$WS_HAS_GATEWAY" != true && -z "$WS_SESSION_ENV" ]]; then
+    log "No attribution trailer, gateway, or session env to write; skipping settings.local.json"
     return
   fi
 
@@ -582,6 +675,22 @@ write_settings_local() {
 Co-Authored-By: Claude <noreply@anthropic.com>
 Crow-Session: $SESSION_ID"
 
+  # Build a JSON object from the resolved KEY=VALUE session-env pairs (CROW-543).
+  # Values are baked via `jq --arg` so quotes/specials are safe; the iterative
+  # .[$k]=$v overwrite makes flag pairs (emitted last by resolve_session_env)
+  # win over a same-named config key.
+  local session_env_json="{}" pair key value
+  if [[ -n "$WS_SESSION_ENV" ]]; then
+    while IFS= read -r pair; do
+      [[ -n "$pair" ]] || continue
+      key="${pair%%=*}"
+      value="${pair#*=}"
+      if ! session_env_json=$(jq --arg k "$key" --arg v "$value" '.[$k] = $v' <<< "$session_env_json"); then
+        die "settings_local" "jq failed to build session env object"
+      fi
+    done <<< "$WS_SESSION_ENV"
+  fi
+
   local merged
   if ! merged=$(jq \
     --argjson want_attr "$want_attribution" \
@@ -589,7 +698,9 @@ Crow-Session: $SESSION_ID"
     --argjson want_gw "$WS_HAS_GATEWAY" \
     --arg base_url "$WS_BASE_URL" \
     --arg headers "$WS_CUSTOM_HEADERS" \
+    --argjson session_env "$session_env_json" \
     '(if $want_attr then .attribution.commit = $commit else . end)
+     | (if ($session_env | length) > 0 then .env = (.env // {}) + $session_env else . end)
      | (if $want_gw then .env.ANTHROPIC_BASE_URL = $base_url
                        | .env.ANTHROPIC_CUSTOM_HEADERS = $headers else . end)' \
     <<< "$base"); then
@@ -600,11 +711,11 @@ Crow-Session: $SESSION_ID"
   # owner-only — matching ConfigStore's 0600 on config.json.
   chmod 600 "$settings_path" 2>/dev/null || true
 
-  if [[ "$WS_HAS_GATEWAY" == true ]]; then
-    log "Wrote settings.local.json (attribution + gateway env) to $settings_path (agent: $display_name)"
-  else
-    log "Wrote attribution settings to $settings_path (agent: $display_name)"
-  fi
+  local wrote=""
+  [[ "$want_attribution" == true ]] && wrote="attribution"
+  [[ "$WS_HAS_GATEWAY" == true ]] && wrote="${wrote:+$wrote + }gateway env"
+  [[ -n "$WS_SESSION_ENV" ]] && wrote="${wrote:+$wrote + }session env"
+  log "Wrote settings.local.json ($wrote) to $settings_path (agent: $display_name)"
 
   # Belt-and-suspenders: add the file to the per-worktree git exclude so it
   # is never accidentally committed even if the repo's .gitignore does not

--- a/skills/crow-workspace/setup_session_env_test.sh
+++ b/skills/crow-workspace/setup_session_env_test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Unit tests for the generic per-session env injection in setup.sh (CROW-543).
+#
+# Sources setup.sh (the bottom `main` is guarded so sourcing is side-effect free)
+# and exercises substitute_session_env_tokens / resolve_session_env /
+# write_settings_local against a synthetic config.json. Mirrors the structure of
+# setup_gateway_test.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/setup.sh"
+
+pass=0; fail=0
+check() { # check <description> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    pass=$((pass+1)); echo "  ok: $1"
+  else
+    fail=$((fail+1)); echo "  FAIL: $1"; echo "    expected: [$2]"; echo "    actual:   [$3]"
+  fi
+}
+contains() { # contains <description> <haystack> <needle>
+  if [[ "$2" == *"$3"* ]]; then
+    pass=$((pass+1)); echo "  ok: $1"
+  else
+    fail=$((fail+1)); echo "  FAIL: $1"; echo "    [$2] does not contain [$3]"
+  fi
+}
+not_contains() { # not_contains <description> <haystack> <needle>
+  if [[ "$2" != *"$3"* ]]; then
+    pass=$((pass+1)); echo "  ok: $1"
+  else
+    fail=$((fail+1)); echo "  FAIL: $1"; echo "    [$2] unexpectedly contains [$3]"
+  fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Synthetic devRoot + config.json. RadiusMethod carries a sessionEnv map (one
+# templated value); Bare carries no sessionEnv; WithGateway carries both a
+# gateway block and a sessionEnv map (coexistence case).
+DEV_ROOT="$TMP/devroot"
+mkdir -p "$DEV_ROOT/.claude"
+cat > "$DEV_ROOT/.claude/config.json" <<'JSON'
+{
+  "workspaces": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "RadiusMethod",
+      "provider": "github",
+      "cli": "gh",
+      "sessionEnv": {
+        "COORD_SESSION_NAME": "{{session_name}}",
+        "STATIC_KEY": "fixed-value"
+      }
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "name": "Bare",
+      "provider": "github",
+      "cli": "gh"
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "WithGateway",
+      "provider": "github",
+      "cli": "gh",
+      "gateway": {
+        "baseURL": "https://corveil.io",
+        "customHeaders": { "x-plain": "literal-value" }
+      },
+      "sessionEnv": { "COORD_SESSION_NAME": "{{session_name}}" }
+    }
+  ]
+}
+JSON
+
+# Source the helpers (main is guarded). NOTE: sourcing runs the top-level global
+# initializers (DEV_ROOT="", WORKSPACE="", …), so reset globals *after* this.
+# shellcheck disable=SC1090
+source "$SETUP_SH"
+DEV_ROOT="$TMP/devroot"
+
+# Reset the per-case session-env state. resolve_session_env is idempotent via
+# WS_SESSION_ENV_RESOLVED, so flip it back to false between workspaces.
+reset_session_env() {
+  WS_SESSION_ENV=""
+  WS_SESSION_ENV_RESOLVED=false
+  CLI_SESSION_ENV=""
+}
+reset_gateway() {
+  WS_GATEWAY_RESOLVED=false; WS_HAS_GATEWAY=false; WS_BASE_URL=""; WS_CUSTOM_HEADERS=""
+}
+
+# ── 1. Config map → settings.local.json .env (token substitution) ──────────────
+echo "== config sessionEnv map =="
+WORKSPACE="RadiusMethod"
+SESSION_NAME="crow-543-session-env"
+SLUG="543-session-env"; BRANCH="feature/crow-543-session-env"; REPO="crow"
+TICKET_NUMBER="543"; TICKET_URL=""; SESSION_ID="ABCD-1234"
+WORKTREE_PATH="$DEV_ROOT/RadiusMethod/crow-543"
+reset_session_env; reset_gateway
+mkdir -p "$WORKTREE_PATH"
+
+resolve_session_env
+contains "WS_SESSION_ENV carries templated value" "$WS_SESSION_ENV" "COORD_SESSION_NAME=crow-543-session-env"
+contains "WS_SESSION_ENV carries static value" "$WS_SESSION_ENV" "STATIC_KEY=fixed-value"
+
+write_settings_local
+settings="$WORKTREE_PATH/.claude/settings.local.json"
+check "settings.local.json written" "yes" "$([[ -f "$settings" ]] && echo yes || echo no)"
+contains "env.COORD_SESSION_NAME = resolved session name" "$(cat "$settings")" '"COORD_SESSION_NAME": "crow-543-session-env"'
+contains "env.STATIC_KEY present" "$(cat "$settings")" '"STATIC_KEY": "fixed-value"'
+contains "attribution still written alongside session env" "$(cat "$settings")" '"attribution"'
+check "settings.local.json is 0600" "600" "$(stat -f '%Lp' "$settings" 2>/dev/null || stat -c '%a' "$settings")"
+
+# ── 2. Flag overrides a config key of the same name ────────────────────────────
+echo "== --session-env overrides config key =="
+reset_session_env
+CLI_SESSION_ENV="COORD_SESSION_NAME=from-flag"
+WORKTREE_PATH="$DEV_ROOT/RadiusMethod/crow-543-flag"
+mkdir -p "$WORKTREE_PATH"
+resolve_session_env
+write_settings_local
+settings="$WORKTREE_PATH/.claude/settings.local.json"
+contains "flag value wins for duplicate key" "$(cat "$settings")" '"COORD_SESSION_NAME": "from-flag"'
+not_contains "config value for duplicate key is gone" "$(cat "$settings")" '"COORD_SESSION_NAME": "crow-543-session-env"'
+contains "non-conflicting config key preserved" "$(cat "$settings")" '"STATIC_KEY": "fixed-value"'
+
+# ── 3. Flag-only on a workspace with no config map ─────────────────────────────
+echo "== --session-env only (no config map) =="
+WORKSPACE="Bare"
+reset_session_env; reset_gateway
+CLI_SESSION_ENV="FLAG_ONLY={{slug}}"
+WORKTREE_PATH="$DEV_ROOT/Bare/crow-543-flagonly"
+mkdir -p "$WORKTREE_PATH"
+resolve_session_env
+write_settings_local
+settings="$WORKTREE_PATH/.claude/settings.local.json"
+contains "flag-only key present with templated value" "$(cat "$settings")" '"FLAG_ONLY": "543-session-env"'
+
+# ── 4. No sessionEnv + no flag → no .env noise (backward compatible) ───────────
+echo "== no sessionEnv + no flag =="
+WORKSPACE="Bare"
+reset_session_env; reset_gateway
+WORKTREE_PATH="$DEV_ROOT/Bare/crow-543-noenv"
+mkdir -p "$WORKTREE_PATH"
+resolve_session_env
+check "WS_SESSION_ENV empty" "" "$WS_SESSION_ENV"
+write_settings_local
+settings="$WORKTREE_PATH/.claude/settings.local.json"
+# Attribution still writes (SESSION_ID set), but there must be no .env block.
+check "settings.local.json written for attribution" "yes" "$([[ -f "$settings" ]] && echo yes || echo no)"
+not_contains "no .env key when no session env / gateway" "$(cat "$settings")" '"env"'
+contains "attribution present" "$(cat "$settings")" '"attribution"'
+
+# ── 5. Coexistence with a gateway ──────────────────────────────────────────────
+echo "== session env + gateway coexist =="
+WORKSPACE="WithGateway"
+reset_session_env; reset_gateway
+WORKTREE_PATH="$DEV_ROOT/WithGateway/crow-543-gw"
+mkdir -p "$WORKTREE_PATH"
+write_settings_local   # resolves both gateway + session env internally
+settings="$WORKTREE_PATH/.claude/settings.local.json"
+contains "session env key present" "$(cat "$settings")" '"COORD_SESSION_NAME": "crow-543-session-env"'
+contains "gateway base URL present" "$(cat "$settings")" '"ANTHROPIC_BASE_URL": "https://corveil.io"'
+contains "gateway header present" "$(cat "$settings")" "x-plain: literal-value"
+contains "attribution present" "$(cat "$settings")" '"attribution"'
+
+echo
+echo "passed: $pass, failed: $fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Closes #543

## What

Adds a domain-agnostic per-session environment-injection mechanism to `setup.sh`, mirroring the existing per-workspace AI-gateway pattern. A workspace can declare arbitrary env vars that get baked into each new session's per-worktree `.claude/settings.local.json .env`.

- **Per-workspace `sessionEnv` map** on a `config.json` workspace entry (peer of `gateway` / `taskProvider` / `customInstructions`). Values support template tokens.
- **Repeatable `--session-env KEY=VALUE` flag**, merged on top of the config map (flag wins for duplicate keys).
- **Template tokens**: `{{session_name}}`, `{{slug}}`, `{{branch}}`, `{{ticket_number}}`, `{{repo}}`, `{{workspace}}`, `{{worktree_path}}`, `{{ticket_url}}`.

Motivating (not hardcoded) case: SecurityScorecard's coordination layer reads `COORD_SESSION_NAME` in a SessionStart hook to auto-name the session — now one config line in *that* workspace, not Crow code.

## How

New `resolve_session_env()` + `substitute_session_env_tokens()` sit beside `resolve_gateway_env()`. `write_settings_local()` folds the resolved pairs into the **same** jq `.env` merge as the gateway block. Session env is applied **before** the gateway/attribution assignments so those keys are never clobbered by a same-named session-env key, and the merge is length-guarded so a workspace with no `sessionEnv` and no flag produces **zero `.env` noise** (fully backward-compatible). The file remains `chmod 600` and git-excluded.

Changes are mirrored identically into `Resources/crow-workspace-setup.sh.template` (the release-build source loaded by `Scaffolder.bundledSetupScript()`); the two files still differ only by the pre-existing `jira_ops` drift. SKILL.md docs added to both the live skill and its byte-identical template.

## Acceptance evidence

Manual dry run with `sessionEnv: { "COORD_SESSION_NAME": "{{session_name}}" }` (workspace `SecurityScorecard`, session `ssc-coord-demo`) plus a `--session-env EXTRA_FLAG=on` flag → resulting `settings.local.json`:

```json
{
  "attribution": {
    "commit": "🐦‍⬛ Generated with Claude Code, orchestrated by Crow\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nCrow-Session: 11111111-2222-3333-4444-555555555555"
  },
  "env": {
    "COORD_SESSION_NAME": "ssc-coord-demo",
    "EXTRA_FLAG": "on"
  }
}
```

## Tests

- New `skills/crow-workspace/setup_session_env_test.sh` — **19/19 pass** (config map + token substitution, `--session-env` overrides a config key, flag-only, no-`sessionEnv`/no-flag → no `.env` noise, coexistence with gateway + attribution).
- Regression: `setup_gateway_test.sh` (17/17) and `setup_hook_test.sh` (27/27) still green.
- `bash -n` clean on both `setup.sh` and the template.
- Drift-guard (`AttributionSkillTests`) conditions verified manually: the `install_commit_hook` block stays byte-identical between live and template, and the SKILL.md trailer strings are present in both. (The Swift suite itself requires the prebuilt `GhosttyKit.xcframework`, which isn't available in this sandbox.)

## Out of scope

- The app's native "new session" button (doesn't go through `setup.sh`) — separate follow-up.
- Adding SecurityScorecard's actual `sessionEnv` line — lands separately once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)