### PR TITLE
Manager + button: pick coding agent before opening new session

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -289,7 +289,9 @@ public final class AppState {
     }
 
     /// Called when the user clicks the sidebar "+" to spawn a new Manager session.
-    public var onCreateManager: (() -> Void)?
+    /// The optional `AgentKind` is a one-shot, per-session agent override chosen
+    /// from the picker menu; `nil` means "use the configured default" (#582).
+    public var onCreateManager: ((AgentKind?) -> Void)?
 
     /// Called when user clicks "Work on" for an assigned issue.
     public var onWorkOnIssue: ((String) -> Void)?  // receives issue URL

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -412,27 +412,68 @@ public struct ManagerReviewsAllowListRow: View {
         }
     }
 
+    /// "+" for a new Manager session. When two or more coding agents are
+    /// available (registered in `AgentRegistry` — which only holds agents whose
+    /// CLI resolved via `findBinary()`), the "+" opens an agent-picker menu so
+    /// the user can launch this one session with a specific agent (#582). With a
+    /// single agent there's nothing to pick, so it stays a plain button that
+    /// opens with the configured default.
+    @ViewBuilder
     private var newManagerButton: some View {
-        Button {
-            appState.onCreateManager?()
-        } label: {
-            Image(systemName: "plus")
-                .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(CorveilTheme.goldDark)
-                .frame(width: 28)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(CorveilTheme.bgSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
-                        )
-                )
+        let agents = AgentRegistry.shared.allAgents()
+        if agents.count >= 2 {
+            Menu {
+                let defaultKind = appState.agentKind(for: .manager)
+                ForEach(agents, id: \.kind) { agent in
+                    Button {
+                        appState.onCreateManager?(agent.kind)
+                    } label: {
+                        // The configured Manager default is pre-marked so it
+                        // reads as the default choice, without changing config.
+                        if agent.kind == defaultKind {
+                            Label("\(agent.displayName) (default)", systemImage: agent.iconSystemName)
+                        } else {
+                            Label(agent.displayName, systemImage: agent.iconSystemName)
+                        }
+                    }
+                }
+            } label: {
+                newManagerLabel
+            }
+            .menuStyle(.button)
+            .menuIndicator(.hidden)
+            .buttonStyle(.plain)
+            .fixedSize()
+            .help("New Manager session")
+            .accessibilityLabel("New Manager session")
+        } else {
+            Button {
+                appState.onCreateManager?(nil)
+            } label: {
+                newManagerLabel
+            }
+            .buttonStyle(.plain)
+            .help("New Manager session")
+            .accessibilityLabel("New Manager session")
         }
-        .buttonStyle(.plain)
-        .help("New Manager session")
-        .accessibilityLabel("New Manager session")
+    }
+
+    /// Shared compact "+" pill used as the label for both the plain button and
+    /// the agent-picker menu variants of `newManagerButton`.
+    private var newManagerLabel: some View {
+        Image(systemName: "plus")
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(CorveilTheme.goldDark)
+            .frame(width: 28)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(CorveilTheme.bgSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
+                    )
+            )
     }
 
     /// Shared full-width pill styling for the toggle buttons in this row.

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -674,15 +674,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Wire create-manager action — spawns an additional Manager session
-        // (auto-named "Manager N") with its own Claude-Code terminal in the devRoot.
-        appState.onCreateManager = { [weak self, weak service] in
+        // (auto-named "Manager N") with its own terminal in the devRoot. The
+        // optional `agentKind` is a one-shot pick from the "+" picker (#582);
+        // nil defers to the configured Manager-agent default.
+        appState.onCreateManager = { [weak self, weak service] agentKind in
             guard let self, let service else { return }
             // Pick the lowest unused "Manager N" so a delete-in-the-middle
             // doesn't produce a duplicate name.
             let existingNames = Set(self.appState.managerSessions.map(\.name))
             var n = 2
             while existingNames.contains("Manager \(n)") { n += 1 }
-            let id = service.createManagerSession(name: "Manager \(n)", cwd: devRoot)
+            let id = service.createManagerSession(name: "Manager \(n)", cwd: devRoot, agentKind: agentKind)
             self.appState.selectedSessionID = id
         }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -963,14 +963,26 @@ final class SessionService {
 
     /// Create an additional (non-primary) Manager session in `cwd`. Returns the
     /// new session's id. The terminal is set up by `createManagerTerminal`.
+    ///
+    /// `agentKind` is an optional one-shot override from the "+" picker menu
+    /// (#582): when supplied it wins over the configured default for this
+    /// session only, without mutating `agentsByKind` / `defaultAgentKind`.
+    /// `nil` falls back to the configured Manager agent.
     @discardableResult
-    func createManagerSession(name: String, cwd: String) -> UUID {
-        let agentKind = appState.agentKind(for: .manager)
+    func createManagerSession(name: String, cwd: String, agentKind override: AgentKind? = nil) -> UUID {
+        let agentKind = resolvedManagerAgentKind(override)
         let session = Session(name: name, status: .active, kind: .manager, agentKind: agentKind)
         appState.sessions.append(session)
         store.mutate { $0.sessions.append(session) }
         createManagerTerminal(session: session, cwd: cwd)
         return session.id
+    }
+
+    /// Resolve the agent for a new Manager session: an explicit per-session
+    /// choice wins, otherwise the configured default
+    /// (`agentsByKind["manager"] ?? defaultAgentKind`). Never mutates config.
+    func resolvedManagerAgentKind(_ explicit: AgentKind?) -> AgentKind {
+        explicit ?? appState.agentKind(for: .manager)
     }
 
     // MARK: - Delete Session

--- a/Tests/CrowTests/ManagerMigrationTests.swift
+++ b/Tests/CrowTests/ManagerMigrationTests.swift
@@ -100,6 +100,48 @@ struct ManagerMigrationTests {
         #expect(!cursorCmd.contains("claude"))
     }
 
+    /// #582: the "+" agent picker passes a one-shot `AgentKind` into
+    /// `createManagerSession`. `resolvedManagerAgentKind` must prefer that
+    /// explicit choice over the configured Manager default.
+    @MainActor
+    @Test
+    func resolvedManagerAgentKindPrefersExplicitOverride() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-mgr-resolve-override-\(UUID().uuidString)")
+        let appState = AppState()
+        appState.defaultAgentKind = .claudeCode
+        appState.agentsByKind = ["manager": .claudeCode]
+        let service = SessionService(store: JSONStore(directory: tmp), appState: appState)
+
+        // Explicit pick wins over both agentsByKind["manager"] and the default.
+        #expect(service.resolvedManagerAgentKind(.cursor) == .cursor)
+        // The configured default is left untouched (no config mutation).
+        #expect(appState.agentsByKind["manager"] == .claudeCode)
+        #expect(appState.defaultAgentKind == .claudeCode)
+    }
+
+    /// #582: with no explicit pick (the RPC / single-agent path passes `nil`),
+    /// resolution falls back to `agentsByKind["manager"] ?? defaultAgentKind`,
+    /// preserving the pre-picker behavior.
+    @MainActor
+    @Test
+    func resolvedManagerAgentKindFallsBackToConfigDefault() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-mgr-resolve-default-\(UUID().uuidString)")
+        let appState = AppState()
+
+        // Per-action override present → it wins.
+        appState.defaultAgentKind = .claudeCode
+        appState.agentsByKind = ["manager": .cursor]
+        let service = SessionService(store: JSONStore(directory: tmp), appState: appState)
+        #expect(service.resolvedManagerAgentKind(nil) == .cursor)
+
+        // No per-action override → falls through to defaultAgentKind.
+        appState.agentsByKind = [:]
+        appState.defaultAgentKind = .codex
+        #expect(service.resolvedManagerAgentKind(nil) == .codex)
+    }
+
     /// #374: hydrating the Manager rebuilds its claude `command` to refresh the
     /// --rc/--name/--permission-mode flags. That rebuild must NOT drop the
     /// terminal's `tmuxBinding` — if it does, `rehydrateTerminalSurface` can't


### PR DESCRIPTION
Closes #582

## What

The **+** button that spawns an extra **Manager** session (the pill next to "Manager" in the Review Board header) silently launched the configured default agent (`agentsByKind["manager"] ?? defaultAgentKind`). This turns it into an **agent-picker menu**: clicking **+** lists the available coding agents (with their icons), and picking one opens a new Manager session with **that** agent — for this session only, without mutating the persisted config.

## How

- **`AppState.onCreateManager`** now carries an optional `AgentKind` (`nil` = "use configured default").
- **`SessionService.createManagerSession`** gains an `agentKind:` override, resolved via a small `resolvedManagerAgentKind` helper: an explicit pick wins, else `agentsByKind["manager"] ?? defaultAgentKind`. No config write. The default-`nil` param keeps the existing create-session RPC path unchanged.
- **`ReviewBoardView`**'s `newManagerButton` becomes a `Menu` of `AgentRegistry.shared.allAgents()` when ≥2 agents are available; the configured Manager default is marked **(default)**. Each item uses the agent's existing `displayName` + `iconSystemName`.

## Availability

No new availability check was needed — `AgentRegistry` only holds agents whose CLI resolved via `findBinary()` at startup (Claude Code always registered; Codex/Cursor/OpenCode only when their binary is found). So the menu lists `allAgents()` directly, mirroring the existing Settings per-action picker. Uninstalled agents never appear.

## Single-agent case

Per the ticket's "implementer's call": with only one agent available there's nothing to pick, so **+** stays a plain button that opens with the default (matches how `CreateSessionView`/`SettingsView` disable their pickers below 2 agents).

## Tests

`Tests/CrowTests/ManagerMigrationTests.swift`:
- `resolvedManagerAgentKindPrefersExplicitOverride` — explicit pick wins over config default; config left untouched.
- `resolvedManagerAgentKindFallsBackToConfigDefault` — `nil` resolves `agentsByKind["manager"] ?? defaultAgentKind`.

`make build` clean; `swift test --filter ManagerMigrationTests` → 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuRA2BAmpVAXDK4pXKPtzm