### PR TITLE
feat(web): replay tmux scrollback into web terminal on (re)connect (CROW-606)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -58,6 +58,44 @@ struct TerminalCockpit: Sendable {
         _ = try? controller.run(["select-window", "-t", "\(group):\(index)"])
     }
 
+    /// How many lines of pane history to replay on (re)connect. Matched to the
+    /// xterm.js client scrollback (`scrollback: 50000` in app.js) and the tmux
+    /// `history-limit` (crow-tmux.conf) so the full retained history survives a
+    /// crowd restart or browser reload (CROW-606).
+    static let replayLines = 50000
+
+    /// Capture window `index`'s pane scrollback (history + current screen) and
+    /// package it as bytes ready to write into a reconnecting xterm.js buffer.
+    /// Returns `nil` when the capture fails (best-effort — a live-only pane is
+    /// still preferable to dropping the connection). See `replayFrame`.
+    func replayData(group: String, index: Int) -> Data? {
+        guard let raw = try? controller.capturePane(
+            target: "\(group):\(index)", linesBack: Self.replayLines, escapes: true)
+        else { return nil }
+        return Self.replayFrame(from: raw)
+    }
+
+    /// Transform a `capture-pane -pe` blob into a self-contained replay frame for
+    /// xterm.js. Pure (no tmux) so it's unit-testable. Steps:
+    ///   1. strip trailing newlines — `capture-pane` pads a trailing LF that would
+    ///      otherwise push the viewport down one row versus tmux's own redraw;
+    ///   2. convert bare LF → CRLF — `capture-pane` emits `\n` only, and xterm.js
+    ///      treats `\n` as line-feed-without-carriage-return, so raw output would
+    ///      stair-step down the screen;
+    ///   3. prepend `ESC[H ESC[2J ESC[3J` (home + clear screen + clear scrollback)
+    ///      so repeated selects/reconnects REBUILD the buffer rather than stack
+    ///      duplicate copies of the history.
+    /// The blob keeps the current screen at its tail, so tmux's live attach redraw
+    /// repaints those same viewport rows in place — the replayed history lands
+    /// above the live viewport regardless of which write wins the race.
+    static func replayFrame(from raw: String) -> Data {
+        let trimmed = raw.replacingOccurrences(of: "[\r\n]+$", with: "", options: .regularExpression)
+        let crlf = trimmed.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\n", with: "\r\n")
+        let clear = "\u{1b}[H\u{1b}[2J\u{1b}[3J"
+        return Data((clear + crlf).utf8)
+    }
+
     /// The desktop app's stable tmux socket: `$TMPDIR/crow-tmux.sock` (#330).
     private static func appTmuxSocketPath() -> String {
         if let override = ProcessInfo.processInfo.environment["CROW_TMUX_SOCKET"], !override.isEmpty {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
@@ -94,6 +94,15 @@ enum TerminalWebSocket {
                         // clients (incl. the desktop app) keep their own view.
                         if let window = control.window {
                             cockpit.selectWindow(group: group, index: window)
+                            // Replay the pane's tmux scrollback into the xterm buffer
+                            // so history survives a crowd restart / browser reload —
+                            // the client re-selects its window on every reconnect and
+                            // tab switch (CROW-606). Yield through the same stream the
+                            // PTY writes to, so this serializes with live output on the
+                            // single `outputTask` (no concurrent `outbound` writes).
+                            if let replay = cockpit.replayData(group: group, index: window) {
+                                continuation.yield(replay)
+                            }
                         }
                     default:
                         break

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/TerminalReplayTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/TerminalReplayTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import CrowDaemon
+
+/// `TerminalCockpit.replayFrame` massages a `capture-pane -pe` blob into a
+/// self-contained frame that rebuilds a reconnecting xterm.js buffer (CROW-606).
+/// Pure transform — no tmux — so its shape is asserted directly here.
+@Suite struct TerminalReplayTests {
+    /// Every frame must lead with the clear so repeated selects/reconnects
+    /// REBUILD the scrollback rather than stack duplicate copies of history.
+    private static let clearPrefix = "\u{1b}[H\u{1b}[2J\u{1b}[3J"
+
+    @Test func prependsClearAndConvertsLineEndings() {
+        let data = TerminalCockpit.replayFrame(from: "line1\nline2\nline3")
+        let s = String(decoding: data, as: UTF8.self)
+        #expect(s == Self.clearPrefix + "line1\r\nline2\r\nline3")
+    }
+
+    @Test func stripsTrailingNewlinesToAvoidRowOffset() {
+        // capture-pane pads a trailing LF; keeping it would push the viewport
+        // one row below where tmux's live redraw repaints.
+        let data = TerminalCockpit.replayFrame(from: "only\n\n")
+        #expect(String(decoding: data, as: UTF8.self) == Self.clearPrefix + "only")
+    }
+
+    @Test func preservesInteriorBlankLinesAndEscapes() {
+        // Interior blanks are real history rows; SGR escapes (from `-e`) pass
+        // through untouched.
+        let raw = "a\n\n\u{1b}[31mred\u{1b}[0m\n"
+        let data = TerminalCockpit.replayFrame(from: raw)
+        #expect(String(decoding: data, as: UTF8.self)
+            == Self.clearPrefix + "a\r\n\r\n\u{1b}[31mred\u{1b}[0m")
+    }
+
+    @Test func idempotentOnAlreadyCRLFInput() {
+        // Guards against double-CR if a capture ever arrives with CRLF.
+        let data = TerminalCockpit.replayFrame(from: "x\r\ny")
+        #expect(String(decoding: data, as: UTF8.self) == Self.clearPrefix + "x\r\ny")
+    }
+
+    @Test func emptyCaptureIsJustTheClear() {
+        let data = TerminalCockpit.replayFrame(from: "")
+        #expect(String(decoding: data, as: UTF8.self) == Self.clearPrefix)
+    }
+}

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -123,10 +123,16 @@ bind -T root TripleClick1Pane select-pane -t = \; if -F -t = "#{mouse_any_flag}"
 # after the user scrolls.
 bind -T root WheelUpPane if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -t = "#{pane_in_mode}" "send-keys -M" "copy-mode -et=" }
 
-# Default history-limit is 2000 lines per pane. Phase 3 §2 (the spike)
-# measured 5 windows × 10k lines as a 400kB RSS delta, so we have plenty
-# of headroom. 5000 matches typical session-detail expectations.
-set -gs history-limit 5000
+# Default history-limit is 2000 lines per pane. We match the web terminal's
+# xterm.js client scrollback (50000) so that on (re)connect the daemon can
+# replay the pane's FULL retained history back into the browser buffer
+# (`capture-pane -pe -S -N` in TerminalWebSocket / TerminalCockpit, CROW-606)
+# with nothing truncated below what the client itself can hold. Phase 3 §2 (the
+# spike) measured 5 windows × 10k lines as a 400kB RSS delta; extrapolated,
+# 5 fully-populated windows × 50k ≈ low-single-MB, and tmux allocates history
+# lazily as it accrues, so idle sessions cost nothing. This is the ceiling on
+# how far back the user can scroll after a crowd restart or browser reload.
+set -gs history-limit 50000
 
 # No escape-key delay — interactive editors (vi-mode shells, etc.) feel
 # sluggish with tmux's default 500ms.

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -273,12 +273,17 @@ public struct TmuxController: Sendable {
 
     // MARK: - Diagnostic
 
-    /// `tmux capture-pane -p -t <target> -S -<linesBack>`. Returns the
-    /// visible pane contents (last `linesBack` lines). Used by the readiness
-    /// timeout diagnostics to show what state the shell got stuck in
-    /// (issue #256).
-    public func capturePane(target: String, linesBack: Int = 200) throws -> String {
-        try run(["capture-pane", "-p", "-t", target, "-S", "-\(linesBack)"])
+    /// `tmux capture-pane -p [-e] -t <target> -S -<linesBack>`. Returns the
+    /// pane contents from `linesBack` lines of history through the current
+    /// screen. Used by the readiness timeout diagnostics to show what state the
+    /// shell got stuck in (issue #256), and — with `escapes: true` (`-e`, which
+    /// keeps SGR/color sequences) — to replay a pane's scrollback into a
+    /// reconnecting web terminal (CROW-606).
+    public func capturePane(target: String, linesBack: Int = 200, escapes: Bool = false) throws -> String {
+        var args = ["capture-pane", "-p"]
+        if escapes { args.append("-e") }
+        args.append(contentsOf: ["-t", target, "-S", "-\(linesBack)"])
+        return try run(args)
     }
 
     /// `tmux display-message -p -t <target> <format>`. Used by the readiness

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -105,4 +105,23 @@ struct TmuxControllerTests {
         // "tmux 3.6a" or similar.
         #expect(version.hasPrefix("tmux "))
     }
+
+    @Test func capturePaneReturnsHistory() throws {
+        let ctrl = makeController()
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: ctrl.socketPath)
+        }
+        // Print three known lines, then keep the pane alive so capture-pane can
+        // read them back out of the pane's scrollback (CROW-606 replay path).
+        try ctrl.newSessionDetached(
+            command: "/bin/sh -c 'printf \"alpha\\nbravo\\ncharlie\\n\"; sleep 60'")
+        // Give the shell a beat to emit before capturing.
+        Thread.sleep(forTimeInterval: 0.3)
+        let out = try ctrl.capturePane(
+            target: "\(ctrl.sessionName):0", linesBack: 1000, escapes: true)
+        #expect(out.contains("alpha"))
+        #expect(out.contains("bravo"))
+        #expect(out.contains("charlie"))
+    }
 }


