### PR TITLE
Install crow CLI onto PATH via Scaffolder symlink

### DIFF
--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -196,14 +196,16 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
 
     // MARK: - Find crow Binary
 
-    /// Find the crow binary, checking common install locations.
-    public static func findCrowBinary() -> String? {
-        // Check same directory as running executable first (development builds)
+    /// Resolve the running app's own `crow` CLI — the bundled binary in a
+    /// release `.app` (`Contents/MacOS/crow`), or `.build/{config}/crow` in
+    /// dev. Does not consult `{devRoot}/.claude/bin/crow`; use that for
+    /// agent-facing resolution via `findCrowBinary(devRoot:)`.
+    public static func appCrowBinary() -> String? {
+        // Same directory as the running executable (dev + release bundles).
         let execURL = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
-        let buildDir = execURL.deletingLastPathComponent()
-        let devPath = buildDir.appendingPathComponent("crow").path
-        if FileManager.default.isExecutableFile(atPath: devPath) {
-            return devPath
+        let sibling = execURL.deletingLastPathComponent().appendingPathComponent("crow").path
+        if FileManager.default.isExecutableFile(atPath: sibling) {
+            return sibling
         }
 
         let candidates = [
@@ -217,5 +219,18 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
             }
         }
         return nil
+    }
+
+    /// Find the `crow` binary agents and hook configs should invoke. Prefers
+    /// `{devRoot}/.claude/bin/crow` when scaffolded and executable (CROW-552),
+    /// then falls back to `appCrowBinary()` and common install locations.
+    public static func findCrowBinary(devRoot: String? = nil) -> String? {
+        if let devRoot {
+            let symlink = (devRoot as NSString).appendingPathComponent(".claude/bin/crow")
+            if FileManager.default.isExecutableFile(atPath: symlink) {
+                return symlink
+            }
+        }
+        return appCrowBinary()
     }
 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -493,7 +493,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 NSLog("[Crow] Codex scaffold failed: %@", error.localizedDescription)
             }
