### PR TITLE
Add crow job CLI: list/get/add/edit/enable/run/delete (closes #604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 - #228 — Settings split into discrete tabs; every automation toggle lives under Settings → Automation. New `docs/automation.md` covers the full lifecycle.
 - #327 — Scheduled Jobs scope to a workspace + repo, where the repo picker is populated from the workspace's provider by expanding its "Always Include Repos" specs (`owner/*` globs or `owner/repo` slugs). Repos not yet checked out are cloned on demand when the job fires.
 - #461 — Remove the PR auto-label workflow (reverts #222); `crow:auto` on a PR was a no-op since only assigned issues consume the label. The label itself stays for issue auto-launch.
+- #604 — Full job management from the CLI: `crow job list/get/add/edit/enable/disable/run/delete/duplicate`. Mutations route through the running app's live config (picked up by the scheduler and Settings UI without a restart), and `crow job run --id` fires a job immediately regardless of its schedule or enabled flag, returning the launched session/terminal ids.
 
 ### Review Board & Sessions
 

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/JobCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/JobCommands.swift
@@ -86,6 +86,8 @@ public struct JobAdd: ParsableCommand {
     public init() {}
 
     public func validate() throws {
+        try validateJobName(name)
+        try validateRepoSlug(repo)
         guard try JobScheduleArgs.scheduleJSON(
             intervalSeconds: intervalSeconds, dailyAt: dailyAt, weekdays: weekdays
         ) != nil else {
@@ -123,8 +125,9 @@ public struct JobEdit: ParsableCommand {
         discussion: """
         Only the provided flags change; everything else keeps its value. Any \
         --prompt/--prompt-file replaces the job's whole prompt list, and any \
-        schedule flag replaces the whole schedule. Use enable/disable to toggle \
-        the enabled flag.
+        schedule flag replaces the whole schedule — so changing --weekdays \
+        requires restating --daily-at. Use enable/disable to toggle the \
+        enabled flag.
         """
     )
 
@@ -148,6 +151,8 @@ public struct JobEdit: ParsableCommand {
 
     public func validate() throws {
         try validateUUID(id, label: "job UUID")
+        if let name { try validateJobName(name) }
+        if let repo { try validateRepoSlug(repo) }
         _ = try JobScheduleArgs.scheduleJSON(
             intervalSeconds: intervalSeconds, dailyAt: dailyAt, weekdays: weekdays
         )

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/JobCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/JobCommands.swift
@@ -1,0 +1,278 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+/// Parent command for scheduled-job management: `crow job <subcommand>`.
+///
+/// Jobs are timed prompt-sets scoped to a repo (the Jobs sidebar feature).
+/// Every subcommand goes through the running app's RPC socket so mutations hit
+/// the app's live in-memory config — the scheduler and the Settings UI pick
+/// them up immediately, with no app restart.
+public struct Job: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "job",
+        abstract: "Manage scheduled jobs",
+        subcommands: [
+            JobList.self,
+            JobGet.self,
+            JobAdd.self,
+            JobEdit.self,
+            JobEnable.self,
+            JobDisable.self,
+            JobRun.self,
+            JobDelete.self,
+            JobDuplicate.self,
+        ]
+    )
+
+    public init() {}
+}
+
+public struct JobList: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "list", abstract: "List all jobs")
+
+    public init() {}
+
+    public func run() throws {
+        let result = try rpc("job-list")
+        printJSON(result)
+    }
+}
+
+public struct JobGet: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "get", abstract: "Show one job's full details")
+
+    @Option(name: .long, help: "Job UUID") var id: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("job-get", params: ["job_id": .string(id)])
+        printJSON(result)
+    }
+}
+
+public struct JobAdd: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "add",
+        abstract: "Create a job",
+        discussion: """
+        Prompts are sent in order: every --prompt first, then the contents of \
+        every --prompt-file. Exactly one schedule is required: --interval-seconds \
+        or --daily-at HH:MM (optionally restricted with --weekdays).
+        """
+    )
+
+    @Option(name: .long, help: "Job name (must be unique)") var name: String
+    @Option(name: .long, help: "Workspace name (folder under the dev root)") var workspace: String
+    @Option(name: .long, help: "Repository slug (owner/repo)") var repo: String
+    @Option(name: .long, parsing: .singleValue, help: "Prompt text (repeatable; sent in order)")
+    var prompt: [String] = []
+    @Option(name: .customLong("prompt-file"), parsing: .singleValue,
+            help: "Read a prompt from a file; '-' reads stdin (repeatable)")
+    var promptFile: [String] = []
+    @Option(name: .customLong("interval-seconds"), help: "Run every N seconds")
+    var intervalSeconds: Int?
+    @Option(name: .customLong("daily-at"), help: "Run daily at HH:MM (24-hour, local time)")
+    var dailyAt: String?
+    @Option(name: .long, help: "Comma-separated weekdays for --daily-at (sun,mon,… or 1-7); omit for every day")
+    var weekdays: String?
+    @Flag(name: .long, help: "Create the job disabled") var disabled: Bool = false
+
+    public init() {}
+
+    public func validate() throws {
+        guard try JobScheduleArgs.scheduleJSON(
+            intervalSeconds: intervalSeconds, dailyAt: dailyAt, weekdays: weekdays
+        ) != nil else {
+            throw ValidationError("A schedule is required: --interval-seconds or --daily-at.")
+        }
+        guard !prompt.isEmpty || !promptFile.isEmpty else {
+            throw ValidationError("At least one --prompt or --prompt-file is required.")
+        }
+        guard promptFile.filter({ $0 == "-" }).count <= 1 else {
+            throw ValidationError("At most one --prompt-file may read from stdin ('-').")
+        }
+    }
+
+    public func run() throws {
+        let schedule = try JobScheduleArgs.scheduleJSON(
+            intervalSeconds: intervalSeconds, dailyAt: dailyAt, weekdays: weekdays
+        )!
+        let prompts = try prompt + promptFile.map(JobScheduleArgs.readPromptText)
+        let result = try rpc("job-add", params: [
+            "name": .string(name),
+            "workspace": .string(workspace),
+            "repo": .string(repo),
+            "prompts": .array(prompts.map { .string($0) }),
+            "schedule": schedule,
+            "enabled": .bool(!disabled),
+        ])
+        printJSON(result)
+    }
+}
+
+public struct JobEdit: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "edit",
+        abstract: "Update fields on an existing job",
+        discussion: """
+        Only the provided flags change; everything else keeps its value. Any \
+        --prompt/--prompt-file replaces the job's whole prompt list, and any \
+        schedule flag replaces the whole schedule. Use enable/disable to toggle \
+        the enabled flag.
+        """
+    )
+
+    @Option(name: .long, help: "Job UUID") var id: String
+    @Option(name: .long, help: "New job name (must be unique)") var name: String?
+    @Option(name: .long, help: "New workspace name") var workspace: String?
+    @Option(name: .long, help: "New repository slug (owner/repo)") var repo: String?
+    @Option(name: .long, parsing: .singleValue, help: "Replacement prompt text (repeatable; replaces all prompts)")
+    var prompt: [String] = []
+    @Option(name: .customLong("prompt-file"), parsing: .singleValue,
+            help: "Read a replacement prompt from a file; '-' reads stdin (repeatable)")
+    var promptFile: [String] = []
+    @Option(name: .customLong("interval-seconds"), help: "Run every N seconds")
+    var intervalSeconds: Int?
+    @Option(name: .customLong("daily-at"), help: "Run daily at HH:MM (24-hour, local time)")
+    var dailyAt: String?
+    @Option(name: .long, help: "Comma-separated weekdays for --daily-at (sun,mon,… or 1-7); omit for every day")
+    var weekdays: String?
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+        _ = try JobScheduleArgs.scheduleJSON(
+            intervalSeconds: intervalSeconds, dailyAt: dailyAt, weekdays: weekdays
+        )
+        guard name != nil || workspace != nil || repo != nil
+            || !prompt.isEmpty || !promptFile.isEmpty
+            || intervalSeconds != nil || dailyAt != nil else {
+            throw ValidationError("Nothing to edit — provide at least one field flag.")
+        }
+        guard promptFile.filter({ $0 == "-" }).count <= 1 else {
+            throw ValidationError("At most one --prompt-file may read from stdin ('-').")
+        }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["job_id": .string(id)]
+        if let name { params["name"] = .string(name) }
+        if let workspace { params["workspace"] = .string(workspace) }
+        if let repo { params["repo"] = .string(repo) }
+        if !prompt.isEmpty || !promptFile.isEmpty {
+            let prompts = try prompt + promptFile.map(JobScheduleArgs.readPromptText)
+            params["prompts"] = .array(prompts.map { .string($0) })
+        }
+        if let schedule = try JobScheduleArgs.scheduleJSON(
+            intervalSeconds: intervalSeconds, dailyAt: dailyAt, weekdays: weekdays
+        ) {
+            params["schedule"] = schedule
+        }
+        let result = try rpc("job-edit", params: params)
+        printJSON(result)
+    }
+}
+
+public struct JobEnable: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "enable", abstract: "Enable a job")
+
+    @Option(name: .long, help: "Job UUID") var id: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("job-enable", params: ["job_id": .string(id)])
+        printJSON(result)
+    }
+}
+
+public struct JobDisable: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "disable", abstract: "Disable a job")
+
+    @Option(name: .long, help: "Job UUID") var id: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("job-disable", params: ["job_id": .string(id)])
+        printJSON(result)
+    }
+}
+
+public struct JobRun: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Run a job now, regardless of its schedule or enabled flag",
+        discussion: """
+        Returns the launched session and terminal ids. The run continues in the \
+        app even if the CLI times out waiting (e.g. while a repo is cloned on \
+        demand).
+        """
+    )
+
+    @Option(name: .long, help: "Job UUID") var id: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+    }
+
+    public func run() throws {
+        // Launching can clone a repo on demand — allow well past the default 30s.
+        let result = try rpc("job-run", params: ["job_id": .string(id)], timeoutSeconds: 120)
+        printJSON(result)
+    }
+}
+
+public struct JobDelete: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "delete", abstract: "Delete a job")
+
+    @Option(name: .long, help: "Job UUID") var id: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("job-delete", params: ["job_id": .string(id)])
+        printJSON(result)
+    }
+}
+
+public struct JobDuplicate: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "duplicate",
+        abstract: "Duplicate a job (the copy starts disabled with a unique name)"
+    )
+
+    @Option(name: .long, help: "Job UUID") var id: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(id, label: "job UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("job-duplicate", params: ["job_id": .string(id)])
+        printJSON(result)
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -21,6 +21,7 @@ public struct CrowCommand: ParsableCommand {
             SetPinned.self,
             DeleteSession.self,
             SetTicket.self,
+            Job.self,
             AddWorktree.self,
             ListWorktrees.self,
             NewTerminal.self,

--- a/Packages/CrowCLI/Sources/CrowCLILib/Helpers.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Helpers.swift
@@ -7,11 +7,12 @@ import Foundation
 /// - Parameters:
 ///   - method: The RPC method name (e.g., "new-session").
 ///   - params: Key-value parameters for the RPC call.
+///   - timeoutSeconds: Read timeout for the response (default 30).
 /// - Returns: The result dictionary from the server response.
 /// - Throws: `ValidationError` if the server returns an error or the socket connection fails.
-public func rpc(_ method: String, params: [String: JSONValue] = [:]) throws -> [String: JSONValue] {
+public func rpc(_ method: String, params: [String: JSONValue] = [:], timeoutSeconds: Int = 30) throws -> [String: JSONValue] {
     let client = SocketClient()
-    let response = try client.send(method: method, params: params)
+    let response = try client.send(method: method, params: params, timeoutSeconds: timeoutSeconds)
     if let error = response.error {
         throw ValidationError("Error \(error.code): \(error.message)")
     }

--- a/Packages/CrowCLI/Sources/CrowCLILib/JobScheduleArgs.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/JobScheduleArgs.swift
@@ -1,0 +1,100 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+/// Parsing for the `crow job add`/`edit` schedule and prompt flags.
+///
+/// Emits the canonical `JobSchedule` JSON shape
+/// (`{"type":"interval","seconds":N}` /
+/// `{"type":"dailyAt","hour":H,"minute":M,"weekdays":[...]}`) so the app can
+/// decode it with the model's own `Codable` conformance.
+enum JobScheduleArgs {
+    /// Weekday names accepted by `--weekdays`, indexed by `Calendar` weekday
+    /// number (1 = Sunday … 7 = Saturday).
+    private static let weekdayNames = [
+        "sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday",
+    ]
+
+    /// Build the schedule JSON from the raw flag values, or `nil` when no
+    /// schedule flag was given (edit = "leave the schedule unchanged").
+    ///
+    /// - Throws: `ValidationError` when both schedule kinds are given, when
+    ///   `--weekdays` is used without `--daily-at`, or when a value is malformed.
+    static func scheduleJSON(intervalSeconds: Int?, dailyAt: String?, weekdays: String?) throws -> JSONValue? {
+        if intervalSeconds != nil && dailyAt != nil {
+            throw ValidationError("--interval-seconds and --daily-at are mutually exclusive.")
+        }
+        if weekdays != nil && dailyAt == nil {
+            throw ValidationError("--weekdays requires --daily-at.")
+        }
+        if let seconds = intervalSeconds {
+            guard seconds >= 1 else {
+                throw ValidationError("--interval-seconds must be at least 1.")
+            }
+            return .object(["type": .string("interval"), "seconds": .int(seconds)])
+        }
+        if let dailyAt {
+            let (hour, minute) = try parseHHMM(dailyAt)
+            let days = try weekdays.map(parseWeekdays) ?? []
+            return .object([
+                "type": .string("dailyAt"),
+                "hour": .int(hour),
+                "minute": .int(minute),
+                "weekdays": .array(days.map { .int($0) }),
+            ])
+        }
+        return nil
+    }
+
+    /// Parse a "HH:MM" (24-hour) time; single-digit hours are accepted.
+    static func parseHHMM(_ value: String) throws -> (hour: Int, minute: Int) {
+        let parts = value.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let hour = Int(parts[0]), let minute = Int(parts[1]),
+              (0...23).contains(hour), (0...59).contains(minute) else {
+            throw ValidationError("'\(value)' is not a valid time. Expected HH:MM (24-hour), e.g. 09:30.")
+        }
+        return (hour, minute)
+    }
+
+    /// Parse a comma-separated weekday list into sorted, deduped `Calendar`
+    /// weekday numbers. Accepts names ("mon", "monday", case-insensitive)
+    /// or integers 1–7 (1 = Sunday … 7 = Saturday).
+    static func parseWeekdays(_ value: String) throws -> [Int] {
+        var days = Set<Int>()
+        for token in value.split(separator: ",") {
+            let trimmed = token.trimmingCharacters(in: .whitespaces).lowercased()
+            if let n = Int(trimmed) {
+                guard (1...7).contains(n) else {
+                    throw ValidationError("'\(trimmed)' is not a valid weekday number (1 = Sunday … 7 = Saturday).")
+                }
+                days.insert(n)
+            } else if trimmed.count >= 3,
+                      let idx = weekdayNames.firstIndex(where: { $0.hasPrefix(trimmed) }) {
+                days.insert(idx + 1)
+            } else {
+                throw ValidationError("'\(trimmed)' is not a valid weekday. Use names (sun…sat) or numbers 1–7.")
+            }
+        }
+        guard !days.isEmpty else {
+            throw ValidationError("--weekdays must list at least one weekday.")
+        }
+        return days.sorted()
+    }
+
+    /// Read a prompt from a file path, or from stdin when the path is "-".
+    static func readPromptText(_ path: String) throws -> String {
+        if path == "-" {
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw ValidationError("stdin is not valid UTF-8.")
+            }
+            return text
+        }
+        do {
+            return try String(contentsOfFile: path, encoding: .utf8)
+        } catch {
+            throw ValidationError("Could not read prompt file '\(path)': \(error.localizedDescription)")
+        }
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -34,6 +34,30 @@ func validateLinkType(_ value: String) throws {
     }
 }
 
+/// Validate that a job repo is an `owner/repo` slug (nested GitLab groups
+/// allowed). The slug's last component becomes an on-disk folder name, so
+/// path-like components (`.`, `..`, empty) are rejected. Mirrors the server's
+/// check for fast local feedback.
+///
+/// - Throws: `ValidationError` for a bare name or path-like slug.
+func validateRepoSlug(_ value: String) throws {
+    let repo = value.trimmingCharacters(in: .whitespaces)
+    let components = repo.split(separator: "/", omittingEmptySubsequences: false)
+    guard components.count >= 2,
+          components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+        throw ValidationError("'\(value)' is not a valid repo. Expected an owner/repo slug (e.g. radiusmethod/crow); components must not be empty, '.', or '..'.")
+    }
+}
+
+/// Validate that a job name is not blank after trimming.
+///
+/// - Throws: `ValidationError` for an empty or whitespace-only name.
+func validateJobName(_ value: String) throws {
+    guard !value.trimmingCharacters(in: .whitespaces).isEmpty else {
+        throw ValidationError("--name must not be blank.")
+    }
+}
+
 /// Validate that at least one optional field is provided for set-ticket.
 ///
 /// - Throws: `ValidationError` if all three fields are nil.

--- a/Packages/CrowCLI/Tests/CrowCLITests/JobCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/JobCommandParsingTests.swift
@@ -84,6 +84,36 @@ private let jobUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
 }
 
+@Test func jobAddRejectsBlankName() {
+    #expect(throws: (any Error).self) {
+        _ = try JobAdd.parse(["--name", "  ", "--workspace", "ws", "--repo", "o/r", "--prompt", "p", "--interval-seconds", "60"])
+    }
+}
+
+@Test func jobAddRejectsBareOrPathLikeRepo() {
+    // repo must be an owner/repo slug; its last component becomes a folder
+    // name, so bare names and path-like components are rejected client-side.
+    for bad in ["api", "foo/..", "../foo", "/repo", "owner/"] {
+        #expect(throws: (any Error).self, "expected '\(bad)' to be rejected") {
+            _ = try JobAdd.parse(["--name", "x", "--workspace", "ws", "--repo", bad, "--prompt", "p", "--interval-seconds", "60"])
+        }
+    }
+}
+
+@Test func jobAddAcceptsNestedGroupRepo() throws {
+    let cmd = try JobAdd.parse(["--name", "x", "--workspace", "ws", "--repo", "group/sub/project", "--prompt", "p", "--interval-seconds", "60"])
+    #expect(cmd.repo == "group/sub/project")
+}
+
+@Test func jobEditRejectsBlankNameAndBadRepo() {
+    #expect(throws: (any Error).self) {
+        _ = try JobEdit.parse(["--id", jobUUID, "--name", "  "])
+    }
+    #expect(throws: (any Error).self) {
+        _ = try JobEdit.parse(["--id", jobUUID, "--repo", "foo/.."])
+    }
+}
+
 @Test func jobEditParsesPartialFields() throws {
     let cmd = try JobEdit.parse(["--id", jobUUID, "--name", "renamed"])
     #expect(cmd.id == jobUUID)

--- a/Packages/CrowCLI/Tests/CrowCLITests/JobCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/JobCommandParsingTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+import ArgumentParser
+@testable import CrowCLILib
+
+// MARK: - `crow job` command parsing (CROW-604)
+
+private let jobUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+@Test func jobAddParsesFullArgs() throws {
+    let cmd = try JobAdd.parse([
+        "--name", "nightly triage",
+        "--workspace", "RadiusMethod",
+        "--repo", "radiusmethod/api",
+        "--prompt", "first prompt",
+        "--prompt", "second prompt",
+        "--daily-at", "09:30",
+        "--weekdays", "mon,fri",
+        "--disabled",
+    ])
+    #expect(cmd.name == "nightly triage")
+    #expect(cmd.workspace == "RadiusMethod")
+    #expect(cmd.repo == "radiusmethod/api")
+    #expect(cmd.prompt == ["first prompt", "second prompt"])
+    #expect(cmd.dailyAt == "09:30")
+    #expect(cmd.weekdays == "mon,fri")
+    #expect(cmd.disabled)
+}
+
+@Test func jobAddParsesIntervalSchedule() throws {
+    let cmd = try JobAdd.parse([
+        "--name", "hourly", "--workspace", "ws", "--repo", "o/r",
+        "--prompt", "p", "--interval-seconds", "3600",
+    ])
+    #expect(cmd.intervalSeconds == 3600)
+    #expect(!cmd.disabled)
+}
+
+@Test func jobAddRequiresSchedule() {
+    // validate() runs during parse, so a missing schedule throws here.
+    #expect(throws: (any Error).self) {
+        _ = try JobAdd.parse(["--name", "x", "--workspace", "ws", "--repo", "o/r", "--prompt", "p"])
+    }
+}
+
+@Test func jobAddRejectsBothSchedules() {
+    #expect(throws: (any Error).self) {
+        _ = try JobAdd.parse([
+            "--name", "x", "--workspace", "ws", "--repo", "o/r", "--prompt", "p",
+            "--interval-seconds", "60", "--daily-at", "09:00",
+        ])
+    }
+}
+
+@Test func jobAddRejectsWeekdaysWithoutDailyAt() {
+    #expect(throws: (any Error).self) {
+        _ = try JobAdd.parse([
+            "--name", "x", "--workspace", "ws", "--repo", "o/r", "--prompt", "p",
+            "--interval-seconds", "60", "--weekdays", "mon",
+        ])
+    }
+}
+
+@Test func jobAddRequiresPrompt() {
+    #expect(throws: (any Error).self) {
+        _ = try JobAdd.parse(["--name", "x", "--workspace", "ws", "--repo", "o/r", "--interval-seconds", "60"])
+    }
+}
+
+@Test func jobAddAcceptsPromptFileOnly() throws {
+    let cmd = try JobAdd.parse([
+        "--name", "x", "--workspace", "ws", "--repo", "o/r",
+        "--prompt-file", "/tmp/prompt.md", "--interval-seconds", "60",
+    ])
+    #expect(cmd.promptFile == ["/tmp/prompt.md"])
+}
+
+@Test func jobAddRejectsMultipleStdinPromptFiles() {
+    #expect(throws: (any Error).self) {
+        _ = try JobAdd.parse([
+            "--name", "x", "--workspace", "ws", "--repo", "o/r",
+            "--prompt-file", "-", "--prompt-file", "-", "--interval-seconds", "60",
+        ])
+    }
+}
+
+@Test func jobEditParsesPartialFields() throws {
+    let cmd = try JobEdit.parse(["--id", jobUUID, "--name", "renamed"])
+    #expect(cmd.id == jobUUID)
+    #expect(cmd.name == "renamed")
+    #expect(cmd.workspace == nil)
+    #expect(cmd.repo == nil)
+    #expect(cmd.prompt.isEmpty)
+    #expect(cmd.intervalSeconds == nil)
+}
+
+@Test func jobEditParsesScheduleChange() throws {
+    let cmd = try JobEdit.parse(["--id", jobUUID, "--daily-at", "18:00", "--weekdays", "sat,sun"])
+    #expect(cmd.dailyAt == "18:00")
+    #expect(cmd.weekdays == "sat,sun")
+}
+
+@Test func jobEditRequiresAtLeastOneField() {
+    #expect(throws: (any Error).self) {
+        _ = try JobEdit.parse(["--id", jobUUID])
+    }
+}
+
+@Test func jobEditRejectsInvalidUUID() {
+    #expect(throws: (any Error).self) {
+        _ = try JobEdit.parse(["--id", "not-a-uuid", "--name", "x"])
+    }
+}
+
+@Test func jobIdSubcommandsParseValidUUID() throws {
+    #expect(try JobGet.parse(["--id", jobUUID]).id == jobUUID)
+    #expect(try JobEnable.parse(["--id", jobUUID]).id == jobUUID)
+    #expect(try JobDisable.parse(["--id", jobUUID]).id == jobUUID)
+    #expect(try JobRun.parse(["--id", jobUUID]).id == jobUUID)
+    #expect(try JobDelete.parse(["--id", jobUUID]).id == jobUUID)
+    #expect(try JobDuplicate.parse(["--id", jobUUID]).id == jobUUID)
+}
+
+@Test func jobIdSubcommandsRejectInvalidUUID() {
+    #expect(throws: (any Error).self) { _ = try JobGet.parse(["--id", "nope"]) }
+    #expect(throws: (any Error).self) { _ = try JobEnable.parse(["--id", "nope"]) }
+    #expect(throws: (any Error).self) { _ = try JobDisable.parse(["--id", "nope"]) }
+    #expect(throws: (any Error).self) { _ = try JobRun.parse(["--id", "nope"]) }
+    #expect(throws: (any Error).self) { _ = try JobDelete.parse(["--id", "nope"]) }
+    #expect(throws: (any Error).self) { _ = try JobDuplicate.parse(["--id", "nope"]) }
+}
+
+@Test func jobGroupRoutesToSubcommands() throws {
+    // The nested `crow job <sub>` group resolves each verb to its command type.
+    let parsed = try Job.parseAsRoot(["list"])
+    #expect(parsed is JobList)
+    let get = try Job.parseAsRoot(["get", "--id", jobUUID])
+    #expect(get is JobGet)
+}

