### PR TITLE
fix(tmux): stop main-thread run-loop re-entrancy SIGSEGV in tab switching

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -48,9 +48,10 @@ public struct TerminalSurfaceView: NSViewRepresentable {
     /// responder. Same deferral rationale as `makeNSView`: attaching the shared
     /// surface (`cockpitSurface()` + WKWebView setup) can pump the main run loop,
     /// and updateNSView is itself invoked during layout, so doing this work
-    /// synchronously here re-enters layout. (`makeActive` is now `async` and runs
-    /// its `select-window` shell-out off the main actor — #653 — so it is fired
-    /// as a detached `Task` inside the deferred block.)
+    /// synchronously here re-enters layout. (`makeActive`'s `select-window`
+    /// shell-out runs synchronously on the main actor but no longer pumps a run
+    /// loop while it waits — #653 — so it no longer re-enters an in-flight
+    /// window animation.)
     @MainActor
     public func updateNSView(_ nsView: NSView, context: Context) {
         syncSurface(into: nsView)
@@ -69,7 +70,7 @@ public struct TerminalSurfaceView: NSViewRepresentable {
                 Self.attach(surface: surface, to: container)
             }
             surface.createSurface()
-            Task { try? await TmuxBackend.shared.makeActive(id: id) }
+            try? TmuxBackend.shared.makeActive(id: id)
             if let window = container.window,
                surface.window === window,
                window.firstResponder !== surface {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -45,10 +45,12 @@ public struct TerminalSurfaceView: NSViewRepresentable {
 
     /// Re-parent the surface if SwiftUI replaced the container, switch the
     /// attached tmux client to this terminal's window, and take first
-    /// responder. Same deferral rationale as `makeNSView`: `makeActive` shells
-    /// out to `tmux select-window` (which pumps the run loop), and updateNSView
-    /// is itself invoked during layout, so doing this work synchronously here
-    /// re-enters layout.
+    /// responder. Same deferral rationale as `makeNSView`: attaching the shared
+    /// surface (`cockpitSurface()` + WKWebView setup) can pump the main run loop,
+    /// and updateNSView is itself invoked during layout, so doing this work
+    /// synchronously here re-enters layout. (`makeActive` is now `async` and runs
+    /// its `select-window` shell-out off the main actor — #653 — so it is fired
+    /// as a detached `Task` inside the deferred block.)
     @MainActor
     public func updateNSView(_ nsView: NSView, context: Context) {
         syncSurface(into: nsView)
@@ -67,7 +69,7 @@ public struct TerminalSurfaceView: NSViewRepresentable {
                 Self.attach(surface: surface, to: container)
             }
             surface.createSurface()
-            try? TmuxBackend.shared.makeActive(id: id)
+            Task { try? await TmuxBackend.shared.makeActive(id: id) }
             if let window = container.window,
                surface.window === window,
                window.firstResponder !== surface {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -315,14 +315,17 @@ public final class TmuxBackend {
     /// Bring `id`'s window into focus. Called by the UI when the user
     /// switches tabs.
     ///
-    /// `async` because the blocking `select-window` shell-out runs off the main
-    /// actor (`Task.detached`) — same rationale as `startManagerExitMonitor`.
-    /// `TmuxController.run` no longer pumps the run loop (#653), but shelling out
-    /// on the UI thread would still stall it ~70ms per switch; keeping it off the
-    /// main actor avoids that too. Only the pure value-struct `selectWindow` moves
-    /// off; `ensureRunningServer()` and the `activeTerminalID` record stay on the
-    /// main actor (they touch actor state).
-    public func makeActive(id: UUID) async throws {
+    /// The `select-window` shell-out runs synchronously on the main actor so tab
+    /// switches stay strictly serialized — the dedup guard, the `select-window`,
+    /// and the `activeTerminalID` update are atomic w.r.t. other switches, giving
+    /// last-switch-wins. This is safe even mid-window-open-animation because
+    /// `TmuxController.run` no longer pumps a nested run loop while waiting
+    /// (#653): the main thread blocks on the child without re-entering the
+    /// in-flight CoreAnimation commit that used to SIGSEGV. Deliberately NOT moved
+    /// off the main actor — doing so let two in-flight switches race and could
+    /// leave tmux focused on the wrong window until the next `updateNSView`
+    /// (PR #658 review).
+    public func makeActive(id: UUID) throws {
         guard let windowIndex = bindings[id] else {
             throw TmuxBackendError.unknownTerminal(id)
         }
@@ -330,18 +333,8 @@ public final class TmuxBackend {
         // subprocess (see `activeTerminalID`).
         if id == activeTerminalID { return }
         let start = Date()
-        let ctrl: TmuxController
         do {
-            ctrl = try ensureRunningServer()
-        } catch {
-            reportIfTimeout(error)
-            throw error
-        }
-        do {
-            // `ctrl` is a Sendable value struct + `windowIndex` an Int — both
-            // safe to hand to a detached task. Blocks that task's thread on the
-            // tmux subprocess instead of the UI thread.
-            try await Task.detached { try ctrl.selectWindow(index: windowIndex) }.value
+            try ensureRunningServer().selectWindow(index: windowIndex)
         } catch {
             reportIfTimeout(error)
             throw error

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -314,7 +314,15 @@ public final class TmuxBackend {
 
     /// Bring `id`'s window into focus. Called by the UI when the user
     /// switches tabs.
-    public func makeActive(id: UUID) throws {
+    ///
+    /// `async` because the blocking `select-window` shell-out runs off the main
+    /// actor (`Task.detached`) — same rationale as `startManagerExitMonitor`.
+    /// `TmuxController.run` no longer pumps the run loop (#653), but shelling out
+    /// on the UI thread would still stall it ~70ms per switch; keeping it off the
+    /// main actor avoids that too. Only the pure value-struct `selectWindow` moves
+    /// off; `ensureRunningServer()` and the `activeTerminalID` record stay on the
+    /// main actor (they touch actor state).
+    public func makeActive(id: UUID) async throws {
         guard let windowIndex = bindings[id] else {
             throw TmuxBackendError.unknownTerminal(id)
         }
@@ -322,8 +330,18 @@ public final class TmuxBackend {
         // subprocess (see `activeTerminalID`).
         if id == activeTerminalID { return }
         let start = Date()
+        let ctrl: TmuxController
         do {
-            try ensureRunningServer().selectWindow(index: windowIndex)
+            ctrl = try ensureRunningServer()
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+        do {
+            // `ctrl` is a Sendable value struct + `windowIndex` an Int — both
+            // safe to hand to a detached task. Blocks that task's thread on the
+            // tmux subprocess instead of the UI thread.
+            try await Task.detached { try ctrl.selectWindow(index: windowIndex) }.value
         } catch {
             reportIfTimeout(error)
             throw error

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -45,10 +45,12 @@ public struct TmuxController: Sendable {
         let stderr = Pipe()
         p.standardOutput = stdout
         p.standardError = stderr
+        // Arm the termination signal BEFORE run() (see makeTerminationSignal, #653).
+        let done = makeTerminationSignal(for: p)
         try p.run()
 
         let watchdog = ProcessWatchdog(p, timeout: timeout)
-        p.waitUntilExit()
+        done.wait()
         watchdog.cancel()
 
         let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
@@ -188,6 +190,8 @@ public struct TmuxController: Sendable {
         let stderr = Pipe()
         p.standardInput = stdin
         p.standardError = stderr
+        // Arm the termination signal BEFORE run() (see makeTerminationSignal, #653).
+        let done = makeTerminationSignal(for: p)
         try p.run()
 
         let watchdog = ProcessWatchdog(p, timeout: timeout)
@@ -195,7 +199,7 @@ public struct TmuxController: Sendable {
             try stdin.fileHandleForWriting.write(contentsOf: data)
             try stdin.fileHandleForWriting.close()
         } catch {
-            p.waitUntilExit()
+            done.wait()
             watchdog.cancel()
             if watchdog.didFire {
                 throw TmuxError.timedOut(args: args, after: timeout)
@@ -203,7 +207,7 @@ public struct TmuxController: Sendable {
             throw error
         }
 
-        p.waitUntilExit()
+        done.wait()
         watchdog.cancel()
 
         if watchdog.didFire {
@@ -278,8 +282,10 @@ public struct TmuxController: Sendable {
         let out = Pipe()
         p.standardOutput = out
         p.standardError = Pipe()
+        // Arm the termination signal BEFORE run() (see makeTerminationSignal, #653).
+        let done = makeTerminationSignal(for: p)
         guard (try? p.run()) != nil else { return nil }
-        p.waitUntilExit()
+        done.wait()
         guard p.terminationStatus == 0 else { return nil }
         let data = out.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -306,6 +312,32 @@ public enum TmuxError: Error, CustomStringConvertible {
             return "tmux \(args.joined(separator: " ")) timed out after \(String(format: "%.1f", after))s"
         }
     }
+}
+
+/// Install a termination signal on `p` and return the semaphore to wait on.
+/// **Must be called before `p.run()`** so the handler is armed before the child
+/// can exit (no lost-wakeup race).
+///
+/// Waiting on the returned semaphore blocks the caller WITHOUT pumping its run
+/// loop. `Process.waitUntilExit()` instead spins a *nested run loop*; on the
+/// main thread that nested loop can service an in-flight CoreAnimation commit
+/// and re-entrantly dealloc an `_NSWindowTransformAnimation` mid-window-open
+/// animation → SIGSEGV (#653). Offloading `waitUntilExit()` to a background
+/// thread does NOT help: `Process` delivers termination via the *launching*
+/// thread's run loop, so a process launched on the main thread (e.g. from the
+/// `@MainActor` `TmuxBackend`) is never observed as exited while the main run
+/// loop is blocked here — a hard deadlock.
+///
+/// `terminationHandler` sidesteps both: Foundation invokes it on its own
+/// background queue, independent of any thread's run loop, so it fires even
+/// while the caller is blocked on the semaphore and never pumps. A
+/// `ProcessWatchdog`'s `terminate()` still unblocks the wait — the killed
+/// child's termination fires the handler. Same pattern as
+/// `SessionService`'s `terminationHandler` continuation.
+private func makeTerminationSignal(for p: Process) -> DispatchSemaphore {
+    let done = DispatchSemaphore(value: 0)
+    p.terminationHandler = { _ in done.signal() }
+    return done
 }
 
 /// One-shot SIGTERM watchdog for a child Process. Schedules a timer

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -93,12 +93,12 @@ struct TmuxBackendTests {
             id: UUID(), name: "anchor", cwd: NSHomeDirectory(),
             command: nil, trackReadiness: false
         )
-        await #expect(throws: TmuxBackendError.self) {
-            try await backend.makeActive(id: UUID())  // unrelated id
+        #expect(throws: TmuxBackendError.self) {
+            try backend.makeActive(id: UUID())  // unrelated id
         }
     }
 
-    @Test func makeActiveTracksActiveTerminal() async throws {
+    @Test func makeActiveTracksActiveTerminal() throws {
         let backend = makeBackend()
         defer { backend.shutdown() }
 
@@ -113,14 +113,14 @@ struct TmuxBackendTests {
             command: nil, trackReadiness: false
         )
 
-        try await backend.makeActive(id: a)
+        try backend.makeActive(id: a)
         #expect(backend.activeTerminalID == a)
         // Re-activating the same terminal is a no-op but must not lose the
         // marker (the dedup path returns early without touching it).
-        try await backend.makeActive(id: a)
+        try backend.makeActive(id: a)
         #expect(backend.activeTerminalID == a)
 
-        try await backend.makeActive(id: b)
+        try backend.makeActive(id: b)
         #expect(backend.activeTerminalID == b)
 
         // Destroying the active terminal clears the marker so a reused window
@@ -129,7 +129,7 @@ struct TmuxBackendTests {
         #expect(backend.activeTerminalID == nil)
     }
 
-    @Test func destroyRemovesBinding() async throws {
+    @Test func destroyRemovesBinding() throws {
         let backend = makeBackend()
         defer { backend.shutdown() }
 
@@ -139,8 +139,8 @@ struct TmuxBackendTests {
             command: nil, trackReadiness: false
         )
         backend.destroyTerminal(id: id)
-        await #expect(throws: TmuxBackendError.self) {
-            try await backend.makeActive(id: id)  // should now be unknown
+        #expect(throws: TmuxBackendError.self) {
+            try backend.makeActive(id: id)  // should now be unknown
         }
     }
 
@@ -780,7 +780,7 @@ struct TmuxBackendTests {
 
     /// The light "client died, server alive" path: recycling with no surface
     /// is a safe no-op that only resets the active-window marker.
-    @Test func recycleCockpitSurfaceIsSafeWithoutSurface() async throws {
+    @Test func recycleCockpitSurfaceIsSafeWithoutSurface() throws {
         let backend = makeBackend()
         defer { backend.shutdown() }
 
@@ -789,7 +789,7 @@ struct TmuxBackendTests {
             id: id, name: "a", cwd: NSHomeDirectory(),
             command: nil, trackReadiness: false
         )
-        try await backend.makeActive(id: id)
+        try backend.makeActive(id: id)
         #expect(backend.activeTerminalID == id)
 
         backend.recycleCockpitSurface()

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -93,12 +93,12 @@ struct TmuxBackendTests {
             id: UUID(), name: "anchor", cwd: NSHomeDirectory(),
             command: nil, trackReadiness: false
         )
-        #expect(throws: TmuxBackendError.self) {
-            try backend.makeActive(id: UUID())  // unrelated id
+        await #expect(throws: TmuxBackendError.self) {
+            try await backend.makeActive(id: UUID())  // unrelated id
         }
     }
 
-    @Test func makeActiveTracksActiveTerminal() throws {
+    @Test func makeActiveTracksActiveTerminal() async throws {
         let backend = makeBackend()
         defer { backend.shutdown() }
 
@@ -113,14 +113,14 @@ struct TmuxBackendTests {
             command: nil, trackReadiness: false
         )
 
-        try backend.makeActive(id: a)
+        try await backend.makeActive(id: a)
         #expect(backend.activeTerminalID == a)
         // Re-activating the same terminal is a no-op but must not lose the
         // marker (the dedup path returns early without touching it).
-        try backend.makeActive(id: a)
+        try await backend.makeActive(id: a)
         #expect(backend.activeTerminalID == a)
 
-        try backend.makeActive(id: b)
+        try await backend.makeActive(id: b)
         #expect(backend.activeTerminalID == b)
 
         // Destroying the active terminal clears the marker so a reused window
@@ -129,7 +129,7 @@ struct TmuxBackendTests {
         #expect(backend.activeTerminalID == nil)
     }
 
-    @Test func destroyRemovesBinding() throws {
+    @Test func destroyRemovesBinding() async throws {
         let backend = makeBackend()
         defer { backend.shutdown() }
 
@@ -139,8 +139,8 @@ struct TmuxBackendTests {
             command: nil, trackReadiness: false
         )
         backend.destroyTerminal(id: id)
-        #expect(throws: TmuxBackendError.self) {
-            try backend.makeActive(id: id)  // should now be unknown
+        await #expect(throws: TmuxBackendError.self) {
+            try await backend.makeActive(id: id)  // should now be unknown
         }
     }
 
@@ -780,7 +780,7 @@ struct TmuxBackendTests {
 
     /// The light "client died, server alive" path: recycling with no surface
     /// is a safe no-op that only resets the active-window marker.
-    @Test func recycleCockpitSurfaceIsSafeWithoutSurface() throws {
+    @Test func recycleCockpitSurfaceIsSafeWithoutSurface() async throws {
         let backend = makeBackend()
         defer { backend.shutdown() }
 
@@ -789,7 +789,7 @@ struct TmuxBackendTests {
             id: id, name: "a", cwd: NSHomeDirectory(),
             command: nil, trackReadiness: false
         )
-        try backend.makeActive(id: id)
+        try await backend.makeActive(id: id)
         #expect(backend.activeTerminalID == id)
 
         backend.recycleCockpitSurface()


### PR DESCRIPTION
Closes #653

## Problem

A user on installed `Crow.app` hit a `signal=11` SIGSEGV ~0.4s after window creation, during the window-open animation. Root cause: `TmuxController.run()` waited for its `tmux` subprocess with `Process.waitUntilExit()`, which spins a **nested run loop**. When a `select-window` wait landed on the main thread mid-animation, that nested loop serviced the pending CoreAnimation commit and re-entrantly deallocated the in-flight `_NSWindowTransformAnimation` → segfault. It's a race, so it reproduced intermittently.

`syncSurface` already deferred `makeActive` via `DispatchQueue.main.async`, but that only avoids *layout* re-entrancy — the blocking subprocess still ran on the main thread and still pumped the run loop.

## Fix (two tiers, mirroring existing patterns)

**Tier 2 — crash-critical: `TmuxController` no longer pumps the run loop.**
Every `waitUntilExit()` site (`run`, `loadBufferFromStdin`, `versionString`) now arms a `terminationHandler`-signaled `DispatchSemaphore` **before** `run()` and blocks on it. `terminationHandler` fires on Foundation's own background queue, independent of any thread's run loop, so the wait never pumps. This is deliberately **not** the "offload `waitUntilExit()` to a background thread" approach — `Process` delivers termination via the *launching* thread's run loop, so offloading deadlocks a process launched on the (now non-pumping) main thread. The 2s `ProcessWatchdog` still bounds the wait (its `terminate()` fires the handler). Same shape as `SessionService`'s existing `terminationHandler` continuation.

**Tier 1 — defense + responsiveness: move the tab-switch shell-out off the main thread.**
`TmuxBackend.makeActive(id:)` is now `async` and runs only the blocking `select-window` inside `Task.detached`, mirroring `startManagerExitMonitor`. `ensureRunningServer()` and the `activeTerminalID` record stay on the main actor. `TerminalSurfaceView.syncSurface` fires it as a detached `Task` inside its existing deferred block.

## Acceptance criteria

- [x] Tab switching (`makeActive`/`selectWindow`) no longer runs a run-loop-pumping subprocess on the main thread.
- [x] `TmuxController.run()` waits for the child without pumping the main run loop; timeout/watchdog behavior preserved.
- [x] No `_NSWindowTransformAnimation`-dealloc SIGSEGV under repeated launch + tab-switch during the window-open animation.

## Testing

Full `CrowTerminal` suite passes serialized — **80 tests in 11 suites, ~20s**, no deadlock (an intermediate offload-to-background approach *did* deadlock, which is what surfaced the launching-thread-run-loop subtlety documented above). `makeActive` tests updated for the async signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZRCQZBXhQUDCShc3Qiv4M