### PR TITLE
fix(tmux): drain stdout while waiting so large capture-pane doesn't deadlock (CROW-606)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -132,6 +132,13 @@ bind -T root WheelUpPane if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -
 # 5 fully-populated windows × 50k ≈ low-single-MB, and tmux allocates history
 # lazily as it accrues, so idle sessions cost nothing. This is the ceiling on
 # how far back the user can scroll after a crowd restart or browser reload.
+#
+# Caveat (tmux man page): history-limit "applies only to new windows —
+# existing window histories are not resized". Reloading this conf / raising
+# the server option does NOT lift the per-pane cap on windows created under
+# the old 5000 (or 2000) limit; only windows created after the bump inherit
+# 50000. Surviving panes keep whatever they were born with until the window
+# is recreated.
 set -gs history-limit 50000
 
 # No escape-key delay — interactive editors (vi-mode shells, etc.) feel

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -36,6 +36,12 @@ public struct TmuxController: Sendable {
     /// Run `tmux -S <socket> <args...>`. Returns stdout on exit-0,
     /// throws on non-zero exit with stdout/stderr captured. Throws
     /// `TmuxError.timedOut` if the child doesn't exit within `timeout`.
+    ///
+    /// Stdout/stderr are drained on background threads **while** waiting for
+    /// the child. Reading only after `waitUntilExit` deadlocks once output
+    /// exceeds the ~64 KB pipe buffer — `capture-pane -pe -S -N` for a rich
+    /// TUI pane routinely does, which made CROW-606 web-terminal replay
+    /// silently no-op (`try?` swallowed the timeout).
     @discardableResult
     public func run(_ args: [String], timeout: TimeInterval = TmuxController.defaultTimeout) throws -> String {
         let p = Process()
@@ -47,14 +53,32 @@ public struct TmuxController: Sendable {
         p.standardError = stderr
         try p.run()
 
+        // Drain both pipes concurrently so a large capture can't fill the OS
+        // pipe buffer and stall tmux before it exits. Boxes keep the mutable
+        // Data off the caller's stack so the concurrent readers don't race a
+        // local `var`.
+        final class PipeBox: @unchecked Sendable { var data = Data() }
+        let stdoutBox = PipeBox()
+        let stderrBox = PipeBox()
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            stdoutBox.data = stdout.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            stderrBox.data = stderr.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+
         let watchdog = ProcessWatchdog(p, timeout: timeout)
         p.waitUntilExit()
         watchdog.cancel()
+        group.wait()
 
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-        let outString = String(data: stdoutData, encoding: .utf8) ?? ""
-        let errString = String(data: stderrData, encoding: .utf8) ?? ""
+        let outString = String(data: stdoutBox.data, encoding: .utf8) ?? ""
+        let errString = String(data: stderrBox.data, encoding: .utf8) ?? ""
 
         if watchdog.didFire {
             throw TmuxError.timedOut(args: args, after: timeout)
@@ -283,7 +307,9 @@ public struct TmuxController: Sendable {
         var args = ["capture-pane", "-p"]
         if escapes { args.append("-e") }
         args.append(contentsOf: ["-t", target, "-S", "-\(linesBack)"])
-        return try run(args)
+        // Rich TUI panes (Claude/Cursor) with escapes can be hundreds of KB;
+        // give the drain room beyond the default 2s CLI budget (CROW-606).
+        return try run(args, timeout: max(TmuxController.defaultTimeout, 10.0))
     }
 
     /// `tmux display-message -p -t <target> <format>`. Used by the readiness

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -124,4 +124,38 @@ struct TmuxControllerTests {
         #expect(out.contains("bravo"))
         #expect(out.contains("charlie"))
     }
+
+    /// Regression for the CROW-606 silent no-op: `run()` used to wait for the
+    /// child to exit *before* draining stdout, so a `capture-pane -pe` larger
+    /// than the ~64 KB pipe buffer deadlocked, hit the 2s watchdog, and
+    /// `TerminalCockpit.replayData`'s `try?` swallowed it — reconnect showed
+    /// live-only. This emits >64 KB of scrollback and asserts capture returns
+    /// the full blob (not a timeout).
+    @Test func capturePaneDrainsLargeStdoutWithoutDeadlock() throws {
+        let ctrl = makeController()
+        let confURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-hist-\(UUID().uuidString).conf")
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: ctrl.socketPath)
+            try? FileManager.default.removeItem(at: confURL)
+        }
+        // history-limit is frozen at window birth — bake 50k into the server
+        // conf so the pane can retain the full blob.
+        try "set -gs history-limit 50000\n".write(to: confURL, atomically: true, encoding: .utf8)
+        // 1200 × ~60-char lines ≈ 72 KB — above the ~64 KB pipe buffer.
+        let script = #"/bin/sh -c 'i=0; while [ $i -lt 1200 ]; do printf "LINE-%04d-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n" "$i"; i=$((i+1)); done; printf "SENTINEL-DONE\n"; sleep 60'"#
+        try ctrl.newSessionDetached(configPath: confURL.path, command: script)
+        var out = ""
+        let deadline = Date().addingTimeInterval(5)
+        repeat {
+            Thread.sleep(forTimeInterval: 0.2)
+            out = (try? ctrl.capturePane(
+                target: "\(ctrl.sessionName):0", linesBack: 50000, escapes: true)) ?? ""
+        } while !out.contains("SENTINEL-DONE") && Date() < deadline
+        #expect(out.contains("SENTINEL-DONE"))
+        #expect(out.utf8.count > 64 * 1024)
+        #expect(out.contains("LINE-0000-"))
+        #expect(out.contains("LINE-1199-"))
+    }
 }


### PR DESCRIPTION
## Summary
- Web terminal scrollback replay (CROW-606) silently no-op'd on reconnect: `capture-pane -pe` of a rich TUI pane exceeds the ~64KB pipe buffer, `TmuxController.run()` waited for exit before reading stdout, the 2s watchdog fired, and `try?` in `replayData` swallowed it.
- Drain stdout/stderr concurrently while waiting; give `capturePane` a longer timeout; add a regression test; document that `history-limit` only applies to new windows.

## Test plan
- [x] `swift test --package-path Packages/CrowTerminal --filter capturePane` (2/2)
- [ ] Restart crowd on this branch, reload the browser, confirm prior scrollback appears after reconnect
- [ ] Confirm wheel-scroll of retained history still does not enter tmux copy-mode


Made with [Cursor](https://cursor.com)