--- a/Packages/CrowCLI/Tests/CrowCLITests/JobScheduleArgsTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/JobScheduleArgsTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+import CrowIPC
+@testable import CrowCLILib
+
+// MARK: - HH:MM parsing
+
+@Test func parseHHMMAcceptsPaddedAndBareHours() throws {
+    var t = try JobScheduleArgs.parseHHMM("09:30")
+    #expect(t.hour == 9 && t.minute == 30)
+    t = try JobScheduleArgs.parseHHMM("9:05")
+    #expect(t.hour == 9 && t.minute == 5)
+    t = try JobScheduleArgs.parseHHMM("23:59")
+    #expect(t.hour == 23 && t.minute == 59)
+    t = try JobScheduleArgs.parseHHMM("0:00")
+    #expect(t.hour == 0 && t.minute == 0)
+}
+
+@Test func parseHHMMRejectsMalformedTimes() {
+    for bad in ["25:00", "9:60", "930", "9", "9:3:0", "", "ab:cd", "-1:30"] {
+        #expect(throws: (any Error).self, "expected '\(bad)' to be rejected") {
+            _ = try JobScheduleArgs.parseHHMM(bad)
+        }
+    }
+}
+
+// MARK: - Weekday parsing
+
+@Test func parseWeekdaysAcceptsNamesAndNumbers() throws {
+    #expect(try JobScheduleArgs.parseWeekdays("mon,wed,fri") == [2, 4, 6])
+    #expect(try JobScheduleArgs.parseWeekdays("Sunday,saturday") == [1, 7])
+    #expect(try JobScheduleArgs.parseWeekdays("1,7") == [1, 7])
+    #expect(try JobScheduleArgs.parseWeekdays("tue, thu") == [3, 5])
+}
+
+@Test func parseWeekdaysDedupesAndSorts() throws {
+    #expect(try JobScheduleArgs.parseWeekdays("fri,mon,fri,2") == [2, 6])
+}
+
+@Test func parseWeekdaysRejectsInvalidTokens() {
+    for bad in ["0", "8", "funday", "mo", ""] {
+        #expect(throws: (any Error).self, "expected '\(bad)' to be rejected") {
+            _ = try JobScheduleArgs.parseWeekdays(bad)
+        }
+    }
+}
+
+// MARK: - Schedule JSON
+
+@Test func scheduleJSONEmitsCanonicalInterval() throws {
+    let json = try JobScheduleArgs.scheduleJSON(intervalSeconds: 3600, dailyAt: nil, weekdays: nil)
+    #expect(json == .object(["type": .string("interval"), "seconds": .int(3600)]))
+}
+
+@Test func scheduleJSONEmitsCanonicalDailyAt() throws {
+    let json = try JobScheduleArgs.scheduleJSON(intervalSeconds: nil, dailyAt: "09:30", weekdays: "fri,mon")
+    #expect(json == .object([
+        "type": .string("dailyAt"),
+        "hour": .int(9),
+        "minute": .int(30),
+        "weekdays": .array([.int(2), .int(6)]),
+    ]))
+}
+
+@Test func scheduleJSONDailyAtWithoutWeekdaysMeansEveryDay() throws {
+    let json = try JobScheduleArgs.scheduleJSON(intervalSeconds: nil, dailyAt: "6:00", weekdays: nil)
+    #expect(json?.objectValue?["weekdays"] == .array([]))
+}
+
+@Test func scheduleJSONReturnsNilWhenNoScheduleFlags() throws {
+    #expect(try JobScheduleArgs.scheduleJSON(intervalSeconds: nil, dailyAt: nil, weekdays: nil) == nil)
+}
+
+@Test func scheduleJSONRejectsBothKinds() {
+    #expect(throws: (any Error).self) {
+        _ = try JobScheduleArgs.scheduleJSON(intervalSeconds: 60, dailyAt: "09:00", weekdays: nil)
+    }
+}
+
+@Test func scheduleJSONRejectsWeekdaysWithoutDailyAt() {
+    #expect(throws: (any Error).self) {
+        _ = try JobScheduleArgs.scheduleJSON(intervalSeconds: 60, dailyAt: nil, weekdays: "mon")
+    }
+    #expect(throws: (any Error).self) {
+        _ = try JobScheduleArgs.scheduleJSON(intervalSeconds: nil, dailyAt: nil, weekdays: "mon")
+    }
+}
+
+@Test func scheduleJSONRejectsNonPositiveInterval() {
+    for bad in [0, -5] {
+        #expect(throws: (any Error).self) {
+            _ = try JobScheduleArgs.scheduleJSON(intervalSeconds: bad, dailyAt: nil, weekdays: nil)
+        }
+    }
+}
+
+// MARK: - Prompt files
+
+@Test func readPromptTextReadsFileContents() throws {
+    let path = NSTemporaryDirectory() + "crow-prompt-\(UUID().uuidString).md"
+    try "triage the error store\n".write(toFile: path, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    #expect(try JobScheduleArgs.readPromptText(path) == "triage the error store\n")
+}
+
+@Test func readPromptTextRejectsMissingFile() {
+    #expect(throws: (any Error).self) {
+        _ = try JobScheduleArgs.readPromptText("/nonexistent/prompt-\(UUID().uuidString).md")
+    }
+}