### PR DESCRIPTION
Closes #606

## Problem
The web terminal (`xterm.js` over `/terminal`) seeded its buffer **only with the live viewport** on attach. On a crowd restart or browser reload the reconnecting client saw a live-only pane — the scrollback tmux still held was never sent.

## Fix
Replay the target pane's tmux scrollback into xterm on every `/terminal` (re)connect and window switch. The client already re-sends `select-window` on `onopen` and on each tab click, so that's the hook — **no client change** (replay is just terminal bytes to `term.write`).

- **`TerminalWebSocket`** — on `select-window`, after switching, capture the pane's history *including the current screen* and `continuation.yield(...)` it through the **same** `AsyncStream` the PTY writes to, so it serializes with live output on the single output task (no concurrent `outbound` writes).
- **`TerminalCockpit.replayFrame`** (pure/testable) — trims the trailing LF, converts bare `LF → CRLF` (xterm treats `\n` as line-feed-only and would stair-step), and prepends `ESC[H ESC[2J ESC[3J` so repeated selects **rebuild** rather than stack duplicate history. The blob keeps the current screen at its tail, so tmux's live redraw repaints those viewport rows in place — history lands **above** the live viewport regardless of write ordering.
- **`TmuxController.capturePane`** — gains `escapes:` to add `-e` (preserve SGR/color).
- **`crow-tmux.conf`** — `history-limit` 5000 → 50000 to match the xterm client scrollback so "entire history" is meaningful; tmux allocates history lazily as it accrues.

The native wheel-scrollback path in `app.js` (deliberately no copy-mode takeover) is untouched.

## Boundary
History lives in the tmux server's memory, not on disk, so it survives a **crowd restart / browser reload** (the acceptance criteria) but not the tmux server itself dying (reboot / `kill-server`). Disk persistence was only an optional aside in the ticket and is out of scope.

## Tests
- `TerminalReplayTests` — `replayFrame` shape: clear prefix, `LF→CRLF`, trailing-newline trim, CRLF-idempotence, empty input. (5 pass)
- `TmuxControllerTests.capturePaneReturnsHistory` — real-tmux round-trip of `capturePane(escapes: true)`. (passes; auto-skips without tmux)

## Manual verification
1. Open a session terminal, emit scrollback (`seq 1 3000`).
2. Browser reload → prior history shown; wheel-scroll the full history, no copy-mode.
3. Restart crowd → reconnect re-seeds the same history.
4. Switch tabs → each window shows its own replayed history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAvY73Ahu5W2Sbi8X8AedL