### PR TITLE
fix(crow-workspace): use Closes #{number} instead of literal #123 in PR body

### DIFF
--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -455,7 +455,7 @@ gh api repos/{owner}/{repo}/issues/{number}/comments
 6. Open a pull request linked to the ticket:
 
 ```bash
-gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
+gh pr create --title "<summary>" --body "Closes #{number}" --base {base_branch}
 ```
 
 ## Custom Instructions
@@ -465,7 +465,9 @@ gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
 
 If the workspace config contains a non-empty `customInstructions` field, append a `## Custom Instructions` section at the end of the prompt with its contents verbatim. Omit this section entirely if the field is absent, null, or empty.
 
-For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
+On step 6, substitute the real ticket number into `{number}` in the PR body (same substitution as `{base_branch}`) so the body reads e.g. `Closes #654` — the closing keyword with the real number is what makes GitHub link the PR to the issue and auto-close it on merge into the default branch. When no ticket number is available, drop the `--body` and fall back to `gh pr create --fill`.
+
+For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the description and fall back to `glab mr create --fill`.
 
 ### Embedding pre-fetched content
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -455,7 +455,7 @@ gh api repos/{owner}/{repo}/issues/{number}/comments
 6. Open a pull request linked to the ticket:
 
 ```bash
-gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
+gh pr create --title "<summary>" --body "Closes #{number}" --base {base_branch}
 ```
 
 ## Custom Instructions
@@ -465,7 +465,9 @@ gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
 
 If the workspace config contains a non-empty `customInstructions` field, append a `## Custom Instructions` section at the end of the prompt with its contents verbatim. Omit this section entirely if the field is absent, null, or empty.
 
-For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
+On step 6, substitute the real ticket number into `{number}` in the PR body (same substitution as `{base_branch}`) so the body reads e.g. `Closes #654` — the closing keyword with the real number is what makes GitHub link the PR to the issue and auto-close it on merge into the default branch. When no ticket number is available, drop the `--body` and fall back to `gh pr create --fill`.
+
+For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the description and fall back to `glab mr create --fill`.
 
 ### Embedding pre-fetched content
 


### PR DESCRIPTION
Closes #654

## Problem

Auto-picked-up and manual `/crow-workspace` PRs on GitHub don't link to their issue under the Development panel and don't auto-close it on merge.

## Root cause

The worker-prompt template's PR-open step hardcoded a literal `Closes #123` instead of the `{number}` placeholder used everywhere else in the template (SKILL.md lines 113, 275, 445…), while the GitLab variant already did `Closes #{number}` correctly. GitHub derives **both** the issue↔PR link and auto-close-on-merge from a closing keyword carrying the *real* issue number in the PR body, so a literal `#123` meant the real number never landed in the body — GitHub linked/closed the wrong issue, or nothing.

## Fix

In both the live skill (`skills/crow-workspace/SKILL.md`) and its mirrored `Resources/crow-workspace-SKILL.md.template`:

1. `Closes #123` → `Closes #{number}` in the GitHub PR step.
2. Added an explicit manager instruction to substitute the real ticket number into `{number}` (same treatment as `{base_branch}`), with a `gh pr create --fill` fallback when no number is available — mirroring the existing GitLab guidance.

The optional watcher-hardening from the ticket is intentionally out of scope; this is a targeted prompt-template fix.

## Verification

`rg -n "Closes #" skills/crow-workspace/SKILL.md Resources/crow-workspace-SKILL.md.template` shows every occurrence is now `Closes #{number}` with zero `#123` literals. This PR itself was opened with a real `Closes #654` — the behavior the fix produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sgjB2SnGTg79iq9Q3WVi4