### PR TITLE
Auto-detect tmux server crash and reattach + claude --continue (closes #588)

### DIFF
--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeCodeAgentLaunchTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeCodeAgentLaunchTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowClaude
+
+/// Locks in the resume-vs-initial-prompt decision in
+/// `ClaudeCodeAgent.autoLaunchCommand` (#588): work/manager sessions always
+/// resume with `--continue`; review/job sessions read their pre-written
+/// prompt file exactly once (`reviewPromptDispatched == false`) and resume
+/// with `--continue` on every relaunch after that — including the rebuild
+/// after a tmux server crash.
+@Suite("ClaudeCodeAgent.autoLaunchCommand resume semantics")
+struct ClaudeCodeAgentLaunchTests {
+
+    private let agent = ClaudeCodeAgent()
+
+    private func command(kind: SessionKind, dispatched: Bool) -> String? {
+        agent.autoLaunchCommand(
+            session: Session(name: "s", kind: kind, reviewPromptDispatched: dispatched),
+            worktreePath: "/tmp/wt",
+            remoteControlEnabled: false,
+            autoPermissionMode: false,
+            telemetryPort: nil
+        )
+    }
+
+    @Test func workAndManagerAlwaysResume() throws {
+        for kind in [SessionKind.work, .manager] {
+            for dispatched in [false, true] {
+                let cmd = try #require(command(kind: kind, dispatched: dispatched))
+                #expect(cmd.hasSuffix(" --continue\n"))
+                #expect(!cmd.contains("$(cat"))
+            }
+        }
+    }
+
+    @Test func reviewAndJobReadPromptFileOnFirstLaunchOnly() throws {
+        let review = try #require(command(kind: .review, dispatched: false))
+        #expect(review.contains("\"$(cat /tmp/wt/.crow-review-prompt.md)\""))
+        #expect(!review.contains("--continue"))
+
+        let job = try #require(command(kind: .job, dispatched: false))
+        #expect(job.contains("\"$(cat /tmp/wt/.crow-job-prompt.md)\""))
+        #expect(!job.contains("--continue"))
+    }
+
+    @Test func reviewAndJobResumeAfterPromptDispatched() throws {
+        for kind in [SessionKind.review, .job] {
+            let cmd = try #require(command(kind: kind, dispatched: true))
+            #expect(cmd.hasSuffix(" --continue\n"))
+            #expect(!cmd.contains("$(cat"))
+        }
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -54,6 +54,12 @@ public final class AppState {
     /// and enables the "Restart Manager" action. Reset when the Manager relaunches.
     public var managerProcessExited: Bool = false
 
+    /// `true` while Crow auto-recovers from a tmux server crash (#588): set at
+    /// detection, cleared once every tracked terminal settles (`.shellReady`
+    /// or `.timedOut`) or by a fallback timeout. Drives the crash-specific
+    /// "tmux server crashed — reconnecting and resuming…" terminal overlay.
+    public var tmuxCrashRecovering: Bool = false
+
     /// The agent seeded into new sessions when the caller doesn't pick one.
     /// Mirrors `AppConfig.defaultAgentKind` so creation flows can read the
     /// current default without a config round-trip.

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -82,7 +82,19 @@ public struct TerminalSurfaceView: NSViewRepresentable {
     /// `setFrameSize` here races with autolayout and is unnecessary.
     @MainActor
     private static func attach(surface: XTermSurfaceView, to container: NSView) {
-        container.addSubview(surface)
+        // A previous (destroyed) surface may still be parented here — a server
+        // restart/crash-recovery replaces the shared cockpit surface (#588).
+        // Drop the dead view so it doesn't sit over the live one.
+        for stale in container.subviews where stale is XTermSurfaceView && stale !== surface {
+            stale.removeFromSuperview()
+        }
+        // Keep the surface below any existing search bar — a plain addSubview
+        // would stack it on top and hide the bar.
+        if let existingBar = container.subviews.first(where: { $0 is TerminalSearchBar }) {
+            container.addSubview(surface, positioned: .below, relativeTo: existingBar)
+        } else {
+            container.addSubview(surface)
+        }
         surface.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             surface.leadingAnchor.constraint(equalTo: container.leadingAnchor),
@@ -92,8 +104,12 @@ public struct TerminalSurfaceView: NSViewRepresentable {
         ])
 
         // Float the Cmd+F search bar over the surface (#471 gap 2). Only
-        // install one per container; later re-parents keep the same bar.
-        if container.subviews.contains(where: { $0 is TerminalSearchBar }) == false {
+        // install one per container; later re-parents keep the same bar —
+        // but re-point it at the current surface in case a restart swapped
+        // the cockpit view out from under it.
+        if let bar = container.subviews.first(where: { $0 is TerminalSearchBar }) as? TerminalSearchBar {
+            bar.setHostSurface(surface)
+        } else {
             let bar = TerminalSearchBar(frame: .zero)
             bar.translatesAutoresizingMaskIntoConstraints = false
             bar.setHostSurface(surface)

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -44,6 +44,19 @@ public final class TmuxBackend {
     /// the caller for normal handling.
     public var onUnresponsive: ((TmuxError) -> Void)?
 
+    /// Fired when the cockpit attach client's PTY exits outside a deliberate
+    /// `shutdown()`/`destroy()` — i.e. the tmux server crashed out from under
+    /// the app, or the user detached the client (#588). Deliberate teardown
+    /// never fires this: `shutdown()` destroys the surface (which nils the
+    /// underlying `onProcessExit`) before touching the server.
+    public var onCockpitExit: ((Int32) -> Void)?
+
+    /// Fired when a cached controller's cockpit session has vanished mid-run —
+    /// the server died while the app was live (#588). A fresh launch (no
+    /// cached controller) never fires this. Secondary, lazy detection: it only
+    /// triggers on the next tmux command; the primary signal is `onCockpitExit`.
+    public var onServerLost: (() -> Void)?
+
     // MARK: - Internal state
 
     /// Created on first use of the backend. Survives until app exit (or a
@@ -136,11 +149,16 @@ public final class TmuxBackend {
         if controller != nil {
             NSLog("[CrowTelemetry tmux:\(killServer ? "server_killed" : "server_detach") bindings=\(bindings.count)]")
         }
+        // Destroy the surface BEFORE kill-server: destroy() nils the surface's
+        // onProcessExit synchronously, and killServer's waitUntilExit pumps the
+        // main run loop — without this order the attach client's death would be
+        // delivered mid-shutdown and a deliberate restart would masquerade as
+        // a server crash (#588).
+        sharedSurface?.destroy()
+        sharedSurface = nil
         if killServer {
             controller?.killServer()
         }
-        sharedSurface?.destroy()
-        sharedSurface = nil
         controller = nil
         bindings.removeAll()
         activeTerminalID = nil
@@ -264,7 +282,7 @@ public final class TmuxBackend {
     /// server (e.g. on app restart with a long-lived session). No new
     /// window is created.
     public func adoptTerminal(id: UUID, binding: TmuxBinding, trackReadiness: Bool) throws {
-        let ctrl = try ensureRunningServer()
+        let (ctrl, serverWasResurrected) = try ensureRunningServerReportingResurrection()
         guard ctrl.socketPath == binding.socketPath, ctrl.sessionName == binding.sessionName else {
             throw TmuxBackendError.bindingMismatch(
                 expected: binding.socketPath + ":" + binding.sessionName,
@@ -273,7 +291,13 @@ public final class TmuxBackend {
         }
         let liveIndices = try ctrl.listWindowIndices()
         guard liveIndices.contains(binding.windowIndex) else {
-            throw TmuxBackendError.windowNotFound(binding.windowIndex)
+            // A binding exists but the server had to be respawned from
+            // scratch: every window is gone, not just this one — the server
+            // crashed (or the machine rebooted) since the binding was made.
+            // Distinguish that from a single closed window (#588).
+            throw serverWasResurrected
+                ? TmuxBackendError.serverCrashed
+                : TmuxBackendError.windowNotFound(binding.windowIndex)
         }
         bindings[id] = binding.windowIndex
         // No sentinel re-fire on adoption — the wrapper's precmd already
@@ -730,6 +754,15 @@ public final class TmuxBackend {
             workingDirectory: NSHomeDirectory(),
             command: attachCommand
         )
+        // The attach client exiting on its own means the server crashed or the
+        // user detached — deliberate teardown goes through destroy(), which
+        // nils onProcessExit first, so this only fires for the unexpected case
+        // (#588). Wired here (not by the caller) so every recreated surface is
+        // automatically re-armed after recovery.
+        view.onProcessExit = { [weak self] code in
+            NSLog("[CrowTelemetry tmux:cockpit_client_exited code=\(code)]")
+            self?.onCockpitExit?(code)
+        }
         NSLog("[TmuxBackend] created cockpit surface attach=%@", attachCommand)
         // Cache before SwiftUI re-parents into the visible tab container.
         // WKWebView must load in a visible window — do not park offscreen or
@@ -746,6 +779,19 @@ public final class TmuxBackend {
         sharedSurface
     }
 
+    /// Destroy only the cockpit attach surface; the server, window bindings,
+    /// sentinels and readiness watches all survive. The next `cockpitSurface()`
+    /// call re-attaches to the live session. Used when the attach client died
+    /// but the server is still healthy (e.g. the user hit prefix-d) (#588).
+    public func recycleCockpitSurface() {
+        sharedSurface?.destroy()
+        sharedSurface = nil
+        // A fresh attach lands on the session's current window, which may not
+        // match what we last selected — force the next makeActive to actually
+        // run select-window instead of short-circuiting.
+        activeTerminalID = nil
+    }
+
     /// Whether `id` has a live tmux-window binding. Used by callers that
     /// want to gate a send/destroy/makeActive on "this terminal is actually
     /// wired up" without relying on the throwing dispatch path.
@@ -756,8 +802,26 @@ public final class TmuxBackend {
     // MARK: - Internal helpers
 
     private func ensureRunningServer() throws -> TmuxController {
-        if let ctrl = controller, ctrl.hasSession() {
-            return ctrl
+        try ensureRunningServerReportingResurrection().ctrl
+    }
+
+    /// Like `ensureRunningServer()`, but also reports whether the cockpit
+    /// session had to be created from scratch (`resurrected == true`) —
+    /// i.e. the server was NOT running when the caller needed it. Callers
+    /// that see a persisted binding fail against a resurrected server know
+    /// the whole server died, not just one window (#588).
+    private func ensureRunningServerReportingResurrection()
+        throws -> (ctrl: TmuxController, resurrected: Bool)
+    {
+        if let ctrl = controller {
+            if ctrl.hasSession() { return (ctrl, false) }
+            // We had a live cockpit this run and it's gone — the server died
+            // mid-run (or is hung past the watchdog; recovery handles both
+            // identically). Fire BEFORE resurrecting so the handler can
+            // observe the dead state; it's reentrancy-guarded and hops to a
+            // later main-actor turn, so recovery never races this call.
+            NSLog("[CrowTelemetry tmux:server_died_midrun bindings=\(bindings.count)]")
+            onServerLost?()
         }
         guard !tmuxBinary.isEmpty, !socketPath.isEmpty else {
             // Backend wasn't configured this run (tmux not discovered).
@@ -783,7 +847,7 @@ public final class TmuxBackend {
         if serverWasAlreadyLive {
             Self.reconcileBundledConfigIfStale(controller: ctrl, configURL: confURL)
         }
-        return ctrl
+        return (ctrl, !serverWasAlreadyLive)
     }
 
     // MARK: - Stale-config reconciliation (#450)
@@ -1203,6 +1267,7 @@ public enum TmuxBackendError: Error, CustomStringConvertible {
     case unknownTerminal(UUID)
     case bindingMismatch(expected: String, actual: String)
     case windowNotFound(Int)
+    case serverCrashed
     case notConfigured
 
     public var description: String {
@@ -1215,6 +1280,8 @@ public enum TmuxBackendError: Error, CustomStringConvertible {
             return "TmuxBackend binding mismatch: expected \(expected), got \(actual)"
         case let .windowNotFound(index):
             return "TmuxBackend: no live window at index \(index)"
+        case .serverCrashed:
+            return "TmuxBackend: tmux server was not running (crashed or rebooted); cockpit was recreated empty"
         case .notConfigured:
             return "TmuxBackend.configure(...) was not called this run (no tmux ≥ 3.3 binary was found)"
         }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -650,6 +650,124 @@ struct TmuxBackendTests {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(status == "on")
     }
+
+    // MARK: - Server-crash detection (#588)
+
+    /// `shutdown(killServer: true)` on an already-dead server must complete
+    /// (kill-server on a missing socket fails fast and is swallowed) and leave
+    /// the backend able to register fresh windows.
+    @Test func shutdownOnDeadServerCompletesAndRecovers() throws {
+        let socket = sharedSocketPath()
+        let backend = makeBackend(socket: socket)
+        defer { backend.shutdown() }
+
+        _ = try backend.registerTerminal(
+            id: UUID(), name: "victim", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        // Simulate the crash: kill the server out-of-band.
+        killLeftoverServer(socket: socket)
+
+        backend.shutdown(killServer: true)
+
+        let binding = try backend.registerTerminal(
+            id: UUID(), name: "reborn", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        #expect(binding.windowIndex >= 0)
+        #expect(backend.isRunning)
+    }
+
+    /// A cached controller whose session vanished mid-run means the server
+    /// died while the app was live: the next backend call fires `onServerLost`
+    /// exactly once and still self-heals (resurrects the cockpit).
+    @Test func externalKillFiresOnServerLostOnNextCall() throws {
+        let socket = sharedSocketPath()
+        let backend = makeBackend(socket: socket)
+        defer { backend.shutdown() }
+
+        _ = try backend.registerTerminal(
+            id: UUID(), name: "victim", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+
+        var fired = 0
+        backend.onServerLost = { fired += 1 }
+
+        killLeftoverServer(socket: socket)
+        _ = try backend.registerTerminal(
+            id: UUID(), name: "after-crash", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        #expect(fired == 1)
+
+        // Healthy server again — further calls must not re-fire.
+        _ = try backend.registerTerminal(
+            id: UUID(), name: "healthy", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        #expect(fired == 1)
+    }
+
+    /// After a server crash, adopting a persisted binding fails with the
+    /// crash-specific error, not the generic single-window `windowNotFound`;
+    /// a single closed window on a healthy server keeps `windowNotFound`.
+    @Test func adoptDistinguishesServerCrashFromMissingWindow() throws {
+        let socket = sharedSocketPath()
+        let backend = makeBackend(socket: socket)
+        defer { backend.shutdown() }
+
+        let id = UUID()
+        let binding = try backend.registerTerminal(
+            id: id, name: "victim", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+
+        // Healthy server, one window gone → windowNotFound.
+        backend.destroyTerminal(id: id)
+        do {
+            try backend.adoptTerminal(id: id, binding: binding, trackReadiness: false)
+            Issue.record("adopt of a closed window should throw")
+        } catch let error as TmuxBackendError {
+            guard case .windowNotFound = error else {
+                Issue.record("expected windowNotFound, got \(error)")
+                return
+            }
+        }
+
+        // Whole server gone → serverCrashed.
+        killLeftoverServer(socket: socket)
+        do {
+            try backend.adoptTerminal(id: id, binding: binding, trackReadiness: false)
+            Issue.record("adopt after a server crash should throw")
+        } catch let error as TmuxBackendError {
+            guard case .serverCrashed = error else {
+                Issue.record("expected serverCrashed, got \(error)")
+                return
+            }
+        }
+    }
+
+    /// The light "client died, server alive" path: recycling with no surface
+    /// is a safe no-op that only resets the active-window marker.
+    @Test func recycleCockpitSurfaceIsSafeWithoutSurface() throws {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        let id = UUID()
+        _ = try backend.registerTerminal(
+            id: id, name: "a", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        try backend.makeActive(id: id)
+        #expect(backend.activeTerminalID == id)
+
+        backend.recycleCockpitSurface()
+
+        #expect(backend.existingCockpitSurface == nil)
+        #expect(backend.activeTerminalID == nil)
+        #expect(backend.isRunning)  // server untouched
+    }
 }
 
 // MARK: - CROW-487 crowBinDir propagation

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -616,14 +616,19 @@ struct ReadinessAwareTerminal: View {
                 // interactive. Common on cold tmux start + App Nap on a
                 // backgrounded app + heavy zshrc. The user can retry now, or
                 // the app will retry automatically next time it returns to
-                // the foreground.
+                // the foreground. During tmux crash auto-recovery (#588) the
+                // same overlay reads as the crash, not a generic slow shell.
                 VStack(spacing: 10) {
                     Image(systemName: "clock.badge.exclamationmark")
                         .font(.system(size: 28))
                         .foregroundStyle(.yellow)
-                    Text("Terminal didn't become ready in time")
+                    Text(appState.tmuxCrashRecovering
+                        ? "tmux server crashed — reconnecting and resuming…"
+                        : "Terminal didn't become ready in time")
                         .font(.headline)
-                    Text("The shell took longer than expected to start. This usually means the app was backgrounded while a tmux session was warming up.")
+                    Text(appState.tmuxCrashRecovering
+                        ? "Crow is rebuilding this terminal and resuming its agent with claude --continue. If it stays stuck, Retry re-arms the readiness watch."
+                        : "The shell took longer than expected to start. This usually means the app was backgrounded while a tmux session was warming up.")
                         .font(.caption)
                         .foregroundStyle(CorveilTheme.textMuted)
                         .multilineTextAlignment(.center)
@@ -658,7 +663,9 @@ struct ReadinessAwareTerminal: View {
                 VStack(spacing: 8) {
                     ProgressView()
                         .controlSize(.regular)
-                    Text(readiness == .uninitialized ? "Waiting for terminal..." : "Shell starting...")
+                    Text(appState.tmuxCrashRecovering
+                        ? "tmux server crashed — reconnecting and resuming…"
+                        : (readiness == .uninitialized ? "Waiting for terminal..." : "Shell starting..."))
                         .font(.caption)
                         .foregroundStyle(CorveilTheme.textMuted)
                 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -246,6 +246,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     private func handleTmuxUnresponsive(error: TmuxError) {
         guard !tmuxUnresponsiveAlertShowing else { return }
+        // Crash auto-recovery is already killing + rebuilding the server; a
+        // transient timeout during that rebuild must not stack a modal alert
+        // on top of it (#588).
+        guard !appState.tmuxCrashRecovering else { return }
         tmuxUnresponsiveAlertShowing = true
         defer { tmuxUnresponsiveAlertShowing = false }
 
@@ -456,6 +460,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             TmuxBackend.shared.onUnresponsive = { [weak self] error in
                 Task { @MainActor in self?.handleTmuxUnresponsive(error: error) }
+            }
+            // Crash auto-recovery (#588). `sessionService` is looked up at
+            // fire time, so wiring before the service exists is fine (same
+            // pattern as onUnresponsive above).
+            TmuxBackend.shared.onCockpitExit = { [weak self] _ in
+                Task { @MainActor in self?.sessionService?.handleCockpitClientExit() }
+            }
+            TmuxBackend.shared.onServerLost = { [weak self] in
+                Task { @MainActor in self?.sessionService?.handleTmuxServerCrash() }
             }
             NSLog("[Crow] tmux backend configured: binary=\(tmuxBinary) socket=\(socketPath)")
         } else {

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -239,17 +239,27 @@ final class SessionService {
         wireTerminalReadiness()
 
         for session in appState.sessions {
-            guard let terminals = appState.terminals[session.id] else { continue }
+            guard var terminals = appState.terminals[session.id] else { continue }
             let isManagerSession = session.isManager
             let sid = session.id
 
             if forceRegister, !isManagerSession {
                 // The previous adopt (#367) / launchClaude cleared these; re-arm
                 // so the fresh shell's .shellReady relaunches claude --continue.
-                for terminal in terminals where terminal.isManaged {
-                    appState.terminalReadiness[terminal.id] = .uninitialized
-                    appState.autoLaunchTerminals.insert(terminal.id)
+                for i in terminals.indices where terminals[i].isManaged {
+                    appState.terminalReadiness[terminals[i].id] = .uninitialized
+                    appState.autoLaunchTerminals.insert(terminals[i].id)
+                    // Mirror the hydrate-clear (#374): a managed terminal must
+                    // never re-run a stored claude command verbatim on a
+                    // rebuild — the relaunch goes through autoLaunchCommand
+                    // (`claude --continue`) instead. In-memory rows are already
+                    // nil today (the new-terminal RPC persists nil); this makes
+                    // the re-run-the-initial-plan failure impossible (#588).
+                    if let cmd = terminals[i].command, cmd.contains("claude") {
+                        terminals[i].command = nil
+                    }
                 }
+                appState.terminals[session.id] = terminals
             }
 
             for original in terminals {
@@ -419,6 +429,23 @@ final class SessionService {
                 // automatically when the app returns to the foreground.
                 self.appState.terminalReadiness[terminalID] = .timedOut
             }
+            self.clearCrashRecoveryFlagIfSettled()
+        }
+    }
+
+    /// End the "tmux server crashed — reconnecting…" state once every tracked
+    /// terminal has settled (reached `.shellReady`/beyond, or `.timedOut` —
+    /// which then shows the normal Retry overlay in its crash flavor) (#588).
+    @MainActor
+    private func clearCrashRecoveryFlagIfSettled() {
+        guard appState.tmuxCrashRecovering else { return }
+        let stillPending = appState.terminalReadiness.values.contains {
+            $0 == .uninitialized || $0 == .surfaceCreated
+        }
+        if !stillPending {
+            appState.tmuxCrashRecovering = false
+            crashRecoveryClearFallback?.cancel()
+            crashRecoveryClearFallback = nil
         }
     }
 
@@ -774,6 +801,17 @@ final class SessionService {
     @MainActor
     func restartTmuxServer() {
         NSLog("[CrowTelemetry tmux:server_restart_by_user]")
+        // A manual restart supersedes any in-flight crash recovery — clear the
+        // flag so the crash overlay doesn't linger over the user-driven rebuild.
+        appState.tmuxCrashRecovering = false
+        recycleTmuxServerAndRebuild()
+    }
+
+    /// Shared server-recycle routine: tear down the tmux server and rebuild
+    /// every terminal surface + agent from scratch. Used by the manual menu
+    /// path (`restartTmuxServer`) and crash auto-recovery (#588).
+    @MainActor
+    private func recycleTmuxServerAndRebuild() {
         let savedSelection = appState.selectedSessionID
         let savedActive = appState.activeTerminalID
 
@@ -800,6 +838,71 @@ final class SessionService {
         // surface and re-attaches a fresh tmux client; preserves focus.
         appState.selectedSessionID = savedSelection
         appState.activeTerminalID = savedActive
+    }
+
+    // MARK: - tmux crash auto-recovery (#588)
+
+    /// Wall-clock of the last crash auto-recovery, to debounce a tight
+    /// crash → recover → crash loop (e.g. a broken tmux install).
+    private var lastCrashRecoveryAt: Date?
+
+    /// Force-clears `tmuxCrashRecovering` if readiness callbacks never settle
+    /// (e.g. tmux unconfigured so no terminal was re-registered at all).
+    private var crashRecoveryClearFallback: Task<Void, Never>?
+
+    /// The cockpit attach client exited on its own. Probe the server: dead →
+    /// full crash recovery; alive (user detach / client-only death) → just
+    /// recreate the attach surface and leave every window running.
+    @MainActor
+    func handleCockpitClientExit() {
+        guard !appState.tmuxCrashRecovering else { return }
+        if TmuxBackend.shared.isRunning {
+            NSLog("[CrowTelemetry tmux:cockpit_client_reattach]")
+            TmuxBackend.shared.recycleCockpitSurface()
+            // Same SwiftUI re-render trick as recycleTmuxServerAndRebuild: a
+            // same-value reassignment makes TerminalSurfaceView re-create the
+            // destroyed cockpit surface and re-attach a fresh tmux client.
+            let savedSelection = appState.selectedSessionID
+            let savedActive = appState.activeTerminalID
+            appState.selectedSessionID = savedSelection
+            appState.activeTerminalID = savedActive
+        } else {
+            handleTmuxServerCrash()
+        }
+    }
+
+    /// The tmux server died mid-run. Automatically re-register every terminal
+    /// window and relaunch each session's agent — work/review/job sessions
+    /// resume via `claude --continue` (their initial prompt was already
+    /// dispatched and is never re-pasted); a terminal still holding its
+    /// never-dispatched launch in `pendingLaunchCommands` pastes it exactly
+    /// once, as on first creation. No per-session user clicks required (#588).
+    @MainActor
+    func handleTmuxServerCrash() {
+        guard !appState.tmuxCrashRecovering else { return }
+        if let last = lastCrashRecoveryAt, Date().timeIntervalSince(last) < 10 {
+            NSLog("[CrowTelemetry tmux:server_crash_recovery_debounced]")
+            return
+        }
+        lastCrashRecoveryAt = Date()
+        NSLog("[CrowTelemetry tmux:server_crash_autorecovery]")
+        // Set the flag BEFORE shutdown: the subprocess waits inside the rebuild
+        // pump the main run loop, so a re-entrant crash signal during recovery
+        // must find the guard already up.
+        appState.tmuxCrashRecovering = true
+        recycleTmuxServerAndRebuild()
+
+        // Belt-and-braces: if no readiness callback ever settles the flag
+        // (nothing was re-registered), don't leave the crash overlay up forever.
+        crashRecoveryClearFallback?.cancel()
+        crashRecoveryClearFallback = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 120 * 1_000_000_000)
+            guard let self, !Task.isCancelled else { return }
+            if self.appState.tmuxCrashRecovering {
+                NSLog("[CrowTelemetry tmux:server_crash_recovery_timeout]")
+                self.appState.tmuxCrashRecovering = false
+            }
+        }
     }
 
     /// Build the shell command for a Manager terminal, dispatched through

--- a/Tests/CrowTests/TmuxCrashRecoveryTests.swift
+++ b/Tests/CrowTests/TmuxCrashRecoveryTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowTerminal
+@testable import Crow
+
+/// Covers the #588 tmux-server-crash auto-recovery: `handleTmuxServerCrash`
+/// re-arms every managed work terminal and relaunches via the existing
+/// `.shellReady` machinery (`--continue`, never a re-paste of a dispatched
+/// initial plan), `tmuxCrashRecovering` drives the crash overlay and clears
+/// once every tracked terminal settles, and the rebuild never re-runs a
+/// stored claude command verbatim.
+// Serialized for the same reason as DeferredLaunchTests: these tests overwrite
+// the singleton `TmuxBackend.shared.onReadinessChanged` (via the rebuild's
+// `wireTerminalReadiness()`) and then fire it directly.
+@Suite("tmux crash auto-recovery (#588)", .serialized)
+struct TmuxCrashRecoveryTests {
+
+    @MainActor
+    private struct Fixture {
+        let appState = AppState()
+        let service: SessionService
+
+        init(name: String) {
+            let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("crow-crash-\(name)-\(UUID().uuidString)")
+            service = SessionService(store: JSONStore(directory: tmp), appState: appState)
+        }
+
+        /// Seed a work session with one managed terminal that already launched
+        /// its agent (the steady state when a crash hits).
+        @discardableResult
+        func seedLaunchedWorkTerminal(command: String? = nil) -> (sessionID: UUID, terminalID: UUID) {
+            let sessionID = UUID()
+            let terminalID = UUID()
+            appState.sessions.append(Session(id: sessionID, name: "feat-\(terminalID)", kind: .work))
+            appState.terminals[sessionID] = [SessionTerminal(
+                id: terminalID, sessionID: sessionID, name: "Claude Code",
+                cwd: "/tmp", command: command, isManaged: true, tmuxBinding: nil
+            )]
+            appState.terminalReadiness[terminalID] = .agentLaunched
+            return (sessionID, terminalID)
+        }
+    }
+
+    @MainActor
+    @Test func crashSetsRecoveringFlagAndReArmsManagedTerminals() {
+        let f = Fixture(name: "rearm")
+        let (_, terminalID) = f.seedLaunchedWorkTerminal()
+
+        f.service.handleTmuxServerCrash()
+
+        #expect(f.appState.tmuxCrashRecovering)
+        // Re-armed exactly like the manual restart path: fresh shell's
+        // .shellReady drives launchAgent → autoLaunchCommand → --continue.
+        #expect(f.appState.terminalReadiness[terminalID] == .uninitialized)
+        #expect(f.appState.autoLaunchTerminals.contains(terminalID))
+    }
+
+    @MainActor
+    @Test func crashHandlerIsReentrancySafe() {
+        let f = Fixture(name: "reentrant")
+        let (_, terminalID) = f.seedLaunchedWorkTerminal()
+
+        f.service.handleTmuxServerCrash()
+        // Simulate the terminal having progressed mid-recovery; a re-entrant
+        // crash signal (run-loop pumping during shutdown) must not stomp it.
+        f.appState.terminalReadiness[terminalID] = .shellReady
+        f.service.handleTmuxServerCrash()
+
+        #expect(f.appState.terminalReadiness[terminalID] == .shellReady)
+    }
+
+    @MainActor
+    @Test func recoveringFlagClearsOnlyWhenAllTrackedTerminalsSettle() {
+        let f = Fixture(name: "settle")
+        let (_, terminalA) = f.seedLaunchedWorkTerminal()
+        let (_, terminalB) = f.seedLaunchedWorkTerminal()
+
+        f.service.handleTmuxServerCrash()
+        #expect(f.appState.tmuxCrashRecovering)
+
+        // First terminal comes back — the other is still rebuilding.
+        TmuxBackend.shared.onReadinessChanged?(terminalA, .shellReady)
+        #expect(f.appState.tmuxCrashRecovering)
+
+        // Last terminal settles (a timeout also counts as settled: the user
+        // gets the crash-flavored Retry overlay, not an eternal spinner).
+        TmuxBackend.shared.onReadinessChanged?(terminalB, .timedOut)
+        #expect(!f.appState.tmuxCrashRecovering)
+    }
+
+    @MainActor
+    @Test func rapidRepeatCrashIsDebounced() {
+        let f = Fixture(name: "debounce")
+        let (_, terminalID) = f.seedLaunchedWorkTerminal()
+
+        f.service.handleTmuxServerCrash()
+        TmuxBackend.shared.onReadinessChanged?(terminalID, .shellReady)
+        #expect(!f.appState.tmuxCrashRecovering)
+
+        // Server dies again immediately (broken tmux install): the second
+        // recovery inside the debounce window must not re-kill the panes.
+        f.service.handleTmuxServerCrash()
+        #expect(!f.appState.tmuxCrashRecovering)
+        #expect(f.appState.terminalReadiness[terminalID] == .shellReady)
+    }
+
+    /// A terminal whose initial plan was never dispatched keeps its pending
+    /// launch across a crash rebuild and pastes it exactly once — the prompt
+    /// is neither lost nor double-dispatched.
+    @MainActor
+    @Test func pendingInitialLaunchSurvivesCrashAndPastesOnce() {
+        let f = Fixture(name: "pending")
+        let (_, terminalID) = f.seedLaunchedWorkTerminal()
+        let command = "cd /tmp && claude \"$(cat plan.md)\""
+        f.appState.terminalReadiness[terminalID] = .uninitialized
+        f.appState.pendingLaunchCommands[terminalID] = command
+        f.appState.autoLaunchTerminals.insert(terminalID)
+
+        f.service.handleTmuxServerCrash()
+        // The rebuild must not consume the never-dispatched launch.
+        #expect(f.appState.pendingLaunchCommands[terminalID] == command)
+
+        TmuxBackend.shared.onReadinessChanged?(terminalID, .shellReady)
+        // Pasted and consumed — a later spurious .shellReady can't re-paste.
+        #expect(f.appState.pendingLaunchCommands[terminalID] == nil)
+        #expect(!f.appState.autoLaunchTerminals.contains(terminalID))
+        #expect(f.appState.terminalReadiness[terminalID] == .agentLaunched)
+    }
+
+    /// The force-register rebuild mirrors the hydrate-clear: a managed work
+    /// terminal must never re-run a stored claude command verbatim (that's
+    /// the "re-ran the initial plan" failure #588 forbids); the Manager keeps
+    /// its stored launch command, and unmanaged shells are untouched.
+    @MainActor
+    @Test func forceRegisterRebuildClearsManagedClaudeCommandsOnly() {
+        let f = Fixture(name: "clear")
+        let claudeCmd = "cd /tmp && claude \"$(cat plan.md)\""
+        let (workSessionID, workTerminalID) = f.seedLaunchedWorkTerminal(command: claudeCmd)
+
+        let unmanagedID = UUID()
+        f.appState.terminals[workSessionID]?.append(SessionTerminal(
+            id: unmanagedID, sessionID: workSessionID, name: "Shell",
+            cwd: "/tmp", command: claudeCmd, isManaged: false, tmuxBinding: nil
+        ))
+
+        let managerSessionID = AppState.managerSessionID
+        let managerTerminalID = UUID()
+        f.appState.sessions.append(Session(id: managerSessionID, name: "Manager", kind: .manager))
+        f.appState.terminals[managerSessionID] = [SessionTerminal(
+            id: managerTerminalID, sessionID: managerSessionID, name: "Manager",
+            cwd: "/tmp", command: "claude --permission-mode auto", isManaged: true, tmuxBinding: nil
+        )]
+
+        f.service.rebuildAllSurfaces(forceRegister: true)
+
+        let workRows = f.appState.terminals[workSessionID] ?? []
+        #expect(workRows.first(where: { $0.id == workTerminalID })?.command == nil)
+        #expect(workRows.first(where: { $0.id == unmanagedID })?.command == claudeCmd)
+        #expect(f.appState.terminals[managerSessionID]?.first?.command == "claude --permission-mode auto")
+    }
+
+    @MainActor
+    @Test func manualRestartClearsStaleCrashFlag() {
+        let f = Fixture(name: "manual")
+        f.seedLaunchedWorkTerminal()
+        f.appState.tmuxCrashRecovering = true
+
+        f.service.restartTmuxServer()
+
+        #expect(!f.appState.tmuxCrashRecovering)
+    }
+}


### PR DESCRIPTION
Closes #588

## What

When the tmux server crashes while Crow is running, Crow now detects it immediately, auto-reattaches every terminal, and relaunches each session's agent with `claude --continue` — with a crash-specific "tmux server crashed — reconnecting and resuming…" status instead of the generic readiness-timeout overlay. No per-session clicks.

## Root cause (corrected from the ticket)

- **No detection existed.** The cockpit attach client (`tmux attach-session`) dies with the server, but nothing subscribed to `XTermSurfaceView.onProcessExit`. Adopt failures were swallowed as generic `windowNotFound` (a dead server and a single closed window were indistinguishable — `ensureRunningServer` silently resurrects an empty cockpit first). The 2s watchdog only routes *hung*-server timeouts to an alert; a *crashed* server yields `cliFailed`, which was never surfaced.
- **The ticket's `terminal.command` hypothesis didn't hold**: `resolveLaunch` reads the in-memory `pendingLaunchCommands`, not `terminal.command`, and managed terminals are registered/persisted with `command: nil`. The existing rebuild machinery (`rebuildAllSurfaces(forceRegister: true)` + persisted `reviewPromptDispatched`) already yields `--continue` — the gaps were purely: no crash detection, no auto-trigger of that recovery, and no legible status.

## How

**Detection** (`TmuxBackend`)
- New `onCockpitExit`, wired to the cockpit surface's `onProcessExit` inside `cockpitSurface()` (recreated surfaces re-arm automatically). `shutdown()` reordered to destroy the surface *before* `kill-server` — its `waitUntilExit` pumps the run loop, so the old order would let a deliberate restart masquerade as a crash.
- New `onServerLost` fires when a cached controller's cockpit session has vanished mid-run (lazy secondary signal on the next tmux command).
- `adoptTerminal` throws a new `TmuxBackendError.serverCrashed` (whole server resurrected) distinct from `windowNotFound` (one window gone).

**Auto-recovery** (`SessionService`)
- `handleCockpitClientExit()`: server dead → `handleTmuxServerCrash()`; server alive (user detach) → `recycleCockpitSurface()` light reattach that leaves all windows running (behavior change: prefix-d previously left a dead view silently).
- `handleTmuxServerCrash()`: reentrancy-guarded + 10s crash-loop debounce + 120s fallback flag clear; runs `recycleTmuxServerAndRebuild()` (extracted from, and shared with, the manual Restart tmux Server menu path). Dispatched sessions resume via `autoLaunchCommand` → `claude --continue`; a never-dispatched initial prompt survives in `pendingLaunchCommands` and pastes exactly once; Manager/review/job semantics unchanged.
- Defensive guard: `rebuildAllSurfaces(forceRegister:)` nils a managed terminal's stored claude command (mirrors the hydrate-clear) so re-running the initial plan verbatim is structurally impossible.

**UX**
- New `AppState.tmuxCrashRecovering` drives the crash wording on both the loading and timed-out overlays (Retry + Copy diagnostics kept as the escape hatch); cleared when every tracked terminal settles. The hung-server alert is suppressed during recovery; a manual restart clears a stale flag.
- `TerminalSurfaceView.attach` now removes the previous destroyed cockpit view and re-points the search bar at the replacement (pre-existing leak on manual restart, user-visible with auto-recovery).

## Testing

- `Tests/CrowTests/TmuxCrashRecoveryTests.swift` (7): flag + re-arm, reentrancy, debounce, settle-based flag clear, pending-prompt survival/single paste, managed-only command clear, manual-restart interplay.
- `Packages/CrowClaude/.../ClaudeCodeAgentLaunchTests.swift` (3): `autoLaunchCommand` resume matrix (work/manager always `--continue`; review/job prompt-file first launch only).
- `Packages/CrowTerminal/.../TmuxBackendTests.swift` (+4 real-tmux integration): shutdown on an already-dead server recovers; external `kill-server` fires `onServerLost` exactly once and self-heals; `serverCrashed` vs `windowNotFound`; surface recycle no-op safety.
- Full gate: `make test` — all packages + root (283 root tests / 33 suites) green.
- Note: the full GUI flow (cockpit PTY exit → overlay) needs a visible window and wasn't driven headless — this branch's dev session runs *inside* the production Crow tmux server, so killing the live socket would sever active sessions. Manual check: run the patched app with 2–3 sessions, `tmux -S $TMPDIR/crow-tmux.sock kill-server`, expect immediate crash status + auto-resume via `--continue`; `tmux detach-client` should silently reattach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)