### PR TITLE
Wire Manager process-exit banner via tmux exit monitor (#558)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -78,6 +78,12 @@ public final class TmuxBackend {
     /// `onReadinessChanged` for a tab the user just closed. Issue #282.
     private var readinessTasks: [UUID: [Task<Void, Never>]] = [:]
 
+    /// Poll loop watching the Manager window's foreground command so the
+    /// "Manager process exited" banner reappears under the shared xterm.js
+    /// attach client (#558). At most one runs at a time; re-armed by
+    /// `SessionService` on launch / restart. See `startManagerExitMonitor`.
+    private var managerExitMonitor: Task<Void, Never>?
+
     /// Public for test isolation. Production callers use `.shared`.
     public init() {}
 
@@ -143,6 +149,9 @@ public final class TmuxBackend {
         // cleanup (#282).
         for tasks in readinessTasks.values { tasks.forEach { $0.cancel() } }
         readinessTasks.removeAll()
+        // Stop the Manager exit poll too — its window is gone with the server
+        // (#558). `SessionService` re-arms it after `rebuildAllSurfaces`.
+        stopManagerExitMonitor()
         // Only unlink the per-terminal scratch files when we're actually
         // killing the server. On a clean quit that leaves the server running
         // they must survive so the next launch's `adoptTerminal` can detect
@@ -575,6 +584,20 @@ public final class TmuxBackend {
         return orphanLoginShells.contains(command)
     }
 
+    /// Decide whether the Manager agent has exited, from one poll sample of its
+    /// window's foreground command (#558). Because the agent (`claude …`) runs
+    /// *inside* the window's shell wrapper rather than as the pane's direct
+    /// child, its exit doesn't kill the pane — the foreground just falls back to
+    /// a bare login shell. So we report an exit only once we've seen the agent
+    /// actually running (`sawAgentRunning`, a non-shell foreground) and now see
+    /// a bare login shell. `nil` (window gone / read failed) is never an exit —
+    /// that path also covers teardown, keeping restart/shutdown false-positive
+    /// free. Pure so the transition policy is unit-testable without tmux.
+    nonisolated static func managerAgentDidExit(paneCommand: String?, sawAgentRunning: Bool) -> Bool {
+        guard sawAgentRunning, let command = paneCommand else { return false }
+        return orphanLoginShells.contains(command)
+    }
+
     /// Reap cockpit windows that no live terminal references AND that are
     /// sitting at a bare login shell — leaked windows from a timed-out
     /// `new-window` or a forgotten terminal (#408). `keepWindowIndices` is the
@@ -602,6 +625,66 @@ public final class TmuxBackend {
             NSLog("[Crow] Reaped \(reaped) orphaned bare-shell cockpit window(s) (#408)")
         }
         return reaped
+    }
+
+    // MARK: - Manager exit monitor (#558)
+
+    /// Watch the Manager terminal's tmux window and fire `onExit` the first time
+    /// its foreground command falls back to a bare login shell after the agent
+    /// was seen running — i.e. the Manager's `claude`/`codex`/… process exited.
+    ///
+    /// Under the shared xterm.js cockpit, `XTermSurfaceView.onProcessExit` only
+    /// fires when the whole `tmux attach-session` client dies, so it can't tell
+    /// a per-window agent exit apart (#558). We poll `#{pane_current_command}`
+    /// for the Manager window instead — the same signal the orphan reaper reads.
+    ///
+    /// At most one monitor runs; a second call cancels the first. The poll skips
+    /// samples where the binding is absent (async adopt on launch hasn't landed
+    /// yet) or the `display-message` throws (window gone / server down), so
+    /// attach-client teardown and restart/shutdown never false-positive. Stops
+    /// after firing once; `SessionService` re-arms it on the next Manager launch.
+    public func startManagerExitMonitor(
+        id: UUID,
+        pollInterval: TimeInterval = 3.0,
+        onExit: @escaping @MainActor () -> Void
+    ) {
+        stopManagerExitMonitor()
+        let nanos = UInt64(pollInterval * 1_000_000_000)
+        managerExitMonitor = Task { [weak self] in
+            var sawAgentRunning = false
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: nanos)
+                if Task.isCancelled { return }
+                guard let self else { return }
+                // Read the Manager window's foreground command. A missing
+                // binding or a thrown read is inconclusive (not an exit): skip.
+                guard let windowIndex = self.bindings[id],
+                      let ctrl = self.controller,
+                      let raw = try? ctrl.displayMessage(
+                          target: "\(ctrl.sessionName):\(windowIndex)",
+                          format: "#{pane_current_command}"
+                      )
+                else { continue }
+                let command = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                if Self.orphanLoginShells.contains(command) {
+                    if Self.managerAgentDidExit(paneCommand: command, sawAgentRunning: sawAgentRunning) {
+                        NSLog("[CrowTelemetry manager:exit_detected terminal=\(id) command=\(command)]")
+                        onExit()
+                        return
+                    }
+                    // Bare shell before the agent ever launched (startup window);
+                    // keep watching until we see it running.
+                } else if !command.isEmpty {
+                    sawAgentRunning = true
+                }
+            }
+        }
+    }
+
+    /// Cancel the Manager exit monitor if one is running. Idempotent.
+    public func stopManagerExitMonitor() {
+        managerExitMonitor?.cancel()
+        managerExitMonitor = nil
     }
 
     /// Return the shared cockpit xterm surface, lazily creating it the

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -598,6 +598,24 @@ public final class TmuxBackend {
         return orphanLoginShells.contains(command)
     }
 
