### PR TITLE
Auto-complete: reconcile unwatched done job sessions on startup/tick

### DIFF
--- a/Sources/Crow/App/JobScheduler.swift
+++ b/Sources/Crow/App/JobScheduler.swift
@@ -68,6 +68,13 @@ final class JobScheduler {
     }
 
     func start() {
+        // Adopt any already-done job sessions we aren't watching so they still
+        // auto-complete after a relaunch, or if they predate this feature — the
+        // in-memory watch is otherwise lost and the run lingers in `.active`
+        // (CROW-579). Runs post-hydration (`start()` is wired after
+        // `hydrateState`), so restored sessions/terminals are present.
+        reconcileUnwatchedJobs(now: Date())
+
         // First tick after one interval — gives the app a grace period at
         // launch and lets overdue jobs fire shortly after.
         timer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { [weak self] _ in
@@ -85,6 +92,9 @@ final class JobScheduler {
 
     private func tick() {
         let now = Date()
+        // Adopt any active job sessions we aren't already watching (relaunched
+        // or predating the feature) so they can auto-complete too (CROW-579).
+        reconcileUnwatchedJobs(now: now)
         // Auto-complete any job runs that have finished successfully. Runs on
         // every tick regardless of whether jobs are due (CROW-561).
         checkFinishedRuns(now: now)
@@ -201,6 +211,55 @@ final class JobScheduler {
     /// the settle window before it can be judged finished.
     private func markPromptsDelivered(sessionID: UUID) {
         watchedRuns[sessionID]?.promptsDeliveredAt = Date()
+    }
+
+    // MARK: - Reconcile unwatched runs (CROW-579)
+
+    /// Adopt any active `.job` session we aren't already watching so it can be
+    /// auto-completed like a run we fired ourselves. Covers runs this process
+    /// never watched: the app was relaunched after the run finished (the
+    /// in-memory `watchedRuns` was lost), or the run predates CROW-566.
+    ///
+    /// The adopted watch stamps both `startedAt` and `promptsDeliveredAt` at
+    /// `now`, which does two things:
+    /// - The run is inside the settle window, so `finishDecision` won't complete
+    ///   it until a later tick when it is *still* at rest — i.e. at rest across a
+    ///   full tick. That guards against completing a multi-prompt job mid-gap.
+    /// - The `maxWatchDuration` cap counts from adoption, not the session's real
+    ///   start, so a days-old predates-the-feature run is still eligible (using
+    ///   its actual start would trip the cap and never complete it).
+    ///
+    /// Sessions already in `watchedRuns` (runs we fired) are skipped so their
+    /// real delivery timestamp / settle timing is never disturbed.
+    private func reconcileUnwatchedJobs(now: Date) {
+        for session in appState.sessions where Self.shouldReconcile(
+            kind: session.kind,
+            status: session.status,
+            alreadyWatched: watchedRuns[session.id] != nil
+        ) {
+            // Need the managed terminal to read readiness/activity; if it's gone
+            // (e.g. the session was torn down mid-run) there's nothing to judge —
+            // leave it `.active` so the anomaly surfaces rather than completing it.
+            guard let terminalID = appState.terminals[session.id]?
+                .first(where: { $0.isManaged })?.id else { continue }
+            watchedRuns[session.id] = RunWatch(
+                terminalID: terminalID,
+                startedAt: now,
+                promptsDeliveredAt: now
+            )
+        }
+    }
+
+    /// Whether an unwatched session should be adopted for finish-watching on
+    /// reconciliation (CROW-579). Pure so it's unit-testable without an
+    /// `AppState`. The stateful caller additionally requires a managed terminal
+    /// to derive readiness.
+    static func shouldReconcile(
+        kind: SessionKind,
+        status: SessionStatus,
+        alreadyWatched: Bool
+    ) -> Bool {
+        kind == .job && status == .active && !alreadyWatched
     }
 
     /// Auto-complete watched job runs whose agent has finished successfully.

--- a/Tests/CrowTests/JobFinishDecisionTests.swift
+++ b/Tests/CrowTests/JobFinishDecisionTests.swift
@@ -6,8 +6,9 @@ import CrowCore
 /// Auto-complete decision for finished job runs (CROW-561). A job's session
 /// should transition to `.completed` only when its agent has finished
 /// successfully — every prompt delivered, a settle window elapsed, the agent
-/// launched and now at rest (`.done`/`.idle`) — and never while it is still
-/// working, awaiting input, or errored (`.waiting`).
+/// launched and now at rest (`.done`) — and never while it is still working,
+/// awaiting input, or errored (`.waiting`), nor at the never-started default
+/// (`.idle`).
 @Suite("Job finish decision")
 @MainActor
 struct JobFinishDecisionTests {

--- a/Tests/CrowTests/JobReconcileDecisionTests.swift
+++ b/Tests/CrowTests/JobReconcileDecisionTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// Reconciliation of unwatched job runs (CROW-579). On startup and each tick,
+/// `JobScheduler` adopts active `.job` sessions it isn't already watching so a
+/// finished run still auto-completes after an app relaunch (in-memory watch
+/// lost) or if it predates the feature. `shouldReconcile` is the pure
+/// eligibility gate; the adopted run is then judged by the same
+/// `finishDecision` the fired path uses, so the two can't diverge.
+@Suite("Job reconcile decision")
+@MainActor
+struct JobReconcileDecisionTests {
+
+    // MARK: - Eligibility (shouldReconcile)
+
+    @Test func adoptsActiveUnwatchedJob() {
+        #expect(JobScheduler.shouldReconcile(kind: .job, status: .active, alreadyWatched: false))
+    }
+
+    @Test func skipsAlreadyWatchedJob() {
+        // Runs we fired are already watched with their real delivery timestamp;
+        // re-adopting would clobber their settle timing.
+        #expect(!JobScheduler.shouldReconcile(kind: .job, status: .active, alreadyWatched: true))
+    }
+
+    @Test func skipsNonJobKinds() {
+        for kind: SessionKind in [.work, .review, .manager] {
+            #expect(!JobScheduler.shouldReconcile(kind: kind, status: .active, alreadyWatched: false))
+        }
+    }
+
+    @Test func skipsNonActiveStatuses() {
+        // Only `.active` job sessions are candidates — a completed/paused/
+        // in-review/archived job must not be adopted (and re-completed).
+        for status: SessionStatus in [.completed, .paused, .inReview, .archived] {
+            #expect(!JobScheduler.shouldReconcile(kind: .job, status: status, alreadyWatched: false))
+        }
+    }
+
+    // MARK: - Adoption contract (via the shared finishDecision)
+
+    /// A reconciled run is adopted with `promptsDeliveredAt == now`, so it sits
+    /// inside the settle window and can't complete on the adopting tick even
+    /// when the agent already reads `.done`. This is the mid-gap guard: a
+    /// multi-prompt job momentarily at rest between prompts isn't completed
+    /// until it stays at rest across a full tick.
+    @Test func adoptedRunWaitsOutSettleWindowBeforeCompleting() {
+        let adoptedAt = Date(timeIntervalSince1970: 10_000)
+        let settle: TimeInterval = 20
+        let maxWatch: TimeInterval = 12 * 3600
+
+        // Same instant it was adopted: 0s < settle → keep waiting.
+        #expect(JobScheduler.finishDecision(
+            now: adoptedAt,
+            status: .active,
+            startedAt: adoptedAt,
+            promptsDeliveredAt: adoptedAt,
+            readiness: .agentLaunched,
+            activityState: .done,
+            finishSettleDelay: settle,
+            maxWatchDuration: maxWatch
+        ) == .keepWaiting)
+
+        // A full tick later, still at rest → complete.
+        #expect(JobScheduler.finishDecision(
+            now: adoptedAt.addingTimeInterval(30),
+            status: .active,
+            startedAt: adoptedAt,
+            promptsDeliveredAt: adoptedAt,
+            readiness: .agentLaunched,
+            activityState: .done,
+            finishSettleDelay: settle,
+            maxWatchDuration: maxWatch
+        ) == .complete)
+    }
+
+    /// Adopting with `startedAt == now` (not the session's real, possibly
+    /// days-old, start) keeps a predates-the-feature run eligible: the
+    /// `maxWatchDuration` cap counts from adoption, so it doesn't trip on an old
+    /// session and can still complete once the settle window elapses.
+    @Test func adoptedRunIsNotImmediatelyCappedForAnOldSession() {
+        let adoptedAt = Date(timeIntervalSince1970: 10_000)
+        #expect(JobScheduler.finishDecision(
+            now: adoptedAt.addingTimeInterval(30),
+            status: .active,
+            startedAt: adoptedAt,               // adoption time, not createdAt
+            promptsDeliveredAt: adoptedAt,
+            readiness: .agentLaunched,
+            activityState: .done,
+            finishSettleDelay: 20,
+            maxWatchDuration: 12 * 3600
+        ) == .complete)
+    }
+}


