### PR TITLE
RFC/design: AI-usage rubric — efficiency+outcome scoring (design doc + feasibility) (refs #648)

### DIFF
--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -11,7 +11,7 @@ Most AI-usage leaderboards rank by raw spend or token count. That is a perverse 
 Three metric categories frame the design:
 
 - **A. Efficiency / hygiene** (penalties/normalizers): compaction count, context accumulation (avg input per turn), cache hit ratio, cost-per-outcome, rework.
-- **B. Outcomes / throughput** (rewards): tickets done, PRs merged, merge rate.
+- **B. Outcomes / throughput** (rewards): sessions shipped (v1's headline), then tickets done, PRs merged, merge rate as attribution data lands.
 - **C. Alignment** (weights/flags): does the work ladder up to an org KPI/goal; priority weighting.
 
 ### Data feasibility (verified against the code)
@@ -45,14 +45,14 @@ Crow rates AI usage with **two separate surfaces — a per-session A–F efficie
 
 The **efficiency grade** is a penalty-point deduction from 100 within a single unit, mapped to A–F bands. Every deduction is labeled with its cause, so the grade is a coachable sentence, not a number: *"C — 3 compactions (−15), 12% API error rate (−10)."* Additive arithmetic is fine *inside* the grade because everything is the same unit (penalty points) and each deduction is independently explainable.
 
-The **throughput surface** is plain counts (tickets done, sessions that shipped) shown alongside — never multiplied into the grade in v1.
+The **throughput surface** is a plain count — **sessions shipped** in v1, with ticket/PR counts joining once attribution data exists (follow-ups 5–6) — shown alongside, never multiplied into the grade in v1.
 
 The strawman from #648 — `throughput × efficiency-multiplier × alignment-weight` — is the right **v2** shape, and this ADR names its trigger conditions: adopt it **only after** PR→session attribution (follow-up 5), rework tracking (6), and alignment tagging (8) exist and the headline unit is per-user-per-week. Multiplicative is correct *then* because it makes waste un-buyable with volume — an additive combination lets high throughput mask terrible hygiene, which recreates the raw-spend-leaderboard failure with extra steps. It is wrong *now* because at session grain the throughput factor is usually zero, producing unstable, unexplainable scores.
 
 ### Unit, window, surface
 
 - **Unit:** the **session** is the atomic graded unit — it is the natural grain of every verified field. Sessions with fewer than ~5 prompts are shown as *insufficient data*, not graded.
-- **Window:** the headline view is a **weekly rollup** (smooths small samples, absorbs session-splitting); per-session grades are the drill-down.
+- **Window:** the headline view is a **weekly rollup** (smooths small samples, absorbs session-splitting); per-session grades are the drill-down. The weekly grade **re-aggregates raw numerators and denominators** across the week's sessions (Σ compactions / Σ active hours, Σ input tokens / Σ prompts, …) — it is *not* an average of per-session grades, which would let many short clean sessions dilute one disastrous one and reintroduce the session-splitting incentive.
 - **Surface:** a **private scorecard, not a leaderboard**. The comparison baseline is the user's own trailing 4-week median — "this week vs. your normal." A leaderboard of one user is meaningless, and leaderboards maximize gaming incentive for minimum informational value. The intended audience of the grade is **the user themself**; this is a design constraint, and any future team leaderboard proposal must supersede this ADR explicitly rather than quietly repurposing the scorecard as a surveillance instrument.
 
 ### v1 metrics (all formulas from verified fields)
@@ -63,7 +63,7 @@ The strawman from #648 — `throughput × efficiency-multiplier × alignment-wei
 | Context pressure | `inputTokens / max(1, promptCount)` | graded |
 | Cache hit ratio | `cacheReadTokens / max(1, inputTokens + cacheCreationTokens)` | graded |
 | API error rate | `apiErrorCount / max(1, apiRequestCount)` | graded |
-| Cost per done ticket | weekly grain only: `Σ totalCost / max(1, sessionsShipped)` | graded (weekly) |
+| Cost per shipped session | weekly grain only: `Σ totalCost / sessionsShipped`; a week with `sessionsShipped == 0` is **not graded** on this metric (shown as "insufficient outcomes"), never divided by 1 | graded (weekly) |
 | Session outcome flag | ticket reached done via `markIssueDone` / status → `.completed` | throughput surface |
 | Sessions shipped (week) | count of outcome-flagged sessions in the window, derived from persisted per-session snapshots (follow-up 2) | throughput surface — the weekly headline |
 | Churn hint | `linesRemoved / max(1, linesAdded)` | informational only (too weak as a rework proxy to grade) |

--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-07-10
-- **Deciders:** Crow maintainers
+- **Deciders:** @dhilgaertner, @dgershman
 
 ## Context
 
@@ -10,7 +10,7 @@ Most AI-usage leaderboards rank by raw spend or token count. That is a perverse 
 
 Three metric categories frame the design:
 
-- **A. Efficiency / hygiene** (penalties/normalizers): compaction count, context accumulation (avg input per turn), cache-read:output ratio, cost-per-outcome, rework.
+- **A. Efficiency / hygiene** (penalties/normalizers): compaction count, context accumulation (avg input per turn), cache hit ratio, cost-per-outcome, rework.
 - **B. Outcomes / throughput** (rewards): tickets done, PRs merged, merge rate.
 - **C. Alignment** (weights/flags): does the work ladder up to an org KPI/goal; priority weighting.
 
@@ -22,8 +22,8 @@ Every claim below was traced in the source; this table is the ground truth the r
 |---|---|---|---|
 | Session cost + tokens (input/output/cacheRead/cacheCreation) | `SessionAnalytics` (`Packages/CrowCore/Sources/CrowCore/Models/SessionAnalytics.swift`), aggregated from OTLP telemetry (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, local receiver in `Packages/CrowTelemetry`) | **Computable today** (in-memory) | Aggregate struct is not persisted — lives on `SessionHookState.analytics`, blank after relaunch until new telemetry arrives. Raw datapoints *are* persisted (`~/Library/Application Support/crow/telemetry.db`, 180-day retention). Telemetry is **off by default** (`AppConfig.telemetry.enabled = false`) and **Claude-Code-only** (Codex/Cursor emit no OTEL). |
 | Avg input tokens per turn | `inputTokens / promptCount` from the same struct | **Computable today** (proxy) | "Turn" is proxied by `promptCount` (count of `user_prompt` events); true per-turn records are reconstructable from `telemetry.db` rows but not modeled. |
-| Cache-read:output ratio, API error rate, active time, lines added/removed, commit count, tool calls | `SessionAnalytics` fields (`cacheReadTokens`, `apiErrorCount`/`apiRequestCount`, `activeTimeSeconds`, …) | **Computable today** | Same persistence caveat. Note `totalTokens` includes cache tokens, so it overstates billed I/O. |
-| Compaction count per session | `PreCompact`/`PostCompact` hooks are registered (`Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift`) and arrive session-resolved at the `hook-event` handler (`Sources/Crow/App/AppDelegate.swift`) | **Needs light plumbing** | Events land only in a 50-entry in-memory ring buffer; nothing counts or persists them. Fix is a counter field on `PersistedHookState` + an increment in the existing handler's persist-on-change path. No new wiring. |
+| Cache hit ratio, API error rate, active time, lines added/removed, commit count, tool calls | `SessionAnalytics` fields (`cacheReadTokens`, `apiErrorCount`/`apiRequestCount`, `activeTimeSeconds`, …) | **Computable today** | Same persistence caveat. Note `totalTokens` includes cache tokens, so it overstates billed I/O. |
+| Compaction count per session | `PreCompact`/`PostCompact` hooks are registered (`Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift`) and arrive session-resolved at the `hook-event` handler (`Sources/Crow/App/AppDelegate.swift`) | **Needs light plumbing** | Events land only in a 50-entry in-memory ring buffer; nothing counts or persists them. Fix is a counter incremented in the existing handler and persisted with the session analytics snapshot (follow-up 2) — not on `PersistedHookState`, whose documented contract is the color-driving UI subset. No new wiring. |
 | Session wall-clock duration | `SessionStart`/`SessionEnd` hooks arrive but no timestamps are derived; `Session` persists only `createdAt`/`updatedAt` | **Needs light plumbing** | Capture start/end timestamps, or persist telemetry's `activeTimeSeconds`. |
 | Tickets done | `AppState.doneIssuesLast24h`, computed in `IssueTracker.refresh()` from GitHub `state:closed` + Jira `statusCategory=Done` | **Computable today** (aggregate only) | Single viewer-scoped integer, trailing-24h, recomputed not persisted, no history; GitLab not counted. No attribution from a closed ticket back to the session that closed it. |
 | Session outcome flag ("this session shipped") | `IssueTracker.markIssueDone(sessionID:)` + session `status` → `.completed` | **Computable today** | Per-action UI state; usable as a boolean outcome bit per session. |
@@ -59,30 +59,35 @@ The strawman from #648 — `throughput × efficiency-multiplier × alignment-wei
 
 | Metric | Formula | Role |
 |---|---|---|
-| Compaction count | new persisted counter (increment on `PreCompact` in the existing hook handler) | graded — heaviest penalty |
+| Compaction count | new persisted counter (increment on `PostCompact` — a *completed* compaction — in the existing hook handler; persisted with the analytics snapshot) | graded — heaviest penalty |
 | Context pressure | `inputTokens / max(1, promptCount)` | graded |
-| Cache efficiency | `cacheReadTokens / max(1, inputTokens + cacheCreationTokens)` | graded |
+| Cache hit ratio | `cacheReadTokens / max(1, inputTokens + cacheCreationTokens)` | graded |
 | API error rate | `apiErrorCount / max(1, apiRequestCount)` | graded |
-| Cost per done ticket | weekly grain only: `Σ totalCost / max(1, ticketsDone)` | graded (weekly) |
+| Cost per done ticket | weekly grain only: `Σ totalCost / max(1, sessionsShipped)` | graded (weekly) |
 | Session outcome flag | ticket reached done via `markIssueDone` / status → `.completed` | throughput surface |
-| Tickets done (week) | count of outcome-flagged sessions; `doneIssuesLast24h` stays as-is | throughput surface |
+| Sessions shipped (week) | count of outcome-flagged sessions in the window, derived from persisted per-session snapshots (follow-up 2) | throughput surface — the weekly headline |
 | Churn hint | `linesRemoved / max(1, linesAdded)` | informational only (too weak as a rework proxy to grade) |
 | Cost, active time, commits | `totalCost`, `activeTimeSeconds`, `commitCount` | displayed, not graded |
+
+Two definitional notes:
+
+- **Cache hit ratio deliberately reinterprets #648.** The issue framed a high cache-read:output ratio as a bloated-context smell ("should have been split/reset"). This ADR grades the opposite polarity on a different denominator: a high cache-read *share of context* (`cacheRead / (input + cacheCreation)`) means the context being carried is served from prompt cache rather than re-sent as fresh input — the cheap way to carry context. The bloat smell #648 was pointing at is captured by the metrics that measure *how much* context is carried: context pressure and compaction count. Graded polarity: higher hit ratio = better.
+- **`doneIssuesLast24h` is not a scorecard input.** It is viewer-scoped, trailing-24h, includes tickets closed outside any Crow session, and is recomputed with no history — it stays as the existing board badge, nothing more. The scorecard's throughput metric is **sessions shipped**, which is session-attributed and computable weekly precisely because follow-up 2 persists per-session snapshots.
 
 ### Grade bands are tunable priors, not gospel
 
 Starting heuristics — stored as named constants, revised against real distributions after an explicit **4-week calibration period**:
 
-- Compactions: normalized **per active hour**, 0 = no deduction, scaling penalty above.
+- Compactions: normalized **per active hour**, 0 = no deduction, scaling penalty above. The authoritative clock for all penalty normalization is telemetry's `activeTimeSeconds`; wall-clock session duration (follow-up 4) is displayed for context but never a penalty denominator (an idle-overnight session shouldn't launder its compactions).
 - API error rate: < 2% clean, > 10% heavy deduction.
-- Cache efficiency: > 0.7 good (high cache-read share means context is being reused, not re-sent).
+- Cache hit ratio: > 0.7 good (high cache-read share means context is being reused, not re-sent).
 - Context pressure: flag a rising within-session trend rather than an absolute cutoff, once per-turn data exists; until then a per-session average threshold.
 
 The calibration period is binding: if real data says a threshold punishes legitimately hard sessions, the threshold moves.
 
 ### Anti-gaming guardrails (design-level)
 
-- The headline is **weekly**, and compaction/context penalties are normalized **per active hour and per outcome**, not per session — splitting one long session into three short ones doesn't reset the denominator.
+- The headline is **weekly**, and compaction/context penalties are normalized **per active hour** — never per session (splitting one long session into three short ones doesn't reset the denominator) and never per outcome (the ADR's own zero-outcome argument applies to penalties too). Outcomes enter the grade only through the weekly cost-per-outcome metric.
 - The **minimum-sample floor** (< ~5 prompts → ungraded) prevents farming A-grades with trivial sessions.
 - **Cost-per-outcome is computed only at weekly grain**, so outcome-free sessions neither score nor dodge.
 - **No combined number exists in v1** — there is nothing to farm.
@@ -95,9 +100,9 @@ Deferred guardrails (explicit non-goals until their data exists): trivial-PR far
 
 | # | Follow-up ticket | Scope | Blocks |
 |---|---|---|---|
-| 1 | Fix telemetry aggregation-temporality handling | Check delta vs. cumulative on OTLP datapoints before `SUM` — today `sumMetric` sums blindly; a cumulative export would double-count. **Prerequisite for trusting any token/cost metric; grades ship behind this fix.** | v1 |
+| 1 | Fix telemetry aggregation-temporality handling | Handle delta vs. cumulative **at ingest**: `OTLPSum.aggregationTemporality` is parsed but dropped — the metrics table has no temporality column, so a query-time check in `sumMetric` is impossible with the current schema. Either normalize cumulative datapoints to deltas on insert, or persist a temporality column and account for it in aggregation. **Prerequisite for trusting any token/cost metric; grades ship behind this fix.** | v1 |
 | 2 | Persist a `SessionAnalytics` snapshot at session end | Durable per-session record so weekly rollups and the 4-week baseline survive relaunch (today the aggregate is in-memory; only raw rows persist). | v1 |
-| 3 | Persist a per-session compaction counter | New field on `PersistedHookState` + increment in the existing `PreCompact` handler path. | v1 |
+| 3 | Persist a per-session compaction counter | Increment on `PostCompact` (completed compactions only — a failed/aborted compaction isn't graded waste) in the existing hook handler; persist with the session analytics snapshot from ticket 2, not on `PersistedHookState` (its documented contract is the color-driving UI subset and should stay that way). | v1 (depends on 2) |
 | 4 | Persist session wall-clock duration | Capture `SessionStart`/`SessionEnd` timestamps on the session model. | v1 |
 | 5 | PR→session attribution store | Persist `extractCrowSessionUUIDs` results; merged-PR-per-window counts per session (today the trailer parse is a discard-after-use auto-merge gate). | v2, 6 |
 | 6 | Rework / merge-rate metrics | Revert detection, merged-vs-closed PR rate, post-merge-fix tracking. | v2 |
@@ -130,6 +135,7 @@ No prototype ships with this ADR: the smallest useful one requires persisting th
 ## References
 
 - Ticket: [#648](https://github.com/radiusmethod/crow/issues/648)
+- PR: [#657](https://github.com/corveil/crow/pull/657)
 - Related ADRs: [0005](./0005-task-and-code-backend-protocols.md) (backend protocols the throughput/alignment follow-ups build on)
 - Code (verified for the feasibility table):
   - `Packages/CrowCore/Sources/CrowCore/Models/SessionAnalytics.swift`

--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -6,11 +6,11 @@
 
 ## Context
 
-Most AI-usage leaderboards rank by raw spend or token count. That is a perverse incentive: it rewards volume, not value. A context-bloated session that compacted five times and shipped nothing "wins" a spend leaderboard; a tight session that closed a P0 in twenty minutes doesn't register. [#648](https://github.com/radiusmethod/crow/issues/648) asks for a rubric that rates AI usage on **efficiency**, **outcomes**, and **alignment** instead, so Crow can surface a healthier signal.
+Most AI-usage leaderboards rank by raw spend or token count. That is a perverse incentive: it rewards volume, not value. A context-bloated session that compacted five times and shipped nothing "wins" a spend leaderboard; a tight session that closed a P0 in twenty minutes doesn't register. [#648](https://github.com/corveil/crow/issues/648) asks for a rubric that rates AI usage on **efficiency**, **outcomes**, and **alignment** instead, so Crow can surface a healthier signal.
 
 Three metric categories frame the design:
 
-- **A. Efficiency / hygiene** (penalties/normalizers): compaction count, context accumulation (avg input per turn), cache hit ratio, cost-per-outcome, rework.
+- **A. Efficiency / hygiene** (penalties/normalizers): compaction count, context accumulation (avg input per turn), cache hit ratio, cost per shipped session, rework.
 - **B. Outcomes / throughput** (rewards): sessions shipped (v1's headline), then tickets done, PRs merged, merge rate as attribution data lands.
 - **C. Alignment** (weights/flags): does the work ladder up to an org KPI/goal; priority weighting.
 
@@ -87,9 +87,9 @@ The calibration period is binding: if real data says a threshold punishes legiti
 
 ### Anti-gaming guardrails (design-level)
 
-- The headline is **weekly**, and compaction/context penalties are normalized **per active hour** — never per session (splitting one long session into three short ones doesn't reset the denominator) and never per outcome (the ADR's own zero-outcome argument applies to penalties too). Outcomes enter the grade only through the weekly cost-per-outcome metric.
+- The headline is **weekly**, and compaction/context penalties are normalized **per active hour** — never per session (splitting one long session into three short ones doesn't reset the denominator) and never per outcome (the ADR's own zero-outcome argument applies to penalties too). Outcomes enter the grade only through the weekly cost-per-shipped-session metric.
 - The **minimum-sample floor** (< ~5 prompts → ungraded) prevents farming A-grades with trivial sessions.
-- **Cost-per-outcome is computed only at weekly grain**, so outcome-free sessions neither score nor dodge.
+- **Cost per shipped session is computed only at weekly grain**, so outcome-free sessions neither score nor dodge.
 - **No combined number exists in v1** — there is nothing to farm.
 
 Deferred guardrails (explicit non-goals until their data exists): trivial-PR farming detection (needs PR size + rework data), revert/merged-vs-closed-rate signals, alignment-tag misuse.
@@ -134,7 +134,7 @@ No prototype ships with this ADR: the smallest useful one requires persisting th
 
 ## References
 
-- Ticket: [#648](https://github.com/radiusmethod/crow/issues/648)
+- Ticket: [#648](https://github.com/corveil/crow/issues/648)
 - PR: [#657](https://github.com/corveil/crow/pull/657)
 - Related ADRs: [0005](./0005-task-and-code-backend-protocols.md) (backend protocols the throughput/alignment follow-ups build on)
 - Code (verified for the feasibility table):

--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -1,0 +1,139 @@
+# 0008 — AI-usage efficiency scorecard (rate usage by efficiency + outcomes, not spend)
+
+- **Status:** Proposed
+- **Date:** 2026-07-10
+- **Deciders:** Crow maintainers
+
+## Context
+
+Most AI-usage leaderboards rank by raw spend or token count. That is a perverse incentive: it rewards volume, not value. A context-bloated session that compacted five times and shipped nothing "wins" a spend leaderboard; a tight session that closed a P0 in twenty minutes doesn't register. [#648](https://github.com/radiusmethod/crow/issues/648) asks for a rubric that rates AI usage on **efficiency**, **outcomes**, and **alignment** instead, so Crow can surface a healthier signal.
+
+Three metric categories frame the design:
+
+- **A. Efficiency / hygiene** (penalties/normalizers): compaction count, context accumulation (avg input per turn), cache-read:output ratio, cost-per-outcome, rework.
+- **B. Outcomes / throughput** (rewards): tickets done, PRs merged, merge rate.
+- **C. Alignment** (weights/flags): does the work ladder up to an org KPI/goal; priority weighting.
+
+### Data feasibility (verified against the code)
+
+Every claim below was traced in the source; this table is the ground truth the rest of the ADR builds on.
+
+| Metric | Data source | Status | Gap |
+|---|---|---|---|
+| Session cost + tokens (input/output/cacheRead/cacheCreation) | `SessionAnalytics` (`Packages/CrowCore/Sources/CrowCore/Models/SessionAnalytics.swift`), aggregated from OTLP telemetry (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, local receiver in `Packages/CrowTelemetry`) | **Computable today** (in-memory) | Aggregate struct is not persisted — lives on `SessionHookState.analytics`, blank after relaunch until new telemetry arrives. Raw datapoints *are* persisted (`~/Library/Application Support/crow/telemetry.db`, 180-day retention). Telemetry is **off by default** (`AppConfig.telemetry.enabled = false`) and **Claude-Code-only** (Codex/Cursor emit no OTEL). |
+| Avg input tokens per turn | `inputTokens / promptCount` from the same struct | **Computable today** (proxy) | "Turn" is proxied by `promptCount` (count of `user_prompt` events); true per-turn records are reconstructable from `telemetry.db` rows but not modeled. |
+| Cache-read:output ratio, API error rate, active time, lines added/removed, commit count, tool calls | `SessionAnalytics` fields (`cacheReadTokens`, `apiErrorCount`/`apiRequestCount`, `activeTimeSeconds`, …) | **Computable today** | Same persistence caveat. Note `totalTokens` includes cache tokens, so it overstates billed I/O. |
+| Compaction count per session | `PreCompact`/`PostCompact` hooks are registered (`Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift`) and arrive session-resolved at the `hook-event` handler (`Sources/Crow/App/AppDelegate.swift`) | **Needs light plumbing** | Events land only in a 50-entry in-memory ring buffer; nothing counts or persists them. Fix is a counter field on `PersistedHookState` + an increment in the existing handler's persist-on-change path. No new wiring. |
+| Session wall-clock duration | `SessionStart`/`SessionEnd` hooks arrive but no timestamps are derived; `Session` persists only `createdAt`/`updatedAt` | **Needs light plumbing** | Capture start/end timestamps, or persist telemetry's `activeTimeSeconds`. |
+| Tickets done | `AppState.doneIssuesLast24h`, computed in `IssueTracker.refresh()` from GitHub `state:closed` + Jira `statusCategory=Done` | **Computable today** (aggregate only) | Single viewer-scoped integer, trailing-24h, recomputed not persisted, no history; GitLab not counted. No attribution from a closed ticket back to the session that closed it. |
+| Session outcome flag ("this session shipped") | `IssueTracker.markIssueDone(sessionID:)` + session `status` → `.completed` | **Computable today** | Per-action UI state; usable as a boolean outcome bit per session. |
+| PRs merged / merge rate | PR state is per-item (`OPEN`/`MERGED`/`CLOSED`) via `CodeBackend.listMonitoredPRs` | **Needs new capture** | No merged-PR-per-window counter, no author/date analytics. |
+| PR → session attribution | `Crow-Session:` commit trailer is written *and* parsed (`IssueTracker.extractCrowSessionUUIDs`) | **Needs new capture** | Parse result is used only as a boolean auto-merge eligibility gate over locally-known sessions; no persisted PR→session store. |
+| Rework / revert / re-review churn | — | **Needs new capture** | Confirmed absent; no revert/rework/merge-rate tracking anywhere. |
+| Alignment / KPI mapping, priority weighting | Session stores `ticketURL`/`ticketTitle`/`ticketNumber`; `JiraTaskBackend` reads key/summary/status/assignee/labels | **Needs new capture** (greenfield) | No epic/parent/priority/goal concept exists anywhere in the codebase. Jira priority and epic-link are not fetched. |
+
+Two structural realities constrain the design:
+
+1. **Crow is a single-user, local macOS app.** Every throughput query is viewer-scoped (`assignee:@me`); sessions live on one machine. "Per-user" is trivially true, and a multi-person leaderboard implies cross-machine aggregation that does not exist.
+2. **Most sessions have zero countable outcomes** at any instant — exploration, in-progress work, review sessions. Any formula that divides or multiplies by outcomes is degenerate at the session grain.
+
+## Decision
+
+Crow rates AI usage with **two separate surfaces — a per-session A–F efficiency grade and a plain throughput count — rolled up weekly on a private, self-comparison scorecard. There is no combined score in v1.** Raw spend is displayed as context, never ranked.
+
+### Scoring model: separate surfaces now, multiplicative later
+
+The **efficiency grade** is a penalty-point deduction from 100 within a single unit, mapped to A–F bands. Every deduction is labeled with its cause, so the grade is a coachable sentence, not a number: *"C — 3 compactions (−15), 12% API error rate (−10)."* Additive arithmetic is fine *inside* the grade because everything is the same unit (penalty points) and each deduction is independently explainable.
+
+The **throughput surface** is plain counts (tickets done, sessions that shipped) shown alongside — never multiplied into the grade in v1.
+
+The strawman from #648 — `throughput × efficiency-multiplier × alignment-weight` — is the right **v2** shape, and this ADR names its trigger conditions: adopt it **only after** PR→session attribution (follow-up 5), rework tracking (6), and alignment tagging (8) exist and the headline unit is per-user-per-week. Multiplicative is correct *then* because it makes waste un-buyable with volume — an additive combination lets high throughput mask terrible hygiene, which recreates the raw-spend-leaderboard failure with extra steps. It is wrong *now* because at session grain the throughput factor is usually zero, producing unstable, unexplainable scores.
+
+### Unit, window, surface
+
+- **Unit:** the **session** is the atomic graded unit — it is the natural grain of every verified field. Sessions with fewer than ~5 prompts are shown as *insufficient data*, not graded.
+- **Window:** the headline view is a **weekly rollup** (smooths small samples, absorbs session-splitting); per-session grades are the drill-down.
+- **Surface:** a **private scorecard, not a leaderboard**. The comparison baseline is the user's own trailing 4-week median — "this week vs. your normal." A leaderboard of one user is meaningless, and leaderboards maximize gaming incentive for minimum informational value. The intended audience of the grade is **the user themself**; this is a design constraint, and any future team leaderboard proposal must supersede this ADR explicitly rather than quietly repurposing the scorecard as a surveillance instrument.
+
+### v1 metrics (all formulas from verified fields)
+
+| Metric | Formula | Role |
+|---|---|---|
+| Compaction count | new persisted counter (increment on `PreCompact` in the existing hook handler) | graded — heaviest penalty |
+| Context pressure | `inputTokens / max(1, promptCount)` | graded |
+| Cache efficiency | `cacheReadTokens / max(1, inputTokens + cacheCreationTokens)` | graded |
+| API error rate | `apiErrorCount / max(1, apiRequestCount)` | graded |
+| Cost per done ticket | weekly grain only: `Σ totalCost / max(1, ticketsDone)` | graded (weekly) |
+| Session outcome flag | ticket reached done via `markIssueDone` / status → `.completed` | throughput surface |
+| Tickets done (week) | count of outcome-flagged sessions; `doneIssuesLast24h` stays as-is | throughput surface |
+| Churn hint | `linesRemoved / max(1, linesAdded)` | informational only (too weak as a rework proxy to grade) |
+| Cost, active time, commits | `totalCost`, `activeTimeSeconds`, `commitCount` | displayed, not graded |
+
+### Grade bands are tunable priors, not gospel
+
+Starting heuristics — stored as named constants, revised against real distributions after an explicit **4-week calibration period**:
+
+- Compactions: normalized **per active hour**, 0 = no deduction, scaling penalty above.
+- API error rate: < 2% clean, > 10% heavy deduction.
+- Cache efficiency: > 0.7 good (high cache-read share means context is being reused, not re-sent).
+- Context pressure: flag a rising within-session trend rather than an absolute cutoff, once per-turn data exists; until then a per-session average threshold.
+
+The calibration period is binding: if real data says a threshold punishes legitimately hard sessions, the threshold moves.
+
+### Anti-gaming guardrails (design-level)
+
+- The headline is **weekly**, and compaction/context penalties are normalized **per active hour and per outcome**, not per session — splitting one long session into three short ones doesn't reset the denominator.
+- The **minimum-sample floor** (< ~5 prompts → ungraded) prevents farming A-grades with trivial sessions.
+- **Cost-per-outcome is computed only at weekly grain**, so outcome-free sessions neither score nor dodge.
+- **No combined number exists in v1** — there is nothing to farm.
+
+Deferred guardrails (explicit non-goals until their data exists): trivial-PR farming detection (needs PR size + rework data), revert/merged-vs-closed-rate signals, alignment-tag misuse.
+
+## Rollout & follow-ups
+
+**v1 = follow-ups 1–4 plus a read-only scorecard** computing/presenting the table above. Everything else is deferred, in dependency order:
+
+| # | Follow-up ticket | Scope | Blocks |
+|---|---|---|---|
+| 1 | Fix telemetry aggregation-temporality handling | Check delta vs. cumulative on OTLP datapoints before `SUM` — today `sumMetric` sums blindly; a cumulative export would double-count. **Prerequisite for trusting any token/cost metric; grades ship behind this fix.** | v1 |
+| 2 | Persist a `SessionAnalytics` snapshot at session end | Durable per-session record so weekly rollups and the 4-week baseline survive relaunch (today the aggregate is in-memory; only raw rows persist). | v1 |
+| 3 | Persist a per-session compaction counter | New field on `PersistedHookState` + increment in the existing `PreCompact` handler path. | v1 |
+| 4 | Persist session wall-clock duration | Capture `SessionStart`/`SessionEnd` timestamps on the session model. | v1 |
+| 5 | PR→session attribution store | Persist `extractCrowSessionUUIDs` results; merged-PR-per-window counts per session (today the trailer parse is a discard-after-use auto-merge gate). | v2, 6 |
+| 6 | Rework / merge-rate metrics | Revert detection, merged-vs-closed PR rate, post-merge-fix tracking. | v2 |
+| 7 | Per-turn analytics reader | Model turns from `telemetry.db` raw rows instead of `promptCount` proxies; enables within-session context-trend detection. | — |
+| 8 | Alignment / KPI mapping | Extend `JiraTaskBackend` to read priority + epic/parent; org-goal tagging on sessions; alignment weight. Greenfield. | v2 |
+| 9 | GitLab throughput parity | Include GitLab in done-ticket counting. | — |
+| 10 | Cross-machine aggregation + team surface | Prerequisite for any leaderboard; out of scope here. | — |
+| 11 | Combined multiplicative score (v2) | `alignment-weighted throughput × efficiency multiplier`, per-user-per-week. | blocked on 5, 6, 8 |
+
+No prototype ships with this ADR: the smallest useful one requires persisting the compaction counter (a write-path model change, follow-up 3), which exceeds the read-only bar for a design PR.
+
+## Consequences
+
+- **Goodhart risk is inherent.** Any graded metric will be optimized; the compaction penalty may discourage legitimately long, hard sessions. The tunable-priors + calibration-period framing is the mitigation, and it is binding, not decorative.
+- **No task-difficulty normalization.** A hard ticket grades worse than an easy one at session grain; weekly aggregation only partially washes this out. Fairness improves with alignment/priority data (follow-up 8).
+- **Claude-Code-only, opt-in.** Grades cover only sessions running Claude Code with telemetry enabled (off by default). Sessions on other agent backends are invisible.
+- **"Done" ≠ value** until alignment weighting exists; closing low-value tickets counts the same as closing important ones in v1.
+- **Data trust gates the launch.** Token sums may double-count until the temporality fix (follow-up 1) lands.
+- **Cold start.** The self-comparison baseline needs ~4 weeks of history before "vs. your normal" means anything.
+- **What we gain:** a coachable, gaming-resistant signal built almost entirely on data Crow already captures, with a clearly staged path to the richer combined score once attribution, rework, and alignment data exist.
+
+## Alternatives considered
+
+- **Multiplicative combined score now** (the #648 strawman). Rejected for v1 — divides/multiplies by outcomes that are usually zero at session grain, producing unstable, unexplainable scores; adopted as the named v2 shape instead.
+- **Additive score with penalties.** Rejected — mixes incommensurable units (dollars, tickets, compactions) under arbitrary weights, invites endless weight-tuning debates, and lets volume mask bad hygiene.
+- **Raw-spend leaderboard.** Rejected — the perverse incentive this ADR exists to avoid.
+- **Per-session combined score.** Rejected — same zero-outcome degeneracy as multiplicative-now, at the grain where it is worst.
+- **Team leaderboard as the primary surface.** Rejected — meaningless for a single-user app, maximally gameable, and blocked on cross-machine aggregation (follow-up 10).
+
+## References
+
+- Ticket: [#648](https://github.com/radiusmethod/crow/issues/648)
+- Related ADRs: [0005](./0005-task-and-code-backend-protocols.md) (backend protocols the throughput/alignment follow-ups build on)
+- Code (verified for the feasibility table):
+  - `Packages/CrowCore/Sources/CrowCore/Models/SessionAnalytics.swift`
+  - `Packages/CrowCore/Sources/CrowCore/AppState.swift` (`SessionHookState`, `PersistedHookState`, `doneIssuesLast24h`)
+  - `Packages/CrowTelemetry/Sources/CrowTelemetry/` (`OTLPReceiver.swift`, `Storage/TelemetryDatabase.swift`)
+  - `Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift`, `ClaudeCodeAgent.swift`
+  - `Sources/Crow/App/AppDelegate.swift` (hook-event handler), `Sources/Crow/App/IssueTracker.swift` (done counting, `Crow-Session:` trailer parse)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0005 | [TaskBackend and CodeBackend protocols](./0005-task-and-code-backend-protocols.md) | Proposed | 2026-06-03 |
 | 0006 | [xterm.js terminal renderer (Intel support)](./0006-universal-macos-binary.md) | Accepted | 2026-07-01 |
 | 0007 | [Swift CI runs on Linux, not macOS](./0007-linux-ci-swift.md) | Accepted | 2026-07-10 |
+| 0008 | [AI-usage efficiency scorecard](./0008-ai-usage-efficiency-scorecard.md) | Proposed | 2026-07-10 |


### PR DESCRIPTION
Design doc + data-feasibility for #648 (refs #648). **Not a feature build** — this PR adds ADR 0008 (`docs/adr/0008-ai-usage-efficiency-scorecard.md`, status Proposed; renumbered from 0007 after the Linux-CI ADR took that slot on main) and proposes the v1 scope + follow-up implementation tickets to split off the RFC.

## Recommendation (TL;DR)

**v1 = two separate surfaces, no combined number**: a per-session **A–F efficiency grade** (labeled penalty-point deductions from 100 — every deduction is a coachable sentence like "3 compactions: −15") plus a **plain throughput count**, rolled up **weekly** on a **private self-comparison scorecard** (baseline = your own trailing 4-week median). The #648 strawman `throughput × efficiency × alignment` is adopted as the **v2** shape with named trigger conditions (PR→session attribution + rework tracking + alignment tagging must exist first) — multiplicative is right then because it makes waste un-buyable with volume, but degenerate now because most sessions have zero countable outcomes at session grain.

## Data feasibility (code-verified)

| Metric | Data source | Status | Gap |
|---|---|---|---|
| Session cost + tokens | `SessionAnalytics` ← OTLP telemetry (`CrowTelemetry`) | ✅ Computable today | Aggregate is in-memory only; raw rows persist in `telemetry.db` (180d). Telemetry off by default; Claude-Code-only. |
| Avg input tokens/turn | `inputTokens / promptCount` | ✅ Computable today (proxy) | "Turn" proxied by `user_prompt` count; true per-turn reconstructable from DB rows, not modeled. |
| Cache ratio, API error rate, active time, lines, commits | `SessionAnalytics` fields | ✅ Computable today | Same persistence caveat. |
| Compaction count / session | `PreCompact`/`PostCompact` hooks → `hook-event` handler (session-resolved) | 🔧 Light plumbing | Events hit a 50-entry in-memory ring buffer only; needs a counter in the existing handler, persisted with the session analytics snapshot (ticket 2). |
| Session wall-clock duration | `SessionStart`/`SessionEnd` hooks | 🔧 Light plumbing | No timestamps derived today; `Session` persists only `createdAt`/`updatedAt`. |
| Tickets done | `AppState.doneIssuesLast24h` (GitHub closed + Jira Done) | ✅ Computable today (aggregate) | Viewer-scoped single int, recomputed not persisted, no session attribution, GitLab excluded. |
| Session outcome flag | `markIssueDone` / session status → `.completed` | ✅ Computable today | Usable per-session "shipped" bit. |
| PRs merged / merge rate | Per-item PR state exists (`OPEN`/`MERGED`/`CLOSED`) | 🆕 New capture | No merged-per-window counts or author/date analytics. |
| PR→session attribution | `Crow-Session:` trailer written **and** parsed | 🆕 New capture | Parse used only as boolean auto-merge gate; no persisted attribution store. |
| Rework / revert / churn | — | 🆕 New capture | Confirmed absent. |
| Alignment / KPI / priority | Session stores `ticketURL` only; Jira backend doesn't read priority/epic | 🆕 New capture (greenfield) | The main genuinely new piece, as the ticket suspected. |

## Proposed v1 scope

Read-only scorecard over metrics computable today + light plumbing (follow-ups 1–4 below): persisted compaction count, context pressure (`inputTokens/promptCount`), cache hit ratio, API error rate, weekly cost-per-outcome, sessions-shipped count (session-attributed; `doneIssuesLast24h` explicitly excluded from the scorecard). Guardrails: weekly headline, penalties normalized per active-hour only (never per session or per outcome — session-splitting doesn't reset the denominator, zero-outcome sessions aren't distorted), <~5-prompt sessions ungraded, no combined number to farm. Grade bands ship as tunable priors with a binding 4-week calibration period.

## Proposed follow-up tickets

1. **Fix telemetry aggregation-temporality handling at ingest** — temporality is parsed but never persisted, so a query-time check is impossible; normalize to deltas on insert or persist a temporality column. Prerequisite for trusting any token/cost metric; grades ship behind this.
2. **Persist `SessionAnalytics` snapshot at session end** — rollups/baselines survive relaunch.
3. **Persist per-session compaction counter** — increment on `PostCompact` in existing handler; persist via the ticket-2 snapshot (not `PersistedHookState`).
4. **Persist session wall-clock duration** — `SessionStart`/`SessionEnd` timestamps.
5. **PR→session attribution store** — persist trailer-parse results; merged-PR-per-window counts. *(blocks v2, 6)*
6. **Rework / merge-rate metrics** — revert detection, merged-vs-closed rate.
7. **Per-turn analytics reader** over `telemetry.db` raw rows — replace `promptCount` proxies.
8. **Alignment/KPI mapping** — Jira priority/epic-parent read + org-goal tagging + alignment weight (greenfield). *(blocks v2)*
9. **GitLab throughput parity** in done-ticket counting.
10. **Cross-machine aggregation + team surface** — prerequisite for any leaderboard.
11. **Combined multiplicative score (v2)** — blocked on 5, 6, 8.

No prototype included: the smallest useful one requires persisting the compaction counter (a write-path change, ticket 3), which exceeds the read-only bar for a design PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