+    /// Advance the exit-monitor state machine by one poll sample, so the whole
+    /// transition — not just its terminal condition — is unit-testable without
+    /// tmux (#558). `sample` is the window's foreground command, or `nil` when
+    /// the read was inconclusive (binding absent / `display-message` threw /
+    /// window gone). Returns the updated `sawAgentRunning` latch and whether an
+    /// exit should fire. A non-empty non-shell command latches "agent running";
+    /// a bare login shell after that latch fires; `nil` and `""` are no-ops.
+    nonisolated static func advanceExitMonitor(
+        sawAgentRunning: Bool, sample: String?
+    ) -> (sawAgentRunning: Bool, fired: Bool) {
+        guard let command = sample else { return (sawAgentRunning, false) }
+        if orphanLoginShells.contains(command) {
+            return (sawAgentRunning, managerAgentDidExit(paneCommand: command, sawAgentRunning: sawAgentRunning))
+        }
+        if !command.isEmpty { return (true, false) }
+        return (sawAgentRunning, false)
+    }
+
     /// Reap cockpit windows that no live terminal references AND that are
     /// sitting at a bare login shell — leaked windows from a timed-out
     /// `new-window` or a forgotten terminal (#408). `keepWindowIndices` is the
@@ -643,6 +661,16 @@ public final class TmuxBackend {
     /// yet) or the `display-message` throws (window gone / server down), so
     /// attach-client teardown and restart/shutdown never false-positive. Stops
     /// after firing once; `SessionService` re-arms it on the next Manager launch.
+    ///
+    /// The blocking `display-message` runs off the main actor (`Task.detached`)
+    /// and only the `onExit` hop-back touches the UI thread — a perpetual poll
+    /// must never stall AppKit even if the tmux subprocess wedges to its
+    /// watchdog timeout.
+    ///
+    /// Sampling floor: an agent that both launches and exits inside one
+    /// `pollInterval` is never observed running, so `sawAgentRunning` stays
+    /// false and no banner fires. That's an accepted missed-detection inherent
+    /// to polling, not a false positive.
     public func startManagerExitMonitor(
         id: UUID,
         pollInterval: TimeInterval = 3.0,
@@ -656,26 +684,27 @@ public final class TmuxBackend {
                 try? await Task.sleep(nanoseconds: nanos)
                 if Task.isCancelled { return }
                 guard let self else { return }
-                // Read the Manager window's foreground command. A missing
-                // binding or a thrown read is inconclusive (not an exit): skip.
-                guard let windowIndex = self.bindings[id],
-                      let ctrl = self.controller,
-                      let raw = try? ctrl.displayMessage(
-                          target: "\(ctrl.sessionName):\(windowIndex)",
-                          format: "#{pane_current_command}"
-                      )
-                else { continue }
-                let command = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                if Self.orphanLoginShells.contains(command) {
-                    if Self.managerAgentDidExit(paneCommand: command, sawAgentRunning: sawAgentRunning) {
-                        NSLog("[CrowTelemetry manager:exit_detected terminal=\(id) command=\(command)]")
-                        onExit()
-                        return
-                    }
-                    // Bare shell before the agent ever launched (startup window);
-                    // keep watching until we see it running.
-                } else if !command.isEmpty {
-                    sawAgentRunning = true
+                // Capture the tmux handle + window index on the main actor, then
+                // read `#{pane_current_command}` off it: `TmuxController.run`
+                // blocks on `waitUntilExit()`, so keep that subprocess off the UI
+                // thread. A missing binding/controller yields a `nil` sample (skip).
+                let ctrl = self.controller
+                let windowIndex = self.bindings[id]
+                let raw: String? = await Task.detached { () -> String? in
+                    guard let ctrl, let windowIndex else { return nil }
+                    return try? ctrl.displayMessage(
+                        target: "\(ctrl.sessionName):\(windowIndex)",
+                        format: "#{pane_current_command}"
+                    )
+                }.value
+                let sample = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if Task.isCancelled { return }
+                let (nextSaw, fired) = Self.advanceExitMonitor(sawAgentRunning: sawAgentRunning, sample: sample)
+                sawAgentRunning = nextSaw
+                if fired {
+                    NSLog("[CrowTelemetry manager:exit_detected terminal=\(id) command=\(sample ?? "")]")
+                    onExit()
+                    return
                 }
             }
         }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -717,3 +717,38 @@ struct TmuxBackendConfigPolicyTests {
         #expect(TmuxBackend.shouldReconcile(configMTime: nil, serverStartTime: nil))
     }
 }
+
+/// Policy tests for the Manager exit detector (#558): report an exit only once
+/// the agent was seen running and the window's foreground has fallen back to a
+/// bare login shell. Pure over `managerAgentDidExit`, so no tmux needed.
+@Suite("Manager exit-monitor policy (#558)")
+struct ManagerExitMonitorTests {
+
+    @Test func firesWhenAgentRanThenDroppedToShell() {
+        // The agent (claude/codex/…) exited and the pane fell back to a shell.
+        #expect(TmuxBackend.managerAgentDidExit(paneCommand: "zsh", sawAgentRunning: true))
+        #expect(TmuxBackend.managerAgentDidExit(paneCommand: "-zsh", sawAgentRunning: true))
+        #expect(TmuxBackend.managerAgentDidExit(paneCommand: "bash", sawAgentRunning: true))
+        #expect(TmuxBackend.managerAgentDidExit(paneCommand: "fish", sawAgentRunning: true))
+    }
+
+    @Test func doesNotFireBeforeAgentSeenRunning() {
+        // Startup window: the wrapper shell shows before `claude` launches.
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: "zsh", sawAgentRunning: false))
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: "bash", sawAgentRunning: false))
+    }
+
+    @Test func doesNotFireWhileAgentRunning() {
+        // A non-shell foreground means the agent (or a child of it) is running.
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: "claude", sawAgentRunning: true))
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: "node", sawAgentRunning: true))
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: "codex", sawAgentRunning: true))
+    }
+
+    @Test func doesNotFireWhenWindowGone() {
+        // nil = display-message failed / window vanished. Covers attach-client
+        // teardown and restart/shutdown — never a false positive.
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: nil, sawAgentRunning: true))
+        #expect(!TmuxBackend.managerAgentDidExit(paneCommand: nil, sawAgentRunning: false))
+    }
+}

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -751,4 +751,32 @@ struct ManagerExitMonitorTests {
         #expect(!TmuxBackend.managerAgentDidExit(paneCommand: nil, sawAgentRunning: true))
         #expect(!TmuxBackend.managerAgentDidExit(paneCommand: nil, sawAgentRunning: false))
     }
