### PR TITLE
fix(skill): inject matched workspace's customInstructions into worker prompt

### DIFF
--- a/Resources/crow-batch-workspace-SKILL.md.template
+++ b/Resources/crow-batch-workspace-SKILL.md.template
@@ -82,7 +82,7 @@ For each workspace spec, perform the same resolution as `/crow-workspace`:
    - Jira (task-only): fetch via the `jira` MCP server (`jira_get_issue {key}`); title is the work item `summary`.
 6. **Check for existing PR**: `gh pr list --repo {owner}/{repo} --search "{issue_number}" --state open --json number,title,headRefName,url --limit 5` (with `dangerouslyDisableSandbox: true`). For a Jira-task session this runs against the workspace's configured GitHub/GitLab code repo, not Jira.
 7. **Generate names**: slug, branch, worktree path, session name (following `/crow-workspace` naming conventions). **Jira:** resolve `{ticket_number}` as the **numeric suffix** of the key (`MAXX-6859` → `6859`); `{ticket_url}` is the full `…/browse/{key}` URL; the slug uses the lowercased full key (`{repo}-maxx-6859-{slug}`).
-8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`
+8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`. Resolve `{custom_instructions}` from the **matched** workspace's `workspaces["{workspace}"].customInstructions` in the config read in step 1 (not `defaults`, not another workspace) and append a verbatim `## Custom Instructions` section when non-empty — exactly per `/crow-workspace`'s **Resolve custom instructions** step and **First Prompt Template**.
 9. **Write prompt file**: `cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md`
 
 This phase is sequential because each resolution involves LLM reasoning (scoring repos, generating slugs). It's fast (~2-3 seconds per workspace).

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -307,6 +307,17 @@ Store the result as `{base_branch}` for substitution into Step 2 and into the pr
 
 Render the fetched content into the prompt template per the formatting rules in **First Prompt Template** below.
 
+**Resolve custom instructions (required before writing the prompt).** Read the
+**matched** workspace's entry in `{devRoot}/.claude/config.json` —
+`workspaces["{workspace}"].customInstructions`, where `{workspace}` is the same
+value passed to `setup.sh --workspace` — and store it as `{custom_instructions}`.
+This must be the matched workspace's own field: **do not** read `defaults`, **do
+not** use another workspace's value, and **do not** copy the example strings shown
+in the config sample above (`"Always run …"` / `null`). If the field is `null`,
+absent, or empty after trimming, treat `{custom_instructions}` as empty (no
+section). This value feeds the `## Custom Instructions` block of the prompt
+template (see **First Prompt Template** below).
+
 #### Step 1: Write the prompt file
 
 The LLM writes the prompt content (see template below — with the pre-fetched ticket/PR content embedded) to a file:
@@ -460,10 +471,15 @@ gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
 
 ## Custom Instructions
 
-{workspace customInstructions text — include verbatim}
+{custom_instructions}
 ~~~
 
