### PR TITLE
fix(web-terminal): focus-gated tmux sizing across surfaces (#667)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2174,6 +2174,14 @@ function ensureTerminal() {
   enableWheelScroll(document.getElementById('terminal'));
   enableFileDrop(document.getElementById('terminal'));
   window.addEventListener('resize', fitTerminal);
+  // #667: on regaining focus/visibility, this surface reclaims ownership of the
+  // shared tmux window size (re-asserts even if unchanged) — so "window-size
+  // latest" converges to "the surface you most recently focused." Registered
+  // once (ensureTerminal is `if (term) return` guarded).
+  window.addEventListener('focus', takeTerminalOwnership);
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) takeTerminalOwnership();
+  });
   // Observe the container itself, not just the window: splitter drags / panel
   // collapses resize the surface without firing a window `resize` (#661). Both
   // routes funnel through the coalesced, deduped fitTerminal.
@@ -2358,6 +2366,14 @@ let fitScheduled = false;
 
 function applyTermFit() {
   if (!term || !fitAddon) return;
+  // #667: a backgrounded surface must not become tmux's "latest" client and
+  // steal the shared window size. Multiple surfaces (Tauri desktop, browser,
+  // phone) share one grouped-session window whose size is `window-size latest`,
+  // so an idle tab that fit()s + resizes on relayout would reflow the window for
+  // the surface actually in use → the garbled rows from #661. Gate here: only
+  // the focused/visible surface owns the size. It re-asserts on regaining focus
+  // via takeTerminalOwnership() (window focus / visibilitychange).
+  if (document.hidden || !document.hasFocus()) return;
   const node = document.getElementById('terminal');
   if (!node || !node.isConnected || node.clientWidth < 1 || node.clientHeight < 1) return;
   try { fitAddon.fit(); } catch (_) { return; }
@@ -2379,6 +2395,18 @@ function fitTerminal() {
   if (fitScheduled) return;
   fitScheduled = true;
   requestAnimationFrame(() => { fitScheduled = false; applyTermFit(); });
+}
+
+// #667: on regaining focus, re-assert this surface's size so it becomes tmux's
+// "latest" client and reclaims the shared window size from whatever background
+// surface last touched it — even if this surface's own grid didn't change (which
+// applyTermFit's lastTermCols/lastTermRows dedup would otherwise swallow). Reset
+// the dedup, then fit; the reset + the visible/focused state let applyTermFit
+// send the resize frame. Wired to window `focus` and document `visibilitychange`.
+function takeTerminalOwnership() {
+  lastTermCols = 0;
+  lastTermRows = 0;
+  applyTermFit();
 }
 
 function selectWindow(win) {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -28,9 +28,40 @@ struct TerminalCockpit: Sendable {
     /// one (default shell anchor) so the daemon works standalone too. A failed
     /// create surfaces as an attach error in the browser rather than aborting.
     private func ensureSession() {
-        guard !controller.hasSession() else { return }
-        let conf = BundledResources.tmuxConfURL?.path
-        try? controller.newSessionDetached(configPath: conf, env: [:], command: nil)
+        if !controller.hasSession() {
+            let conf = BundledResources.tmuxConfURL?.path
+            try? controller.newSessionDetached(configPath: conf, env: [:], command: nil)
+        }
+        // Reap grouped sessions this or a prior crowd leaked (#667). Runs on
+        // every startup, whether we adopted or created the cockpit.
+        reapOrphanedViewSessions()
+    }
+
+    /// Kill `crowd-web-*` grouped sessions left detached by a prior crowd's
+    /// restart/crash (#667). Each `/terminal` connection creates one via
+    /// `openViewSession` and is supposed to tear it down via
+    /// `defer closeViewSession` (TerminalWebSocket), but a crowd that dies
+    /// mid-connection never runs that defer — while the separate tmux server
+    /// keeps the group alive. These groups carry no persisted state and are
+    /// never re-adopted (a reconnecting browser opens a fresh group), so any
+    /// DETACHED one is pure garbage; leaked groups also pin windows at stale
+    /// sizes and pile up on the shared server across restarts.
+    ///
+    /// Safety: only kill groups with `session_attached == 0`. A live browser
+    /// holds its group attached via the PTY running `attach-session`, so an
+    /// in-use view (even one owned by a concurrent crowd on this shared server)
+    /// is `attached >= 1` and skipped. Best-effort; never throws.
+    private func reapOrphanedViewSessions() {
+        guard let out = try? controller.run(
+            ["list-sessions", "-F", "#{session_name} #{session_attached}"]
+        ) else { return }
+        for line in out.split(separator: "\n") {
+            let parts = line.split(separator: " ")
+            guard parts.count == 2,
+                  parts[0].hasPrefix("crowd-web-"),
+                  parts[1] == "0" else { continue }
+            _ = try? controller.run(["kill-session", "-t", String(parts[0])])
+        }
     }
 
     /// Create an ephemeral grouped session sharing `crow-cockpit`'s windows but

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -141,6 +141,21 @@ bind -T root WheelUpPane if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -
 # is recreated.
 set -gs history-limit 50000
 
+# Size each window from only the clients for which it is the CURRENT window
+# (#667). Every web surface (Tauri desktop, browser, phone) opens a GROUPED
+# session off crow-cockpit that shares the window list — so a window's size is
+# shared, and tmux's default `window-size latest` hands it to the most recent
+# client to touch it, with no notion of focus. With `aggressive-resize off`
+# (the default) a background surface parked on a DIFFERENT window still counts
+# toward this window's size and can drag it on relayout. `on` scopes size
+# negotiation to the clients actually viewing the window, complementing app.js's
+# focus-gated resize (only the focused surface sends a resize frame). tmux docs:
+# aggressive-resize applies per-window and is honored when window-size is
+# `smallest`/`largest`; under `latest` it still narrows which clients a window
+# tracks. Takes effect on the next attach / after the conf is re-sourced —
+# reconnect the terminal to pick it up on existing windows.
+set -gw aggressive-resize on
+
 # No escape-key delay — interactive editors (vi-mode shells, etc.) feel
 # sluggish with tmux's default 500ms.
 set -gs escape-time 0


### PR DESCRIPTION
Closes #667

Follow-up to #661 / #663. #663 debounced each web client's *own* resize storm; this addresses the *cross-surface* fight over the shared tmux window size.

## Root cause
Every web surface (Tauri desktop, browser, phone) opens a **grouped** tmux session (`crowd-web-*`) off the one `crow-cockpit`. Grouped sessions share the window list — so a window's **size** is shared; only the current-window *pointer* is independent. With tmux defaults `window-size latest` + `aggressive-resize off`, the **most recent client to touch a window wins its size, with no notion of focus**. An idle phone or background tab grabs the size the moment it attaches/relayouts → the focused surface renders at the wrong width → the overlapping/garbled rows from #661. A page reload only "fixes" it by momentarily being the sole/latest client.

## Fix (tmux has no focus signal → gate at the app layer)
- **`app.js`** — `applyTermFit()` early-returns when `document.hidden || !document.hasFocus()`, so a backgrounded surface never becomes tmux's "latest" and can't steal the size. New `takeTerminalOwnership()` (wired to `window` `focus` + document `visibilitychange`) re-asserts this surface's size on refocus even if unchanged, so "latest" converges to *"the surface you most recently focused."* Background surfaces show a stable, clipped, non-corrupting view.
- **`crow-tmux.conf`** — `set -gw aggressive-resize on` so a surface parked on a *different* window can't drag this window's size.
- **`TerminalCockpit.swift`** — reap **detached** `crowd-web-*` groups at crowd startup (leaked when a prior crowd died before its `defer closeViewSession` ran). `session_attached == 0` filter never kills a live browser's view.

No regression to #663's debounce or right-click "Reload terminal".

## Acceptance
- Two surfaces on the same terminal at different sizes → only the **focused** surface drives the shared window size; switching focus transfers ownership cleanly; the background surface is stable (possibly clipped) with no garbled rows.
- `tmux show-options -gw aggressive-resize` → `on`.

## Notes
Inherent limit (unchanged): one shared tmux window has exactly one size, so a background device can't be pixel-perfect while a differently-sized surface is focused — but it's stable, non-corrupting, and correct once focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vtUHdzP8ZE1Nbi46JdC8m