### PR TITLE
Rename session "Pin" to "Lock" (#573)

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
@@ -120,12 +120,12 @@ public struct SetStatus: ParsableCommand {
     }
 }
 
-/// Pin or unpin a session, exempting it from (or restoring it to) the retention
-/// cleanup reaper.
-public struct SetPinned: ParsableCommand {
-    public static let configuration = CommandConfiguration(commandName: "set-pinned", abstract: "Pin/unpin a session to protect it from auto-cleanup")
+/// Lock or unlock a session, exempting it from (or restoring it to) the
+/// retention cleanup reaper.
+public struct SetLocked: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "set-locked", abstract: "Lock/unlock a session to protect it from auto-cleanup")
     @Option(name: .long, help: "Session UUID") var session: String
-    @Argument(help: "Pinned state: true or false") var pinned: Bool
+    @Argument(help: "Locked state: true or false") var locked: Bool
 
     public init() {}
 
@@ -134,7 +134,26 @@ public struct SetPinned: ParsableCommand {
     }
 
     public func run() throws {
-        let result = try rpc("set-pinned", params: ["session_id": .string(session), "pinned": .bool(pinned)])
+        let result = try rpc("set-locked", params: ["session_id": .string(session), "locked": .bool(locked)])
+        printJSON(result)
+    }
+}
+
+/// Deprecated alias for `set-locked` (renamed in CROW-573). Hidden from help but
+/// still accepted so existing scripts keep working.
+public struct SetPinned: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "set-pinned", abstract: "Deprecated alias for set-locked", shouldDisplay: false)
+    @Option(name: .long, help: "Session UUID") var session: String
+    @Argument(help: "Locked state: true or false") var pinned: Bool
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(session, label: "session UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("set-locked", params: ["session_id": .string(session), "locked": .bool(pinned)])
         printJSON(result)
     }
 }

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -17,6 +17,7 @@ public struct CrowCommand: ParsableCommand {
             ListSessions.self,
             GetSession.self,
             SetStatus.self,
+            SetLocked.self,
             SetPinned.self,
             DeleteSession.self,
             SetTicket.self,

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -362,9 +362,9 @@ public final class AppState {
     /// Called to update session status back to .active (persists to store).
     public var onSetSessionActive: ((UUID) -> Void)?
 
-    /// Called to pin/unpin a session, exempting it from the retention cleanup
-    /// reaper. Receives (sessionID, pinned). Persists to store (CROW-569).
-    public var onSetPinned: ((UUID, Bool) -> Void)?
+    /// Called to lock/unlock a session, exempting it from the retention cleanup
+    /// reaper. Receives (sessionID, locked). Persists to store (CROW-573).
+    public var onSetLocked: ((UUID, Bool) -> Void)?
 
     /// Whether a given session is currently being marked as "In Review" (loading state).
     /// Must be cleaned up when a session is deleted (see `SessionService.deleteSession`).

--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -33,12 +33,14 @@ public struct Session: Identifiable, Codable, Sendable {
     // linked PR (CROW-299). Non-nil means the one-shot enable has already
     // run; the auto-merge watcher skips this session on subsequent polls.
     public var autoMergeEnabledAt: Date?
-    // Whether the user has pinned this session to exempt it from the retention
-    // cleanup reaper (CROW-569). Pinned sessions are never auto-archived/deleted
-    // by `cleanup.retentionHours` regardless of age. Applies to any session kind,
+    // Whether the user has locked this session to exempt it from the retention
+    // cleanup reaper (CROW-569 shipped this as "pinned"; CROW-573 renamed the
+    // metaphor to "lock"). Locked sessions are never auto-archived/deleted by
+    // `cleanup.retentionHours` regardless of age. Applies to any session kind,
     // including scheduled `job` sessions (the motivating case). Defaults to
-    // `false`; legacy persisted sessions predating this field decode as unpinned.
-    public var pinned: Bool
+    // `false`; the decoder also reads the legacy `pinned` key so sessions locked
+    // under CROW-569 stay locked after upgrade.
+    public var locked: Bool
 
     /// Whether this session is a Manager (orchestration) session. Managers run
     /// Claude Code in the devRoot and are excluded from PR/issue tracking.
@@ -75,7 +77,7 @@ public struct Session: Identifiable, Codable, Sendable {
         reviewPromptDispatched: Bool = false,
         lastReviewedHeadSha: String? = nil,
         autoMergeEnabledAt: Date? = nil,
-        pinned: Bool = false
+        locked: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -92,7 +94,7 @@ public struct Session: Identifiable, Codable, Sendable {
         self.reviewPromptDispatched = reviewPromptDispatched
         self.lastReviewedHeadSha = lastReviewedHeadSha
         self.autoMergeEnabledAt = autoMergeEnabledAt
-        self.pinned = pinned
+        self.locked = locked
     }
 
     /// Parse a GitHub PR URL (`https://github.com/<owner>/<repo>/pull/<number>`)
@@ -129,6 +131,21 @@ public struct Session: Identifiable, Codable, Sendable {
         reviewPromptDispatched = try container.decodeIfPresent(Bool.self, forKey: .reviewPromptDispatched) ?? true
         lastReviewedHeadSha = try container.decodeIfPresent(String.self, forKey: .lastReviewedHeadSha)
         autoMergeEnabledAt = try container.decodeIfPresent(Date.self, forKey: .autoMergeEnabledAt)
-        pinned = try container.decodeIfPresent(Bool.self, forKey: .pinned) ?? false
+        // CROW-573 renamed `pinned` → `locked`. Prefer the new key, but fall
+        // back to the legacy `pinned` key so sessions locked under CROW-569
+        // remain locked after upgrade.
+        if let locked = try container.decodeIfPresent(Bool.self, forKey: .locked) {
+            self.locked = locked
+        } else {
+            let legacy = try? decoder.container(keyedBy: LegacyCodingKeys.self)
+            self.locked = (try? legacy?.decodeIfPresent(Bool.self, forKey: .pinned)) ?? nil ?? false
+        }
+    }
+
+    /// Legacy coding keys for fields renamed after they shipped. Used only by
+    /// the decoder to read older persisted data; the synthesized encoder always
+    /// writes the current key names.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case pinned
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
@@ -114,10 +114,10 @@ import Testing
     #expect(decoded.lastReviewedHeadSha == "deadbeef")
 }
 
-@Test func sessionBackwardCompatDecodingPinned() throws {
-    // Persisted state.json predating CROW-569 has no `pinned`. Decode must
-    // succeed and default the field to false so legacy sessions remain
-    // eligible for normal auto-cleanup.
+@Test func sessionBackwardCompatDecodingLocked() throws {
+    // Persisted state.json predating CROW-569 has neither `locked` nor the
+    // legacy `pinned` key. Decode must succeed and default to false so legacy
+    // sessions remain eligible for normal auto-cleanup.
     let id = UUID()
     let date = Date()
     let formatter = ISO8601DateFormatter()
@@ -135,14 +135,39 @@ import Testing
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
     let session = try decoder.decode(Session.self, from: data)
-    #expect(session.pinned == false)
+    #expect(session.locked == false)
 }
 
-@Test func sessionRoundTripsPinned() throws {
-    let session = Session(name: "pinned-job", kind: .job, pinned: true)
+@Test func sessionDecodesLegacyPinnedKeyAsLocked() throws {
+    // A session locked under CROW-569 was persisted with the `pinned` key.
+    // After the CROW-573 rename it must still decode as locked so users don't
+    // silently lose the protection on upgrade.
+    let id = UUID()
+    let date = Date()
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let dateStr = formatter.string(from: date)
+    let json: [String: Any] = [
+        "id": id.uuidString,
+        "name": "legacy-pinned",
+        "status": "completed",
+        "kind": "job",
+        "createdAt": dateStr,
+        "updatedAt": dateStr,
+        "pinned": true,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let session = try decoder.decode(Session.self, from: data)
+    #expect(session.locked == true)
+}
+
+@Test func sessionRoundTripsLocked() throws {
+    let session = Session(name: "locked-job", kind: .job, locked: true)
     let data = try JSONEncoder().encode(session)
     let decoded = try JSONDecoder().decode(Session.self, from: data)
-    #expect(decoded.pinned == true)
+    #expect(decoded.locked == true)
 }
 
 @Test func sessionManagerKindRoundTrip() throws {

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -332,10 +332,10 @@ public struct SessionListView: View {
         addMergeLabelButton(session)
 
         Button {
-            appState.onSetPinned?(session.id, !session.pinned)
+            appState.onSetLocked?(session.id, !session.locked)
         } label: {
-            Label(session.pinned ? "Unpin" : "Pin",
-                  systemImage: session.pinned ? "pin.slash" : "pin")
+            Label(session.locked ? "Unlock" : "Lock",
+                  systemImage: session.locked ? "lock.open" : "lock")
         }
         .disabled(deleting)
 
@@ -671,12 +671,12 @@ struct SessionRow: View {
                     RemoteControlBadge(compact: true)
                 }
                 Spacer()
-                if session.pinned {
-                    Image(systemName: "pin.fill")
+                if session.locked {
+                    Image(systemName: "lock.fill")
                         .font(.caption)
                         .foregroundStyle(CorveilTheme.textSecondary)
-                        .help("Pinned — exempt from auto-cleanup")
-                        .accessibilityLabel("Pinned")
+                        .help("Locked — exempt from auto-cleanup")
+                        .accessibilityLabel("Locked")
                 }
                 if session.autoMergeEnabledAt != nil {
                     Image(systemName: "arrow.triangle.merge")

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -400,7 +400,7 @@ public struct SettingsView: View {
             Section("Session Cleanup") {
                 Toggle("Auto-delete completed sessions", isOn: $config.cleanup.enabled)
                     .onChange(of: config.cleanup.enabled) { _, _ in save() }
-                Text("Automatically deletes completed and archived sessions after the retention period. Includes worktree and branch cleanup. Manager, virtual tab, and pinned sessions are never deleted.")
+                Text("Automatically deletes completed and archived sessions after the retention period. Includes worktree and branch cleanup. Manager, virtual tab, and locked sessions are never deleted.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -624,8 +624,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onSetSessionActive = { [weak service] id in
             service?.setSessionActive(id: id)
         }
-        appState.onSetPinned = { [weak service] id, pinned in
-            service?.setPinned(id: id, pinned: pinned)
+        appState.onSetLocked = { [weak service] id, locked in
+            service?.setLocked(id: id, locked: locked)
         }
 
         appState.onLaunchAgent = { [weak service] terminalID in
@@ -1439,7 +1439,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         "provider": s.provider.map { .string($0.rawValue) } ?? .null,
                         "created_at": .string(fmt.string(from: s.createdAt)),
                         "updated_at": .string(fmt.string(from: s.updatedAt)),
-                        "pinned": .bool(s.pinned),
+                        "locked": .bool(s.locked),
+                        // Legacy alias (CROW-569 named this `pinned`); kept for
+                        // one release so existing scripts keep working.
+                        "pinned": .bool(s.locked),
                     ]
                 }
             },
@@ -1463,17 +1466,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     return ["session_id": .string(idStr), "status": .string(statusStr)]
                 }
             },
+            "set-locked": { @Sendable params in
+                // Accept the new `locked` param, or the legacy CROW-569 `pinned`
+                // param, so the `set-pinned` alias below can share this handler.
+                guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr),
+                      let locked = params["locked"]?.boolValue ?? params["pinned"]?.boolValue else {
+                    throw RPCError.invalidParams("session_id and locked required")
+                }
+                return try await MainActor.run {
+                    guard capturedAppState.sessions.contains(where: { $0.id == id }) else {
+                        throw RPCError.applicationError("Session not found")
+                    }
+                    capturedService.setLocked(id: id, locked: locked)
+                    return ["session_id": .string(idStr), "locked": .bool(locked)]
+                }
+            },
+            // Deprecated alias for `set-locked` (CROW-569 → CROW-573 rename).
             "set-pinned": { @Sendable params in
                 guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr),
-                      let pinned = params["pinned"]?.boolValue else {
+                      let locked = params["pinned"]?.boolValue ?? params["locked"]?.boolValue else {
                     throw RPCError.invalidParams("session_id and pinned required")
                 }
                 return try await MainActor.run {
                     guard capturedAppState.sessions.contains(where: { $0.id == id }) else {
                         throw RPCError.applicationError("Session not found")
                     }
-                    capturedService.setPinned(id: id, pinned: pinned)
-                    return ["session_id": .string(idStr), "pinned": .bool(pinned)]
+                    capturedService.setLocked(id: id, locked: locked)
+                    return ["session_id": .string(idStr), "locked": .bool(locked)]
                 }
             },
             "delete-session": { @Sendable params in

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -2384,7 +2384,7 @@ final class IssueTracker {
         return sessions.compactMap { session in
             guard !protectedSessionIDs.contains(session.id) else { return nil }
             guard !session.isManager else { return nil }
-            guard !session.pinned else { return nil }
+            guard !session.locked else { return nil }
             guard session.status == .completed || session.status == .archived else { return nil }
             guard session.updatedAt < cutoff else { return nil }
             return session.id

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -2198,17 +2198,18 @@ final class SessionService {
         }
     }
 
-    /// Pin or unpin a session to exempt it from (or restore it to) the retention
-    /// cleanup reaper (CROW-569). Deliberately leaves `updatedAt` untouched so the
-    /// retention clock is preserved — unpinning restores the session's original
-    /// age-based eligibility rather than resetting it.
-    func setPinned(id: UUID, pinned: Bool) {
+    /// Lock or unlock a session to exempt it from (or restore it to) the
+    /// retention cleanup reaper (CROW-569 shipped this as "pin"; CROW-573 renamed
+    /// it to "lock"). Deliberately leaves `updatedAt` untouched so the retention
+    /// clock is preserved — unlocking restores the session's original age-based
+    /// eligibility rather than resetting it.
+    func setLocked(id: UUID, locked: Bool) {
         if let idx = appState.sessions.firstIndex(where: { $0.id == id }) {
-            appState.sessions[idx].pinned = pinned
+            appState.sessions[idx].locked = locked
         }
         store.mutate { data in
             if let idx = data.sessions.firstIndex(where: { $0.id == id }) {
-                data.sessions[idx].pinned = pinned
+                data.sessions[idx].locked = locked
             }
         }
     }

--- a/Tests/CrowTests/IssueTrackerCompletionTests.swift
+++ b/Tests/CrowTests/IssueTrackerCompletionTests.swift
@@ -17,7 +17,7 @@ struct IssueTrackerCompletionTests {
         provider: Provider? = .github,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
-        pinned: Bool = false
+        locked: Bool = false
     ) -> Session {
         Session(
             id: id,
@@ -28,7 +28,7 @@ struct IssueTrackerCompletionTests {
             provider: provider,
             createdAt: createdAt,
             updatedAt: updatedAt,
-            pinned: pinned
+            locked: locked
         )
     }
 
@@ -488,27 +488,27 @@ struct IssueTrackerCompletionTests {
     }
 
     @Test
-    func pinnedSessionPastRetentionIsNotEligible() {
-        // A pinned completed/job session must survive the reaper regardless of
-        // age (CROW-569). Unpinning restores normal eligibility.
-        let pinned = makeSession(
-            name: "pinned-job",
+    func lockedSessionPastRetentionIsNotEligible() {
+        // A locked completed/job session must survive the reaper regardless of
+        // age (CROW-569/CROW-573). Unlocking restores normal eligibility.
+        let locked = makeSession(
+            name: "locked-job",
             status: .completed,
             kind: .job,
             updatedAt: hoursAgo(48),
-            pinned: true
+            locked: true
         )
-        let unpinned = makeSession(
-            name: "unpinned-job",
+        let unlocked = makeSession(
+            name: "unlocked-job",
             status: .completed,
             kind: .job,
             updatedAt: hoursAgo(48)
         )
         let eligible = IssueTracker.sessionsEligibleForCleanup(
-            sessions: [pinned, unpinned],
+            sessions: [locked, unlocked],
             retentionHours: 24
         )
-        #expect(eligible == [unpinned.id])
+        #expect(eligible == [unlocked.id])
     }
 
     @Test


### PR DESCRIPTION
Closes #573

Follow-up to #569 / #571. Renames the retention-cleanup exemption metaphor from **Pin** to **Lock** — "Lock" reads more clearly as *protected / cannot be removed*. **Behavior is unchanged**; this is a rename with upgrade-safe persistence.

## Changes
- **Model** (`Session.swift`): `pinned` → `locked`. The decoder prefers the new `locked` key but falls back to the legacy `pinned` key (`LegacyCodingKeys`), so sessions locked under #571 **stay locked after upgrade**. The synthesized encoder always writes `locked`.
- **UI** (`SessionListView.swift`, `SettingsView.swift`): context menu **Pin/Unpin → Lock/Unlock**; row icon `pin.fill → lock.fill`; menu glyphs `lock` / `lock.open`; help + settings copy updated.
- **Service / AppState / RPC**: `setPinned → setLocked`, `onSetPinned → onSetLocked`. New `set-locked` RPC handler; **`set-pinned` kept as a deprecated alias**. `get-session` now reports `locked` (plus `pinned` as a legacy alias for one release).
- **CLI**: `crow set-locked --session <uuid> true|false`; `crow set-pinned` retained as a **hidden deprecated alias** that forwards to `set-locked`.

## Upgrade safety
The key risk in a rename is losing state persisted under the old key. Covered by a test: a session persisted with `"pinned": true` decodes to `locked == true`.

## Verification
- `make build` ✅
- `swift test` — 5 tests ✅: locked round-trip, **legacy `pinned` key decodes as locked**, default-false back-compat, reaper skips locked (+ mixed-eligibility control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtTVcJkZDYpYmjSqy81Qde