### PR TITLE
Add Settings → Automation toggle to launch new coder views in auto permission mode (closes #586)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -49,6 +49,12 @@ public final class AppState {
     /// Applies only to `.job`-kind sessions; manager/review/CLI sessions are unaffected.
     public var jobsAutoPermissionMode: Bool = true
 
+    /// Whether newly launched work coder views start with
+    /// `--permission-mode auto` (auto-accept) instead of plan mode. Mirrors
+    /// `AppConfig.coderViewAutoPermissionMode`. Applies only to `.work`-kind
+    /// sessions; manager/review/job sessions are unaffected (#586).
+    public var coderViewAutoPermissionMode: Bool = false
+
     /// `true` when the Manager's `claude` process has exited (crash, kill, OOM)
     /// and has not yet been restarted. Drives the "Manager process exited" banner
     /// and enables the "Restart Manager" action. Reset when the Manager relaunches.

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -17,6 +17,12 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// `git` without per-call approval. Defaults to true — jobs are
     /// unattended by definition.
     public var jobsAutoPermissionMode: Bool
+    /// When true, newly launched work coder views start with
+    /// `--permission-mode auto` (auto-accept) instead of the default plan
+    /// mode. Applies to `.work` sessions only — Manager and jobs have their
+    /// own toggles. Defaults to false so existing behavior is preserved
+    /// unless the user opts in (#586).
+    public var coderViewAutoPermissionMode: Bool
     public var telemetry: TelemetryConfig
     public var autoRespond: AutoRespondSettings
     /// When true, `setup.sh` writes a per-worktree `.claude/settings.local.json`
@@ -83,6 +89,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         remoteControlEnabled: Bool = false,
         managerAutoPermissionMode: Bool = true,
         jobsAutoPermissionMode: Bool = true,
+        coderViewAutoPermissionMode: Bool = false,
         telemetry: TelemetryConfig = TelemetryConfig(),
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         attributionTrailers: Bool = true,
@@ -102,6 +109,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.remoteControlEnabled = remoteControlEnabled
         self.managerAutoPermissionMode = managerAutoPermissionMode
         self.jobsAutoPermissionMode = jobsAutoPermissionMode
+        self.coderViewAutoPermissionMode = coderViewAutoPermissionMode
         self.telemetry = telemetry
         self.autoRespond = autoRespond
         self.attributionTrailers = attributionTrailers
@@ -124,6 +132,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         remoteControlEnabled = try container.decodeIfPresent(Bool.self, forKey: .remoteControlEnabled) ?? false
         managerAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .managerAutoPermissionMode) ?? true
         jobsAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .jobsAutoPermissionMode) ?? true
+        coderViewAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .coderViewAutoPermissionMode) ?? false
         telemetry = try container.decodeIfPresent(TelemetryConfig.self, forKey: .telemetry) ?? TelemetryConfig()
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
@@ -181,7 +190,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, coderViewAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential
     }
 
     /// Resolve the agent that should drive a newly-created session of the

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -232,6 +232,30 @@ import Testing
     #expect(config.jobsAutoPermissionMode == true)
 }
 
