### PR TITLE
Auto-trust worktree/clone folders so Claude Code's trust prompt doesn't block automated flows (closes #600)

### DIFF
--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeTrustSeeder.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeTrustSeeder.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Seeds per-project trust into `~/.claude.json` so Claude Code skips the
+/// "Do you trust the files in this folder?" dialog when Crow auto-launches
+/// a session in a fresh worktree or review clone (CROW-600).
+///
+/// Claude Code records trust per absolute project path under
+/// `projects["<path>"].hasTrustDialogAccepted` (plus
+/// `hasCompletedProjectOnboarding`), and trust does NOT inherit from parent
+/// directories — so every fresh worktree/clone would otherwise prompt and
+/// block unattended review/job flows.
+///
+/// `~/.claude.json` is Claude Code's own mutable state (other projects,
+/// mcpServers, oauthAccount, …), so this merges — it never overwrites
+/// unrelated keys, refuses to touch a file it can't parse, and skips the
+/// write entirely when the path is already trusted. A concurrently running
+/// `claude` may rewrite the file; the atomic write plus skip-when-trusted
+/// keeps that race window small, and losing our write only re-shows the
+/// dialog (benign).
+public enum ClaudeTrustSeeder {
+
+    public enum Outcome: Equatable {
+        /// Trust keys were written/updated for the project path.
+        case seeded
+        /// The project path already had both trust keys true; nothing written.
+        case alreadyTrusted
+        /// The file exists but isn't a JSON object; refused to touch it.
+        case skippedUnparseable
+        /// Read or write failed.
+        case failed(String)
+    }
+
+    /// The keys Claude Code checks before showing the trust dialog.
+    private static let trustKeys = ["hasTrustDialogAccepted", "hasCompletedProjectOnboarding"]
+
+    /// Ensure `~/.claude.json` marks `projectPath` as trusted before Claude
+    /// Code launches there. Pass `claudeJSONPath` to target a different file
+    /// (tests); `nil` uses the real `~/.claude.json`.
+    @discardableResult
+    public static func seedTrust(
+        projectPath: String,
+        claudeJSONPath: String? = nil
+    ) -> Outcome {
+        let jsonPath = claudeJSONPath
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".claude.json").path
+
+        // Claude Code keys `projects` by its resolved cwd, which may differ
+        // from the path Crow launches with (symlinks). Trust both spellings.
+        var projectPaths = [projectPath]
+        let resolved = URL(fileURLWithPath: projectPath).resolvingSymlinksInPath().path
+        if resolved != projectPath {
+            projectPaths.append(resolved)
+        }
+
+        let fm = FileManager.default
+        var root: [String: Any] = [:]
+        let fileExists = fm.fileExists(atPath: jsonPath)
+        if fileExists {
+            guard let data = fm.contents(atPath: jsonPath),
+                  let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            else {
+                NSLog("[ClaudeTrustSeeder] %@ exists but is not a JSON object; refusing to modify it", jsonPath)
+                return .skippedUnparseable
+            }
+            root = parsed
+        }
+
+        var projects = root["projects"] as? [String: Any] ?? [:]
+        var changed = false
+        for path in projectPaths {
+            var entry = projects[path] as? [String: Any] ?? [:]
+            for key in trustKeys where (entry[key] as? Bool) != true {
+                entry[key] = true
+                changed = true
+            }
+            projects[path] = entry
+        }
+        if !changed {
+            return .alreadyTrusted
+        }
+        root["projects"] = projects
+
+        // Preserve the file's existing permissions on rewrite; a freshly
+        // created file gets owner-only since ~/.claude.json can carry
+        // credentials (matching ConfigStore's 0600 on config.json).
+        let existingPerms = fileExists
+            ? (try? fm.attributesOfItem(atPath: jsonPath))?[.posixPermissions] as? NSNumber
+            : nil
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: jsonPath), options: .atomic)
+            let perms = existingPerms ?? NSNumber(value: 0o600)
+            try? fm.setAttributes([.posixPermissions: perms], ofItemAtPath: jsonPath)
+        } catch {
+            NSLog("[ClaudeTrustSeeder] Failed to write %@: %@", jsonPath, error.localizedDescription)
+            return .failed(error.localizedDescription)
+        }
+        return .seeded
+    }
+}

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeTrustSeederTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeTrustSeederTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+@testable import CrowClaude
+
+/// Tests for CROW-600: seeding worktree trust into ~/.claude.json so Claude
+/// Code's "Do you trust the files in this folder?" dialog never blocks an
+/// auto-launched session. Mirrors the ScaffolderSettingsMergeTests pattern:
+/// temp files + JSONSerialization round-trip assertions.
+@Suite struct ClaudeTrustSeederTests {
+
+    private func makeTempDir() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crow-trust-seeder-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func readJSON(_ path: String) throws -> [String: Any] {
+        let data = try #require(FileManager.default.contents(atPath: path))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func trustEntry(_ root: [String: Any], _ projectPath: String) -> [String: Any]? {
+        (root["projects"] as? [String: Any])?[projectPath] as? [String: Any]
+    }
+
+    @Test func missingFileIsCreatedWithTrustKeysAndOwnerOnlyPerms() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .seeded)
+        let root = try readJSON(jsonPath)
+        let entry = try #require(trustEntry(root, dir))
+        #expect(entry["hasTrustDialogAccepted"] as? Bool == true)
+        #expect(entry["hasCompletedProjectOnboarding"] as? Bool == true)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: jsonPath)
+        let perms = try #require(attrs[.posixPermissions] as? NSNumber)
+        #expect(perms.uint16Value == 0o600)
+    }
+
+    @Test func mergePreservesOtherProjectsAndTopLevelKeys() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        let existing: [String: Any] = [
+            "numStartups": 42,
+            "oauthAccount": ["emailAddress": "user@example.com", "uuid": "abc-123"],
+            "mcpServers": ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]],
+            "projects": [
+                "/Users/someone/other-project": [
+                    "hasTrustDialogAccepted": true,
+                    "allowedTools": ["Bash(git status:*)"],
+                    "history": [["display": "hi"]],
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: URL(fileURLWithPath: jsonPath))
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .seeded)
+        let root = try readJSON(jsonPath)
+        #expect(root["numStartups"] as? Int == 42)
+        let oauth = try #require(root["oauthAccount"] as? [String: Any])
+        #expect(oauth["emailAddress"] as? String == "user@example.com")
+        let mcp = try #require(root["mcpServers"] as? [String: Any])
+        #expect((mcp["jira"] as? [String: Any])?["command"] as? String == "uvx")
+
+        let other = try #require(trustEntry(root, "/Users/someone/other-project"))
+        #expect(other["hasTrustDialogAccepted"] as? Bool == true)
+        #expect(other["allowedTools"] as? [String] == ["Bash(git status:*)"])
+        #expect((other["history"] as? [[String: Any]])?.first?["display"] as? String == "hi")
+
+        let entry = try #require(trustEntry(root, dir))
+        #expect(entry["hasTrustDialogAccepted"] as? Bool == true)
+        #expect(entry["hasCompletedProjectOnboarding"] as? Bool == true)
+    }
+
+    @Test func untrustedEntryIsFlippedTrueWithSiblingKeysIntact() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        let existing: [String: Any] = [
+            "projects": [
+                dir: [
+                    "hasTrustDialogAccepted": false,
+                    "allowedTools": ["Bash(ls:*)"],
+                    "projectOnboardingSeenCount": 3,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: URL(fileURLWithPath: jsonPath))
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .seeded)
+        let entry = try #require(trustEntry(try readJSON(jsonPath), dir))
+        #expect(entry["hasTrustDialogAccepted"] as? Bool == true)
+        #expect(entry["hasCompletedProjectOnboarding"] as? Bool == true)
+        #expect(entry["allowedTools"] as? [String] == ["Bash(ls:*)"])
+        #expect(entry["projectOnboardingSeenCount"] as? Int == 3)
+    }
+
+    @Test func alreadyTrustedSkipsRewriteAndLeavesFileAlone() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        let existing: [String: Any] = [
+            "projects": [
+                dir: [
+                    "hasTrustDialogAccepted": true,
+                    "hasCompletedProjectOnboarding": true,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: URL(fileURLWithPath: jsonPath))
+        let bytesBefore = try #require(FileManager.default.contents(atPath: jsonPath))
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .alreadyTrusted)
+        let bytesAfter = try #require(FileManager.default.contents(atPath: jsonPath))
+        #expect(bytesAfter == bytesBefore)
+    }
+
+    @Test func unparseableFileIsLeftUntouched() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        let garbage = "{not json"
+        try garbage.write(toFile: jsonPath, atomically: true, encoding: .utf8)
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .skippedUnparseable)
+        #expect(try String(contentsOfFile: jsonPath, encoding: .utf8) == garbage)
+    }
+
+    @Test func topLevelArrayIsLeftUntouched() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        let array = "[1, 2, 3]"
+        try array.write(toFile: jsonPath, atomically: true, encoding: .utf8)
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .skippedUnparseable)
+        #expect(try String(contentsOfFile: jsonPath, encoding: .utf8) == array)
+    }
+
+    @Test func missingProjectsKeyIsAddedWithoutDisturbingTopLevel() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        try JSONSerialization.data(withJSONObject: ["numStartups": 7])
+            .write(to: URL(fileURLWithPath: jsonPath))
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .seeded)
+        let root = try readJSON(jsonPath)
+        #expect(root["numStartups"] as? Int == 7)
+        let entry = try #require(trustEntry(root, dir))
+        #expect(entry["hasTrustDialogAccepted"] as? Bool == true)
+    }
+
+    @Test func existingFilePermissionsArePreservedOnRewrite() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        try JSONSerialization.data(withJSONObject: ["projects": [:]])
+            .write(to: URL(fileURLWithPath: jsonPath))
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644], ofItemAtPath: jsonPath)
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: dir, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .seeded)
+        let attrs = try FileManager.default.attributesOfItem(atPath: jsonPath)
+        let perms = try #require(attrs[.posixPermissions] as? NSNumber)
+        #expect(perms.uint16Value == 0o644)
+    }
+
+    @Test func symlinkedProjectPathTrustsBothSpellings() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let jsonPath = (dir as NSString).appendingPathComponent("claude.json")
+        let realProject = (dir as NSString).appendingPathComponent("real-project")
+        try FileManager.default.createDirectory(atPath: realProject, withIntermediateDirectories: true)
+        let linkPath = (dir as NSString).appendingPathComponent("link-project")
+        try FileManager.default.createSymbolicLink(atPath: linkPath, withDestinationPath: realProject)
+
+        let outcome = ClaudeTrustSeeder.seedTrust(projectPath: linkPath, claudeJSONPath: jsonPath)
+
+        #expect(outcome == .seeded)
+        let root = try readJSON(jsonPath)
+        let literal = try #require(trustEntry(root, linkPath))
+        #expect(literal["hasTrustDialogAccepted"] as? Bool == true)
+        let resolvedPath = URL(fileURLWithPath: linkPath).resolvingSymlinksInPath().path
+        #expect(resolvedPath != linkPath)
+        let resolved = try #require(trustEntry(root, resolvedPath))
+        #expect(resolved["hasTrustDialogAccepted"] as? Bool == true)
+    }
+}

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -156,6 +156,12 @@ final class SessionService {
                 // Before writeManagerGatewayEnv() so its 0o600 re-apply is last.
                 if let managerCwd = terminals.first?.cwd {
                     writeManagerHookConfig(for: reconciled, dirPath: managerCwd)
+                    // CROW-600: pre-trust the Manager's cwd so a devRoot the
+                    // user hasn't opened Claude Code in before doesn't block
+                    // on the trust dialog. No-ops when already trusted.
+                    if reconciled.agentKind == .claudeCode {
+                        ClaudeTrustSeeder.seedTrust(projectPath: managerCwd)
+                    }
                 }
                 writeManagerGatewayEnv()
                 // Remote-control bookkeeping reflects what the agent actually
@@ -593,6 +599,12 @@ final class SessionService {
         // Claude-specific; the Manager uses `managerGateway` instead.
         var gatewayPrefix = ""
         if agent.kind == .claudeCode {
+            // CROW-600: pre-trust the worktree in ~/.claude.json so the
+            // "Do you trust the files in this folder?" dialog never blocks
+            // an auto-launched session. Trust does not inherit from parent
+            // directories, so every fresh worktree/clone would prompt.
+            ClaudeTrustSeeder.seedTrust(projectPath: worktree.worktreePath)
+
             let gatewayResolved = workspaceGatewayResolved(for: sessionID)
             ClaudeHookConfigWriter.writeGatewayEnv(
                 dirPath: worktree.worktreePath, resolved: gatewayResolved)
@@ -1035,6 +1047,11 @@ final class SessionService {
         // can carry a bearer token) is the final write; both merge into the same
         // {devRoot}/.claude/settings.local.json without clobbering each other.
         writeManagerHookConfig(for: session, dirPath: cwd)
+        // CROW-600: a brand-new devRoot would otherwise block the Manager on
+        // Claude Code's trust dialog. No-ops when already trusted.
+        if session.agentKind == .claudeCode {
+            ClaudeTrustSeeder.seedTrust(projectPath: cwd)
+        }
         // CROW-402: write the Manager gateway env block to {devRoot}/.claude so
         // manual `claude` re-runs in this terminal inherit the same routing. The
         // Manager's cwd is the devRoot.


### PR DESCRIPTION
Closes #600

## Problem

Claude Code shows its **"Do you trust the files in this folder?"** dialog the first time it runs in a directory. Trust is recorded per absolute path in `~/.claude.json` (`projects["<path>"].hasTrustDialogAccepted` / `hasCompletedProjectOnboarding`) and **does not inherit from parent directories** (verified against a real `~/.claude.json`: `~/Dev` trusted, a child repo untrusted). Every fresh worktree/review clone Crow launches into therefore prompted, blocking unattended review/job flows until a human clicked through.

## Approach — issue option 1 (seed `~/.claude.json`, merge-not-overwrite)

Chosen over `--dangerously-skip-permissions` (option 2) because it suppresses **only** the trust dialog and leaves the permission model intact for every session kind. The trust keys were confirmed against the installed Claude Code's real `~/.claude.json` before implementing.

- **New `ClaudeTrustSeeder`** (`Packages/CrowClaude`): read-modify-write of `~/.claude.json`, modeled on `Scaffolder.mergeSettings` / `ClaudeHookConfigWriter`:
  - forces `hasTrustDialogAccepted` + `hasCompletedProjectOnboarding` to `true` for the project path (and its symlink-resolved variant — Claude Code keys projects by resolved cwd)
  - preserves every other top-level key (`mcpServers`, `oauthAccount`, other projects) and every sibling key in the entry
  - refuses to touch a file it can't parse (never clobbers), skips the write when already trusted (minimizes racing a live `claude` process), atomic write, preserves existing file perms (0600 for a freshly created file)
- **Call sites** (`SessionService.swift`):
  - `launchAgent` — inside the existing `agent.kind == .claudeCode` gate; this is the single choke point through which review, job, work, and rehydrated sessions all launch, so review clones (`prepareReviewClone` output) and fresh worktrees are covered in one spot
  - the two Manager prep sites (`createManagerTerminal` + hydrate rebuild), gated on `.claudeCode`, so a brand-new devRoot doesn't block the Manager either

## Re the suspected trigger (#596 / xterm.js migration)

Ruled out as the cause: neither touched `~/.claude.json`, and nothing was previously masking the dialog — this is a longstanding gap that becomes visible whenever a session launches into a never-trusted path.

## Testing

- New `ClaudeTrustSeederTests` (9 tests, swift-testing, mirroring `ScaffolderSettingsMergeTests`): fresh-file creation + 0600, rich-file merge preservation (other projects / `mcpServers` / `oauthAccount`), false→true flip with siblings intact, already-trusted no-op (bytes unchanged), unparseable/array refusal, missing `projects` key, perms preserved on rewrite, symlink dual-seeding.
- `swift build` + `make test` pass (except `CrowGit` `RebaseTests`, which fail pre-existing on this machine for lack of a global git identity — unrelated to this change).
- Real-data smoke test: ran the seeder against a copy of the actual `~/.claude.json` (26 projects, MCP servers, oauth) — only the one new project entry was added; every other key value-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)