### PR TITLE
Fix Swift 6.2 strict-concurrency build failure in SocketServer

### DIFF
--- a/Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift
+++ b/Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift
@@ -156,18 +156,18 @@ public final class SocketServer: @unchecked Sendable {
         // request at a time. A full async I/O rewrite would avoid the blocked
         // thread but is out of scope for the current architecture.
         let semaphore = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var response: JSONRPCResponse?
+        let box = ResponseBox()
         let capturedRouter = router
         let capturedRequest = request
 
         Task {
-            response = await capturedRouter.handle(request: capturedRequest)
+            box.value = await capturedRouter.handle(request: capturedRequest)
             semaphore.signal()
         }
 
         semaphore.wait()
 
-        if let response {
+        if let response = box.value {
             writeResponse(response, to: fd)
         }
     }
@@ -188,6 +188,15 @@ public final class SocketServer: @unchecked Sendable {
             }
         }
     }
+}
+
+/// Single-slot carrier used to hand the async handler's result back across the
+/// semaphore barrier in `handleClient`. Written once inside the `Task` before
+/// `signal()`, read once after `wait()`; the semaphore provides the happens-before
+/// ordering, so unsynchronized access is safe. Marked `@unchecked Sendable` so the
+/// `Task` closure that captures it stays Sendable under Swift 6.2 strict concurrency.
+private final class ResponseBox: @unchecked Sendable {
+    var value: JSONRPCResponse?
 }
 
 public enum SocketError: Error, LocalizedError {


### PR DESCRIPTION
## Problem

`make build` and `swift build --arch x86_64` fail on the Swift 6.2 toolchain (Xcode's default on Intel Macs) with:

```
Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift:163:9: error: sending value of non-Sendable type '() async -> ()' risks causing data races [#SendingRisksDataRace]
```

Pre-existing in `CrowIPC`; only surfaces under 6.2's stricter concurrency checker. Unrelated to the xterm.js migration (#556).

## Root cause

`handleClient` bridges sync socket I/O to the async `CommandRouter.handle` via a `DispatchSemaphore`. It captured a `nonisolated(unsafe) var response` and mutated it inside a `Task { }`. Capturing a mutable `var` makes the closure non-Sendable, which Swift 6.2 rejects when passing it to `Task.init`.

## Fix

Replace the loose `nonisolated(unsafe) var` with a small `ResponseBox` reference type marked `@unchecked Sendable`. The result is handed back across the same semaphore barrier (written before `signal()`, read after `wait()`), so synchronization is unchanged.

## Verification

- `make build` (arm64) → **Build complete**
- `swift build --arch x86_64` (Intel compile check) → **Build complete**

Closes #559