### PR TITLE
fix(web-terminal): steady overlay on sustained disconnect, no strobe (#687)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -365,6 +365,21 @@ html, body {
 }
 #terminal-wrap.loading #terminal-skeleton { opacity: 1; transition: none; } /* instant show, smooth fade only on hide */
 .term-skel-bar { height: 12px; max-width: 78%; }
+/* #687: sustained-disconnect state. The overlay is a single steady surface (no
+   strobe); the `.reconnecting` class calms the shimmer bars and reveals a
+   centered "Reconnecting…" caption so it reads as one quiet state. */
+#terminal-reconnect-note {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+#terminal-wrap.reconnecting #terminal-skeleton .skel { opacity: 0.35; }
+#terminal-wrap.reconnecting #terminal-reconnect-note { display: flex; }
 #detail-empty {
   position: absolute;
   inset: 0;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2148,22 +2148,33 @@ let fitAddon = null;
 let searchAddon = null;
 let termWs = null;
 let termSkelTimer = null; // #677: safety timeout that clears the skeleton overlay
+let termReconnectDelay = 1000; // #687: backoff between reconnect attempts (ms), reset on open
 
 // Skeleton loading overlay (#677): mask the artifact-prone xterm (re)attach
 // window (blank/garbled grid, reflow flash, mid-paint scrollback replay) with
 // the CROW-613 shimmer. Toggled via a `.loading` class on #terminal-wrap.
+// Idempotent (#687): a sustained reconnect loop re-enters this per attempt, so
+// no-op when already up — re-adding `.loading` would restart the shimmer and, in
+// the old code, re-arm the safety auto-hide, producing the strobe. The safety
+// auto-hide now lives in connectTerminalWs's `onopen` (connected-but-quiet PTY
+// case only), never in the connecting/reconnecting path.
 function showTerminalSkeleton() {
   const wrap = document.getElementById('terminal-wrap');
-  if (wrap) wrap.classList.add('loading');
-  // Never strand the overlay on a quiet PTY that sends no immediate output.
-  clearTimeout(termSkelTimer);
-  termSkelTimer = setTimeout(hideTerminalSkeleton, 1500);
+  if (!wrap || wrap.classList.contains('loading')) return;
+  wrap.classList.add('loading');
 }
 function hideTerminalSkeleton() {
   clearTimeout(termSkelTimer);
   termSkelTimer = null;
   const wrap = document.getElementById('terminal-wrap');
-  if (wrap) wrap.classList.remove('loading');
+  if (wrap) wrap.classList.remove('loading', 'reconnecting');
+}
+// #687: switch the overlay to a calm, steady "Reconnecting…" treatment during a
+// sustained disconnect (distinct from the brief attach shimmer). Cleared on a
+// successful (re)attach (onopen) and on hide.
+function setTerminalReconnecting(on) {
+  const wrap = document.getElementById('terminal-wrap');
+  if (wrap) wrap.classList.toggle('reconnecting', on);
 }
 
 // Terminal font stack: Nerd Fonts → system monospace.
