### PR TITLE
fix(web-terminal): hide tab bar for manager sessions (#680)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1678,6 +1678,13 @@ async function refreshTerminals() {
 function renderTabs() {
   const bar = document.getElementById('tabbar');
   bar.innerHTML = '';
+  // #680: managers are a single terminal — no tabs, no "+", no "×". Leaving
+  // #tabbar empty lets the `#tabbar:empty { display:none }` rule (app.css)
+  // collapse it so no empty strip sits above the manager terminal. (This also
+  // moots the stale-tab naming bug: a renamed manager session has no tab to go
+  // stale, since tabs are labeled from the terminal name, not the session name.)
+  const sel = sessions.find((x) => x.id === selectedId);
+  if (sel && sel.kind === 'manager') return;
   for (const t of terminals) {
     const tab = el('div', 'tab' + (activeTerminal && t.id === activeTerminal.id ? ' active' : ''));
     const label = el('span', null, t.name);


### PR DESCRIPTION
Closes #680

## What
Managers are a single terminal — they have no terminal tabs. `renderTabs()` now returns early (after clearing `#tabbar`) when the selected session is a manager, so **no tabs, no "+", and no "×"** render. The existing `#tabbar:empty { display: none; }` rule (`app.css:329`) collapses the empty bar, so no strip is left above the manager terminal.

## Why
Renaming a **manager** session updated the header but left a stale "Manager" **tab**, because tabs are labeled from the *terminal* name (`t.name`), and renaming a *session* doesn't rename the terminal. Hiding the tab bar for managers removes the useless UI and makes that stale-tab bug moot (no tab, nothing to go stale).

## How
Single-file change in `Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js` — `renderTabs()`:

```js
const sel = sessions.find((x) => x.id === selectedId);
if (sel && sel.kind === 'manager') return;
```

- `sel.kind === 'manager'` is the same predicate already used throughout app.js (`:616`, `:869`, `:1201`, …).
- No CSS change: `#tabbar:empty { display: none; }` already collapses the empty bar.
- `renderTabs()` runs from `refreshTerminals()`, which reads `selectedId` first, so the lookup is populated.

## Non-goals
- Work (non-manager) sessions: **unchanged** — tabs render, "+" adds a terminal, "×" closes one.
- Desktop (SwiftUI) tab UI: out of scope; separate follow-up if it also shows tabs for managers.

## Verification
1. Select a **manager** session → no tab bar; terminal fills the area with no empty strip.
2. Rename the manager session → header updates; no stale tab.
3. Select a **work** session → tabs, "+", and "×" all work as before.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow