### PR TITLE
fix(web-terminal): switching active terminal does a full Reload (#673)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1690,17 +1690,21 @@ function renderTabs() {
 }
 
 function switchTerminal(t) {
+  // #673: re-clicking the active tab shouldn't tear down the socket/PTY.
+  if (activeTerminal && activeTerminal.id === t.id) { if (term) term.focus(); return; }
   activeTerminal = t;
   renderTabs();
   if (term) term.focus();
-  // #671: mirror reloadTerminal's onopen order — reclaim this surface's size for
-  // the shared tmux window (forced resize), THEN replay. Recovers a mismatched/
-  // stuck-small grid the cheap way, with no socket/PTY teardown. takeTerminalOwnership
-  // resets the applyTermFit dedup so the resize frame is sent even when this surface's
-  // CSS grid is unchanged, re-asserting size on the shared window before select-window
-  // replays the pane at the corrected size.
-  takeTerminalOwnership();
-  selectWindow(t.window);
+  // #673: the cheap resize-then-replay path (#671/#672) — takeTerminalOwnership()
+  // (forced resize) then selectWindow() on the live socket — couldn't recover the
+  // cursor/grid mismatch on switch; the shared grouped-session window stays desynced
+  // and only the heavyweight reload fixes it. Do the full "Reload terminal" recovery
+  // instead: term.reset() + fresh WebSocket reconnect. connectTerminalWs's onopen
+  // re-fits then selectWindow(activeTerminal.window) — set above, so the fresh socket
+  // selects the newly-chosen window — and crowd replays the pane against a stable
+  // layout, identical to right-click "Reload terminal". Correctness over the snappier
+  // in-place path, which proved insufficient.
+  reloadTerminal();
 }
 
 async function addTerminal() {


### PR DESCRIPTION
Closes #673

## Problem
The lightweight fix in #672 (issue #671) — `takeTerminalOwnership()` (forced resize) then `selectWindow()` on the **live** socket — did not resolve the corruption. Switching the active terminal still left the rendered xterm grid out of sync with the true tmux pane: the cursor was not where the line actually was. Multiple surfaces share one grouped-session tmux window (`window-size latest`), so a resize-then-replay on the same socket can't recover the mismatch. Only right-click **"Reload terminal"** (`term.reset()` + fresh WebSocket reconnect) fixed it.

## Fix
Make `switchTerminal()` run the full `reloadTerminal()` recovery instead of the in-place path:

- Set `activeTerminal = t` (and `renderTabs()`) **first**, then call `reloadTerminal()`. `connectTerminalWs`'s `onopen` re-fits (`applyTermFit()`) then `selectWindow(activeTerminal.window)`, so the fresh socket selects the newly-chosen window and crowd replays the pane against a stable layout — identical to right-click "Reload terminal".
- **Guard:** re-clicking the already-active tab just re-focuses (no needless socket/PTY teardown).

## Non-regressions
- `takeTerminalOwnership()` stays wired to `window focus` / `visibilitychange` — focus-gated sizing (#667) unaffected.
- Right-click "Reload terminal" and #663's resize debounce are untouched.
- `addTerminal()` → `switchTerminal(created)`: `created` is non-active, so it gets the full reload + correct window selection.

Out of scope: session-switch (sidebar) flows through `refreshTerminals()`, not `switchTerminal()`; the ticket names only `switchTerminal()` / `reloadTerminal()`.

Related: #661, #663, #667, #670, #671, PR #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyS8LgTE55m2zfce8Sjh5f