-If the workspace config contains a non-empty `customInstructions` field, append a `## Custom Instructions` section at the end of the prompt with its contents verbatim. Omit this section entirely if the field is absent, null, or empty.
+Fill the `## Custom Instructions` block with `{custom_instructions}` — the
+**matched** workspace's `customInstructions` resolved above — included **verbatim**
+(preserve markdown, code fences, line breaks; do not summarize, reword, or
+substitute `defaults` or another workspace's text). If `{custom_instructions}` is
+empty, `null`, or absent, **omit the entire `## Custom Instructions` heading and
+body** so the prompt has no such section.
 
 For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
 

--- a/Tests/CrowTests/CustomInstructionsSkillTests.swift
+++ b/Tests/CrowTests/CustomInstructionsSkillTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+/// Regression guard for issue #683: new-workspace creation must inject the
+/// **matched** workspace's `customInstructions` into the worker prompt.
+///
+/// Workspace/session creation is driven by the `/crow-workspace` (and
+/// `/crow-batch-workspace`) skill — the Manager Claude Code writes the prompt
+/// file per those instructions; no Swift code assembles the creation prompt. So
+/// the fix surface, and what these tests guard, is the skill instruction itself:
+/// each skill (and its bundled `Resources/*.template`, which release builds
+/// scaffold from — see [[crow-scaffolded-docs-dual-source]]) must tell the
+/// Manager to resolve the matched workspace's `customInstructions` and append a
+/// verbatim `## Custom Instructions` section, without falling back to `defaults`
+/// or another workspace.
+@Suite("Workspace custom-instructions skill guard")
+struct CustomInstructionsSkillTests {
+
+    /// Walk up from this test source file until we find Package.swift; return the repo root.
+    private static func repoRoot(file: StaticString = #file) -> URL {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0..<10 {
+            if FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("Package.swift").path
+            ) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        Issue.record("Could not locate Package.swift walking up from \(file)")
+        return URL(fileURLWithPath: "/")
+    }
+
+    private static func read(_ relativePath: String) throws -> String {
+        try String(contentsOf: repoRoot().appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    /// The `/crow-workspace` skill and its bundled template are dual-sourced —
+    /// `Scaffolder` copies the template into new dev roots, while the live skill
+    /// runs in this repo — so a fix must land in both or scaffolded installs
+    /// silently regress.
+    private static let workspaceFiles = [
+        "skills/crow-workspace/SKILL.md",
+        "Resources/crow-workspace-SKILL.md.template",
+    ]
+
+    private static let batchFiles = [
+        "skills/crow-batch-workspace/SKILL.md",
+        "Resources/crow-batch-workspace-SKILL.md.template",
+    ]
+
+    @Test func crowWorkspaceResolvesMatchedWorkspaceCustomInstructions() throws {
+        for path in Self.workspaceFiles {
+            let body = try Self.read(path)
+
+            #expect(body.contains("Resolve custom instructions"),
+                "\(path) must contain an explicit 'Resolve custom instructions' step so the Manager resolves the value before writing the prompt (issue #683).")
+            #expect(body.contains("workspaces[\"{workspace}\"].customInstructions"),
+                "\(path) must point the Manager at the matched workspace's `workspaces[\"{workspace}\"].customInstructions`, not a generic 'the config' lookup.")
+            #expect(body.contains("{custom_instructions}"),
+                "\(path) must thread the resolved `{custom_instructions}` token into the `## Custom Instructions` template block.")
+            #expect(body.contains("## Custom Instructions"),
+                "\(path) must keep the `## Custom Instructions` heading in the prompt template.")
+            #expect(body.contains("verbatim"),
+                "\(path) must require the custom instructions be included verbatim.")
+            #expect(body.contains("do not** read `defaults`"),
+                "\(path) must explicitly forbid falling back to `defaults` when resolving customInstructions (issue #683 acceptance criteria).")
+        }
+    }
+
+    @Test func crowBatchWorkspaceResolvesMatchedWorkspaceCustomInstructions() throws {
+        for path in Self.batchFiles {
+            let body = try Self.read(path)
+
+            #expect(body.contains("workspaces[\"{workspace}\"].customInstructions"),
+                "\(path) must resolve the matched workspace's `customInstructions` per session so batch creation doesn't drop the section (issue #683).")
+            #expect(body.contains("## Custom Instructions"),
+                "\(path) must reference appending the `## Custom Instructions` section.")
+            #expect(body.contains("not `defaults`"),
+                "\(path) must forbid the `defaults` fallback when resolving per-workspace customInstructions.")
+        }
+    }
+}

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -82,7 +82,7 @@ For each workspace spec, perform the same resolution as `/crow-workspace`:
    - Jira (task-only): fetch via the `jira` MCP server (`jira_get_issue {key}`); title is the work item `summary`.
 6. **Check for existing PR**: `gh pr list --repo {owner}/{repo} --search "{issue_number}" --state open --json number,title,headRefName,url --limit 5` (with `dangerouslyDisableSandbox: true`). For a Jira-task session this runs against the workspace's configured GitHub/GitLab code repo, not Jira.
 7. **Generate names**: slug, branch, worktree path, session name (following `/crow-workspace` naming conventions). **Jira:** resolve `{ticket_number}` as the **numeric suffix** of the key (`MAXX-6859` → `6859`); `{ticket_url}` is the full `…/browse/{key}` URL; the slug uses the lowercased full key (`{repo}-maxx-6859-{slug}`).
-8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`
+8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`. Resolve `{custom_instructions}` from the **matched** workspace's `workspaces["{workspace}"].customInstructions` in the config read in step 1 (not `defaults`, not another workspace) and append a verbatim `## Custom Instructions` section when non-empty — exactly per `/crow-workspace`'s **Resolve custom instructions** step and **First Prompt Template**.
 9. **Write prompt file**: `cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md`
 
 This phase is sequential because each resolution involves LLM reasoning (scoring repos, generating slugs). It's fast (~2-3 seconds per workspace).

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -307,6 +307,17 @@ Store the result as `{base_branch}` for substitution into Step 2 and into the pr
 
 Render the fetched content into the prompt template per the formatting rules in **First Prompt Template** below.
 