--- a/Packages/CrowIPC/Sources/CrowIPC/SocketClient.swift
+++ b/Packages/CrowIPC/Sources/CrowIPC/SocketClient.swift
@@ -13,8 +13,8 @@ import Glibc
 public struct SocketClient: Sendable {
     private let socketPath: String
 
-    /// Read timeout in seconds applied via `SO_RCVTIMEO`.
-    private static let readTimeoutSeconds: Int = 30
+    /// Default read timeout in seconds applied via `SO_RCVTIMEO`.
+    public static let readTimeoutSeconds: Int = 30
 
     public init(socketPath: String? = nil) {
         self.socketPath = socketPath ?? {
@@ -28,10 +28,16 @@ public struct SocketClient: Sendable {
 
     /// Send a JSON-RPC request and return the response.
     ///
-    /// - Throws: `SocketError.timeout` if the server doesn't respond within 30 seconds.
+    /// - Parameter timeoutSeconds: Read timeout; defaults to 30. Slow methods
+    ///   (e.g. `job-run`, which may clone a repo) pass a larger value.
+    /// - Throws: `SocketError.timeout` if the server doesn't respond within the timeout.
     /// - Throws: `SocketError.responseTooLarge` if the response exceeds 1 MB.
     /// - Throws: `SocketError.writeFailed` if sending the request fails.
-    public func send(method: String, params: [String: JSONValue] = [:]) throws -> JSONRPCResponse {
+    public func send(
+        method: String,
+        params: [String: JSONValue] = [:],
+        timeoutSeconds: Int = SocketClient.readTimeoutSeconds
+    ) throws -> JSONRPCResponse {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
             throw SocketError.createFailed(errno)
@@ -59,7 +65,7 @@ public struct SocketClient: Sendable {
         }
 
         // Set read timeout so a hung server doesn't block the CLI indefinitely
-        var timeout = timeval(tv_sec: Self.readTimeoutSeconds, tv_usec: 0)
+        var timeout = timeval(tv_sec: timeoutSeconds, tv_usec: 0)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
 
         // Send request

--- a/Packages/CrowIPC/Tests/CrowIPCTests/SocketRoundTripTests.swift
+++ b/Packages/CrowIPC/Tests/CrowIPCTests/SocketRoundTripTests.swift
@@ -228,3 +228,46 @@ private func startServer(
         _ = try client.send(method: "test")
     }
 }
+
+@Test func nestedObjectParamsSurviveRoundTrip() throws {
+    // The `job-add`/`job-edit` RPCs send the schedule as a nested JSON object
+    // and prompts as an array (CROW-604) — assert compound JSONValue params
+    // survive client → server → handler → response intact.
+    let path = tempSocketPath()
+    let server = try startServer(path: path, handlers: [
+        "job-add": { @Sendable params in
+            ["schedule": params["schedule"] ?? .null, "prompts": params["prompts"] ?? .null]
+        },
+    ])
+    defer { server.stop(); unlink(path) }
+
+    let schedule = JSONValue.object([
+        "type": .string("dailyAt"),
+        "hour": .int(9),
+        "minute": .int(30),
+        "weekdays": .array([.int(2), .int(6)]),
+    ])
+    let prompts = JSONValue.array([.string("first"), .string("second")])
+    let client = SocketClient(socketPath: path)
+    let response = try client.send(method: "job-add", params: ["schedule": schedule, "prompts": prompts])
+    #expect(response.error == nil)
+    #expect(response.result?["schedule"] == schedule)
+    #expect(response.result?["prompts"] == prompts)
+}
+
+@Test func clientAcceptsPerCallTimeout() throws {
+    // `job run` passes a longer read timeout; a short one must still time out.
+    let path = tempSocketPath()
+    let server = try startServer(path: path, handlers: [
+        "slow": { @Sendable _ in
+            try await Task.sleep(nanoseconds: 60_000_000_000) // 60s
+            return [:]
+        },
+    ])
+    defer { server.stop(); unlink(path) }
+
+    let client = SocketClient(socketPath: path)
+    #expect(throws: SocketError.self) {
+        _ = try client.send(method: "slow", timeoutSeconds: 1)
+    }
+}

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1347,22 +1347,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return appConfig
     }
 
-    /// Canonical job mutation: transform the live in-memory `appConfig` (the
-    /// same source the scheduler's `jobsProvider` and the Settings UI read),
-    /// reassign, then persist. Mirrors `recordJobRun`, but surfaces save
-    /// failures to the CLI instead of just logging them.
+    /// Canonical job mutation: transform a copy of the live `appConfig`,
+    /// persist it, and only then swap it in as the in-memory config (the same
+    /// source the scheduler's `jobsProvider` and the Settings UI read).
+    /// Persisting first means a failed disk write leaves memory and disk
+    /// consistent — the CLI gets an error and nothing changed.
     @discardableResult
     private func mutateJobConfig<T>(_ transform: (inout AppConfig) throws -> T) throws -> T {
         guard var config = appConfig, let devRoot else {
             throw RPCError.applicationError("App not fully initialized — no dev root/config loaded")
         }
         let result = try transform(&config)
-        self.appConfig = config
         do {
             try ConfigStore.saveConfig(config, devRoot: devRoot)
         } catch {
-            throw RPCError.applicationError("Job change applied in memory but failed to persist: \(error.localizedDescription)")
+            throw RPCError.applicationError("Failed to persist job change: \(error.localizedDescription)")
         }
+        self.appConfig = config
         return result
     }
 
@@ -1380,16 +1381,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleJobAdd(params: [String: JSONValue]) throws -> [String: JSONValue] {
-        guard let name = params["name"]?.stringValue else {
-            throw RPCError.invalidParams("name required")
-        }
+        let name = try JobRPC.decodeName(params["name"])
         guard let workspace = params["workspace"]?.stringValue else {
             throw RPCError.invalidParams("workspace required")
         }
-        let repo = params["repo"]?.stringValue?.trimmingCharacters(in: .whitespaces) ?? ""
-        guard !repo.isEmpty else {
-            throw RPCError.invalidParams("repo required (owner/repo slug)")
-        }
+        let repo = try JobRPC.validateRepoSlug(params["repo"]?.stringValue ?? "")
         guard let scheduleValue = params["schedule"] else {
             throw RPCError.invalidParams("schedule required")
         }
@@ -1421,23 +1417,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 throw RPCError.applicationError("Job not found")
             }
             var job = config.jobs[idx]
-            if let name = params["name"]?.stringValue, name != job.name {
-                let otherNames = config.jobs.filter { $0.id != id }.map(\.name)
-                if let error = JobConfig.validateName(name, existingNames: otherNames) {
-                    throw RPCError.invalidParams(error)
+            if params["name"] != nil {
+                let name = try JobRPC.decodeName(params["name"])
+                if name != job.name {
+                    let otherNames = config.jobs.filter { $0.id != id }.map(\.name)
+                    if let error = JobConfig.validateName(name, existingNames: otherNames) {
+                        throw RPCError.invalidParams(error)
+                    }
+                    job.name = name
                 }
-                job.name = name
             }
             if let workspace = params["workspace"]?.stringValue {
                 try Self.validateJobWorkspace(workspace, config: config)
                 job.workspace = workspace
             }
             if let repo = params["repo"]?.stringValue {
-                let trimmed = repo.trimmingCharacters(in: .whitespaces)
-                guard !trimmed.isEmpty else {
-                    throw RPCError.invalidParams("repo must not be empty")
-                }
-                job.repo = trimmed
+                job.repo = try JobRPC.validateRepoSlug(repo)
             }
             if let newPrompts { job.prompts = newPrompts }
             if let newSchedule { job.schedule = newSchedule }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1322,6 +1322,187 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - Job RPC handlers (CROW-604)
+
+    /// Parse the `job_id` param shared by every id-taking `job-*` method.
+    private nonisolated static func jobID(from params: [String: JSONValue]) throws -> UUID {
+        guard let idStr = params["job_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
+            throw RPCError.invalidParams("job_id required (UUID)")
+        }
+        return id
+    }
+
+    private nonisolated static func validateJobWorkspace(_ workspace: String, config: AppConfig) throws {
+        guard config.workspaces.contains(where: { $0.name == workspace }) else {
+            throw RPCError.invalidParams("Unknown workspace '\(workspace)'")
+        }
+    }
+
+    /// The live config, or a clean RPC error when the app hasn't finished
+    /// launching (e.g. the setup wizard hasn't completed).
+    private func requireJobConfig() throws -> AppConfig {
+        guard let appConfig else {
+            throw RPCError.applicationError("App not fully initialized — no config loaded")
+        }
+        return appConfig
+    }
+
+    /// Canonical job mutation: transform the live in-memory `appConfig` (the
+    /// same source the scheduler's `jobsProvider` and the Settings UI read),
+    /// reassign, then persist. Mirrors `recordJobRun`, but surfaces save
+    /// failures to the CLI instead of just logging them.
+    @discardableResult
+    private func mutateJobConfig<T>(_ transform: (inout AppConfig) throws -> T) throws -> T {
+        guard var config = appConfig, let devRoot else {
+            throw RPCError.applicationError("App not fully initialized — no dev root/config loaded")
+        }
+        let result = try transform(&config)
+        self.appConfig = config
+        do {
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+        } catch {
+            throw RPCError.applicationError("Job change applied in memory but failed to persist: \(error.localizedDescription)")
+        }
+        return result
+    }
+
+    private func handleJobList() throws -> [String: JSONValue] {
+        let config = try requireJobConfig()
+        return ["jobs": .array(config.jobs.map { JobRPC.jobJSON($0) })]
+    }
+
+    private func handleJobGet(id: UUID) throws -> [String: JSONValue] {
+        let config = try requireJobConfig()
+        guard let job = config.jobs.first(where: { $0.id == id }) else {
+            throw RPCError.applicationError("Job not found")
+        }
+        return ["job": JobRPC.jobJSON(job)]
+    }
+
+    private func handleJobAdd(params: [String: JSONValue]) throws -> [String: JSONValue] {
+        guard let name = params["name"]?.stringValue else {
+            throw RPCError.invalidParams("name required")
+        }
+        guard let workspace = params["workspace"]?.stringValue else {
+            throw RPCError.invalidParams("workspace required")
+        }
+        let repo = params["repo"]?.stringValue?.trimmingCharacters(in: .whitespaces) ?? ""
+        guard !repo.isEmpty else {
+            throw RPCError.invalidParams("repo required (owner/repo slug)")
+        }
+        guard let scheduleValue = params["schedule"] else {
+            throw RPCError.invalidParams("schedule required")
+        }
+        let schedule = try JobRPC.decodeSchedule(scheduleValue)
+        let prompts = try JobRPC.decodePrompts(params["prompts"])
+        let enabled = params["enabled"]?.boolValue ?? true
+        let job = try mutateJobConfig { config -> JobConfig in
+            try Self.validateJobWorkspace(workspace, config: config)
+            if let error = JobConfig.validateName(name, existingNames: config.jobs.map(\.name)) {
+                throw RPCError.invalidParams(error)
+            }
+            let job = JobConfig(
+                name: name, workspace: workspace, repo: repo,
+                prompts: prompts, schedule: schedule, enabled: enabled
+            )
+            config.jobs.append(job)
+            return job
+        }
+        return ["job": JobRPC.jobJSON(job)]
+    }
+
+    /// Patch semantics: only the provided params change; prompts and schedule
+    /// are replaced whole when present. Matches the Settings UI's replace-by-id.
+    private func handleJobEdit(id: UUID, params: [String: JSONValue]) throws -> [String: JSONValue] {
+        let newSchedule = try params["schedule"].map { try JobRPC.decodeSchedule($0) }
+        let newPrompts = try params["prompts"].map { try JobRPC.decodePrompts($0) }
+        let job = try mutateJobConfig { config -> JobConfig in
+            guard let idx = config.jobs.firstIndex(where: { $0.id == id }) else {
+                throw RPCError.applicationError("Job not found")
+            }
+            var job = config.jobs[idx]
+            if let name = params["name"]?.stringValue, name != job.name {
+                let otherNames = config.jobs.filter { $0.id != id }.map(\.name)
+                if let error = JobConfig.validateName(name, existingNames: otherNames) {
+                    throw RPCError.invalidParams(error)
+                }
+                job.name = name
+            }
+            if let workspace = params["workspace"]?.stringValue {
+                try Self.validateJobWorkspace(workspace, config: config)
+                job.workspace = workspace
+            }
+            if let repo = params["repo"]?.stringValue {
+                let trimmed = repo.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else {
+                    throw RPCError.invalidParams("repo must not be empty")
+                }
+                job.repo = trimmed
+            }
+            if let newPrompts { job.prompts = newPrompts }
+            if let newSchedule { job.schedule = newSchedule }
+            config.jobs[idx] = job
+            return job
+        }
+        return ["job": JobRPC.jobJSON(job)]
+    }
+
+    private func handleJobSetEnabled(id: UUID, enabled: Bool) throws -> [String: JSONValue] {
+        let job = try mutateJobConfig { config -> JobConfig in
+            guard let idx = config.jobs.firstIndex(where: { $0.id == id }) else {
+                throw RPCError.applicationError("Job not found")
+            }
+            config.jobs[idx].enabled = enabled
+            return config.jobs[idx]
+        }
+        return ["job": JobRPC.jobJSON(job)]
+    }
+
+    private func handleJobDelete(id: UUID) throws -> [String: JSONValue] {
+        try mutateJobConfig { config in
+            guard config.jobs.contains(where: { $0.id == id }) else {
+                throw RPCError.applicationError("Job not found")
+            }
+            config.jobs.removeAll { $0.id == id }
+        }
+        return ["deleted": .bool(true), "job_id": .string(id.uuidString)]
+    }
+
+    private func handleJobDuplicate(id: UUID) throws -> [String: JSONValue] {
+        let copy = try mutateJobConfig { config -> JobConfig in
+            guard let original = config.jobs.first(where: { $0.id == id }) else {
+                throw RPCError.applicationError("Job not found")
+            }
+            let copy = original.duplicated(existingNames: config.jobs.map(\.name))
+            config.jobs.append(copy)
+            return copy
+        }
+        return ["job": JobRPC.jobJSON(copy)]
+    }
+
+    /// Run a job immediately (ignoring its schedule/enabled flag) and return
+    /// the launched session/terminal ids. `lastRunAt` persistence rides the
+    /// existing `onJobRan` → `recordJobRun` wiring.
+    private func jobRunForCLI(_ id: UUID) async throws -> [String: JSONValue] {
+        let config = try requireJobConfig()
+        guard config.jobs.contains(where: { $0.id == id }) else {
+            throw RPCError.applicationError("Job not found")
+        }
+        guard let jobScheduler else {
+            throw RPCError.applicationError("Job scheduler is not running")
+        }
+        do {
+            let result = try await jobScheduler.runNowReporting(id)
+            return [
+                "job_id": .string(id.uuidString),
+                "session_id": .string(result.sessionID.uuidString),
+                "terminal_id": .string(result.terminalID.uuidString),
+            ]
+        } catch let error as JobScheduler.RunNowError {
+            throw RPCError.applicationError(error.localizedDescription)
+        }
+    }
+
     // MARK: - Socket Server
 
     /// Maximum allowed length for session names.
@@ -2068,6 +2249,55 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         "event_name": .string(eventName),
                     ]
                 }
+            },
+            // Job management (CROW-604). These read/mutate the *live*
+            // `appConfig` — the same source the scheduler's `jobsProvider` and
+            // the Settings UI use — so `self` is captured weakly and state is
+            // read at call time, never snapshotted at server start.
+            "job-list": { @Sendable [weak self] _ in
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobList() }
+            },
+            "job-get": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobGet(id: id) }
+            },
+            "job-add": { @Sendable [weak self] params in
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobAdd(params: params) }
+            },
+            "job-edit": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobEdit(id: id, params: params) }
+            },
+            "job-enable": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobSetEnabled(id: id, enabled: true) }
+            },
+            "job-disable": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobSetEnabled(id: id, enabled: false) }
+            },
+            "job-delete": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobDelete(id: id) }
+            },
+            "job-duplicate": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                return try await MainActor.run { try self.handleJobDuplicate(id: id) }
+            },
+            "job-run": { @Sendable [weak self] params in
+                let id = try AppDelegate.jobID(from: params)
+                guard let self else { throw RPCError.applicationError("App is shutting down") }
+                // Must await mid-handler (the launch itself), so this hops to
+                // the MainActor via the isolated method instead of MainActor.run.
+                return try await self.jobRunForCLI(id)
             },
         ])
 

