### PR TITLE
fix(review): preserve gateway secrets on update; PATH-safe crowd re-exec (PR #594)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Artifacts.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Artifacts.swift
@@ -47,7 +47,15 @@ enum Artifacts {
                   isSafeImageName(file) else {
                 return Response(status: .badRequest)
             }
-            guard let data = try? Data(contentsOf: dir.appendingPathComponent(file)) else {
+            // Resolve symlinks and require the final path stay inside `dir` —
+            // otherwise a planted `shot.png` → `~/.claude/config.json` symlink
+            // would leak secrets that strippedForTransport keeps off every other
+            // transport (review Yellow / CROW-593).
+            let candidate = dir.appendingPathComponent(file)
+            guard let resolved = resolvedPathInside(dir: dir, file: candidate) else {
+                return Response(status: .notFound)
+            }
+            guard let data = try? Data(contentsOf: resolved) else {
                 return Response(status: .notFound)
             }
             var headers: HTTPFields = [.contentType: contentType(for: file), .cacheControl: "no-store"]
@@ -69,6 +77,21 @@ enum Artifacts {
     static func isSafeImageName(_ name: String) -> Bool {
         !name.isEmpty && !name.contains("/") && !name.contains("..")
             && imageExtensions.contains((name as NSString).pathExtension.lowercased())
+    }
+
+    /// Resolve `file` (following symlinks) and return it only when the final
+    /// path is still under `dir`. Rejects dangling / escaping symlinks.
+    static func resolvedPathInside(dir: URL, file: URL) -> URL? {
+        let root = dir.resolvingSymlinksInPath().standardizedFileURL.path
+        let resolved = file.resolvingSymlinksInPath().standardizedFileURL.path
+        // Exact match (file is the dir itself — shouldn't happen) or a child.
+        guard resolved == root || resolved.hasPrefix(root + "/") else { return nil }
+        // The resolved path must still exist as a regular file (not a dir).
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: resolved, isDirectory: &isDir), !isDir.boolValue else {
+            return nil
+        }
+        return URL(fileURLWithPath: resolved)
     }
 
     private static func contentType(for file: String) -> String {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -1,5 +1,6 @@
 #if canImport(Darwin)
 import Darwin
+import MachO
 #elseif canImport(Glibc)
 import Glibc
 #endif
@@ -304,22 +305,64 @@ public enum CrowDaemon {
 
     /// Close the single-instance lock fd (no `O_CLOEXEC`, so an inherited fd
     /// would still hold the flock and the re-exec'd image's
-    /// `acquireSingleInstanceLock` would fail), then `execv` the same binary
+    /// `acquireSingleInstanceLock` would fail), then re-exec the same binary
     /// and args. Does not return on success.
+    ///
+    /// Resolves the real executable path first — `execv(argv[0])` does **not**
+    /// search `PATH`, so a user who ran `crowd` from `~/.local/bin` (the README
+    /// install flow) would hit ENOENT and the daemon would `exit(1)` after the
+    /// first-run wizard instead of restarting (review Yellow #2 / CROW-605).
     static func reexec(_ argv: [String]) {
         if singleInstanceLockFD >= 0 {
             close(singleInstanceLockFD)
             singleInstanceLockFD = -1
         }
-        guard let executable = argv.first, !executable.isEmpty else {
+        guard let argv0 = argv.first, !argv0.isEmpty else {
             log("re-exec failed: empty argv")
             exit(1)
         }
         let cArgv: [UnsafeMutablePointer<CChar>?] = argv.map { strdup($0) } + [nil]
         defer { for p in cArgv where p != nil { free(p) } }
-        execv(executable, cArgv)
-        log("re-exec failed: \(String(cString: strerror(errno)))")
+
+        // Prefer the kernel's view of this process's executable (absolute path),
+        // then a path-shaped argv[0], then `execvp` so a bare `crowd` on PATH still
+        // restarts.
+        if let resolved = resolvedExecutablePath() {
+            execv(resolved, cArgv)
+            log("re-exec failed (execv \(resolved)): \(String(cString: strerror(errno)))")
+        } else if argv0.contains("/") {
+            execv(argv0, cArgv)
+            log("re-exec failed (execv \(argv0)): \(String(cString: strerror(errno)))")
+        } else {
+            execvp(argv0, cArgv)
+            log("re-exec failed (execvp \(argv0)): \(String(cString: strerror(errno)))")
+        }
         exit(1)
+    }
+
+    /// Absolute path of the running `crowd` binary, or `nil` if it can't be
+    /// resolved (caller falls back to `execvp`). Exposed for tests.
+    static func resolvedExecutablePath() -> String? {
+        #if canImport(Darwin)
+        var size: UInt32 = 0
+        _ = _NSGetExecutablePath(nil, &size)
+        guard size > 0 else { return nil }
+        var buf = [CChar](repeating: 0, count: Int(size))
+        guard _NSGetExecutablePath(&buf, &size) == 0 else { return nil }
+        // `_NSGetExecutablePath` may return a relative path; realpath makes it
+        // absolute so a later cwd change can't break the re-exec.
+        var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(buf, &resolved) != nil else { return String(cString: buf) }
+        return String(cString: resolved)
+        #elseif os(Linux)
+        var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
+        let n = readlink("/proc/self/exe", &buf, buf.count - 1)
+        guard n > 0 else { return nil }
+        buf[n] = 0
+        return String(cString: buf)
+        #else
+        return nil
+        #endif
     }
 
     /// Wire the IssueTracker's background automation hooks: spawns go to the

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -745,6 +745,10 @@ func makeCommandRouter(
         // writes config.json + the App Support pointer, then asks the daemon to
         // re-exec so every subsystem that captured `devRoot` at startup adopts
         // the new path. Rejected once a pointer already exists.
+        //
+        // Local-direct only: the `/rpc` WebSocket handler rejects non-local
+        // callers before this runs (review Yellow). Documented here so a future
+        // Unix-socket / CLI path doesn't reintroduce a remote write+re-exec.
         "run-setup": { params in
             if ConfigStore.loadDevRoot() != nil {
                 throw DaemonRPCError.invalidParams("Already configured — setup wizard is one-shot")

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -42,7 +42,14 @@ enum RPCWebSocketHandler {
                 configProvider: { ConfigStore.loadConfig(devRoot: devRoot) },
                 sessions: sessions)
             return (originOK && auth.isAuthorized) ? .upgrade() : .dontUpgrade
-        } onUpgrade: { inbound, outbound, _ in
+        } onUpgrade: { inbound, outbound, wsContext in
+            // Captured at upgrade: first-run `run-setup` is a write+re-exec and
+            // must stay local-direct (loopback, no XFF) like SecretRoutes — on a
+            // non-loopback bind with auth still inert, Origin alone isn't enough
+            // (review Yellow / CROW-605).
+            let localDirect = WebAuthGuard.isLocalDirect(
+                remoteAddress: wsContext.requestContext.remoteAddress,
+                forwardedFor: wsContext.request.headers[HTTPField.Name("x-forwarded-for")!])
             // One outbound channel per connection: RPC responses (from the
             // reader task) and hub notifications (fanned in via `subscribe`)
             // both feed the single writer below.
@@ -71,7 +78,15 @@ enum RPCWebSocketHandler {
                               let request = try? decoder.decode(JSONRPCRequest.self, from: data) else {
                             continue
                         }
-                        let response = await commandRouter.handle(request: request)
+                        let response: JSONRPCResponse
+                        if request.method == "run-setup", !localDirect {
+                            response = .error(
+                                id: request.id,
+                                code: RPCErrorCode.invalidParams,
+                                message: "run-setup is local-only")
+                        } else {
+                            response = await commandRouter.handle(request: request)
+                        }
                         if let out = try? encoder.encode(response), let text = String(data: out, encoding: .utf8) {
                             outCont.yield(text)
                         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1814,6 +1814,7 @@ function renderAllowlist(root) {
   selectAll.onclick = () => { promotable.forEach((p) => allowlistSelection.add(p)); renderBoard(); };
   head.appendChild(selectAll);
   const clearSel = el('button', 'action-btn', 'Clear');
+  clearSel.id = 'allow-clear';
   clearSel.disabled = allowlistSelection.size === 0;
   clearSel.onclick = () => { allowlistSelection.clear(); renderBoard(); };
   head.appendChild(clearSel);
@@ -1840,11 +1841,16 @@ function allowRow(e) {
     box.checked = allowlistSelection.has(e.pattern);
     box.onchange = () => {
       if (box.checked) allowlistSelection.add(e.pattern); else allowlistSelection.delete(e.pattern);
-      const btn = document.getElementById('allow-promote');
-      if (btn) {
-        btn.textContent = 'Promote to Global (' + allowlistSelection.size + ')';
-        btn.disabled = allowlistSelection.size === 0;
+      const empty = allowlistSelection.size === 0;
+      const promote = document.getElementById('allow-promote');
+      if (promote) {
+        promote.textContent = 'Promote to Global (' + allowlistSelection.size + ')';
+        promote.disabled = empty;
       }
+      // Clear was fixed at render time; refresh it here too so ticking the first
+      // row from an empty selection enables Clear (review Yellow).
+      const clear = document.getElementById('allow-clear');
+      if (clear) clear.disabled = empty;
     };
     row.appendChild(box);
   } else {
@@ -2015,6 +2021,7 @@ function showTerminalMenu(e) {
 }
 
 function connectTerminalWs() {
+  if (sessionDead) return; // don't loop after an expired remote cookie (review Yellow)
   termWs = new WebSocket(wsURL('/terminal'));
   termWs.binaryType = 'arraybuffer';
   termWs.onopen = () => {
@@ -2024,7 +2031,10 @@ function connectTerminalWs() {
   termWs.onmessage = (event) => {
     if (event.data instanceof ArrayBuffer) term.write(new Uint8Array(event.data));
   };
-  termWs.onclose = () => { setTimeout(connectTerminalWs, 1000); };
+  termWs.onclose = () => {
+    if (sessionDead) return;
+    setTimeout(connectTerminalWs, 1000);
+  };
   termWs.onerror = () => termWs.close();
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -161,7 +161,13 @@
     if (!backdrop) {
       backdrop = el('div', 'settings-backdrop');
       backdrop.onclick = (ev) => { if (ev.target === backdrop) closeSettings(); };
-      escHandler = (ev) => { if (ev.key === 'Escape') closeSettings(); };
+      // Escape backs out of the topmost overlay first (sub-form), then Settings —
+      // matching backdrop-click behavior (review Yellow).
+      escHandler = (ev) => {
+        if (ev.key !== 'Escape') return;
+        if (subForm) { subForm = null; render(); return; }
+        closeSettings();
+      };
       document.addEventListener('keydown', escHandler);
       document.body.appendChild(backdrop);
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
@@ -67,7 +67,9 @@ enum SecretRoutes {
                 do {
                     try ConfigStore.withConfigLock {
                         var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-                        c.managerGateway = gateway
+                        // Blank header values mean "keep stored" — the local editor
+                        // prefills stripped keys with empty values (review Yellow #1).
+                        c.managerGateway = mergingPreservedHeaders(incoming: gateway, stored: c.managerGateway)
                         try ConfigStore.saveConfig(c, devRoot: devRoot)
                     }
                     return json(["saved": true, "gateway_set": gateway != nil])
@@ -94,7 +96,8 @@ enum SecretRoutes {
                     let found = try ConfigStore.withConfigLock { () -> Bool in
                         var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
                         guard let idx = c.workspaces.firstIndex(where: { $0.id == uid }) else { return false }
-                        c.workspaces[idx].gateway = gateway
+                        c.workspaces[idx].gateway = mergingPreservedHeaders(
+                            incoming: gateway, stored: c.workspaces[idx].gateway)
                         try ConfigStore.saveConfig(c, devRoot: devRoot)
                         return true
                     }
@@ -130,15 +133,45 @@ enum SecretRoutes {
     /// enforcing `WorkspaceGateway`'s both-or-neither invariant: a base URL and
     /// at least one header, or neither. `clear: true` (or an all-empty body)
     /// clears it.
+    ///
+    /// Header *values* may still be blank here — the local editor ships stripped
+    /// keys with empty values. Callers must run the result through
+    /// ``mergingPreservedHeaders(incoming:stored:)`` under the config lock so a
+    /// blank value keeps the currently-stored secret (review Yellow #1 / CROW-593).
     static func buildGateway(_ body: GatewayBody?) -> Result<WorkspaceGateway?, GatewayValidationError> {
         guard let body, body.clear != true else { return .success(nil) }
         let url = (body.baseURL ?? "").trimmingCharacters(in: .whitespaces)
+        // Keep blank-valued headers (keys present) so the merge step can restore
+        // stored secrets; only drop empty *keys*.
         let headers = (body.headers ?? [:]).filter { !$0.key.trimmingCharacters(in: .whitespaces).isEmpty }
         if url.isEmpty && headers.isEmpty { return .success(nil) }
         if url.isEmpty != headers.isEmpty {
             return .failure(GatewayValidationError(message: "a gateway needs both a base URL and at least one header, or neither"))
         }
         return .success(WorkspaceGateway(baseURL: url, customHeaders: headers))
+    }
+
+    /// Merge an incoming gateway (from the local editor) with the currently
+    /// stored one so blank header values mean "keep the stored secret" — matching
+    /// the help text and the `strippedForTransport` contract (review Yellow #1).
+    /// `nil` incoming clears; non-nil with blank values restores from `stored`.
+    static func mergingPreservedHeaders(
+        incoming: WorkspaceGateway?,
+        stored: WorkspaceGateway?
+    ) -> WorkspaceGateway? {
+        guard let incoming else { return nil }
+        var headers = incoming.customHeaders
+        if let stored {
+            for (key, value) in headers where value.trimmingCharacters(in: .whitespaces).isEmpty {
+                if let kept = stored.customHeaders[key], !kept.isEmpty {
+                    headers[key] = kept
+                }
+            }
+        }
+        // Drop keys that are still blank after merge (no stored value to keep /
+        // no stored gateway at all) so we don't persist empty secrets.
+        headers = headers.filter { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }
+        return WorkspaceGateway(baseURL: incoming.baseURL, customHeaders: headers)
     }
 
     // MARK: - Gating

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
@@ -65,14 +65,19 @@ enum SecretRoutes {
                 return json(["error": e.message], status: .badRequest)
             case .success(let gateway):
                 do {
-                    try ConfigStore.withConfigLock {
+                    let saved: WorkspaceGateway? = try ConfigStore.withConfigLock {
                         var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
                         // Blank header values mean "keep stored" — the local editor
                         // prefills stripped keys with empty values (review Yellow #1).
-                        c.managerGateway = mergingPreservedHeaders(incoming: gateway, stored: c.managerGateway)
+                        let merged = try mergingPreservedHeaders(
+                            incoming: gateway, stored: c.managerGateway).get()
+                        c.managerGateway = merged
                         try ConfigStore.saveConfig(c, devRoot: devRoot)
+                        return merged
                     }
-                    return json(["saved": true, "gateway_set": gateway != nil])
+                    return json(["saved": true, "gateway_set": saved != nil])
+                } catch let e as GatewayValidationError {
+                    return json(["error": e.message], status: .badRequest)
                 } catch {
                     return json(["error": "failed to save: \(error.localizedDescription)"], status: .internalServerError)
                 }
@@ -93,16 +98,21 @@ enum SecretRoutes {
                 return json(["error": e.message], status: .badRequest)
             case .success(let gateway):
                 do {
-                    let found = try ConfigStore.withConfigLock { () -> Bool in
+                    let outcome = try ConfigStore.withConfigLock { () -> (found: Bool, set: Bool) in
                         var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-                        guard let idx = c.workspaces.firstIndex(where: { $0.id == uid }) else { return false }
-                        c.workspaces[idx].gateway = mergingPreservedHeaders(
-                            incoming: gateway, stored: c.workspaces[idx].gateway)
+                        guard let idx = c.workspaces.firstIndex(where: { $0.id == uid }) else {
+                            return (false, false)
+                        }
+                        let merged = try mergingPreservedHeaders(
+                            incoming: gateway, stored: c.workspaces[idx].gateway).get()
+                        c.workspaces[idx].gateway = merged
                         try ConfigStore.saveConfig(c, devRoot: devRoot)
-                        return true
+                        return (true, merged != nil)
                     }
-                    guard found else { return json(["error": "workspace not found"], status: .notFound) }
-                    return json(["saved": true, "gateway_set": gateway != nil])
+                    guard outcome.found else { return json(["error": "workspace not found"], status: .notFound) }
+                    return json(["saved": true, "gateway_set": outcome.set])
+                } catch let e as GatewayValidationError {
+                    return json(["error": e.message], status: .badRequest)
                 } catch {
                     return json(["error": "failed to save: \(error.localizedDescription)"], status: .internalServerError)
                 }
@@ -155,11 +165,16 @@ enum SecretRoutes {
     /// stored one so blank header values mean "keep the stored secret" — matching
     /// the help text and the `strippedForTransport` contract (review Yellow #1).
     /// `nil` incoming clears; non-nil with blank values restores from `stored`.
+    ///
+    /// Rejects a URL with no remaining headers after the blank-drop — that shape
+    /// encodes fine but `WorkspaceGateway` refuses to decode it, which would make
+    /// the next `loadConfig` return `nil` and wipe the whole config on the next
+    /// write (review Red on #623).
     static func mergingPreservedHeaders(
         incoming: WorkspaceGateway?,
         stored: WorkspaceGateway?
-    ) -> WorkspaceGateway? {
-        guard let incoming else { return nil }
+    ) -> Result<WorkspaceGateway?, GatewayValidationError> {
+        guard let incoming else { return .success(nil) }
         var headers = incoming.customHeaders
         if let stored {
             for (key, value) in headers where value.trimmingCharacters(in: .whitespaces).isEmpty {
@@ -171,7 +186,12 @@ enum SecretRoutes {
         // Drop keys that are still blank after merge (no stored value to keep /
         // no stored gateway at all) so we don't persist empty secrets.
         headers = headers.filter { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }
-        return WorkspaceGateway(baseURL: incoming.baseURL, customHeaders: headers)
+        let hasURL = !incoming.baseURL.trimmingCharacters(in: .whitespaces).isEmpty
+        if hasURL && headers.isEmpty {
+            return .failure(GatewayValidationError(
+                message: "a gateway header has no value and no stored secret to keep"))
+        }
+        return .success(WorkspaceGateway(baseURL: incoming.baseURL, customHeaders: headers))
     }
 
     // MARK: - Gating

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/ArtifactsTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/ArtifactsTests.swift
@@ -22,6 +22,32 @@ import Testing
         #expect(!Artifacts.isSafeImageName(""))
     }
 
+    @Test func rejectsSymlinkEscapingTheScratchDir() throws {
+        // A planted shot.png → ~/.ssh/id_rsa (or config.json) must not be served
+        // (review Yellow — Data(contentsOf:) follows symlinks).
+        let session = UUID().uuidString
+        let dir = Artifacts.dir(sessionID: session)!
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-artifact-secret-\(UUID().uuidString).txt")
+        try Data("SECRET".utf8).write(to: outside)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        let link = dir.appendingPathComponent("shot.png")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        #expect(Artifacts.resolvedPathInside(dir: dir, file: link) == nil)
+
+        // A real in-tree file still resolves.
+        let real = dir.appendingPathComponent("ok.png")
+        try Data("png".utf8).write(to: real)
+        let resolved = Artifacts.resolvedPathInside(dir: dir, file: real)
+        #expect(resolved != nil)
+        #expect(resolved?.lastPathComponent == "ok.png")
+    }
+
     @Test func listsOnlyImagesNewestFirst() throws {
         let session = UUID().uuidString
         let dir = Artifacts.dir(sessionID: session)!

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -468,6 +468,57 @@ import CrowPersistence
             Issue.record("headers with no baseURL should be rejected")
         }
     }
+
+    @Test func blankHeaderValuesKeepStoredSecrets() {
+        // Local editor prefills stripped keys with empty values; updating only
+        // the base URL must not wipe the stored auth header (review Yellow #1).
+        let stored = WorkspaceGateway(
+            baseURL: "https://old.example",
+            customHeaders: ["X-Api-Key": "SECRET", "X-Extra": "keep-me"])
+        let incoming = WorkspaceGateway(
+            baseURL: "https://new.example",
+            customHeaders: ["X-Api-Key": "", "X-Extra": "", "X-New": "fresh"])
+        let merged = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored)
+        #expect(merged?.baseURL == "https://new.example")
+        #expect(merged?.customHeaders["X-Api-Key"] == "SECRET")
+        #expect(merged?.customHeaders["X-Extra"] == "keep-me")
+        #expect(merged?.customHeaders["X-New"] == "fresh")
+    }
+
+    @Test func blankHeaderWithNoStoredValueIsDropped() {
+        let incoming = WorkspaceGateway(
+            baseURL: "https://gw.example",
+            customHeaders: ["X-Api-Key": "real", "X-Empty": ""])
+        let merged = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: nil)
+        #expect(merged?.customHeaders["X-Api-Key"] == "real")
+        #expect(merged?.customHeaders["X-Empty"] == nil)
+    }
+
+    @Test func nilIncomingClearsGateway() {
+        let stored = WorkspaceGateway(baseURL: "https://gw", customHeaders: ["X": "y"])
+        #expect(SecretRoutes.mergingPreservedHeaders(incoming: nil, stored: stored) == nil)
+    }
+
+    @Test func nonBlankIncomingValueOverridesStored() {
+        let stored = WorkspaceGateway(
+            baseURL: "https://gw", customHeaders: ["X-Api-Key": "OLD"])
+        let incoming = WorkspaceGateway(
+            baseURL: "https://gw", customHeaders: ["X-Api-Key": "NEW"])
+        let merged = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored)
+        #expect(merged?.customHeaders["X-Api-Key"] == "NEW")
+    }
+}
+
+/// `CrowDaemon.resolvedExecutablePath` must return an absolute path to *this*
+/// process so `reexec` can `execv` after a PATH-launched `crowd` (review Yellow #2).
+@Suite struct ReexecPathResolutionTests {
+    @Test func resolvedExecutablePathIsAbsoluteAndExists() {
+        let path = CrowDaemon.resolvedExecutablePath()
+        #expect(path != nil)
+        guard let path else { return }
+        #expect(path.hasPrefix("/"), "expected absolute path, got \(path)")
+        #expect(FileManager.default.isExecutableFile(atPath: path))
+    }
 }
 
 /// The `webAuth` hash/salt are secrets: blanked on transport (the browser only

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -469,7 +469,7 @@ import CrowPersistence
         }
     }
 
-    @Test func blankHeaderValuesKeepStoredSecrets() {
+    @Test func blankHeaderValuesKeepStoredSecrets() throws {
         // Local editor prefills stripped keys with empty values; updating only
         // the base URL must not wipe the stored auth header (review Yellow #1).
         let stored = WorkspaceGateway(
@@ -478,33 +478,57 @@ import CrowPersistence
         let incoming = WorkspaceGateway(
             baseURL: "https://new.example",
             customHeaders: ["X-Api-Key": "", "X-Extra": "", "X-New": "fresh"])
-        let merged = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored)
+        let merged = try SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored).get()
         #expect(merged?.baseURL == "https://new.example")
         #expect(merged?.customHeaders["X-Api-Key"] == "SECRET")
         #expect(merged?.customHeaders["X-Extra"] == "keep-me")
         #expect(merged?.customHeaders["X-New"] == "fresh")
     }
 
-    @Test func blankHeaderWithNoStoredValueIsDropped() {
+    @Test func blankHeaderWithNoStoredValueIsDroppedWhenSiblingRemains() throws {
         let incoming = WorkspaceGateway(
             baseURL: "https://gw.example",
             customHeaders: ["X-Api-Key": "real", "X-Empty": ""])
-        let merged = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: nil)
+        let merged = try SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: nil).get()
         #expect(merged?.customHeaders["X-Api-Key"] == "real")
         #expect(merged?.customHeaders["X-Empty"] == nil)
     }
 
-    @Test func nilIncomingClearsGateway() {
-        let stored = WorkspaceGateway(baseURL: "https://gw", customHeaders: ["X": "y"])
-        #expect(SecretRoutes.mergingPreservedHeaders(incoming: nil, stored: stored) == nil)
+    @Test func allBlankHeadersWithNoStoredSecretAreRejected() {
+        // URL + only blank headers (no stored secret to restore) would encode a
+        // half-filled gateway that AppConfig refuses to decode — wiping the
+        // whole config on the next load (review Red on #623).
+        let incoming = WorkspaceGateway(
+            baseURL: "https://gw.example",
+            customHeaders: ["X-Api-Key": ""])
+        if case .success = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: nil) {
+            Issue.record("URL with no keepable headers must be rejected")
+        }
     }
 
-    @Test func nonBlankIncomingValueOverridesStored() {
+    @Test func renamedBlankHeaderWithNoStoredMatchIsRejected() {
+        // Renaming the only header key to a blank-valued new name leaves no
+        // keepable headers after merge — same undecodable shape as above.
+        let stored = WorkspaceGateway(
+            baseURL: "https://gw.example", customHeaders: ["X-Old": "SECRET"])
+        let incoming = WorkspaceGateway(
+            baseURL: "https://gw.example", customHeaders: ["X-New": ""])
+        if case .success = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored) {
+            Issue.record("renamed blank header with no stored match must be rejected")
+        }
+    }
+
+    @Test func nilIncomingClearsGateway() throws {
+        let stored = WorkspaceGateway(baseURL: "https://gw", customHeaders: ["X": "y"])
+        #expect(try SecretRoutes.mergingPreservedHeaders(incoming: nil, stored: stored).get() == nil)
+    }
+
+    @Test func nonBlankIncomingValueOverridesStored() throws {
         let stored = WorkspaceGateway(
             baseURL: "https://gw", customHeaders: ["X-Api-Key": "OLD"])
         let incoming = WorkspaceGateway(
             baseURL: "https://gw", customHeaders: ["X-Api-Key": "NEW"])
-        let merged = SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored)
+        let merged = try SecretRoutes.mergingPreservedHeaders(incoming: incoming, stored: stored).get()
         #expect(merged?.customHeaders["X-Api-Key"] == "NEW")
     }
 }


### PR DESCRIPTION
## Summary
Addresses round-5 Yellows on #594:

- **Yellow 1** — Updating an AI gateway no longer wipes stored auth-header secrets. Blank header values from the local editor (stripped transport) merge with the currently-stored gateway under `withConfigLock`.
- **Yellow 2** — `CrowDaemon.reexec` resolves the real executable path (`_NSGetExecutablePath` / `/proc/self/exe`) and falls back to `execvp`, so a PATH-launched `crowd` restarts after the first-run wizard instead of `exit(1)`.

Greens left as-is (non-blocking).

## Test plan
- [x] `swift test --package-path Packages/CrowDaemon --filter 'SecretGatewayValidationTests|ReexecPathResolutionTests'` (8/8)
- [ ] Local: edit only a gateway base URL → stored API key still present after save
- [ ] Local: `crowd` from PATH → complete first-run wizard → daemon comes back online without manual relaunch


Made with [Cursor](https://cursor.com)