### PR DESCRIPTION
Closes #579

Follow-up to #561/#566. Auto-completion of finished job sessions worked **only** for runs the current `JobScheduler` process fired and was still watching in memory (`watchedRuns` is in-memory only), so a job session left visibly done (green, agent at rest) stayed stuck in `.active` whenever:

- the app was **relaunched** after the run finished (watch state lost), or
- the run **predated** #566 (never watched).

## Change

Add a reconciliation pass — **on startup and on the existing 30s tick** — that adopts any active `.job` session not already in `watchedRuns`. Rather than duplicate the settle/decide machine, it inserts a `RunWatch` stamped with `startedAt`/`promptsDeliveredAt` at *now*, so the existing `checkFinishedRuns` loop judges it via the **same pure `finishDecision`** the fired path uses — the watched and reconciled paths can't diverge.

Adopting at *now* does two things for free:
- The run sits inside the `finishSettleDelay` window, so it can only complete on a **later** tick if it is *still* at rest (at rest across a full tick) — guarding against completing a multi-prompt job mid-gap.
- The 12h `maxWatchDuration` cap counts from adoption, not the session's real start, so a days-old predates-the-feature run is still eligible (using its real start would trip the cap and never complete it).

Errored / awaiting-input runs (`.waiting`) and the never-started default (`.idle`) stay `.active` unchanged — `finishDecision` only completes on `.done`. Runs we fired (already watched) are skipped so their real delivery timing is untouched; a session whose managed terminal is gone is left `.active` to surface.

