### PR TITLE
fix(tmux): lengthen paste→Enter settle for Cursor large prompts

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -338,23 +338,33 @@ public final class TmuxBackend {
         NSLog("[CrowTelemetry tmux:tab_switch_ms=\(elapsedMS) terminal=\(id)]")
     }
 
+    /// Settle time between `paste-buffer` and the submitting `Enter`.
+    ///
+    /// Bracketed-paste TUIs (Claude Code, Cursor's `agent`) need the
+    /// `\e[201~` bracket-end to finish before Enter arrives. 50ms was enough
+    /// for short Claude auto-respond lines (#272) but large Cursor pastes
+    /// (multi-KB Manager / job prompts) still race: the agent starts working
+    /// while sticky text remains in the composer, looking like a double paste
+    /// (#631). 200ms clears the composer for those payloads without a second
+    /// Enter (which would re-submit leftover text).
+    public static let pasteEnterSettleDelay: TimeInterval = 0.2
+
     /// Send text to `id`'s window via the buffer-paste path. Works for
     /// arbitrary-size payloads (Phase 3 §3 finding: send-keys -l fails
     /// on >10KB; load-buffer + paste-buffer scales to 50KB+ in 133ms).
     ///
-    /// Quirk: Claude Code's TUI enables bracketed-paste mode, which wraps
+    /// Quirk: agent TUIs enable bracketed-paste mode, which wraps
     /// `paste-buffer` output in `\e[200~…\e[201~`. A trailing `\n` inside the
     /// bracket is treated as literal text, not as Enter — so prompts that
     /// rely on `\n` to submit (quick actions, auto-respond) get pasted but
     /// never submitted (#264). Strip the trailing newline before pasting and
-    /// deliver a separate `Enter` via `send-keys` afterwards, mirroring what
-    /// a separate `Enter` via `send-keys` afterwards.
+    /// deliver a separate `Enter` via `send-keys` afterwards.
     ///
-    /// A 50ms delay between the paste and the Enter keystroke gives the TUI
-    /// time to process the bracket-end sequence (`\e[201~`). Without this,
-    /// auto-respond prompts (which fire when the terminal has been idle) can
-    /// race: the Enter arrives before the TUI finishes handling the paste,
-    /// causing it to be silently dropped (#272).
+    /// `pasteEnterSettleDelay` between the paste and the Enter keystroke
+    /// gives the TUI time to process the bracket-end sequence (`\e[201~`).
+    /// Without this, Enter can arrive early: Claude may drop it entirely
+    /// (#272); Cursor may submit but leave the prompt sitting in the input
+    /// box (#631).
     ///
     /// We also pre-cancel copy-mode on the pane before any delivery (#486).
     /// The bundled `crow-tmux.conf` keeps `mouse on` so wheel scrollback
@@ -395,7 +405,7 @@ public final class TmuxBackend {
                 // the Enter key arrives. Only needed when we actually pasted
                 // content — a bare "\n" (Enter-only) needs no delay.
                 if didPaste {
-                    Thread.sleep(forTimeInterval: 0.05)
+                    Thread.sleep(forTimeInterval: Self.pasteEnterSettleDelay)
                 }
                 try ctrl.sendKeys(target: target, keys: ["Enter"])
             }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -202,9 +202,39 @@ struct TmuxBackendTests {
             trackReadiness: false
         )
 
-        // Trailing \n triggers the paste + separate Enter path (#264/#272).
+        // Trailing \n triggers the paste + settle + Enter path (#264/#272/#631).
         // Verify the full code path executes without throwing.
+        #expect(TmuxBackend.pasteEnterSettleDelay == 0.2)
         let payload = "AUTO-RESPOND-TEST-\(UUID().uuidString)\n"
+        try backend.sendText(id: id, text: payload)
+    }
+
+    @Test func sendTextLargeMultilineWithTrailingNewlineDoesNotThrow() throws {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        let id = UUID()
+        _ = try backend.registerTerminal(
+            id: id,
+            name: "large-paste-test",
+            cwd: NSHomeDirectory(),
+            command: nil,
+            trackReadiness: false
+        )
+
+        // Large multi-KB pastes are the Cursor #631 failure mode: Enter used
+        // to race bracket-end at 50ms and leave sticky composer text. This
+        // exercises the same paste + settle + Enter path with a realistic
+        // payload size (unit-level: no throw; settle delay is asserted above).
+        var lines: [String] = ["# Workspace Context", ""]
+        for i in 0..<80 {
+            lines.append("| repo-\(i) | /tmp/wt-\(i) | feature/branch-\(i) | desc |")
+        }
+        lines.append("")
+        lines.append("## Instructions")
+        lines.append(String(repeating: "x", count: 2000))
+        let payload = lines.joined(separator: "\n") + "\n"
+        #expect(payload.utf8.count > 2000)
         try backend.sendText(id: id, text: payload)
     }
 


### PR DESCRIPTION
## Summary
- Cursor's `agent` TUI uses bracketed paste; Crow's 50ms paste→Enter delay was enough for short Claude lines (#272) but large multi-KB Cursor prompts still race.
- Enter can submit while sticky text remains in the composer (looks like a double paste). Bump settle delay to 200ms.
- Do not send a second Enter — that re-submits leftover text.

Closes #631

## Test plan
- [x] CrowTerminal `TmuxBackendTests.sendText*` 
- [ ] Manual: send a large prompt into a Cursor agent session via Crow; composer should clear after submit
- [ ] Manual regression: Claude Code quick-action / auto-respond still submits


Made with [Cursor](https://cursor.com)