### PR TITLE
Launch code-review sessions in auto permission mode (reviewAutoPermissionMode toggle) (closes #602)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -49,6 +49,12 @@ public final class AppState {
     /// Applies only to `.job`-kind sessions; manager/review/CLI sessions are unaffected.
     public var jobsAutoPermissionMode: Bool = true
 
+    /// Whether code-review sessions start with `--permission-mode auto` so the
+    /// review prompt can run `crow`, `gh`, and `git` without per-call approval.
+    /// Mirrors `AppConfig.reviewAutoPermissionMode`. Applies only to
+    /// `.review`-kind sessions; manager/work/CLI sessions are unaffected.
+    public var reviewAutoPermissionMode: Bool = true
+
     /// `true` when the Manager's `claude` process has exited (crash, kill, OOM)
     /// and has not yet been restarted. Drives the "Manager process exited" banner
     /// and enables the "Restart Manager" action. Reset when the Manager relaunches.

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -17,6 +17,10 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// `git` without per-call approval. Defaults to true — jobs are
     /// unattended by definition.
     public var jobsAutoPermissionMode: Bool
+    /// When true, code-review sessions start with `--permission-mode auto` so
+    /// the review prompt can run `crow`, `gh`, and `git` without per-call
+    /// approval. Defaults to true — reviews kick off unattended, like jobs.
+    public var reviewAutoPermissionMode: Bool
     public var telemetry: TelemetryConfig
     public var autoRespond: AutoRespondSettings
     /// When true, `setup.sh` writes a per-worktree `.claude/settings.local.json`
@@ -83,6 +87,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         remoteControlEnabled: Bool = false,
         managerAutoPermissionMode: Bool = true,
         jobsAutoPermissionMode: Bool = true,
+        reviewAutoPermissionMode: Bool = true,
         telemetry: TelemetryConfig = TelemetryConfig(),
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         attributionTrailers: Bool = true,
@@ -102,6 +107,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.remoteControlEnabled = remoteControlEnabled
         self.managerAutoPermissionMode = managerAutoPermissionMode
         self.jobsAutoPermissionMode = jobsAutoPermissionMode
+        self.reviewAutoPermissionMode = reviewAutoPermissionMode
         self.telemetry = telemetry
         self.autoRespond = autoRespond
         self.attributionTrailers = attributionTrailers
@@ -124,6 +130,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         remoteControlEnabled = try container.decodeIfPresent(Bool.self, forKey: .remoteControlEnabled) ?? false
         managerAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .managerAutoPermissionMode) ?? true
         jobsAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .jobsAutoPermissionMode) ?? true
+        reviewAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .reviewAutoPermissionMode) ?? true
         telemetry = try container.decodeIfPresent(TelemetryConfig.self, forKey: .telemetry) ?? TelemetryConfig()
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
@@ -181,7 +188,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential
     }
 
     /// Resolve the agent that should drive a newly-created session of the

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -232,6 +232,29 @@ import Testing
     #expect(config.jobsAutoPermissionMode == true)
 }
 
