### PR TITLE
refactor(terminal): share jump-to-bottom as an xterm.js addon (desktop + web)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2141,6 +2141,9 @@ function ensureTerminal() {
   term.loadAddon(searchAddon);
   term.loadAddon(webLinksAddon);
   term.open(document.getElementById('terminal'));
+  // Jump-to-bottom pill (#668), shared with the desktop surface. Must load after
+  // open() so the addon can anchor its button to the terminal's container.
+  term.loadAddon(new CrowJumpBottomAddon.CrowJumpBottomAddon());
   // WebGL renderer for throughput; must load after open(). Falls back to the
   // default renderer if the GL context is unavailable or gets lost.
   try {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -39,6 +39,7 @@
   <script src="/xterm/xterm-addon-search.js"></script>
   <script src="/xterm/xterm-addon-web-links.js"></script>
   <script src="/xterm/xterm-addon-webgl.js"></script>
+  <script src="/xterm/xterm-addon-crow-jumpbottom.js"></script>
   <script src="/app.js"></script>
   <script src="/settings.js"></script>
 </body>

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -39,6 +39,7 @@
   <script src="/xterm/xterm.js"></script>
   <script src="/xterm/xterm-addon-fit.js"></script>
   <script src="/xterm/xterm-addon-image.js"></script>
+  <script src="/xterm/xterm-addon-crow-jumpbottom.js"></script>
   <script>
     // WebSocket transport variant of CrowTerminal's terminal.html. The xterm.js
     // config block is copied verbatim so font/scrollback/inline-image behavior
@@ -90,6 +91,9 @@
       term.parser.registerCsiHandler({ prefix: '?', final: 'l' }, swallowMouseMode);
 
       term.open(document.getElementById('terminal'));
+      // Jump-to-bottom pill (#668) — load after open() so it can anchor its
+      // button to the terminal container.
+      term.loadAddon(new CrowJumpBottomAddon.CrowJumpBottomAddon());
 
       const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
       const ws = new WebSocket(proto + '://' + window.location.host + '/terminal');

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
@@ -17,45 +17,14 @@
       width: 100%;
       height: 100%;
     }
-    #crow-jump-bottom {
-      position: absolute;
-      right: 16px;
-      bottom: 16px;
-      width: 34px;
-      height: 34px;
-      padding: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 20px;
-      line-height: 1;
-      color: #ddc482;
-      background: #22262a;
-      border: 1px solid rgba(221, 196, 130, 0.35);
-      border-radius: 17px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-      cursor: pointer;
-      z-index: 10;
-      opacity: 1;
-      transition: opacity 0.12s ease;
-    }
-    #crow-jump-bottom:hover {
-      background: #2a2f34;
-      border-color: rgba(221, 196, 130, 0.6);
-    }
-    #crow-jump-bottom.hidden {
-      opacity: 0;
-      visibility: hidden;
-      pointer-events: none;
-    }
   </style>
 </head>
 <body>
   <div id="terminal"></div>
-  <button id="crow-jump-bottom" class="hidden" aria-label="Jump to latest output" title="Jump to bottom">&#9662;</button>
   <script src="xterm.js"></script>
   <script src="xterm-addon-fit.js"></script>
   <script src="xterm-addon-image.js"></script>
