### PR TITLE
fix(terminal): stop resize clobber by coalescing + deduping fits

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
@@ -84,9 +84,37 @@
           }, true);
         }
 
-        function reportSize() {
+        // Resize path (#637): the agent TUI clobbers when it's SIGWINCH'd
+        // faster than it can redraw, so coalesce bursts and drop no-op resizes.
+        //  - applyFit() fits, then posts crowResize ONLY when cols/rows actually
+        //    changed since the last post. Same-size cycles → zero SIGWINCH.
+        //    (fitAddon.fit() already no-ops xterm's own resize when unchanged;
+        //    the postMessage is what storms the PTY, so we gate that here.)
+        //  - scheduleFit() collapses a drag's rapid resize events to one fit per
+        //    animation frame. Both Swift (window.crowFit) and the DOM resize
+        //    listener route through it.
+        let lastCols = 0;
+        let lastRows = 0;
+        let fitPending = false;
+
+        function applyFit() {
           fitAddon.fit();
-          handlers.crowResize.postMessage({ cols: term.cols, rows: term.rows });
+          if (term.cols !== lastCols || term.rows !== lastRows) {
+            lastCols = term.cols;
+            lastRows = term.rows;
+            handlers.crowResize.postMessage({ cols: term.cols, rows: term.rows });
+          }
+        }
+
+        function scheduleFit() {
+          if (fitPending) {
+            return;
+          }
+          fitPending = true;
+          requestAnimationFrame(function () {
+            fitPending = false;
+            applyFit();
+          });
         }
 
         window.crowWrite = function (b64) {
@@ -99,7 +127,7 @@
           term.write(bytes);
         };
 
-        window.crowFit = reportSize;
+        window.crowFit = scheduleFit;
 
         // xterm.js emits the same bare \r for Enter and Shift+Enter, so
         // Claude Code can't tell them apart and submits on both (#598).
@@ -137,9 +165,16 @@
           handlers.crowInput.postMessage({ data: data });
         });
 
-        window.addEventListener('resize', reportSize);
+        window.addEventListener('resize', scheduleFit);
         handlers.crowReady.postMessage({});
-        reportSize();
+        // Synchronous first fit so the PTY gets a correct initial winsize.
+        applyFit();
+        // The first fit can run with the Menlo fallback before "MesloLGS NF"
+        // loads; once the Nerd Font's cell metrics settle the grid recomputes,
+        // so re-fit and post the (deduped) corrective size. (#637 repro hint 2)
+        if (document.fonts && document.fonts.ready) {
+          document.fonts.ready.then(scheduleFit);
+        }
       } catch (err) {
         reportError(String(err));
       }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/XTermSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/XTermSurfaceView.swift
@@ -14,6 +14,7 @@ public final class XTermSurfaceView: NSView {
     private var isWebReady = false
     private var isPTYStarted = false
     private var fitDebounceWorkItem: DispatchWorkItem?
+    private var lastFitSize: CGSize = .zero
     private var webContentReloadCount = 0
     private static let maxWebContentReloadAttempts = 3
 
@@ -101,6 +102,7 @@ public final class XTermSurfaceView: NSView {
         loadStarted = false
         pendingOutput.removeAll()
         webContentReloadCount = 0
+        lastFitSize = .zero
         navigationHandler.allowedResourceDirectory = nil
         webView.navigationDelegate = nil
         webView.configuration.userContentController.removeAllScriptMessageHandlers()
@@ -252,9 +254,15 @@ public final class XTermSurfaceView: NSView {
         if window != nil, !loadStarted {
             createSurface()
         }
-        if isWebReady {
-            scheduleFit()
-        }
+        guard isWebReady else { return }
+        // Only fit on a real size change. layout() also fires on tab-switch
+        // reparents and other no-op passes; re-fitting those re-posts the same
+        // cols/rows and SIGWINCHes the agent for nothing (#637).
+        let size = bounds.size
+        guard abs(size.width - lastFitSize.width) >= 1
+                || abs(size.height - lastFitSize.height) >= 1 else { return }
+        lastFitSize = size
+        scheduleFit()
     }
 }
 


### PR DESCRIPTION
Closes #637

## Problem
The embedded terminal intermittently painted garbage — double lines, staggered/overlapping rows, misaligned frames — after resizing the window/sidebar or switching tabs. The stack is a single shared xterm.js cockpit (WKWebView) → native PTY (`TIOCSWINSZ`) → tmux → agent TUI. The agent clobbers when SIGWINCH'd faster than it can redraw.

## Root cause (resize spam)
1. `terminal.html` `reportSize()` posted `crowResize` on **every** fit, even when cols/rows were unchanged → a no-op fit still SIGWINCH'd the agent.
2. The DOM `resize` listener (`window.addEventListener('resize', reportSize)`) was **un-debounced** → a live drag fired dozens of fits/sec, each posting a resize mid-frame.
3. `XTermSurfaceView.layout()` called `scheduleFit()` on **every** layout pass, including tab-switch reparents and no-op passes that didn't change size.

## Fix
- **`terminal.html`** — `applyFit()` posts `crowResize` only when `cols`/`rows` actually change since the last post (same-size cycles → zero SIGWINCH). `scheduleFit()` coalesces drag bursts to one fit per `requestAnimationFrame`; both `window.crowFit` (Swift) and the DOM `resize` listener route through it. Added a one-shot re-fit after `document.fonts.ready` so the initial grid corrects once the `MesloLGS NF` cell metrics settle (first-paint off-by-a-few-columns).
- **`XTermSurfaceView.swift`** — `layout()` only `scheduleFit()`s on a real `bounds.size` change (tracked via `lastFitSize`, reset in `destroy()`), so reparents/no-op passes stop re-posting the size.

No tmux/backend changes needed: with a single attached client and no `window-size`/`aggressive-resize` overrides, one clean `TIOCSWINSZ` makes tmux resize the pane and force the agent redraw on its own. Eliminating the storm is the whole fix.

## Acceptance criteria
- ✅ Resize/sidebar/tab-switch no longer leaves permanently clobbered content — drags coalesce to one settled resize tmux redraws cleanly.
- ✅ Same-size fit cycles don't spam SIGWINCH — JS dedupe + `layout()` size-guard.
- ✅ Agent TUIs realign cleanly after real size changes (incl. the post-font-load correction), no manual refocus.

## Testing
- `make build` — clean.
- `swift test --package-path Packages/CrowTerminal` — 80/80 pass.
- Manual: drag-resize window + sidebar and switch tabs repeatedly; grid realigns cleanly on release; no continuous resize stream on tab switch; first-paint grid corrects after the Nerd Font loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x9Vz9M9yxyXvSnn1RKJHG