### PR TITLE
fix(daemon): clear throwless try + deprecated String(cString:) warnings

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -340,6 +340,13 @@ public enum CrowDaemon {
         exit(1)
     }
 
+    /// Decode a null-terminated `[CChar]` C-string buffer into a `String`,
+    /// truncating at the first NUL. Replaces the deprecated `String(cString:)`
+    /// array initializer.
+    private static func decodeCString(_ buf: [CChar]) -> String {
+        String(decoding: buf.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+
     /// Absolute path of the running `crowd` binary, or `nil` if it can't be
     /// resolved (caller falls back to `execvp`). Exposed for tests.
     static func resolvedExecutablePath() -> String? {
@@ -352,14 +359,14 @@ public enum CrowDaemon {
         // `_NSGetExecutablePath` may return a relative path; realpath makes it
         // absolute so a later cwd change can't break the re-exec.
         var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
-        guard realpath(buf, &resolved) != nil else { return String(cString: buf) }
-        return String(cString: resolved)
+        guard realpath(buf, &resolved) != nil else { return decodeCString(buf) }
+        return decodeCString(resolved)
         #elseif os(Linux)
         var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
         let n = readlink("/proc/self/exe", &buf, buf.count - 1)
         guard n > 0 else { return nil }
         buf[n] = 0
-        return String(cString: buf)
+        return decodeCString(buf)
         #else
         return nil
         #endif

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -56,7 +56,7 @@ enum RPCWebSocketHandler {
             let (outStream, outCont) = AsyncStream.makeStream(of: String.self)
             let subscription = await eventHub.subscribe(outCont)
 
-            try await withThrowingTaskGroup(of: Void.self) { group in
+            await withThrowingTaskGroup(of: Void.self) { group in
                 // Writer — the sole owner of `outbound`.
                 group.addTask {
                     for await text in outStream {


### PR DESCRIPTION
Closes #640

Cleans up the two compile-warning classes surfaced when building `CrowDaemon`.

## Base branch note
The `CrowDaemon` package exists only on the in-flight headless-engine migration branch (`fix/crow-594-rebase-onto-main`, ADR 0007/0008) — it is **not on `main`**. The warnings the ticket describes live there, so this PR targets that branch. (GitHub won't auto-close #640 until the migration branch reaches `main`.)

## Changes
1. **`RPCWebSocketHandler.swift`** — dropped the unnecessary `try` on `withThrowingTaskGroup`. All throwing calls (`outbound.write`, `inbound.messages`) run inside `group.addTask` child closures; the only body-level error site is `try? await group.next()`, which swallows the error — so nothing throws out of the group closure and the outer `try` was unwarranted. The throwing group variant is kept because the child tasks are throwing.
2. **`CrowDaemon.resolvedExecutablePath()`** — replaced the three array-based `String(cString:)` calls (deprecated `init(cString: [CChar])`) with a null-truncated `String(decoding:as:)` via a small private `decodeCString([CChar])` helper, covering the Darwin realpath fallback/success paths and the Linux branch. The `strerror` pointer-based `String(cString:)` calls are left untouched — they use the non-deprecated pointer overload and produce no warning.

## Acceptance criteria
- [x] Cold build of `CrowDaemon` is free of both warning classes (`swift build --package-path Packages/CrowDaemon` → `Build complete!`, no `no calls to throwing` / `DeprecatedDeclaration` warnings on the two files).
- [x] Path-resolution and task-group teardown behavior unchanged.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow