### PR TITLE
Fix done-in-24h badge Jira/provider cap: use search total, not capped node count (closes #572)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/JiraSearchClient.swift
+++ b/Packages/CrowCore/Sources/CrowCore/JiraSearchClient.swift
@@ -16,6 +16,10 @@ import Foundation
 /// Cloud). A single page of up to `maxResults` items is fetched, matching the
 /// previous `acli --limit 100` behavior; token pagination (`nextPageToken`) is a
 /// follow-up if boards ever exceed a page.
+///
+/// The enhanced endpoint dropped the legacy `total` field, so match totals that
+/// must exceed the page cap (the done-in-24h badge, #572) come from
+/// `POST /rest/api/3/search/approximate-count` via ``fetchApproximateCount``.
 public enum JiraSearchClient {
     public enum FetchError: Error, Equatable {
         case badSite
@@ -58,6 +62,63 @@ public enum JiraSearchClient {
             return nil
         }
         return issues
+    }
+
+    /// Build the approximate-count REST URL for a site host. Same bare-host
+    /// handling and forced-https as ``searchURL(site:jql:fields:maxResults:)``.
+    static func approximateCountURL(site: String) -> URL? {
+        let trimmedSite = site.trimmingCharacters(in: .whitespaces)
+        guard !trimmedSite.isEmpty else { return nil }
+        let bareHost = trimmedSite.range(of: "://").map { String(trimmedSite[$0.upperBound...]) } ?? trimmedSite
+        guard !bareHost.isEmpty else { return nil }
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = bareHost
+        components.path = "/rest/api/3/search/approximate-count"
+        return components.url
+    }
+
+    /// Parse the approximate-count payload (`{ "count": N }`). NSNumber bridges
+    /// both integer and double JSON encodings.
+    static func parseApproximateCount(_ data: Data) -> Int? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return (json["count"] as? NSNumber)?.intValue
+    }
+
+    /// Fetch the (eventually-consistent) total number of work items matching
+    /// `jql` on `site` via `POST /rest/api/3/search/approximate-count` — the
+    /// enhanced search API's replacement for the legacy `total` field. Used so
+    /// counts that must exceed the fetched page cap (the done-in-24h badge,
+    /// #572) don't saturate at the page size. Injectable transport for testing.
+    public static func fetchApproximateCount(
+        site: String,
+        jql: String,
+        authorization: String,
+        transport: (URLRequest) async throws -> (Data, URLResponse) = { try await URLSession.shared.data(for: $0) }
+    ) async -> Result<Int, FetchError> {
+        let trimmedJQL = jql.trimmingCharacters(in: .whitespaces)
+        guard let url = approximateCountURL(site: site), !trimmedJQL.isEmpty else {
+            return .failure(.badSite)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["jql": trimmedJQL])
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await transport(request)
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                return .failure(.http(http.statusCode))
+            }
+            guard let count = parseApproximateCount(data) else { return .failure(.decode) }
+            return .success(count)
+        } catch {
+            return .failure(.transport(error.localizedDescription))
+        }
     }
 
     /// Fetch the assigned work items matching `jql` on `site`, authenticated with

--- a/Packages/CrowCore/Tests/CrowCoreTests/JiraSearchClientTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JiraSearchClientTests.swift
@@ -98,6 +98,65 @@ import Foundation
         let result = await JiraSearchClient.fetchAssigned(site: "", jql: "x", authorization: "Basic creds")
         #expect(result.failureError == .badSite)
     }