+@Test func appConfigCoderViewAutoPermissionModeRoundTrip() throws {
+    var config = AppConfig()
+    config.coderViewAutoPermissionMode = true
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.coderViewAutoPermissionMode == true)
+
+    config.coderViewAutoPermissionMode = false
+    let data2 = try JSONEncoder().encode(config)
+    let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
+    #expect(decoded2.coderViewAutoPermissionMode == false)
+}
+
+@Test func appConfigCoderViewAutoPermissionModeDefaultsFalseWhenKeyMissing() throws {
+    // Unlike the Manager/jobs toggles, coder views default to plan mode —
+    // legacy configs without the key must NOT opt in, so existing work
+    // sessions keep launching in plan mode unless the user flips the
+    // Settings → Automation toggle (#586).
+    let json = #"{"workspaces": [], "remoteControlEnabled": false}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.coderViewAutoPermissionMode == false)
+}
+
 @Test func appConfigDecodeWithPartialKeys() throws {
     let json = """
     {"workspaces": [{"id": "00000000-0000-0000-0000-000000000001", "name": "Org", "provider": "github", "cli": "gh", "alwaysInclude": []}]}

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
@@ -48,6 +48,23 @@ import Testing
     // Legacy configs should opt in to auto permission mode by default so the
     // Manager benefits without requiring users to re-save settings.
     #expect(loaded?.managerAutoPermissionMode == true)
+    // Coder views are the opposite: default to plan mode unless the user
+    // explicitly opts in (#586).
+    #expect(loaded?.coderViewAutoPermissionMode == false)
+}
+
+@Test func configStoreCoderViewAutoPermissionModeRoundTrip() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let claudeDir = tmpDir.appendingPathComponent(".claude", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    var config = AppConfig()
+    config.coderViewAutoPermissionMode = true
+    try ConfigStore.saveConfig(config, to: claudeDir)
+
+    let configURL = claudeDir.appendingPathComponent("config.json")
+    let loaded = ConfigStore.loadConfig(from: configURL)
+    #expect(loaded?.coderViewAutoPermissionMode == true)
 }
 
 @Test func configStoreManagerAutoPermissionModeRoundTrip() throws {

--- a/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
@@ -8,6 +8,7 @@ public struct AutomationSettingsView: View {
     @Binding var defaults: ConfigDefaults
     @Binding var remoteControlEnabled: Bool
     @Binding var managerAutoPermissionMode: Bool
+    @Binding var coderViewAutoPermissionMode: Bool
     @Binding var managerGateway: WorkspaceGateway?
     @Binding var jiraCredential: JiraCredential?
     @Binding var autoRespond: AutoRespondSettings
@@ -26,6 +27,7 @@ public struct AutomationSettingsView: View {
         defaults: Binding<ConfigDefaults>,
         remoteControlEnabled: Binding<Bool>,
         managerAutoPermissionMode: Binding<Bool>,
+        coderViewAutoPermissionMode: Binding<Bool>,
         managerGateway: Binding<WorkspaceGateway?>,
         jiraCredential: Binding<JiraCredential?>,
         autoRespond: Binding<AutoRespondSettings>,
@@ -37,6 +39,7 @@ public struct AutomationSettingsView: View {
         self._defaults = defaults
         self._remoteControlEnabled = remoteControlEnabled
         self._managerAutoPermissionMode = managerAutoPermissionMode
+        self._coderViewAutoPermissionMode = coderViewAutoPermissionMode
         self._managerGateway = managerGateway
         self._jiraCredential = jiraCredential
         self._autoRespond = autoRespond
@@ -151,6 +154,14 @@ public struct AutomationSettingsView: View {
                 Toggle("Launch in auto permission mode", isOn: $managerAutoPermissionMode)
                     .onChange(of: managerAutoPermissionMode) { _, _ in onSave?() }
                 Text("Passes --permission-mode auto so the Manager can run crow, gh, and git commands without per-call approval. Requires Claude Code 2.1.83+ on a Max, Team, Enterprise, or API plan with the Anthropic provider. Turn off if your account reports auto mode as unavailable. Takes effect on next app launch.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Coder Views") {
+                Toggle("Launch new coder views in auto permission mode", isOn: $coderViewAutoPermissionMode)
+                    .onChange(of: coderViewAutoPermissionMode) { _, _ in onSave?() }
+                Text("Passes --permission-mode auto so new work coder views start in auto-accept instead of plan mode. Applies to newly kicked-off sessions and to relaunches after an app restart; the Manager and scheduled jobs have their own toggles. Off by default.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -100,6 +100,7 @@ public struct SettingsView: View {
                 defaults: $config.defaults,
                 remoteControlEnabled: $config.remoteControlEnabled,
                 managerAutoPermissionMode: $config.managerAutoPermissionMode,
+                coderViewAutoPermissionMode: $config.coderViewAutoPermissionMode,
                 managerGateway: $config.managerGateway,
                 jiraCredential: $config.jiraCredential,
                 autoRespond: $config.autoRespond,

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -410,7 +410,7 @@ Detect each secondary repo's default branch with the same `gh repo view --json d
 
 IMPORTANT: Always use full absolute paths, never abbreviated (`...`) or home-relative (`~`) paths.
 
-The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. Plan mode is set by the `--permission-mode plan` flag in `setup.sh`'s launch command — do not prepend `/plan` to the prompt body (it would be parsed as a slash command by the receiving session). See issue #313.
+The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. The permission mode is set by the `--permission-mode` flag in `setup.sh`'s launch command — plan mode by default, or auto-accept when the Settings → Automation "Launch new coder views in auto permission mode" toggle is on (#586). Do not prepend `/plan` to the prompt body (it would be parsed as a slash command by the receiving session). See issue #313.
 
 **Repo descriptions for the prompt table:**
 

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -114,6 +114,17 @@ is_remote_control_enabled() {
     | grep -qE '"remoteControlEnabled"[[:space:]]*:[[:space:]]*true'
 }
 
+# Read the coderViewAutoPermissionMode flag from {devRoot}/.claude/config.json.
+# Returns 0 if true, 1 otherwise. Missing file / malformed JSON / missing
+# key all default to 1 (off — plan mode), matching AppConfig's decodeIfPresent
+# behavior (#586).
+is_coder_view_auto_permission_enabled() {
+  local config_path="$DEV_ROOT/.claude/config.json"
+  [[ -f "$config_path" ]] || return 1
+  tr -d '\n' < "$config_path" \
+    | grep -qE '"coderViewAutoPermissionMode"[[:space:]]*:[[:space:]]*true'
+}
+
 # Read the attributionTrailers flag from {devRoot}/.claude/config.json.
 # Defaults to 0 (on) when the file is missing, malformed, or the key is
 # absent — matches AppConfig's decodeIfPresent default. Returns 1 only
@@ -1315,7 +1326,15 @@ launch_claude_code() {
   resolve_gateway_env
   local gw_prefix
   gw_prefix=$(gateway_launch_prefix)
-  local launch_cmd="cd $WORKTREE_PATH && ${gw_prefix}$bin --permission-mode plan$rc_args \"\$(cat $prompt_path)\""
+  # New coder views default to plan mode; the Settings → Automation
+  # "Launch new coder views in auto permission mode" toggle opts the launch
+  # into auto-accept instead (#586).
+  local perm_mode="plan"
+  if is_coder_view_auto_permission_enabled; then
+    perm_mode="auto"
+    log "coderViewAutoPermissionMode enabled — launching with --permission-mode auto"
+  fi
+  local launch_cmd="cd $WORKTREE_PATH && ${gw_prefix}$bin --permission-mode $perm_mode$rc_args \"\$(cat $prompt_path)\""
   create_agent_terminal "Claude Code" "$launch_cmd"
 }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -565,6 +565,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
+        appState.coderViewAutoPermissionMode = config.coderViewAutoPermissionMode
         appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
@@ -1285,6 +1286,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
+        appState.coderViewAutoPermissionMode = config.coderViewAutoPermissionMode
         appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -574,9 +574,14 @@ final class SessionService {
 
         let rcEnabled = appState.remoteControlEnabled
         // Jobs are unattended, so opt-in (default-on) auto-permission mode lets
-        // their prompts run crow/gh/git without per-call approval. Scoped to
-        // .job kind so review and other session kinds are unaffected.
-        let autoPermissionMode = (session.kind == .job) && appState.jobsAutoPermissionMode
+        // their prompts run crow/gh/git without per-call approval. Work coder
+        // views get auto mode only via the opt-in (default-off)
+        // coderViewAutoPermissionMode toggle (#586). Review sessions and the
+        // Manager (which has its own managerAutoPermissionMode path) are
+        // unaffected.
+        let autoPermissionMode =
+            (session.kind == .job && appState.jobsAutoPermissionMode) ||
+            (session.kind == .work && appState.coderViewAutoPermissionMode)
         // The agent's autoLaunchCommand mirrors this condition — the initial
         // prompt file is only used on first launch (CROW-224, CROW-317).
         // Compute it here so we know whether to flip `reviewPromptDispatched`

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -410,7 +410,7 @@ Detect each secondary repo's default branch with the same `gh repo view --json d
 
 IMPORTANT: Always use full absolute paths, never abbreviated (`...`) or home-relative (`~`) paths.
 
-The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. Plan mode is set by the `--permission-mode plan` flag in `setup.sh`'s launch command — do not prepend `/plan` to the prompt body (it would be parsed as a slash command by the receiving session). See issue #313.
+The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. The permission mode is set by the `--permission-mode` flag in `setup.sh`'s launch command — plan mode by default, or auto-accept when the Settings → Automation "Launch new coder views in auto permission mode" toggle is on (#586). Do not prepend `/plan` to the prompt body (it would be parsed as a slash command by the receiving session). See issue #313.
 
 **Repo descriptions for the prompt table:**
 

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -114,6 +114,17 @@ is_remote_control_enabled() {
     | grep -qE '"remoteControlEnabled"[[:space:]]*:[[:space:]]*true'
 }
 
+# Read the coderViewAutoPermissionMode flag from {devRoot}/.claude/config.json.
+# Returns 0 if true, 1 otherwise. Missing file / malformed JSON / missing
+# key all default to 1 (off — plan mode), matching AppConfig's decodeIfPresent
+# behavior (#586).
+is_coder_view_auto_permission_enabled() {
+  local config_path="$DEV_ROOT/.claude/config.json"
+  [[ -f "$config_path" ]] || return 1
+  tr -d '\n' < "$config_path" \
+    | grep -qE '"coderViewAutoPermissionMode"[[:space:]]*:[[:space:]]*true'
+}
+
 # Read the attributionTrailers flag from {devRoot}/.claude/config.json.
 # Defaults to 0 (on) when the file is missing, malformed, or the key is
 # absent — matches AppConfig's decodeIfPresent default. Returns 1 only
@@ -1315,7 +1326,15 @@ launch_claude_code() {
   resolve_gateway_env
   local gw_prefix
   gw_prefix=$(gateway_launch_prefix)
-  local launch_cmd="cd $WORKTREE_PATH && ${gw_prefix}$bin --permission-mode plan$rc_args \"\$(cat $prompt_path)\""
+  # New coder views default to plan mode; the Settings → Automation
+  # "Launch new coder views in auto permission mode" toggle opts the launch
+  # into auto-accept instead (#586).
+  local perm_mode="plan"
+  if is_coder_view_auto_permission_enabled; then
+    perm_mode="auto"
+    log "coderViewAutoPermissionMode enabled — launching with --permission-mode auto"
+  fi
+  local launch_cmd="cd $WORKTREE_PATH && ${gw_prefix}$bin --permission-mode $perm_mode$rc_args \"\$(cat $prompt_path)\""
   create_agent_terminal "Claude Code" "$launch_cmd"
 }
 


### PR DESCRIPTION
Closes #586

Adds a persisted **coderViewAutoPermissionMode** setting (default **off**) so newly kicked-off work coder views start with `--permission-mode auto` instead of the hard-locked plan mode — the missing third toggle alongside the existing Manager and jobs auto-mode settings.

## Changes

- **AppConfig** — new `coderViewAutoPermissionMode: Bool` (default `false`, `decodeIfPresent ?? false`, registered in `CodingKeys`), plus the `AppState` mirror and both `AppDelegate` config→AppState sync sites.
- **SessionService.launchAgent** — a `.work` session is now eligible for auto mode when the toggle is on; the `.job` (`jobsAutoPermissionMode`) and Manager (`managerAutoPermissionMode`) paths are unchanged. This covers relaunches after an app restart (`claude --continue`) and recovered orphans.
- **setup.sh** (skills copy + bundled `Resources` template, kept identical) — `launch_claude_code()` now picks `--permission-mode plan|auto` via a new `is_coder_view_auto_permission_enabled()` config.json reader (mirroring `is_remote_control_enabled`), so **brand-new** coder views honor the toggle from their very first launch. This goes beyond the ticket's file list: `launchAgent` only fires for restored/recovered terminals, while new coder views get their launch command from setup.sh — without this, the acceptance criterion "auto from the start" wouldn't hold. SKILL.md plan-mode note updated accordingly.
- **Settings → Automation** — new "Coder Views" section with the toggle ("Launch new coder views in auto permission mode"), persisted via `onSave` like the neighboring toggles.

## Acceptance criteria

- Toggle off (or key absent in legacy configs): new work coder views launch in plan mode exactly as today — verified by the defaults-false decode tests and the setup.sh helper checks.
- Toggle on: new work coder views launch with `--permission-mode auto`, both at first kick-off (setup.sh) and on relaunch (`launchAgent`).
- Manager and jobs behavior unchanged.
- Persists across restarts (same `config.json` persistence as the other Automation toggles).

## Testing

- New unit tests: `appConfigCoderViewAutoPermissionModeRoundTrip`, `appConfigCoderViewAutoPermissionModeDefaultsFalseWhenKeyMissing`, `configStoreCoderViewAutoPermissionModeRoundTrip`, plus the legacy-default assertion in the forward-compat test.
- `make test` — all package + root suites pass (276 tests in root alone).
- `swift build` — app target compiles.
- `bash -n` on both setup.sh copies; all four existing `setup_*_test.sh` suites pass; `is_coder_view_auto_permission_enabled` exercised against synthetic config.json (true / false / key absent / file absent / multiline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)