### PR TITLE
feat(web-ui): block interaction with a scrim overlay on session-expired

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -714,6 +714,43 @@ html, body {
 }
 .artifact-thumb:hover { border-color: var(--blue, #4a86e8); }
 
+/* Session-expired scrim (#679): a dimming overlay that blocks all interaction with
+   #app once the web session is confirmed dead (sessionDead). z-index sits between
+   #app content (max ~50) and #statusbar (60) so the statusbar Log in stays above
+   and clickable; the scrim itself also offers a centered Log in. */
+#session-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 55;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.6);
+  /* fixed + inset:0 captures every click/keypress aimed at #app beneath it */
+}
+#session-scrim[hidden] { display: none; }
+.scrim-card {
+  width: min(360px, 92vw);
+  text-align: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.6);
+  padding: 22px 24px;
+}
+.scrim-title { color: var(--red); font-weight: 700; font-size: 16px; margin-bottom: 6px; }
+.scrim-msg { color: var(--text-secondary); font-size: 13px; margin-bottom: 16px; }
+.scrim-login {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 7px 20px;
+  background: var(--gold); color: var(--bg-deep);
+  border: 1px solid var(--gold); border-radius: 8px;
+  font-weight: 600; font-size: 13px; cursor: pointer;
+}
+.scrim-login:hover { filter: brightness(1.08); }
+.scrim-login:active { transform: translateY(1px); }
+
 #lightbox {
   position: fixed;
   inset: 0;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -806,6 +806,11 @@ function renderStatusBar() {
   bar.classList.toggle('connected', wsConnected && !sessionDead);
   bar.classList.toggle('disconnected', !wsConnected && !sessionDead);
   bar.classList.toggle('session-expired', sessionDead);
+  // Full-app scrim (#679): block interaction with #app once the session is
+  // definitively dead. Keyed on sessionDead only — never on a transient
+  // !wsConnected reconnect ("Connecting…"), which self-heals.
+  const scrim = document.getElementById('session-scrim');
+  if (scrim) scrim.hidden = !sessionDead;
   const label = bar.querySelector('.conn-label');
   if (label) label.textContent = sessionDead ? 'Session expired' : (wsConnected ? 'Connected' : 'Connecting…');
   const actions = document.getElementById('statusbar-actions');
@@ -1360,6 +1365,12 @@ function openLightbox(url, alt) {
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && box && !box.hidden) { box.hidden = true; document.getElementById('lightbox-img').src = ''; }
   });
+})();
+
+// Session-expired scrim Log in (#679): reuses the statusbar login handler (~:820).
+(function wireSessionScrim() {
+  const btn = document.getElementById('scrim-login');
+  if (btn) btn.onclick = () => { location.href = '/login'; };
 })();
 
 function shorten(path) {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -40,6 +40,17 @@
       </div>
     </main>
   </div>
+  <!-- Session-expired scrim (#679): on a confirmed 401 (sessionDead) this blocks
+       all interaction with #app until re-login. Sits below #statusbar so the
+       statusbar Log in stays reachable; only shown on sessionDead, never on a
+       transient reconnect. -->
+  <div id="session-scrim" hidden>
+    <div class="scrim-card" role="alertdialog" aria-label="Session expired">
+      <div class="scrim-title">Session expired</div>
+      <div class="scrim-msg">Your web session ended. Log in again to continue.</div>
+      <button id="scrim-login" class="scrim-login" type="button">Log in</button>
+    </div>
+  </div>
   <!-- Fixed connection/status bar, bottom-left (CROW-593): a light for the /rpc
        socket state, plus a logout button on signed-in remote sessions. -->
   <div id="statusbar" class="disconnected">


### PR DESCRIPTION
Closes #679

## What

On a confirmed 401 (`sessionDead`), overlay a semi-transparent dark scrim over `#app` that **blocks all interaction** beneath it (sidebar, tabs, terminal, board, action buttons) and draws attention to the expired state with a centered **Session expired — Log in** card. Previously the only reaction to `sessionDead` was the statusbar flip to "Session expired" + Log in — the rest of `#app` stayed fully clickable/typeable into a dead session.

## How

- **`web/index.html`** — `#session-scrim` element (sibling of `#app`, before `#statusbar`), hidden by default, mirroring the `#lightbox` pattern.
- **`web/app.css`** — `position: fixed; inset: 0; z-index: 55`. The z-index is deliberately between `#app` inner content (max ~50) and `#statusbar` (60), so the scrim covers the app while the statusbar Log in stays above and clickable. `fixed + inset:0` captures every click/keypress aimed at `#app`. Card + gold CTA reuse the existing `.sb-login` look and CSS tokens.
- **`web/app.js`** — toggle `scrim.hidden = !sessionDead` inside `renderStatusBar()` (the single choke point already called on every `sessionDead` change); wire `#scrim-login` → `location.href = '/login'` via an IIFE mirroring `wireLightbox()`, reusing the existing statusbar login handler.

Keyed on `sessionDead` **only** — never on a transient `!wsConnected` reconnect ("Connecting…"), which self-heals. Recovery is automatic: successful re-login reloads the app fresh (no scrim), and any `sessionDead → false` flip hides it on the next `renderStatusBar()`.

## Acceptance criteria
- [x] On `sessionDead`, a dimming scrim covers `#app` and blocks clicks/typing on sidebar, tabs, terminal, board, and action buttons.
- [x] A Log in action is visible and clickable (both on the scrim and the statusbar, which stays above); it goes to `/login`, and after re-login the app is interactive with no leftover scrim.
- [x] No scrim during normal "Connecting…"/reconnect — only on a definitive expired session.

## Verify
1. Sign in over web. In devtools: `sessionDead = true; renderStatusBar();` → scrim appears, `#app` dimmed and non-interactive, statusbar + scrim Log in reachable and navigate to `/login`.
2. `sessionDead = false; renderStatusBar();` → scrim clears, app interactive again.
3. `setWsConnected(false)` → statusbar shows "Connecting…" with **no** scrim.

> Base is `feature/crow-593-web-ui-parity` — the web UI does not exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDoZQyEa34tFL9BmQkAbqs