### PR TITLE
feat(web-terminal): skeleton loading overlay while xterm attaches/reloads (#677)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -342,8 +342,29 @@ html, body {
 .tab.add { color: var(--gold); font-size: 16px; font-weight: 700; }
 .tab-close { color: var(--text-muted); font-size: 14px; }
 .tab-close:hover { color: var(--red); }
-#terminal-wrap { flex: 1; min-height: 0; background: #1e1e1e; }
+#terminal-wrap { flex: 1; min-height: 0; background: #1e1e1e; position: relative; }
 #terminal { width: 100%; height: 100%; }
+
+/* ---- Terminal skeleton loading overlay (#677) ----
+   Masks the xterm attach/reload window (blank/garbled grid, reflow flash,
+   mid-paint scrollback replay) with the CROW-613 .skel shimmer, restyled as
+   terminal-shaped placeholder lines. #1e1e1e matches the xterm theme
+   (ensureTerminal) so there's no flash-of-wrong-color. */
+#terminal-skeleton {
+  position: absolute;
+  inset: 0;
+  background: #1e1e1e;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;          /* never steal input/focus from xterm */
+  opacity: 0;                    /* hidden by default; .loading fades it in/out */
+  transition: opacity 200ms ease;
+  z-index: 3;
+}
+#terminal-wrap.loading #terminal-skeleton { opacity: 1; transition: none; } /* instant show, smooth fade only on hide */
+.term-skel-bar { height: 12px; max-width: 78%; }
 #detail-empty {
   position: absolute;
   inset: 0;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2129,6 +2129,24 @@ let term = null;
 let fitAddon = null;
 let searchAddon = null;
 let termWs = null;
+let termSkelTimer = null; // #677: safety timeout that clears the skeleton overlay
+
+// Skeleton loading overlay (#677): mask the artifact-prone xterm (re)attach
+// window (blank/garbled grid, reflow flash, mid-paint scrollback replay) with
+// the CROW-613 shimmer. Toggled via a `.loading` class on #terminal-wrap.
+function showTerminalSkeleton() {
+  const wrap = document.getElementById('terminal-wrap');
+  if (wrap) wrap.classList.add('loading');
+  // Never strand the overlay on a quiet PTY that sends no immediate output.
+  clearTimeout(termSkelTimer);
+  termSkelTimer = setTimeout(hideTerminalSkeleton, 1500);
+}
+function hideTerminalSkeleton() {
+  clearTimeout(termSkelTimer);
+  termSkelTimer = null;
+  const wrap = document.getElementById('terminal-wrap');
+  if (wrap) wrap.classList.remove('loading');
+}
 
 // Terminal font stack: Nerd Fonts → system monospace.
 const DEFAULT_TERM_FONT = '"MesloLGS NF", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", "FiraCode Nerd Font", Menlo, Monaco, monospace';