+
+    // MARK: - advanceExitMonitor (poll-loop state machine)
+
+    @Test func latchesRunningOnNonShellCommand() {
+        // A non-shell foreground latches sawAgentRunning and never fires.
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: false, sample: "claude") == (true, false))
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: false, sample: "node") == (true, false))
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: true, sample: "codex") == (true, false))
+    }
+
+    @Test func firesOnRunThenShellTransition() {
+        // Latched running → bare shell fires and keeps the latch.
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: true, sample: "zsh") == (true, true))
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: true, sample: "-zsh") == (true, true))
+    }
+
+    @Test func startupShellDoesNotLatchOrFire() {
+        // Bare shell before the agent ever ran: no latch, no fire.
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: false, sample: "zsh") == (false, false))
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: false, sample: "bash") == (false, false))
+    }
+
+    @Test func inconclusiveSamplesPreserveState() {
+        // nil (binding absent / read threw) and "" leave the latch untouched.
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: true, sample: nil) == (true, false))
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: false, sample: nil) == (false, false))
+        #expect(TmuxBackend.advanceExitMonitor(sawAgentRunning: true, sample: "") == (true, false))
+    }
 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -416,7 +416,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Initialize terminal backend (xterm.js + tmux attach).
-        // Manager process-exit banner is not wired for the shared attach client yet (#558).
+        // Manager process-exit detection is wired via TmuxBackend's exit
+        // monitor, armed by SessionService.ensureManagerSession (#558).
         NSLog("[Crow] Terminal backend ready (xterm.js + tmux)")
 
         NSLog("[Crow] Config loaded (workspaces: %d)", config.workspaces.count)
