### PR TITLE
Stop wiping user settings.json on every launch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,6 @@ Crow auto-generates certain files into `{devRoot}/.claude/` on launch (see `Scaf
 
 - `CLAUDE.md` — scaffolded from the root `CLAUDE.md`
 - `skills/crow-workspace/SKILL.md` — scaffolded from `Resources/crow-workspace-SKILL.md.template`
-- `settings.json` — always overwritten with pre-approved permissions
+- `settings.local.json` — merged with pre-approved permissions on every launch; `settings.json` is the user's own file and Crow never writes it
 
 **Do not edit the scaffolded copies.** Instead, modify the source files in the repository root or `Resources/` directory.

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -139,10 +139,21 @@ struct Scaffolder {
         try CrowAttribution.expandSkillBody(attributionFooter, agentKind: managerAgentKind)
             .write(toFile: attributionFooterPath, atomically: true, encoding: .utf8)
 
-        // Always overwrite settings.json (permissions for crow, gh, git commands)
-        let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.json")
+        // Write Crow's required permissions to settings.local.json, not
+        // settings.json. settings.json is the user's own file —
+        // Crow never writes it and never has to reconcile with whatever the
+        // user puts there. settings.local.json is Claude Code's local-
+        // override layer: its `permissions.allow` entries are merged with
+        // settings.json's at load time, so crow/gh/git commands still run
+        // without a prompt. `mergeSettings` still guards this file too — a
+        // full overwrite on every launch would just move the "nukes my
+        // customizations" bug from one filename to another. It fills in
+        // only what's missing and leaves the file untouched when there's
+        // nothing to add.
+        let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.local.json")
         let settingsTemplate = Self.bundledSettings()
-        try settingsTemplate.write(toFile: settingsPath, atomically: true, encoding: .utf8)
+        let mergedSettings = Self.mergeSettings(existingPath: settingsPath, template: settingsTemplate)
+        try mergedSettings.write(toFile: settingsPath, atomically: true, encoding: .utf8)
 
         // Create prompts directory for crow-workspace prompt files
         let promptsDir = (claudeDir as NSString).appendingPathComponent("prompts")
@@ -500,7 +511,10 @@ struct Scaffolder {
         return CrowAttribution.sharedFooterInstructions
     }
 
-    /// The settings.json template with pre-approved permissions.
+    /// The pre-approved-permissions template, sourced from the repo's own
+    /// `settings.json` (used as a bundled resource name, not a hint about
+    /// the runtime destination — see `scaffold(...)`, which writes this
+    /// content to `{devRoot}/.claude/settings.local.json`).
     static func bundledSettings() -> String {
         if let content = loadFromRepo("settings.json") {
             return content
@@ -557,6 +571,64 @@ struct Scaffolder {
           }
         }
         """
+    }
+
+    /// Merges `template` into whatever's already on disk at `existingPath`,
+    /// instead of overwriting it. Guarantees:
+    ///
+    /// - `permissions.allow`: the union of the template's and the existing
+    ///   file's entries — any bundled entry the user's file is missing gets
+    ///   appended, but nothing already there is ever removed.
+    /// - Every other top-level key (`outputStyle`, `statusLine`, `hooks`,
+    ///   `env`, a hand-edited `sandbox` block, …): filled in from the
+    ///   template only if the user's file doesn't already have that key.
+    ///   An existing value always wins, even if it differs from the
+    ///   template.
+    ///
+    /// Returns the existing file's contents byte-for-byte, untouched, when
+    /// there's nothing to add — so a user's formatting isn't churned on
+    /// every launch. Falls back to `template` verbatim when there's no
+    /// existing file yet, or it isn't valid JSON.
+    static func mergeSettings(existingPath: String, template: String) -> String {
+        guard let existingData = FileManager.default.contents(atPath: existingPath),
+              let existingString = String(data: existingData, encoding: .utf8),
+              let existingObj = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any],
+              let templateData = template.data(using: .utf8),
+              let templateObj = try? JSONSerialization.jsonObject(with: templateData) as? [String: Any]
+        else {
+            return template
+        }
+
+        var merged = existingObj
+        var changed = false
+
+        for (key, templateValue) in templateObj {
+            if key == "permissions", let templatePerms = templateValue as? [String: Any] {
+                var mergedPerms = merged["permissions"] as? [String: Any] ?? [:]
+                let templateAllow = templatePerms["allow"] as? [String] ?? []
+                let existingAllow = mergedPerms["allow"] as? [String] ?? []
+                let existingSet = Set(existingAllow)
+                let missing = templateAllow.filter { !existingSet.contains($0) }
+                if !missing.isEmpty {
+                    mergedPerms["allow"] = existingAllow + missing
+                    merged["permissions"] = mergedPerms
+                    changed = true
+                }
+            } else if merged[key] == nil {
+                merged[key] = templateValue
+                changed = true
+            }
+        }
+
+        guard changed else { return existingString }
+
+        guard let mergedData = try? JSONSerialization.data(
+            withJSONObject: merged,
+            options: [.prettyPrinted, .sortedKeys]
+        ), let mergedString = String(data: mergedData, encoding: .utf8) else {
+            return existingString
+        }
+        return mergedString
     }
 
     /// Try to load a file from the repo root (for development builds).

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -148,12 +148,23 @@ struct Scaffolder {
         // without a prompt. `mergeSettings` still guards this file too — a
         // full overwrite on every launch would just move the "nukes my
         // customizations" bug from one filename to another. It fills in
-        // only what's missing and leaves the file untouched when there's
-        // nothing to add.
+        // only what's missing and reports `.upToDate` when there's nothing
+        // to add, so a steady-state launch skips the write entirely — the
+        // on-disk file (bytes, inode, mtime, mode) is left completely alone.
         let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.local.json")
         let settingsTemplate = Self.bundledSettings()
-        let mergedSettings = Self.mergeSettings(existingPath: settingsPath, template: settingsTemplate)
-        try mergedSettings.write(toFile: settingsPath, atomically: true, encoding: .utf8)
+        if case let .write(mergedSettings) = Self.mergeSettings(existingPath: settingsPath, template: settingsTemplate) {
+            try mergedSettings.write(toFile: settingsPath, atomically: true, encoding: .utf8)
+            // `atomically: true` renames a fresh temp file over the target,
+            // which resets its mode to the umask default (~0o644). This same
+            // file's `env` block can carry a resolved gateway bearer token —
+            // ClaudeHookConfigWriter.writeGatewayEnv deliberately restricts
+            // it to owner-only — so re-apply 0o600 here to match that sibling
+            // writer. Without it the Settings → "Re-scaffold" action (which
+            // runs scaffold with no following writeGatewayEnv) would leave a
+            // token-bearing file group/world-readable until the next launch.
+            try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: settingsPath)
+        }
 
         // Create prompts directory for crow-workspace prompt files
         let promptsDir = (claudeDir as NSString).appendingPathComponent("prompts")
@@ -573,6 +584,22 @@ struct Scaffolder {
         """
     }
 
+    /// Outcome of merging the bundled permissions template into an existing
+    /// `settings.local.json`.
+    ///
+    /// - `.upToDate`: the on-disk file already has everything the template
+    ///   would contribute. The caller skips the write entirely, so the file
+    ///   is left completely alone — bytes, inode, mtime, and its owner-only
+    ///   0o600 mode (which `ClaudeHookConfigWriter.writeGatewayEnv` applies
+    ///   to the token-bearing `env` block) all survive untouched. This is
+    ///   the steady state on every launch after the first.
+    /// - `.write`: the payload must be persisted (a fresh file, or the merge
+    ///   added something). The caller writes it, then re-asserts 0o600.
+    enum SettingsMergeOutcome: Equatable {
+        case upToDate
+        case write(String)
+    }
+
     /// Merges `template` into whatever's already on disk at `existingPath`,
     /// instead of overwriting it. Guarantees:
     ///
@@ -585,18 +612,18 @@ struct Scaffolder {
     ///   An existing value always wins, even if it differs from the
     ///   template.
     ///
-    /// Returns the existing file's contents byte-for-byte, untouched, when
-    /// there's nothing to add — so a user's formatting isn't churned on
-    /// every launch. Falls back to `template` verbatim when there's no
+    /// Returns `.upToDate` when there's nothing to add, so the caller skips
+    /// the write and a user's formatting (and the file's mode) isn't churned
+    /// on every launch. Returns `.write(template)` verbatim when there's no
     /// existing file yet, or it isn't valid JSON.
-    static func mergeSettings(existingPath: String, template: String) -> String {
+    static func mergeSettings(existingPath: String, template: String) -> SettingsMergeOutcome {
         guard let existingData = FileManager.default.contents(atPath: existingPath),
-              let existingString = String(data: existingData, encoding: .utf8),
+              String(data: existingData, encoding: .utf8) != nil,
               let existingObj = try? JSONSerialization.jsonObject(with: existingData) as? [String: Any],
               let templateData = template.data(using: .utf8),
               let templateObj = try? JSONSerialization.jsonObject(with: templateData) as? [String: Any]
         else {
-            return template
+            return .write(template)
         }
 
         var merged = existingObj
@@ -620,15 +647,19 @@ struct Scaffolder {
             }
         }
 
-        guard changed else { return existingString }
+        // Nothing to add — leave the on-disk file untouched (skip the write).
+        guard changed else { return .upToDate }
 
+        // Serialization can't realistically fail on a dict we just built from
+        // valid JSON, but if it did there's no better content to write than
+        // what's already there — so skip rather than churn/relax the file.
         guard let mergedData = try? JSONSerialization.data(
             withJSONObject: merged,
             options: [.prettyPrinted, .sortedKeys]
         ), let mergedString = String(data: mergedData, encoding: .utf8) else {
-            return existingString
+            return .upToDate
         }
-        return mergedString
+        return .write(mergedString)
     }
 
     /// Try to load a file from the repo root (for development builds).

--- a/Tests/CrowTests/ScaffolderSettingsMergeTests.swift
+++ b/Tests/CrowTests/ScaffolderSettingsMergeTests.swift
@@ -33,23 +33,34 @@ struct ScaffolderSettingsMergeTests {
     }
     """
 
+    /// Unwrap the payload of a `.write` outcome; returns `nil` (→ a test
+    /// failure at the `#require` call site) when the merge reported
+    /// `.upToDate` and thus wouldn't have written anything.
+    private static func writtenContent(_ outcome: Scaffolder.SettingsMergeOutcome) -> String? {
+        guard case let .write(content) = outcome else { return nil }
+        return content
+    }
+
     @Test func noExistingFileFallsBackToTemplateVerbatim() throws {
         let devRoot = try Self.makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let missingPath = (devRoot as NSString).appendingPathComponent("settings.json")
 
         let result = Scaffolder.mergeSettings(existingPath: missingPath, template: Self.template)
-        #expect(result == Self.template)
+        #expect(result == .write(Self.template))
     }
 
     @Test func userAddedPermissionSurvives() throws {
         let devRoot = try Self.makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        // User added `Bash(npm test:*)` and (say, from an older Crow) is
+        // missing the bundled `Bash(gh pr view:*)`. The merge must add the
+        // bundled entry back *and* keep the user's — a write, not a skip.
         let existing = """
         {
           "permissions": {
-            "allow": ["Bash(crow *)", "Bash(gh pr view:*)", "Bash(npm test:*)"]
+            "allow": ["Bash(crow *)", "Bash(npm test:*)"]
           },
           "sandbox": {
             "enabled": true
@@ -58,7 +69,8 @@ struct ScaffolderSettingsMergeTests {
         """
         try existing.write(toFile: path, atomically: true, encoding: .utf8)
 
-        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let outcome = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let result = try #require(Self.writtenContent(outcome))
         let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
         let allow = try #require((obj["permissions"] as? [String: Any])?["allow"] as? [String])
         #expect(Set(allow) == Set(["Bash(crow *)", "Bash(gh pr view:*)", "Bash(npm test:*)"]))
@@ -83,7 +95,8 @@ struct ScaffolderSettingsMergeTests {
         """
         try existing.write(toFile: path, atomically: true, encoding: .utf8)
 
-        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let outcome = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let result = try #require(Self.writtenContent(outcome))
         let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
         let allow = try #require((obj["permissions"] as? [String: Any])?["allow"] as? [String])
         #expect(Set(allow).isSuperset(of: ["Bash(crow *)", "Bash(gh pr view:*)"]))
@@ -93,10 +106,13 @@ struct ScaffolderSettingsMergeTests {
         let devRoot = try Self.makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        // Missing the bundled `gh pr view` entry so the merge actually
+        // writes — the point is that the custom top-level keys ride along
+        // untouched in that written output.
         let existing = """
         {
           "permissions": {
-            "allow": ["Bash(crow *)", "Bash(gh pr view:*)"]
+            "allow": ["Bash(crow *)"]
           },
           "sandbox": {
             "enabled": true
@@ -113,7 +129,8 @@ struct ScaffolderSettingsMergeTests {
         """
         try existing.write(toFile: path, atomically: true, encoding: .utf8)
 
-        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let outcome = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let result = try #require(Self.writtenContent(outcome))
         let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
         #expect(obj["outputStyle"] as? String == "concise")
         #expect((obj["statusLine"] as? [String: Any])?["command"] as? String == "~/.claude/statusline.sh")
@@ -124,10 +141,13 @@ struct ScaffolderSettingsMergeTests {
         let devRoot = try Self.makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        // Missing the bundled `gh pr view` entry so the merge writes; the
+        // user's `sandbox.enabled = false` must survive into that output
+        // rather than being reset to the template's `true`.
         let existing = """
         {
           "permissions": {
-            "allow": ["Bash(crow *)", "Bash(gh pr view:*)"]
+            "allow": ["Bash(crow *)"]
           },
           "sandbox": {
             "enabled": false
@@ -136,17 +156,20 @@ struct ScaffolderSettingsMergeTests {
         """
         try existing.write(toFile: path, atomically: true, encoding: .utf8)
 
-        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let outcome = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let result = try #require(Self.writtenContent(outcome))
         let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
         #expect((obj["sandbox"] as? [String: Any])?["enabled"] as? Bool == false)
     }
 
-    @Test func nothingToAddLeavesFileByteForByteUntouched() throws {
+    @Test func nothingToAddReportsUpToDate() throws {
         let devRoot = try Self.makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let path = (devRoot as NSString).appendingPathComponent("settings.json")
-        // Deliberately odd formatting/key order — must survive verbatim
-        // since every template key is already present.
+        // Deliberately odd formatting/key order. Every template key is
+        // already present, so the merge reports `.upToDate` — the caller
+        // then skips the write, leaving the file byte-for-byte (and
+        // inode/mtime/mode) untouched.
         let existing = """
         {
           "sandbox":   { "enabled": true },
@@ -156,7 +179,7 @@ struct ScaffolderSettingsMergeTests {
         try existing.write(toFile: path, atomically: true, encoding: .utf8)
 
         let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
-        #expect(result == existing)
+        #expect(result == .upToDate)
     }
 
     @Test func fullScaffoldPreservesUserSettingsAcrossRelaunches() throws {
@@ -218,5 +241,83 @@ struct ScaffolderSettingsMergeTests {
 
         let after = try String(contentsOfFile: settingsJSONPath, encoding: .utf8)
         #expect(after == userContent)
+    }
+
+    // MARK: - File mode + write-skip (CROW-595 review round-trip)
+
+    /// settings.local.json's `env` block can carry a resolved gateway bearer
+    /// token, so scaffold must write it owner-only (0o600) — matching the
+    /// sibling `ClaudeHookConfigWriter.writeGatewayEnv`. `atomically: true`
+    /// alone resets the mode to the umask default (~0o644).
+    @Test func freshScaffoldWritesSettingsLocalOwnerOnly() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        _ = try Scaffolder(devRoot: devRoot).scaffold(workspaceNames: [])
+
+        let settingsPath = (devRoot as NSString).appendingPathComponent(".claude/settings.local.json")
+        let attrs = try FileManager.default.attributesOfItem(atPath: settingsPath)
+        #expect((attrs[.posixPermissions] as? Int) == 0o600)
+    }
+
+    /// In the steady state (nothing to add) scaffold must not rewrite the
+    /// file at all — otherwise every launch churns a new inode/mtime and the
+    /// `atomically: true` rename would relax the mode. Proven by relaxing the
+    /// mode after the first scaffold and confirming a second scaffold leaves
+    /// both the inode and that relaxed mode exactly as-is.
+    @Test func steadyStateScaffoldSkipsRewriteAndLeavesFileAlone() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let scaffolder = Scaffolder(devRoot: devRoot)
+
+        _ = try scaffolder.scaffold(workspaceNames: [])
+
+        let settingsPath = (devRoot as NSString).appendingPathComponent(".claude/settings.local.json")
+        let firstInode = try #require(
+            (try FileManager.default.attributesOfItem(atPath: settingsPath))[.systemFileNumber] as? Int)
+        // A distinctive mode no code path would ever set on its own; if the
+        // second scaffold rewrites, atomically:true + our 0o600 re-apply
+        // would erase it.
+        try FileManager.default.setAttributes([.posixPermissions: 0o640], ofItemAtPath: settingsPath)
+
+        _ = try scaffolder.scaffold(workspaceNames: [])
+
+        let afterAttrs = try FileManager.default.attributesOfItem(atPath: settingsPath)
+        #expect((afterAttrs[.systemFileNumber] as? Int) == firstInode)
+        #expect((afterAttrs[.posixPermissions] as? Int) == 0o640)
+    }
+
+    /// The Settings → "Re-scaffold" action runs scaffold with no following
+    /// `writeGatewayEnv`, so scaffold itself must restore 0o600 whenever it
+    /// writes. Drop a bundled permission (forcing a write) and relax the mode
+    /// the way an atomic rewrite would; the re-scaffold must both add the
+    /// permission back and re-restrict the file to owner-only.
+    @Test func rescaffoldReAddsMissingPermissionAndRestoresOwnerOnly() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let scaffolder = Scaffolder(devRoot: devRoot)
+
+        _ = try scaffolder.scaffold(workspaceNames: [])
+
+        let settingsPath = (devRoot as NSString).appendingPathComponent(".claude/settings.local.json")
+        let firstData = try #require(FileManager.default.contents(atPath: settingsPath))
+        var obj = try #require(try JSONSerialization.jsonObject(with: firstData) as? [String: Any])
+        var perms = try #require(obj["permissions"] as? [String: Any])
+        var allow = try #require(perms["allow"] as? [String])
+        let dropped = try #require(allow.first)
+        allow.removeAll { $0 == dropped }
+        perms["allow"] = allow
+        obj["permissions"] = perms
+        try JSONSerialization.data(withJSONObject: obj).write(to: URL(fileURLWithPath: settingsPath))
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: settingsPath)
+
+        _ = try scaffolder.scaffold(workspaceNames: [])
+
+        let reloaded = try #require(FileManager.default.contents(atPath: settingsPath))
+        let reloadedObj = try #require(try JSONSerialization.jsonObject(with: reloaded) as? [String: Any])
+        let reloadedAllow = try #require((reloadedObj["permissions"] as? [String: Any])?["allow"] as? [String])
+        #expect(reloadedAllow.contains(dropped))
+        let attrs = try FileManager.default.attributesOfItem(atPath: settingsPath)
+        #expect((attrs[.posixPermissions] as? Int) == 0o600)
     }
 }

--- a/Tests/CrowTests/ScaffolderSettingsMergeTests.swift
+++ b/Tests/CrowTests/ScaffolderSettingsMergeTests.swift
@@ -1,0 +1,222 @@
+import CrowCore
+import Foundation
+import Testing
+@testable import Crow
+
+/// Coverage for `Scaffolder.mergeSettings`: settings.json used to
+/// be overwritten wholesale on every launch, silently discarding anything a
+/// user added by hand. Crow now writes its required permissions to
+/// settings.local.json instead, and never touches settings.json at all —
+/// that file is the user's own. These tests exercise the merge directly,
+/// plus the full `scaffold(...)` entry point to confirm a user's
+/// settings.local.json survives repeat launches and settings.json is left
+/// completely alone.
+@Suite("Scaffolder settings.local.json merge")
+struct ScaffolderSettingsMergeTests {
+
+    private static func makeTempDevRoot() throws -> String {
+        let base = NSTemporaryDirectory()
+        let unique = "crow-593-\(UUID().uuidString)"
+        let path = (base as NSString).appendingPathComponent(unique)
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return path
+    }
+
+    private static let template = """
+    {
+      "permissions": {
+        "allow": ["Bash(crow *)", "Bash(gh pr view:*)"]
+      },
+      "sandbox": {
+        "enabled": true
+      }
+    }
+    """
+
+    @Test func noExistingFileFallsBackToTemplateVerbatim() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let missingPath = (devRoot as NSString).appendingPathComponent("settings.json")
+
+        let result = Scaffolder.mergeSettings(existingPath: missingPath, template: Self.template)
+        #expect(result == Self.template)
+    }
+
+    @Test func userAddedPermissionSurvives() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        let existing = """
+        {
+          "permissions": {
+            "allow": ["Bash(crow *)", "Bash(gh pr view:*)", "Bash(npm test:*)"]
+          },
+          "sandbox": {
+            "enabled": true
+          }
+        }
+        """
+        try existing.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
+        let allow = try #require((obj["permissions"] as? [String: Any])?["allow"] as? [String])
+        #expect(Set(allow) == Set(["Bash(crow *)", "Bash(gh pr view:*)", "Bash(npm test:*)"]))
+    }
+
+    @Test func missingBundledPermissionIsAddedBack() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        // User's file is missing the bundled `gh pr view` entry (e.g. from
+        // an older Crow version) — it should be added back so `gh` keeps
+        // working without a permission prompt.
+        let existing = """
+        {
+          "permissions": {
+            "allow": ["Bash(crow *)"]
+          },
+          "sandbox": {
+            "enabled": true
+          }
+        }
+        """
+        try existing.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
+        let allow = try #require((obj["permissions"] as? [String: Any])?["allow"] as? [String])
+        #expect(Set(allow).isSuperset(of: ["Bash(crow *)", "Bash(gh pr view:*)"]))
+    }
+
+    @Test func customTopLevelKeysArePreserved() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        let existing = """
+        {
+          "permissions": {
+            "allow": ["Bash(crow *)", "Bash(gh pr view:*)"]
+          },
+          "sandbox": {
+            "enabled": true
+          },
+          "outputStyle": "concise",
+          "statusLine": {
+            "type": "command",
+            "command": "~/.claude/statusline.sh"
+          },
+          "env": {
+            "FOO": "bar"
+          }
+        }
+        """
+        try existing.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
+        #expect(obj["outputStyle"] as? String == "concise")
+        #expect((obj["statusLine"] as? [String: Any])?["command"] as? String == "~/.claude/statusline.sh")
+        #expect((obj["env"] as? [String: Any])?["FOO"] as? String == "bar")
+    }
+
+    @Test func userSandboxOverrideWins() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        let existing = """
+        {
+          "permissions": {
+            "allow": ["Bash(crow *)", "Bash(gh pr view:*)"]
+          },
+          "sandbox": {
+            "enabled": false
+          }
+        }
+        """
+        try existing.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        let obj = try #require(try JSONSerialization.jsonObject(with: Data(result.utf8)) as? [String: Any])
+        #expect((obj["sandbox"] as? [String: Any])?["enabled"] as? Bool == false)
+    }
+
+    @Test func nothingToAddLeavesFileByteForByteUntouched() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let path = (devRoot as NSString).appendingPathComponent("settings.json")
+        // Deliberately odd formatting/key order — must survive verbatim
+        // since every template key is already present.
+        let existing = """
+        {
+          "sandbox":   { "enabled": true },
+          "permissions": { "allow": ["Bash(gh pr view:*)", "Bash(crow *)"] }
+        }
+        """
+        try existing.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let result = Scaffolder.mergeSettings(existingPath: path, template: Self.template)
+        #expect(result == existing)
+    }
+
+    @Test func fullScaffoldPreservesUserSettingsAcrossRelaunches() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let scaffolder = Scaffolder(devRoot: devRoot)
+
+        _ = try scaffolder.scaffold(workspaceNames: [])
+
+        // Simulate the user hand-editing settings.local.json after first launch.
+        let settingsPath = (devRoot as NSString).appendingPathComponent(".claude/settings.local.json")
+        var data = try #require(FileManager.default.contents(atPath: settingsPath))
+        var obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        obj["outputStyle"] = "concise"
+        var perms = obj["permissions"] as? [String: Any] ?? [:]
+        var allow = perms["allow"] as? [String] ?? []
+        allow.append("Bash(npm test:*)")
+        perms["allow"] = allow
+        obj["permissions"] = perms
+        data = try JSONSerialization.data(withJSONObject: obj)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        // Relaunch: scaffold runs again, as it does on every app launch.
+        _ = try scaffolder.scaffold(workspaceNames: [])
+
+        let reloaded = try #require(FileManager.default.contents(atPath: settingsPath))
+        let reloadedObj = try #require(try JSONSerialization.jsonObject(with: reloaded) as? [String: Any])
+        #expect(reloadedObj["outputStyle"] as? String == "concise")
+        let reloadedAllow = try #require((reloadedObj["permissions"] as? [String: Any])?["allow"] as? [String])
+        #expect(reloadedAllow.contains("Bash(npm test:*)"))
+    }
+
+    @Test func scaffoldNeverCreatesSettingsJSON() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        _ = try Scaffolder(devRoot: devRoot).scaffold(workspaceNames: [])
+
+        let settingsJSONPath = (devRoot as NSString).appendingPathComponent(".claude/settings.json")
+        let settingsLocalPath = (devRoot as NSString).appendingPathComponent(".claude/settings.local.json")
+        #expect(!FileManager.default.fileExists(atPath: settingsJSONPath))
+        #expect(FileManager.default.fileExists(atPath: settingsLocalPath))
+    }
+
+    @Test func scaffoldNeverTouchesAPreExistingSettingsJSON() throws {
+        // A user's own settings.json — Crow must never read or write it,
+        // even if one happens to already exist at the devRoot (e.g. hand
+        // authored, or left over from an older Crow version that used to
+        // write settings.json directly).
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let claudeDir = (devRoot as NSString).appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(atPath: claudeDir, withIntermediateDirectories: true)
+        let settingsJSONPath = (claudeDir as NSString).appendingPathComponent("settings.json")
+        let userContent = "{\n  \"outputStyle\": \"my-own-file-leave-it-alone\"\n}"
+        try userContent.write(toFile: settingsJSONPath, atomically: true, encoding: .utf8)
+
+        _ = try Scaffolder(devRoot: devRoot).scaffold(workspaceNames: [])
+
+        let after = try String(contentsOfFile: settingsJSONPath, encoding: .utf8)
+        #expect(after == userContent)
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ There are two `CrowCLI` directories:
 | **AppDelegate**           | `Sources/Crow/App/AppDelegate.swift`               | Initializes the app, creates the main window, starts the IPC socket server and issue tracker                     |
 | **SessionService**        | `Sources/Crow/App/SessionService.swift`            | CRUD for sessions/worktrees/terminals, terminal readiness tracking, orphan recovery on startup                    |
 | **IssueTracker**          | `Sources/Crow/App/IssueTracker.swift`              | Polls GitHub/GitLab every 60 seconds for assigned issues, PR status, project board status, auto-completes merged sessions |
-| **Scaffolder**            | `Sources/Crow/App/Scaffolder.swift`                | First-run devRoot scaffold: `.claude/` + bundled skills + settings.json                                           |
+| **Scaffolder**            | `Sources/Crow/App/Scaffolder.swift`                | First-run devRoot scaffold: `.claude/` + bundled skills + settings.local.json (never touches the user's own settings.json)  |
 | **TmuxBackend**           | `Packages/CrowTerminal/.../TmuxBackend.swift`      | The terminal backend (introduced in #229, defaulted on in #301, the only backend since #303). Owns the tmux server and the shared cockpit `XTermSurfaceView` that renders it |
 | **TerminalRouter**        | `Sources/Crow/App/TerminalRouter.swift`            | Thin facade over `TmuxBackend` for per-terminal `send` / `destroy` / `trackReadiness` |
 | **AutoRespondCoordinator**| `Sources/Crow/App/AutoRespondCoordinator.swift`    | Watches PR review / CI signals and types follow-up instructions into the linked Claude Code terminal (#214)       |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,8 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
 | `~/.local/share/crow/crow.sock`                                       | Unix socket for CLI ↔ app IPC                                 |
 | `{devRoot}/.claude/config.json`                                       | Workspace configuration (see below)                          |
 | `{devRoot}/.claude/CLAUDE.md`                                         | Manager-tab context with the `crow` CLI reference             |
-| `{devRoot}/.claude/settings.json`                                     | Pre-approved permissions for Claude Code sessions             |
+| `{devRoot}/.claude/settings.local.json`                               | Crow-managed pre-approved permissions, merged on every launch  |
+| `{devRoot}/.claude/settings.json`                                     | The user's own file — Crow never reads or writes it            |
 | `{devRoot}/.claude/prompts/`                                          | Prompt files used by the `/crow-workspace` skill              |
 | `{devRoot}/.claude/skills/crow-workspace/SKILL.md`                    | Workspace setup skill invoked via `/crow-workspace`           |
 | `{devRoot}/.claude/skills/crow-workspace/setup.sh`                    | Deterministic setup script called by the skill                |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,7 +138,7 @@ When you finish the wizard, Crow scaffolds the following under the dev root (see
 ├── crow-reviews/                     # temporary clones for PR reviews
 └── .claude/
     ├── CLAUDE.md                     # manager-tab context (crow CLI reference)
-    ├── settings.json                 # pre-approved permissions for crow/gh/git
+    ├── settings.local.json           # pre-approved permissions for crow/gh/git (settings.json is yours — untouched)
     ├── config.json                   # workspace config (workspaces + defaults)
     ├── prompts/                      # prompt files for crow-workspace sessions
     └── skills/

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -26,7 +26,7 @@ The crow CLI is safe for concurrent use. Multiple `crow` commands can run simult
 ## Autonomous Execution
 
 This skill runs autonomously without permission prompts because:
-1. All `crow`, `gh`, `glab`, and `git` commands are pre-approved in `{devRoot}/.claude/settings.json`
+1. All `crow`, `gh`, `glab`, and `git` commands are pre-approved in `{devRoot}/.claude/settings.local.json`
 2. All commands use `dangerouslyDisableSandbox: true` (sandbox excludes these binaries)
 3. `setup.sh` is pre-approved via `Bash(bash .claude/skills/crow-workspace/setup.sh *)`
 


### PR DESCRIPTION
## Summary

- `Scaffolder.scaffold(...)` runs on every app launch and used to unconditionally overwrite `{devRoot}/.claude/settings.json` with the bundled permissions template, silently discarding anything a user added by hand (extra `permissions.allow` entries, `outputStyle`, `statusLine`, `hooks`, `env`, a tweaked `sandbox` block).
- Crow now writes its required permissions to `{devRoot}/.claude/settings.local.json` instead, and never reads or writes `settings.json` at all — that file is now entirely the user's own.
- Claude Code merges `permissions.allow` across `settings.json` and `settings.local.json` (confirmed against Claude Code's docs), so `crow`/`gh`/`git` commands still run without a permission prompt.
- `settings.local.json` is itself guarded by a new `Scaffolder.mergeSettings(...)`, so hand-edits to *that* file survive too: it only fills in permissions/keys that are missing, and leaves the file byte-for-byte untouched when there's nothing to add.

Closes #595.

## Changes

- `Sources/Crow/App/Scaffolder.swift` — merge instead of overwrite; target `settings.local.json` instead of `settings.json`.
- `Tests/CrowTests/ScaffolderSettingsMergeTests.swift` — new suite: template fallback, user-added permissions survive, a missing bundled permission gets re-added, custom top-level keys survive, a user's `sandbox` override wins, a no-op write leaves the file untouched, a full `scaffold()` round-trip across a simulated relaunch, and two tests locking in that `settings.json` is never created or touched (even when one already exists).
- Doc/skill text updated for accuracy: `CONTRIBUTING.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/getting-started.md`, `skills/crow-batch-workspace/SKILL.md`.

## Test plan

- [x] `swift test` — all 285 tests pass across 33 suites, including the 9 new ones.
- [x] Reproduced the original bug against the pre-fix binary: a hand-edited `settings.json` (custom permission + `outputStyle` + a marker key) was completely wiped after one launch, replaced by the bundled template.
- [x] Verified the fix against the built binary: same setup, but after the fix `settings.json` is left alone entirely and the custom permissions/keys land (and survive) in `settings.local.json` — including a deliberately-removed bundled permission getting silently re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)