### PR TITLE
Disable automatic Touch Bar to fix first-window SIGSEGV (#563)

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -324,7 +324,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hostingView = NSHostingView(rootView: wizardView)
-        let window = NSWindow(
+        let window = NoTouchBarWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 420),
             styleMask: [.titled, .closable],
             backing: .buffered,
@@ -1009,7 +1009,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Close wizard window if it exists, create main window
         window?.close()
 
-        let mainWindow = NSWindow(
+        let mainWindow = NoTouchBarWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1200, height: 800),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
@@ -1159,7 +1159,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hostingView = NSHostingView(rootView: AboutView())
-        let win = NSWindow(
+        let win = NoTouchBarWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 380),
             styleMask: [.titled, .closable],
             backing: .buffered,
@@ -1229,7 +1229,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         let hostingView = NSHostingView(rootView: settingsView)
-        let win = NSWindow(
+        let win = NoTouchBarWindow(
             contentRect: NSRect(x: 0, y: 0, width: 720, height: 480),
             styleMask: [.titled, .closable],
             backing: .buffered,

--- a/Sources/Crow/App/NoTouchBarWindow.swift
+++ b/Sources/Crow/App/NoTouchBarWindow.swift
@@ -1,0 +1,11 @@
+import AppKit
+
+/// An `NSWindow` that opts out of AppKit's automatic Touch Bar.
+///
+/// Crow never uses the Touch Bar, and the automatic teardown path
+/// (`NSTouchBarFinder` → `NSMapTable dealloc`) intermittently SIGSEGVs during
+/// the first window display commit (crow#563). Returning `nil` here keeps the
+/// window's `touchBar` nil, so that code path is never exercised.
+final class NoTouchBarWindow: NSWindow {
+    override func makeTouchBar() -> NSTouchBar? { nil }
+}


### PR DESCRIPTION
Closes #563

## Problem

On cold launch Crow intermittently crashes with a **SIGSEGV during the first window's display-cycle commit**, inside AppKit's automatic Touch Bar teardown:

```
4  Foundation  dealloc
5  Foundation  -[NSConcreteMapTable dealloc]
6  AppKit  ___NSTouchBarFinderSetNeedsUpdateOnMain_block_invoke_2
7  AppKit  NSDisplayCycleObserverInvoke
...
10 QuartzCore  CA::Transaction::commit
```

`NSTouchBar` tracks its items in an `NSMapTable` of weak references. During the first `NSHostingView` (SwiftUI-in-AppKit) display commit, an object it weakly holds is released out from under it, so the map-table `dealloc` segfaults. It is timing-dependent — an immediate relaunch renders fine. The crashing launch had **0 sessions / no terminal-WKWebView yet**, so this is *not* related to the xterm.js migration (#556); it dies right after `[Crow] Main app launch complete — creating window`.

## Fix

Crow never uses the Touch Bar, so opt every window out of the automatic Touch Bar to remove the entire code path the crash lives in. Adds a small `NoTouchBarWindow: NSWindow` subclass that overrides `makeTouchBar()` to return `nil`, and uses it at all four `NSWindow` construction sites (setup wizard, main, about, settings) in `AppDelegate`. This is preferred over the undocumented `NSFunctionBarAPIEnabled` default.

## Testing

- `make build` / `swift build` — clean, no new warnings.
- The rebuilt `CrowApp` binary launches and starts cleanly with no crash on load.
- Full cold-launch exercise of the main-window first-display path could not be run in this environment because a live Crow instance (the one hosting the dev session) holds the single-instance lock; a fresh cold launch detects the running instance and exits before creating the main window. The primary evidence is that **no window ever constructs an `NSTouchBar`**, so the crashing teardown path is removed entirely.
- Per the ticket, final confirmation should be on the Intel Mac (macOS 15 / Darwin 24.6) repro environment.