@@ -2152,6 +2170,9 @@ function ensureTerminal() {
   term.loadAddon(imageAddon);
   term.loadAddon(searchAddon);
   term.loadAddon(webLinksAddon);
+  // #677: seed the skeleton before first open() so it covers the initial xterm
+  // layout / first-fit reflow flash; connectTerminalWs() re-arms it below.
+  showTerminalSkeleton();
   term.open(document.getElementById('terminal'));
   // Jump-to-bottom pill (#668), shared with the desktop surface. Must load after
   // open() so the addon can anchor its button to the terminal's container.
@@ -2346,6 +2367,11 @@ function showTerminalMenu(e) {
 
 function connectTerminalWs() {
   if (sessionDead) return; // don't loop after an expired remote cookie (review Yellow)
+  // #677: cover this (re)attach — initial connect, auto-reconnect, and (via
+  // reloadTerminal) the #675 right-click Reload + tab/session switch — with the
+  // skeleton. `painted` gates the hide to the FIRST PTY byte of THIS socket.
+  showTerminalSkeleton();
+  let painted = false;
   termWs = new WebSocket(wsURL('/terminal'));
   termWs.binaryType = 'arraybuffer';
   termWs.onopen = () => {
@@ -2363,13 +2389,19 @@ function connectTerminalWs() {
     }
   };
   termWs.onmessage = (event) => {
-    if (event.data instanceof ArrayBuffer) term.write(new Uint8Array(event.data));
+    if (event.data instanceof ArrayBuffer) {
+      term.write(new Uint8Array(event.data));
+      // Fade the skeleton out once the first real content has landed — rAF so
+      // the hide follows the paint, not precedes it.
+      if (!painted) { painted = true; requestAnimationFrame(hideTerminalSkeleton); }
+    }
   };
   termWs.onclose = () => {
+    hideTerminalSkeleton(); // don't strand the overlay; a reconnect re-shows it
     if (sessionDead) return;
     setTimeout(connectTerminalWs, 1000);
   };
-  termWs.onerror = () => termWs.close();
+  termWs.onerror = () => termWs.close(); // funnels to onclose (hides skeleton)
 }
 
 // Resize path (#661): in a browser the window `resize` event and normal page

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -17,7 +17,22 @@
       <header id="detail-header"></header>
       <div id="detail-artifacts"></div>
       <div id="tabbar"></div>
-      <div id="terminal-wrap"><div id="terminal"></div></div>
+      <div id="terminal-wrap"><div id="terminal"></div><!--
+        Skeleton loading overlay (#677): shimmer bars over the terminal area
+        while xterm attaches/reloads, masking the blank/garbled grid + reflow
+        flash + mid-paint scrollback replay. Reuses the CROW-613 .skel shimmer.
+        pointer-events:none so it never steals input/focus from xterm.
+      --><div id="terminal-skeleton" aria-hidden="true">
+          <div class="skel term-skel-bar" style="--skel-delay: 0s; width: 58%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .08s; width: 34%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .16s; width: 66%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .24s; width: 45%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .32s; width: 71%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .40s; width: 28%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .48s; width: 52%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .56s; width: 39%"></div>
+          <div class="skel term-skel-bar" style="--skel-delay: .64s; width: 61%"></div>
+      </div></div>
       <div id="board"></div>
       <div id="detail-empty">
         <img class="empty-brand" src="/brand.svg" alt="Crow">


### PR DESCRIPTION
Closes #677

## What
Loading a terminal on the crow-593 web UI briefly showed **artifacts** — a blank/garbled grid, a reflow flash, and mid-paint scrollback replay — before the grid settled. Most visible on the #675 full-`reloadTerminal()` recovery (`term.reset()` + fresh WebSocket), but also on initial attach, tab/session switch, and auto-reconnect. This wraps that loading window with a shimmer **skeleton overlay** so it reads as a clean loading screen.

Reuses the existing CROW-613 sidebar shimmer (`.skel` + `@keyframes crow-skel-shimmer`), restyled as terminal-shaped placeholder bars over the terminal background — no new shimmer invented.

## Changes (web only)
- **`index.html`** — `#terminal-skeleton` inside `#terminal-wrap` (sibling of `#terminal`), a handful of `.skel term-skel-bar` bars; `aria-hidden`.
- **`app.css`** — `#terminal-wrap` gets `position: relative`; overlay is `position:absolute; inset:0` on `#1e1e1e` (matches the xterm theme → no flash-of-wrong-color), `pointer-events:none` (never steals input/focus), fades via a `.loading` class on the wrap. Reduced-motion inherits the existing `.skel` media rule.
- **`app.js`** — `showTerminalSkeleton()` / `hideTerminalSkeleton()` toggle `.loading`. Seeded in `ensureTerminal()` before `term.open()`; shown at the top of `connectTerminalWs()` — the single choke point covering initial connect, auto-reconnect, and (via `reloadTerminal`) the #675 right-click **Reload terminal** + tab/session switch. Hidden on the first PTY byte of each socket behind `requestAnimationFrame` (paint has landed), on socket `close`, and via a ~1.5s safety timeout so a quiet PTY can't strand it.

## Scope / non-goals
Web surface only — desktop `terminal.html` untouched (shared-addon path is #668). No changes to #675 reload, #663 resize debounce, or #661/#667 sizing — only the loading window is wrapped.

## Testing
- Select a session → shimmer over the terminal, fades as PTY content paints; no garble.
- Right-click **Reload terminal**, switch terminal tab, switch session → skeleton on each reload, fades on repaint.
- Quiet terminal (no immediate output) → clears within ~1.5s, doesn't linger.
- Typing while skeleton is up goes to xterm (overlay is `pointer-events:none`).
- `node --check app.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F39H7TyV92GuFEsrDYBGf