--- a/Sources/Crow/App/JobRPCSupport.swift
+++ b/Sources/Crow/App/JobRPCSupport.swift
@@ -1,0 +1,78 @@
+import CrowCore
+import CrowIPC
+import Foundation
+
+/// Pure decode/encode helpers for the `job-*` RPC handlers (CROW-604).
+///
+/// Kept out of AppDelegate so the param validation and response shapes are
+/// unit-testable without a socket (same pattern as `JobScheduler.finishDecision`).
+enum JobRPC {
+    /// Decode the canonical `JobSchedule` JSON (`{"type":"interval",...}` /
+    /// `{"type":"dailyAt",...}`) and range-check it.
+    ///
+    /// - Throws: `RPCError.invalidParams` on a malformed shape or out-of-range
+    ///   values (seconds < 1, hour ∉ 0–23, minute ∉ 0–59, weekdays ⊄ 1–7).
+    static func decodeSchedule(_ value: JSONValue) throws -> JobSchedule {
+        let schedule: JobSchedule
+        do {
+            let data = try JSONEncoder().encode(value)
+            schedule = try JSONDecoder().decode(JobSchedule.self, from: data)
+        } catch {
+            throw RPCError.invalidParams(
+                "Malformed schedule. Expected {\"type\":\"interval\",\"seconds\":N} or {\"type\":\"dailyAt\",\"hour\":H,\"minute\":M,\"weekdays\":[1-7]}"
+            )
+        }
+        switch schedule {
+        case .interval(let seconds):
+            guard seconds >= 1 else {
+                throw RPCError.invalidParams("Schedule interval must be at least 1 second")
+            }
+        case .dailyAt(let hour, let minute, let weekdays):
+            guard (0...23).contains(hour), (0...59).contains(minute) else {
+                throw RPCError.invalidParams("Schedule time out of range (hour 0-23, minute 0-59)")
+            }
+            guard weekdays.allSatisfy({ (1...7).contains($0) }) else {
+                throw RPCError.invalidParams("Schedule weekdays must be 1-7 (1 = Sunday)")
+            }
+        }
+        return schedule
+    }
+
+    /// Extract a prompts array, requiring at least one non-empty prompt.
+    ///
+    /// - Throws: `RPCError.invalidParams` when missing, not an array of
+    ///   strings, or all prompts are blank.
+    static func decodePrompts(_ value: JSONValue?) throws -> [String] {
+        guard let items = value?.arrayValue else {
+            throw RPCError.invalidParams("prompts must be an array of strings")
+        }
+        let prompts = items.compactMap(\.stringValue)
+        guard prompts.count == items.count else {
+            throw RPCError.invalidParams("prompts must be an array of strings")
+        }
+        guard prompts.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            throw RPCError.invalidParams("At least one non-empty prompt is required")
+        }
+        return prompts
+    }
+
+    /// Canonical job JSON for RPC responses: snake_case keys, ISO8601 dates,
+    /// the model's own `schedule` encoding, plus a computed `next_run_at`
+    /// (`null` when the schedule is unsatisfiable). `last_run_at` is omitted
+    /// for a job that has never run.
+    static func jobJSON(_ job: JobConfig) -> JSONValue {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        guard let data = try? encoder.encode(job),
+              var object = (try? JSONDecoder().decode(JSONValue.self, from: data))?.objectValue else {
+            return .object(["id": .string(job.id.uuidString)])
+        }
+        if let next = job.nextRunDate(after: job.lastRunAt ?? job.createdAt) {
+            object["next_run_at"] = .string(ISO8601DateFormatter().string(from: next))
+        } else {
+            object["next_run_at"] = .null
+        }
+        return .object(object)
+    }
+}