@@ -603,9 +604,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Ensure manager session exists
         service.ensureManagerSession(devRoot: devRoot)
 
-        // Manager process exit detection is not wired for the shared tmux
-        // attach client (cockpit surface). Manager shells run inside tmux
-        // windows, not as the attach process child.
+        // ensureManagerSession also arms the TmuxBackend Manager exit monitor
+        // that drives the "Manager process exited" banner (#558).
 
         // Wire closures for UI actions
         appState.onDeleteSession = { [weak self, weak service] id in

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -707,6 +707,26 @@ final class SessionService {
         if appState.selectedSessionID == nil {
             appState.selectedSessionID = managerID
         }
+
+        // (Re)arm the exit monitor so the "Manager process exited" banner
+        // reappears under the shared xterm.js cockpit (#558). Covers fresh
+        // launch, hydrate/adopt relaunch, and `restartManager` (which routes
+        // back through here).
+        armManagerExitMonitor()
+    }
+
+    /// Start the `TmuxBackend` poll that flips `appState.managerProcessExited`
+    /// when the Manager's agent process exits (#558). Idempotent — the backend
+    /// cancels any prior monitor. No-op until the Manager terminal row exists;
+    /// the poll itself tolerates the tmux binding being registered slightly
+    /// later by the async `rebuildAllSurfaces` adopt path.
+    private func armManagerExitMonitor() {
+        let managerID = AppState.managerSessionID
+        guard let managerTerminal = appState.terminals(for: managerID).first else { return }
+        TmuxBackend.shared.startManagerExitMonitor(id: managerTerminal.id) { [weak self] in
+            guard let self, !self.appState.managerProcessExited else { return }
+            self.appState.managerProcessExited = true
+        }
     }
 
     /// Relaunch the Manager's `claude` process in place after it has exited
@@ -722,6 +742,11 @@ final class SessionService {
         let terminals = appState.terminals(for: managerID)
         // Fall back to a dead terminal's cwd if the caller's devRoot is empty.
         let resolvedDevRoot = devRoot.isEmpty ? (terminals.first?.cwd ?? devRoot) : devRoot
+
+        // Stop the exit monitor before tearing down the window so the imminent
+        // kill-window isn't mistaken for anything, and the fresh agent launch
+        // is observed from scratch. `ensureManagerSession` re-arms it (#558).
+        TmuxBackend.shared.stopManagerExitMonitor()
 
         for terminal in terminals {
             TerminalRouter.destroy(terminal)
@@ -758,6 +783,10 @@ final class SessionService {
         TmuxBackend.shared.shutdown(killServer: true)
 
         rebuildAllSurfaces(forceRegister: true)
+
+        // `shutdown` cancelled the exit monitor and `rebuildAllSurfaces` doesn't
+        // route through `ensureManagerSession`, so re-arm it here (#558).
+        armManagerExitMonitor()
 
         // Re-assign selection (even to the same values) to force a SwiftUI
         // re-render so TerminalSurfaceView re-creates the destroyed cockpit

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -784,6 +784,13 @@ final class SessionService {
 
         rebuildAllSurfaces(forceRegister: true)
 
+        // A full server restart relaunches a fresh Manager agent, so clear any
+        // showing exit banner — mirrors `restartManager` (#558). The re-arm's
+        // `!managerProcessExited` guard only blocks re-firing, it can't clear a
+        // stale flag, so an already-visible banner would otherwise persist over
+        // a healthy Manager.
+        appState.managerProcessExited = false
+
         // `shutdown` cancelled the exit monitor and `rebuildAllSurfaces` doesn't
         // route through `ensureManagerSession`, so re-arm it here (#558).
         armManagerExitMonitor()


### PR DESCRIPTION
Closes #558

## Problem

PR #556 replaced GhosttyKit with one shared `XTermSurfaceView` running a single `tmux attach-session` client. That dropped the old `GhosttyApp.onChildExited` seam that set `AppState.managerProcessExited`, so nothing ever set the flag `true` again — the **"Manager process exited — Restart" banner became dead code**.

The old callback can't be reconnected as-is: there's now one shared attach client with no per-window identity, and `XTermSurfaceView.onProcessExit` only fires when the *whole* attach client dies.

## Key insight

Under tmux, every terminal is a window inside one shared session, and the Manager's agent (`claude …`) runs **inside the window's shell wrapper**, not as the pane's direct child. So when the agent exits it does **not** kill the pane — the window persists and its foreground command falls back to a bare login shell (the exact state the orphan-window reaper already recognizes). `#{pane_dead}`/"window gone" therefore never fire on a normal agent exit.

## Approach

- **`TmuxBackend`** gains a poll monitor (`startManagerExitMonitor` / `stopManagerExitMonitor`) that reads the Manager window's `#{pane_current_command}` every 3s and fires once it observes the agent *run* and then return to a bare login shell. A pure, unit-tested classifier (`managerAgentDidExit`) encodes the transition policy and reuses `orphanLoginShells`. Inconclusive samples (missing binding on async launch, or a thrown `display-message` when the window is gone) are skipped, so attach-client teardown and restart/shutdown never false-positive. Stops after firing; re-armed on the next Manager launch.
- **`SessionService`** arms the monitor from `ensureManagerSession` (covers fresh launch, hydrate/adopt relaunch, and `restartManager`) and after `restartTmuxServer`; stops it at the start of `restartManager`. The existing restart path still clears the flag at `SessionService.swift:735`.
- **`AppDelegate`** stale `#558` breadcrumb comments replaced.

## Acceptance

- [x] Manager agent exits → `appState.managerProcessExited` becomes `true`, banner appears.
- [x] Restarting the Manager clears the flag (existing `restartManager` path) and re-arms the monitor.
- [x] Attach-client teardown (`XTermSurfaceView.destroy`) does not false-positive (monitor reads tmux window state, not the attach client; `nil`/window-gone samples never fire).

## Testing

- `make build` — clean.
- `swift test --package-path Packages/CrowTerminal --filter "ManagerExitMonitorTests|OrphanWindowReaperTests"` — 7/7 green (4 new `ManagerExitMonitorTests` covering: fires after run→shell; no fire before agent seen; no fire while running; no fire when window gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfYBT6dvEatoRus4xuNnhu