### PR TITLE
feat(web): first-run setup wizard (CROW-605)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -275,6 +275,51 @@ public enum CrowDaemon {
 
         log("HTTP/WS listening on http://\(options.host):\(options.httpPort) (terminal at /)")
         try await app.runService()
+        // First-run setup (`run-setup`) asks us to re-exec so the freshly-written
+        // devroot pointer is adopted by every subsystem that captured it at
+        // startup (CROW-605). Hummingbird's runService() returns cleanly on
+        // SIGTERM (NIO closes the TCP listener → port freed); we then drop the
+        // flock and execv the same binary/args.
+        if Self.pendingReexec {
+            Self.reexec(arguments)
+        }
+    }
+
+    /// Set by `run-setup` so `run()` re-execs after graceful shutdown. Written
+    /// from the RPC handler's Task and read once on the main run path after
+    /// `runService()` returns — never mutated concurrently with a read.
+    nonisolated(unsafe) static var pendingReexec = false
+
+    /// Ask the daemon to shut down and re-exec itself (so a newly-written
+    /// `~/Library/Application Support/crow/devroot` pointer is adopted). Delays
+    /// the SIGTERM briefly so the JSON-RPC `ok` result can flush to the client
+    /// before graceful shutdown begins (CROW-605).
+    static func requestReexec() {
+        pendingReexec = true
+        Task {
+            try? await Task.sleep(for: .milliseconds(250))
+            raise(SIGTERM)
+        }
+    }
+
+    /// Close the single-instance lock fd (no `O_CLOEXEC`, so an inherited fd
+    /// would still hold the flock and the re-exec'd image's
+    /// `acquireSingleInstanceLock` would fail), then `execv` the same binary
+    /// and args. Does not return on success.
+    static func reexec(_ argv: [String]) {
+        if singleInstanceLockFD >= 0 {
+            close(singleInstanceLockFD)
+            singleInstanceLockFD = -1
+        }
+        guard let executable = argv.first, !executable.isEmpty else {
+            log("re-exec failed: empty argv")
+            exit(1)
+        }
+        let cArgv: [UnsafeMutablePointer<CChar>?] = argv.map { strdup($0) } + [nil]
+        defer { for p in cArgv where p != nil { free(p) } }
+        execv(executable, cArgv)
+        log("re-exec failed: \(String(cString: strerror(errno)))")
+        exit(1)
     }
 
     /// Wire the IssueTracker's background automation hooks: spawns go to the

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -698,7 +698,19 @@ func makeCommandRouter(
                   let json = String(data: data, encoding: .utf8) else {
                 throw DaemonRPCError.applicationError("Failed to encode config")
             }
-            return ["config": .string(json), "dev_root": .string(devRoot), "app_running": .bool(false)]
+            // `configured` mirrors the desktop's first-run gate
+            // (`ConfigStore.loadDevRoot() == nil`); `dev_root` itself is never
+            // empty (cwd fallback), so it can't detect first-run. `default_dev_root`
+            // lets the web wizard prefill step 1 without knowing $HOME (CROW-605).
+            let defaultDevRoot = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Dev").path
+            return [
+                "config": .string(json),
+                "dev_root": .string(devRoot),
+                "app_running": .bool(false),
+                "configured": .bool(ConfigStore.loadDevRoot() != nil),
+                "default_dev_root": .string(defaultDevRoot),
+            ]
         },
         "set-config": { params in
             guard let json = params["config"]?.stringValue,
@@ -727,6 +739,43 @@ func makeCommandRouter(
                 throw DaemonRPCError.applicationError("Failed to encode config")
             }
             return ["config": .string(outJSON), "saved": .bool(true)]
+        },
+
+        // First-run setup wizard (CROW-605). Scaffolds the chosen dev root,
+        // writes config.json + the App Support pointer, then asks the daemon to
+        // re-exec so every subsystem that captured `devRoot` at startup adopts
+        // the new path. Rejected once a pointer already exists.
+        "run-setup": { params in
+            if ConfigStore.loadDevRoot() != nil {
+                throw DaemonRPCError.invalidParams("Already configured — setup wizard is one-shot")
+            }
+            guard let rawRoot = params["dev_root"]?.stringValue?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !rawRoot.isEmpty else {
+                throw DaemonRPCError.invalidParams("dev_root required")
+            }
+            let chosen = expandSetupDevRoot(rawRoot)
+            guard !chosen.isEmpty else {
+                throw DaemonRPCError.invalidParams("dev_root required")
+            }
+            guard let json = params["config"]?.stringValue,
+                  let data = json.data(using: .utf8),
+                  let config = try? JSONDecoder().decode(AppConfig.self, from: data) else {
+                throw DaemonRPCError.invalidParams("config must be a valid AppConfig JSON string")
+            }
+            do {
+                try ConfigStore.withConfigLock {
+                    try Scaffolder(devRoot: chosen).scaffold(
+                        workspaceNames: config.workspaces.map(\.name))
+                    try ConfigStore.saveConfig(config, devRoot: chosen)
+                    try ConfigStore.saveDevRoot(chosen)
+                }
+            } catch {
+                throw DaemonRPCError.applicationError(
+                    "Setup failed: \(error.localizedDescription)")
+            }
+            CrowDaemon.requestReexec()
+            return ["ok": .bool(true), "dev_root": .string(chosen)]
         },
 
         // NOTE: the web-access password and AI gateways are secret writes and