--- a/Sources/Crow/App/JobRPCSupport.swift
+++ b/Sources/Crow/App/JobRPCSupport.swift
@@ -38,6 +38,36 @@ enum JobRPC {
         return schedule
     }
 
+    /// Extract and trim a job name, rejecting missing or whitespace-only
+    /// values (the Settings UI validates the trimmed name; mirror that here
+    /// so the CLI can't create a blank-named job).
+    ///
+    /// - Throws: `RPCError.invalidParams` when missing or blank after trimming.
+    static func decodeName(_ value: JSONValue?) throws -> String {
+        guard let name = value?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
+            throw RPCError.invalidParams("Name is required")
+        }
+        return name
+    }
+
+    /// Validate and trim a repo slug. A job's `repo` must be an `owner/repo`
+    /// slug (nested GitLab groups allowed); its last path component becomes an
+    /// on-disk folder name, so path-like components (`.`, `..`, empty) are
+    /// rejected to keep the checkout inside the workspace folder.
+    ///
+    /// - Throws: `RPCError.invalidParams` on a bare name or path-like slug.
+    static func validateRepoSlug(_ raw: String) throws -> String {
+        let repo = raw.trimmingCharacters(in: .whitespaces)
+        let components = repo.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.count >= 2,
+              components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+            throw RPCError.invalidParams(
+                "repo must be an owner/repo slug (e.g. \"radiusmethod/crow\"); components must not be empty, '.', or '..'"
+            )
+        }
+        return repo
+    }
+
     /// Extract a prompts array, requiring at least one non-empty prompt.
     ///
     /// - Throws: `RPCError.invalidParams` when missing, not an array of

