### PR TITLE
fix(new-terminal): default cwd to primary worktree when omitted (#639)

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -656,9 +656,21 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 return ["worktrees": .array(items)]
             },
             "new-terminal": { @Sendable params in
-                guard let idStr = params["session_id"]?.stringValue, let sessionID = UUID(uuidString: idStr),
-                      let cwd = params["cwd"]?.stringValue else {
-                    throw RPCError.invalidParams("session_id and cwd required")
+                guard let idStr = params["session_id"]?.stringValue, let sessionID = UUID(uuidString: idStr) else {
+                    throw RPCError.invalidParams("session_id required")
+                }
+                // cwd is optional (#639): the web UI's "+" add-terminal button
+                // sends only session_id — it can't reliably know the worktree
+                // path. Default to the session's primary worktree — mirroring
+                // SessionService.addTerminal — then devRoot, so the derived
+                // path always satisfies the traversal guard below.
+                let cwd: String
+                if let explicit = params["cwd"]?.stringValue, !explicit.isEmpty {
+                    cwd = explicit
+                } else {
+                    cwd = await MainActor.run {
+                        capturedAppState.primaryWorktree(for: sessionID)?.worktreePath ?? devRoot
+                    }
                 }
                 // Validate cwd is within devRoot to prevent path traversal
                 guard Validation.isPathWithinRoot(cwd, root: devRoot) else {

--- a/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
@@ -37,4 +37,56 @@ struct EngineRouterSmokeTests {
         #expect(response.error == nil)
         #expect(response.result != nil)
     }
+
+    /// #639: the web UI's "+" add-terminal button sends only `session_id` (it
+    /// can't know the worktree path). `new-terminal` must no longer reject that
+    /// with `invalidParams("session_id and cwd required")` — it derives `cwd`
+    /// from the session's primary worktree instead.
+    ///
+    /// We deliberately point the primary worktree *outside* devRoot so the
+    /// derived cwd trips the path-traversal guard, which fires *before* the
+    /// handler touches `TmuxBackend` (a real-tmux dependency the smoke suite
+    /// avoids). Reaching that downstream guard at all proves the missing-cwd
+    /// guard passed and the worktree path was derived — the #639 fix — without
+    /// needing a live tmux server.
+    @Test("new-terminal without cwd derives it from the primary worktree, not rejecting the request")
+    func newTerminalDerivesCwdFromPrimaryWorktree() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-engine-smoke-\(UUID().uuidString)")
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+
+        // Primary worktree lives OUTSIDE devRoot (home ≠ the temp devRoot), so
+        // the derived cwd fails the traversal guard rather than reaching tmux.
+        let sessionID = UUID()
+        let outsidePath = FileManager.default.homeDirectoryForCurrentUser.path
+        appState.worktrees[sessionID] = [
+            SessionWorktree(sessionID: sessionID, repoName: "repo", repoPath: outsidePath,
+                            worktreePath: outsidePath, branch: "feature/x", isPrimary: true),
+        ]
+
+        let ctx = EngineContext(
+            appState: appState,
+            store: store,
+            sessionService: service,
+            issueTracker: nil,
+            telemetryPort: nil,
+            devRoot: tmp.path,
+            hostBridge: NoopHostBridge(),
+            loadConfig: { nil },
+            applyConfig: { _ in nil }
+        )
+        let router = makeEngineRouter(ctx)
+
+        // Only session_id — no cwd, exactly like the web UI's addTerminal().
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 2, method: "new-terminal", params: ["session_id": .string(sessionID.uuidString)]))
+
+        // The request is no longer rejected for a missing cwd (the #639 bug)...
+        #expect(response.error?.message != "session_id and cwd required")
+        // ...instead the derived worktree cwd (outside devRoot here) trips the
+        // traversal guard — proving cwd was derived from the primary worktree.
+        #expect(response.error?.message == "Terminal cwd must be within the configured devRoot")
+    }
 }


### PR DESCRIPTION
Closes #639

## Problem
Adding a terminal from the web UI failed with:

```
[crow] new-terminal failed: session_id and cwd required
```

The web UI's "+" add-terminal button (`Resources/web/app.js`) calls `rpc('new-terminal', { session_id })` without a `cwd` — it can't reliably know the session's worktree path. The `new-terminal` RPC handler in `EngineRouter.swift` required **both** `session_id` and `cwd`, so the request was rejected. (The CLI is unaffected — `crow new-terminal` forces `--cwd` at parse time, so only the web UI hit this.)

## Fix
Make `cwd` optional on the `new-terminal` RPC. When it's absent, derive it server-side from the session's **primary worktree** (mirroring `SessionService.addTerminal`), falling back to `devRoot` so the derived path always satisfies the existing path-traversal guard. The server is the source of truth for worktree paths, so this fixes every client without the browser needing to know the path. No web UI change required — `app.js` already sends `session_id`.

## Test
Adds a regression test in `EngineRouterSmokeTests` proving a `new-terminal` request with only `session_id` is no longer rejected with "session_id and cwd required", and that `cwd` is derived from the primary worktree. It asserts at the guard boundary so the side-effect-free smoke suite stays independent of a live tmux server.

## Scope
Targets `feature/crow-593-web-ui-parity`, where the web UI and the headless `EngineRouter` handler live (`AppDelegate.swift` is deleted on that branch). Main's handler carries the same guard but its only client (the CLI) always sends `cwd`, so the reported symptom doesn't occur there — a matching relaxation on main is a possible follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WniYXBrXjPWjgtK3iBaGSc