### PR TITLE
fix(daemon): drop deprecated String(cString:) in realpath resolution

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -340,6 +340,13 @@ public enum CrowDaemon {
         exit(1)
     }
 
+    /// Decode a null-terminated `[CChar]` C-string buffer into a `String`,
+    /// truncating at the first NUL. Replaces the deprecated `String(cString:)`
+    /// array initializer.
+    private static func decodeCString(_ buf: [CChar]) -> String {
+        String(decoding: buf.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+
     /// Absolute path of the running `crowd` binary, or `nil` if it can't be
     /// resolved (caller falls back to `execvp`). Exposed for tests.
     static func resolvedExecutablePath() -> String? {
@@ -352,14 +359,14 @@ public enum CrowDaemon {
         // `_NSGetExecutablePath` may return a relative path; realpath makes it
         // absolute so a later cwd change can't break the re-exec.
         var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
-        guard realpath(buf, &resolved) != nil else { return String(cString: buf) }
-        return String(cString: resolved)
+        guard realpath(buf, &resolved) != nil else { return decodeCString(buf) }
+        return decodeCString(resolved)
         #elseif os(Linux)
         var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
         let n = readlink("/proc/self/exe", &buf, buf.count - 1)
         guard n > 0 else { return nil }
         buf[n] = 0
-        return String(cString: buf)
+        return decodeCString(buf)
         #else
         return nil
         #endif


### PR DESCRIPTION
Closes #649

## Problem
`CrowDaemon.resolvedExecutablePath()` decoded null-terminated `[CChar]` buffers with the array initializer `String(cString: [CChar])`, which Swift now deprecates — three `DeprecatedDeclaration` warnings on a cold build.

## Fix
Replace all three array-based call sites (Darwin `realpath` fallback + success, Linux `readlink`) with a null-truncated `String(decoding:as:)` via a small private `decodeCString([CChar])` helper. The `strerror` `String(cString:)` calls are left untouched — they use the non-deprecated **pointer** overload and emit no warning. Same bytes, same NUL truncation → path-resolution behavior unchanged.

## Base branch
Targets **`feature/crow-593-web-ui-parity`**, not `main`: the `CrowDaemon` package only exists on the headless-engine migration line (ADR 0007/0008).

Mirrors #642 (closes #640) verbatim. That fix landed only on `fix/crow-594-rebase-onto-main`, so the 593 line still emitted the warnings; keeping the helper byte-identical keeps future merges trivial.

## Acceptance criteria
- [x] Cold build of CrowDaemon no longer emits the `String(cString:)` deprecation warnings (`swift build --package-path Packages/CrowDaemon` → `Build complete!`, no `DeprecatedDeclaration` on this file).
- [x] Path-resolution behavior unchanged — `resolvedExecutablePathIsAbsoluteAndExists` passes.
- [x] PR targets `crow-593-*`, not `main`.

🐦‍⬛ Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyUtX7PJiyMP3Pu629vAoR