--- a/Sources/Crow/App/JobScheduler.swift
+++ b/Sources/Crow/App/JobScheduler.swift
@@ -110,36 +110,97 @@ final class JobScheduler {
 
     // MARK: - Manual run
 
+    /// Why a manual run request could not launch (CROW-604).
+    enum RunNowError: Error, LocalizedError, Equatable {
+        case noDevRoot
+        case jobNotFound
+        case alreadyRunning
+        case launchFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .noDevRoot: "No dev root configured"
+            case .jobNotFound: "Job not found"
+            case .alreadyRunning: "Job is already running"
+            case .launchFailed: "Failed to launch job (no non-empty prompts, or the repo/worktree could not be prepared)"
+            }
+        }
+    }
+
+    /// The reason a `runNow` request would be rejected, or `nil` if it can
+    /// proceed. Pure so it's unit-testable (like `finishDecision`).
+    nonisolated static func runNowPrecheck(
+        jobID: UUID, jobs: [JobConfig], devRoot: String?, inFlight: Set<UUID>
+    ) -> RunNowError? {
+        guard devRoot != nil else { return .noDevRoot }
+        guard jobs.contains(where: { $0.id == jobID }) else { return .jobNotFound }
+        guard !inFlight.contains(jobID) else { return .alreadyRunning }
+        return nil
+    }
+
     /// Fire a job on demand, regardless of its enabled flag or schedule.