@@ -2384,7 +2395,7 @@ function showTerminalMenu(e) {
 }
 
 function connectTerminalWs() {
-  if (sessionDead) return; // don't loop after an expired remote cookie (review Yellow)
+  if (sessionDead) { hideTerminalSkeleton(); return; } // don't loop after an expired remote cookie (review Yellow); clear any overlay so the #679 scrim owns the screen
   // #677: cover this (re)attach — initial connect, auto-reconnect, and (via
   // reloadTerminal) the #675 right-click Reload + tab/session switch — with the
   // skeleton. `painted` gates the hide to the FIRST PTY byte of THIS socket.
@@ -2393,6 +2404,15 @@ function connectTerminalWs() {
   termWs = new WebSocket(wsURL('/terminal'));
   termWs.binaryType = 'arraybuffer';
   termWs.onopen = () => {
+    // Connected — this is the brief attach case, not a reconnect loop. Drop the
+    // steady "Reconnecting…" treatment, reset the backoff, and (only now) arm
+    // the safety auto-hide so the overlay never strands on a quiet PTY that
+    // sends no immediate output. #687: this timer must NOT live in
+    // showTerminalSkeleton, or it re-fires during the disconnect loop → strobe.
+    setTerminalReconnecting(false);
+    termReconnectDelay = 1000;
+    clearTimeout(termSkelTimer);
+    termSkelTimer = setTimeout(hideTerminalSkeleton, 1500);
     // A fresh PTY starts at a default winsize, so force the real size through
     // even if cols/rows match the previous socket, and fit synchronously so the
     // resize reaches the PTY before the scrollback replay (select-window) below.
@@ -2415,11 +2435,22 @@ function connectTerminalWs() {
     }
   };
   termWs.onclose = () => {
-    hideTerminalSkeleton(); // don't strand the overlay; a reconnect re-shows it
-    if (sessionDead) return;
-    setTimeout(connectTerminalWs, 1000);
+    // #687: a sustained disconnect must show ONE steady overlay, not strobe. So
+    // don't hide here — keep the overlay up (idempotent showTerminalSkeleton is
+    // a no-op if already loading) and switch it to the calm "Reconnecting…"
+    // state; it clears on the first painted byte once reconnected. Only cancel
+    // the connected-quiet safety auto-hide so it can't fire mid-loop and blank
+    // the overlay. A dead session still stops reconnecting and hands off to the
+    // #679 expired scrim.
+    clearTimeout(termSkelTimer);
+    termSkelTimer = null;
+    if (sessionDead) { hideTerminalSkeleton(); return; }
+    setTerminalReconnecting(true);
+    showTerminalSkeleton();
+    setTimeout(connectTerminalWs, termReconnectDelay);
+    termReconnectDelay = Math.min(termReconnectDelay * 2, 10000);
   };
-  termWs.onerror = () => termWs.close(); // funnels to onclose (hides skeleton)
+  termWs.onerror = () => termWs.close(); // funnels to onclose (keeps overlay up)
 }
 
 // Resize path (#661): in a browser the window `resize` event and normal page

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -32,6 +32,10 @@
           <div class="skel term-skel-bar" style="--skel-delay: .48s; width: 52%"></div>
           <div class="skel term-skel-bar" style="--skel-delay: .56s; width: 39%"></div>
           <div class="skel term-skel-bar" style="--skel-delay: .64s; width: 61%"></div>
+          <!-- #687: steady caption shown (via #terminal-wrap.reconnecting) during
+               a sustained disconnect, so the overlay reads as one calm
+               "Reconnecting…" state instead of a strobing attach shimmer. -->
+          <div id="terminal-reconnect-note" aria-hidden="true">Reconnecting…</div>
       </div></div>
       <div id="board"></div>
       <div id="detail-empty">


### PR DESCRIPTION
Closes #687

## Problem
When the terminal WebSocket stays disconnected (crowd down, network drop), the #677 skeleton overlay **strobed** on/off ~once a second instead of showing a single steady state.

Root cause: the overlay was toggled per reconnect attempt in the 1s retry loop — `connectTerminalWs()` calls `showTerminalSkeleton()` at the top of every attempt, `onclose` hid it before retrying, and a 1.5s safety auto-hide was re-armed on every show. So a sustained disconnect cycled show → fail-fast → hide → wait 1s → show → …

## Fix
- **`showTerminalSkeleton()` is now idempotent** — no-op if `#terminal-wrap` is already `.loading`, so a reconnect loop can't restart the shimmer or timer churn.
- **Moved the 1.5s connected-but-quiet safety auto-hide out of `show` and into `onopen`** — it only exists once we're actually connected (masking a silent PTY), so it can't fire mid-loop and blank the overlay.
- **`onclose` keeps the overlay up across retries** instead of hiding it, and switches it to a calm, steady **"Reconnecting…"** treatment (the `.skel` shimmer is already a smooth continuous animation, not a strobe). It clears on the first painted byte once reconnected.
- **`sessionDead` short-circuits preserved** — a dead/expired session still stops reconnecting, hides the overlay, and hands off to the #679 session-expired scrim (z-index 55, above the z-index-3 skeleton).
- **Capped exponential backoff** (1s → 10s, reset on open) on the reconnect to reduce churn during long outages.

## Files
- `Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js` — handler rework, idempotent show, backoff.
- `index.html` / `app.css` — steady "Reconnecting…" caption revealed via the `reconnecting` class (dims the shimmer bars; respects the existing `prefers-reduced-motion` treatment).

## Acceptance criteria
- ✅ Sustained disconnect → single steady reconnecting overlay, no strobe.
- ✅ Normal quick reconnect → reattach artifact masked once, fades on first painted byte.
- ✅ Dead/expired session → reconnect loop stops, expired scrim (#679) shows, not the skeleton.

## Test plan
1. `make build`, run crowd + web UI, attach a live terminal — normal attach still shimmers once and fades on first output.
2. Stop crowd while attached → overlay stays steady with "Reconnecting…", no flashing. Restart crowd → fades on first byte.
3. Restart crowd so the web cookie dies (`sessionDead`) → reconnect stops, expired scrim shows.

Base: `feature/crow-593-web-ui-parity` (builds on #677), not `main`.

🐦‍⬛ Generated with Crow