### PR TITLE
test: re-home coverage dropped with the macOS app (CROW-607)

### DIFF
--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowClaude
+
+/// Re-homes the manager-hook secret-permission invariant dropped with the root
+/// suite (`ManagerHookConfigTests`, CROW-607). `writeGatewayEnv` is the only
+/// `0o600` path in `ClaudeHookConfigWriter`: the `env` block can carry a
+/// resolved AI-gateway bearer token, so the file it writes
+/// (`.claude/settings.local.json`) must be owner-only, matching
+/// `ConfigStore`'s `0o600` on `config.json` (CROW-402).
+@Suite("ClaudeHookConfigWriter.writeGatewayEnv")
+struct ClaudeHookConfigWriterTests {
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-gwenv-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func settings(at dir: URL) throws -> [String: Any] {
+        let path = dir.appendingPathComponent(".claude/settings.local.json")
+        let data = try #require(FileManager.default.contents(atPath: path.path))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func posixPerms(at dir: URL) throws -> Int {
+        let path = dir.appendingPathComponent(".claude/settings.local.json").path
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        return try #require((attrs[.posixPermissions] as? NSNumber)?.intValue)
+    }
+
+    @Test func writesGatewayEnvOwnerOnly() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        ClaudeHookConfigWriter.writeGatewayEnv(
+            dirPath: dir.path,
+            resolved: .init(baseURL: "https://gw.example", customHeaders: "X-Api-Key: secret"))
+
+        // The bearer-token-bearing file must be readable only by its owner.
+        #expect(try posixPerms(at: dir) == 0o600)
+
+        let env = try #require(try settings(at: dir)["env"] as? [String: Any])
+        #expect(env["ANTHROPIC_BASE_URL"] as? String == "https://gw.example")
+        #expect(env["ANTHROPIC_CUSTOM_HEADERS"] as? String == "X-Api-Key: secret")
+    }
+
+    @Test func clearingRemovesGatewayKeysButPreservesOtherSettings() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Pre-seed a settings file with our gateway keys, an unrelated env var,
+        // and an unrelated top-level key — none of which we own.
+        let claudeDir = dir.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let seed: [String: Any] = [
+            "env": [
+                "ANTHROPIC_BASE_URL": "https://old.gw",
+                "ANTHROPIC_CUSTOM_HEADERS": "X-Api-Key: old",
+                "USER_VAR": "keep-me",
+            ],
+            "permissions": ["allow": ["Bash"]],
+        ]
+        let seedData = try JSONSerialization.data(withJSONObject: seed)
+        try seedData.write(to: claudeDir.appendingPathComponent("settings.local.json"))
+
+        ClaudeHookConfigWriter.writeGatewayEnv(dirPath: dir.path, resolved: nil)
+
+        let merged = try settings(at: dir)
+        let env = try #require(merged["env"] as? [String: Any])
+        #expect(env["ANTHROPIC_BASE_URL"] == nil)          // gateway keys cleared…
+        #expect(env["ANTHROPIC_CUSTOM_HEADERS"] == nil)
+        #expect(env["USER_VAR"] as? String == "keep-me")   // …unrelated env var preserved
+        #expect(merged["permissions"] != nil)              // unrelated top-level key preserved
+        // Re-write still restricts the file (unrelated USER_VAR could be secret too).
+        #expect(try posixPerms(at: dir) == 0o600)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
@@ -91,7 +91,7 @@ enum StaticAssets {
         // debug-only page. `style-src 'unsafe-inline'` covers xterm's injected
         // renderer styles; blob:/data: cover its canvas/image atlases; `connect-src
         // 'self'` covers the same-origin /rpc + /terminal WebSockets (CROW-593 review).
-        if name == "index.html" {
+        if appliesCSP(to: name) {
             headers[.contentSecurityPolicy] = contentSecurityPolicy
         }
         return Response(
@@ -100,7 +100,12 @@ enum StaticAssets {
             body: .init(byteBuffer: ByteBuffer(bytes: data)))
     }
 
-    private static let contentSecurityPolicy = [
+    /// Whether the Content-Security-Policy is attached to `name`. Scoped to the
+    /// main app page: `login.html` carries an inline script and `terminal.html`
+    /// is a debug-only page, so neither gets it (CROW-593 review).
+    static func appliesCSP(to name: String) -> Bool { name == "index.html" }
+
+    static let contentSecurityPolicy = [
         "default-src 'self'",
         // `wasm-unsafe-eval` lets xterm's image addon compile its Sixel-decoder
         // WebAssembly without enabling arbitrary `eval` (CROW-593 review).

--- a/Packages/CrowDaemon/Sources/CrowDaemon/WebAuthRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/WebAuthRoutes.swift
@@ -58,8 +58,7 @@ struct WebAuthMiddleware<Context: RemoteAddressRequestContext>: RouterMiddleware
         context: Context,
         next: (Request, Context) async throws -> Response
     ) async throws -> Response {
-        let path = request.uri.path
-        if path == "/login" || path == "/logout" || path == "/health" || path == "/brand.svg" {
+        if Self.isAuthExempt(path: request.uri.path) {
             return try await next(request, context)
         }
         let decision = WebAuthGuard.authorize(
@@ -72,9 +71,23 @@ struct WebAuthMiddleware<Context: RemoteAddressRequestContext>: RouterMiddleware
         if decision.isAuthorized {
             return try await next(request, context)
         }
-        if request.method == .get, (request.headers[.accept] ?? "").contains("text/html") {
+        if Self.serveLoginPageForUnauthorized(method: request.method, accept: request.headers[.accept]) {
             return StaticAssets.loginPage(webDir: webDir)
         }
         return Response(status: .unauthorized)
+    }
+
+    /// Paths served without the web-auth gate: the login/logout endpoints, the
+    /// health probe, and the brand asset the login page needs before auth. Every
+    /// other path (incl. `/auth/check`, `/`, `/rpc`, the secret POSTs) is gated.
+    static func isAuthExempt(path: String) -> Bool {
+        path == "/login" || path == "/logout" || path == "/health" || path == "/brand.svg"
+    }
+
+    /// For an unauthorized request, whether to answer with the login page (200)
+    /// rather than a bare 401: only for navigational GETs (an `Accept: text/html`
+    /// GET), so XHR/fetch and WS-adjacent probes still get a clean 401.
+    static func serveLoginPageForUnauthorized(method: HTTPRequest.Method, accept: String?) -> Bool {
+        method == .get && (accept ?? "").contains("text/html")
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -1,4 +1,6 @@
+import Dispatch
 import Foundation
+import HTTPTypes
 import Testing
 import NIOCore
 import CrowCore
@@ -490,3 +492,117 @@ import CrowPersistence
         #expect(merged.webAuth?.saltB64 == "REAL_SALT")
     }
 }
+
+// MARK: - Security surface re-homed from the retired root suite (CROW-607)
+
+/// `WebAuthMiddleware` is the HTTP-side gate: it exempts the login/health/brand
+/// endpoints and runs every other path — crucially `/auth/check`, the web UI's
+/// session-validity probe — through `WebAuthGuard.authorize` (exhaustively
+/// covered in `WebAuthGuardTests`). These lock in the wrapper decisions: the
+/// exempt allowlist and the unauthorized-response selector (login page vs 401).
+@Suite struct WebAuthMiddlewareGatingTests {
+    private typealias MW = WebAuthMiddleware<CrowHTTPContext>
+
+    @Test func exemptsOnlyLoginLogoutHealthAndBrand() {
+        for path in ["/login", "/logout", "/health", "/brand.svg"] {
+            #expect(MW.isAuthExempt(path: path), "\(path) must bypass the auth gate")
+        }
+    }
+
+    @Test func authCheckAndAppRoutesAreGated() {
+        // `/auth/check` is NOT exempt — it flows through `authorize`, so an
+        // unauthenticated remote peer gets 401 rather than a blanket 204. That
+        // routing is the whole point of the probe (CROW-593).
+        #expect(!MW.isAuthExempt(path: "/auth/check"))
+        for path in ["/", "/index.html", "/app.js", "/rpc",
+                     "/config/web-password", "/config/manager-gateway"] {
+            #expect(!MW.isAuthExempt(path: path), "\(path) must be gated")
+        }
+    }
+
+    @Test func servesLoginPageOnlyForNavigationalGET() {
+        // A browser navigation (GET + Accept: text/html) → the login page (200)…
+        #expect(MW.serveLoginPageForUnauthorized(method: .get, accept: "text/html"))
+        #expect(MW.serveLoginPageForUnauthorized(method: .get, accept: "text/html,application/xhtml+xml"))
+        // …but an XHR/fetch GET, a non-GET, or a missing Accept → a bare 401.
+        #expect(!MW.serveLoginPageForUnauthorized(method: .get, accept: "application/json"))
+        #expect(!MW.serveLoginPageForUnauthorized(method: .get, accept: nil))
+        #expect(!MW.serveLoginPageForUnauthorized(method: .post, accept: "text/html"))
+    }
+}
+
+/// The Content-Security-Policy is attached to the provider-data-rendering app
+/// page only, and carries the hardening directives that make a future
+/// innerHTML slip non-exploitable (no external/inline script, no exfiltration)
+/// (CROW-593 review).
+@Suite struct ContentSecurityPolicyTests {
+    @Test func appliesToIndexOnly() {
+        #expect(StaticAssets.appliesCSP(to: "index.html"))
+        // login.html has an inline script; terminal.html is a debug page; the
+        // static assets don't render provider data — none carry the CSP.
+        for name in ["login.html", "terminal.html", "app.js", "app.css", "settings.js", "brand.svg"] {
+            #expect(!StaticAssets.appliesCSP(to: name), "\(name) must not carry the CSP")
+        }
+    }
+
+    @Test func policyCarriesHardeningDirectives() {
+        let csp = StaticAssets.contentSecurityPolicy
+        for directive in [
+            "default-src 'self'",
+            "script-src 'self' 'wasm-unsafe-eval'",   // xterm's Sixel wasm, no arbitrary eval
+            "connect-src 'self'",                      // same-origin /rpc + /terminal WS only
+            "object-src 'none'",
+            "base-uri 'none'",
+            "frame-ancestors 'none'",                  // no clickjacking
+        ] {
+            #expect(csp.contains(directive), "CSP missing: \(directive)")
+        }
+        // No wildcard host or inline-script escape hatch slipped in.
+        #expect(!csp.contains("script-src 'self' 'unsafe-inline'"))
+        #expect(!csp.contains("*"))
+    }
+}
+
+/// `ConfigStore.withConfigLock` serializes the load → mutate → save of
+/// `config.json` so concurrent writers (set-config / set-web-password /
+/// gateway saves / onJobRan) can't clobber each other's just-loaded copy
+/// (CROW-593 review #10).
+@Suite struct ConfigLockConcurrencyTests {
+    /// A shared, deliberately non-atomic read-modify-write under the lock: if the
+    /// lock didn't serialize, concurrent increments would lose updates.
+    @Test func serializesConcurrentCriticalSections() {
+        final class Counter: @unchecked Sendable { var value = 0 }
+        let counter = Counter()
+        let iterations = 2_000
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            ConfigStore.withConfigLock {
+                let current = counter.value    // RMW window — lossy without the lock
+                counter.value = current + 1
+            }
+        }
+        #expect(counter.value == iterations)
+    }
+
+    /// The real use-case: concurrent load-modify-save against one config.json.
+    /// Every writer's append must survive — the final file has all N entries.
+    @Test func concurrentLoadModifySaveLosesNoUpdates() throws {
+        let devRoot = NSTemporaryDirectory() + "crow-configlock-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: devRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
+
+        let iterations = 100
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            ConfigStore.withConfigLock {
+                var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+                c.defaults.excludeTicketRepos.append("repo-\(i)")
+                try? ConfigStore.saveConfig(c, devRoot: devRoot)
+            }
+        }
+
+        let final = try #require(ConfigStore.loadConfig(devRoot: devRoot))
+        #expect(final.defaults.excludeTicketRepos.count == iterations)
+        #expect(Set(final.defaults.excludeTicketRepos).count == iterations)   // all distinct, none lost
+    }
+}
+

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AgentLaunchTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AgentLaunchTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowEngine
+
+/// Re-homes the root-suite coverage for launch-token detection and the shared
+/// launch-text prep, which moved into `CrowEngine/AgentLaunch.swift` when the
+/// send path left `AppDelegate` (CROW-581). Was `CommandLaunchesTokenTests`
+/// (token anchoring) and `DeferredLaunchTests` (hook-write + OTEL prep).
+
+// MARK: - Token anchoring (was CommandLaunchesTokenTests)
+
+@Suite struct CommandLaunchesTokenTests {
+    private func launches(_ command: String, _ token: String = "claude") -> Bool {
+        AgentLaunch.commandLaunchesToken(command, token: token)
+    }
+
+    @Test func matchesAtStartOfCommand() {
+        #expect(launches("claude"))
+        #expect(launches("claude --continue"))
+        #expect(launches("claude 'do the thing'"))          // token then quote
+    }
+
+    @Test func matchesAfterShellSeparators() {
+        #expect(launches("cd /repo && claude"))
+        #expect(launches("export X=1; claude --resume"))
+        #expect(launches("false || claude"))
+        #expect(launches("echo hi | claude"))
+    }
+
+    @Test func matchesAfterPathSeparator() {
+        // A launch by absolute/relative path still counts.
+        #expect(launches("/opt/homebrew/bin/claude --continue"))
+        #expect(launches("./claude"))
+    }
+
+    @Test func rejectsIncidentalSubstrings() {
+        // The token embedded in prose or another word must NOT flip readiness —
+        // the anchoring guard against e.g. Cursor's "agent" token in a sentence.
+        #expect(launches("agent", "agent"))                  // sanity: bare token DOES launch
+        #expect(!launches("the agent finished the task", "agent"))
+        #expect(!launches("please ask claude to help"))      // mid-sentence, space-prefixed word
+        #expect(!launches("claudette --run"))                // token is a prefix of a longer word
+        #expect(!launches("myclaude"))                       // token is a suffix of a longer word
+        #expect(!launches("echo claude-is-great"))           // token then '-', not a boundary
+    }
+
+    @Test func respectsTrailingBoundary() {
+        // Boundary is space, end-of-string, or a quote — not arbitrary punctuation.
+        #expect(launches("claude"))                          // end of string
+        #expect(launches("claude\t--flag"))                  // whitespace (tab)
+        #expect(launches(#"claude"quoted""#))                // double-quote boundary
+    }
+}
+
+// MARK: - Launch-text prep (was DeferredLaunchTests)
+
+/// Records whether `writeHookConfig` was invoked, and with what, so the test can
+/// assert the hook file gets written exactly on the launch path.
+private final class SpyHookConfigWriter: HookConfigWriter, @unchecked Sendable {
+    struct Call: Equatable { let worktreePath: String; let sessionID: UUID; let crowPath: String }
+    private(set) var calls: [Call] = []
+    func writeHookConfig(worktreePath: String, sessionID: UUID, crowPath: String) throws {
+        calls.append(Call(worktreePath: worktreePath, sessionID: sessionID, crowPath: crowPath))
+    }
+    func removeHookConfig(worktreePath: String) {}
+}
+
+private struct NoopStateSignalSource: StateSignalSource {
+    func transition(
+        for event: AgentHookEvent,
+        currentActivityState: AgentActivityState,
+        currentNotificationType: String?,
+        currentLastTopLevelStopAt: Date?
+    ) -> AgentStateTransition { AgentStateTransition() }
+}
+
+/// Minimal `CodingAgent` for exercising `AgentLaunch.prepareAgentLaunchText`.
+/// Only `kind`, `launchCommandToken`, and `hookConfigWriter` are consulted by
+/// the code under test; the rest are inert stubs.
+private struct MockAgent: CodingAgent {
+    var kind: AgentKind
+    let spy: SpyHookConfigWriter
+    var launchCommandToken: String = "claude"
+
+    var displayName: String { "Mock" }
+    var iconSystemName: String { "sparkles" }
+    var supportsRemoteControl: Bool { false }
+    var hookConfigWriter: any HookConfigWriter { spy }
+    var stateSignalSource: any StateSignalSource { NoopStateSignalSource() }
+    func findBinary() -> String? { "/usr/bin/true" }
+    func autoLaunchCommand(session: Session, worktreePath: String, remoteControlEnabled: Bool, autoPermissionMode: Bool, telemetryPort: UInt16?) -> String? { nil }
+    func generatePrompt(session: Session, worktrees: [SessionWorktree], ticketURL: String?, provider: Provider?, codeProvider: Provider?) async -> String { "" }
+    func launchCommand(sessionID: UUID, worktreePath: String, prompt: String) async throws -> String { "" }
+}
+
+@Suite struct PrepareAgentLaunchTextTests {
+    private func agent(_ kind: AgentKind) -> MockAgent { MockAgent(kind: kind, spy: SpyHookConfigWriter()) }
+
+    @Test func nonLaunchCommandPassesThroughAndWritesNoHook() {
+        let a = agent(.claudeCode)
+        let (text, didLaunch) = AgentLaunch.prepareAgentLaunchText(
+            command: "ls -la", agent: a, sessionID: UUID(),
+            worktreePath: "/tmp/wt", crowPath: "/usr/local/bin/crow", telemetryPort: 4318)
+        #expect(text == "ls -la")
+        #expect(!didLaunch)
+        #expect(a.spy.calls.isEmpty)   // no launch → no hook config written
+    }
+
+    @Test func launchWritesHookConfigForTheSession() {
+        let a = agent(.claudeCode)
+        let sid = UUID()
+        let (_, didLaunch) = AgentLaunch.prepareAgentLaunchText(
+            command: "claude --continue", agent: a, sessionID: sid,
+            worktreePath: "/tmp/wt", crowPath: "/usr/local/bin/crow", telemetryPort: nil)
+        #expect(didLaunch)
+        #expect(a.spy.calls == [.init(worktreePath: "/tmp/wt", sessionID: sid, crowPath: "/usr/local/bin/crow")])
+    }
+
+    @Test func missingWorktreeSkipsHookConfig() {
+        let a = agent(.claudeCode)
+        let (_, didLaunch) = AgentLaunch.prepareAgentLaunchText(
+            command: "claude", agent: a, sessionID: UUID(),
+            worktreePath: nil, crowPath: nil, telemetryPort: nil)
+        #expect(didLaunch)
+        #expect(a.spy.calls.isEmpty)   // no worktree/crowPath → nothing to write
+    }
+
+    @Test func prependsOtelForClaudeWithPort() {
+        let a = agent(.claudeCode)
+        let sid = UUID()
+        let (text, didLaunch) = AgentLaunch.prepareAgentLaunchText(
+            command: "claude --continue", agent: a, sessionID: sid,
+            worktreePath: nil, crowPath: nil, telemetryPort: 4318)
+        #expect(didLaunch)
+        #expect(text.hasPrefix("export CLAUDE_CODE_ENABLE_TELEMETRY=1 "))
+        #expect(text.contains("OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318"))
+        #expect(text.contains("crow.session.id=\(sid.uuidString)"))
+        #expect(text.hasSuffix("&& claude --continue"))
+    }
+
+    @Test func noOtelForClaudeWithoutPort() {
+        let a = agent(.claudeCode)
+        let (text, _) = AgentLaunch.prepareAgentLaunchText(
+            command: "claude", agent: a, sessionID: UUID(),
+            worktreePath: nil, crowPath: nil, telemetryPort: nil)
+        #expect(text == "claude")   // no port → no telemetry export
+    }
+
+    @Test func noOtelForNonClaudeAgentEvenWithPort() {
+        // OTEL is Claude-specific — a Cursor/Codex launch never gets the export
+        // block even when a telemetry port is available.
+        var a = agent(.cursor)
+        a.launchCommandToken = "cursor-agent"
+        let (text, didLaunch) = AgentLaunch.prepareAgentLaunchText(
+            command: "cursor-agent chat", agent: a, sessionID: UUID(),
+            worktreePath: nil, crowPath: nil, telemetryPort: 4318)
+        #expect(didLaunch)
+        #expect(text == "cursor-agent chat")
+    }
+}


### PR DESCRIPTION
Closes #607

Re-homes the test coverage that fell out when the macOS app was retired (root `Tests/CrowTests/` deletion). Behaviors survived the refactor into the per-package targets, but several landed without replacement coverage, and the CROW-593 daemon security surface was largely untested — **PR #594 review Yellow #14**. This PR is based on `feature/crow-593-web-ui-parity` to clear that blocker.

## Security surface (clears the Yellow blocker) — `DaemonSecurityTests`
- **`WebAuthMiddlewareGatingTests`** — `/auth/check` is **not** auth-exempt (it flows through the already-covered `WebAuthGuard.authorize` gate); the exempt allowlist is exactly `/login /logout /health /brand.svg`; the login-page-vs-401 selector fires only for navigational (`Accept: text/html`) GETs.
- **`ContentSecurityPolicyTests`** — the CSP is attached to `index.html` only and carries the hardening directives (`default-src`/`object-src`/`base-uri`/`frame-ancestors`, `script-src 'self' 'wasm-unsafe-eval'`, `connect-src 'self'`); no `unsafe-inline`/wildcard escape hatch.
- **`ConfigLockConcurrencyTests`** — `ConfigStore.withConfigLock` serializes concurrent read-modify-write of `config.json` (a shared RMW counter and a concurrent load-modify-save both lose no updates).

(`WebAuthGuard.authorize`/`isLocalDirect` and `SecretRoutes.buildGateway` were already covered in `b545271`; these cover the *wrappers* around `authorize`, not `authorize` itself.)

## Ported behaviors
- **`AgentLaunchTests`** (`CrowEngine`) — re-homes `CommandLaunchesTokenTests` (token anchoring: start / after `;&|` / after path separator, rejecting incidental substrings) and `DeferredLaunchTests` (`prepareAgentLaunchText` writes the hook config only on the launch path, and prepends the OTEL exporter env for Claude + telemetry port only).
- **`ClaudeHookConfigWriterTests`** (`CrowClaude`) — re-homes `ManagerHookConfigTests`: `writeGatewayEnv` writes `.claude/settings.local.json` at **`0o600`** (it can carry a resolved gateway bearer token) and clears only the `ANTHROPIC_*` keys, preserving unrelated settings.

## Covered elsewhere — explicit decision (per acceptance criteria)
- **tmux crash recovery** (`TmuxCrashRecoveryTests`) → already re-homed in `CrowTerminal/Tests/.../TmuxBackendTests.swift`, "Server-crash detection (#588)" (`adoptDistinguishesServerCrashFromMissingWindow`, crash-restart adoption).
- **attribution `${CROW_AGENT_DISPLAY_NAME}`** (`AttributionSkillTests`) → already covered in `CrowCore/Tests/.../CrowAttributionTests.swift` (`expandSkillBody` variants, `environmentEntries`, `agentDisplayName(fromEnvironment:)`, footer-matches-repo).

## Source changes
Two testability seams only, **no behavior change**:
- `StaticAssets`: `contentSecurityPolicy` made internal + `appliesCSP(to:)` helper (called from `fileResponse`).
- `WebAuthMiddleware`: `isAuthExempt(path:)` and `serveLoginPageForUnauthorized(method:accept:)` extracted from `handle()`.

## Test results
`swift test` green for the three affected packages: CrowDaemon (85 tests / 27 suites), CrowEngine (`AgentLaunch` filter, 12 tests), CrowClaude (`ClaudeHookConfigWriter`, 2 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMj9CpufqSn1coG4zJE5ez