+    /// Fire-and-forget (Settings UI "Run now"); failures are silently dropped.
     func runNow(_ jobID: UUID) {
         guard let devRoot = devRootProvider() else { return }
         guard let job = jobsProvider().first(where: { $0.id == jobID }) else { return }
         fire(job, devRoot: devRoot)
     }
 
-    /// Launch one job: guard against double-launch, spin up the worktree/session/
-    /// Claude terminal, persist the run time, then deliver any remaining prompts.
-    /// Shared by `tick()` (scheduled) and `runNow(_:)` (manual).
-    private func fire(_ job: JobConfig, devRoot: String) {
-        guard !inFlight.contains(job.id) else { return }
-        inFlight.insert(job.id)
-        let captured = job
-        Task { @MainActor in
-            defer { self.inFlight.remove(captured.id) }
-            if let result = await self.sessionService.runJob(captured, devRoot: devRoot) {
-                // Persist run time first so the job isn't re-fired next tick.
-                self.onJobRan(captured.id, Date())
-                // Watch this run so its session auto-completes on success (CROW-561).
-                self.watchedRuns[result.sessionID] = RunWatch(
-                    terminalID: result.terminalID,
-                    startedAt: Date(),
-                    promptsDeliveredAt: nil
-                )
-                self.deliverRemainingPrompts(
-                    captured, sessionID: result.sessionID, terminalID: result.terminalID
-                )
-            }
+    /// Fire a job on demand and report the launched session/terminal, so the
+    /// `job run` RPC can return them to the CLI (CROW-604). Same semantics as
+    /// `runNow(_:)` — the enabled flag and schedule are ignored — but launch
+    /// problems surface as `RunNowError` instead of being dropped.
+    func runNowReporting(_ jobID: UUID) async throws -> (sessionID: UUID, terminalID: UUID) {
+        if let error = Self.runNowPrecheck(
+            jobID: jobID, jobs: jobsProvider(), devRoot: devRootProvider(), inFlight: inFlight
+        ) {
+            throw error
         }
+        guard let devRoot = devRootProvider(),
+              let job = jobsProvider().first(where: { $0.id == jobID }),
+              markInFlight(job.id) else {
+            // Providers changed between the precheck and here — treat as busy.
+            throw RunNowError.alreadyRunning
+        }
+        return try await launchMarked(job, devRoot: devRoot)
+    }
+
+    /// Launch one job: guard against double-launch, then hand off to
+    /// `launchMarked`. Shared by `tick()` (scheduled) and `runNow(_:)` (manual).
+    private func fire(_ job: JobConfig, devRoot: String) {
+        guard markInFlight(job.id) else { return }
+        Task { @MainActor in
+            _ = try? await self.launchMarked(job, devRoot: devRoot)
+        }
+    }
+
+    /// Mark a job as launching. Returns `false` if it already is — the caller
+    /// must not proceed. Synchronous so check-and-insert is atomic on the
+    /// MainActor, closing the double-launch window between two callers.
+    private func markInFlight(_ id: UUID) -> Bool {
+        guard !inFlight.contains(id) else { return false }
+        inFlight.insert(id)
+        return true
+    }
+
+    /// Spin up the worktree/session/Claude terminal, persist the run time, then
+    /// deliver any remaining prompts. Requires a successful `markInFlight`;
+    /// clears the mark when done.
+    private func launchMarked(_ job: JobConfig, devRoot: String) async throws -> (sessionID: UUID, terminalID: UUID) {
+        defer { inFlight.remove(job.id) }
+        guard let result = await sessionService.runJob(job, devRoot: devRoot) else {
+            throw RunNowError.launchFailed
+        }
+        // Persist run time first so the job isn't re-fired next tick.
+        onJobRan(job.id, Date())
+        // Watch this run so its session auto-completes on success (CROW-561).
+        watchedRuns[result.sessionID] = RunWatch(
+            terminalID: result.terminalID,
+            startedAt: Date(),
+            promptsDeliveredAt: nil
+        )
+        deliverRemainingPrompts(job, sessionID: result.sessionID, terminalID: result.terminalID)
+        return result
     }
 
     // MARK: - Multi-prompt delivery (best-effort)

--- a/Tests/CrowTests/JobRPCSupportTests.swift
+++ b/Tests/CrowTests/JobRPCSupportTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowIPC
+@testable import Crow
+
+/// Param decoding and response encoding for the `job-*` RPC handlers (CROW-604).
+@Suite("Job RPC support")
+struct JobRPCSupportTests {
+
+    // MARK: - decodeSchedule
+
+    @Test func decodeScheduleRoundTripsInterval() throws {
+        let schedule = try JobRPC.decodeSchedule(
+            .object(["type": .string("interval"), "seconds": .int(3600)])
+        )
+        #expect(schedule == .interval(seconds: 3600))
+    }
+
+    @Test func decodeScheduleRoundTripsDailyAt() throws {
+        let schedule = try JobRPC.decodeSchedule(.object([
+            "type": .string("dailyAt"),
+            "hour": .int(9),
+            "minute": .int(30),
+            "weekdays": .array([.int(2), .int(6)]),
+        ]))
+        #expect(schedule == .dailyAt(hour: 9, minute: 30, weekdays: [2, 6]))
+    }
+
+    @Test func decodeScheduleRejectsMalformedShapes() {
+        let bad: [JSONValue] = [
+            .string("interval"),
+            .object([:]),
+            .object(["type": .string("weekly")]),
+            .object(["type": .string("interval")]),  // missing seconds
+        ]
+        for value in bad {
+            #expect(throws: RPCError.self) { _ = try JobRPC.decodeSchedule(value) }
+        }
+    }
+
+    @Test func decodeScheduleRejectsOutOfRangeValues() {
+        let bad: [JSONValue] = [
+            .object(["type": .string("interval"), "seconds": .int(0)]),
+            .object(["type": .string("dailyAt"), "hour": .int(24), "minute": .int(0), "weekdays": .array([])]),
+            .object(["type": .string("dailyAt"), "hour": .int(9), "minute": .int(60), "weekdays": .array([])]),
+            .object(["type": .string("dailyAt"), "hour": .int(9), "minute": .int(0), "weekdays": .array([.int(0)])]),
+            .object(["type": .string("dailyAt"), "hour": .int(9), "minute": .int(0), "weekdays": .array([.int(8)])]),
+        ]
+        for value in bad {
+            #expect(throws: RPCError.self) { _ = try JobRPC.decodeSchedule(value) }
+        }
+    }
+
+    // MARK: - decodePrompts
+
+    @Test func decodePromptsAcceptsStringArray() throws {
+        let prompts = try JobRPC.decodePrompts(.array([.string("first"), .string("second")]))
+        #expect(prompts == ["first", "second"])
+    }
+
+    @Test func decodePromptsRejectsMissingEmptyAndBlank() {
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodePrompts(nil) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodePrompts(.array([])) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodePrompts(.array([.string("  \n ")])) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodePrompts(.array([.int(1)])) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodePrompts(.string("not an array")) }
+    }
+
+    // MARK: - jobJSON
+
+    @Test func jobJSONUsesSnakeCaseKeysAndISO8601Dates() throws {
+        let created = Date(timeIntervalSince1970: 1_750_000_000)
+        let job = JobConfig(
+            name: "triage",
+            workspace: "RadiusMethod",
+            repo: "radiusmethod/api",
+            prompts: ["go"],
+            schedule: .interval(seconds: 3600),
+            enabled: true,
+            lastRunAt: nil,
+            createdAt: created
+        )
+        let object = try #require(JobRPC.jobJSON(job).objectValue)
+        #expect(object["id"] == .string(job.id.uuidString))
+        #expect(object["name"] == .string("triage"))
+        #expect(object["workspace"] == .string("RadiusMethod"))
+        #expect(object["repo"] == .string("radiusmethod/api"))
+        #expect(object["prompts"] == .array([.string("go")]))
+        #expect(object["enabled"] == .bool(true))
+        #expect(object["schedule"] == .object(["type": .string("interval"), "seconds": .int(3600)]))
+        // Never run → no last_run_at key at all.
+        #expect(object["last_run_at"] == nil)
+        #expect(object["created_at"] == .string(ISO8601DateFormatter().string(from: created)))
+        // Interval of 1h after createdAt.
+        #expect(object["next_run_at"] == .string(
+            ISO8601DateFormatter().string(from: created.addingTimeInterval(3600))
+        ))
+    }
+
+    @Test func jobJSONIncludesLastRunAtWhenPresent() throws {
+        let lastRun = Date(timeIntervalSince1970: 1_760_000_000)
+        let job = JobConfig(
+            name: "n", workspace: "w", repo: "o/r", prompts: ["p"],
+            schedule: .interval(seconds: 60), lastRunAt: lastRun
+        )
+        let object = try #require(JobRPC.jobJSON(job).objectValue)
+        #expect(object["last_run_at"] == .string(ISO8601DateFormatter().string(from: lastRun)))
+        // next run is computed from lastRunAt, not createdAt.
+        #expect(object["next_run_at"] == .string(
+            ISO8601DateFormatter().string(from: lastRun.addingTimeInterval(60))
+        ))
+    }
+}