@@ -833,4 +882,16 @@ func makeCommandRouter(
             return ["ok": .bool(true)]
         },
     ], fallback: fallback)
+}
+
+/// Expand a wizard-supplied `dev_root`: leading `~` → home; relative paths
+/// resolve under home. Absolute paths pass through unchanged (CROW-605).
+private func expandSetupDevRoot(_ raw: String) -> String {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    if raw == "~" { return home }
+    if raw.hasPrefix("~/") {
+        return (home as NSString).appendingPathComponent(String(raw.dropFirst(2)))
+    }
+    if (raw as NSString).isAbsolutePath { return raw }
+    return (home as NSString).appendingPathComponent(raw)
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -725,3 +725,182 @@ html, body {
   .session-row .meta,
   .session-row .row-badges { padding-right: 0; }
 }
+
+/* First-run setup wizard (CROW-605) — full-screen overlay over the empty board. */
+#wizard {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(10, 12, 14, 0.92);
+  animation: modal-backdrop-in 0.18s ease-out;
+}
+.wizard-card {
+  width: min(520px, 94vw);
+  min-height: 380px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.6);
+  padding: 22px 24px 18px;
+  animation: modal-slide-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.wizard-card.wizard-setting-up {
+  min-height: 220px;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 10px;
+}
+.wizard-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+.wizard-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  opacity: 0.35;
+}
+.wizard-dot.active {
+  background: var(--gold);
+  opacity: 1;
+}
+.wizard-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.wizard-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-align: center;
+}
+.wizard-sub {
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.45;
+  margin-bottom: 4px;
+}
+.wizard-field { display: flex; flex-direction: column; gap: 5px; }
+.wizard-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.wizard-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 13px;
+}
+.wizard-input:focus { outline: none; border-color: var(--gold); }
+.wizard-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 12px 0;
+}
+.wizard-list { display: flex; flex-direction: column; gap: 6px; max-height: 140px; overflow-y: auto; }
+.wizard-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+}
+.wizard-row-info { flex: 1; min-width: 0; }
+.wizard-row-name { font-weight: 600; font-size: 13px; }
+.wizard-row-meta { font-size: 11px; color: var(--text-secondary); }
+.wizard-row-rm {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.wizard-row-rm:hover { color: var(--red); }
+.wizard-add {
+  align-self: flex-start;
+  border: 1px dashed var(--border-strong);
+  background: transparent;
+  color: var(--gold);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.wizard-add:hover { background: rgba(221, 196, 130, 0.08); }
+.wizard-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+}
+.wizard-add-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.wizard-summary {
+  padding: 14px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.wizard-summary-row { font-size: 13px; font-weight: 600; word-break: break-all; }
+.wizard-summary-meta { font-size: 12px; color: var(--text-secondary); padding-left: 12px; }
+.wizard-error {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(255, 69, 58, 0.12);
+  border: 1px solid rgba(255, 69, 58, 0.4);
+  color: var(--red);
+  font-size: 12px;
+}
+.wizard-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+.wizard-spinner {
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--gold);
+  border-radius: 50%;
+  animation: wizard-spin 0.7s linear infinite;
+  margin-bottom: 6px;
+}
+@keyframes wizard-spin { to { transform: rotate(360deg); } }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -114,6 +114,10 @@ async function loadUIConfig() {
     uiConfig.notifications = parseNotificationSettings(cfg.notifications);
     // Presence of the (secret-stripped) webAuth block means a web password is set.
     uiConfig.webPasswordSet = !!cfg.webAuth;
+    // First-run gate: pointer absent → show the setup wizard (CROW-605).
+    if (res && res.configured === false && !document.getElementById('wizard')) {
+      showWizard(res.default_dev_root || '');
+    }
   } catch (_) { /* keep defaults */ }
   renderSidebar();
   renderStatusBar();
@@ -2037,6 +2041,273 @@ function selectWindow(win) {
   if (termWs && termWs.readyState === WebSocket.OPEN) {
     termWs.send(JSON.stringify({ type: 'select-window', window: win }));
   }
+}
+
+// ---------------------------------------------------------------------------
+// First-run setup wizard (CROW-605) — port of SetupWizardView.
+// Shown when get-config reports configured:false (no App Support pointer).
+// ---------------------------------------------------------------------------
+function wizardUuid() {
+  if (window.crypto && crypto.randomUUID) return crypto.randomUUID();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}
+
+function showWizard(defaultDevRoot) {
+  if (document.getElementById('wizard')) return;
+  const state = {
+    step: 1,
+    devRoot: defaultDevRoot || '',
+    workspaces: [],
+    adding: false,
+    draft: { name: '', provider: 'github', host: '' },
+    error: null,
+    settingUp: false,
+  };
+
+  const overlay = el('div');
+  overlay.id = 'wizard';
+  document.body.appendChild(overlay);
+
+  function render() {
+    overlay.innerHTML = '';
+    if (state.settingUp) {
+      const card = el('div', 'wizard-card wizard-setting-up');
+      card.appendChild(el('div', 'wizard-spinner'));
+      card.appendChild(el('div', 'wizard-title', 'Setting up Crow…'));
+      card.appendChild(el('div', 'wizard-sub', 'Adopting your dev root — reconnecting shortly.'));
+      if (state.error) card.appendChild(el('div', 'wizard-error', state.error));
+      overlay.appendChild(card);
+      return;
+    }
+
+    const card = el('div', 'wizard-card');
+    const dots = el('div', 'wizard-dots');
+    for (let s = 1; s <= 3; s++) {
+      const d = el('span', 'wizard-dot' + (s <= state.step ? ' active' : ''));
+      dots.appendChild(d);
+    }
+    card.appendChild(dots);
+
+    const body = el('div', 'wizard-body');
+    if (state.step === 1) renderStep1(body);
+    else if (state.step === 2) renderStep2(body);
+    else renderStep3(body);
+    card.appendChild(body);
+
+    if (state.error) card.appendChild(el('div', 'wizard-error', state.error));
+
+    const foot = el('div', 'wizard-foot');
+    if (state.step > 1) {
+      const back = el('button', 'action-btn', 'Back');
+      back.onclick = () => { state.step -= 1; state.error = null; render(); };
+      foot.appendChild(back);
+    } else {
+      foot.appendChild(el('div'));
+    }
+    if (state.step < 3) {
+      const next = el('button', 'action-btn action-primary', 'Next');
+      next.disabled = state.step === 1 && !state.devRoot.trim();
+      next.onclick = () => {
+        if (state.step === 1 && !state.devRoot.trim()) return;
+        state.step += 1;
+        state.error = null;
+        render();
+      };
+      foot.appendChild(next);
+    } else {
+      const go = el('button', 'action-btn action-primary', 'Get Started');
+      go.onclick = () => completeSetup();
+      foot.appendChild(go);
+    }
+    card.appendChild(foot);
+    overlay.appendChild(card);
+  }
+
+  function renderStep1(body) {
+    body.appendChild(el('div', 'wizard-title', 'Welcome to Crow'));
+    body.appendChild(el('div', 'wizard-sub', 'Where do you want your development workspaces?'));
+    const field = el('div', 'wizard-field');
+    field.appendChild(el('label', 'wizard-label', 'Dev root'));
+    const input = document.createElement('input');
+    input.className = 'wizard-input';
+    input.type = 'text';
+    input.value = state.devRoot;
+    input.placeholder = '~/Dev';
+    input.oninput = () => {
+      state.devRoot = input.value;
+      const next = overlay.querySelector('.wizard-foot .action-primary');
+      if (next) next.disabled = !state.devRoot.trim();
+    };
+    field.appendChild(input);
+    body.appendChild(field);
+  }
+
+  function renderStep2(body) {
+    body.appendChild(el('div', 'wizard-title', 'Add Workspace Folders'));
+    body.appendChild(el('div', 'wizard-sub',
+      'Each workspace is a folder under your dev root containing git repos.'));
+    if (!state.workspaces.length && !state.adding) {
+      body.appendChild(el('div', 'wizard-empty', 'No workspaces yet — you can add one now or skip.'));
+    }
+    const list = el('div', 'wizard-list');
+    for (const ws of state.workspaces) {
+      const row = el('div', 'wizard-row');
+      const info = el('div', 'wizard-row-info');
+      info.appendChild(el('div', 'wizard-row-name', ws.name));
+      info.appendChild(el('div', 'wizard-row-meta',
+        ws.provider + (ws.host ? ' · ' + ws.host : '')));
+      row.appendChild(info);
+      const rm = el('button', 'wizard-row-rm', '×');
+      rm.title = 'Remove';
+      rm.onclick = () => {
+        state.workspaces = state.workspaces.filter((x) => x.id !== ws.id);
+        render();
+      };
+      row.appendChild(rm);
+      list.appendChild(row);
+    }
+    body.appendChild(list);
+
+    if (state.adding) {
+      const form = el('div', 'wizard-add-form');
+      const nameField = el('div', 'wizard-field');
+      nameField.appendChild(el('label', 'wizard-label', 'Name'));
+      const nameIn = document.createElement('input');
+      nameIn.className = 'wizard-input';
+      nameIn.type = 'text';
+      nameIn.placeholder = 'MyOrg';
+      nameIn.value = state.draft.name;
+      nameIn.oninput = () => { state.draft.name = nameIn.value; };
+      nameField.appendChild(nameIn);
+      form.appendChild(nameField);
+
+      const provField = el('div', 'wizard-field');
+      provField.appendChild(el('label', 'wizard-label', 'Provider'));
+      const sel = document.createElement('select');
+      sel.className = 'wizard-input';
+      for (const [v, label] of [['github', 'GitHub'], ['gitlab', 'GitLab']]) {
+        const o = document.createElement('option');
+        o.value = v; o.textContent = label;
+        if (state.draft.provider === v) o.selected = true;
+        sel.appendChild(o);
+      }
+      sel.onchange = () => { state.draft.provider = sel.value; render(); };
+      provField.appendChild(sel);
+      form.appendChild(provField);
+
+      if (state.draft.provider === 'gitlab') {
+        const hostField = el('div', 'wizard-field');
+        hostField.appendChild(el('label', 'wizard-label', 'GitLab host'));
+        const hostIn = document.createElement('input');
+        hostIn.className = 'wizard-input';
+        hostIn.type = 'text';
+        hostIn.placeholder = 'gitlab.example.com';
+        hostIn.value = state.draft.host || '';
+        hostIn.oninput = () => { state.draft.host = hostIn.value; };
+        hostField.appendChild(hostIn);
+        form.appendChild(hostField);
+      }
+
+      const actions = el('div', 'wizard-add-actions');
+      const cancel = el('button', 'action-btn', 'Cancel');
+      cancel.onclick = () => {
+        state.adding = false;
+        state.draft = { name: '', provider: 'github', host: '' };
+        render();
+      };
+      const add = el('button', 'action-btn action-primary', 'Add');
+      add.onclick = () => {
+        const name = (state.draft.name || '').trim();
+        if (!name) { state.error = 'Workspace name is required.'; render(); return; }
+        if (state.workspaces.some((w) => w.name.toLowerCase() === name.toLowerCase())) {
+          state.error = 'A workspace with that name already exists.'; render(); return;
+        }
+        const provider = state.draft.provider || 'github';
+        state.workspaces.push({
+          id: wizardUuid(),
+          name,
+          provider,
+          cli: provider === 'gitlab' ? 'glab' : 'gh',
+          host: provider === 'gitlab' && state.draft.host ? state.draft.host.trim() : undefined,
+          alwaysInclude: [],
+          autoReviewRepos: [],
+          excludeReviewRepos: [],
+        });
+        state.adding = false;
+        state.draft = { name: '', provider: 'github', host: '' };
+        state.error = null;
+        render();
+      };
+      actions.appendChild(cancel);
+      actions.appendChild(add);
+      form.appendChild(actions);
+      body.appendChild(form);
+      setTimeout(() => nameIn.focus(), 0);
+    } else {
+      const addBtn = el('button', 'wizard-add', '+ Add workspace');
+      addBtn.onclick = () => { state.adding = true; state.error = null; render(); };
+      body.appendChild(addBtn);
+    }
+  }
+
+  function renderStep3(body) {
+    body.appendChild(el('div', 'wizard-title', 'Ready to Go'));
+    body.appendChild(el('div', 'wizard-sub', 'Confirm your setup and get started.'));
+    const summary = el('div', 'wizard-summary');
+    summary.appendChild(el('div', 'wizard-summary-row', state.devRoot.trim()));
+    if (!state.workspaces.length) {
+      summary.appendChild(el('div', 'wizard-summary-meta', 'No workspaces yet — add them later in Settings.'));
+    } else {
+      for (const ws of state.workspaces) {
+        summary.appendChild(el('div', 'wizard-summary-meta',
+          ws.name + ' (' + ws.provider + (ws.host ? ' · ' + ws.host : '') + ')'));
+      }
+    }
+    body.appendChild(summary);
+  }
+
+  async function completeSetup() {
+    const root = state.devRoot.trim();
+    if (!root) { state.error = 'Dev root is required.'; state.step = 1; render(); return; }
+    state.settingUp = true;
+    state.error = null;
+    render();
+    const config = {
+      workspaces: state.workspaces,
+      defaults: { provider: 'github', cli: 'gh', branchPrefix: 'feature/' },
+    };
+    try {
+      await rpc('run-setup', { dev_root: root, config: JSON.stringify(config) });
+    } catch (e) {
+      state.settingUp = false;
+      state.error = (e && e.message) || String(e);
+      render();
+      return;
+    }
+    // Daemon re-execs → /rpc drops → rpcConnect auto-reconnects. Poll until
+    // configured flips true, then tear down the overlay and refresh the board.
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      try {
+        const res = await rpc('get-config');
+        if (res && res.configured) {
+          overlay.remove();
+          refreshSessions();
+          refreshBoard('tickets');
+          refreshBoard('reviews');
+          loadUIConfig();
+          return;
+        }
+      } catch (_) { /* still reconnecting */ }
+    }
+    state.error = 'Setup saved, but Crow did not come back online. Reload the page.';
+    render();
+  }
+
+  render();
 }
 
 // ---------------------------------------------------------------------------

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
@@ -216,6 +216,11 @@ import CrowPersistence
         #expect(resp.error == nil)
         #expect(resp.result?["app_running"]?.boolValue == false)
         #expect(resp.result?["dev_root"]?.stringValue == devRoot)
