### PR TITLE
feat(web): skeleton-load the left pane before list-sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 
+### Web UI
+
+- #613 — Left pane paints chrome + skeleton (or cached last-known) session rows on first load before `list-sessions` returns, then swaps in real rows without a blank flash.
+
 ### Automation
 
 - #137 — Session analytics emitted via Claude Code's OpenTelemetry exporter (configure via `CLAUDE_CODE_ENABLE_TELEMETRY` and `OTEL_EXPORTER_OTLP_ENDPOINT`).

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -166,6 +166,39 @@ html, body {
 .activity-badge { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; }
 .empty { color: var(--text-muted); padding: 20px 6px; }
 
+/* ---- Sidebar skeleton (first paint before list-sessions, CROW-613) ---- */
+.session-row.skeleton-row {
+  cursor: default;
+  pointer-events: none;
+  border-left-color: var(--border-subtle);
+}
+.session-row.skeleton-row:hover { border-color: var(--border-subtle); }
+.skel {
+  display: block;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.09) 45%,
+    rgba(255, 255, 255, 0.04) 90%
+  );
+  background-size: 200% 100%;
+  animation: crow-skel-shimmer 1.35s ease-in-out infinite;
+  animation-delay: var(--skel-delay, 0s);
+}
+.skel-agent { width: 12px; height: 12px; flex: 0 0 auto; border-radius: 3px; }
+.skel-name { flex: 1 1 auto; height: 12px; max-width: 58%; }
+.skel-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; margin-left: auto; }
+.skel-subtle { height: 10px; width: 72%; margin-top: 8px; }
+.skel-meta { height: 10px; width: 48%; margin-top: 6px; }
+@keyframes crow-skel-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skel { animation: none; background: rgba(255, 255, 255, 0.06); }
+}
+
 /* ---- Detail ---- */
 #detail {
   display: flex;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -462,6 +462,13 @@ const boardData = { tickets: null, reviews: null, allowlist: null };
 // Last-known sidebar layout (sessions + ticket/review badge counts) so first
 // paint isn't blank while /rpc connects (CROW-613).
 const SIDEBAR_CACHE_KEY = 'crow.sidebar.cache';
+// True when boot restored a cache entry (including an empty sessions list) —
+// distinguishes "remembered empty" from a cold start that should show skeletons.
+let sidebarCacheHit = false;
+function clearSidebarCache() {
+  try { localStorage.removeItem(SIDEBAR_CACHE_KEY); } catch (_) {}
+  sidebarCacheHit = false;
+}
 function restoreSidebarCache() {
   try {
     const raw = localStorage.getItem(SIDEBAR_CACHE_KEY);
@@ -470,6 +477,7 @@ function restoreSidebarCache() {
     if (Array.isArray(data.sessions)) sessions = data.sessions;
     if (data.tickets) boardData.tickets = data.tickets;
     if (data.reviews) boardData.reviews = data.reviews;
+    sidebarCacheHit = true;
   } catch (_) { /* corrupt cache — start empty */ }
 }
 function persistSidebarCache() {
@@ -479,6 +487,7 @@ function persistSidebarCache() {
       tickets: boardData.tickets,
       reviews: boardData.reviews,
     }));
+    sidebarCacheHit = true;
   } catch (_) { /* quota / private mode */ }
 }
 let ticketFilter = 'All'; // pipeline segment ('All' or a status rawValue); default to All so the board isn't misread as empty when work moves to Done