--- a/Tests/CrowTests/JobRPCSupportTests.swift
+++ b/Tests/CrowTests/JobRPCSupportTests.swift
@@ -52,6 +52,37 @@ struct JobRPCSupportTests {
         }
     }
 
+    // MARK: - decodeName
+
+    @Test func decodeNameTrimsWhitespace() throws {
+        #expect(try JobRPC.decodeName(.string("  triage \n")) == "triage")
+    }
+
+    @Test func decodeNameRejectsMissingAndBlank() {
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodeName(nil) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodeName(.string("")) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodeName(.string("   ")) }
+        #expect(throws: RPCError.self) { _ = try JobRPC.decodeName(.int(7)) }
+    }
+
+    // MARK: - validateRepoSlug
+
+    @Test func validateRepoSlugAcceptsSlugsAndNestedGroups() throws {
+        #expect(try JobRPC.validateRepoSlug("radiusmethod/crow") == "radiusmethod/crow")
+        #expect(try JobRPC.validateRepoSlug("group/sub/project") == "group/sub/project")
+        #expect(try JobRPC.validateRepoSlug("  owner/repo  ") == "owner/repo")
+    }
+
+    @Test func validateRepoSlugRejectsBareNamesAndPathLikeComponents() {
+        // The slug's last component becomes an on-disk folder, so anything
+        // path-like must be rejected before persist.
+        for bad in ["", "   ", "api", "foo/..", "../foo", "foo/.", "./foo", "/repo", "owner/", "a//b"] {
+            #expect(throws: RPCError.self, "expected '\(bad)' to be rejected") {
+                _ = try JobRPC.validateRepoSlug(bad)
+            }
+        }
+    }
+
     // MARK: - decodePrompts
 
     @Test func decodePromptsAcceptsStringArray() throws {

--- a/Tests/CrowTests/JobRunNowPrecheckTests.swift
+++ b/Tests/CrowTests/JobRunNowPrecheckTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// The pure precheck behind `JobScheduler.runNowReporting` (CROW-604): why a
+/// manual `job run` would be rejected before anything launches.
+@Suite("Job run-now precheck")
+struct JobRunNowPrecheckTests {
+
+    private func job(enabled: Bool = true) -> JobConfig {
+        JobConfig(
+            name: "triage", workspace: "ws", repo: "o/r",
+            prompts: ["go"], schedule: .interval(seconds: 3600), enabled: enabled
+        )
+    }
+
+    @Test func rejectsWhenNoDevRoot() {
+        let j = job()
+        let error = JobScheduler.runNowPrecheck(jobID: j.id, jobs: [j], devRoot: nil, inFlight: [])
+        #expect(error == .noDevRoot)
+    }
+
+    @Test func rejectsUnknownJob() {
+        let error = JobScheduler.runNowPrecheck(jobID: UUID(), jobs: [job()], devRoot: "/dev", inFlight: [])
+        #expect(error == .jobNotFound)
+    }
+
+    @Test func rejectsJobAlreadyInFlight() {
+        let j = job()
+        let error = JobScheduler.runNowPrecheck(jobID: j.id, jobs: [j], devRoot: "/dev", inFlight: [j.id])
+        #expect(error == .alreadyRunning)
+    }
+
+    @Test func allowsValidJob() {
+        let j = job()
+        #expect(JobScheduler.runNowPrecheck(jobID: j.id, jobs: [j], devRoot: "/dev", inFlight: []) == nil)
+    }
+
+    @Test func allowsDisabledJob() {
+        // Manual runs ignore the enabled flag (and the schedule).
+        let j = job(enabled: false)
+        #expect(JobScheduler.runNowPrecheck(jobID: j.id, jobs: [j], devRoot: "/dev", inFlight: []) == nil)
+    }
+}


### PR DESCRIPTION
Closes #604

Extends the `crow` CLI with full job management over the existing Unix-socket JSON-RPC.

## What's new

**Nested command group** — `crow job <sub>` (first use of ArgumentParser nesting in this CLI; everything else is flat — chosen per the ticket's stated preference):

| Command | Does |
|---|---|
| `crow job list` | All jobs with schedule, enabled, last/next run |
| `crow job get --id <uuid>` | Full details incl. prompts |
| `crow job add --name … --workspace … --repo … --prompt …/--prompt-file … --interval-seconds N \| --daily-at HH:MM [--weekdays …] [--disabled]` | Create; returns the new job |
| `crow job edit --id <uuid> [fields…]` | Patch semantics — only provided flags change; prompts/schedule replace whole |
| `crow job enable/disable --id <uuid>` | Toggle enabled |
| `crow job run --id <uuid>` | Run now regardless of schedule/enabled; returns launched `session_id`/`terminal_id` |
| `crow job delete --id <uuid>` | Remove |
| `crow job duplicate --id <uuid>` | UI-identical `duplicated()` (copy starts disabled) |

`--prompt` is repeatable; `--prompt-file` is repeatable and accepts `-` for stdin (large prompts).

## How it works

- New `job-*` RPC handlers in `AppDelegate` mutate the **live in-memory `AppConfig.jobs`** — the same source the scheduler's `jobsProvider` and the Settings UI read — with the UI's exact semantics (append / replace-by-id / set-flag / remove-by-id / `duplicated`), then persist via `ConfigStore.saveConfig`. The CLI never writes `config.json` directly, so changes apply on the next scheduler tick and appear in the UI without a restart (the ticket's critical design note).
- `JobScheduler.fire()` refactored into `markInFlight` + `launchMarked`; new `runNowReporting()` awaits the launch and returns `(sessionID, terminalID)` while preserving all side effects (in-flight guard, `onJobRan` → `recordJobRun` persistence, `RunWatch` auto-complete registration, multi-prompt delivery). The UI's sync `runNow` path is unchanged.
- `SocketClient.send` gains a per-call `timeoutSeconds` (default 30 unchanged); `job run` passes 120s since a clone-on-demand launch can exceed 30s.
- Validation both sides: CLI `validate()` catches UUID/HH:MM/weekday/mutual-exclusion errors before any RPC; handlers re-validate (unknown workspace, duplicate name via `JobConfig.validateName`, schedule ranges, non-empty prompts, unknown job id) and return clean JSON-RPC errors.

## Tests

- `JobCommandParsingTests` — per-subcommand arg parsing, schedule mutual exclusion, prompt requirements, nested-group routing.
- `JobScheduleArgsTests` — HH:MM / weekday / schedule-JSON parsing.
- `JobRPCSupportTests` — schedule/prompt decoding, response shape (snake_case, ISO8601, `next_run_at`).
- `JobRunNowPrecheckTests` — run-now precheck incl. disabled-job-still-runs.
- `SocketRoundTripTests` — nested-object params survive the wire; per-call timeout works.

`make test`: all suites pass except 3 pre-existing environmental failures in `CrowGitTests.RebaseTests` (git committer identity unavailable on this machine) — they fail identically on a clean checkout of main.

## Verification notes

- Full package build + all test gates run.
- New CLI verified against the live socket: existing commands unaffected by the timeout change; unknown method / bad UUID / missing schedule all produce clean errors.
- Live handler verification (job appears in Settings without restart, `job run` launches a `.job` session) needs the app relaunched with this branch's build — not done here to avoid restarting the running Crow instance hosting active sessions.
- Known pre-existing nuance (out of scope): the Settings window holds a detached `@State` copy of the config, so saving it can clobber concurrent CLI edits (last-writer-wins) — true of any external mutation today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)