### PR TITLE
Add jump-to-bottom control to terminal surface

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
@@ -17,10 +17,44 @@
       width: 100%;
       height: 100%;
     }
+    /* Jump-to-bottom control (#633): floats over the xterm viewport,
+       styled to the Corveil gold accent (see CorveilTheme.swift). */
+    #crow-jump-bottom {
+      position: absolute;
+      right: 16px;
+      bottom: 16px;
+      width: 34px;
+      height: 34px;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      line-height: 1;
+      color: #ddc482;
+      background: #22262a;
+      border: 1px solid rgba(221, 196, 130, 0.35);
+      border-radius: 17px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+      cursor: pointer;
+      z-index: 10;
+      opacity: 1;
+      transition: opacity 0.12s ease;
+    }
+    #crow-jump-bottom:hover {
+      background: #2a2f34;
+      border-color: rgba(221, 196, 130, 0.6);
+    }
+    #crow-jump-bottom.hidden {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
   <div id="terminal"></div>
+  <button id="crow-jump-bottom" class="hidden" aria-label="Jump to latest output" title="Jump to bottom">&#9662;</button>
   <script src="xterm.js"></script>
   <script src="xterm-addon-fit.js"></script>
   <script src="xterm-addon-image.js"></script>
@@ -84,6 +118,32 @@
           }, true);
         }
 
+        // Jump-to-bottom control (#633). Long agent/chat output leaves no fast
+        // path back to the live edge once you scroll up; show a pill when the
+        // viewport is above the bottom and snap back on click. onScroll is the
+        // primary trigger (leaving the bottom only ever happens via a user
+        // scroll — new output while pinned auto-scrolls and stays pinned);
+        // onRender is a safety-net re-check.
+        const jumpBtn = document.getElementById('crow-jump-bottom');
+        function atBottom() {
+          const b = term.buffer.active;
+          return b.viewportY >= b.baseY;
+        }
+        function updateJumpButton() {
+          if (jumpBtn) {
+            jumpBtn.classList.toggle('hidden', atBottom());
+          }
+        }
+        if (jumpBtn) {
+          jumpBtn.addEventListener('click', function () {
+            term.scrollToBottom();
+            term.focus(); // restore typing focus stolen by the button
+            updateJumpButton();
+          });
+        }
+        term.onScroll(updateJumpButton);
+        term.onRender(updateJumpButton);
+
         function reportSize() {
           fitAddon.fit();
           handlers.crowResize.postMessage({ cols: term.cols, rows: term.rows });
@@ -140,6 +200,7 @@
         window.addEventListener('resize', reportSize);
         handlers.crowReady.postMessage({});
         reportSize();
+        updateJumpButton();
       } catch (err) {
         reportError(String(err));
       }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -82,6 +82,19 @@ struct BundledResourcesTests {
         #expect(body.contains(#"\x1b\r"#))
     }
 
+    @Test func terminalHTMLHasJumpToBottomControl() throws {
+        // #633: a jump-to-bottom control must live in the host page so
+        // scrolling up over long agent output has a fast path back to the
+        // live edge. The xterm resources get re-vendored wholesale (see
+        // Resources/xterm/VERSION), so pin the control's presence against an
+        // accidental overwrite.
+        let url = try #require(BundledResources.terminalHTMLURL)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        #expect(body.contains("crow-jump-bottom"))
+        #expect(body.contains("scrollToBottom"))
+        #expect(body.contains("onScroll"))
+    }
+
     @Test func tmuxConfHasNoBarePrefixUnbind() throws {
         // #473: a bare `unbind-key -a` (no `-T`) defaults to the prefix
         // table, which is empty/non-existent after the first clear on


### PR DESCRIPTION
Closes #633

## What & why
Scrolling up over long agent/chat/terminal output left no fast way back to the live edge — you had to wheel all the way down. This adds a floating **jump-to-bottom** pill to the terminal surface: it appears when the viewport is scrolled above the bottom and snaps back to the latest line on click, then hides when pinned.

## Approach
In Crow the "chat/terminal" is a single **xterm.js** instance in a WKWebView (`terminal.html`) — Claude Code and the agents run inside it, and there's no separate native chat view. The control is therefore implemented **entirely inside `terminal.html`**:

- A gold-accent pill (matching the Corveil theme) floats bottom-right, hidden by default (`pointer-events: none` when hidden so it never blocks selection/wheel at the bottom).
- Visibility is driven by xterm's `buffer.active.viewportY`/`baseY` (at bottom ⇒ hidden). `onScroll` is the primary trigger — leaving the bottom only ever happens via a user scroll, since new output while pinned auto-scrolls and stays pinned — with `onRender` as a safety-net re-check.
- Click calls `term.scrollToBottom()` and restores typing focus.

Because the cockpit surface shares one webview across all tabs, every session gets the control automatically. No native Swift, message-handler bridge, or SwiftUI overlay was needed.

## Scope
Terminal-only. The only other `ScrollView`s in the app are the short kanban columns in `TicketBoardView`, which aren't long agent output and are out of scope.

## Tests
- Added `terminalHTMLHasJumpToBottomControl` to `BundledResourcesTests` (the xterm resources get re-vendored wholesale, so the control's presence is pinned against accidental overwrite), alongside the existing modified-Enter guard.
- `swift test --package-path Packages/CrowTerminal --filter BundledResourcesTests` — all 9 pass.
- `make build` — clean.

## Manual verification
Open a session terminal, produce lots of output (e.g. `seq 1 500`), scroll up → the pill appears bottom-right → click → snaps to the latest line and the pill disappears; typing focus retained. Stays hidden when already pinned to the bottom.