### PR TITLE
feat(agent): mid-session handoff when credits run out (CROW-627)

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -980,16 +980,13 @@ public final class SessionService {
         let worktrees = appState.worktrees(for: sessionID)
 
         // Build the handoff prompt + launch command *before* mutating session
-        // state or destroying terminals. `launchCommand` does real I/O (e.g.
-        // writing a prompt file) and can throw — if we tear down first, a
-        // failure leaves the session half-migrated with no running agent
-        // (CROW-627 review).
-        var sessionForPrompt = session
-        sessionForPrompt.agentKind = targetKind
+        // state or destroying terminals. `launchCommand` writes a temp prompt
+        // file and can throw on I/O failure — leaving the prior agent running
+        // is far better than a flipped agentKind with no managed pane (review).
         let prompt = await AgentHandoff.buildPrompt(
             from: priorKind,
             to: target,
-            session: sessionForPrompt,
+            session: session,
             worktrees: worktrees,
             note: note
         )
@@ -1002,6 +999,15 @@ public final class SessionService {
             )
         } catch {
             throw AgentHandoffError.launchFailed(error.localizedDescription)
+        }
+
+        // Claude-specific prep (trust + gateway) before the new process starts.
+        // Idempotent file writes — safe to run before teardown.
+        if target.kind == .claudeCode {
+            ClaudeTrustSeeder.seedTrust(projectPath: worktree.worktreePath)
+            let gatewayResolved = workspaceGatewayResolved(for: sessionID)
+            ClaudeHookConfigWriter.writeGatewayEnv(
+                dirPath: worktree.worktreePath, resolved: gatewayResolved)
         }
 
         // Persist the new agent only after launch prep succeeds so register /
@@ -1030,14 +1036,6 @@ public final class SessionService {
         }
         store.mutate { data in
             data.terminals.removeAll { $0.sessionID == sessionID && $0.isManaged }
-        }
-
-        // Claude-specific prep (trust + gateway) before the new process starts.
-        if target.kind == .claudeCode {
-            ClaudeTrustSeeder.seedTrust(projectPath: worktree.worktreePath)
-            let gatewayResolved = workspaceGatewayResolved(for: sessionID)
-            ClaudeHookConfigWriter.writeGatewayEnv(
-                dirPath: worktree.worktreePath, resolved: gatewayResolved)
         }
 
         // Deferred paste on `.shellReady` (#408) — same path as `new-terminal --command`.


### PR DESCRIPTION
## Summary
- Add `crow handoff-agent` / RPC `handoff-agent` to switch a session's coding agent mid-flight (e.g. Claude Code → Cursor when credits run out)
- Preserve Crow session identity, worktree, branch, and ticket; replace the managed agent terminal and seed the incoming agent with a resume brief (ADR 0009 — chat history does not transfer)
- Web UI: “Switch agent…” in the session menu + clickable Agent row in the detail header

Closes #627

## Test plan
- [ ] `swift test --package-path Packages/CrowEngine --filter AgentHandoff`
- [ ] `swift test --package-path Packages/CrowCLI --filter handoffAgent`
- [ ] From a work session with ≥2 agents installed: web “Switch agent…” → new managed terminal launches target agent with handoff prompt
- [ ] `crow handoff-agent --session <uuid> --agent cursor --note "hit credit limit"` returns `session_id` / `agent_kind` / `terminal_id`
- [ ] Manager sessions reject handoff; Shell tabs survive the switch


Made with [Cursor](https://cursor.com)