### PR TITLE
Fix SocketServer sync→async bridge for Swift 6.2 strict concurrency

### DIFF
--- a/Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift
+++ b/Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift
@@ -156,18 +156,18 @@ public final class SocketServer: @unchecked Sendable {
         // request at a time. A full async I/O rewrite would avoid the blocked
         // thread but is out of scope for the current architecture.
         let semaphore = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var response: JSONRPCResponse?
+        let responseBox = ResponseBox()
         let capturedRouter = router
         let capturedRequest = request
 
         Task {
-            response = await capturedRouter.handle(request: capturedRequest)
+            responseBox.value = await capturedRouter.handle(request: capturedRequest)
             semaphore.signal()
         }
 
         semaphore.wait()
 
-        if let response {
+        if let response = responseBox.value {
             writeResponse(response, to: fd)
         }
     }
@@ -188,6 +188,14 @@ public final class SocketServer: @unchecked Sendable {
             }
         }
     }
+}
+
+/// Thread-safe carrier that lets the async handler hand its result back to the
+/// blocked socket thread. Access is serialized by the surrounding semaphore
+/// (the value is only read after `semaphore.wait()` observes the signal), so
+/// `@unchecked Sendable` is sound here.
+private final class ResponseBox: @unchecked Sendable {
+    var value: JSONRPCResponse?
 }
 
 public enum SocketError: Error, LocalizedError {


### PR DESCRIPTION
## Summary

Fixes the build failure on the Swift 6.2 toolchain (Intel Mac / current Xcode default). The xterm.js migration (#556) compiles fine; the blocker was a pre-existing `CrowIPC` issue that only surfaces under Swift 6.2's stricter concurrency checker.

`handleClient` bridges sync socket I/O to the async `CommandRouter.handle` via a `DispatchSemaphore`. It captured a `nonisolated(unsafe) var response` and mutated it inside a `Task { }` — capturing a mutable `var` makes the closure non-Sendable, which Swift 6.2 rejects when passing it to `Task.init` (`#SendingRisksDataRace`).

The fix replaces the loose `nonisolated(unsafe) var` with a small `ResponseBox` reference type marked `@unchecked Sendable`. The result is still handed back across the same semaphore barrier (written before `signal()`, read after `wait()`), so synchronization is unchanged and the `@unchecked` is sound — the Task closure is now fully Sendable.

## Test plan

- [x] `make build` (arm64) → Build complete
- [x] `swift build --arch x86_64` (Intel compile check) → Build complete

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)