### PR TITLE
fix(web-terminal): tab switch self-heals display like Reload (#671)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1692,8 +1692,15 @@ function renderTabs() {
 function switchTerminal(t) {
   activeTerminal = t;
   renderTabs();
-  selectWindow(t.window);
   if (term) term.focus();
+  // #671: mirror reloadTerminal's onopen order — reclaim this surface's size for
+  // the shared tmux window (forced resize), THEN replay. Recovers a mismatched/
+  // stuck-small grid the cheap way, with no socket/PTY teardown. takeTerminalOwnership
+  // resets the applyTermFit dedup so the resize frame is sent even when this surface's
+  // CSS grid is unchanged, re-asserting size on the shared window before select-window
+  // replays the pane at the corrected size.
+  takeTerminalOwnership();
+  selectWindow(t.window);
 }
 
 async function addTerminal() {


### PR DESCRIPTION
Closes #671. Follow-up to #667/#670.

## Problem
The web terminal shares one grouped-session tmux window (`window-size latest`) across surfaces (Tauri desktop, browser, phone). When another surface resizes that window, this surface's pane is laid out for the wrong width → garbled/overlapping rows (the #661 corruption), or stays stuck-small after the small surface goes away.

Right-click **Reload terminal** recovers it, but it's heavy (tears down the WebSocket + PTY + `tmux attach` + replays ~50k lines of scrollback). Switching session tabs recovered *nothing* — `switchTerminal()` only sent `select-window`, replaying the pane at the window's current (wrong) size with no size re-assert. `term.focus()` there doesn't fire the `window` `focus` event, so `takeTerminalOwnership()` never ran.

## Fix (app.js only)
Reorder `switchTerminal()` to mirror `reloadTerminal`'s `onopen` ordering, reusing the existing `takeTerminalOwnership()` primitive (`lastTermCols=0; lastTermRows=0; applyTermFit()`):

- **resize THEN replay** — call `takeTerminalOwnership()` (forces this surface's real size onto the shared window) **before** `selectWindow(t.window)`, so the replay comes back at the corrected size.
- No socket/PTY/scrollback teardown → instant.

`takeTerminalOwnership()` already exists (used by the window `focus` / `visibilitychange` listeners); its `applyTermFit()` guard checks *document* focus, which is true when clicking a tab in a visible browser, so the forced `{type:'resize'}` frame is sent synchronously before the `{type:'select-window'}` replay — the exact ordering that makes Reload work. No `term.reset()` needed: the backend replay prepends `ESC[H ESC[2J ESC[3J`.

Does not touch `reloadTerminal`, `connectTerminalWs`, or #663's resize debounce.

## Test plan
1. Open a session terminal in the browser; resize the same window from another surface (desktop/phone) so this surface goes garbled / stuck-small.
2. Switch session tabs (or terminal tabs) and back — display snaps to correct size, no garbled rows, **instantly** (no scrollback stall), matching right-click Reload.
3. "Stays small after closing the phone tab": switching tabs re-grows this surface.
4. Regression: right-click Reload still works; normal resize/reflow (#663 debounce) unchanged.

## Out of scope
Stopping a concurrently-foreground small surface (phone) from re-stealing the size while both are visible (`window-size latest`→`largest`) — separate follow-up. This is recovery-on-switch only.