+@Test func appConfigReviewAutoPermissionModeRoundTrip() throws {
+    var config = AppConfig()
+    config.reviewAutoPermissionMode = false
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.reviewAutoPermissionMode == false)
+
+    config.reviewAutoPermissionMode = true
+    let data2 = try JSONEncoder().encode(config)
+    let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
+    #expect(decoded2.reviewAutoPermissionMode == true)
+}
+
+@Test func appConfigReviewAutoPermissionModeDefaultsTrueWhenKeyMissing() throws {
+    // Reviews kick off unattended, like jobs — legacy configs without the key
+    // opt in by default so the review flow can run crow/gh/git without
+    // per-call approval, matching the Manager and Jobs toggles' defaults.
+    let json = #"{"workspaces": [], "remoteControlEnabled": false}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.reviewAutoPermissionMode == true)
+}
+
 @Test func appConfigDecodeWithPartialKeys() throws {
     let json = """
     {"workspaces": [{"id": "00000000-0000-0000-0000-000000000001", "name": "Org", "provider": "github", "cli": "gh", "alwaysInclude": []}]}

--- a/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 import CrowCore
 
 /// Settings view for automation toggles: which repos surface review/ticket activity,
-/// whether new sessions opt into remote control, Manager Terminal permission mode,
-/// and auto-respond on PR review / CI signals.
+/// whether new sessions opt into remote control, Manager Terminal and code-review
+/// permission modes, and auto-respond on PR review / CI signals.
 public struct AutomationSettingsView: View {
     @Binding var defaults: ConfigDefaults
     @Binding var remoteControlEnabled: Bool
     @Binding var managerAutoPermissionMode: Bool
+    @Binding var reviewAutoPermissionMode: Bool
     @Binding var managerGateway: WorkspaceGateway?
     @Binding var jiraCredential: JiraCredential?
     @Binding var autoRespond: AutoRespondSettings
@@ -26,6 +27,7 @@ public struct AutomationSettingsView: View {
         defaults: Binding<ConfigDefaults>,
         remoteControlEnabled: Binding<Bool>,
         managerAutoPermissionMode: Binding<Bool>,
+        reviewAutoPermissionMode: Binding<Bool>,
         managerGateway: Binding<WorkspaceGateway?>,
         jiraCredential: Binding<JiraCredential?>,
         autoRespond: Binding<AutoRespondSettings>,
@@ -37,6 +39,7 @@ public struct AutomationSettingsView: View {
         self._defaults = defaults
         self._remoteControlEnabled = remoteControlEnabled
         self._managerAutoPermissionMode = managerAutoPermissionMode
+        self._reviewAutoPermissionMode = reviewAutoPermissionMode
         self._managerGateway = managerGateway
         self._jiraCredential = jiraCredential
         self._autoRespond = autoRespond
@@ -151,6 +154,14 @@ public struct AutomationSettingsView: View {
                 Toggle("Launch in auto permission mode", isOn: $managerAutoPermissionMode)
                     .onChange(of: managerAutoPermissionMode) { _, _ in onSave?() }
                 Text("Passes --permission-mode auto so the Manager can run crow, gh, and git commands without per-call approval. Requires Claude Code 2.1.83+ on a Max, Team, Enterprise, or API plan with the Anthropic provider. Turn off if your account reports auto mode as unavailable. Takes effect on next app launch.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Code Review") {
+                Toggle("Run code reviews in auto permission mode", isOn: $reviewAutoPermissionMode)
+                    .onChange(of: reviewAutoPermissionMode) { _, _ in onSave?() }
+                Text("Passes --permission-mode auto so review sessions can run their review flow — crow, gh, and git commands — without per-call approval. Turn off to launch reviews in plan mode instead. Applies to newly kicked-off reviews.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -100,6 +100,7 @@ public struct SettingsView: View {
                 defaults: $config.defaults,
                 remoteControlEnabled: $config.remoteControlEnabled,
                 managerAutoPermissionMode: $config.managerAutoPermissionMode,
+                reviewAutoPermissionMode: $config.reviewAutoPermissionMode,
                 managerGateway: $config.managerGateway,
                 jiraCredential: $config.jiraCredential,
                 autoRespond: $config.autoRespond,

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -578,6 +578,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
+        appState.reviewAutoPermissionMode = config.reviewAutoPermissionMode
         appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
@@ -1298,6 +1299,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
+        appState.reviewAutoPermissionMode = config.reviewAutoPermissionMode
         appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -612,10 +612,14 @@ final class SessionService {
         }
 
         let rcEnabled = appState.remoteControlEnabled
-        // Jobs are unattended, so opt-in (default-on) auto-permission mode lets
-        // their prompts run crow/gh/git without per-call approval. Scoped to
-        // .job kind so review and other session kinds are unaffected.
-        let autoPermissionMode = (session.kind == .job) && appState.jobsAutoPermissionMode
+        // Jobs and reviews are unattended, so opt-in (default-on) auto-permission
+        // mode lets their prompts run crow/gh/git without per-call approval.
+        // Other session kinds (work) are unaffected; the Manager has its own
+        // path via managerAutoPermissionMode.
+        let autoPermissionMode = Self.shouldAutoPermission(
+            kind: session.kind,
+            jobsAuto: appState.jobsAutoPermissionMode,
+            reviewAuto: appState.reviewAutoPermissionMode)
         // The agent's autoLaunchCommand mirrors this condition — the initial
         // prompt file is only used on first launch (CROW-224, CROW-317).
         // Compute it here so we know whether to flip `reviewPromptDispatched`
@@ -2248,6 +2252,21 @@ final class SessionService {
         case .review: return ".crow-review-prompt.md"
         case .job:    return ".crow-job-prompt.md"
         case .work, .manager: return nil
+        }
+    }
+
+    /// Whether a worker session of the given kind launches with
+    /// `--permission-mode auto`. Jobs and reviews are unattended, so each has
+    /// an opt-in (default-on) toggle; `work` sessions never get auto mode, and
+    /// the Manager is launched elsewhere via `managerAutoPermissionMode`.
+    /// `internal` static so the launch decision is unit-testable (CROW-602).
+    nonisolated static func shouldAutoPermission(
+        kind: SessionKind, jobsAuto: Bool, reviewAuto: Bool
+    ) -> Bool {
+        switch kind {
+        case .job:    return jobsAuto
+        case .review: return reviewAuto
+        case .work, .manager: return false
         }
     }
 

--- a/Tests/CrowTests/SessionServiceAutoPermissionTests.swift
+++ b/Tests/CrowTests/SessionServiceAutoPermissionTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// Tests for `SessionService.shouldAutoPermission(kind:jobsAuto:reviewAuto:)` —
+/// the launch decision that grants worker sessions `--permission-mode auto`
+/// (CROW-602). Jobs and reviews each have their own opt-in (default-on)
+/// toggle; `work` sessions never get auto mode, and the Manager is launched
+/// through a separate path gated by `managerAutoPermissionMode`.
+@Suite("Auto-permission launch decision")
+struct SessionServiceAutoPermissionTests {
+
+    @Test func reviewFollowsReviewToggle() {
+        #expect(SessionService.shouldAutoPermission(kind: .review, jobsAuto: false, reviewAuto: true))
+        #expect(!SessionService.shouldAutoPermission(kind: .review, jobsAuto: true, reviewAuto: false))
+    }
+
+    @Test func jobFollowsJobsToggle() {
+        #expect(SessionService.shouldAutoPermission(kind: .job, jobsAuto: true, reviewAuto: false))
+        #expect(!SessionService.shouldAutoPermission(kind: .job, jobsAuto: false, reviewAuto: true))
+    }
+
+    @Test func workAndManagerNeverAutoPermission() {
+        // Work sessions are attended; the Manager is gated by its own
+        // `managerAutoPermissionMode` on a separate launch path. Neither may
+        // pick up auto mode from the jobs/review toggles.
+        #expect(!SessionService.shouldAutoPermission(kind: .work, jobsAuto: true, reviewAuto: true))
+        #expect(!SessionService.shouldAutoPermission(kind: .manager, jobsAuto: true, reviewAuto: true))
+    }
+}


### PR DESCRIPTION
Closes #602

## What

Adds a persisted `reviewAutoPermissionMode` setting (Settings → Automation → **Code Review** → "Run code reviews in auto permission mode") and honors it when launching `.review` sessions, so a kicked-off review starts with `--permission-mode auto` and runs its `.crow-review-prompt.md` flow unattended instead of coming up in plan mode. Mirrors the existing `jobsAutoPermissionMode` pattern exactly.

## Changes

- **AppConfig** (`Packages/CrowCore/.../Models/AppConfig.swift`): new `reviewAutoPermissionMode` property — init param, `decodeIfPresent ?? true`, `CodingKeys` entry (encoding is synthesized).
- **AppState** mirror (`Packages/CrowCore/.../AppState.swift`) + both config→state sync sites in `AppDelegate.swift` (startup + settings-save).
- **Launch decision** (`Sources/Crow/App/SessionService.swift`): extracted into an internal static `shouldAutoPermission(kind:jobsAuto:reviewAuto:)` (the inline decision had no direct test coverage) — `.job` → jobs toggle, `.review` → new toggle, `.work`/`.manager` → false. Manager keeps its separate `managerAutoPermissionMode` path, unchanged. Stale "reviews are unaffected" comment updated.
- **Settings UI** (`Packages/CrowUI/.../AutomationSettingsView.swift` + `SettingsView.swift`): new "Code Review" section in the Automation tab beside "Manager Terminal", same `onChange { save() }` persistence as the existing toggles.
- **Tests**: `appConfigReviewAutoPermissionMode{RoundTrip,DefaultsTrueWhenKeyMissing}` mirroring the jobs pair, plus a new `SessionServiceAutoPermissionTests` suite covering the launch decision for all four session kinds.

## Decisions (called out per the ticket)

- **Default ON** (`true`): matches jobs and Manager — reviews kick off unattended, and legacy configs without the key opt in via the `?? true` decode fallback.
- **Review-only**: the coder-view (`.work`) case from #586 / abandoned PR #589 is intentionally NOT included, keeping this PR a strict mirror of the jobs pattern. #586 can be reopened separately.

## Verification

- `make build` clean; `make test` — all suites in touched packages pass (CrowCore 335, CrowUI, root CrowTests 298 incl. the new suites). The only failures are the pre-existing `CrowGit` `RebaseTests` integration tests, which fail on any tree on a machine without a global git identity (unrelated package, untouched by this diff).
- With the toggle on, `.review` hits the new decision → `autoPermissionMode: true` → `--permission-mode auto` (flag emission already covered by `ClaudeLaunchArgsTests`). Off → plan mode as today. Jobs/Manager paths untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)