### PR TITLE
xterm.js: restore Shift+Enter → insert newline in Claude Code (closes #598)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
@@ -101,6 +101,38 @@
 
         window.crowFit = reportSize;
 
+        // xterm.js emits the same bare \r for Enter and Shift+Enter, so
+        // Claude Code can't tell them apart and submits on both (#598).
+        // Intercept modified Enter and send a distinct sequence through the
+        // same crowInput bridge:
+        //  - Shift+Enter → CSI-u \x1b[13;2u. crow-tmux.conf's extended-keys
+        //    setup carries it to apps that negotiate extended keys (Claude
+        //    Code → insert newline) and downgrades it to plain \r for apps
+        //    that don't, so nothing leaks into vim/shells.
+        //  - Option+Enter → \x1b\r (ESC CR), Claude Code's other native
+        //    insert-newline chord. macOptionIsMeta stays off so Option-key
+        //    composed characters keep working for regular typing.
+        // Returning false suppresses xterm.js's default \r for every event
+        // phase (keydown/keypress/keyup) of the combo.
+        term.attachCustomKeyEventHandler(function (e) {
+          if (e.key !== 'Enter' || e.ctrlKey || e.metaKey) {
+            return true;
+          }
+          if (e.shiftKey && !e.altKey) {
+            if (e.type === 'keydown') {
+              handlers.crowInput.postMessage({ data: '\x1b[13;2u' });
+            }
+            return false;
+          }
+          if (e.altKey && !e.shiftKey) {
+            if (e.type === 'keydown') {
+              handlers.crowInput.postMessage({ data: '\x1b\r' });
+            }
+            return false;
+          }
+          return true;
+        });
+
         term.onData(function (data) {
           handlers.crowInput.postMessage({ data: data });
         });

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -63,6 +63,20 @@ struct BundledResourcesTests {
         #expect(body.contains(#"send-keys -X select-line ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy""#))
     }
 
+    @Test func terminalHTMLHandlesModifiedEnter() throws {
+        // #598: xterm.js sends the same \r for Enter and Shift+Enter, so the
+        // host page must intercept modified Enter and emit distinct sequences
+        // (CSI-u \x1b[13;2u for Shift+Enter, ESC CR for Option+Enter) or
+        // Claude Code submits instead of inserting a newline. The xterm
+        // resources get re-vendored wholesale (see Resources/xterm/VERSION),
+        // so pin the handler's presence against an accidental overwrite.
+        let url = try #require(BundledResources.terminalHTMLURL)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        #expect(body.contains("attachCustomKeyEventHandler"))
+        #expect(body.contains(#"\x1b[13;2u"#))
+        #expect(body.contains(#"\x1b\r"#))
+    }
+
     @Test func tmuxConfHasNoBarePrefixUnbind() throws {
         // #473: a bare `unbind-key -a` (no `-T`) defaults to the prefix
         // table, which is empty/non-existent after the first clear on


### PR DESCRIPTION
Closes #598

## Problem

The Ghostty→xterm.js migration (#548) lost modifier-aware Enter handling: xterm.js emits the same bare `\r` for Enter and Shift+Enter, so Claude Code submitted the prompt instead of inserting a newline.

## Fix

Add `term.attachCustomKeyEventHandler(...)` in `terminal.html` that intercepts modified Enter on keydown, sends a distinct sequence through the existing `crowInput` → PTY bridge, and returns `false` to suppress xterm.js's default `\r`:

- **Shift+Enter → CSI-u `\x1b[13;2u`** — the sequence `crow-tmux.conf`'s `extended-keys on` + `extkeys` terminal-features were already configured to carry. tmux forwards it to apps that negotiate extended keys (Claude Code → insert newline) and **downgrades it to plain `\r`** for apps that don't, so nothing leaks into vim/shells.
- **Option+Enter → `\x1b\r`** (ESC CR) — Claude Code's other native insert-newline chord, which also regressed in #548. `macOptionIsMeta` stays off so Option-key composed characters keep working for regular typing.

Plain Enter stays on the default path and still submits. No tmux config changes (already correct). Added a bundled-resource test pinning the handler's presence, since the xterm resources get re-vendored wholesale (`Resources/xterm/VERSION`).

## Verification

Ran end-to-end against a **real Claude Code prompt inside a tmux server started from the bundled `crow-tmux.conf`**, injecting the exact bytes through a PTY-attached client (`TERM=xterm-256color`, same as `PTYProcess`):

- `alpha` + `\x1b[13;2u` + `bravo` + `\x1b\r` + `charlie` → three lines in the prompt box, **no submission**.
- Plain `\r` in a shell pane still executes commands.
- Raw-mode pane byte capture: client `\x1b[13;2u` arrives as plain `\r` in a non-negotiating pane (clean degradation); `\x1b\r` passes through as Meta+Enter.
- `swift build` + `make test`: all suites pass. (CrowGit `RebaseTests` fail pre-existing and unrelated — the environment has no global git `user.email`/`user.name`, and those tests commit in temp repos outside any `includeIf` scope; they fail identically on `main`.)

## Follow-up notes (other Ghostty-era modified keys)

Ctrl combos (Ctrl+C/D/R/etc.) go through xterm.js's standard control-byte handling and were unaffected. General Option-as-Meta (e.g. Option+B/F word motion) remains off, matching the current ctor config — turning on `macOptionIsMeta` globally would break Option-composed characters, so that's left as a deliberate non-change; can file a follow-up if someone misses those bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)