### PR TITLE
Add opt-in auto-rebase + conflict-resolution setting (closes #551)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -35,12 +35,6 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// issue. While disabled, the label is left alone so a later opt-in
     /// can still pick up previously-labeled issues.
     public var autoCreateWatcherEnabled: Bool
-    /// When true, the IssueTracker rebases watched Crow-authored PR branches
-    /// onto their base and force-pushes (`--force-with-lease`) whenever they
-    /// fall BEHIND base or become CONFLICTING — no label required (unlike
-    /// `autoMergeWatcherEnabled`). Rebases that hit conflicts are handed to
-    /// the session's Claude terminal. Opt-in: defaults to false (CROW-318).
-    public var autoRebaseWatcherEnabled: Bool
     public var cleanup: CleanupConfig
     /// Scheduled jobs: named sets of prompts that fire automatically on a
     /// schedule, scoped to a repo. Driven by `JobScheduler` (CROW-317).
@@ -94,7 +88,6 @@ public struct AppConfig: Codable, Sendable, Equatable {
         attributionTrailers: Bool = true,
         autoMergeWatcherEnabled: Bool = false,
         autoCreateWatcherEnabled: Bool = false,
-        autoRebaseWatcherEnabled: Bool = false,
         cleanup: CleanupConfig = CleanupConfig(),
         jobs: [JobConfig] = [],
         defaultAgentKind: AgentKind = .claudeCode,
@@ -114,7 +107,6 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.attributionTrailers = attributionTrailers
         self.autoMergeWatcherEnabled = autoMergeWatcherEnabled
         self.autoCreateWatcherEnabled = autoCreateWatcherEnabled
-        self.autoRebaseWatcherEnabled = autoRebaseWatcherEnabled
         self.cleanup = cleanup
         self.jobs = jobs
         self.defaultAgentKind = defaultAgentKind
@@ -137,7 +129,15 @@ public struct AppConfig: Codable, Sendable, Equatable {
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
         autoMergeWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoMergeWatcherEnabled) ?? false
         autoCreateWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoCreateWatcherEnabled) ?? false
-        autoRebaseWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoRebaseWatcherEnabled) ?? false
+        // Backward-compat (CROW-551): the pre-CROW-551 top-level
+        // `autoRebaseWatcherEnabled` moved into
+        // `autoRespond.autoRebaseAndResolveConflicts`. Carry an existing opt-in
+        // forward; the legacy key stays out of `CodingKeys`, so the next encode
+        // drops it and a later opt-out sticks.
+        let rebaseLegacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
+        if try rebaseLegacyContainer.decodeIfPresent(Bool.self, forKey: .autoRebaseWatcherEnabled) == true {
+            autoRespond.autoRebaseAndResolveConflicts = true
+        }
         cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
         jobs = try container.decodeIfPresent([JobConfig].self, forKey: .jobs) ?? []
         defaultAgentKind = try container.decodeIfPresent(AgentKind.self, forKey: .defaultAgentKind) ?? .claudeCode
@@ -177,10 +177,11 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// property (so they must stay out of `CodingKeys`, which drives encoding).
     private enum LegacyCodingKeys: String, CodingKey {
         case atlassianMCP
+        case autoRebaseWatcherEnabled
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, autoRebaseWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential
     }
 
     /// Resolve the agent that should drive a newly-created session of the
