### PR TITLE
Remove dead Ghostty references (tmux/xterm.js cleanup)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,14 +23,14 @@ Open a [GitHub Issue](https://github.com/radiusmethod/crow/issues/new?template=f
 See [README.md](README.md#detailed-setup) for full build instructions. The short version:
 
 ```bash
-git clone --recurse-submodules https://github.com/radiusmethod/crow.git
+git clone https://github.com/radiusmethod/crow.git
 cd crow
 make build
 ```
 
-> Always use `make build` for full builds. It handles submodules, the Ghostty
-> framework, and the Swift build. Use `swift build` only for quick iteration
-> after the initial build.
+> Always use `make build` for full builds. It generates build info and runs
+> the Swift build. Use `swift build` only for quick iteration after the
+> initial build.
 
 **Note:** Code signing is not required for development. Unsigned builds work normally for local testing. Official releases are signed and notarized automatically via GitHub Actions.
 
@@ -61,7 +61,7 @@ New functionality should go in the appropriate existing package:
 |---------|-------|
 | `CrowCore` | Data models, observable app state |
 | `CrowUI` | SwiftUI views, theme |
-| `CrowTerminal` | Ghostty terminal surface management |
+| `CrowTerminal` | xterm.js terminal surface management |
 | `CrowGit` | Git operations |
 | `CrowProvider` | GitHub/GitLab provider abstraction |
 | `CrowPersistence` | JSON store, config I/O |

--- a/Crow.entitlements
+++ b/Crow.entitlements
@@ -2,16 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Hardened Runtime: allow unsigned executable memory (Zig-compiled GhosttyKit) -->
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-
-    <!-- Hardened Runtime: disable library validation (GhosttyKit objects aren't team-signed) -->
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-
-    <!-- Hardened Runtime: allow JIT (Metal shader compilation via Ghostty) -->
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
+    <!-- No Hardened Runtime exceptions are required: the terminal renders via
+         xterm.js in WKWebView (JS/JIT runs in the out-of-process WebContent
+         process under Apple-provided entitlements), so the app needs no
+         unsigned-executable-memory, library-validation, or JIT exceptions. -->
 </dict>
 </plist>

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -134,7 +134,7 @@ public extension CodingAgent {
     }
 
     /// Default Manager launch command: invoke the agent's CLI binary by
-    /// name with no extra flags. The terminal backend (tmux/Ghostty) owns
+    /// name with no extra flags. The tmux terminal backend owns
     /// the submitting Enter — return the raw command without a trailing
     /// newline so the convention is uniform across agents (CROW-433 review).
     func managerLaunchCommand(

--- a/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Which terminal backend hosts a `SessionTerminal`'s shell.
 ///
 /// tmux is the only backend (#198 → defaulted on in #301 → legacy
-/// per-terminal Ghostty path removed in #303): all terminals share a single
-/// embedded Ghostty surface that's attached to a tmux session, and each
+/// per-terminal path removed in #303): all terminals share a single
+/// embedded xterm.js surface that's attached to a tmux session, and each
 /// terminal is one tmux window inside that session. The enum is retained as
 /// a single-case discriminator so the persisted schema is stable and a
 /// future backend can be added without another migration.
@@ -39,7 +39,7 @@ public struct SessionTerminal: Identifiable, Codable, Sendable {
     public var isManaged: Bool
     public var createdAt: Date
     /// Which backend hosts this terminal. Always `.tmux` since #303; the
-    /// custom decoder maps legacy `"ghostty"` rows forward.
+    /// custom decoder maps legacy/unknown backend strings forward.
     public var backend: TerminalBackend
     /// The tmux window that backs this terminal. Nil only when registration
     /// hasn't happened yet or failed this run.
@@ -79,7 +79,7 @@ public struct SessionTerminal: Identifiable, Codable, Sendable {
         isManaged = try container.decodeIfPresent(Bool.self, forKey: .isManaged) ?? false
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         // tmux is the only backend since #303. Decode the raw string and map
-        // anything that isn't a known case — including legacy `"ghostty"` rows
+        // anything that isn't a known case — including legacy backend values
         // and rows written before this field existed — forward to `.tmux`, so
         // an upgrade never throws on an old store.
         if let raw = try container.decodeIfPresent(String.self, forKey: .backend) {

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionTerminalTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionTerminalTests.swift
@@ -146,10 +146,10 @@ struct SessionTerminalTests {
         #expect(decoded.tmuxBinding == binding)
     }
 
-    /// Legacy rows persisted with `"backend":"ghostty"` (before #303) must
-    /// migrate forward to `.tmux` on load rather than throwing on the
-    /// now-removed enum case.
-    @Test func legacyGhosttyBackendMigratesToTmux() throws {
+    /// Legacy rows persisted with an unrecognized `backend` string (before
+    /// #303 collapsed the enum to a single case) must migrate forward to
+    /// `.tmux` on load rather than throwing on the now-removed enum case.
+    @Test func legacyUnknownBackendMigratesToTmux() throws {
         let json = """
         {
             "id": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
@@ -158,7 +158,7 @@ struct SessionTerminalTests {
             "cwd": "/Users/test",
             "isManaged": false,
             "createdAt": 1700000000,
-            "backend": "ghostty"
+            "backend": "legacy-unknown"
         }
         """.data(using: .utf8)!
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
@@ -119,8 +119,8 @@ _crow_precmd() {
   crow_log "precmd_fired"
   if [ -n "${TMUX:-}" ]; then
     # Emit OSC 133;A twice under tmux: the wrapped form passes through to
-    # Ghostty (which uses the mark for #470 hyperlink and #471 cursor
-    # gating), and the bare form is consumed by tmux's emulator so
+    # the xterm.js surface (which uses the mark for #470 hyperlink and #471
+    # cursor gating), and the bare form is consumed by tmux's emulator so
     # `send-keys -X previous-prompt` / `next-prompt` can navigate marks
     # for Cmd+up/down prompt jumps (#471 gap 6).
     printf '\033]133;A\007'
@@ -185,8 +185,8 @@ _crow_precmd() {
   crow_log "precmd_fired"
   if [ -n "${TMUX:-}" ]; then
     # Emit OSC 133;A twice under tmux: the wrapped form passes through to
-    # Ghostty (which uses the mark for #470 hyperlink and #471 cursor
-    # gating), and the bare form is consumed by tmux's emulator so
+    # the xterm.js surface (which uses the mark for #470 hyperlink and #471
+    # cursor gating), and the bare form is consumed by tmux's emulator so
     # `send-keys -X previous-prompt` / `next-prompt` can navigate marks
     # for Cmd+up/down prompt jumps (#471 gap 6).
     printf '\033]133;A\007'
@@ -220,7 +220,7 @@ BRC
     crow_log "hook_skipped reason=unsupported_shell shell=$SHELL"
     if [ -n "${TMUX:-}" ]; then
       # See `_crow_precmd` above for why we emit OSC 133;A twice under
-      # tmux (bare for tmux's prompt tracking, wrapped for Ghostty).
+      # tmux (bare for tmux's prompt tracking, wrapped for the xterm.js surface).
       printf '\033]133;A\007'
       printf '\033Ptmux;\033\033]133;A\007\033\\\033Ptmux;\033\033]9;crow-ready\007\033\\'
     else

--- a/Packages/CrowTerminal/Sources/CrowTerminal/SentinelWaiter.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/SentinelWaiter.swift
@@ -7,9 +7,9 @@ import Foundation
 /// First appearance = the shell has reached its first interactive prompt
 /// = ready to accept input.
 ///
-/// This replaces the historical 5-second sleep used by the now-removed
-/// per-terminal Ghostty path. The sentinel approach is tmux-agnostic — the
-/// wrapper writes directly to disk, bypassing the tmux emulator's
+/// This replaces the historical 5-second sleep used by an earlier,
+/// now-removed per-terminal path. The sentinel approach is tmux-agnostic —
+/// the wrapper writes directly to disk, bypassing the tmux emulator's
 /// escape-sequence handling.
 ///
 /// See `docs/tmux-backend-spec.md` §6 for the rationale and the empirical

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ If you discover a security vulnerability in Crow, please report it by emailing *
 
 The following components are maintained by other projects. Please report vulnerabilities directly to them:
 
-- **Ghostty terminal** — [ghostty-org/ghostty](https://github.com/ghostty-org/ghostty)
+- **xterm.js terminal** — [xtermjs/xterm.js](https://github.com/xtermjs/xterm.js)
 - **Claude Code** — [Anthropic](https://www.anthropic.com/responsible-disclosure-policy)
 - **GitHub CLI (`gh`)** / **GitLab CLI (`glab`)** — Their respective maintainers
 

--- a/Sources/Crow/App/CrashReporter.swift
+++ b/Sources/Crow/App/CrashReporter.swift
@@ -5,8 +5,8 @@ import Foundation
 ///
 /// Three classes of crash motivated this (#266):
 ///   1. POSIX signals (SIGABRT/SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP) raised
-///      out of SwiftUI's AttributeGraph or libghostty wrappers, which can
-///      vanish the process without producing a `.ips` file.
+///      out of SwiftUI's AttributeGraph or native library wrappers, which
+///      can vanish the process without producing a `.ips` file.
 ///   2. Swift runtime traps (`fatalError`, `precondition`) which print to
 ///      stderr and then `abort()` — stderr is otherwise discarded for
 ///      .app bundles double-clicked from Finder.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,11 +25,9 @@ crow/
 │   ├── CrowIPC/                     # Unix socket RPC protocol
 │   ├── CrowPersistence/             # JSON store, config persistence
 │   ├── CrowProvider/                # GitHub/GitLab provider abstraction
-│   ├── CrowTerminal/                # Ghostty terminal surface management
+│   ├── CrowTerminal/                # xterm.js terminal surface management
 │   └── CrowUI/                      # SwiftUI views, Corveil theme
-├── Frameworks/                # Built GhosttyKit (gitignored)
-├── vendor/ghostty/            # Ghostty submodule
-├── scripts/                   # Build helpers (build-ghostty.sh, bundle.sh, …)
+├── scripts/                   # Build/packaging helpers (bundle.sh, sign-and-notarize.sh, …)
 └── skills/                    # Bundled Claude Code skills (crow-workspace, etc.)
 ```
 
@@ -48,7 +46,7 @@ There are two `CrowCLI` directories:
 | **SessionService**        | `Sources/Crow/App/SessionService.swift`            | CRUD for sessions/worktrees/terminals, terminal readiness tracking, orphan recovery on startup                    |
 | **IssueTracker**          | `Sources/Crow/App/IssueTracker.swift`              | Polls GitHub/GitLab every 60 seconds for assigned issues, PR status, project board status, auto-completes merged sessions |
 | **Scaffolder**            | `Sources/Crow/App/Scaffolder.swift`                | First-run devRoot scaffold: `.claude/` + bundled skills + settings.json                                           |
-| **TmuxBackend**           | `Packages/CrowTerminal/.../TmuxBackend.swift`      | The terminal backend (introduced in #229, defaulted on in #301, the only backend since #303). Owns the tmux server and the shared cockpit `GhosttySurfaceView` that renders it |
+| **TmuxBackend**           | `Packages/CrowTerminal/.../TmuxBackend.swift`      | The terminal backend (introduced in #229, defaulted on in #301, the only backend since #303). Owns the tmux server and the shared cockpit `XTermSurfaceView` that renders it |
 | **TerminalRouter**        | `Sources/Crow/App/TerminalRouter.swift`            | Thin facade over `TmuxBackend` for per-terminal `send` / `destroy` / `trackReadiness` |
 | **AutoRespondCoordinator**| `Sources/Crow/App/AutoRespondCoordinator.swift`    | Watches PR review / CI signals and types follow-up instructions into the linked Claude Code terminal (#214)       |
 | **TerminalReadiness**     | `Packages/CrowCore/Sources/CrowCore/Models/Enums.swift:41` | Four-state enum (uninitialized → surfaceCreated → shellReady → claudeLaunched) driving the sidebar status dot |
@@ -63,7 +61,7 @@ There are two `CrowCLI` directories:
 ```
 User clicks session tab
   → SwiftUI renders TerminalSurfaceView
-  → GhosttySurfaceView.createSurface() spawns shell
+  → XTermSurfaceView.createSurface() spawns the shell (via PTYProcess)
   → TerminalManager transitions created → shellReady
   → TerminalReadiness: uninitialized → surfaceCreated → shellReady → claudeLaunched
   → Auto-sends `claude --continue` when shell becomes ready
@@ -102,15 +100,15 @@ User starts a session via /crow-workspace (or clicks "Mark In Review")
 
 See `Sources/Crow/App/IssueTracker.swift:636-774` for the full `markInReview` implementation.
 
-## Why Ghostty?
+## Terminal rendering
 
-Crow embeds [Ghostty](https://ghostty.org) as a terminal emulator via a compiled `libghostty` XCFramework. Ghostty gives each session tab a real GPU-accelerated terminal surface with the same behavior as the standalone Ghostty app, and its C API exposes the `ghostty_surface_t` lifecycle so Crow can track when the shell is ready and auto-launch `claude --continue`. The framework is built from the vendored submodule by `scripts/build-ghostty.sh` (invoked by `make ghostty`).
+Crow renders each session's terminal with [xterm.js](https://xtermjs.org) hosted in a `WKWebView` (`XTermSurfaceView`), backed by a native PTY (`PTYProcess`) whose child command is `tmux attach-session`. The vendored xterm.js assets live under `Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/`. The surface lifecycle lets Crow track when the shell is ready and auto-launch `claude --continue`. See [ADR 0006](adr/0006-universal-macos-binary.md) for why this replaced the earlier native terminal surface.
 
 ## Terminal Backends
 
-PR #229 introduced a tmux backend behind a feature flag; #301 made it the default; #303 removed the legacy per-terminal Ghostty path and made tmux the only backend. The Manager session runs on tmux like every other session (#324).
+PR #229 introduced a tmux backend behind a feature flag; #301 made it the default; #303 removed the legacy per-terminal path and made tmux the only backend. The Manager session runs on tmux like every other session (#324).
 
-- **tmux** — a headless PTY plus a tmux server, driven by `TmuxBackend`. Each session terminal corresponds to a tmux window; rendering is decoupled from the window so terminals can spin up before any view is materialized. All visible tabs share a single embedded `GhosttySurfaceView` (the "cockpit") whose child command is `tmux attach-session`, so Ghostty still does the GPU-accelerated rendering. Requires `tmux ≥ 3.3` on `PATH` (`brew install tmux`).
+- **tmux** — a headless PTY plus a tmux server, driven by `TmuxBackend`. Each session terminal corresponds to a tmux window; rendering is decoupled from the window so terminals can spin up before any view is materialized. All visible tabs share a single embedded `XTermSurfaceView` (the "cockpit") whose child command is `tmux attach-session`, so xterm.js in WKWebView renders the shared surface. Requires `tmux ≥ 3.3` on `PATH` (`brew install tmux`).
 
 Per-terminal dispatch happens in `Sources/Crow/App/TerminalRouter.swift`, a thin facade over `TmuxBackend`. `SessionTerminal` still carries a single-case `backend` discriminator (`.tmux`) so the persisted schema is stable and a future backend can be added without another migration.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,8 +260,8 @@ Worktrees are created **at the same level as the main repo**, not in a `worktree
 
 `TerminalReadiness` (`Packages/CrowCore/Sources/CrowCore/Models/Enums.swift:41`) tracks how far each managed terminal has progressed through startup. The sidebar dot in `Packages/CrowUI/Sources/CrowUI/SessionListView.swift:325-372` reflects the current state:
 
-1. **Gray dot (`uninitialized`)** — `GhosttySurfaceView` exists but `createSurface()` has not been called yet.
-2. **Yellow dot (`surfaceCreated`)** — `ghostty_surface_t` exists, the shell process is spawning.
+1. **Gray dot (`uninitialized`)** — `XTermSurfaceView` exists but `createSurface()` has not been called yet.
+2. **Yellow dot (`surfaceCreated`)** — the xterm.js surface exists and the shell process (`PTYProcess`) is spawning.
 3. **Blue dot (`shellReady`)** — Shell prompt detected (probe file appeared).
 4. **Green dot (`claudeLaunched`)** — `claude --continue` has been sent. The dot shows:
    - Solid green when Claude is idle

--- a/docs/terminal-runtime-research.md
+++ b/docs/terminal-runtime-research.md
@@ -1,5 +1,10 @@
 # Terminal Runtime Alternatives: Research & Recommendations
 
+> **Archived / historical.** This is the original #103 investigation and reflects the
+> state when Crow still embedded Ghostty. The terminal now renders via xterm.js in
+> WKWebView over a tmux-backed PTY — see [ADR 0006](adr/0006-universal-macos-binary.md).
+> Kept as-is for the historical record.
+
 **Issue:** [#103 — Investigate: Terminal Alternatives to Ghostty for Background Execution](https://github.com/radiusmethod/crow/issues/103)
 **Date:** 2026-04-06
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,12 +4,8 @@
 
 | Problem                                                  | Solution                                                                 |
 | -------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `zig` not found                                          | `brew install zig@0.15` or download from [ziglang.org](https://ziglang.org/download/) |
-| Zig version mismatch                                     | Version **0.15.2** is required (plain `brew install zig` is now 0.16.0 — use `brew install zig@0.15`). Check with `zig version` |
-| Metal toolchain not found                                | Run `xcodebuild -downloadComponent MetalToolchain`                       |
-| Ghostty submodule missing                                | Run `git submodule update --init vendor/ghostty`                         |
-| `swift build` fails with linker errors                   | Build `GhosttyKit` first: `./scripts/build-ghostty.sh` (or just run `make build`) |
-| `make build` reports "Prerequisites OK" then fails later | Run `make clean-all && make build` to force a full rebuild of `Frameworks/` |
+| `swift build` fails on missing `BuildInfo`               | Use `make build` — it generates build info before compiling. Bare `swift build` only works after an initial `make build`. |
+| `make build` fails partway through                       | Run `make clean-all && make build` to force a clean rebuild. |
 
 ## Runtime Issues
 
@@ -19,7 +15,7 @@
 | GitHub API errors / empty issue list                     | Check auth: `gh auth status`. Ensure scopes include `repo`, `read:org`, `project`. If missing, run `gh auth refresh -s project,read:org,repo`. |
 | `INSUFFICIENT_SCOPES` in `[IssueTracker]` stderr         | Run `gh auth refresh -s project`. **`read:project` is NOT sufficient** — the write `project` scope is required to update ticket status via `updateProjectV2ItemFieldValue`. See `Sources/Crow/App/IssueTracker.swift:691-692,768-769`. |
 | Ticket stays "Backlog" when starting a session           | Same as above — the `markInReview` code path requires the write `project` scope |
-| Terminal not starting                                    | Check stderr for `[TmuxBackend]` or `[Ghostty]` messages. Managed terminals run on tmux; if one is stuck, close and reopen it from the session detail header, or use the on-terminal Retry affordance after a readiness timeout. |
+| Terminal not starting                                    | Check stderr for `[TmuxBackend]` or `[XTermSurfaceView]` messages. Managed terminals run on tmux; if one is stuck, close and reopen it from the session detail header, or use the on-terminal Retry affordance after a readiness timeout. |
 | tmux backend not starting                                | tmux is required for managed terminals (#303). If tmux is missing or < 3.3, Crow surfaces a launch alert with a `brew install tmux` hint and managed terminals won't render until tmux is installed. Verify with `tmux -V`, then relaunch Crow. |
 | Issue tracker shows no tickets                           | Verify `gh auth status` shows `repo`, `read:org`, `project` scopes       |
 | GitLab tickets missing                                   | Run `glab auth status --hostname <your-host>`; ensure `GITLAB_HOST` matches what's in `{devRoot}/.claude/config.json`. After #215, Crow silently skips GitLab candidates whose host can't be determined instead of failing the whole reconcile pass — check the workspace's `host` field if a repo isn't being polled. |
@@ -37,7 +33,7 @@ The app logs diagnostic information to stderr with component tags:
 - `[SessionService]` — Orphan detection, session lifecycle changes
 - `[IssueTracker]` — GitHub/GitLab API errors, scope issues, project status queries
 - `[JSONStore]` — Decode failures (store data loss prevention)
-- `[Ghostty]` — Surface creation success/failure
+- `[XTermSurfaceView]` — Surface creation success/failure
 - `[TerminalRouter]` — tmux send/destroy errors when the tmux backend is enabled (#229)
 - `[AppSupportDirectory]` — One-time `rm-ai-ide` → `crow` migration events
 - `[Scaffolder]` — Template file loading (development builds)


### PR DESCRIPTION
Closes #570

## Summary

The tmux + xterm.js-in-WKWebView migration (ADR 0006) already removed the ~1 GB of vendored Ghostty artifacts (`vendor/ghostty/`, `Frameworks/GhosttyKit.xcframework/`, `Frameworks/ghostty-resources/`, `scripts/build-ghostty.sh`) and GhosttyKit in earlier commits on this branch — those paths are absent from the tree, untracked by git, and linked by zero `Package.swift` targets, linker flags, the `Makefile`, or `scripts/`. This PR clears the **stale references** that remained.

## Changes

- **Live Swift / scripts — comment rewording only, no behavior change:** `CodingAgent.swift`, `Terminal.swift`, `SentinelWaiter.swift`, `crow-shell-wrapper.sh`, `CrashReporter.swift`. The tmux legacy-data migration logic and the OSC 133 dual-emit `printf` lines are untouched.
- **Migration test genericized:** the decoder maps *any* unknown persisted `backend` string to `.tmux` (no ghostty-specific branch), so `legacyGhosttyBackendMigratesToTmux` → `legacyUnknownBackendMigratesToTmux` with a neutral fixture value. Identical code path, identical assertions.
- **Entitlements:** dropped the three GhosttyKit-justified Hardened Runtime keys (`allow-unsigned-executable-memory`, `disable-library-validation`, `allow-jit`). With xterm.js in WKWebView, JS/JIT runs in the out-of-process WebContent process under Apple-provided entitlements, so the host app needs no exceptions.
- **User-facing docs rewritten to present state** (`architecture.md`, `configuration.md`, `troubleshooting.md`, `CONTRIBUTING.md`, `SECURITY.md`) using `XTermSurfaceView` / `PTYProcess` / `[XTermSurfaceView]` terminology; one-line archived note added to `docs/terminal-runtime-research.md`.

## Intentionally left as-is (historical record)

Per the repo ADR policy, Ghostty references remain **only** in `docs/adr/0001-*`, `docs/adr/0006-*`, `CHANGELOG.md`, and `docs/terminal-runtime-research.md`.

## Verification

- `rg -ni ghostty` → hits only in the four historical files above; live Swift/scripts/entitlements/current docs are clean.
- `make build` ✅ and `make test` ✅ (264 tests, 31 suites), including the renamed migration test.
- **Reviewer note:** the entitlement-key removal only takes effect under Hardened Runtime at sign/notarize time; a local unsigned `make build` doesn't exercise it. Worth a sanity check on a signed/notarized release build that the app launches and terminals render (the tmux path itself is unchanged).