+
+    // MARK: - Approximate count (#572)
+
+    @Test func buildsApproximateCountURL() {
+        let url = JiraSearchClient.approximateCountURL(site: "acme.atlassian.net")
+        #expect(url?.absoluteString == "https://acme.atlassian.net/rest/api/3/search/approximate-count")
+        // Forced https on a cleartext origin, nil on a blank site.
+        #expect(JiraSearchClient.approximateCountURL(site: "http://acme.atlassian.net")?.scheme == "https")
+        #expect(JiraSearchClient.approximateCountURL(site: " ") == nil)
+    }
+
+    @Test func parseApproximateCountReadsCount() {
+        #expect(JiraSearchClient.parseApproximateCount(Data(#"{"count":96}"#.utf8)) == 96)
+        #expect(JiraSearchClient.parseApproximateCount(Data("{}".utf8)) == nil)
+        #expect(JiraSearchClient.parseApproximateCount(Data("not json".utf8)) == nil)
+    }
+
+    @Test func fetchApproximateCountPostsJQLWithAuth() async {
+        let result = await JiraSearchClient.fetchApproximateCount(
+            site: "acme.atlassian.net",
+            jql: "statusCategory = Done",
+            authorization: "Basic creds",
+            transport: { request in
+                #expect(request.httpMethod == "POST")
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Basic creds")
+                #expect(request.url?.path == "/rest/api/3/search/approximate-count")
+                let body = try? JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+                #expect(body == ["jql": "statusCategory = Done"])
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (Data(#"{"count":96}"#.utf8), response)
+            }
+        )
+        guard case .success(let count) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(count == 96)
+    }
+
+    @Test func fetchApproximateCountFailsOnNon2xxAndDecode() async {
+        let unauthorized = await JiraSearchClient.fetchApproximateCount(
+            site: "acme.atlassian.net", jql: "x", authorization: "Basic creds",
+            transport: { request in
+                (Data(), HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!)
+            }
+        )
+        #expect(unauthorized.failureError == .http(401))
+
+        let garbage = await JiraSearchClient.fetchApproximateCount(
+            site: "acme.atlassian.net", jql: "x", authorization: "Basic creds",
+            transport: { request in
+                (Data("not json".utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+        )
+        #expect(garbage.failureError == .decode)
+
+        let blank = await JiraSearchClient.fetchApproximateCount(site: "", jql: "x", authorization: "Basic creds")
+        #expect(blank.failureError == .badSite)
+    }
 }
 
 /// `Result<[[String:Any]], _>` isn't `Equatable` (the success payload holds

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -215,7 +215,8 @@ public struct AssignedListing: Sendable {
     public let closed: [AssignedIssue]
     /// Total recently-closed matches, independent of the page cap on `closed`
     /// (GitHub's `search` fetches at most 50 nodes but reports the full
-    /// `issueCount`). Falls back to `closed.count` when the backend doesn't
+    /// `issueCount`; Jira reports the REST approximate-count / `acli --count`
+    /// total, #572). Falls back to `closed.count` when the backend doesn't
     /// report a total, so it's always safe to badge from.
     public let closedTotalCount: Int
     /// GitHub-only; nil for GitLab.

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
@@ -71,6 +71,11 @@ public struct GitLabTaskBackend: TaskBackend {
             return AssignedListing(open: open, closed: [])
         }
 
+        // `closed` is a single `per_page=50` page and `closedTotalCount` falls
+        // back to its length — if this path ever feeds a done-count badge, the
+        // total must come from the `X-Total` header (`glab api -i`) instead,
+        // per the #562/#572 cap fixes. Today IssueTracker only calls GitLab
+        // with `includeClosed: false` and never badges its closed count.
         let updatedAfter = Self.updatedAfterString()
         let closedOut: String
         do {

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
@@ -65,6 +65,10 @@ public struct JiraTaskBackend: TaskBackend {
     /// Recently-closed half, mirroring the 24h window GitHub/GitLab use for
     /// closed-issue removal detection in IssueTracker.
     static let closedJQL = "assignee = currentUser() AND statusCategory = Done AND updated >= -1d"
+    /// Page cap for the recently-closed half. The listing's `closedTotalCount`
+    /// comes from a separate count query so the done-in-24h badge doesn't
+    /// saturate at this cap (#572, mirroring GitHub's #562 fix).
+    static let closedPageLimit = 50
 
     public init(
         shellRunner: ShellRunner,
@@ -122,13 +126,23 @@ public struct JiraTaskBackend: TaskBackend {
             }
 
             let closed: [AssignedIssue]
-            switch await JiraSearchClient.fetchAssigned(site: site, jql: Self.closedJQL, authorization: authorization, maxResults: 50, transport: transport) {
+            switch await JiraSearchClient.fetchAssigned(site: site, jql: Self.closedJQL, authorization: authorization, maxResults: Self.closedPageLimit, transport: transport) {
             case .success(let items):
                 closed = Self.parseAssigned(items: items, site: config.site, statusOverride: .done, statusMap: config.statusMap)
             case .failure:
                 return AssignedListing(open: open, closed: [])
             }
-            return AssignedListing(open: open, closed: closed)
+
+            // Total matches in the window — `closed` is a single capped page, so
+            // the badge count must come from a count query or it saturates at
+            // the page cap (#572). Best-effort: nil falls back to closed.count.
+            var closedTotal: Int?
+            if case .success(let count) = await JiraSearchClient.fetchApproximateCount(site: site, jql: Self.closedJQL, authorization: authorization, transport: transport) {
+                // The count is eventually consistent; never report below the
+                // page we literally fetched.
+                closedTotal = max(count, closed.count)
+            }
+            return AssignedListing(open: open, closed: closed, closedTotalCount: closedTotal)
         }
 
         // Legacy fallback: `acli` (no REST credential configured).
@@ -147,12 +161,20 @@ public struct JiraTaskBackend: TaskBackend {
 
         let closed: [AssignedIssue]
         do {
-            let closedOut = try await search(jql: Self.closedJQL, limit: 50)
+            let closedOut = try await search(jql: Self.closedJQL, limit: Self.closedPageLimit)
             closed = Self.parseAssigned(closedOut, site: config.site, statusOverride: .done, statusMap: config.statusMap)
         } catch {
             return AssignedListing(open: open, closed: [])
         }
-        return AssignedListing(open: open, closed: closed)
+
+        // Same badge-total story as the REST path (#572): `--count` reports the
+        // full match count independent of `--limit`. Best-effort.
+        var closedTotal: Int?
+        if let countOut = try? await run(["acli", "jira", "workitem", "search", "--jql", Self.closedJQL, "--count"]),
+           let count = Self.firstInt(countOut) {
+            closedTotal = max(count, closed.count)
+        }
+        return AssignedListing(open: open, closed: closed, closedTotalCount: closedTotal)
     }
 
     public func setLabels(url: String, add: [String], remove: [String]) async throws {
@@ -343,6 +365,13 @@ public struct JiraTaskBackend: TaskBackend {
         if let arr = json as? [[String: Any]] { return arr.first }
         if let obj = json as? [String: Any] { return obj }
         return nil
+    }
+
+    /// Leniently pull the first integer out of `acli … --count` output, whose
+    /// exact shape isn't contract ("96", "96 work items", `{"count":96}` all parse).
+    static func firstInt(_ output: String) -> Int? {
+        guard let range = output.range(of: #"\d+"#, options: .regularExpression) else { return nil }
+        return Int(output[range])
     }
 
     /// Fallback when `create --json` returns non-JSON: scrape the first KEY-123

--- a/Packages/CrowProvider/Tests/CrowProviderTests/JiraTaskBackendTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/JiraTaskBackendTests.swift
@@ -120,12 +120,58 @@ final class JiraTaskBackendTests: XCTestCase {
         let b = backend(fake, config: JiraConfig(site: "acme.atlassian.net", jql: "project = PROJ AND assignee = currentUser()"))
         let listing = try await b.listAssigned(includeClosed: true)
 
-        XCTAssertEqual(fake.calls.count, 2)
+        // Three calls: open search, closed search, closed `--count` (#572).
+        XCTAssertEqual(fake.calls.count, 3)
         XCTAssertTrue(fake.calls[0].args.contains("project = PROJ AND assignee = currentUser()"))
         XCTAssertTrue(fake.calls[1].args.contains(JiraTaskBackend.closedJQL))
         XCTAssertEqual(listing.closed.count, 1)
         XCTAssertEqual(listing.closed[0].state, "closed")
         XCTAssertEqual(listing.closed[0].projectStatus, .done)
+        // Count response exhausted (empty output) → falls back to the page count.
+        XCTAssertEqual(listing.closedTotalCount, 1)
+    }
+
+    // MARK: - Closed total beyond the page cap (#572)
+
+    /// The badge total must come from `--count`, not the `--limit`-capped page:
+    /// 96 done tickets with a 50-item page must badge as 96, not 50.
+    func testListAssignedAcliUsesCountForClosedTotal() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [
+            .success("[]"),
+            .success(#"[{"key":"PROJ-9","fields":{"summary":"Done one","status":{"name":"Done","statusCategory":{"key":"done"}}}}]"#),
+            .success("96 work items"),
+        ]
+        let listing = try await backend(fake).listAssigned(includeClosed: true)
+
+        XCTAssertEqual(fake.calls.count, 3)
+        let countArgs = fake.calls[2].args
+        XCTAssertEqual(Array(countArgs.prefix(4)), ["acli", "jira", "workitem", "search"])
+        XCTAssertTrue(countArgs.contains("--count"))
+        XCTAssertTrue(countArgs.contains(JiraTaskBackend.closedJQL))
+        XCTAssertFalse(countArgs.contains("--json"))
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closedTotalCount, 96)
+    }
+
+    /// A failed `--count` call degrades to the page count — never the whole listing.
+    func testListAssignedAcliCountFailureFallsBackToPageCount() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [
+            .success("[]"),
+            .success(#"[{"key":"PROJ-9","fields":{"summary":"Done one","status":{"name":"Done","statusCategory":{"key":"done"}}}}]"#),
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "boom")),
+        ]
+        let listing = try await backend(fake).listAssigned(includeClosed: true)
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closedTotalCount, 1)
+    }
+
+    func testFirstIntLenientParsing() {
+        XCTAssertEqual(JiraTaskBackend.firstInt("96"), 96)
+        XCTAssertEqual(JiraTaskBackend.firstInt("96 work items\n"), 96)
+        XCTAssertEqual(JiraTaskBackend.firstInt(#"{"count":96}"#), 96)
+        XCTAssertNil(JiraTaskBackend.firstInt("no digits here"))
     }
 
     func testListAssignedDegradesToEmptyOnFailure() async throws {
@@ -210,6 +256,55 @@ final class JiraTaskBackendTests: XCTestCase {
         let listing = try await b.listAssigned(includeClosed: false)
         XCTAssertTrue(listing.open.isEmpty)
         XCTAssertTrue(listing.closed.isEmpty)
+    }
+
+    // MARK: - listAssigned REST closed total (#572)
+
+    /// A closed page saturated at the 50-item cap with a true total of 96 must
+    /// report `closedTotalCount == 96` from the approximate-count endpoint —
+    /// the Jira mirror of GitHub's #562 `issueCount` fix.
+    func testListAssignedRESTUsesApproximateCountForClosedTotal() async throws {
+        let fake = FakeShellRunner()
+        let cfg = JiraConfig(site: "acme.atlassian.net", authorization: "Basic creds")
+        let closedNodes = (1...50).map {
+            #"{"key":"PROJ-\#($0)","fields":{"summary":"d","status":{"name":"Done","statusCategory":{"key":"done"}}}}"#
+        }.joined(separator: ",")
+        let searchCalls = Box<Int>(0)
+        let b = JiraTaskBackend(shellRunner: fake, config: cfg, transport: { request in
+            let ok = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if request.url?.path == "/rest/api/3/search/approximate-count" {
+                XCTAssertEqual(request.httpMethod, "POST")
+                let body = try? JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+                XCTAssertEqual(body?["jql"], JiraTaskBackend.closedJQL)
+                return (Data(#"{"count":96}"#.utf8), ok)
+            }
+            // First /search/jql call is the open half, second the closed half.
+            let call = searchCalls.get()
+            searchCalls.set(call + 1)
+            let payload = call == 0 ? #"{"issues":[]}"# : #"{"issues":[\#(closedNodes)]}"#
+            return (payload.data(using: .utf8)!, ok)
+        })
+        let listing = try await b.listAssigned(includeClosed: true)
+
+        XCTAssertTrue(fake.calls.isEmpty, "REST path must not shell out to acli")
+        XCTAssertEqual(listing.closed.count, 50)
+        XCTAssertEqual(listing.closedTotalCount, 96)
+    }
+
+    /// A failed approximate-count call degrades to the page count.
+    func testListAssignedRESTCountFailureFallsBackToPageCount() async throws {
+        let fake = FakeShellRunner()
+        let cfg = JiraConfig(site: "acme.atlassian.net", authorization: "Basic creds")
+        let b = JiraTaskBackend(shellRunner: fake, config: cfg, transport: { request in
+            if request.url?.path == "/rest/api/3/search/approximate-count" {
+                return (Data(), HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!)
+            }
+            let payload = #"{"issues":[{"key":"PROJ-9","fields":{"summary":"d","status":{"name":"Done","statusCategory":{"key":"done"}}}}]}"#
+            return (payload.data(using: .utf8)!, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        })
+        let listing = try await b.listAssigned(includeClosed: true)
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closedTotalCount, 1)
     }
 
     // MARK: - setLabels

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -2507,13 +2507,15 @@ final class IssueTracker {
 
     /// Merge a Jira `AssignedListing` into the board's flat issue list: open
     /// issues plus the closed (Done) issues deduped by `id` against the open
-    /// set, mirroring the GitHub closed-issue merge. `doneCount` is the full
-    /// closed count (the 24h Done window), matching GitHub's `doneIssuesLast24h`
-    /// semantics — it counts the window, not just the post-dedup remainder.
+    /// set, mirroring the GitHub closed-issue merge. `doneCount` is the
+    /// backend-reported window total (`closedTotalCount`), not the length of
+    /// the capped closed page, so the badge doesn't saturate at the 50-item
+    /// page cap (#572, mirroring GitHub's #562 fix) — and it counts the window,
+    /// not just the post-dedup remainder, matching GitHub's semantics.
     nonisolated static func mergeJiraListing(_ listing: AssignedListing) -> (issues: [AssignedIssue], doneCount: Int) {
         let openIDs = Set(listing.open.map(\.id))
         let uniqueDone = listing.closed.filter { !openIDs.contains($0.id) }
-        return (listing.open + uniqueDone, listing.closed.count)
+        return (listing.open + uniqueDone, listing.closedTotalCount)
     }
 
     /// Fetch open Corveil tasks assigned to the user for one workspace config.

--- a/Tests/CrowTests/IssueTrackerJiraDoneTests.swift
+++ b/Tests/CrowTests/IssueTrackerJiraDoneTests.swift
@@ -66,4 +66,25 @@ struct IssueTrackerJiraDoneTests {
         #expect(merged.issues.isEmpty)
         #expect(merged.doneCount == 0)
     }
+
+    /// CROW-572: the badge must reflect the backend-reported window total, not
+    /// the length of the capped closed page — 96 done tickets with a 50-item
+    /// page must badge as 96, mirroring GitHub's #562 `issueCount` fix.
+    @Test func doneCountUsesBackendTotalOverPageCount() {
+        let listing = AssignedListing(
+            open: [issue("PROJ-1", status: .inProgress, state: "open")],
+            closed: [
+                issue("PROJ-2", status: .done, state: "closed"),
+                issue("PROJ-3", status: .done, state: "closed"),
+            ],
+            closedTotalCount: 96
+        )
+
+        let merged = IssueTracker.mergeJiraListing(listing)
+
+        // The flat list still only carries the fetched page…
+        #expect(merged.issues.count == 3)
+        // …but the Done window count is the search total, uncapped.
+        #expect(merged.doneCount == 96)
+    }
 }


### PR DESCRIPTION
Closes #572

## Problem

Follow-up to #562. The sidebar "done in last 24h" badge aggregates per-provider done counts, and the Jira contribution still saturated at 50: `IssueTracker.mergeJiraListing` counted `closed.count` of a page capped at 50 (REST `maxResults: 50` / `acli --limit 50`), so 96 done Jira tickets badged as 52 (2 GitHub + 50 capped Jira).

## Grounding finding (per the ticket's instruction #1)

The ticket's premise about this checkout was stale: there is **no `StubCorveilTaskBackend`** in this tree — `JiraTaskBackend` (and `CorveilTaskBackend`) are fully implemented here, so the capped Jira done-count was directly fixable in this repo.

## Fix (mirrors #562's total-count pattern)

- **`JiraSearchClient.fetchApproximateCount`** (new): `POST /rest/api/3/search/approximate-count` — the enhanced `/rest/api/3/search/jql` endpoint dropped the legacy `total` field, and this is Jira Cloud's documented replacement.
- **`JiraTaskBackend.listAssigned`**: after the closed page succeeds, fetch the window total — approximate-count on the REST path, `acli jira workitem search --jql … --count` on the acli fallback (parsed leniently; live output verified: `✓ Number of work items in the search: 90`) — and populate `AssignedListing.closedTotalCount`. Clamped to `max(count, closed.count)`; any count failure degrades to today's `closed.count` behavior. The ≤50 page still drives list rendering.
- **`IssueTracker.mergeJiraListing`**: badge from `closedTotalCount` instead of the capped page length.

The total is fetched unconditionally (not gated on a "full" page) because the enhanced search endpoint may return fewer than `maxResults` items per page even when more matches exist.

## GitLab sibling cap — documented non-goal

`GitLabTaskBackend`'s `per_page=50` closed fetch is real but **doubly dormant**: `IssueTracker.fetchGitLabIssues` only ever calls `listAssigned(includeClosed: false)`, and GitLab never contributes to `doneCount`. Per the ticket's conditional ("fix it … if that count feeds a badge"), it doesn't — so instead of adding `glab api -i` / `X-Total` header parsing for a dead path, a call-site comment now records that requirement for whenever the path is activated.

## Tests

- `JiraSearchClientTests`: approximate-count URL building, payload parsing, POST body/auth, non-2xx/decode failures.
- `JiraTaskBackendTests`: **regression test — 50-item closed page + count 96 → `closedTotalCount == 96`** (REST and acli paths), count-failure fallback to page count, `--count` argv shape, lenient integer parsing.
- `IssueTrackerJiraDoneTests`: listing with `closedTotalCount: 96` over a 2-item page → `doneCount == 96` (the #562 mirror at the badge seam).

`swift build` + full test suites pass: root (266 tests), CrowCore (332), CrowProvider (36 Jira + rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)