### PR TITLE
feat(terminal): drag-and-drop images into agent chats (closes #644)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Artifacts.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Artifacts.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CrowCore
+import HTTPTypes
 import Hummingbird
 import NIOCore
 
@@ -13,6 +14,16 @@ import NIOCore
 /// outside this scratch tree is reachable.
 enum Artifacts {
     static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "svg"]
+
+    /// Extensions accepted for *dropped* images (drag-and-drop into the composer,
+    /// #644). Deliberately a subset of `imageExtensions`: SVG is script-bearing
+    /// and not a raster the agents consume, so it's kept out of the input path.
+    static let uploadableImageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp"]
+
+    /// Cap for a single dropped image (10 MB). Screenshots blow past the 1 MB
+    /// WebSocket frame limit, which is why uploads take this dedicated HTTP route
+    /// rather than the `/rpc` or `/terminal` sockets.
+    static let maxUploadBytes = 10 * 1024 * 1024
 
     /// A session's dir, or nil if `sessionID` isn't a valid UUID (traversal guard).
     /// Shares `CrowCore.ArtifactPaths` with the terminal-env injection so the
@@ -38,8 +49,10 @@ enum Artifacts {
         }.sorted { $0.2 > $1.2 }
     }
 
-    /// Mount `GET /artifacts/:session/:file`.
-    static func mount(on router: Router<CrowHTTPContext>) {
+    /// Mount `GET /artifacts/:session/:file` (view) and `POST /artifacts/:session`
+    /// (drop an image into the composer, #644). Both sit behind `WebAuthMiddleware`;
+    /// the write side additionally requires a same-origin request (anti-CSRF).
+    static func mount(on router: Router<CrowHTTPContext>, boundHost: String) {
         router.get("/artifacts/:session/:file") { _, context -> Response in
             guard let session = context.parameters.get("session"),
                   let dir = dir(sessionID: session),
@@ -69,6 +82,51 @@ enum Artifacts {
                 status: .ok,
                 headers: headers,
                 body: .init(byteBuffer: ByteBuffer(bytes: data)))
+        }
+
+        // Write side of the same scratch dir: a dropped image is stored here so
+        // the agent (running on the host) can read it at an absolute path, and it
+        // shows up in the client's Artifacts panel too (#644). The middleware
+        // already requires a valid session; the Origin check blocks a cross-site
+        // page from driving an upload+inject via the ambient cookie.
+        router.post("/artifacts/:session") { request, context -> Response in
+            guard WebSocketOriginGuard.isAllowedOrigin(
+                request.headers[.origin],
+                boundHost: boundHost,
+                forwardedHost: request.headers[HTTPField.Name("x-forwarded-host")!],
+                peerIsLoopback: WebAuthGuard.isLoopbackPeer(context.remoteAddress)) else {
+                return Response(status: .forbidden)
+            }
+            guard let session = context.parameters.get("session"),
+                  let dir = dir(sessionID: session) else {
+                return Response(status: .badRequest)
+            }
+            let filename = request.headers[HTTPField.Name("x-filename")!]
+                .flatMap { $0.removingPercentEncoding ?? $0 }
+            guard let ext = uploadExtension(
+                contentType: request.headers[.contentType], filename: filename) else {
+                return Response(status: .init(code: 415)) // Unsupported Media Type
+            }
+            // `collect(upTo:)` throws when the body exceeds the cap → 413.
+            guard let buffer = try? await request.body.collect(upTo: maxUploadBytes) else {
+                return Response(status: .init(code: 413)) // Content Too Large
+            }
+            let data = Data(buffer.readableBytesView)
+            guard !data.isEmpty else { return Response(status: .badRequest) }
+            let name = sanitizedUploadName(filename: filename, ext: ext)
+            guard isSafeImageName(name) else { return Response(status: .badRequest) }
+            do {
+                try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                try data.write(to: dir.appendingPathComponent(name), options: .atomic)
+            } catch {
+                return Response(status: .internalServerError)
+            }
+            let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
+            return json([
+                "name": name,
+                "path": dir.appendingPathComponent(name).path,
+                "url": "/artifacts/\(session)/\(encoded)",
+            ])
         }
     }
 
@@ -103,5 +161,54 @@ enum Artifacts {
         case "svg": return "image/svg+xml"
         default: return "application/octet-stream"
         }
+    }
+
+    // MARK: - Upload helpers (#644)
+
+    /// Resolve a safe, uploadable image extension for a dropped file: the
+    /// filename's own extension when it's a raster we accept, else derived from
+    /// the `Content-Type` media type. `nil` (→ 415) for anything else (incl. SVG,
+    /// PDFs, text). Filename wins so an `image/*` body with a real `.gif` name
+    /// keeps `gif` rather than a content-type guess.
+    static func uploadExtension(contentType: String?, filename: String?) -> String? {
+        if let filename {
+            let ext = (filename as NSString).pathExtension.lowercased()
+            if uploadableImageExtensions.contains(ext) { return ext }
+        }
+        // Media type only — strip any `; charset=…`/params.
+        guard let media = contentType?
+            .split(separator: ";").first?
+            .trimmingCharacters(in: .whitespaces).lowercased() else { return nil }
+        switch media {
+        case "image/png": return "png"
+        case "image/jpeg", "image/jpg": return "jpg"
+        case "image/gif": return "gif"
+        case "image/webp": return "webp"
+        default: return nil
+        }
+    }
+
+    /// A collision-free, traversal-proof name for a dropped image:
+    /// `drop-<8hex>-<sanitized-stem>.<ext>`. The stem keeps only
+    /// `[A-Za-z0-9_-]` from the original filename (spaces/slashes/dots/`..`
+    /// dropped), so the result always satisfies ``isSafeImageName``. The random
+    /// token keeps repeated drops of the same name from overwriting each other.
+    static func sanitizedUploadName(filename: String?, ext: String) -> String {
+        let allowed = CharacterSet(charactersIn:
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        let stem = filename.map { ($0 as NSString).lastPathComponent } ?? ""
+        let base = (stem as NSString).deletingPathExtension
+        let cleaned = String(String.UnicodeScalarView(base.unicodeScalars.filter { allowed.contains($0) }))
+        let safeStem = cleaned.isEmpty ? "image" : String(cleaned.prefix(48))
+        let token = UUID().uuidString.prefix(8).lowercased()
+        return "drop-\(token)-\(safeStem).\(ext)"
+    }
+
+    private static func json(_ dict: [String: Any], status: HTTPResponse.Status = .ok) -> Response {
+        let data = (try? JSONSerialization.data(withJSONObject: dict)) ?? Data("{}".utf8)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json; charset=utf-8"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data)))
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -262,7 +262,7 @@ public enum CrowDaemon {
         StaticAssets.mount(on: httpRouter, webDir: options.webDir)
         // Per-session generated images (diagrams/screenshots an agent dropped
         // in the scratch dir), served read-only + sandboxed (CROW-593).
-        Artifacts.mount(on: httpRouter)
+        Artifacts.mount(on: httpRouter, boundHost: options.host)
         if let webDir = options.webDir {
             log("serving web UI live from \(webDir) (edit + refresh, no rebuild)")
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2076,6 +2076,7 @@ function ensureTerminal() {
   });
   enableTouchScroll(document.getElementById('terminal'));
   enableWheelScroll(document.getElementById('terminal'));
+  enableImageDrop(document.getElementById('terminal'));
   window.addEventListener('resize', fitTerminal);
   connectTerminalWs();
 }
@@ -2110,6 +2111,66 @@ function enableWheelScroll(node) {
     e.preventDefault();
     e.stopPropagation();
   }, { capture: true, passive: false });
+}
+
+// Drag-and-drop images into the composer (#644). The browser can't read a
+// dropped file's filesystem path (and may be a remote client), so upload the
+// bytes to crowd, which writes them into the session's artifacts dir on the
+// host and returns an absolute path. We then paste that (escaped) path into the
+// terminal — parity with a Finder drop into the standalone Cursor/Claude Code
+// TUIs, which the agents already consume. No trailing newline → the path is
+// inserted, not submitted, so the user can add a prompt before pressing Enter.
+function enableImageDrop(node) {
+  node.addEventListener('dragover', (e) => {
+    // dataTransfer.files is empty during dragover — only .types is populated —
+    // so accept any file drag here and filter to images on drop.
+    if (e.dataTransfer && Array.from(e.dataTransfer.types || []).includes('Files')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    }
+  });
+  node.addEventListener('drop', (e) => {
+    const files = e.dataTransfer && e.dataTransfer.files;
+    if (!files || !files.length) return; // not a file drop → leave to the browser
+    e.preventDefault();                   // never navigate the app away on a file drop
+    const images = Array.from(files).filter((f) => (f.type || '').startsWith('image/'));
+    if (images.length && selectedId) uploadDroppedImages(images);
+  });
+}
+
+// Backslash-escape whitespace and shell metacharacters, matching what
+// Terminal.app/iTerm insert on a Finder drop (the byte stream the agent TUIs
+// already parse). In practice the artifacts path has none of these, so this is
+// belt-and-suspenders.
+function shellEscapePath(p) {
+  return p.replace(/([\s'"\\$`&|;<>()*?!#~\[\]{}])/g, '\\$1');
+}
+
+async function uploadDroppedImages(images) {
+  const sid = selectedId;
+  const paths = [];
+  for (const file of images) {
+    try {
+      const res = await fetch('/artifacts/' + encodeURIComponent(sid), {
+        method: 'POST',
+        headers: {
+          'Content-Type': file.type,
+          'X-Filename': encodeURIComponent(file.name || 'image'),
+        },
+        body: file,
+        credentials: 'same-origin',
+      });
+      if (!res.ok) continue;
+      const data = await res.json();
+      if (data && data.path) paths.push(shellEscapePath(data.path));
+    } catch (_) { /* skip this file */ }
+  }
+  if (paths.length && term) {
+    term.focus();
+    // Route through xterm's paste so bracketed-paste mode wraps it (same path as
+    // pasteIntoTerminal); onData forwards the wrapped bytes to the PTY.
+    term.paste(paths.join(' ') + ' ');
+  }
 }
 
 // Paste the browser clipboard into the terminal (writes to the PTY, same path

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/ArtifactsTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/ArtifactsTests.swift
@@ -61,4 +61,48 @@ import Testing
         let names = Artifacts.list(sessionID: session).map(\.name)
         #expect(Set(names) == ["a.png", "b.svg"])   // .txt excluded
     }
+
+    // MARK: - Upload helpers (#644)
+
+    @Test func uploadExtensionPrefersFilenameThenContentType() {
+        // Filename extension wins when it's an accepted raster.
+        #expect(Artifacts.uploadExtension(contentType: "image/png", filename: "shot.PNG") == "png")
+        #expect(Artifacts.uploadExtension(contentType: nil, filename: "a.jpeg") == "jpeg")
+        #expect(Artifacts.uploadExtension(contentType: nil, filename: "b.gif") == "gif")
+        #expect(Artifacts.uploadExtension(contentType: nil, filename: "c.webp") == "webp")
+        // Falls back to the Content-Type media type (params stripped).
+        #expect(Artifacts.uploadExtension(contentType: "image/jpeg; charset=binary", filename: "notes.txt") == "jpg")
+        #expect(Artifacts.uploadExtension(contentType: "image/png", filename: nil) == "png")
+    }
+
+    @Test func uploadExtensionRejectsNonRasterInput() {
+        // SVG is script-bearing → kept out of the drop input path.
+        #expect(Artifacts.uploadExtension(contentType: "image/svg+xml", filename: "logo.svg") == nil)
+        #expect(Artifacts.uploadExtension(contentType: "application/pdf", filename: "doc.pdf") == nil)
+        #expect(Artifacts.uploadExtension(contentType: "text/plain", filename: "notes.txt") == nil)
+        #expect(Artifacts.uploadExtension(contentType: nil, filename: nil) == nil)
+    }
+
+    @Test func sanitizedUploadNameIsSafeUniqueAndTraversalProof() {
+        // Spaces/metachars stripped from the stem; result is always a safe name.
+        let a = Artifacts.sanitizedUploadName(filename: "my shot!.png", ext: "png")
+        #expect(a.hasPrefix("drop-"))
+        #expect(a.hasSuffix(".png"))
+        #expect(Artifacts.isSafeImageName(a))
+        #expect(!a.contains(" "))
+
+        // A traversal-y name collapses to its bare component and stays safe.
+        let b = Artifacts.sanitizedUploadName(filename: "../../etc/passwd", ext: "png")
+        #expect(Artifacts.isSafeImageName(b))
+        #expect(!b.contains("/"))
+        #expect(!b.contains(".."))
+
+        // Empty/nil stem defaults to "image".
+        #expect(Artifacts.sanitizedUploadName(filename: nil, ext: "gif").contains("-image.gif"))
+
+        // Unique token → repeated drops of the same file don't collide.
+        let c = Artifacts.sanitizedUploadName(filename: "x.png", ext: "png")
+        let d = Artifacts.sanitizedUploadName(filename: "x.png", ext: "png")
+        #expect(c != d)
+    }
 }

--- a/crow-desktop/src-tauri/tauri.conf.json
+++ b/crow-desktop/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
         "width": 1400,
         "height": 900,
         "minWidth": 900,
-        "minHeight": 600
+        "minHeight": 600,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
Closes #644

## What

Drag-and-drop images into the agent terminal, with parity to the standalone Cursor / Claude Code TUIs (which accept a Finder image drop by inserting the file path into the composer).

Because the browser can't read a dropped file's filesystem path — and may even be a remote client — the image **bytes** are uploaded to crowd, which writes them into the session's artifacts scratch dir on the host and returns an absolute path. The client then pastes that (backslash-escaped) path into the composer via bracketed paste, **without submitting**, so the user can add a prompt before pressing Enter.

Reusing the existing per-session artifacts dir (`$TMPDIR/crow/artifacts/<uuid>/`) means the agent reads the file at a known absolute path **and** the drop shows up in the client's Artifacts "Images" panel.

## Changes

- **`Artifacts.swift`** — `POST /artifacts/:session`, the write side of the existing `GET /artifacts/:session/:file`. Behind `WebAuthMiddleware` (valid session required) plus a same-origin check (anti-CSRF, matching the secret-POST pattern). 10 MB cap, raster-only (`png/jpg/jpeg/gif/webp` — SVG deliberately excluded as script-bearing), sanitized collision-free filename (`drop-<8hex>-<stem>.<ext>`). Uploads take a dedicated HTTP route because both the `/rpc` and `/terminal` WebSockets cap frames at 1 MB.
- **`app.js`** — `dragover`/`drop` on the terminal; image files are uploaded and the returned path pasted into the composer via `term.paste` (bracketed). Non-image drops are ignored and never navigate the app away.
- **`tauri.conf.json`** — `dragDropEnabled: false` so the desktop webview forwards OS file drops to the DOM (Tauri v2 intercepts them by default), unifying browser + desktop on one code path.
- **Tests** — `uploadExtension` / `sanitizedUploadName` helpers in `ArtifactsTests`.

## Notes

- Based on `feature/crow-593-web-ui-parity` (the web-UI architecture), not `main`.
- `make daemon` builds clean; `ArtifactsTests` (7 tests) pass.

## Verification

1. Run crowd + open the web UI; select a Claude Code / Cursor session.
2. Drag a `.png` from Finder onto the terminal → escaped host path appears in the composer (not submitted); the image also appears in the Artifacts panel; the agent attaches it on send.
3. Path with spaces / multiple images → handled. Drag a `.txt`/`.pdf` → ignored (no navigation).
4. Typing + clipboard paste in the composer → unaffected.
5. Desktop: rebuild the Tauri app and repeat the Finder-drop check inside the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1NvQbNrsEekQymspbKJ4J
