### PR TITLE
Web UI settings: disk-fallback when the app doesn't know get/set-config (CROW-581)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -467,10 +467,20 @@ func makeCommandRouter(
         // (CROW-581, desktop-only creds). Only one writer at a time: forward when
         // reachable, else write locally.
         "get-config": { params in
-            if let forwardSocket {
-                do { return try forwardToApp("get-config", params, socket: forwardSocket) }
-                catch let error as DaemonRPCError { throw error }
-                catch { /* app not running → read from disk */ }
+            // Forward to the app when it's reachable AND recognizes the method;
+            // otherwise read {devRoot}/.claude/config.json directly. The fallback
+            // covers both the app being down (socket error) and an app too old to
+            // know get-config (method-not-found) during a daemon-ahead rollout.
+            if let forwardSocket,
+               let response = try? SocketClient(socketPath: forwardSocket).send(method: "get-config", params: params) {
+                if let error = response.error {
+                    if error.code != RPCErrorCode.methodNotFound {
+                        throw DaemonRPCError.applicationError(error.message)
+                    }
+                    // else: old app → fall through to disk
+                } else {
+                    return response.result ?? [:]
+                }
             }
             let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
             let stripped = SettingsSecrets.strippedForTransport(config)
@@ -486,10 +496,16 @@ func makeCommandRouter(
                   let incoming = try? JSONDecoder().decode(AppConfig.self, from: data) else {
                 throw DaemonRPCError.invalidParams("config must be a valid AppConfig JSON string")
             }
-            if let forwardSocket {
-                do { return try forwardToApp("set-config", params, socket: forwardSocket) }
-                catch let error as DaemonRPCError { throw error }
-                catch { /* app not running → write to disk */ }
+            if let forwardSocket,
+               let response = try? SocketClient(socketPath: forwardSocket).send(method: "set-config", params: params) {
+                if let error = response.error {
+                    if error.code != RPCErrorCode.methodNotFound {
+                        throw DaemonRPCError.applicationError(error.message)
+                    }
+                    // else: old app → write to disk below
+                } else {
+                    return response.result ?? [:]
+                }
             }
             // The browser can't see or change credentials, so keep whatever is
             // already on disk (nil-current drops any credential shell — see


### PR DESCRIPTION
Follow-up to #590 (merged). When the web Settings modal calls `get-config`/`set-config`, the daemon forwards to the desktop app when it's reachable. Previously it rethrew any app-level error — so a **new daemon talking to an older app** (one that predates these handlers) surfaced `Unknown method: get-config` to the browser instead of falling back.

This treats the app's method-not-found (`-32601`) the same as the app being down: read/write `{devRoot}/.claude/config.json` directly via `ConfigStore`. The web Settings modal then works as soon as the **daemon** is current, without also requiring the desktop app to be rebuilt/relaunched in the same window.

Only `Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift` changes; the existing `ConfigForwarderTests` (app-down disk fallback) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux2at2KRE2EqYSVAPe1LuF
