### PR TITLE
M0+M1: crowd daemon — Hummingbird HTTP/WS + core JSON-RPC handlers + Linux terminal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,10 @@ let package = Package(
     products: [
         .executable(name: "CrowApp", targets: ["Crow"]),
         .executable(name: "crow", targets: ["CrowCLI"]),
+        // Headless cross-platform daemon (CROW-581). Build standalone on Linux
+        // with `swift build --product crowd` — it does not depend on the AppKit
+        // `Crow` target or its generated BuildInfo.
+        .executable(name: "crowd", targets: ["crowd"]),
     ],
     dependencies: [
         .package(path: "Packages/CrowCore"),
@@ -22,6 +26,7 @@ let package = Package(
         .package(path: "Packages/CrowIPC"),
         .package(path: "Packages/CrowTelemetry"),
         .package(path: "Packages/CrowCLI"),
+        .package(path: "Packages/CrowDaemon"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     ],
     targets: [
@@ -56,6 +61,13 @@ let package = Package(
                 .product(name: "CrowCLILib", package: "CrowCLI"),
             ],
             path: "Sources/CrowCLI"
+        ),
+        .executableTarget(
+            name: "crowd",
+            dependencies: [
+                .product(name: "CrowDaemon", package: "CrowDaemon"),
+            ],
+            path: "Sources/crowd"
         ),
         .testTarget(
             name: "CrowTests",

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -1,4 +1,9 @@
 import Foundation
+// `@Observable` is re-exported by Foundation on Apple platforms, but on Linux
+// the Observation module must be imported explicitly for the macro to resolve.
+// Importing it unconditionally is harmless on macOS and unblocks the headless
+// `crowd` daemon reusing `AppState` on Linux (CROW-581).
+import Observation
 
 /// Check whether a repo name matches any of the given patterns.
 /// Supports exact matches and simple glob patterns with `*` (e.g., `org/*`, `*/repo`).

--- a/Packages/CrowDaemon/Package.swift
+++ b/Packages/CrowDaemon/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CrowDaemon",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "CrowDaemon", targets: ["CrowDaemon"]),
+    ],
+    dependencies: [
+        .package(path: "../CrowCore"),
+        .package(path: "../CrowPersistence"),
+        .package(path: "../CrowGit"),
+        .package(path: "../CrowIPC"),
+        .package(path: "../CrowTerminal"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "CrowDaemon",
+            dependencies: [
+                .product(name: "CrowCore", package: "CrowCore"),
+                .product(name: "CrowPersistence", package: "CrowPersistence"),
+                .product(name: "CrowGit", package: "CrowGit"),
+                .product(name: "CrowIPC", package: "CrowIPC"),
+                .product(name: "CrowTerminal", package: "CrowTerminal"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+            ],
+            resources: [
+                .copy("Resources/web"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CrowDaemon/Package.swift
+++ b/Packages/CrowDaemon/Package.swift
@@ -32,5 +32,9 @@ let package = Package(
                 .copy("Resources/web"),
             ]
         ),
+        .testTarget(
+            name: "CrowDaemonTests",
+            dependencies: ["CrowDaemon"]
+        ),
     ]
 )

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -1,4 +1,6 @@
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #endif
 import CrowCore
@@ -34,13 +36,24 @@ public enum CrowDaemon {
         let commandRouter = makeCommandRouter(
             appState: appState, store: store, git: git, devRoot: options.devRoot)
 
-        // Unix socket — lets the existing `crow` CLI talk to the daemon.
-        let socketServer = SocketServer(socketPath: options.socketPath, router: commandRouter)
-        do {
-            try socketServer.start()
-            log("JSON-RPC Unix socket listening at \(options.socketPath)")
-        } catch {
-            log("WARNING: socket bind failed (\(error)); continuing with HTTP/WS only")
+        // Unix socket — lets the existing `crow` CLI talk to the daemon. Refuse
+        // to bind a socket another server already answers on (e.g. the desktop
+        // app's crow.sock): `SocketServer.start()` unlinks unconditionally, so
+        // binding it would hijack the app's CLI channel and dual-write the store
+        // (CROW-581 review). The daemon's default is a distinct `crowd.sock`;
+        // sharing the app's path is explicit via --socket, and even then we
+        // won't steal a live one.
+        if Self.socketInUse(options.socketPath) {
+            log("WARNING: \(options.socketPath) is already in use (another crowd or the Crow app). "
+                + "Not binding the Unix socket to avoid hijacking it — use a distinct --socket. Continuing with HTTP/WS only.")
+        } else {
+            let socketServer = SocketServer(socketPath: options.socketPath, router: commandRouter)
+            do {
+                try socketServer.start()
+                log("JSON-RPC Unix socket listening at \(options.socketPath)")
+            } catch {
+                log("WARNING: socket bind failed (\(error)); continuing with HTTP/WS only")
+            }
         }
 
         // Terminal cockpit (tmux). Optional — RPC still works without tmux.
@@ -96,6 +109,30 @@ public enum CrowDaemon {
     private static func log(_ message: String) {
         FileHandle.standardError.write(Data("[crowd] \(message)\n".utf8))
     }
+
+    /// Whether a live server is already accepting connections on the Unix socket
+    /// at `path` — used to avoid stealing another process's socket. A stale
+    /// socket file (nothing listening) returns false, so normal startup still
+    /// replaces it.
+    private static func socketInUse(_ path: String) -> Bool {
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        _ = path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { p in
+                p.withMemoryRebound(to: CChar.self, capacity: 104) { dest in strlcpy(dest, ptr, 104) }
+            }
+        }
+        let connected = withUnsafePointer(to: &addr) { p in
+            p.withMemoryRebound(to: sockaddr.self, capacity: 1) { sp in
+                connect(fd, sp, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        return connected == 0
+    }
 }
 
 /// Minimal CLI/env option parsing — kept dependency-free (no argument-parser,
@@ -104,8 +141,16 @@ public enum CrowDaemon {
 struct DaemonOptions {
     var httpPort: Int = 8787
     var host: String = "127.0.0.1"
-    var socketPath: String = SocketServer.defaultSocketPath()
+    var socketPath: String = DaemonOptions.defaultDaemonSocketPath()
     var devRoot: String = FileManager.default.currentDirectoryPath
+
+    /// A DISTINCT default from the app's `crow.sock`, in the same owner-only dir,
+    /// so running `crowd` with defaults never unlinks/steals the desktop app's
+    /// socket. Sharing the app's path is opt-in via `--socket` (CROW-581 review).
+    static func defaultDaemonSocketPath() -> String {
+        let dir = (SocketServer.defaultSocketPath() as NSString).deletingLastPathComponent
+        return (dir as NSString).appendingPathComponent("crowd.sock")
+    }
 
     static func parse(_ arguments: [String]) -> DaemonOptions {
         var options = DaemonOptions()
@@ -130,7 +175,10 @@ struct DaemonOptions {
             case "--host": if let value = next { options.host = value }; index += 1
             case "--socket", "--socket-path": if let value = next { options.socketPath = value }; index += 1
             case "--dev-root": if let value = next { options.devRoot = value }; index += 1
-            default: break
+            default:
+                if flag.hasPrefix("-") {
+                    FileHandle.standardError.write(Data("[crowd] WARNING: ignoring unknown flag '\(flag)'\n".utf8))
+                }
             }
             index += 1
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -18,6 +18,16 @@ public enum CrowDaemon {
     public static func run(arguments: [String] = CommandLine.arguments) async throws {
         let options = DaemonOptions.parse(arguments)
 
+        // The WS endpoints are unauthenticated; the Origin guard blocks
+        // cross-site browser hijacking but not same-origin/native clients on the
+        // network. Binding beyond loopback exposes git + a shell — warn loudly
+        // (CROW-581 review). Token auth for remote access is a follow-up.
+        if !WebSocketOriginGuard.isLoopbackHost(options.host) {
+            log("WARNING: binding to non-loopback host \(options.host) — /rpc and /terminal are UNAUTHENTICATED. "
+                + "Cross-origin browser requests are rejected, but any same-origin page or native client that can "
+                + "reach this address can run git and open a shell. Use only on trusted networks.")
+        }
+
         let store = JSONStore()
         let git = GitManager()
         let appState = await seedAppState(from: store)
@@ -107,7 +117,16 @@ struct DaemonOptions {
             let flag = arguments[index]
             let next = index + 1 < arguments.count ? arguments[index + 1] : nil
             switch flag {
-            case "--http-port": if let value = next, let port = Int(value) { options.httpPort = port }; index += 1
+            case "--http-port":
+                if let value = next {
+                    if let port = Int(value) {
+                        options.httpPort = port
+                    } else {
+                        FileHandle.standardError.write(Data(
+                            "[crowd] WARNING: ignoring malformed --http-port '\(value)'; using \(options.httpPort)\n".utf8))
+                    }
+                }
+                index += 1
             case "--host": if let value = next { options.host = value }; index += 1
             case "--socket", "--socket-path": if let value = next { options.socketPath = value }; index += 1
             case "--dev-root": if let value = next { options.devRoot = value }; index += 1

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -1,0 +1,120 @@
+#if canImport(Glibc)
+import Glibc
+#endif
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+import Foundation
+import Hummingbird
+import HummingbirdWebSocket
+import NIOCore
+
+/// The headless `crowd` daemon: serves Crow's JSON-RPC domain logic and the
+/// browser terminal over HTTP + WebSocket, reusing `CrowCore`/`CrowIPC`/
+/// `CrowGit`/`CrowPersistence`/`CrowTerminal` verbatim. Also binds the existing
+/// Unix socket so the current `crow` CLI can drive it (CROW-581, M0 + M1).
+public enum CrowDaemon {
+    public static func run(arguments: [String] = CommandLine.arguments) async throws {
+        let options = DaemonOptions.parse(arguments)
+
+        let store = JSONStore()
+        let git = GitManager()
+        let appState = await seedAppState(from: store)
+        let commandRouter = makeCommandRouter(
+            appState: appState, store: store, git: git, devRoot: options.devRoot)
+
+        // Unix socket — lets the existing `crow` CLI talk to the daemon.
+        let socketServer = SocketServer(socketPath: options.socketPath, router: commandRouter)
+        do {
+            try socketServer.start()
+            log("JSON-RPC Unix socket listening at \(options.socketPath)")
+        } catch {
+            log("WARNING: socket bind failed (\(error)); continuing with HTTP/WS only")
+        }
+
+        // Terminal cockpit (tmux). Optional — RPC still works without tmux.
+        let cockpit = TerminalCockpit(devRoot: options.devRoot)
+        if cockpit == nil {
+            log("WARNING: tmux not found; /terminal disabled (set CROW_TMUX to override)")
+        }
+
+        // WebSocket router: JSON-RPC at /rpc, terminal byte-stream at /terminal.
+        let wsRouter = Router(context: BasicWebSocketRequestContext.self)
+        RPCWebSocketHandler.mount(on: wsRouter, commandRouter: commandRouter)
+        if let cockpit { TerminalWebSocket.mount(on: wsRouter, cockpit: cockpit) }
+
+        // HTTP router: terminal page, xterm assets, health.
+        let httpRouter = Router()
+        httpRouter.get("/health") { _, _ in "ok" }
+        StaticAssets.mount(on: httpRouter, indexHTML: loadIndexHTML())
+
+        let app = Application(
+            router: httpRouter,
+            server: .http1WebSocketUpgrade(webSocketRouter: wsRouter),
+            configuration: .init(
+                address: .hostname(options.host, port: options.httpPort),
+                serverName: "crowd"))
+
+        log("HTTP/WS listening on http://\(options.host):\(options.httpPort) (terminal at /)")
+        try await app.runService()
+    }
+
+    @MainActor
+    private static func seedAppState(from store: JSONStore) -> AppState {
+        // Minimal hydration: sessions + their worktrees. The app's fuller
+        // `SessionService.hydrateState` (hook state, terminal migration, agent
+        // wiring) is AppKit-bound and out of scope for the daemon's M0 surface.
+        let appState = AppState()
+        let data = store.data
+        appState.sessions = data.sessions
+        for session in appState.sessions {
+            appState.worktrees[session.id] = data.worktrees.filter { $0.sessionID == session.id }
+        }
+        return appState
+    }
+
+    private static func loadIndexHTML() -> ByteBuffer {
+        if let url = Bundle.module.url(
+            forResource: "terminal", withExtension: "html", subdirectory: "web"),
+            let data = try? Data(contentsOf: url) {
+            return ByteBuffer(bytes: data)
+        }
+        return ByteBuffer(string: "<!doctype html><title>crowd</title><p>terminal.html missing from bundle</p>")
+    }
+
+    private static func log(_ message: String) {
+        FileHandle.standardError.write(Data("[crowd] \(message)\n".utf8))
+    }
+}
+
+/// Minimal CLI/env option parsing — kept dependency-free (no argument-parser,
+/// no generated BuildInfo) so `crowd` builds standalone on Linux via
+/// `swift build --product crowd`.
+struct DaemonOptions {
+    var httpPort: Int = 8787
+    var host: String = "127.0.0.1"
+    var socketPath: String = SocketServer.defaultSocketPath()
+    var devRoot: String = FileManager.default.currentDirectoryPath
+
+    static func parse(_ arguments: [String]) -> DaemonOptions {
+        var options = DaemonOptions()
+        if let envRoot = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"] {
+            options.devRoot = envRoot
+        }
+        var index = 1
+        while index < arguments.count {
+            let flag = arguments[index]
+            let next = index + 1 < arguments.count ? arguments[index + 1] : nil
+            switch flag {
+            case "--http-port": if let value = next, let port = Int(value) { options.httpPort = port }; index += 1
+            case "--host": if let value = next { options.host = value }; index += 1
+            case "--socket", "--socket-path": if let value = next { options.socketPath = value }; index += 1
+            case "--dev-root": if let value = next { options.devRoot = value }; index += 1
+            default: break
+            }
+            index += 1
+        }
+        return options
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -1,0 +1,124 @@
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+import Foundation
+
+/// JSON-RPC errors thrown by the daemon's handlers, carrying the right
+/// JSON-RPC error code. Mirrors the app's `AppDelegate.RPCError` (which is not
+/// reachable from the headless daemon — it lives in the AppKit target).
+enum DaemonRPCError: Error, LocalizedError, RPCErrorCoded {
+    case invalidParams(String)
+    case applicationError(String)
+
+    var rpcErrorCode: Int {
+        switch self {
+        case .invalidParams: return RPCErrorCode.invalidParams
+        case .applicationError: return RPCErrorCode.applicationError
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidParams(message), let .applicationError(message):
+            return message
+        }
+    }
+}
+
+/// Builds the daemon's `CommandRouter` with the M0 handler set
+/// (`new-session`, `list-sessions`, `add-worktree`). These mirror the
+/// corresponding closures in the macOS app's `AppDelegate.startSocketServer`,
+/// but operate purely on `AppState` + `JSONStore` (+ `GitManager`) with no
+/// AppKit or `SessionService` dependency, so the same domain logic runs on a
+/// headless Linux `crowd` (CROW-581).
+///
+/// `appState` is `@MainActor`-isolated; each handler hops to the main actor for
+/// the in-memory mutation exactly as the app does, keeping the persisted
+/// `store` and the observable `appState` in lockstep.
+func makeCommandRouter(
+    appState: AppState,
+    store: JSONStore,
+    git: GitManager,
+    devRoot: String
+) -> CommandRouter {
+    CommandRouter(handlers: [
+        "new-session": { params in
+            let name = params["name"]?.stringValue ?? "untitled"
+            guard Validation.isValidSessionName(name) else {
+                throw DaemonRPCError.invalidParams(
+                    "Invalid session name (max \(Validation.maxSessionNameLength) chars, no control characters)")
+            }
+            // The daemon creates only `work` sessions. `manager` sessions need
+            // the app's `SessionService` (terminal + agent wiring), which is
+            // AppKit-locked and out of scope for M0.
+            let kindStr = params["kind"]?.stringValue
+            guard kindStr == nil || kindStr == "work" else {
+                throw DaemonRPCError.invalidParams(
+                    "Only work sessions are supported by the daemon (manager sessions require the desktop app)")
+            }
+            let requestedAgentKind = params["agent_kind"]?.stringValue
+                .flatMap { $0.isEmpty ? nil : AgentKind(rawValue: $0) }
+            return await MainActor.run {
+                let agentKind = requestedAgentKind ?? appState.agentKind(for: .work)
+                let session = Session(name: name, kind: .work, agentKind: agentKind)
+                appState.sessions.append(session)
+                store.mutate { $0.sessions.append(session) }
+                return [
+                    "session_id": .string(session.id.uuidString),
+                    "name": .string(session.name),
+                    "agent_kind": .string(session.agentKind.rawValue),
+                ]
+            }
+        },
+
+        "list-sessions": { _ in
+            let sessions = await MainActor.run { appState.sessions }
+            let items: [JSONValue] = sessions.map { session in
+                .object([
+                    "id": .string(session.id.uuidString),
+                    "name": .string(session.name),
+                    "status": .string(session.status.rawValue),
+                ])
+            }
+            return ["sessions": .array(items)]
+        },
+
+        "add-worktree": { params in
+            guard let idStr = params["session_id"]?.stringValue, let sessionID = UUID(uuidString: idStr),
+                  let repo = params["repo"]?.stringValue, !repo.isEmpty,
+                  let path = params["path"]?.stringValue, !path.isEmpty,
+                  let branch = params["branch"]?.stringValue, !branch.isEmpty else {
+                throw DaemonRPCError.invalidParams("session_id, repo, path, branch required (non-empty)")
+            }
+            // Path-traversal guard: worktree + repo paths must live under devRoot.
+            guard Validation.isPathWithinRoot(path, root: devRoot) else {
+                throw DaemonRPCError.invalidParams("Worktree path must be within the configured devRoot")
+            }
+            let repoPath = params["repo_path"]?.stringValue ?? path
+            guard Validation.isPathWithinRoot(repoPath, root: devRoot) else {
+                throw DaemonRPCError.invalidParams("repo_path must be within the configured devRoot")
+            }
+            // Unlike the app (which records metadata and lets `setup.sh` create
+            // the worktree), the daemon materializes it here via CrowGit — this
+            // exercises the reused git layer end-to-end on Linux (CROW-581).
+            do {
+                try await git.createWorktree(repoPath: repoPath, worktreePath: path, branch: branch)
+            } catch {
+                throw DaemonRPCError.applicationError("git worktree add failed: \(error.localizedDescription)")
+            }
+            let worktree = SessionWorktree(
+                sessionID: sessionID, repoName: repo, repoPath: repoPath, worktreePath: path,
+                branch: branch, isPrimary: params["primary"]?.boolValue ?? false)
+            return await MainActor.run {
+                appState.worktrees[sessionID, default: []].append(worktree)
+                store.mutate { $0.worktrees.append(worktree) }
+                return [
+                    "worktree_id": .string(worktree.id.uuidString),
+                    "session_id": .string(idStr),
+                    "path": .string(path),
+                ]
+            }
+        },
+    ])
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -91,6 +91,16 @@ func makeCommandRouter(
                   let branch = params["branch"]?.stringValue, !branch.isEmpty else {
                 throw DaemonRPCError.invalidParams("session_id, repo, path, branch required (non-empty)")
             }
+            // Defense-in-depth: a leading-dash branch would be parsed as an option
+            // by `git ls-remote --heads origin <branch>` (option injection).
+            guard !branch.hasPrefix("-") else {
+                throw DaemonRPCError.invalidParams("branch must not start with '-'")
+            }
+            // Don't persist a worktree row for a session that doesn't exist.
+            let sessionExists = await MainActor.run { appState.sessions.contains { $0.id == sessionID } }
+            guard sessionExists else {
+                throw DaemonRPCError.invalidParams("Unknown session_id (no such session)")
+            }
             // Path-traversal guard: worktree + repo paths must live under devRoot.
             guard Validation.isPathWithinRoot(path, root: devRoot) else {
                 throw DaemonRPCError.invalidParams("Worktree path must be within the configured devRoot")

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -1,0 +1,37 @@
+import CrowIPC
+import Foundation
+import Hummingbird
+import HummingbirdWebSocket
+
+/// Serves the existing JSON-RPC protocol over a WebSocket at `/rpc`.
+///
+/// One JSON object per WebSocket message: decode a ``JSONRPCRequest``, run it
+/// through the shared ``CommandRouter`` (the very same router the Unix-socket
+/// server uses), and write the ``JSONRPCResponse`` back. No semaphore bridge —
+/// unlike `SocketServer`, we're already in an async context (CROW-581).
+enum RPCWebSocketHandler {
+    static func mount(on router: Router<BasicWebSocketRequestContext>, commandRouter: CommandRouter) {
+        router.ws("/rpc") { _, _ in
+            .upgrade()
+        } onUpgrade: { inbound, outbound, _ in
+            let decoder = JSONDecoder()
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            for try await message in inbound.messages(maxSize: 1 << 20) {
+                let payload: Data?
+                switch message {
+                case .text(let text): payload = text.data(using: .utf8)
+                case .binary(let buffer): payload = Data(buffer.readableBytesView)
+                }
+                guard let data = payload,
+                      let request = try? decoder.decode(JSONRPCRequest.self, from: data) else {
+                    continue
+                }
+                let response = await commandRouter.handle(request: request)
+                if let out = try? encoder.encode(response), let text = String(data: out, encoding: .utf8) {
+                    try await outbound.write(.text(text))
+                }
+            }
+        }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -1,5 +1,6 @@
 import CrowIPC
 import Foundation
+import HTTPTypes
 import Hummingbird
 import HummingbirdWebSocket
 
@@ -11,8 +12,10 @@ import HummingbirdWebSocket
 /// unlike `SocketServer`, we're already in an async context (CROW-581).
 enum RPCWebSocketHandler {
     static func mount(on router: Router<BasicWebSocketRequestContext>, commandRouter: CommandRouter) {
-        router.ws("/rpc") { _, _ in
-            .upgrade()
+        router.ws("/rpc") { request, _ in
+            // Reject cross-site upgrades — `/rpc` reaches `add-worktree`, which
+            // shells out to git (CROW-581 review).
+            WebSocketOriginGuard.isAllowedOrigin(request.headers[.origin]) ? .upgrade() : .dontUpgrade
         } onUpgrade: { inbound, outbound, _ in
             let decoder = JSONDecoder()
             let encoder = JSONEncoder()

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Crow Terminal</title>
+  <link rel="stylesheet" href="/xterm/xterm.css">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: #1e1e1e;
+    }
+    #terminal {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="terminal"></div>
+  <script src="/xterm/xterm.js"></script>
+  <script src="/xterm/xterm-addon-fit.js"></script>
+  <script src="/xterm/xterm-addon-image.js"></script>
+  <script>
+    // WebSocket transport variant of CrowTerminal's terminal.html. The xterm.js
+    // config block is copied verbatim so font/scrollback/inline-image behavior
+    // matches the macOS surface; only the WKWebView message bus is swapped for a
+    // WebSocket carrying raw PTY bytes (binary) + a resize control frame (JSON).
+    (function () {
+      if (typeof Terminal !== 'function') {
+        console.error('Crow: Terminal constructor missing (xterm.js failed to load)');
+        return;
+      }
+
+      const fitAddon = new FitAddon.FitAddon();
+      const imageAddon = new ImageAddon.ImageAddon({
+        sixelSupport: true,
+        iipSupport: true,
+        kittySupport: true,
+      });
+      const term = new Terminal({
+        cursorBlink: true,
+        fontSize: 14,
+        fontFamily: '"MesloLGS NF", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", "FiraCode Nerd Font", Menlo, Monaco, monospace',
+        theme: { background: '#1e1e1e', foreground: '#d4d4d4' },
+        scrollback: 10000,
+        allowTransparency: true,
+      });
+      term.loadAddon(fitAddon);
+      term.loadAddon(imageAddon);
+      term.open(document.getElementById('terminal'));
+
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws = new WebSocket(proto + '://' + window.location.host + '/terminal');
+      ws.binaryType = 'arraybuffer';
+
+      function sendResize() {
+        fitAddon.fit();
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'resize', rows: term.rows, cols: term.cols }));
+        }
+      }
+
+      ws.onopen = function () {
+        sendResize();
+        // Keystrokes → PTY. Encode as UTF-8 bytes (binary frame) so multibyte
+        // input round-trips exactly like the macOS `term.onData` path.
+        term.onData(function (data) {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(new TextEncoder().encode(data));
+          }
+        });
+      };
+
+      ws.onmessage = function (event) {
+        // Raw PTY bytes (binary). Feed xterm a Uint8Array, never a string, so
+        // UTF-8 multibyte sequences (Claude/Cursor TUIs) stay intact.
+        if (event.data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(event.data));
+        } else {
+          term.write(event.data);
+        }
+      };
+
+      ws.onclose = function () {
+        term.write('\r\n\x1b[31m[crow] terminal disconnected\x1b[0m\r\n');
+      };
+
+      window.addEventListener('resize', sendResize);
+    })();
+  </script>
+</body>
+</html>

--- a/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
@@ -17,8 +17,7 @@ enum StaticAssets {
         }
         router.get("/xterm/:file") { _, context -> Response in
             // Basename-only guard against path traversal.
-            guard let file = context.parameters.get("file"),
-                  !file.contains("/"), !file.contains("..") else {
+            guard let file = context.parameters.get("file"), isSafeAssetName(file) else {
                 return Response(status: .badRequest)
             }
             guard let dir = BundledResources.xtermDirectoryURL else {
@@ -32,6 +31,13 @@ enum StaticAssets {
                 headers: [.contentType: contentType(for: file)],
                 body: .init(byteBuffer: ByteBuffer(bytes: data)))
         }
+    }
+
+    /// Whether `name` is a safe single path component for `/xterm/*`: non-empty,
+    /// no separators, no `..`. The router decodes percent-escapes before this
+    /// runs, so `%2e%2e`/`%2f` are caught here (CROW-581 review).
+    static func isSafeAssetName(_ name: String) -> Bool {
+        !name.isEmpty && !name.contains("/") && !name.contains("..")
     }
 
     private static func contentType(for file: String) -> String {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
@@ -1,0 +1,43 @@
+import CrowTerminal
+import Foundation
+import Hummingbird
+import NIOCore
+
+/// Serves the browser terminal page (`/`) and the xterm.js 6.0.0 assets
+/// (`/xterm/*`). The assets are streamed straight out of `CrowTerminal`'s
+/// resource bundle, so the web UI reuses the exact same xterm build as the
+/// macOS app instead of duplicating it (CROW-581).
+enum StaticAssets {
+    static func mount(on router: Router<BasicRequestContext>, indexHTML: ByteBuffer) {
+        router.get("/") { _, _ -> Response in
+            Response(
+                status: .ok,
+                headers: [.contentType: "text/html; charset=utf-8"],
+                body: .init(byteBuffer: indexHTML))
+        }
+        router.get("/xterm/:file") { _, context -> Response in
+            // Basename-only guard against path traversal.
+            guard let file = context.parameters.get("file"),
+                  !file.contains("/"), !file.contains("..") else {
+                return Response(status: .badRequest)
+            }
+            guard let dir = BundledResources.xtermDirectoryURL else {
+                return Response(status: .notFound)
+            }
+            guard let data = try? Data(contentsOf: dir.appendingPathComponent(file)) else {
+                return Response(status: .notFound)
+            }
+            return Response(
+                status: .ok,
+                headers: [.contentType: contentType(for: file)],
+                body: .init(byteBuffer: ByteBuffer(bytes: data)))
+        }
+    }
+
+    private static func contentType(for file: String) -> String {
+        if file.hasSuffix(".js") { return "text/javascript; charset=utf-8" }
+        if file.hasSuffix(".css") { return "text/css; charset=utf-8" }
+        if file.hasSuffix(".html") { return "text/html; charset=utf-8" }
+        return "application/octet-stream"
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -15,9 +15,26 @@ struct TerminalCockpit: Sendable {
 
     init?(devRoot: String) {
         guard let tmux = Self.resolveTmuxBinary() else { return nil }
-        let socketPath = NSTemporaryDirectory() + "crowd-tmux.sock"
-        controller = TmuxController(tmuxBinary: tmux, socketPath: socketPath, sessionName: Self.sessionName)
+        controller = TmuxController(tmuxBinary: tmux, socketPath: Self.tmuxSocketPath(), sessionName: Self.sessionName)
         ensureSession()
+    }
+
+    /// The tmux control socket path — in an owner-only directory rather than
+    /// world-writable `/tmp`. On Linux `NSTemporaryDirectory()` is `/tmp`, where a
+    /// predictable name lets another local user squat the path (DoS) and prevents
+    /// two users from running `crowd` on one host (CROW-581 review). Prefer
+    /// `$XDG_RUNTIME_DIR`, else `~/.local/share/crow` created 0700.
+    static func tmuxSocketPath() -> String {
+        let dir: String
+        if let xdg = ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"], !xdg.isEmpty {
+            dir = xdg
+        } else {
+            dir = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".local/share/crow").path
+            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir)
+        }
+        return (dir as NSString).appendingPathComponent("crowd-tmux.sock")
     }
 
     /// Create the cockpit session (default shell, `crow-tmux.conf` applied) if it

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -1,0 +1,59 @@
+import CrowTerminal
+import Foundation
+
+/// Owns the shared tmux "cockpit" session that browser terminals attach to.
+///
+/// Reuses the portable ``TmuxController`` plus the bundled `crow-tmux.conf`
+/// (extended-keys, allow-passthrough, etc.). One session is shared across every
+/// browser tab — each `/terminal` WebSocket runs its own PTY doing
+/// `tmux attach-session`, exactly as the macOS app's cockpit does. Wrapping the
+/// shell in `crow-shell-wrapper.sh` (OSC readiness markers, agent auto-launch)
+/// is a deliberate M1 follow-up; the plain shell already proves the byte path.
+struct TerminalCockpit: Sendable {
+    static let sessionName = "crow-cockpit"
+    let controller: TmuxController
+
+    init?(devRoot: String) {
+        guard let tmux = Self.resolveTmuxBinary() else { return nil }
+        let socketPath = NSTemporaryDirectory() + "crowd-tmux.sock"
+        controller = TmuxController(tmuxBinary: tmux, socketPath: socketPath, sessionName: Self.sessionName)
+        ensureSession()
+    }
+
+    /// Create the cockpit session (default shell, `crow-tmux.conf` applied) if it
+    /// doesn't exist yet. Idempotent — extra browser tabs attach to the same
+    /// session. A failed create surfaces to the user as an attach error inside
+    /// the terminal, which is easier to diagnose than aborting daemon boot.
+    private func ensureSession() {
+        guard !controller.hasSession() else { return }
+        let conf = BundledResources.tmuxConfURL?.path
+        try? controller.newSessionDetached(configPath: conf, env: [:], command: nil)
+    }
+
+    /// The command a PTY runs to join the cockpit:
+    /// `tmux -S <sock> attach-session -t crow-cockpit`. Streaming this PTY's
+    /// bytes to xterm.js is the entire M1 terminal path.
+    func attachCommand() -> String {
+        "\(Self.shellQuote(controller.tmuxBinary)) -S \(Self.shellQuote(controller.socketPath)) "
+            + "attach-session -t \(Self.shellQuote(Self.sessionName))"
+    }
+
+    /// First usable tmux binary: `CROW_TMUX` override, then common install
+    /// locations (Linux `/usr/bin`, Homebrew, `/usr/local`).
+    private static func resolveTmuxBinary() -> String? {
+        let fm = FileManager.default
+        if let override = ProcessInfo.processInfo.environment["CROW_TMUX"],
+           fm.isExecutableFile(atPath: override) {
+            return override
+        }
+        for path in ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/usr/bin/tmux", "/bin/tmux"]
+        where fm.isExecutableFile(atPath: path) {
+            return path
+        }
+        return nil
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
@@ -1,5 +1,6 @@
 import CrowTerminal
 import Foundation
+import HTTPTypes
 import Hummingbird
 import HummingbirdWebSocket
 import NIOCore
@@ -10,9 +11,18 @@ import NIOCore
 /// frames), and a `{"type":"resize",...}` JSON control frame (CROW-581).
 enum TerminalWebSocket {
     static func mount(on router: Router<BasicWebSocketRequestContext>, cockpit: TerminalCockpit) {
-        router.ws("/terminal") { _, _ in
-            .upgrade()
+        router.ws("/terminal") { request, _ in
+            // Reject cross-site upgrades — a plain attach yields an interactive
+            // shell, so an unguarded upgrade is effectively RCE (CROW-581 review).
+            WebSocketOriginGuard.isAllowedOrigin(request.headers[.origin]) ? .upgrade() : .dontUpgrade
         } onUpgrade: { inbound, outbound, _ in
+            // Bound concurrent PTY + tmux attaches.
+            guard TerminalConnectionLimiter.shared.acquire() else {
+                try? await outbound.write(.text("[crow] terminal connection limit reached"))
+                return
+            }
+            defer { TerminalConnectionLimiter.shared.release() }
+
             // deliverOnMainQueue: false — the daemon has no main run loop, so PTY
             // output is delivered synchronously on the PTY read queue and bridged
             // into this async task via an AsyncStream.
@@ -49,9 +59,11 @@ enum TerminalWebSocket {
                     guard let data = text.data(using: .utf8),
                           let control = try? JSONDecoder().decode(TerminalControl.self, from: data),
                           control.type == "resize" else { continue }
+                    // Floor at 1×1 so a zero/negative request can't drive a
+                    // degenerate tmux resize (CROW-581 review).
                     pty.resize(
-                        rows: UInt16(clamping: control.rows ?? 24),
-                        cols: UInt16(clamping: control.cols ?? 80))
+                        rows: UInt16(clamping: max(1, control.rows ?? 24)),
+                        cols: UInt16(clamping: max(1, control.cols ?? 80)))
                 }
             }
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
@@ -1,0 +1,65 @@
+import CrowTerminal
+import Foundation
+import Hummingbird
+import HummingbirdWebSocket
+import NIOCore
+
+/// Streams a PTY running `tmux attach-session` to xterm.js over a WebSocket
+/// (`/terminal`). Replaces the macOS WKWebView message bus with the same four
+/// message types: raw PTY bytes out (binary frames), keystrokes in (binary
+/// frames), and a `{"type":"resize",...}` JSON control frame (CROW-581).
+enum TerminalWebSocket {
+    static func mount(on router: Router<BasicWebSocketRequestContext>, cockpit: TerminalCockpit) {
+        router.ws("/terminal") { _, _ in
+            .upgrade()
+        } onUpgrade: { inbound, outbound, _ in
+            // deliverOnMainQueue: false — the daemon has no main run loop, so PTY
+            // output is delivered synchronously on the PTY read queue and bridged
+            // into this async task via an AsyncStream.
+            let pty = PTYProcess(deliverOnMainQueue: false)
+            let (stream, continuation) = AsyncStream<Data>.makeStream()
+            pty.onOutput = { data in continuation.yield(data) }
+            pty.onExit = { _ in continuation.finish() }
+
+            do {
+                try pty.start(command: cockpit.attachCommand(), workingDirectory: nil)
+            } catch {
+                continuation.finish()
+                return
+            }
+
+            // Pump PTY output → binary WebSocket frames.
+            let outputTask = Task {
+                for await chunk in stream {
+                    try await outbound.write(.binary(ByteBuffer(bytes: chunk)))
+                }
+            }
+            defer {
+                pty.terminate()
+                continuation.finish()
+                outputTask.cancel()
+            }
+
+            // Inbound: binary = keystrokes → PTY; text = JSON control (resize).
+            for try await message in inbound.messages(maxSize: 1 << 20) {
+                switch message {
+                case .binary(let buffer):
+                    pty.write(Data(buffer.readableBytesView))
+                case .text(let text):
+                    guard let data = text.data(using: .utf8),
+                          let control = try? JSONDecoder().decode(TerminalControl.self, from: data),
+                          control.type == "resize" else { continue }
+                    pty.resize(
+                        rows: UInt16(clamping: control.rows ?? 24),
+                        cols: UInt16(clamping: control.cols ?? 80))
+                }
+            }
+        }
+    }
+}
+
+private struct TerminalControl: Decodable {
+    let type: String
+    let rows: Int?
+    let cols: Int?
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/WebSocketOriginGuard.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/WebSocketOriginGuard.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Cross-site WebSocket hijacking defense (CROW-581 review).
+///
+/// Browsers do **not** apply the same-origin policy to *outbound* WebSocket
+/// connections, so binding `crowd` to loopback does not stop a malicious page
+/// the user happens to be visiting from opening `ws://127.0.0.1:<port>/terminal`
+/// and receiving an interactive shell (or driving `/rpc`, which shells out to
+/// git). We therefore reject the upgrade unless the request's `Origin` is:
+///   - absent/empty — a native, non-browser client (the `crow` CLI, `websocat`,
+///     a test harness); browsers always send `Origin` on a WS handshake; or
+///   - a loopback host — the only origins that can legitimately have served the
+///     bundled web UI in a default deployment.
+///
+/// Remote, authenticated browser access (the eventual goal of the epic) needs a
+/// real token and is an explicit follow-up; until then the web UI is a
+/// loopback-only tool.
+enum WebSocketOriginGuard {
+    private static let loopbackHosts: Set<String> = ["127.0.0.1", "localhost", "::1"]
+
+    /// Whether a WebSocket upgrade carrying `origin` should be allowed.
+    static func isAllowedOrigin(_ origin: String?) -> Bool {
+        guard let origin, !origin.isEmpty else { return true }  // native (non-browser) client
+        guard let host = originHost(origin) else { return false }
+        return loopbackHosts.contains(host)
+    }
+
+    /// Host component of an `Origin` value (`scheme://host[:port]`), lowercased
+    /// with IPv6 brackets stripped. Returns nil for unparseable origins —
+    /// including the opaque `"null"` origin sandboxed frames send — which are
+    /// then rejected.
+    static func originHost(_ origin: String) -> String? {
+        guard let host = URL(string: origin)?.host, !host.isEmpty else { return nil }
+        return host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+    }
+
+    /// Whether `host` (a daemon `--host` bind value) is a loopback address.
+    /// `0.0.0.0` is **not** loopback, so binding it trips the daemon's warning.
+    static func isLoopbackHost(_ host: String) -> Bool {
+        loopbackHosts.contains(host.lowercased())
+    }
+}
+
+/// Bounds concurrent `/terminal` connections so a flood of upgrades can't spawn
+/// unbounded PTYs + `tmux attach` clients and exhaust file descriptors
+/// (CROW-581 review). A spike-appropriate ceiling; a real deployment would tune
+/// or replace this alongside auth.
+final class TerminalConnectionLimiter: @unchecked Sendable {
+    static let shared = TerminalConnectionLimiter(max: 16)
+
+    private let lock = NSLock()
+    private let max: Int
+    private var count = 0
+
+    init(max: Int) { self.max = max }
+
+    /// Reserve a slot; returns false when the ceiling is already reached.
+    func acquire() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard count < max else { return false }
+        count += 1
+        return true
+    }
+
+    func release() {
+        lock.lock()
+        defer { lock.unlock() }
+        if count > 0 { count -= 1 }
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -1,0 +1,86 @@
+import Testing
+@testable import CrowDaemon
+
+/// Locks down the security-sensitive guards flagged in the CROW-581 review:
+/// the WebSocket `Origin` allowlist (cross-site hijacking defense), the
+/// non-loopback bind detection, and the static-asset path-traversal guard.
+@Suite struct WebSocketOriginGuardTests {
+    @Test func allowsAbsentOrigin() {
+        // Native (non-browser) clients — the CLI, websocat, test harnesses —
+        // send no Origin and must be allowed.
+        #expect(WebSocketOriginGuard.isAllowedOrigin(nil))
+        #expect(WebSocketOriginGuard.isAllowedOrigin(""))
+    }
+
+    @Test func allowsLoopbackOrigins() {
+        #expect(WebSocketOriginGuard.isAllowedOrigin("http://127.0.0.1:8787"))
+        #expect(WebSocketOriginGuard.isAllowedOrigin("http://localhost:8787"))
+        #expect(WebSocketOriginGuard.isAllowedOrigin("http://[::1]:8787"))
+        #expect(WebSocketOriginGuard.isAllowedOrigin("https://LOCALHOST"))
+    }
+
+    @Test func rejectsCrossSiteOrigins() {
+        #expect(!WebSocketOriginGuard.isAllowedOrigin("https://evil.com"))
+        #expect(!WebSocketOriginGuard.isAllowedOrigin("http://192.168.1.5:8787"))
+        #expect(!WebSocketOriginGuard.isAllowedOrigin("http://127.0.0.1.evil.com"))
+        #expect(!WebSocketOriginGuard.isAllowedOrigin("null"))
+    }
+
+    @Test func loopbackHostDetection() {
+        #expect(WebSocketOriginGuard.isLoopbackHost("127.0.0.1"))
+        #expect(WebSocketOriginGuard.isLoopbackHost("localhost"))
+        #expect(WebSocketOriginGuard.isLoopbackHost("::1"))
+        #expect(!WebSocketOriginGuard.isLoopbackHost("0.0.0.0"))
+        #expect(!WebSocketOriginGuard.isLoopbackHost("192.168.1.5"))
+    }
+}
+
+@Suite struct StaticAssetGuardTests {
+    @Test func acceptsPlainBasenames() {
+        #expect(StaticAssets.isSafeAssetName("xterm.js"))
+        #expect(StaticAssets.isSafeAssetName("xterm-addon-fit.js"))
+    }
+
+    @Test func rejectsTraversalAndSeparators() {
+        #expect(!StaticAssets.isSafeAssetName(""))
+        #expect(!StaticAssets.isSafeAssetName(".."))
+        #expect(!StaticAssets.isSafeAssetName("../Package.swift"))
+        #expect(!StaticAssets.isSafeAssetName("a/b"))
+        #expect(!StaticAssets.isSafeAssetName("/etc/passwd"))
+    }
+}
+
+@Suite struct DaemonOptionsTests {
+    @Test func parsesAllFlags() {
+        let options = DaemonOptions.parse([
+            "crowd", "--http-port", "9001", "--host", "0.0.0.0",
+            "--socket", "/tmp/crowd.sock", "--dev-root", "/tmp/dev",
+        ])
+        #expect(options.httpPort == 9001)
+        #expect(options.host == "0.0.0.0")
+        #expect(options.socketPath == "/tmp/crowd.sock")
+        #expect(options.devRoot == "/tmp/dev")
+    }
+
+    @Test func malformedPortKeepsDefault() {
+        let options = DaemonOptions.parse(["crowd", "--http-port", "not-a-number"])
+        #expect(options.httpPort == 8787)
+    }
+
+    @Test func defaultsAreLoopback() {
+        let options = DaemonOptions.parse(["crowd"])
+        #expect(options.host == "127.0.0.1")
+        #expect(WebSocketOriginGuard.isLoopbackHost(options.host))
+    }
+}
+
+@Suite struct TerminalConnectionLimiterTests {
+    @Test func boundsConcurrentAcquires() {
+        let limiter = TerminalConnectionLimiter(max: 2)
+        #expect(limiter.acquire())
+        #expect(limiter.acquire())
+        #expect(!limiter.acquire())  // ceiling reached
+        limiter.release()
+        #expect(limiter.acquire())   // slot freed
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -1,4 +1,9 @@
+import Foundation
 import Testing
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
 @testable import CrowDaemon
 
 /// Locks down the security-sensitive guards flagged in the CROW-581 review:
@@ -82,5 +87,51 @@ import Testing
         #expect(!limiter.acquire())  // ceiling reached
         limiter.release()
         #expect(limiter.acquire())   // slot freed
+    }
+}
+
+/// The daemon must not steal the desktop app's socket: its default is a distinct
+/// `crowd.sock`, sharing the app's `crow.sock` is opt-in via --socket.
+@Suite struct DaemonSocketDefaultTests {
+    @Test func daemonDefaultIsDistinctFromAppSocket() {
+        let daemonSock = DaemonOptions.defaultDaemonSocketPath()
+        #expect(daemonSock != SocketServer.defaultSocketPath())
+        #expect(daemonSock.hasSuffix("crowd.sock"))
+        #expect(DaemonOptions.parse(["crowd"]).socketPath == daemonSock)
+    }
+
+    @Test func tmuxSocketIsNotInSharedTmp() {
+        // Must not sit in world-writable /tmp (squat/DoS on Linux).
+        let path = TerminalCockpit.tmuxSocketPath()
+        #expect(!path.hasPrefix("/tmp/"))
+        #expect(path.hasSuffix("crowd-tmux.sock"))
+    }
+}
+
+/// add-worktree input hardening (CROW-581 review): option-injection and orphan
+/// rows. Both checks run before any git/fs work, so no tmux/app is needed.
+@Suite struct AddWorktreeValidationTests {
+    @MainActor
+    private func router() -> CommandRouter {
+        makeCommandRouter(appState: AppState(), store: JSONStore(), git: GitManager(), devRoot: NSTemporaryDirectory())
+    }
+
+    private func addWorktree(_ router: CommandRouter, branch: String, session: UUID) async -> JSONRPCResponse {
+        await router.handle(request: JSONRPCRequest(id: 1, method: "add-worktree", params: [
+            "session_id": .string(session.uuidString),
+            "repo": .string("acme"),
+            "path": .string(NSTemporaryDirectory() + "wt"),
+            "branch": .string(branch),
+        ]))
+    }
+
+    @Test @MainActor func rejectsLeadingDashBranch() async {
+        let resp = await addWorktree(router(), branch: "--upload-pack=evil", session: UUID())
+        #expect(resp.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    @Test @MainActor func rejectsUnknownSession() async {
+        let resp = await addWorktree(router(), branch: "feature/x", session: UUID())
+        #expect(resp.error?.code == RPCErrorCode.invalidParams)
     }
 }

--- a/Packages/CrowTerminal/Package.swift
+++ b/Packages/CrowTerminal/Package.swift
@@ -11,10 +11,14 @@ let package = Package(
         .package(path: "../CrowCore"),
     ],
     targets: [
+        // Linux-only C shim exposing openpty(3) from <pty.h> (see Sources/CPty).
+        // Empty/no-op on Apple platforms, where Darwin already declares openpty.
+        .target(name: "CPty"),
         .target(
             name: "CrowTerminal",
             dependencies: [
                 .product(name: "CrowCore", package: "CrowCore"),
+                .target(name: "CPty", condition: .when(platforms: [.linux])),
             ],
             resources: [
                 .copy("Resources/crow-shell-wrapper.sh"),
@@ -22,7 +26,11 @@ let package = Package(
                 .copy("Resources/xterm"),
             ],
             linkerSettings: [
-                .linkedFramework("WebKit"),
+                // WebKit backs the macOS xterm.js surface (XTermSurfaceView);
+                // those files are compiled-away on Linux via #if canImport(WebKit).
+                .linkedFramework("WebKit", .when(platforms: [.macOS])),
+                // libutil provides openpty(3) on Linux (declared via the CPty shim).
+                .linkedLibrary("util", .when(platforms: [.linux])),
             ]
         ),
         .testTarget(

--- a/Packages/CrowTerminal/Sources/CPty/cpty.c
+++ b/Packages/CrowTerminal/Sources/CPty/cpty.c
@@ -1,0 +1,4 @@
+// See include/cpty.h. This translation unit exists so CPty is a normal clang
+// target (not header-only); the openpty(3) declaration it surfaces on Linux
+// comes from <pty.h> via the umbrella header.
+#include "cpty.h"

--- a/Packages/CrowTerminal/Sources/CPty/include/cpty.h
+++ b/Packages/CrowTerminal/Sources/CPty/include/cpty.h
@@ -1,0 +1,17 @@
+#ifndef CROW_CPTY_H
+#define CROW_CPTY_H
+
+/*
+ * Bridges `openpty(3)` into Swift on Linux.
+ *
+ * On Apple platforms `openpty` is declared by the `Darwin` module, so this
+ * shim is a Linux-only dependency of `CrowTerminal` (see Package.swift). glibc
+ * declares `openpty` in <pty.h> and implements it in libutil — neither is
+ * surfaced by Swift's `Glibc` module, so `PTYProcess` imports `CPty` and links
+ * `-lutil` on Linux to resolve the symbol. The header is empty elsewhere.
+ */
+#if defined(__linux__)
+#include <pty.h>
+#endif
+
+#endif /* CROW_CPTY_H */

--- a/Packages/CrowTerminal/Sources/CrowTerminal/BundledResources.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/BundledResources.swift
@@ -27,4 +27,12 @@ public enum BundledResources {
             subdirectory: "xterm"
         )
     }
+
+    /// Directory holding the bundled xterm.js assets (xterm.js, xterm.css,
+    /// addons). The headless `crowd` daemon serves files from here over HTTP so
+    /// the browser terminal reuses the exact same 6.0.0 assets as the macOS app
+    /// (CROW-581) rather than duplicating them.
+    public static var xtermDirectoryURL: URL? {
+        Bundle.module.url(forResource: "xterm", withExtension: nil)
+    }
 }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
@@ -1,4 +1,9 @@
+#if canImport(Glibc)
+import Glibc
+import CPty  // exposes openpty(3) from <pty.h>; libc's Glibc module doesn't
+#else
 import Darwin
+#endif
 import Foundation
 
 enum PTYProcessError: Error {
@@ -12,11 +17,19 @@ public final class PTYProcess: @unchecked Sendable {
     private var childPID: pid_t = -1
     private var readSource: DispatchSourceRead?
     private let readQueue = DispatchQueue(label: "com.radiusmethod.crow.pty-read", qos: .userInteractive)
+    /// When true (default), `onOutput`/`onExit` fire on `DispatchQueue.main` —
+    /// what the AppKit surface needs. The headless `crowd` daemon has no main
+    /// run loop pumping that queue, so it constructs with `false` to receive
+    /// callbacks synchronously on `readQueue` and bridge them into its async
+    /// WebSocket loop (CROW-581).
+    private let deliverOnMain: Bool
 
     public var onOutput: ((Data) -> Void)?
     public var onExit: ((Int32) -> Void)?
 
-    public init() {}
+    public init(deliverOnMainQueue: Bool = true) {
+        self.deliverOnMain = deliverOnMainQueue
+    }
 
     deinit {
         readSource?.cancel()
@@ -114,7 +127,12 @@ public final class PTYProcess: @unchecked Sendable {
         readQueue.async { [rows, cols] in
             guard self.masterFD >= 0 else { return }
             var win = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
+            #if canImport(Glibc)
+            // glibc imports the ioctl request as an unsigned long.
+            _ = ioctl(self.masterFD, UInt(TIOCSWINSZ), &win)
+            #else
             _ = ioctl(self.masterFD, TIOCSWINSZ, &win)
+            #endif
         }
     }
 
@@ -123,7 +141,11 @@ public final class PTYProcess: @unchecked Sendable {
             guard self.masterFD >= 0 else { return }
             data.withUnsafeBytes { buffer in
                 guard let base = buffer.baseAddress else { return }
+                #if canImport(Glibc)
+                _ = Glibc.write(self.masterFD, base, buffer.count)
+                #else
                 _ = Darwin.write(self.masterFD, base, buffer.count)
+                #endif
             }
         }
     }
@@ -160,11 +182,17 @@ public final class PTYProcess: @unchecked Sendable {
         source.setEventHandler { [weak self] in
             guard let self, self.masterFD >= 0 else { return }
             var buffer = [UInt8](repeating: 0, count: 65536)
+            #if canImport(Glibc)
+            let count = Glibc.read(self.masterFD, &buffer, buffer.count)
+            #else
             let count = Darwin.read(self.masterFD, &buffer, buffer.count)
+            #endif
             if count > 0 {
                 let data = Data(buffer.prefix(count))
                 let handler = self.onOutput
-                DispatchQueue.main.async {
+                if self.deliverOnMain {
+                    DispatchQueue.main.async { handler?(data) }
+                } else {
                     handler?(data)
                 }
             } else if count == 0 {
@@ -192,7 +220,9 @@ public final class PTYProcess: @unchecked Sendable {
         guard notifyExit else { return }
         let code = Self.decodeExitStatus(status)
         let handler = onExit
-        DispatchQueue.main.async {
+        if deliverOnMain {
+            DispatchQueue.main.async { handler?(code) }
+        } else {
             handler?(code)
         }
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
@@ -34,17 +34,22 @@ public final class PTYProcess: @unchecked Sendable {
     deinit {
         readSource?.cancel()
         readSource = nil
-        readQueue.sync {
-            if childPID > 0 {
-                let pid = childPID
-                childPID = -1
-                kill(pid, SIGTERM)
-                Self.forceReap(pid)
-            }
-            if masterFD >= 0 {
-                close(masterFD)
-                masterFD = -1
-            }
+        // Do NOT hop onto `readQueue` here. `deinit` can run *on* `readQueue`
+        // when the last strong reference is released by a `readQueue.async`
+        // block (write/resize/terminate all capture `self`), and
+        // `dispatch_sync` onto the current queue traps — the daemon's
+        // short-lived PTYs hit this on disconnect. By `deinit` no other
+        // references or queued self-capturing blocks remain, so this state is
+        // ours to tear down directly without serialization.
+        if childPID > 0 {
+            let pid = childPID
+            childPID = -1
+            kill(pid, SIGTERM)
+            Self.forceReap(pid)
+        }
+        if masterFD >= 0 {
+            close(masterFD)
+            masterFD = -1
         }
     }
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
@@ -1,3 +1,6 @@
+// Gated: AppKit floating search bar for the macOS terminal surface (CROW-581).
+// Not part of the Linux headless build; compiles away there.
+#if canImport(AppKit)
 import AppKit
 import Foundation
 
@@ -185,3 +188,4 @@ public extension Notification.Name {
     /// by `TerminalSearchBar` to show itself.
     static let terminalBeginSearch = Notification.Name("com.crow.terminal.beginSearch")
 }
+#endif

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -1,3 +1,6 @@
+// Gated: SwiftUI/AppKit terminal tab view, macOS-only (CROW-581). The Linux
+// web UI renders the terminal in the browser, so this file compiles away.
+#if canImport(AppKit)
 import SwiftUI
 import AppKit
 import CrowCore
@@ -118,3 +121,4 @@ public struct TerminalSurfaceView: NSViewRepresentable {
         }
     }
 }
+#endif

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -1,4 +1,6 @@
-import AppKit
+#if canImport(AppKit)
+import AppKit  // only for the WKWebView cockpit surface (gated below); Linux uses the daemon's WebSocket terminal instead
+#endif
 import CrowCore
 import Foundation
 
@@ -52,7 +54,9 @@ public final class TmuxBackend {
 
     /// The single embedded surface attached to the cockpit session. Created
     /// lazily on first use; WKWebView must load in a visible window.
+    #if canImport(AppKit)
     private var sharedSurface: XTermSurfaceView?
+    #endif
 
     /// UUID → tmux window index for tabs registered with us.
     private var bindings: [UUID: Int] = [:]
@@ -139,8 +143,10 @@ public final class TmuxBackend {
         if killServer {
             controller?.killServer()
         }
+        #if canImport(AppKit)
         sharedSurface?.destroy()
         sharedSurface = nil
+        #endif
         controller = nil
         bindings.removeAll()
         activeTerminalID = nil
@@ -719,6 +725,7 @@ public final class TmuxBackend {
     /// Return the shared cockpit xterm surface, lazily creating it the
     /// first time. The surface attaches to the live tmux session via
     /// `tmux -S … attach-session -t …` as its child command.
+    #if canImport(AppKit)
     public func cockpitSurface() throws -> XTermSurfaceView {
         if let existing = sharedSurface { return existing }
         let ctrl = try ensureRunningServer()
@@ -745,6 +752,7 @@ public final class TmuxBackend {
     public var existingCockpitSurface: XTermSurfaceView? {
         sharedSurface
     }
+    #endif
 
     /// Whether `id` has a live tmux-window binding. Used by callers that
     /// want to gate a send/destroy/makeActive on "this terminal is actually

--- a/Packages/CrowTerminal/Sources/CrowTerminal/XTermSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/XTermSurfaceView.swift
@@ -1,3 +1,7 @@
+// Gated: the WKWebView-backed terminal surface is macOS-only. On Linux the
+// `crowd` daemon streams the PTY to a browser xterm.js page over a WebSocket
+// (CROW-581), so this whole file compiles away.
+#if canImport(AppKit)
 import AppKit
 import WebKit
 
@@ -365,3 +369,4 @@ private final class NavigationHandler: NSObject, WKNavigationDelegate {
         }
     }
 }
+#endif

--- a/Sources/crowd/main.swift
+++ b/Sources/crowd/main.swift
@@ -1,0 +1,6 @@
+import CrowDaemon
+
+// Thin entrypoint for the `crowd` daemon. All logic lives in the `CrowDaemon`
+// library so it can be unit-tested and reused (CROW-581). A file named
+// `main.swift` supports top-level `await`, so no `@main` type is needed.
+try await CrowDaemon.run()


### PR DESCRIPTION
Implements **M0 + M1** of the cross-platform architecture spike (#581): a headless Swift `crowd` daemon that serves Crow's proven, Foundation-only domain logic over HTTP + WebSocket, so the UI can be a browser / Electron / Tauri thin client and Crow can run on Linux — reusing the Swift, not rewriting in TS.

## M0 — daemon skeleton + core JSON-RPC
- New `Packages/CrowDaemon` library + **`crowd`** executable product. Embeds **Hummingbird 2.x**; serves a WebSocket at **`/rpc`** speaking the existing JSON-RPC 2.0 protocol, reusing `CrowIPC.CommandRouter` verbatim (no semaphore bridge — we're already async).
- Wires 3 real handlers — **`new-session`**, **`list-sessions`**, **`add-worktree`** — on `AppState` + `CrowPersistence` (+ `CrowGit`), mirroring the app's `AppDelegate` closures but with **no AppKit / SessionService**. `add-worktree` materializes the worktree via `GitManager.createWorktree` to exercise the reused git layer on Linux.
- Also binds the existing **Unix socket** (`SocketServer`), so the current **`crow` CLI drives the daemon unchanged**. Both transports share one router.
- Hydrates `AppState` (sessions + worktrees) from `store.json` at boot. `import Observation` added to `AppState` so `@Observable` resolves on Linux (harmless on macOS).

## M1 — terminal over WebSocket
- **Port `PTYProcess` to Linux**: `#if canImport(Glibc)` imports, per-platform `read`/`write`/`ioctl`, and a header-only **`CPty`** C shim exposing `openpty(3)` (`-lutil`, Linux-only target dep). Adds opt-in `deliverOnMainQueue:` (default `true` keeps app behavior) so the daemon gets PTY output on the read queue and bridges it into an `AsyncStream`.
- **`/terminal`** WebSocket streams a PTY running `tmux attach-session` to xterm.js: raw bytes out (binary), keystrokes in (binary), `{type:"resize"}` control frame — the same four message types as the macOS WKWebView bridge. Reuses `TmuxController` + bundled `crow-tmux.conf`.
- Serves a WebSocket-transport `terminal.html` and streams the **xterm.js 6.0.0** assets straight from `CrowTerminal`'s bundle (no duplication).
- Makes **`CrowTerminal` compile on Linux**: the WKWebView/AppKit files and `TmuxBackend.cockpitSurface()` are gated behind `#if canImport(WebKit/AppKit)`; `Package.swift` links WebKit on macOS only, util on Linux only.

## Verification
- **macOS build unaffected**: `make build` (CrowApp + crow) passes; gated code takes its existing macOS branch.
- **Smoke-tested on macOS** (daemon on a test socket/port): `crow list-sessions` over the daemon's Unix socket; `/rpc` list-sessions + method-not-found over WS; `/health`; xterm assets + path-traversal guard (400); and a live **`/terminal` round-trip** — an `echo` keystroke streamed to the PTY and echoed back through PTY→tmux→WS.
- **Linux**: `swift build --product crowd` in a `swift:6` container is the recommended pre-merge check — the Glibc PTY branch + `CPty` shim can't be exercised on macOS.

## Not in this PR (follow-ups)
M2 web UI (session list + terminal), multiplexing `/rpc` + `/terminal` into one socket, the `crow-shell-wrapper.sh` OSC-readiness + agent auto-launch on the daemon terminal, Linux clipboard (`crow-tmux.conf` hardcodes `pbcopy`), and the `desktop/electron` + `desktop/tauri` thin shells.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)