### PR TITLE
feat(web-allowlist): fade global entries + add pattern filter bar

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -521,10 +521,21 @@ html, body {
 }
 
 .allow-list { display: flex; flex-direction: column; gap: 4px; }
+.allow-filter {
+  width: 100%; box-sizing: border-box; margin-bottom: 8px;
+  padding: 7px 10px; border: 1px solid var(--border-subtle); border-radius: 6px;
+  background: var(--bg-card); color: var(--text-primary); font-size: 12px;
+}
+.allow-filter::placeholder { color: var(--text-muted); }
+.allow-filter:focus { outline: none; border-color: var(--border-strong); }
 .allow-row {
   display: flex; align-items: flex-start; gap: 10px; padding: 8px 10px;
   border: 1px solid var(--border-subtle); border-radius: 6px; background: var(--bg-card);
 }
+/* #701: entries already in the global allowlist render faded/muted (parity with
+   desktop AllowListView: .opacity(0.6) + foregroundStyle(textMuted)). */
+.allow-row.is-global { opacity: 0.6; }
+.allow-row.is-global .allow-pattern { color: var(--text-muted); }
 .allow-check-spacer { width: 16px; flex: 0 0 auto; }
 .allow-main { display: flex; flex-direction: column; gap: 5px; min-width: 0; flex: 1; }
 .allow-pattern {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -492,6 +492,7 @@ function persistSidebarCache() {
 }
 let ticketFilter = 'All'; // pipeline segment ('All' or a status rawValue); default to All so the board isn't misread as empty when work moves to Done
 let allowlistHideGlobal = false;
+let allowlistFilter = ''; // #701: case-insensitive substring filter on entry pattern
 const allowlistSelection = new Set();
 // Session multi-select (#5): toggled by the sidebar checkmark button; holds the
 // ids of sessions ticked for a bulk action (delete).
@@ -2054,9 +2055,18 @@ function renderAllowlist(root) {
   const d = boardData.allowlist;
   let entries = ((d && d.entries) || []).slice();
   if (allowlistHideGlobal) entries = entries.filter((e) => !e.is_global);
+  // #701: case-insensitive substring filter on pattern (mirrors desktop's
+  // localizedCaseInsensitiveContains). Applied before deriving `promotable` so
+  // Select All and the pruned selection only ever reference visible rows.
+  const filter = allowlistFilter.trim().toLowerCase();
+  if (filter) entries = entries.filter((e) => e.pattern.toLowerCase().includes(filter));
   entries.sort((a, b) => a.pattern.localeCompare(b.pattern));
   // Only worktree-only patterns are promotable to global.
   const promotable = entries.filter((e) => !e.is_global).map((e) => e.pattern);
+  // #701: prune selections for rows hidden by the filter (or no longer promotable)
+  // so Promote can never act on a pattern that isn't visible.
+  const visiblePromotable = new Set(promotable);
+  for (const p of [...allowlistSelection]) if (!visiblePromotable.has(p)) allowlistSelection.delete(p);
 
   const head = el('div', 'board-head');
   head.appendChild(el('div', 'board-title', 'Allowlist'));
@@ -2082,14 +2092,36 @@ function renderAllowlist(root) {
   head.appendChild(promote);
   root.appendChild(head);
 
-  if (!entries.length) { root.appendChild(boardEmpty('No allowlist entries')); return; }
+  // #701: filter bar above the list. The board fully re-renders on each keystroke,
+  // so restore focus + caret after renderBoard() runs (see oninput).
+  const filterInput = document.createElement('input');
+  filterInput.type = 'text';
+  filterInput.className = 'allow-filter';
+  filterInput.placeholder = 'Filter patterns…';
+  filterInput.value = allowlistFilter;
+  filterInput.oninput = () => {
+    allowlistFilter = filterInput.value;
+    renderBoard();
+    requestAnimationFrame(() => {
+      const n = document.querySelector('.allow-filter');
+      if (n) { n.focus(); n.setSelectionRange(n.value.length, n.value.length); }
+    });
+  };
+  root.appendChild(filterInput);
+
+  if (!entries.length) {
+    root.appendChild(boardEmpty(filter ? 'No matching entries' : 'No allowlist entries'));
+    return;
+  }
   const list = el('div', 'allow-list');
   for (const e of entries) list.appendChild(allowRow(e));
   root.appendChild(list);
 }
 
 function allowRow(e) {
-  const row = el('div', 'allow-row');
+  // #701: fade rows already in the global allowlist (parity with desktop AllowListView)
+  // so promotable (non-global) rows stand out as the actionable ones.
+  const row = el('div', 'allow-row' + (e.is_global ? ' is-global' : ''));
   if (!e.is_global) {
     // Only worktree-only patterns are promotable to global.
     const box = document.createElement('input');

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2101,10 +2101,19 @@ function renderAllowlist(root) {
   filterInput.value = allowlistFilter;
   filterInput.oninput = () => {
     allowlistFilter = filterInput.value;
+    // Capture the live caret/selection before the board tears down this input,
+    // then restore it (clamped) on the recreated input so mid-string edits keep
+    // their position instead of jumping to the end.
+    const selStart = filterInput.selectionStart;
+    const selEnd = filterInput.selectionEnd;
     renderBoard();
     requestAnimationFrame(() => {
       const n = document.querySelector('.allow-filter');
-      if (n) { n.focus(); n.setSelectionRange(n.value.length, n.value.length); }
+      if (n) {
+        n.focus();
+        const len = n.value.length;
+        n.setSelectionRange(Math.min(selStart, len), Math.min(selEnd, len));
+      }
     });
   };
   root.appendChild(filterInput);


### PR DESCRIPTION
Closes #701

Brings the web **Allowlist** board to parity with the desktop `AllowListView` (`main`).

## Changes
- **Fade global rows** — entries already in the global allowlist render at ~0.6 opacity with muted pattern text (`.allow-row.is-global`), mirroring desktop's `.opacity(0.6)` + `foregroundStyle(textMuted)`. Promotable (non-global) rows stay at full emphasis so they clearly stand out as the actionable ones. Globals remain **shown** by default; the existing **Hide Global** toggle is unchanged and composes with the filter.
- **Filter bar** — a case-insensitive substring filter (`Filter patterns…`) above the list, mirroring desktop's `localizedCaseInsensitiveContains`. Clearing it restores the full list; focus/caret is preserved across the per-keystroke re-render.
- **Selection safety** — selections for rows hidden by the filter (or no longer promotable) are pruned before computing button state, so **Promote to Global** / **Select All** only ever act on visible promotable rows.

Files: `Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js`, `app.css` (client-side only; no `.template` twins).

## Test plan
- Open the Allowlist board: rows with a **Global** badge render faded/muted; non-global rows render at full emphasis with a checkbox.
- Type a substring in the filter → list narrows case-insensitively; clear → full list restored; typing focus stays in the input.
- With a filter active: **Select All** selects only visible promotable rows; **Promote to Global** promotes only those; filtering out a selected row drops it from the Promote count. **Clear** still empties the selection.
- **Hide Global** still works alongside the filter.

[🐦‍⬛ Created with Crow]