@@ -335,23 +336,33 @@ public struct AutoRespondSettings: Codable, Sendable, Equatable {
     /// `checksPass == .failing` (keyed on the head SHA, so re-runs of the
     /// same commit don't re-fire).
     public var respondToFailedChecks: Bool
+    /// Auto-rebase Crow-authored PR branches that fall BEHIND base or become
+    /// CONFLICTING: rebase onto base and force-push (`--force-with-lease`);
+    /// when the rebase hits conflicts, inject the fixConflicts prompt into the
+    /// session's managed terminal so Claude resolves them. Force-push-bearing,
+    /// so opt-in: defaults to false (CROW-551; formerly the top-level
+    /// `autoRebaseWatcherEnabled`, CROW-318).
+    public var autoRebaseAndResolveConflicts: Bool
 
     public init(
         respondToChangesRequested: Bool = true,
-        respondToFailedChecks: Bool = false
+        respondToFailedChecks: Bool = false,
+        autoRebaseAndResolveConflicts: Bool = false
     ) {
         self.respondToChangesRequested = respondToChangesRequested
         self.respondToFailedChecks = respondToFailedChecks
+        self.autoRebaseAndResolveConflicts = autoRebaseAndResolveConflicts
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         respondToChangesRequested = try c.decodeIfPresent(Bool.self, forKey: .respondToChangesRequested) ?? true
         respondToFailedChecks = try c.decodeIfPresent(Bool.self, forKey: .respondToFailedChecks) ?? false
+        autoRebaseAndResolveConflicts = try c.decodeIfPresent(Bool.self, forKey: .autoRebaseAndResolveConflicts) ?? false
     }
 
     private enum CodingKeys: String, CodingKey {
-        case respondToChangesRequested, respondToFailedChecks
+        case respondToChangesRequested, respondToFailedChecks, autoRebaseAndResolveConflicts
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -103,6 +103,28 @@ import Testing
     #expect(config.autoMergeWatcherEnabled == false)
 }
 
+@Test func appConfigMigratesLegacyAutoRebaseWatcherEnabled() throws {
+    // CROW-551: the top-level `autoRebaseWatcherEnabled` moved into
+    // `autoRespond.autoRebaseAndResolveConflicts`. An existing opt-in carries
+    // forward across the upgrade.
+    let json = #"{"autoRebaseWatcherEnabled": true}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.autoRespond.autoRebaseAndResolveConflicts == true)
+
+    // Re-encoding drops the legacy key, so a later opt-out sticks.
+    let reencoded = try JSONEncoder().encode(config)
+    let reencodedJSON = String(data: reencoded, encoding: .utf8)!
+    #expect(!reencodedJSON.contains("autoRebaseWatcherEnabled"))
+}
+
+@Test func appConfigLegacyAutoRebaseWatcherFalseOrMissingStaysOff() throws {
+    let missing = try JSONDecoder().decode(AppConfig.self, from: #"{"workspaces":[]}"#.data(using: .utf8)!)
+    #expect(missing.autoRespond.autoRebaseAndResolveConflicts == false)
+
+    let explicitOff = try JSONDecoder().decode(AppConfig.self, from: #"{"autoRebaseWatcherEnabled": false}"#.data(using: .utf8)!)
+    #expect(explicitOff.autoRespond.autoRebaseAndResolveConflicts == false)
+}
+
 @Test func appConfigAutoCreateWatcherEnabledRoundTrip() throws {
     var config = AppConfig()
     config.autoCreateWatcherEnabled = true

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -117,6 +117,19 @@ import Testing
     #expect(!reencodedJSON.contains("autoRebaseWatcherEnabled"))
 }
 
+@Test func appConfigLegacyAutoRebaseWatcherTrueWinsOverExplicitNestedFalse() throws {
+    // Edge case documenting the one-time upgrade semantics: when both keys
+    // coexist, the legacy top-level opt-in ORs into the nested field even if
+    // the nested key is explicitly false. No real pre-CROW-551 config can
+    // have written the nested key, and the legacy key is dropped on the next
+    // encode — so after one save an explicit nested false can no longer be
+    // overridden.
+    let json = #"{"autoRebaseWatcherEnabled": true, "autoRespond": {"autoRebaseAndResolveConflicts": false}}"#
+        .data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.autoRespond.autoRebaseAndResolveConflicts == true)
+}
+
 @Test func appConfigLegacyAutoRebaseWatcherFalseOrMissingStaysOff() throws {
     let missing = try JSONDecoder().decode(AppConfig.self, from: #"{"workspaces":[]}"#.data(using: .utf8)!)
     #expect(missing.autoRespond.autoRebaseAndResolveConflicts == false)

--- a/Packages/CrowCore/Tests/CrowCoreTests/AutoRespondSettingsDefaultsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AutoRespondSettingsDefaultsTests.swift
@@ -44,4 +44,24 @@ struct AutoRespondSettingsDefaultsTests {
         #expect(decoded.respondToChangesRequested == true)
         #expect(decoded.respondToFailedChecks == true)
     }
+
+    // CROW-551: auto-rebase + resolve-conflicts is force-push-bearing, so it
+    // stays opt-in (off by default), unlike respondToChangesRequested.
+    @Test func autoRebaseAndResolveConflictsDefaultsOff() throws {
+        #expect(AutoRespondSettings().autoRebaseAndResolveConflicts == false)
+
+        let json = "{}".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AutoRespondSettings.self, from: json)
+        #expect(decoded.autoRebaseAndResolveConflicts == false)
+    }
+
+    @Test func autoRebaseAndResolveConflictsExplicitChoiceIsSticky() throws {
+        let onJSON = #"{"autoRebaseAndResolveConflicts": true}"#.data(using: .utf8)!
+        let on = try JSONDecoder().decode(AutoRespondSettings.self, from: onJSON)
+        #expect(on.autoRebaseAndResolveConflicts == true)
+
+        let offJSON = #"{"autoRebaseAndResolveConflicts": false}"#.data(using: .utf8)!
+        let off = try JSONDecoder().decode(AutoRespondSettings.self, from: offJSON)
+        #expect(off.autoRebaseAndResolveConflicts == false)
+    }
 }

--- a/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
@@ -14,7 +14,6 @@ public struct AutomationSettingsView: View {
     @Binding var attributionTrailers: Bool
     @Binding var autoMergeWatcherEnabled: Bool
     @Binding var autoCreateWatcherEnabled: Bool
-    @Binding var autoRebaseWatcherEnabled: Bool
     var onSave: (() -> Void)?
 
     @State private var managerGatewayBaseURL: String
@@ -33,7 +32,6 @@ public struct AutomationSettingsView: View {
         attributionTrailers: Binding<Bool>,
         autoMergeWatcherEnabled: Binding<Bool>,
         autoCreateWatcherEnabled: Binding<Bool>,
-        autoRebaseWatcherEnabled: Binding<Bool>,
         onSave: (() -> Void)? = nil
     ) {
         self._defaults = defaults
@@ -45,7 +43,6 @@ public struct AutomationSettingsView: View {
         self._attributionTrailers = attributionTrailers
         self._autoMergeWatcherEnabled = autoMergeWatcherEnabled
         self._autoCreateWatcherEnabled = autoCreateWatcherEnabled
-        self._autoRebaseWatcherEnabled = autoRebaseWatcherEnabled
         self.onSave = onSave
         self._managerGatewayBaseURL = State(initialValue: managerGateway.wrappedValue?.baseURL ?? "")
         self._managerGatewayHeadersText = State(initialValue: managerGateway.wrappedValue.map {
@@ -235,14 +232,6 @@ public struct AutomationSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("Auto-rebase") {
-                Toggle("Auto-rebase Crow-authored PR branches that fall behind or conflict", isOn: $autoRebaseWatcherEnabled)
-                    .onChange(of: autoRebaseWatcherEnabled) { _, _ in onSave?() }
-                Text("When a PR linked to a Crow session falls behind its base or develops conflicts, Crow rebases the session's worktree onto the base and force-pushes with --force-with-lease. No label required. Only PRs whose commits include a Crow-Session trailer matching a known session are eligible. If the rebase hits conflicts, Crow asks the session's Claude Code terminal to resolve them. Off by default.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
             autoRespondSection
         }
         .formStyle(.grouped)
@@ -256,6 +245,11 @@ public struct AutomationSettingsView: View {
             Toggle("Respond to failed CI checks", isOn: $autoRespond.respondToFailedChecks)
                 .onChange(of: autoRespond.respondToFailedChecks) { _, _ in onSave?() }
             Text("When enabled, Crow types an instruction into the session's Claude Code terminal asking Claude to read the review or CI logs and address the issue. Off by default — typing into a terminal unprompted is intrusive.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Toggle("Auto-rebase onto base and resolve conflicts", isOn: $autoRespond.autoRebaseAndResolveConflicts)
+                .onChange(of: autoRespond.autoRebaseAndResolveConflicts) { _, _ in onSave?() }
+            Text("When a Crow-authored PR falls behind its base or develops conflicts, Crow rebases the session's worktree onto the base and force-pushes with --force-with-lease. No label required. Only PRs whose commits include a Crow-Session trailer matching a known session are eligible. If the rebase hits conflicts, Crow asks the session's Claude Code terminal to resolve them. Never applies to review sessions. Off by default.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         } header: {

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -106,7 +106,6 @@ public struct SettingsView: View {
                 attributionTrailers: $config.attributionTrailers,
                 autoMergeWatcherEnabled: $config.autoMergeWatcherEnabled,
                 autoCreateWatcherEnabled: $config.autoCreateWatcherEnabled,
-                autoRebaseWatcherEnabled: $config.autoRebaseWatcherEnabled,
                 onSave: { save() }
             )
                 .tabItem { Label("Automation", systemImage: "bolt.fill") }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -842,8 +842,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         tracker.onAutoMergeEnabled = { [weak self] sessionID, prURL, number in
             self?.notificationManager?.notifyAutoMergeEnabled(prURL: prURL, number: number, sessionID: sessionID)
         }
-        tracker.autoRebaseWatcherEnabledProvider = { [weak self] in
-            self?.appConfig?.autoRebaseWatcherEnabled ?? false
+        tracker.autoRebaseAndResolveConflictsProvider = { [weak self] in
+            self?.appConfig?.autoRespond.autoRebaseAndResolveConflicts ?? false
         }
         tracker.respondToChangesRequestedProvider = { [weak self] in
             self?.appConfig?.autoRespond.respondToChangesRequested ?? false

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -70,11 +70,12 @@ final class IssueTracker {
     /// lands in Console regardless of notification settings.)
     var onAutoMergeEnabled: ((UUID, String, Int) -> Void)?
 
-    /// Reads the latest `AppConfig.autoRebaseWatcherEnabled` snapshot on every
-    /// poll. Closure (not a stored value) so toggling the setting takes effect
-    /// on the next refresh. Defaults to a closure returning `false` so the
-    /// watcher is inert until AppDelegate wires it (CROW-318).
-    var autoRebaseWatcherEnabledProvider: () -> Bool = { false }
+    /// Reads the latest `AutoRespondSettings.autoRebaseAndResolveConflicts`
+    /// snapshot on every poll. Closure (not a stored value) so toggling the
+    /// setting takes effect on the next refresh. Defaults to a closure
+    /// returning `false` so the watcher is inert until AppDelegate wires it
+    /// (CROW-318, moved into AutoRespondSettings by CROW-551).
+    var autoRebaseAndResolveConflictsProvider: () -> Bool = { false }
 
     /// Reads the latest `AutoRespondSettings.respondToChangesRequested`
     /// snapshot on every poll. Gates the stateless "needs refine" emission
@@ -1954,13 +1955,17 @@ final class IssueTracker {
 
     /// Per-refresh entry point for the auto-rebase watcher. Picks candidate
     /// (session, PR) pairs and kicks off one rebase attempt per head commit.
-    /// No-op when `autoRebaseWatcherEnabled` is off.
+    /// No-op when `autoRespond.autoRebaseAndResolveConflicts` is off.
     private func applyAutoRebase(viewerPRs: [ViewerPR]) {
-        guard autoRebaseWatcherEnabledProvider() else { return }
+        guard autoRebaseAndResolveConflictsProvider() else { return }
         guard !viewerPRs.isEmpty else { return }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
         for session in appState.sessions where session.id != AppState.managerSessionID {
+            // Review sessions exist to review someone else's PR — never rewrite
+            // the branch under review, regardless of the toggle (same policy as
+            // AutoRespondCoordinator.shouldSkipReviewSession).
+            guard session.kind != .review else { continue }
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
             guard !autoRebaseInFlight.contains(prLink.url) else { continue }
             guard let pr = byURL[prLink.url] else { continue }

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1953,6 +1953,16 @@ final class IssueTracker {
         return pr.mergeStateStatus == "BEHIND" || pr.mergeable == "CONFLICTING"
     }
 
+    /// Whether a session may be considered by the auto-rebase watcher at all.
+    /// Pure so unit tests can exercise it without an `IssueTracker`. The
+    /// Manager session never owns a PR branch, and review sessions exist to
+    /// review someone else's PR — never rewrite the branch under review,
+    /// regardless of the toggle (same policy as
+    /// `AutoRespondCoordinator.shouldSkipReviewSession`, CROW-551).
+    nonisolated static func sessionEligibleForAutoRebase(_ session: Session) -> Bool {
+        session.id != AppState.managerSessionID && session.kind != .review
+    }
+
     /// Per-refresh entry point for the auto-rebase watcher. Picks candidate
     /// (session, PR) pairs and kicks off one rebase attempt per head commit.
     /// No-op when `autoRespond.autoRebaseAndResolveConflicts` is off.
@@ -1961,11 +1971,7 @@ final class IssueTracker {
         guard !viewerPRs.isEmpty else { return }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
-        for session in appState.sessions where session.id != AppState.managerSessionID {
-            // Review sessions exist to review someone else's PR — never rewrite
-            // the branch under review, regardless of the toggle (same policy as
-            // AutoRespondCoordinator.shouldSkipReviewSession).
-            guard session.kind != .review else { continue }
+        for session in appState.sessions where Self.sessionEligibleForAutoRebase(session) {
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
             guard !autoRebaseInFlight.contains(prLink.url) else { continue }
             guard let pr = byURL[prLink.url] else { continue }

--- a/Tests/CrowTests/IssueTrackerAutoRebaseTests.swift
+++ b/Tests/CrowTests/IssueTrackerAutoRebaseTests.swift
@@ -95,6 +95,27 @@ struct IssueTrackerAutoRebaseTests {
         #expect(!IssueTracker.shouldAttemptAutoRebase(pr: pr))
     }
 
+    // MARK: - Session eligibility (CROW-551)
+
+    /// Review sessions must never be auto-rebased: Crow would be force-pushing
+    /// over someone else's PR under review. Policy gate independent of the
+    /// `autoRebaseAndResolveConflicts` toggle, mirroring
+    /// `AutoRespondCoordinator.shouldSkipReviewSession`.
+    @Test func excludesReviewSessions() {
+        let review = Session(name: "review-crow-42", kind: .review)
+        #expect(!IssueTracker.sessionEligibleForAutoRebase(review))
+    }
+
+    @Test func allowsWorkSessions() {
+        let work = Session(name: "feature-crow-42", kind: .work)
+        #expect(IssueTracker.sessionEligibleForAutoRebase(work))
+    }
+
+    @Test func excludesManagerSession() {
+        let manager = Session(id: AppState.managerSessionID, name: "Manager", kind: .manager)
+        #expect(!IssueTracker.sessionEligibleForAutoRebase(manager))
+    }
+
     // MARK: - Failed-rebase retry policy
 
     @Test func retriesFailuresUnderTheCap() {


### PR DESCRIPTION
Closes #551

## What

Adds the opt-in **"Auto-rebase onto base and resolve conflicts"** toggle to `AutoRespondSettings`, rendered as a third row in Settings → Automation → Auto-respond next to the changes-requested and failed-CI toggles. Off by default (it force-pushes).

## Key discovery

The ticket assumed the auto-rebase path might be ungated — it wasn't. It was already gated by the top-level `AppConfig.autoRebaseWatcherEnabled` (CROW-318), which had its own standalone "Auto-rebase" Settings section. So this PR **consolidates instead of duplicating**: the top-level flag is replaced by `autoRespond.autoRebaseAndResolveConflicts`, exactly where the ticket wants it. Two toggles gating one force-push-bearing behavior would have been confusing.

## Changes

- **`AutoRespondSettings.autoRebaseAndResolveConflicts`** — default off, `decodeIfPresent ?? false` (sticky explicit choices), same persistence as the sibling toggles.
- **Config migration** — a legacy top-level `"autoRebaseWatcherEnabled": true` in an existing `config.json` carries the opt-in forward on decode (via the established `LegacyCodingKeys` pattern); the legacy key is dropped on the next save, so a later opt-out sticks.
- **`IssueTracker`** — provider renamed to `autoRebaseAndResolveConflictsProvider`, wired in `AppDelegate` to the nested setting; `applyAutoRebase` no-ops when the toggle is off. **New:** review sessions are explicitly skipped — Crow never rewrites the branch under review, regardless of the toggle (same policy as `AutoRespondCoordinator.shouldSkipReviewSession`).
- **Settings UI** — the standalone "Auto-rebase" section is folded into the Auto-respond section with copy that makes the `--force-with-lease` force-push explicit.
- **Unchanged safety behavior** — conflict hand-off still flows through `dispatchManual(.fixConflicts)`, which enforces the managed-terminal / initialized-surface / PR-link guards; on conflicts the rebase is aborted (clean tree) before delegation; the manual "Fix conflicts" quick action remains available with the toggle off (explicit click = consent).

No ADR: the default stays off and runtime behavior is unchanged — this is a settings-location consolidation plus an explicit review-session policy guard.

## Testing

- New `CrowCore` tests: default-off + sticky decode for the new field; legacy-key migration (true carries forward, false/missing stays off, re-encode drops the key).
- `swift test` green: CrowCore (325 tests) and root CrowTests (250 tests); CrowUI and CrowPersistence build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)