+        // First-run gate fields (CROW-605). `configured` reflects the App Support
+        // pointer (machine-global), not the per-test cwd-fallback `dev_root`.
+        #expect(resp.result?["configured"]?.boolValue != nil)
+        let defaultRoot = try #require(resp.result?["default_dev_root"]?.stringValue)
+        #expect(defaultRoot.hasSuffix("/Dev"))
 
         let json = try #require(resp.result?["config"]?.stringValue)
         // Plaintext secrets must not appear anywhere in the transported string.
@@ -263,6 +268,30 @@ import CrowPersistence
     @Test @MainActor func setConfigRejectsMalformedConfig() async {
         let resp = await offlineRouter(devRoot: tempDevRoot()).handle(request: JSONRPCRequest(
             id: 1, method: "set-config", params: ["config": .string("not-json")]))
+        #expect(resp.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    @Test @MainActor func runSetupRejectsWhenAlreadyConfigured() async throws {
+        // Isolate the App Support pointer so we don't touch the developer's real one.
+        // ConfigStore reads a fixed path under Application Support — we can't redirect
+        // it, so this test only covers the "already configured" rejection when a
+        // pointer happens to exist. When none exists, skip.
+        guard ConfigStore.loadDevRoot() != nil else { return }
+        let resp = await offlineRouter(devRoot: tempDevRoot()).handle(request: JSONRPCRequest(
+            id: 1, method: "run-setup",
+            params: [
+                "dev_root": .string("/tmp/crow-605-should-not-create"),
+                "config": .string(try encode(AppConfig())),
+            ]))
+        #expect(resp.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    @Test @MainActor func runSetupRejectsMissingDevRoot() async {
+        // Only meaningful when no pointer exists (otherwise the already-configured
+        // guard fires first). Either way we expect invalidParams.
+        let resp = await offlineRouter(devRoot: tempDevRoot()).handle(request: JSONRPCRequest(
+            id: 1, method: "run-setup",
+            params: ["config": .string("{}")]))
         #expect(resp.error?.code == RPCErrorCode.invalidParams)
     }
 }


### PR DESCRIPTION
## Summary
- Ports the retired macOS `SetupWizardView` to the web UI for first-run when no App Support `devroot` pointer exists.
- Adds `configured` / `default_dev_root` on `get-config` and a one-shot `run-setup` RPC that scaffolds, persists config + pointer, then re-execs `crowd` so the new root is adopted.
- Closes #605.

## Test plan
- [ ] Fresh install (no `~/Library/Application Support/crow/devroot`): wizard shows instead of empty board
- [ ] Complete wizard (temp dev root + one workspace): “Setting up…” → reconnect → board loads; pointer, config, and workspace dir exist; `get-config` has `configured: true`
- [ ] Reload / relaunch: wizard does not show again
- [ ] `swift test --package-path Packages/CrowDaemon --filter ConfigForwarderTests`


Made with [Cursor](https://cursor.com)