+**Resolve custom instructions (required before writing the prompt).** Read the
+**matched** workspace's entry in `{devRoot}/.claude/config.json` —
+`workspaces["{workspace}"].customInstructions`, where `{workspace}` is the same
+value passed to `setup.sh --workspace` — and store it as `{custom_instructions}`.
+This must be the matched workspace's own field: **do not** read `defaults`, **do
+not** use another workspace's value, and **do not** copy the example strings shown
+in the config sample above (`"Always run …"` / `null`). If the field is `null`,
+absent, or empty after trimming, treat `{custom_instructions}` as empty (no
+section). This value feeds the `## Custom Instructions` block of the prompt
+template (see **First Prompt Template** below).
+
 #### Step 1: Write the prompt file
 
 The LLM writes the prompt content (see template below — with the pre-fetched ticket/PR content embedded) to a file:
@@ -460,10 +471,15 @@ gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
 
 ## Custom Instructions
 
-{workspace customInstructions text — include verbatim}
+{custom_instructions}
 ~~~
 
-If the workspace config contains a non-empty `customInstructions` field, append a `## Custom Instructions` section at the end of the prompt with its contents verbatim. Omit this section entirely if the field is absent, null, or empty.
+Fill the `## Custom Instructions` block with `{custom_instructions}` — the
+**matched** workspace's `customInstructions` resolved above — included **verbatim**
+(preserve markdown, code fences, line breaks; do not summarize, reword, or
+substitute `defaults` or another workspace's text). If `{custom_instructions}` is
+empty, `null`, or absent, **omit the entire `## Custom Instructions` heading and
+body** so the prompt has no such section.
 
 For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
 


### PR DESCRIPTION
Closes #683

## Problem
New workspace/session creation didn't reliably add a `## Custom Instructions` section to the worker prompt, so per-workspace guidance (e.g. `rm`'s PR-assignment rules, tanzaterra's reviewer/Render steps) never reached the agent.

## Which path is actually used
Creation is driven **entirely by the `/crow-workspace` (and `/crow-batch-workspace`) skill** — the Manager Claude Code writes the prompt to `{devRoot}/.claude/prompts/crow-prompt-<session>.md` and hands it to `setup.sh --prompt-content`.

The app-side `ClaudeLauncher.generatePrompt` (ticket's consumer #2) is **not** on this path: `generatePrompt` is never called anywhere in `Sources/` — only in unit tests. It already handles `customInstructions` correctly, so the bug is in the skill instructions, not Swift launch code.

**Why the skill dropped it:** the resolution note lived at the very end of the "First Prompt Template" section, disconnected from the "Write the prompt file" step, and was vague on *which* workspace to read — never saying to use the matched `workspaces["{workspace}"].customInstructions` and not `defaults`/another workspace/the doc's own examples. The batch skill never mentioned `customInstructions` at all.

## Fix
- **`/crow-workspace`** (`SKILL.md` + `Resources/*.template`): added an explicit **"Resolve custom instructions"** step *before* writing the prompt that reads the **matched** workspace's field (explicitly not `defaults`, not another workspace, not the example strings), and rewrote the template's `## Custom Instructions` block to thread `{custom_instructions}` verbatim / omit when empty.
- **`/crow-batch-workspace`** (`SKILL.md` + `Resources/*.template`): resolve the matched workspace's `customInstructions` per session in Phase 2.
- Edited **both** live skills and their bundled `Resources/*.template` (dual-sourced — release builds scaffold from the templates).
- **Regression guard:** new `Tests/CrowTests/CustomInstructionsSkillTests.swift` asserts each skill + template carries the resolution instruction (matched-workspace lookup, `## Custom Instructions` heading, verbatim, no `defaults` fallback).

## Out of scope
No change to `ClaudeLauncher`/`ClaudeCodeAgent`/`CodingAgent.generatePrompt` — that path is unused by creation and already correct+tested; threading a param no caller passes would be speculative.

## Acceptance criteria
- ✅ Non-empty `customInstructions` → prompt contains `## Custom Instructions` with that workspace's text verbatim.
- ✅ The **matched** workspace's instructions are used — not `defaults`, not another workspace.
- ✅ Empty/absent `customInstructions` → no section.

## Test
`swift test --filter CustomInstructionsSkillTests` (after `bash scripts/generate-build-info.sh`) — both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZWp7QiSX7U57YyHFbyc6L