### PR TITLE
Allow draft PRs in auto-rebase/conflict-resolution (drop shouldAttemptAutoRebase draft guard) (closes #577)

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1947,13 +1947,15 @@ final class IssueTracker {
 
     /// Decide whether `pr` is a candidate for auto-rebase. Pure so unit tests
     /// can exercise it without an `IssueTracker`. Unlike `shouldAttemptAutoMerge`
-    /// there is **no label requirement** and review state is irrelevant — a
-    /// rebase doesn't need approval. Returns true when the PR is OPEN, not a
-    /// draft, and either BEHIND its base or CONFLICTING. Crow-authorship and
-    /// per-head loop-safety are enforced by the caller.
+    /// there is **no label requirement**, and review state and draft-ness are
+    /// irrelevant — a rebase doesn't need approval, and the operation is a
+    /// rebase-onto-base + `--force-with-lease` on the session's own branch,
+    /// never a merge (drafts stay excluded from auto-merge by
+    /// `shouldAttemptAutoMerge`'s own guard). Returns true when the PR is OPEN
+    /// and either BEHIND its base or CONFLICTING. Crow-authorship and per-head
+    /// loop-safety are enforced by the caller.
     nonisolated static func shouldAttemptAutoRebase(pr: ViewerPR) -> Bool {
         guard pr.state == "OPEN" else { return false }
-        guard !pr.isDraft else { return false }
         return pr.mergeStateStatus == "BEHIND" || pr.mergeable == "CONFLICTING"
     }
 

--- a/Tests/CrowTests/IssueTrackerAutoRebaseTests.swift
+++ b/Tests/CrowTests/IssueTrackerAutoRebaseTests.swift
@@ -68,6 +68,19 @@ struct IssueTrackerAutoRebaseTests {
         #expect(IssueTracker.shouldAttemptAutoRebase(pr: pr))
     }
 
+    /// Draft-ness is irrelevant to a rebase (CROW-577): the operation only
+    /// rewrites the session's own branch, it never merges. A draft that has
+    /// fallen behind base is exactly the case the watcher should handle.
+    @Test func acceptsDraftBehindBase() {
+        let pr = makePR(mergeStateStatus: "BEHIND", isDraft: true)
+        #expect(IssueTracker.shouldAttemptAutoRebase(pr: pr))
+    }
+
+    @Test func acceptsDraftConflicting() {
+        let pr = makePR(mergeable: "CONFLICTING", mergeStateStatus: "DIRTY", isDraft: true)
+        #expect(IssueTracker.shouldAttemptAutoRebase(pr: pr))
+    }
+
     // MARK: - Rejects
 
     @Test func rejectsCleanMergeablePR() {
@@ -80,9 +93,18 @@ struct IssueTrackerAutoRebaseTests {
         #expect(!IssueTracker.shouldAttemptAutoRebase(pr: pr))
     }
 
-    @Test func rejectsDraft() {
-        let pr = makePR(mergeStateStatus: "BEHIND", isDraft: true)
-        #expect(!IssueTracker.shouldAttemptAutoRebase(pr: pr))
+    /// Regression (CROW-577): a draft that qualifies for auto-rebase must
+    /// still be excluded from the auto-merge path — `shouldAttemptAutoMerge`
+    /// keeps its own draft guard, so `shouldUpdateBranchBeforeMerge` stays
+    /// false and `applyAutoRebase`'s precedence branch can't hand a draft to
+    /// auto-merge. The `crow:merge` label is present so draft-ness is the
+    /// only thing blocking the merge path.
+    @Test func draftEligibleForRebaseIsStillExcludedFromMergePath() {
+        let pr = makePR(mergeStateStatus: "BEHIND", isDraft: true, labels: [Self.crowMergeLabel])
+        let session = Session(name: "feature-crow-42", kind: .work)
+        #expect(IssueTracker.shouldAttemptAutoRebase(pr: pr))
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: session))
+        #expect(!IssueTracker.shouldUpdateBranchBeforeMerge(pr: pr, session: session))
     }
 
     @Test func rejectsClosedPR() {


### PR DESCRIPTION
Closes #577

## Problem

The opt-in auto-rebase + conflict-resolution watcher (#551 / #555) silently skipped draft PRs: `shouldAttemptAutoRebase` had a `guard !pr.isDraft else { return false }` that returned before the `BEHIND || CONFLICTING` check was ever evaluated. A session whose draft PR was `CONFLICTING` (live repro: PR #494) never got picked up even with the toggle on.

## Fix

Drop the draft guard from `shouldAttemptAutoRebase` and update its doc comment. Draft-ness is irrelevant to a rebase: the operation is a rebase-onto-base + `--force-with-lease` on the session's own branch — it never merges anything.

**Auto-merge is unaffected**: `shouldAttemptAutoMerge` keeps its own independent `guard !pr.isDraft`, and `shouldUpdateBranchBeforeMerge` delegates to it, so a draft still cannot be auto-merged. The `applyAutoRebase` precedence branch also can't hand a draft to auto-merge (for a draft, `shouldUpdateBranchBeforeMerge` is false, so auto-rebase owns it) — regression-tested.

If draft-skip is ever wanted as a policy knob, it can be added later as a sub-setting; per the ticket, this PR takes the minimal removal.

## Tests

- `acceptsDraftBehindBase` / `acceptsDraftConflicting` — draft PRs that are BEHIND or CONFLICTING are now eligible (replaces the old `rejectsDraft`).
- `draftEligibleForRebaseIsStillExcludedFromMergePath` — a draft with the `crow:merge` label qualifies for rebase but still fails `shouldAttemptAutoMerge` and `shouldUpdateBranchBeforeMerge`.
- Existing coverage retained: non-draft BEHIND/CONFLICTING → true; CLOSED/MERGED/clean/unknown → false; auto-merge draft exclusion in `IssueTrackerAutoMergeTests`.

`swift build` + full `swift test` (268 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)