### PR TITLE
feat(web): enable/disable toggle on Jobs list rows

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
@@ -208,7 +208,8 @@
 .st-row-main { flex: 1; min-width: 0; }
 .st-row-title { font-size: 12px; font-weight: 600; color: var(--text-primary); }
 .st-row-sub { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
-.st-row-actions { display: flex; gap: 6px; flex: none; }
+.st-row-actions { display: flex; gap: 6px; flex: none; align-items: center; }
+.st-row-switch { margin-right: 2px; }
 .st-icon-btn {
   display: inline-flex; align-items: center; justify-content: center;
   width: 28px; height: 28px; padding: 0;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -847,6 +847,18 @@
         setTimeout(() => { run.disabled = false; run.title = 'Run now'; setRowIcon(run, 'play'); }, 1500);
       };
       row.querySelector('.st-row-actions').insertBefore(run, row.querySelector('.st-row-actions').firstChild);
+      // Inline enable/disable (CROW-615) — same dirty/save path as Duplicate/Delete.
+      const enable = el('input', 'st-switch st-row-switch');
+      enable.type = 'checkbox';
+      enable.checked = !!job.enabled;
+      enable.title = job.enabled ? 'Disable job' : 'Enable job';
+      enable.setAttribute('aria-label', enable.title);
+      enable.onchange = () => {
+        job.enabled = enable.checked;
+        markDirty();
+        render();
+      };
+      row.querySelector('.st-row-actions').insertBefore(enable, row.querySelector('.st-row-actions').firstChild);
       body.appendChild(row);
     }
     const add = el('button', 'st-add', '+ Add job');


### PR DESCRIPTION
## Summary
- Adds a per-row enable/disable switch on Settings → Jobs so operators can flip `job.enabled` without opening the job editor
- Persists via the existing dirty/save path (same as Duplicate/Delete); subtitle still shows `· disabled` when off

Closes #615

## Test plan
- [ ] Open Settings → Jobs and confirm each job row shows an on/off toggle before Run / Duplicate / Edit / Delete
- [ ] Toggle a job off → subtitle shows `· disabled` and Save becomes enabled
- [ ] Save, reload Settings → Jobs → job remains disabled with toggle off
- [ ] Toggle back on, save, reload → enabled again and subtitle no longer says disabled
- [ ] Confirm Run / Duplicate / Delete still work as before