+  <script src="xterm-addon-crow-jumpbottom.js"></script>
   <script>
     (function () {
       function reportError(message) {
@@ -84,6 +53,10 @@
         reportError('ImageAddon constructor missing');
         return;
       }
+      if (typeof CrowJumpBottomAddon !== 'object' || typeof CrowJumpBottomAddon.CrowJumpBottomAddon !== 'function') {
+        reportError('CrowJumpBottomAddon constructor missing');
+        return;
+      }
 
       try {
         const fitAddon = new FitAddon.FitAddon();
@@ -104,6 +77,9 @@
         term.loadAddon(fitAddon);
         term.loadAddon(imageAddon);
         term.open(document.getElementById('terminal'));
+        // After open() so the addon can find term.element's container and
+        // anchor its button to the terminal viewport.
+        term.loadAddon(new CrowJumpBottomAddon.CrowJumpBottomAddon());
 
         // xterm's hidden textarea triggers WebKit Autofill/Services menus — block only there.
         if (term.textarea) {
@@ -116,32 +92,6 @@
           }, true);
         }
 
-
-        // Jump-to-bottom control (#633). Long agent/chat output leaves no fast
-        // path back to the live edge once you scroll up; show a pill when the
-        // viewport is above the bottom and snap back on click. onScroll is the
-        // primary trigger (leaving the bottom only ever happens via a user
-        // scroll — new output while pinned auto-scrolls and stays pinned);
-        // onRender is a safety-net re-check.
-        const jumpBtn = document.getElementById('crow-jump-bottom');
-        function atBottom() {
-          const b = term.buffer.active;
-          return b.viewportY >= b.baseY;
-        }
-        function updateJumpButton() {
-          if (jumpBtn) {
-            jumpBtn.classList.toggle('hidden', atBottom());
-          }
-        }
-        if (jumpBtn) {
-          jumpBtn.addEventListener('click', function () {
-            term.scrollToBottom();
-            term.focus(); // restore typing focus stolen by the button
-            updateJumpButton();
-          });
-        }
-        term.onScroll(updateJumpButton);
-        term.onRender(updateJumpButton);
 
         // Resize path (#637): the agent TUI clobbers when it's SIGWINCH'd
         // faster than it can redraw, so coalesce bursts and drop no-op resizes.
@@ -234,7 +184,6 @@
         if (document.fonts && document.fonts.ready) {
           document.fonts.ready.then(scheduleFit);
         }
-        updateJumpButton();
       } catch (err) {
         reportError(String(err));
       }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-jumpbottom.js
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-jumpbottom.js
@@ -1,0 +1,159 @@
+// Crow jump-to-bottom control (#635 → #668), as a shared xterm.js addon.
+//
+// Long agent/chat output leaves no fast path back to the live edge once you
+// scroll up; this shows a pill when the viewport is above the bottom and snaps
+// back on click. Implemented once here so BOTH surfaces load it the same way —
+// the desktop WKWebView page (CrowTerminal/Resources/xterm/terminal.html) and
+// the web UI (served at /xterm/… by the daemon: web/index.html + app.js, and
+// the web/terminal.html debug page) — instead of hand-mirroring the control per
+// front-end (the parity drift that bit reflow-debounce #661 and #662).
+//
+// Pure terminal + DOM, no transport coupling: it only needs the Terminal, its
+// element, onScroll/onRender, an at-bottom check (buffer.active.viewportY/baseY)
+// and scrollToBottom(). Loaded via <script src> (not ES modules), so it exposes
+// a namespaced UMD-style global matching the vendored addons
+// (window.FitAddon.FitAddon → window.CrowJumpBottomAddon.CrowJumpBottomAddon).
+(function (global) {
+  'use strict';
+
+  var STYLE_ID = 'crow-jumpbottom-style';
+
+  // Injected once per document; keyed on a CLASS (not an id) because the web UI
+  // can host more than one terminal element. Ported verbatim from the inline
+  // #635 styles that used to live in terminal.html.
+  var CSS = [
+    '.crow-jump-bottom {',
+    '  position: absolute;',
+    '  right: 16px;',
+    '  bottom: 16px;',
+    '  width: 34px;',
+    '  height: 34px;',
+    '  padding: 0;',
+    '  display: flex;',
+    '  align-items: center;',
+    '  justify-content: center;',
+    '  font-size: 20px;',
+    '  line-height: 1;',
+    '  color: #ddc482;',
+    '  background: #22262a;',
+    '  border: 1px solid rgba(221, 196, 130, 0.35);',
+    '  border-radius: 17px;',
+    '  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);',
+    '  cursor: pointer;',
+    '  z-index: 10;',
+    '  opacity: 1;',
+    '  transition: opacity 0.12s ease;',
+    '}',
+    '.crow-jump-bottom:hover {',
+    '  background: #2a2f34;',
+    '  border-color: rgba(221, 196, 130, 0.6);',
+    '}',
+    '.crow-jump-bottom.hidden {',
+    '  opacity: 0;',
+    '  visibility: hidden;',
+    '  pointer-events: none;',
+    '}',
+  ].join('\n');
+
+  function injectStyleOnce() {
+    if (document.getElementById(STYLE_ID)) {
+      return;
+    }
+    var style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = CSS;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
+  function CrowJumpBottomAddon() {}
+
+  // ITerminalAddon.activate — must run after term.open() so term.element exists.
+  CrowJumpBottomAddon.prototype.activate = function (term) {
+    this._term = term;
+    var self = this;
+
+    // The button anchors to the terminal's container (the element passed to
+    // term.open()), NOT document.body — desktop is full-page but web is a
+    // tabbed container, so absolute positioning must be relative to the
+    // viewport it belongs to.
+    var container = term.element && term.element.parentElement;
+    if (!container) {
+      return;
+    }
+    this._container = container;
+
+    injectStyleOnce();
+
+    // Give the absolutely-positioned button a positioning context. Record when
+    // we set it so dispose() can revert (relative with no offsets doesn't move
+    // the container, so fit/resize is unaffected).
+    if (getComputedStyle(container).position === 'static') {
+      container.style.position = 'relative';
+      this._setPosition = true;
+    }
+
+    var btn = document.createElement('button');
+    btn.className = 'crow-jump-bottom hidden';
+    btn.setAttribute('aria-label', 'Jump to latest output');
+    btn.setAttribute('title', 'Jump to bottom');
+    btn.innerHTML = '&#9662;'; // ▾
+    container.appendChild(btn);
+    this._btn = btn;
+
+    this._onClick = function () {
+      term.scrollToBottom();
+      term.focus(); // restore typing focus stolen by the button
+      self._update();
+    };
+    btn.addEventListener('click', this._onClick);
+
+    // onScroll is the primary trigger (leaving the bottom only ever happens via
+    // a user scroll — new output while pinned auto-scrolls and stays pinned);
+    // onRender is a safety-net re-check.
+    this._scrollDisposable = term.onScroll(function () { self._update(); });
+    this._renderDisposable = term.onRender(function () { self._update(); });
+
+    this._update();
+  };
+
+  CrowJumpBottomAddon.prototype._atBottom = function () {
+    var b = this._term.buffer.active;
+    return b.viewportY >= b.baseY;
+  };
+
+  CrowJumpBottomAddon.prototype._update = function () {
+    if (this._btn) {
+      this._btn.classList.toggle('hidden', this._atBottom());
+    }
+  };
+
+  // ITerminalAddon.dispose — tear down cleanly so the web UI (which
+  // creates/switches/closes terminals) never leaks duplicate buttons or
+  // stacked scroll listeners.
+  CrowJumpBottomAddon.prototype.dispose = function () {
+    if (this._scrollDisposable) {
+      this._scrollDisposable.dispose();
+      this._scrollDisposable = null;
+    }
+    if (this._renderDisposable) {
+      this._renderDisposable.dispose();
+      this._renderDisposable = null;
+    }
+    if (this._btn) {
+      if (this._onClick) {
+        this._btn.removeEventListener('click', this._onClick);
+      }
+      this._btn.remove();
+      this._btn = null;
+    }
+    if (this._setPosition && this._container) {
+      this._container.style.position = '';
+      this._setPosition = false;
+    }
+    this._container = null;
+    this._term = null;
+    // The shared <style> is left in place — it's id-guarded and harmless.
+  };
+
+  global.CrowJumpBottomAddon = { CrowJumpBottomAddon: CrowJumpBottomAddon };
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -82,17 +82,39 @@ struct BundledResourcesTests {
         #expect(body.contains(#"\x1b\r"#))
     }
 
-    @Test func terminalHTMLHasJumpToBottomControl() throws {
-        // #633: a jump-to-bottom control must live in the host page so
-        // scrolling up over long agent output has a fast path back to the
-        // live edge. The xterm resources get re-vendored wholesale (see
-        // Resources/xterm/VERSION), so pin the control's presence against an
-        // accidental overwrite.
+    @Test func terminalHTMLLoadsJumpToBottomAddon() throws {
+        // #668: jump-to-bottom (#633/#635) now lives in a shared xterm.js addon
+        // so the desktop AND web surfaces load one implementation. The host page
+        // must pull in the addon script and load it — pin that wiring against an
+        // accidental overwrite when the xterm resources get re-vendored wholesale
+        // (see Resources/xterm/VERSION). The behavior itself is pinned against
+        // the addon file below.
         let url = try #require(BundledResources.terminalHTMLURL)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        #expect(body.contains("xterm-addon-crow-jumpbottom.js"))
+        #expect(body.contains("CrowJumpBottomAddon"))
+        // The old inline control was deleted in favor of the addon — a stray
+        // `#crow-jump-bottom` id/style would mean the inline copy crept back in.
+        // (The addon script filename is `crow-jumpbottom`, no hyphen, so it
+        // doesn't trip this.)
+        #expect(!body.contains("crow-jump-bottom"))
+    }
+
+    @Test func jumpToBottomAddonIsBundled() throws {
+        // #668: the shared addon file is what actually implements the control
+        // (button + scroll wiring), and the daemon serves this exact file to the
+        // web UI at /xterm/…, so both surfaces stay in sync. Pin its presence and
+        // its load-bearing API surface.
+        let dir = try #require(BundledResources.xtermDirectoryURL)
+        let url = dir.appendingPathComponent("xterm-addon-crow-jumpbottom.js")
+        #expect(FileManager.default.fileExists(atPath: url.path))
         let body = try String(contentsOf: url, encoding: .utf8)
         #expect(body.contains("crow-jump-bottom"))
         #expect(body.contains("scrollToBottom"))
         #expect(body.contains("onScroll"))
+        // Namespaced UMD global matching the vendored addons
+        // (window.FitAddon.FitAddon → window.CrowJumpBottomAddon.CrowJumpBottomAddon).
+        #expect(body.contains("CrowJumpBottomAddon"))
     }
 
     @Test func tmuxConfHasNoBarePrefixUnbind() throws {


### PR DESCRIPTION
Closes #668

## What

Jump-to-bottom (#635) lived only in the **desktop** terminal page, so it was missing from the **web** UI. Rather than copy it, implement it once as a custom **xterm.js addon** and load it from both surfaces — deleting the desktop-only #635 implementation so there's one source of truth that can't drift again.

## Changes

- **New addon** `Packages/CrowTerminal/.../Resources/xterm/xterm-addon-crow-jumpbottom.js` (`ITerminalAddon`):
  - `activate(term)` injects a `.crow-jump-bottom` button into the terminal's **container** (anchored to the viewport, not `document.body`, since web is a tabbed container), wires `onScroll`/`onRender` to toggle visibility via the `buffer.active.viewportY >= baseY` at-bottom check, and snaps to latest on click.
  - `dispose()` removes the button + listeners so the web UI's create/switch/close lifecycle never leaks duplicate buttons or handlers.
  - Namespaced UMD global matching the vendored addons (`window.CrowJumpBottomAddon.CrowJumpBottomAddon`).
- **Loaded from all three front-ends** (script tag + `loadAddon` after `term.open`): desktop `terminal.html`, `web/index.html` + `app.js`, and the `web/terminal.html` debug page. The daemon already serves the file to web at `/xterm/…` (dynamic `/xterm/:file` route, `.copy("Resources/xterm")` bundling — no route/Swift change needed).
- **Deleted** the inline #635 button/CSS/wiring from desktop `terminal.html`.
- **Retargeted** `BundledResourcesTests`: pin that `terminal.html` loads the addon and the inline copy is gone, and that the addon file is bundled with its API surface.

## Not in scope (follow-on, tracked separately)
Forking vendored xterm or unifying the whole page across transports (WKWebView `postMessage` vs WebSocket — the correct seam). Making this the first of a shared "Crow terminal behaviors" addon set and migrating fit-coalescing (#638), reflow-debounce (#661), paste-through into it.

## Base branch
Targets `feature/crow-593-web-ui-parity` — the web UI + #635 only exist there, not on `main`.

## Testing
- `make build` — daemon + app compile.
- CrowTerminal `BundledResourcesTests` pass, including the two retargeted assertions (addon bundled + terminal.html loads it, inline copy removed).
- Manual verification of the pill (appears when scrolled up, hides at bottom, click snaps to latest; no fit/search/paste regressions; no leaked buttons on tab switch/close) should be done in both the desktop app and web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwDCNHfWc7TVmS58y2Vmn4