### PR TITLE
Fix done-in-24h badge cap: use search issueCount instead of counting capped nodes (closes #562)

### DIFF
--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -213,6 +213,11 @@ public struct PRMetadata: Sendable {
 public struct AssignedListing: Sendable {
     public let open: [AssignedIssue]
     public let closed: [AssignedIssue]
+    /// Total recently-closed matches, independent of the page cap on `closed`
+    /// (GitHub's `search` fetches at most 50 nodes but reports the full
+    /// `issueCount`). Falls back to `closed.count` when the backend doesn't
+    /// report a total, so it's always safe to badge from.
+    public let closedTotalCount: Int
     /// GitHub-only; nil for GitLab.
     public let rateLimit: GitHubRateLimit?
     /// When non-nil, the backend completed the call but had to degrade the
@@ -230,12 +235,14 @@ public struct AssignedListing: Sendable {
     public init(
         open: [AssignedIssue],
         closed: [AssignedIssue],
+        closedTotalCount: Int? = nil,
         rateLimit: GitHubRateLimit? = nil,
         missingScope: String? = nil,
         samlRestricted: Bool = false
     ) {
         self.open = open
         self.closed = closed
+        self.closedTotalCount = closedTotalCount ?? closed.count
         self.rateLimit = rateLimit
         self.missingScope = missingScope
         self.samlRestricted = samlRestricted

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -354,6 +354,7 @@ public struct GitHubTaskBackend: TaskBackend {
         }
       }
       closedIssues: search(type: ISSUE, query: $closedQuery, first: 50) {
+        issueCount
         nodes {
           ... on Issue {
             number title url state updatedAt
@@ -378,6 +379,7 @@ public struct GitHubTaskBackend: TaskBackend {
         }
       }
       closedIssues: search(type: ISSUE, query: $closedQuery, first: 50) {
+        issueCount
         nodes {
           ... on Issue {
             number title url state updatedAt
@@ -409,8 +411,12 @@ public struct GitHubTaskBackend: TaskBackend {
             dateFormatter: dateFmt,
             projectStatusOverride: .done
         )
+        // Total matches in the 24h window — `nodes` is capped at `first: 50`,
+        // so the badge count must come from the search connection's
+        // `issueCount` or it saturates at 50 (#562).
+        let closedTotal = (dataObj["closedIssues"] as? [String: Any])?["issueCount"] as? Int
         let rate = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
-        return AssignedListing(open: open, closed: closed, rateLimit: rate, missingScope: missingScope)
+        return AssignedListing(open: open, closed: closed, closedTotalCount: closedTotal, rateLimit: rate, missingScope: missingScope)
     }
 
     /// Recover the accessible-org issues GitHub returned alongside a SAML

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -97,7 +97,7 @@ final class BackendsTests: XCTestCase {
              "labels":{"nodes":[{"name":"bug","color":"red"}]},
              "projectItems":{"nodes":[{"fieldValueByName":{"name":"In Progress"}}]}}
           ]},
-          "closedIssues":{"nodes":[
+          "closedIssues":{"issueCount":137,"nodes":[
             {"number":2,"title":"Closed one","url":"https://github.com/a/b/issues/2","state":"closed",
              "repository":{"nameWithOwner":"a/b"},"labels":{"nodes":[]}}
           ]},
@@ -112,9 +112,32 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(listing.open[0].projectStatus, .inProgress)
         XCTAssertEqual(listing.closed.count, 1)
         XCTAssertEqual(listing.closed[0].projectStatus, .done)  // override for closed
+        // The total comes from the search connection's issueCount, not the
+        // node page — the done badge must be able to exceed the first: 50 cap.
+        XCTAssertEqual(listing.closedTotalCount, 137)
         XCTAssertEqual(listing.rateLimit?.remaining, 4999)
         XCTAssertEqual(fake.calls.first?.args[0], "gh")
         XCTAssertTrue(fake.calls.first?.args.contains("graphql") ?? false)
+    }
+
+    func testGitHubTaskBackendClosedTotalFallsBackToNodeCount() async throws {
+        let fake = FakeShellRunner()
+        // No issueCount in the response — closedTotalCount falls back to the
+        // fetched node count.
+        let json = """
+        {"data":{
+          "openIssues":{"nodes":[]},
+          "closedIssues":{"nodes":[
+            {"number":2,"title":"Closed one","url":"https://github.com/a/b/issues/2","state":"closed",
+             "repository":{"nameWithOwner":"a/b"},"labels":{"nodes":[]}}
+          ]}
+        }}
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closedTotalCount, 1)
     }
 
     func testGitHubTaskBackendListAssignedRetriesWithoutProjectsOnScopeError() async throws {

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -434,7 +434,7 @@ final class IssueTracker {
             let openIDs = Set(openIssues.map(\.id))
             let uniqueDone = ghResult.closedIssues.filter { !openIDs.contains($0.id) }
             allIssues.append(contentsOf: uniqueDone)
-            doneCount += ghResult.closedIssues.count
+            doneCount += ghResult.closedTotalCount
         }
 
         // GitLab — unchanged fan-out (one call per host)
@@ -642,6 +642,9 @@ final class IssueTracker {
     private struct ConsolidatedGitHubResponse: Sendable {
         let openIssues: [AssignedIssue]
         let closedIssues: [AssignedIssue]
+        /// True 24h closed total (search `issueCount`) — `closedIssues` holds
+        /// at most the 50 fetched nodes, so the done badge counts this instead.
+        let closedTotalCount: Int
         let viewerPRs: [ViewerPR]
         let reviewRequests: [ReviewRequest]
         let rateLimit: GitHubRateLimit?
@@ -758,6 +761,7 @@ final class IssueTracker {
         return ConsolidatedGitHubResponse(
             openIssues: assigned.open,
             closedIssues: assigned.closed,
+            closedTotalCount: assigned.closedTotalCount,
             viewerPRs: monitored.viewerPRs,
             reviewRequests: monitored.reviewRequests,
             rateLimit: assigned.rateLimit ?? monitored.rateLimit


### PR DESCRIPTION
Closes #562

The sidebar's green done-in-24h ticket badge saturated at 50: it counted the `closedIssues` GraphQL search nodes, which are hard-capped at `first: 50`. GitHub's `search` connection reports the total match count via `issueCount` independent of page size, so the badge now reads that — no pagination, no extra API cost.

- Added `issueCount` to the `closedIssues` search in both `consolidatedIssuesQuery` and `consolidatedIssuesQueryNoProjects`
- Threaded it through `parseIssuesResponse` as `AssignedListing.closedTotalCount`, defaulting to `closed.count` so the Jira/GitLab/Corveil backends and the SAML partial-recovery path are unaffected
- `IssueTracker` accumulates `closedTotalCount` into `doneIssuesLast24h`; the board's Done list still renders the (capped) nodes
- Tests: extended the parse fixture with `issueCount: 137` (> nodes.count) and added a fallback case for responses without `issueCount`

Verified with `swift build`, `swift test` (root, 264 tests), and `swift test --package-path Packages/CrowProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)