-            if let crowPath = ClaudeHookConfigWriter.findCrowBinary() {
+            if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot) {
                 let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"]
                     ?? NSString(string: "~/.codex").expandingTildeInPath
                 do {
@@ -516,7 +516,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 NSLog("[Crow] Cursor scaffold failed: %@", error.localizedDescription)
             }
-            if let crowPath = ClaudeHookConfigWriter.findCrowBinary() {
+            if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot) {
                 let cursorHome = ProcessInfo.processInfo.environment["CURSOR_CONFIG_DIR"]
                     ?? NSString(string: "~/.cursor").expandingTildeInPath
                 do {
@@ -539,7 +539,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } catch {
                 NSLog("[Crow] OpenCode scaffold failed: %@", error.localizedDescription)
             }
-            if let crowPath = ClaudeHookConfigWriter.findCrowBinary() {
+            if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot) {
                 // XDG spec: an empty `XDG_CONFIG_HOME` is treated as unset, so
                 // fall through to ~/.config/opencode rather than a relative path.
                 let xdgConfig = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
@@ -1801,7 +1801,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             agent: agent,
                             sessionID: sessionID,
                             worktreePath: capturedAppState.primaryWorktree(for: sessionID)?.worktreePath,
-                            crowPath: ClaudeHookConfigWriter.findCrowBinary(),
+                            crowPath: ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot),
                             telemetryPort: capturedTelemetryPort
                         )
                         text = prepared.text

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -231,6 +231,9 @@ struct Scaffolder {
     /// Always materialize `{devRoot}/.claude/bin/crow` pointing at the running
     /// app's own CLI (CROW-552). Independent of `defaults.binaries` so every
     /// agent kind discovers `crow` via the tmux shell wrapper's PATH prepend.
+    /// Runs after `installBinarySymlinks`, so a user-set
+    /// `defaults.binaries["crow"]` is overwritten here by design — the app
+    /// binary always wins for PATH discovery.
     /// Idempotent — re-run on every scaffold pass; only ever owns symlinks.
     private func installCrowCLISymlink(claudeDir: String, appCrowPath: String?) {
         let fm = FileManager.default
@@ -249,9 +252,11 @@ struct Scaffolder {
             return
         }
 
-        if fm.fileExists(atPath: link) {
-            guard let attrs = try? fm.attributesOfItem(atPath: link),
-                  (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else {
+        // Drive off attributesOfItem, not fileExists — the latter follows
+        // symlinks, so a dangling `crow` link (target moved/deleted) looks
+        // absent and we'd skip removal, then createSymbolicLink hits EEXIST.
+        if let attrs = try? fm.attributesOfItem(atPath: link) {
+            guard (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else {
                 NSLog("[Scaffolder] crow exists at %@ but is not a symlink — leaving alone", link)
                 return
             }

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -1,3 +1,4 @@
+import CrowClaude
 import CrowCore
 import Foundation
 
@@ -33,11 +34,17 @@ struct Scaffolder {
     /// of `corveil` / `codex` / `cursor` inside spawned agent terminals, so
     /// embedded skills (e.g. `/query-corveil`) resolve to the user-configured
     /// binary instead of whatever happens to be on PATH.
+    ///
+    /// `appCrowBinaryPath` overrides the running app's crow CLI location when
+    /// materializing `{devRoot}/.claude/bin/crow` (CROW-552). Tests inject a
+    /// stand-in executable; production passes `nil` and uses
+    /// `ClaudeHookConfigWriter.appCrowBinary()`.
     @discardableResult
     func scaffold(workspaceNames: [String],
                   managerAgentKind: AgentKind = .claudeCode,
                   corveilBinaryPath: String? = nil,
-                  binaryOverrides: [String: String] = [:]) throws -> ScaffoldResult {
+                  binaryOverrides: [String: String] = [:],
+                  appCrowBinaryPath: String? = nil) throws -> ScaffoldResult {
         let fm = FileManager.default
 
         // Create devRoot
@@ -148,6 +155,7 @@ struct Scaffolder {
         // user rc — so `corveil`, `codex`, `cursor` resolve to the
         // user-configured binary regardless of what's on PATH.
         installBinarySymlinks(binaryOverrides, claudeDir: claudeDir)
+        installCrowCLISymlink(claudeDir: claudeDir, appCrowPath: appCrowBinaryPath)
 
         // Re-install the embedded /query-corveil slash command from the
         // user-configured corveil binary on every launch (CROW-482). Failure
@@ -169,6 +177,10 @@ struct Scaffolder {
     /// - Recreates good links with `removeItem` + `createSymbolicLink`,
     ///   matching `ln -sf` semantics.
     ///
+    /// Symlinks managed outside `defaults.binaries` — never reaped by
+    /// `installBinarySymlinks`, refreshed by their own installer.
+    private static let managedBinarySymlinks: Set<String> = ["crow"]
+
     /// All errors are logged + swallowed; this step is best-effort and must
     /// never fail an otherwise-successful scaffold pass.
     private func installBinarySymlinks(_ overrides: [String: String], claudeDir: String) {
@@ -185,7 +197,7 @@ struct Scaffolder {
         // anything that isn't a symlink — we never want to nuke a real
         // file that someone dropped here by hand.
         let existing = (try? fm.contentsOfDirectory(atPath: binDir)) ?? []
-        for name in existing where overrides[name] == nil {
+        for name in existing where overrides[name] == nil && !Self.managedBinarySymlinks.contains(name) {
             let link = (binDir as NSString).appendingPathComponent(name)
             if let attrs = try? fm.attributesOfItem(atPath: link),
                (attrs[.type] as? FileAttributeType) == .typeSymbolicLink {
@@ -213,6 +225,44 @@ struct Scaffolder {
                 NSLog("[Scaffolder] failed to symlink %@ -> %@: %@",
                       link, trimmed, error.localizedDescription)
             }
+        }
+    }
+
+    /// Always materialize `{devRoot}/.claude/bin/crow` pointing at the running
+    /// app's own CLI (CROW-552). Independent of `defaults.binaries` so every
+    /// agent kind discovers `crow` via the tmux shell wrapper's PATH prepend.
+    /// Idempotent — re-run on every scaffold pass; only ever owns symlinks.
+    private func installCrowCLISymlink(claudeDir: String, appCrowPath: String?) {
+        let fm = FileManager.default
+        let binDir = (claudeDir as NSString).appendingPathComponent("bin")
+        let link = (binDir as NSString).appendingPathComponent("crow")
+        let resolved = appCrowPath ?? ClaudeHookConfigWriter.appCrowBinary()
+
+        guard let target = resolved, fm.isExecutableFile(atPath: target) else {
+            if let attrs = try? fm.attributesOfItem(atPath: link),
+               (attrs[.type] as? FileAttributeType) == .typeSymbolicLink {
+                try? fm.removeItem(atPath: link)
+            }
+            if let resolved {
+                NSLog("[Scaffolder] app crow binary not executable at %@ — skipping symlink", resolved)
+            }
+            return
+        }
+
+        if fm.fileExists(atPath: link) {
+            guard let attrs = try? fm.attributesOfItem(atPath: link),
+                  (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else {
+                NSLog("[Scaffolder] crow exists at %@ but is not a symlink — leaving alone", link)
+                return
+            }
+            try? fm.removeItem(atPath: link)
+        }
+
+        do {
+            try fm.createSymbolicLink(atPath: link, withDestinationPath: target)
+        } catch {
+            NSLog("[Scaffolder] failed to symlink %@ -> %@: %@",
+                  link, target, error.localizedDescription)
         }
     }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -328,7 +328,7 @@ final class SessionService {
                 if trackReadiness {
                     // Re-write hook config so the adopted Claude's hooks still
                     // route back to the correct session if the config was lost.
-                    if let crowPath = ClaudeHookConfigWriter.findCrowBinary(),
+                    if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()),
                        let worktree = appState.primaryWorktree(for: terminal.sessionID) {
                         do {
                             try ClaudeHookConfigWriter().writeHookConfig(
@@ -468,7 +468,7 @@ final class SessionService {
                 agent: agent,
                 sessionID: sessionID,
                 worktreePath: appState.primaryWorktree(for: sessionID)?.worktreePath,
-                crowPath: ClaudeHookConfigWriter.findCrowBinary(),
+                crowPath: ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()),
                 telemetryPort: telemetryPort
             ).text
         }
@@ -544,7 +544,7 @@ final class SessionService {
 
         // Write/refresh hook config (Claude path). Codex's writer is a
         // no-op — its global config was installed once at app launch.
-        if let crowPath = ClaudeHookConfigWriter.findCrowBinary() {
+        if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()) {
             do {
                 try agent.hookConfigWriter.writeHookConfig(
                     worktreePath: worktree.worktreePath,
@@ -821,7 +821,7 @@ final class SessionService {
     /// latter's 0o600 re-apply stays the final write.
     private func writeManagerHookConfig(for session: Session, dirPath: String) {
         guard let agent = AgentRegistry.shared.agent(for: session.agentKind),
-              let crowPath = ClaudeHookConfigWriter.findCrowBinary() else { return }
+              let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()) else { return }
         do {
             try agent.hookConfigWriter.writeHookConfig(
                 worktreePath: dirPath,

--- a/Tests/CrowTests/ScaffolderBinarySymlinkTests.swift
+++ b/Tests/CrowTests/ScaffolderBinarySymlinkTests.swift
@@ -205,6 +205,31 @@ struct ScaffolderBinarySymlinkTests {
         #expect(try FileManager.default.destinationOfSymbolicLink(atPath: crowLink) == secondPath)
     }
 
+    @Test func crowCLISymlinkRepairsDanglingLinkWhenTargetDeleted() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let toolsDir = (devRoot as NSString).appendingPathComponent("_tools")
+        try FileManager.default.createDirectory(atPath: toolsDir, withIntermediateDirectories: true)
+        let firstPath = try Self.makeExecutable(in: toolsDir, name: "crow-old")
+        let secondPath = try Self.makeExecutable(in: toolsDir, name: "crow-new")
+
+        let scaffolder = Scaffolder(devRoot: devRoot)
+        _ = try scaffolder.scaffold(workspaceNames: [], appCrowBinaryPath: firstPath)
+
+        // Simulate the app binary moving (e.g. Crow.app drag to /Applications):
+        // the symlink target is gone but the link inode remains dangling.
+        try FileManager.default.removeItem(atPath: firstPath)
+
+        let crowLink = (devRoot as NSString).appendingPathComponent(".claude/bin/crow")
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: crowLink) == firstPath)
+        #expect(!FileManager.default.isExecutableFile(atPath: crowLink))
+
+        _ = try scaffolder.scaffold(workspaceNames: [], appCrowBinaryPath: secondPath)
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: crowLink) == secondPath)
+        #expect(FileManager.default.isExecutableFile(atPath: crowLink))
+    }
+
     @Test func nonSymlinkCrowFileInBinDirIsLeftAlone() throws {
         let devRoot = try Self.makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }

--- a/Tests/CrowTests/ScaffolderBinarySymlinkTests.swift
+++ b/Tests/CrowTests/ScaffolderBinarySymlinkTests.swift
@@ -151,4 +151,79 @@ struct ScaffolderBinarySymlinkTests {
             .appendingPathComponent(".claude/bin/corveil")
         #expect(try FileManager.default.destinationOfSymbolicLink(atPath: corveilLink) == secondPath)
     }
+
+    @Test func crowCLISymlinkAlwaysMaterialized() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let toolsDir = (devRoot as NSString).appendingPathComponent("_tools")
+        try FileManager.default.createDirectory(atPath: toolsDir, withIntermediateDirectories: true)
+        let appCrowPath = try Self.makeExecutable(in: toolsDir, name: "crow-app")
+
+        _ = try Scaffolder(devRoot: devRoot).scaffold(
+            workspaceNames: [],
+            appCrowBinaryPath: appCrowPath
+        )
+
+        let crowLink = (devRoot as NSString).appendingPathComponent(".claude/bin/crow")
+        #expect(FileManager.default.fileExists(atPath: crowLink))
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: crowLink) == appCrowPath)
+    }
+
+    @Test func crowCLISymlinkSurvivesEmptyBinaryOverrides() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let toolsDir = (devRoot as NSString).appendingPathComponent("_tools")
+        try FileManager.default.createDirectory(atPath: toolsDir, withIntermediateDirectories: true)
+        let appCrowPath = try Self.makeExecutable(in: toolsDir, name: "crow-app")
+
+        let scaffolder = Scaffolder(devRoot: devRoot)
+        _ = try scaffolder.scaffold(workspaceNames: [], appCrowBinaryPath: appCrowPath)
+        let crowLink = (devRoot as NSString).appendingPathComponent(".claude/bin/crow")
+        #expect(FileManager.default.fileExists(atPath: crowLink))
+
+        _ = try scaffolder.scaffold(workspaceNames: [], binaryOverrides: [:], appCrowBinaryPath: appCrowPath)
+        #expect(FileManager.default.fileExists(atPath: crowLink))
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: crowLink) == appCrowPath)
+    }
+
+    @Test func crowCLISymlinkRepointsWhenAppBinaryChanges() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let toolsDir = (devRoot as NSString).appendingPathComponent("_tools")
+        try FileManager.default.createDirectory(atPath: toolsDir, withIntermediateDirectories: true)
+        let firstPath = try Self.makeExecutable(in: toolsDir, name: "crow-a")
+        let secondPath = try Self.makeExecutable(in: toolsDir, name: "crow-b")
+
+        let scaffolder = Scaffolder(devRoot: devRoot)
+        _ = try scaffolder.scaffold(workspaceNames: [], appCrowBinaryPath: firstPath)
+        _ = try scaffolder.scaffold(workspaceNames: [], appCrowBinaryPath: secondPath)
+
+        let crowLink = (devRoot as NSString).appendingPathComponent(".claude/bin/crow")
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: crowLink) == secondPath)
+    }
+
+    @Test func nonSymlinkCrowFileInBinDirIsLeftAlone() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let binDir = (devRoot as NSString).appendingPathComponent(".claude/bin")
+        try FileManager.default.createDirectory(atPath: binDir, withIntermediateDirectories: true)
+        let strangerFile = (binDir as NSString).appendingPathComponent("crow")
+        try "user dropped this".write(toFile: strangerFile, atomically: true, encoding: .utf8)
+
+        let toolsDir = (devRoot as NSString).appendingPathComponent("_tools")
+        try FileManager.default.createDirectory(atPath: toolsDir, withIntermediateDirectories: true)
+        let appCrowPath = try Self.makeExecutable(in: toolsDir, name: "crow-app")
+
+        _ = try Scaffolder(devRoot: devRoot).scaffold(
+            workspaceNames: [],
+            appCrowBinaryPath: appCrowPath
+        )
+
+        let contents = try String(contentsOfFile: strangerFile, encoding: .utf8)
+        #expect(contents == "user dropped this")
+    }
 }


### PR DESCRIPTION
Closes #552

## Summary
- Scaffolder always materializes `{devRoot}/.claude/bin/crow` as a symlink to the running app's crow binary (dev `.build/{config}/crow` or release bundle `Contents/MacOS/crow`), independent of `defaults.binaries`.
- The crow symlink is managed separately from config-driven binary overrides — it survives re-scaffold passes, repoints when the app binary changes, and never clobbers a real file dropped by hand.
- `findCrowBinary(devRoot:)` prefers the scaffolded symlink so hook configs (Claude, Codex, Cursor, OpenCode) invoke crow through the stable PATH entry.

## Test plan
- [x] Added unit tests for crow symlink creation, persistence across empty overrides, repointing, and non-symlink safety
- [ ] Launch Crow, confirm `{devRoot}/.claude/bin/crow` exists and `command -v crow` succeeds in a fresh agent terminal
- [ ] OpenCode TUI + `crow hook-event` plugin resolves crow without manual PATH tweaks


Made with [Cursor](https://cursor.com)