### PR TITLE
fix(review): gate set-config binaries/jobs to local-direct (#594)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -712,6 +712,10 @@ func makeCommandRouter(
                 "default_dev_root": .string(defaultDevRoot),
             ]
         },
+        // Non-secret settings write. `defaults.binaries` and `jobs` are held to
+        // the same local-direct bar as secret writes — the `/rpc` WebSocket
+        // handler rejects those field changes from non-local peers before this
+        // runs (review Yellow). Unix-socket / CLI callers are always local.
         "set-config": { params in
             guard let json = params["config"]?.stringValue,
                   let data = json.data(using: .utf8),
@@ -788,7 +792,9 @@ func makeCommandRouter(
         // reachable over the possibly-remote `/rpc` WebSocket and can't tell a
         // local caller from a logged-in remote one, so it must not carry secret
         // writes — that would let a remote client change the password that gates
-        // remote access (CROW-593).
+        // remote access (CROW-593). The same local-direct bar applies to
+        // `set-config` changes of `defaults.binaries` / `jobs` (gated in
+        // `RPCWebSocketHandler`) — those execute at the next launch.
 
         // Session/board actions — forward-only (need the app's coordinators).
         // Spawning a Manager forwards to the app when it's running (its

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -79,11 +79,11 @@ enum RPCWebSocketHandler {
                             continue
                         }
                         let response: JSONRPCResponse
-                        if request.method == "run-setup", !localDirect {
+                        if !localDirect, let deny = Self.localOnlyDenial(for: request, devRoot: devRoot) {
                             response = .error(
                                 id: request.id,
                                 code: RPCErrorCode.invalidParams,
-                                message: "run-setup is local-only")
+                                message: deny)
                         } else {
                             response = await commandRouter.handle(request: request)
                         }
@@ -102,5 +102,39 @@ enum RPCWebSocketHandler {
 
             await eventHub.unsubscribe(subscription)
         }
+    }
+
+    /// Methods / fields that must stay local-direct (loopback, no XFF), matching
+    /// `SecretRoutes` — the shared `CommandRouter` can't tell a local Unix-socket
+    /// caller from a remote `/rpc` peer (review Yellow / CROW-593).
+    ///
+    /// - `run-setup`: write+re-exec of an arbitrary `dev_root`.
+    /// - `set-config` when `defaults.binaries` or `jobs` change: those execute at
+    ///   the next agent/job launch (persistent RCE on an unauthenticated
+    ///   non-loopback bind). Other `set-config` fields still flow through.
+    static func localOnlyDenial(for request: JSONRPCRequest, devRoot: String) -> String? {
+        switch request.method {
+        case "run-setup":
+            return "run-setup is local-only"
+        case "set-config":
+            guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
+            return "set-config binaries/jobs is local-only"
+        default:
+            return nil
+        }
+    }
+
+    /// True when the incoming `set-config` payload would change agent binary
+    /// overrides or scheduled jobs relative to what's on disk.
+    static func setConfigTouchesPrivilegedFields(_ request: JSONRPCRequest, devRoot: String) -> Bool {
+        guard let json = request.params?["config"]?.stringValue,
+              let data = json.data(using: .utf8),
+              let incoming = try? JSONDecoder().decode(AppConfig.self, from: data) else {
+            // Malformed — let the real handler return invalidParams.
+            return false
+        }
+        let current = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+        return incoming.defaults.binaries != current.defaults.binaries
+            || incoming.jobs != current.jobs
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -681,3 +681,93 @@ import CrowPersistence
     }
 }
 
+/// Local-direct gates on `/rpc` for write+exec surfaces (review Yellow on #594).
+@Suite struct LocalOnlyRPCGateTests {
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crowd-local-rpc-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func encode(_ config: AppConfig) throws -> String {
+        String(decoding: try JSONEncoder().encode(config), as: UTF8.self)
+    }
+
+    @Test func runSetupAlwaysDeniedWhenNotLocal() {
+        let req = JSONRPCRequest(id: 1, method: "run-setup", params: [
+            "dev_root": .string("/tmp/x"),
+            "config": .string("{}"),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
+            == "run-setup is local-only")
+    }
+
+    @Test func setConfigBinariesChangeIsLocalOnly() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
+
+        var incoming = AppConfig()
+        incoming.defaults.binaries = ["claude": "/evil/claude"]
+        let req = JSONRPCRequest(id: 1, method: "set-config", params: [
+            "config": .string(try encode(incoming)),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot)
+            == "set-config binaries/jobs is local-only")
+        #expect(RPCWebSocketHandler.setConfigTouchesPrivilegedFields(req, devRoot: devRoot))
+    }
+
+    @Test func setConfigJobsChangeIsLocalOnly() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
+
+        var incoming = AppConfig()
+        incoming.jobs = [
+            JobConfig(name: "nightly", workspace: "ws", repo: "o/r",
+                      prompts: ["do stuff"], schedule: .interval(seconds: 3600)),
+        ]
+        let req = JSONRPCRequest(id: 1, method: "set-config", params: [
+            "config": .string(try encode(incoming)),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot)
+            == "set-config binaries/jobs is local-only")
+    }
+
+    @Test func setConfigHarmlessToggleIsAllowedRemotely() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        var stored = AppConfig()
+        stored.remoteControlEnabled = true
+        try ConfigStore.saveConfig(stored, devRoot: devRoot)
+
+        var incoming = AppConfig()
+        incoming.remoteControlEnabled = false
+        let req = JSONRPCRequest(id: 1, method: "set-config", params: [
+            "config": .string(try encode(incoming)),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot) == nil)
+        #expect(!RPCWebSocketHandler.setConfigTouchesPrivilegedFields(req, devRoot: devRoot))
+    }
+
+    @Test func setConfigUnchangedBinariesAndJobsIsAllowed() throws {
+        // Remote editor round-trips the same binaries/jobs it just read — must
+        // not trip the gate (only *changes* are local-only).
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        var stored = AppConfig()
+        stored.defaults.binaries = ["claude": "/usr/local/bin/claude"]
+        stored.jobs = [
+            JobConfig(name: "nightly", workspace: "ws", repo: "o/r",
+                      prompts: ["do stuff"], schedule: .interval(seconds: 3600)),
+        ]
+        try ConfigStore.saveConfig(stored, devRoot: devRoot)
+
+        let req = JSONRPCRequest(id: 1, method: "set-config", params: [
+            "config": .string(try encode(stored)),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot) == nil)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extends the `/rpc` local-direct gate (already used for `run-setup`) so `set-config` changes to `defaults.binaries` or `jobs` are rejected for non-local peers.
- Harmless `set-config` fields (and unchanged binaries/jobs round-trips) still work remotely.
- Adds `LocalOnlyRPCGateTests`.

Addresses the remaining Yellow on #594 after #623 merged (`run-setup` was already fixed there; this review still flagged it because it ran against the pre-merge tip).

## Test plan
- [x] `swift test --filter LocalOnlyRPCGateTests`
- [ ] Confirm local Settings can still edit Jobs / binary overrides
- [ ] Confirm a non-loopback `/rpc` client gets `set-config binaries/jobs is local-only` when changing those fields


Made with [Cursor](https://cursor.com)