@@ -559,7 +568,7 @@ function el(tag, className, text) {
 let lastSidebarSig = null;
 function sidebarSignature() {
   return JSON.stringify([
-    sessionsLoaded, sessions, liveById, selectedId, selectedBoard,
+    sessionsLoaded, sidebarCacheHit, sessions, liveById, selectedId, selectedBoard,
     selectionMode, [...selectedSessionIDs],
     uiConfig.hideSessionDetails,
     boardData.tickets && boardData.tickets.counts,
@@ -589,9 +598,10 @@ function renderSidebar() {
   root.appendChild(navPillRow());
   if (selectionMode) root.appendChild(bulkActionBar());
 
-  // First paint with no cache: structured skeleton rows so the left pane isn't
-  // blank while list-sessions is in flight (CROW-613).
-  if (!sessionsLoaded && !sessions.length) {
+  // Cold start only: structured skeleton rows so the left pane isn't blank
+  // while list-sessions is in flight. A cached empty workspace keeps the
+  // remembered "No sessions" state instead of shimmering (CROW-613).
+  if (!sessionsLoaded && !sessions.length && !sidebarCacheHit) {
     root.appendChild(el('div', 'divider', 'Active'));
     for (let i = 0; i < 4; i++) root.appendChild(skeletonRow(i));
     return;
@@ -608,7 +618,9 @@ function renderSidebar() {
     root.appendChild(selectionMode ? sectionHeader(group.title, rows) : el('div', 'divider', group.title));
     for (const s of rows) { root.appendChild(sessionRow(s)); shown++; }
   }
-  if (sessionsLoaded && !shown && !managers.length) root.appendChild(el('div', 'empty', 'No sessions'));
+  if ((sessionsLoaded || sidebarCacheHit) && !shown && !managers.length) {
+    root.appendChild(el('div', 'empty', 'No sessions'));
+  }
 }
 
 // Placeholder session card matching .session-row geometry so real rows swap in
@@ -769,6 +781,10 @@ async function handleAuthOnDisconnect() {
   try {
     if (await sessionExpired()) {
       sessionDead = true;
+      // Parity with explicit logout: drop cached session/ticket payloads when
+      // the remote web cookie dies (crowd restart) so they don't linger in a
+      // shared browser (CROW-613 review).
+      clearSidebarCache();
       renderStatusBar();
     }
   } finally {
@@ -810,7 +826,7 @@ function renderStatusBar() {
       try { await fetch('/logout', { method: 'POST' }); } catch (_) {}
       // Drop cached session/ticket payloads so a shared browser can't read them
       // after logout of a password-protected remote session (CROW-613 review).
-      try { localStorage.removeItem(SIDEBAR_CACHE_KEY); } catch (_) {}
+      clearSidebarCache();
       location.reload();  // now unauthenticated → the auth gate serves the login page
     };
     actions.appendChild(out);
@@ -2390,7 +2406,7 @@ try {
   restoreSidebarCache();
   renderSidebar();
 } catch (_) {
-  try { localStorage.removeItem(SIDEBAR_CACHE_KEY); } catch (_) {}
+  clearSidebarCache();
   sessions = [];
   lastSidebarSig = null;
   try { renderSidebar(); } catch (_) { /* keep going — RPC refresh will paint */ }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -442,6 +442,10 @@ function detectReviewSounds() {
 // State
 // ---------------------------------------------------------------------------
 let sessions = [];
+// False until the first successful list-sessions RPC. While false and sessions
+// are empty, the sidebar paints skeleton placeholders instead of "No sessions"
+// (CROW-613). A localStorage cache can populate `sessions` before that RPC.
+let sessionsLoaded = false;
 let selectedId = null;
 let terminals = [];
 let activeTerminal = null; // { id, name, window }
@@ -454,6 +458,29 @@ let liveById = {};
 // the app isn't running.
 let selectedBoard = null; // 'tickets' | 'reviews' | 'allowlist' | null
 const boardData = { tickets: null, reviews: null, allowlist: null };
+
+// Last-known sidebar layout (sessions + ticket/review badge counts) so first
+// paint isn't blank while /rpc connects (CROW-613).
+const SIDEBAR_CACHE_KEY = 'crow.sidebar.cache';
+function restoreSidebarCache() {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_CACHE_KEY);
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    if (Array.isArray(data.sessions)) sessions = data.sessions;
+    if (data.tickets) boardData.tickets = data.tickets;
+    if (data.reviews) boardData.reviews = data.reviews;
+  } catch (_) { /* corrupt cache — start empty */ }
+}
+function persistSidebarCache() {
+  try {
+    localStorage.setItem(SIDEBAR_CACHE_KEY, JSON.stringify({
+      sessions,
+      tickets: boardData.tickets,
+      reviews: boardData.reviews,
+    }));
+  } catch (_) { /* quota / private mode */ }
+}
 let ticketFilter = 'All'; // pipeline segment ('All' or a status rawValue); default to All so the board isn't misread as empty when work moves to Done
 let allowlistHideGlobal = false;
 const allowlistSelection = new Set();
@@ -494,6 +521,8 @@ async function refreshSessions() {
   try {
     const res = await rpc('list-sessions');
     sessions = res.sessions || [];
+    sessionsLoaded = true;
+    persistSidebarCache();
     detectSessionSounds();
     renderSidebar();
   } catch (_) { /* transient — next poll retries */ }
@@ -528,7 +557,7 @@ function el(tag, className, text) {
 let lastSidebarSig = null;
 function sidebarSignature() {
   return JSON.stringify([
-    sessions, liveById, selectedId, selectedBoard,
+    sessionsLoaded, sessions, liveById, selectedId, selectedBoard,
     selectionMode, [...selectedSessionIDs],
     boardData.tickets && boardData.tickets.counts,
     boardData.tickets && boardData.tickets.done_last_24h,
@@ -557,6 +586,14 @@ function renderSidebar() {
   root.appendChild(navPillRow());
   if (selectionMode) root.appendChild(bulkActionBar());
 
+  // First paint with no cache: structured skeleton rows so the left pane isn't
+  // blank while list-sessions is in flight (CROW-613).
+  if (!sessionsLoaded && !sessions.length) {
+    root.appendChild(el('div', 'divider', 'Active'));
+    for (let i = 0; i < 4; i++) root.appendChild(skeletonRow(i));
+    return;
+  }
+
   // Extra (non-primary) manager sessions render as rows, no section header.
   const managers = sessions.filter((s) => s.kind === 'manager');
   for (const m of managers.slice(1)) root.appendChild(sessionRow(m));
@@ -568,7 +605,26 @@ function renderSidebar() {
     root.appendChild(selectionMode ? sectionHeader(group.title, rows) : el('div', 'divider', group.title));
     for (const s of rows) { root.appendChild(sessionRow(s)); shown++; }
   }
-  if (!shown && !managers.length) root.appendChild(el('div', 'empty', 'No sessions'));
+  if (sessionsLoaded && !shown && !managers.length) root.appendChild(el('div', 'empty', 'No sessions'));
+}
+
+// Placeholder session card matching .session-row geometry so real rows swap in
+// without a full re-layout jump (CROW-613).
+function skeletonRow(i) {
+  const row = el('div', 'session-row skeleton-row');
+  row.setAttribute('aria-hidden', 'true');
+  // Stagger the shimmer so the column doesn't pulse in lockstep.
+  row.style.setProperty('--skel-delay', ((i % 4) * 0.12) + 's');
+  const top = el('div', 'row-top');
+  top.appendChild(el('span', 'skel skel-agent'));
+  top.appendChild(el('span', 'skel skel-name'));
+  top.appendChild(el('span', 'skel skel-dot'));
+  row.appendChild(top);
+  if (!uiConfig.hideSessionDetails) {
+    row.appendChild(el('div', 'skel skel-subtle'));
+    row.appendChild(el('div', 'skel skel-meta'));
+  }
+  return row;
 }
 
 // ---- Multi-select (#5 / CROW-593) ----------------------------------------
@@ -1595,6 +1651,7 @@ async function refreshBoard(key) {
   try { data = await rpc(method); } catch (_) { return; }
   const changed = JSON.stringify(boardData[key]) !== JSON.stringify(data);
   boardData[key] = data;
+  if (changed && (key === 'tickets' || key === 'reviews')) persistSidebarCache();
   if (key === 'reviews') detectReviewSounds();
   if (changed) renderSidebar(); // badge counts
   if (changed && selectedBoard === key) renderBoard();
@@ -2319,6 +2376,12 @@ document.getElementById('back-to-sidebar').onclick = () => {
 // Our own terminal context menu (copy/paste/select-all/clear) replaces the
 // browser default over the coding pane.
 document.getElementById('terminal-wrap').addEventListener('contextmenu', showTerminalMenu);
+
+// Paint the left pane immediately — cached last-known layout, or skeleton
+// placeholders — before the first /rpc round-trip (CROW-613).
+restoreSidebarCache();
+renderSidebar();
+renderStatusBar();
 
 refreshSessions();
 refreshLive();

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -520,9 +520,11 @@ const GROUPS = [
 async function refreshSessions() {
   try {
     const res = await rpc('list-sessions');
-    sessions = res.sessions || [];
+    const next = res.sessions || [];
+    const changed = JSON.stringify(sessions) !== JSON.stringify(next);
+    sessions = next;
     sessionsLoaded = true;
-    persistSidebarCache();
+    if (changed) persistSidebarCache();
     detectSessionSounds();
     renderSidebar();
   } catch (_) { /* transient — next poll retries */ }
@@ -559,6 +561,7 @@ function sidebarSignature() {
   return JSON.stringify([
     sessionsLoaded, sessions, liveById, selectedId, selectedBoard,
     selectionMode, [...selectedSessionIDs],
+    uiConfig.hideSessionDetails,
     boardData.tickets && boardData.tickets.counts,
     boardData.tickets && boardData.tickets.done_last_24h,
     boardData.reviews && boardData.reviews.unseen,
@@ -805,6 +808,9 @@ function renderStatusBar() {
     out.onclick = async () => {
       if (!await confirmModal('Log out of this web session? You’ll need the web password to sign back in.', { title: 'Log out', okLabel: 'Log out' })) return;
       try { await fetch('/logout', { method: 'POST' }); } catch (_) {}
+      // Drop cached session/ticket payloads so a shared browser can't read them
+      // after logout of a password-protected remote session (CROW-613 review).
+      try { localStorage.removeItem(SIDEBAR_CACHE_KEY); } catch (_) {}
       location.reload();  // now unauthenticated → the auth gate serves the login page
     };
     actions.appendChild(out);
@@ -2378,9 +2384,17 @@ document.getElementById('back-to-sidebar').onclick = () => {
 document.getElementById('terminal-wrap').addEventListener('contextmenu', showTerminalMenu);
 
 // Paint the left pane immediately — cached last-known layout, or skeleton
-// placeholders — before the first /rpc round-trip (CROW-613).
-restoreSidebarCache();
-renderSidebar();
+// placeholders — before the first /rpc round-trip (CROW-613). A stale-schema
+// cache entry must not abort the rest of boot (polls / refreshSessions).
+try {
+  restoreSidebarCache();
+  renderSidebar();
+} catch (_) {
+  try { localStorage.removeItem(SIDEBAR_CACHE_KEY); } catch (_) {}
+  sessions = [];
+  lastSidebarSig = null;
+  try { renderSidebar(); } catch (_) { /* keep going — RPC refresh will paint */ }
+}
 renderStatusBar();
 
 refreshSessions();

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -132,6 +132,13 @@ bind -T root WheelUpPane if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -
 # 5 fully-populated windows × 50k ≈ low-single-MB, and tmux allocates history
 # lazily as it accrues, so idle sessions cost nothing. This is the ceiling on
 # how far back the user can scroll after a crowd restart or browser reload.
+#
+# Caveat (tmux man page): history-limit "applies only to new windows —
+# existing window histories are not resized". Reloading this conf / raising
+# the server option does NOT lift the per-pane cap on windows created under
+# the old 5000 (or 2000) limit; only windows created after the bump inherit
+# 50000. Surviving panes keep whatever they were born with until the window
+# is recreated.
 set -gs history-limit 50000
 
 # No escape-key delay — interactive editors (vi-mode shells, etc.) feel

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -36,6 +36,12 @@ public struct TmuxController: Sendable {
     /// Run `tmux -S <socket> <args...>`. Returns stdout on exit-0,
     /// throws on non-zero exit with stdout/stderr captured. Throws
     /// `TmuxError.timedOut` if the child doesn't exit within `timeout`.
+    ///
+    /// Stdout/stderr are drained on background threads **while** waiting for
+    /// the child. Reading only after `waitUntilExit` deadlocks once output
+    /// exceeds the ~64 KB pipe buffer — `capture-pane -pe -S -N` for a rich
+    /// TUI pane routinely does, which made CROW-606 web-terminal replay
+    /// silently no-op (`try?` swallowed the timeout).
     @discardableResult
     public func run(_ args: [String], timeout: TimeInterval = TmuxController.defaultTimeout) throws -> String {
         let p = Process()
@@ -47,14 +53,32 @@ public struct TmuxController: Sendable {
         p.standardError = stderr
         try p.run()
 
+        // Drain both pipes concurrently so a large capture can't fill the OS
+        // pipe buffer and stall tmux before it exits. Boxes keep the mutable
+        // Data off the caller's stack so the concurrent readers don't race a
+        // local `var`.
+        final class PipeBox: @unchecked Sendable { var data = Data() }
+        let stdoutBox = PipeBox()
+        let stderrBox = PipeBox()
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            stdoutBox.data = stdout.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            stderrBox.data = stderr.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+
         let watchdog = ProcessWatchdog(p, timeout: timeout)
         p.waitUntilExit()
         watchdog.cancel()
+        group.wait()
 
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-        let outString = String(data: stdoutData, encoding: .utf8) ?? ""
-        let errString = String(data: stderrData, encoding: .utf8) ?? ""
+        let outString = String(data: stdoutBox.data, encoding: .utf8) ?? ""
+        let errString = String(data: stderrBox.data, encoding: .utf8) ?? ""
 
         if watchdog.didFire {
             throw TmuxError.timedOut(args: args, after: timeout)
@@ -283,7 +307,9 @@ public struct TmuxController: Sendable {
         var args = ["capture-pane", "-p"]
         if escapes { args.append("-e") }
         args.append(contentsOf: ["-t", target, "-S", "-\(linesBack)"])
-        return try run(args)
+        // Rich TUI panes (Claude/Cursor) with escapes can be hundreds of KB;
+        // give the drain room beyond the default 2s CLI budget (CROW-606).
+        return try run(args, timeout: max(TmuxController.defaultTimeout, 10.0))
     }
 
     /// `tmux display-message -p -t <target> <format>`. Used by the readiness

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -124,4 +124,38 @@ struct TmuxControllerTests {
         #expect(out.contains("bravo"))
         #expect(out.contains("charlie"))
     }
+
+    /// Regression for the CROW-606 silent no-op: `run()` used to wait for the
+    /// child to exit *before* draining stdout, so a `capture-pane -pe` larger
+    /// than the ~64 KB pipe buffer deadlocked, hit the 2s watchdog, and
+    /// `TerminalCockpit.replayData`'s `try?` swallowed it — reconnect showed
+    /// live-only. This emits >64 KB of scrollback and asserts capture returns
+    /// the full blob (not a timeout).
+    @Test func capturePaneDrainsLargeStdoutWithoutDeadlock() throws {
+        let ctrl = makeController()
+        let confURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-hist-\(UUID().uuidString).conf")
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: ctrl.socketPath)
+            try? FileManager.default.removeItem(at: confURL)
+        }
+        // history-limit is frozen at window birth — bake 50k into the server
+        // conf so the pane can retain the full blob.
+        try "set -gs history-limit 50000\n".write(to: confURL, atomically: true, encoding: .utf8)
+        // 1200 × ~60-char lines ≈ 72 KB — above the ~64 KB pipe buffer.
+        let script = #"/bin/sh -c 'i=0; while [ $i -lt 1200 ]; do printf "LINE-%04d-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n" "$i"; i=$((i+1)); done; printf "SENTINEL-DONE\n"; sleep 60'"#
+        try ctrl.newSessionDetached(configPath: confURL.path, command: script)
+        var out = ""
+        let deadline = Date().addingTimeInterval(5)
+        repeat {
+            Thread.sleep(forTimeInterval: 0.2)
+            out = (try? ctrl.capturePane(
+                target: "\(ctrl.sessionName):0", linesBack: 50000, escapes: true)) ?? ""
+        } while !out.contains("SENTINEL-DONE") && Date() < deadline
+        #expect(out.contains("SENTINEL-DONE"))
+        #expect(out.utf8.count > 64 * 1024)
+        #expect(out.contains("LINE-0000-"))
+        #expect(out.contains("LINE-1199-"))
+    }
 }


### PR DESCRIPTION
## Summary
- Paint left-pane chrome (brand, tickets card, nav pills) immediately on boot, before the first `/rpc` round-trip.
- Restore last-known sessions + ticket/review badge counts from `localStorage` when available; otherwise show shimmer skeleton rows matching session-card geometry.
- Swap in real session rows once `list-sessions` lands, without flashing a blank/"No sessions" empty state.

Closes #613

## Test plan
- [ ] Cold load (cleared site data): left pane shows brand + tickets chrome + Active section with skeleton rows before sessions appear
- [ ] Warm reload: cached session cards paint immediately, then update when `list-sessions` returns (no blank flash)
- [ ] Empty workspace after load: "No sessions" only after the first successful `list-sessions`, not during the wait
- [ ] Real rows replace skeletons without a jarring full re-layout
- [ ] Ticket counts / Reviews badge restore from cache on warm load