### PR TITLE
fix(web-ui): harden mobile hamburger + edge chrome against notch/safe-area (#685)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -386,8 +386,10 @@ html, body {
 #back-to-sidebar {
   display: none;
   position: fixed;
-  top: 12px;
-  left: 12px;
+  /* Offset by the device safe area so the ☰ clears notches / rounded corners and
+     the status bar on notched phones (viewport-fit=cover). env() → 0 elsewhere. */
+  top: calc(12px + env(safe-area-inset-top));
+  left: calc(12px + env(safe-area-inset-left));
   z-index: 50;
   width: 40px;
   height: 40px;
@@ -416,15 +418,15 @@ html, body {
 
   #app.has-selection #sidebar { display: none; }
   #app.has-selection #back-to-sidebar { display: flex; }
-  #app.has-selection #detail-header { padding-left: 60px; }
+  #app.has-selection #detail-header { padding-left: calc(60px + env(safe-area-inset-left)); }
 
   #app.has-selection.mobile-show-sidebar #sidebar { display: block; }
   #app.has-selection.mobile-show-sidebar #detail { display: none; }
   #app.has-selection.mobile-show-sidebar #back-to-sidebar { display: none; }
-  /* Board content clears the floating hamburger on mobile. */
-  #app.has-selection.board-active #board { padding-top: 56px; }
-  /* Extra room under the last card so it's fully reachable above mobile chrome. */
-  #sidebar { padding-bottom: 64px; }
+  /* Board content clears the floating hamburger on mobile (incl. its safe-area top). */
+  #app.has-selection.board-active #board { padding-top: calc(56px + env(safe-area-inset-top)); }
+  /* Extra room under the last card so it's fully reachable above mobile chrome / home indicator. */
+  #sidebar { padding-bottom: calc(64px + env(safe-area-inset-bottom)); }
   /* The status bar would overlap the fullscreen terminal on mobile — show it only
      while the sidebar is the visible view. */
   #statusbar { display: none; }
@@ -559,8 +561,9 @@ html, body {
 /* ---- Fixed connection/status bar (bottom-left, CROW-593) ---- */
 #statusbar {
   position: fixed;
-  left: 0;
-  bottom: 0;
+  /* Clear the home indicator / rounded corners under viewport-fit=cover. */
+  left: env(safe-area-inset-left);
+  bottom: env(safe-area-inset-bottom);
   z-index: 60;
   display: flex;
   align-items: center;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Crow</title>
   <link rel="icon" type="image/svg+xml" href="/brand.svg">
   <link rel="stylesheet" href="/xterm/xterm.css">


### PR DESCRIPTION
Closes #685

## Finding

The mobile sidebar hamburger (☰, `#back-to-sidebar`) **already stays pinned** while scrolling: `#app` is `height: 100dvh` with `body { overflow: hidden }`, so the page itself never scrolls — only `#board`, `#sidebar` (`overflow-y:auto`) and xterm scroll *internally*. A `position: fixed` element therefore can't scroll away, and there's no transformed/`contain` ancestor to defeat it. Coverage is handled too (☰ `z-index:50`; board `padding-top:56px` + sticky head z‑2; terminal skeleton z‑3; header `padding-left:60px`).

The one real-device gap the ticket flags ("re-verify with mobile chrome / dynamic viewport") is **safe areas**: `top:12px; left:12px` ignored notches/rounded corners, and `viewport-fit=cover` wasn't set (so `env(safe-area-inset-*)` was 0).

## Change

- `index.html`: add `viewport-fit=cover` so iOS reports non-zero safe-area insets.
- `app.css`: offset the ☰ by `env(safe-area-inset-top/left)`, and keep the clearances that stop the ☰ from covering/being-covered consistent with its new position — `#detail-header` padding-left, board `padding-top`, `#sidebar` padding-bottom, and the bottom-left `#statusbar` (clears the home indicator).

`env()` resolves to 0 on desktop / non-notched devices, so those layouts are unchanged. Pure HTML/CSS — no JS/Swift.

## Verify
Run the daemon, open the web UI in Chrome DevTools device mode (notched device, e.g. iPhone 14 Pro) or a real iOS device. With a session selected, scroll each has-selection view (terminal, board/reviews/allowlist, long detail header) and confirm the ☰ stays pinned top-left, isn't clipped by the notch/status bar, and taps through to reveal the sidebar. Confirm the statusbar sits above the home indicator.

🐦‍⬛ Created with Crow