### PR TITLE
fix(daemon): un-gate scheduled jobs from set-config local-only (#665)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -737,10 +737,11 @@ func makeCommandRouter(
                 "default_dev_root": .string(defaultDevRoot),
             ]
         },
-        // Non-secret settings write. `defaults.binaries` and `jobs` are held to
-        // the same local-direct bar as secret writes — the `/rpc` WebSocket
-        // handler rejects those field changes from non-local peers before this
-        // runs (review Yellow). Unix-socket / CLI callers are always local.
+        // Non-secret settings write. `defaults.binaries` is held to the same
+        // local-direct bar as secret writes — the `/rpc` WebSocket handler rejects
+        // that field change from non-local peers before this runs (review Yellow).
+        // Scheduled `jobs` are NOT gated (CROW-665): an authenticated remote
+        // session may edit them. Unix-socket / CLI callers are always local.
         "set-config": { params in
             guard let json = params["config"]?.stringValue,
                   let data = json.data(using: .utf8),
@@ -818,8 +819,9 @@ func makeCommandRouter(
         // local caller from a logged-in remote one, so it must not carry secret
         // writes — that would let a remote client change the password that gates
         // remote access (CROW-593). The same local-direct bar applies to
-        // `set-config` changes of `defaults.binaries` / `jobs` (gated in
-        // `RPCWebSocketHandler`) — those execute at the next launch.
+        // `set-config` changes of `defaults.binaries` (gated in
+        // `RPCWebSocketHandler`) — those absolute binary paths execute at the next
+        // launch. Scheduled `jobs` are no longer gated (CROW-665).
 
         // Session/board actions — forward-only (need the app's coordinators).
         // Spawning a Manager forwards to the app when it's running (its

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -109,27 +109,30 @@ enum RPCWebSocketHandler {
     /// caller from a remote `/rpc` peer (review Yellow / CROW-593).
     ///
     /// - `run-setup`: write+re-exec of an arbitrary `dev_root`.
-    /// - `set-config` when `defaults.binaries` or `jobs` change: those execute at
-    ///   the next agent/job launch (persistent RCE on an unauthenticated
-    ///   non-loopback bind). Other `set-config` fields still flow through.
-    /// - `job-add` / `edit` / `enable` / `disable` / `delete` / `duplicate`: same
-    ///   jobs-array write surface as `set-config` jobs (CROW-604).
+    /// - `set-config` when `defaults.binaries` change: absolute local binary paths
+    ///   that execute at the next agent launch (persistent RCE on an
+    ///   unauthenticated non-loopback bind). Other `set-config` fields flow through.
+    ///
+    /// Scheduled `jobs` are intentionally NOT gated here (CROW-665): the Jobs
+    /// editor is a core web-Settings surface, so an authenticated remote session
+    /// may edit them, matching how the desktop app manages jobs. The `job-*` RPCs
+    /// are likewise un-gated (same jobs-array surface; today only the CLI, which is
+    /// always local, uses them).
     static func localOnlyDenial(for request: JSONRPCRequest, devRoot: String) -> String? {
         switch request.method {
         case "run-setup":
             return "run-setup is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
-            return "set-config binaries/jobs is local-only"
-        case "job-add", "job-edit", "job-enable", "job-disable", "job-delete", "job-duplicate":
-            return "\(request.method) is local-only"
+            return "set-config binaries is local-only"
         default:
             return nil
         }
     }
 
     /// True when the incoming `set-config` payload would change agent binary
-    /// overrides or scheduled jobs relative to what's on disk.
+    /// overrides relative to what's on disk. Scheduled `jobs` are no longer
+    /// privileged — an authenticated remote session may edit them (CROW-665).
     static func setConfigTouchesPrivilegedFields(_ request: JSONRPCRequest, devRoot: String) -> Bool {
         guard let json = request.params?["config"]?.stringValue,
               let data = json.data(using: .utf8),
@@ -139,6 +142,5 @@ enum RPCWebSocketHandler {
         }
         let current = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
         return incoming.defaults.binaries != current.defaults.binaries
-            || incoming.jobs != current.jobs
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1535,6 +1535,11 @@ async function quickAction(id, action, label) {
 function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', danger = false } = {}) {
   return new Promise((resolve) => {
     let done = false;
+    // One dialog at a time: drop any stray backdrop still on screen so a
+    // double-fired error can't stack two overlapping cards whose text abuts into
+    // one concatenated message (CROW-665). These dialogs are always awaited
+    // sequentially, so a leftover here is a duplicate, never a live prompt.
+    document.querySelectorAll('.text-prompt-backdrop').forEach((b) => b.remove());
     const backdrop = el('div', 'text-prompt-backdrop');
     const card = el('div', 'text-prompt-card');
     if (title) card.appendChild(el('div', 'text-prompt-title', title));

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1535,12 +1535,6 @@ async function quickAction(id, action, label) {
 function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', danger = false } = {}) {
   return new Promise((resolve) => {
     let done = false;
-    // One dialog at a time: drop any stray *modalDialog* backdrop still on screen
-    // so a double-fired error can't stack two overlapping cards whose text abuts
-    // into one concatenated message (CROW-665). Scoped to modalDialog's own marker
-    // class — `textPrompt` shares `.text-prompt-backdrop` but resolves only via its
-    // own handlers, so removing it here would orphan a live prompt (review Yellow).
-    document.querySelectorAll('.modal-dialog-backdrop').forEach((b) => b.remove());
     const backdrop = el('div', 'text-prompt-backdrop modal-dialog-backdrop');
     const card = el('div', 'text-prompt-card');
     if (title) card.appendChild(el('div', 'text-prompt-title', title));
@@ -1554,6 +1548,7 @@ function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', dang
       backdrop.remove();
       resolve(v);
     }
+    backdrop.__finish = finish;
     function onKey(e) {
       if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); finish(false); }
       else if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); finish(true); }
@@ -1568,6 +1563,17 @@ function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', dang
     card.appendChild(actions);
     backdrop.appendChild(card);
     backdrop.addEventListener('mousedown', (e) => { if (e.target === backdrop) finish(false); });
+    // One dialog at a time: supersede any stray *modalDialog* backdrop still on
+    // screen so a double-fired error can't stack two overlapping cards whose text
+    // abuts into one concatenated message (CROW-665). Finish (resolve as cancel)
+    // each superseded dialog rather than bare-removing it, so its Promise settles
+    // and its capture-phase keydown listener detaches — a plain .remove() orphans
+    // both (review Yellow). Runs before this backdrop is in the DOM, so it only
+    // matches prior dialogs. Scoped to modalDialog's marker class, so a live
+    // `textPrompt` (shares `.text-prompt-backdrop`, resolves only via its own
+    // handlers) is never touched.
+    document.querySelectorAll('.modal-dialog-backdrop')
+      .forEach((b) => (b.__finish ? b.__finish(false) : b.remove()));
     document.addEventListener('keydown', onKey, true);
     document.body.appendChild(backdrop);
     ok.focus();

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1535,12 +1535,13 @@ async function quickAction(id, action, label) {
 function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', danger = false } = {}) {
   return new Promise((resolve) => {
     let done = false;
-    // One dialog at a time: drop any stray backdrop still on screen so a
-    // double-fired error can't stack two overlapping cards whose text abuts into
-    // one concatenated message (CROW-665). These dialogs are always awaited
-    // sequentially, so a leftover here is a duplicate, never a live prompt.
-    document.querySelectorAll('.text-prompt-backdrop').forEach((b) => b.remove());
-    const backdrop = el('div', 'text-prompt-backdrop');
+    // One dialog at a time: drop any stray *modalDialog* backdrop still on screen
+    // so a double-fired error can't stack two overlapping cards whose text abuts
+    // into one concatenated message (CROW-665). Scoped to modalDialog's own marker
+    // class — `textPrompt` shares `.text-prompt-backdrop` but resolves only via its
+    // own handlers, so removing it here would orphan a live prompt (review Yellow).
+    document.querySelectorAll('.modal-dialog-backdrop').forEach((b) => b.remove());
+    const backdrop = el('div', 'text-prompt-backdrop modal-dialog-backdrop');
     const card = el('div', 'text-prompt-card');
     if (title) card.appendChild(el('div', 'text-prompt-title', title));
     if (body) card.appendChild(el('div', 'text-prompt-body', body));

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -463,8 +463,14 @@
     }
 
     body.appendChild(group('Corveil CLI'));
+    // The corveil binary is an absolute local path executed at agent launch, so
+    // it stays local-only (CROW-593/665) — editable only from a local browser and
+    // read-only when proxied/remote, mirroring the web password & AI gateways.
+    // (Scheduled jobs, by contrast, are editable from any authenticated session.)
     body.appendChild(textField('Path to corveil binary', cfg.defaults.binaries, 'corveil',
-      { placeholder: '/path/to/corveil', help: 'Leave blank to skip. Verify/Reinstall are available in the desktop app.' }));
+      isLocal
+        ? { placeholder: '/path/to/corveil', help: 'Leave blank to skip. Verify/Reinstall are available in the desktop app.' }
+        : { readonly: true, help: 'The corveil binary path is editable only from a local browser (on the machine running crowd).' }));
 
     body.appendChild(group('Sidebar'));
     body.appendChild(toggleField('Hide session details', cfg.sidebar, 'hideSessionDetails',

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -714,11 +714,14 @@ import CrowPersistence
             "config": .string(try encode(incoming)),
         ])
         #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot)
-            == "set-config binaries/jobs is local-only")
+            == "set-config binaries is local-only")
         #expect(RPCWebSocketHandler.setConfigTouchesPrivilegedFields(req, devRoot: devRoot))
     }
 
-    @Test func setConfigJobsChangeIsLocalOnly() throws {
+    @Test func setConfigJobsChangeIsAllowedRemotely() throws {
+        // Jobs are no longer a local-only surface (CROW-665): an authenticated
+        // remote session may edit them, so a jobs-only change must NOT trip the
+        // gate. `defaults.binaries` remains local-only (see the test above).
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
@@ -731,8 +734,8 @@ import CrowPersistence
         let req = JSONRPCRequest(id: 1, method: "set-config", params: [
             "config": .string(try encode(incoming)),
         ])
-        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot)
-            == "set-config binaries/jobs is local-only")
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot) == nil)
+        #expect(!RPCWebSocketHandler.setConfigTouchesPrivilegedFields(req, devRoot: devRoot))
     }
 
     @Test func setConfigHarmlessToggleIsAllowedRemotely() throws {


### PR DESCRIPTION
Closes #665

## Problem
On the crow-593 web UI, saving a Job from the Settings modal failed with `set-config binaries/jobs is local-only`. The web Jobs editor persists the whole `AppConfig` via the `set-config` RPC, and `RPCWebSocketHandler.localOnlyDenial` rejected that call whenever `jobs` changed from a peer that isn't **local-direct** (loopback + no `X-Forwarded-For`) — i.e. a proxied / LAN-IP session. A localhost browser already worked (local-direct peers skip the gate); a job edit blocked the save everywhere else.

## Fix (team decision: allow jobs from any authenticated session)
Jobs are a core, web-managed surface, so an authenticated remote session may edit them — matching how the desktop app manages jobs. Only `defaults.binaries` (absolute local paths executed at agent launch) remains local-only.

- **`RPCWebSocketHandler`** — narrow the gate to `binaries` only: drop the `jobs` comparison in `setConfigTouchesPrivilegedFields` and remove the `job-*` method cases (those are reached only by the CLI, which is always local over the Unix socket). Denial message is now `set-config binaries is local-only`.
- **`settings.js`** — render the corveil-binary field read-only when the session isn't local-direct (mirrors the web password & AI gateways), so remote users don't trip the still-active binaries gate.
- **`app.js`** — `modalDialog` drops any stray `.text-prompt-backdrop` before showing, so a save failure surfaces exactly one dialog (fixes the doubled/concatenated error toast).
- **`DaemonSecurityTests`** — a jobs change is now allowed remotely; a binaries change stays local-only.

## Security note
This intentionally widens the jobs write surface to any **authenticated** (`/rpc` still requires Origin + web-password auth) remote session, per the team decision — reversing part of CROW-604. The `job-*` RPCs are un-gated for coherence (same jobs-array surface). `binaries` (persistent-RCE via absolute launch paths) stays local-only.

## Verification
- `make daemon` ✓
- `swift test --package-path Packages/CrowDaemon --filter DaemonSecurityTests` → 62 tests pass, incl. `setConfigJobsChangeIsAllowedRemotely` and `setConfigBinariesChangeIsLocalOnly`.
- `node --check` on both edited web scripts ✓

## Acceptance
- [x] Editing & saving a Job in the web Settings modal persists with no `set-config … is local-only` error.
- [x] Saved `jobs` round-trips (set-config returns the merged config).
- [x] Other config saves unaffected; `binaries` stays genuinely local-only.
- [x] A single save failure shows exactly one dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PemiJvxc8QSWDVsdTrdMz