## Acceptance criteria

- [x] A job session that finished successfully is auto-completed even if `JobScheduler` never watched it (app restarted, or predates the feature) — no manual action.
- [x] Errored / awaiting-input job sessions are still left `.active`.
- [x] Watched and reconciled paths share the same at-rest decision logic (`finishDecision`, reused verbatim — no change).

## Implementation notes

- Contained in `Sources/Crow/App/JobScheduler.swift`: a new pure `shouldReconcile(kind:status:alreadyWatched:)` eligibility gate, a `reconcileUnwatchedJobs(now:)` stateful adopter, and calls in `start()` and at the top of `tick()`. `finishDecision`, `checkFinishedRuns`, and `SessionService.completeSession` (which guards managers) are unchanged.
- Note: the ticket's "`.idle` for TUI agents" premise is stale — all agent kinds finish at `.done`; reusing `finishDecision` gets this right. Also corrected a stale `.done/.idle` comment in `JobFinishDecisionTests`.

## Testing

- `make build` — clean.
- `swift test --filter JobReconcileDecisionTests` — 6/6 (eligibility gate + adoption/settle contract).
- `swift test --filter JobFinishDecisionTests` — 11/11 still green.
- Post-merge (per acceptance): confirm the currently-stuck green/done job sessions auto-complete once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFKGGRAD3Dhw9iZmzZ8ycB