### PR TITLE
Handle OTLP delta-vs-cumulative temporality at ingest (stop token/cost double-count) (closes #689)

### DIFF
--- a/Packages/CrowTelemetry/.claude/skills/verify/SKILL.md
+++ b/Packages/CrowTelemetry/.claude/skills/verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: verify
+description: Drive CrowTelemetry's OTLP ingest end-to-end — boot the real receiver, POST OTLP JSON with curl, inspect the SQLite db.
+---
+
+# Verifying CrowTelemetry changes
+
+The package's runtime surface is `TelemetryService` (`OTLPReceiver` HTTP
+listener on localhost + `TelemetryDatabase` SQLite file). There is no
+standalone binary — build a throwaway harness executable that depends on this
+package and boots the service:
+
+```swift
+// Sources/otlp-harness/main.swift — usage: otlp-harness <port> <data-dir>
+import Foundation
+import CrowTelemetry
+let service = try TelemetryService(port: UInt16(CommandLine.arguments[1])!,
+                                   dataDirectory: CommandLine.arguments[2]) { id in
+    print("[harness] data received for session \(id)")
+}
+Task { try await service.start() }
+dispatchMain()
+```
+
+Harness `Package.swift`: swift-tools-version 6.0, `platforms: [.macOS(.v14)]`,
+`.package(path: "<repo>/Packages/CrowTelemetry")`. Build with `swift build`,
+run in the background, then drive it.
+
+Gotchas:
+- Ingest is OTLP **HTTP/JSON only** (`OTEL_EXPORTER_OTLP_PROTOCOL=http/json`),
+  paths `/v1/metrics` and `/v1/logs`, POST only. One request per connection
+  (the receiver closes it after responding).
+- The resource must carry `crow.session.id` (a UUID string) in
+  `resource.attributes`, or the payload is silently skipped.
+- Datapoint values: `asDouble` (number) or `asInt` (**string**, e.g. `"100"`).
+- Sum metrics take `aggregationTemporality` (1=delta, 2=cumulative) and
+  `isMonotonic`; cumulative sums are normalized to deltas at insert.
+
+Minimal payload:
+
+```json
+{"resourceMetrics":[{"resource":{"attributes":[{"key":"crow.session.id","value":{"stringValue":"<UUID>"}}]},
+ "scopeMetrics":[{"metrics":[{"name":"claude_code.cost.usage",
+   "sum":{"aggregationTemporality":2,"isMonotonic":true,"dataPoints":[{"asDouble":1.0}]}}]}]}]}
+```
+
+Observe results with the sqlite3 CLI against `<data-dir>/telemetry.db`:
+`SELECT metric_name, value, attributes_json FROM metrics ORDER BY id` and
+compare `SUM(value)` per metric to the expected total. Events land in the
+`events` table via `/v1/logs`.

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
@@ -89,11 +89,22 @@ public struct OTLPMetric: Codable, Sendable {
     public let gauge: OTLPGauge?
 }
 
+/// OTLP aggregation temporality (metrics.proto AggregationTemporality).
+public enum OTLPAggregationTemporality: Int, Sendable {
+    case unspecified = 0
+    case delta = 1
+    case cumulative = 2
+}
+
 /// A sum metric (monotonic counter or non-monotonic up-down counter).
 public struct OTLPSum: Codable, Sendable {
     public let dataPoints: [OTLPNumberDataPoint]?
     public let isMonotonic: Bool?
     public let aggregationTemporality: Int?  // 1 = delta, 2 = cumulative
+
+    public var temporality: OTLPAggregationTemporality {
+        OTLPAggregationTemporality(rawValue: aggregationTemporality ?? 0) ?? .unspecified
+    }
 }
 
 /// A gauge metric (point-in-time value).

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
@@ -181,16 +181,28 @@ public final class OTLPReceiver: Sendable {
             for scope in scopeMetrics {
                 guard let metrics = scope.metrics else { continue }
                 for metric in metrics {
-                    let dataPoints = metric.sum?.dataPoints ?? metric.gauge?.dataPoints ?? []
-                    for point in dataPoints {
-                        let attributesJSON = encodeAttributes(point.attributes)
-                        await database.insertMetric(
-                            crowSessionID: crowSessionID,
-                            metricName: metric.name,
-                            value: point.numericValue,
-                            attributesJSON: attributesJSON,
-                            timestampNs: point.timeUnixNano
-                        )
+                    if let sum = metric.sum {
+                        for point in sum.dataPoints ?? [] {
+                            await database.insertMetric(
+                                crowSessionID: crowSessionID,
+                                metricName: metric.name,
+                                value: point.numericValue,
+                                attributesJSON: encodeAttributes(point.attributes),
+                                timestampNs: point.timeUnixNano,
+                                temporality: sum.temporality,
+                                isMonotonic: sum.isMonotonic
+                            )
+                        }
+                    } else if let gauge = metric.gauge {
+                        for point in gauge.dataPoints ?? [] {
+                            await database.insertMetric(
+                                crowSessionID: crowSessionID,
+                                metricName: metric.name,
+                                value: point.numericValue,
+                                attributesJSON: encodeAttributes(point.attributes),
+                                timestampNs: point.timeUnixNano
+                            )
+                        }
                     }
                 }
             }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Storage/TelemetryDatabase.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Storage/TelemetryDatabase.swift
@@ -13,6 +13,19 @@ public actor TelemetryDatabase {
     private var db: OpaquePointer?
     private let path: String
 
+    /// Identifies a unique metric series: the attributes JSON is stable because
+    /// the receiver encodes it with sorted keys.
+    private struct MetricSeriesKey: Hashable {
+        let sessionID: String
+        let metricName: String
+        let attributesJSON: String?
+    }
+
+    /// Last cumulative value seen per series — NOT the stored-delta sum; the two
+    /// diverge after a counter reset (prev=100, curr=5 → delta 5, stored sum 105,
+    /// but the next reading must diff against 5).
+    private var lastCumulativeValues: [MetricSeriesKey: Double] = [:]
+
     public init(path: String) {
         self.path = path
     }
@@ -100,13 +113,47 @@ public actor TelemetryDatabase {
         sqlite3_step(stmt)
     }
 
+    /// Insert a metric datapoint, normalizing CUMULATIVE sums to deltas so that
+    /// downstream SUM() aggregation stays correct. DELTA sums and gauges
+    /// (`.unspecified`) are stored as-is.
     public func insertMetric(
         crowSessionID: UUID,
         metricName: String,
         value: Double,
         attributesJSON: String?,
-        timestampNs: String?
+        timestampNs: String?,
+        temporality: OTLPAggregationTemporality = .unspecified,
+        isMonotonic: Bool? = nil
     ) {
+        var insertValue = value
+        if temporality == .cumulative {
+            let key = MetricSeriesKey(
+                sessionID: crowSessionID.uuidString,
+                metricName: metricName,
+                attributesJSON: attributesJSON
+            )
+            // App-restart recovery: stored deltas sum to the last cumulative value
+            // seen. Exact unless a counter reset preceded the restart — a rare
+            // overlap whose over-count is bounded by the counter value at restart;
+            // accepted rather than persisting per-series state.
+            let prev = lastCumulativeValues[key] ?? storedSeriesSum(
+                session: key.sessionID,
+                metricName: metricName,
+                attributesJSON: attributesJSON
+            )
+            var delta = value - prev
+            // nil isMonotonic is treated as monotonic — every claude_code sum of
+            // interest is a monotonic counter. Non-monotonic (UpDownCounter)
+            // series legitimately go negative and get no reset clamp.
+            if delta < 0 && isMonotonic != false {
+                // Counter reset (e.g. Claude Code restarted): count from 0.
+                delta = value
+            }
+            lastCumulativeValues[key] = value
+            guard delta != 0 else { return }
+            insertValue = delta
+        }
+
         let sql = """
             INSERT INTO metrics (crow_session_id, metric_name, value, attributes_json, timestamp_ns, received_at)
             VALUES (?, ?, ?, ?, ?, ?)
@@ -117,7 +164,7 @@ public actor TelemetryDatabase {
 
         sqlite3_bind_text(stmt, 1, (crowSessionID.uuidString as NSString).utf8String, -1, nil)
         sqlite3_bind_text(stmt, 2, (metricName as NSString).utf8String, -1, nil)
-        sqlite3_bind_double(stmt, 3, value)
+        sqlite3_bind_double(stmt, 3, insertValue)
         if let json = attributesJSON {
             sqlite3_bind_text(stmt, 4, (json as NSString).utf8String, -1, nil)
         } else {
@@ -231,6 +278,31 @@ public actor TelemetryDatabase {
     @discardableResult
     private func execute(_ sql: String) -> Bool {
         sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
+    }
+
+    /// Sum of stored delta rows for one exact series (null-safe attribute match).
+    /// Used to recover the cumulative baseline after an app restart.
+    private func storedSeriesSum(session: String, metricName: String, attributesJSON: String?) -> Double {
+        let sql = """
+            SELECT COALESCE(SUM(value), 0) FROM metrics
+            WHERE crow_session_id = ? AND metric_name = ? AND attributes_json IS ?
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return 0 }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, (session as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 2, (metricName as NSString).utf8String, -1, nil)
+        if let json = attributesJSON {
+            sqlite3_bind_text(stmt, 3, (json as NSString).utf8String, -1, nil)
+        } else {
+            sqlite3_bind_null(stmt, 3)
+        }
+
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            return sqlite3_column_double(stmt, 0)
+        }
+        return 0
     }
 
     private func sumMetric(_ name: String, session: String) -> Double {

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/TemporalityNormalizationTests.swift
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/TemporalityNormalizationTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import CrowTelemetry
+
+/// Tests for CUMULATIVE→delta normalization at metric ingest (issue #689).
+///
+/// Cumulative sum datapoints are running totals; storing them raw makes the
+/// SUM()-based readers double-count. `insertMetric` normalizes them to deltas
+/// so the stored rows always sum to the true total.
+
+private func makeDatabase() async throws -> (db: TelemetryDatabase, path: String) {
+    let path = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString + ".db").path
+    let db = TelemetryDatabase(path: path)
+    try await db.open()
+    return (db, path)
+}
+
+private func insertCost(
+    _ db: TelemetryDatabase,
+    session: UUID,
+    value: Double,
+    temporality: OTLPAggregationTemporality = .cumulative,
+    isMonotonic: Bool? = true
+) async {
+    await db.insertMetric(
+        crowSessionID: session,
+        metricName: "claude_code.cost.usage",
+        value: value,
+        attributesJSON: nil,
+        timestampNs: nil,
+        temporality: temporality,
+        isMonotonic: isMonotonic
+    )
+}
+
+private func metricRowCount(path: String) -> Int {
+    var handle: OpaquePointer?
+    guard sqlite3_open(path, &handle) == SQLITE_OK else { return -1 }
+    defer { sqlite3_close(handle) }
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(handle, "SELECT COUNT(*) FROM metrics", -1, &stmt, nil) == SQLITE_OK else { return -1 }
+    defer { sqlite3_finalize(stmt) }
+    guard sqlite3_step(stmt) == SQLITE_ROW else { return -1 }
+    return Int(sqlite3_column_int(stmt, 0))
+}
+
+@Test func cumulativeStreamDoesNotDoubleCount() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db, session: session, value: 100)
+    await insertCost(db, session: session, value: 250)
+    await insertCost(db, session: session, value: 400)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 400)
+    await db.close()
+}
+
+@Test func deltaStreamStillSumsCorrectly() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db, session: session, value: 100, temporality: .delta)
+    await insertCost(db, session: session, value: 150, temporality: .delta)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 250)
+    await db.close()
+}
+
+@Test func unspecifiedTemporalityInsertsRaw() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    // Gauge path: no temporality, values stored as-is.
+    await insertCost(db, session: session, value: 5, temporality: .unspecified, isMonotonic: nil)
+    await insertCost(db, session: session, value: 7, temporality: .unspecified, isMonotonic: nil)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 12)
+    await db.close()
+}
+
+@Test func counterResetProducesNoNegativeDelta() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db, session: session, value: 100)
+    await insertCost(db, session: session, value: 250)
+    await insertCost(db, session: session, value: 40)  // reset: new process counts from 0
+    await insertCost(db, session: session, value: 55)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 305)  // 100 + 150 + 40 + 15
+    await db.close()
+}
+
+@Test func firstDatapointOfSeriesIsStoredWhole() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db, session: session, value: 100)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 100)
+    await db.close()
+}
+
+@Test func baselineRecoversAcrossDatabaseRestart() async throws {
+    let (db1, path) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db1, session: session, value: 100)
+    await insertCost(db1, session: session, value: 250)
+    await db1.close()
+
+    // New instance on the same file simulates an app restart: the in-memory
+    // last-value cache is gone, but the stored deltas sum to 250.
+    let db2 = TelemetryDatabase(path: path)
+    try await db2.open()
+    await insertCost(db2, session: session, value: 400)
+
+    let analytics = await db2.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 400)
+    await db2.close()
+}
+
+@Test func attributeSetsAreSeparateSeries() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    func insertTokens(_ value: Double, type: String) async {
+        await db.insertMetric(
+            crowSessionID: session,
+            metricName: "claude_code.token.usage",
+            value: value,
+            attributesJSON: "{\"type\":\"\(type)\"}",
+            timestampNs: nil,
+            temporality: .cumulative,
+            isMonotonic: true
+        )
+    }
+
+    await insertTokens(100, type: "input")
+    await insertTokens(50, type: "output")
+    await insertTokens(200, type: "input")
+    await insertTokens(75, type: "output")
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.inputTokens == 200)
+    #expect(analytics.outputTokens == 75)
+    await db.close()
+}
+
+@Test func zeroDeltaRowsAreSkipped() async throws {
+    let (db, path) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db, session: session, value: 100)
+    await insertCost(db, session: session, value: 100)
+    await insertCost(db, session: session, value: 100)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 100)
+    await db.close()
+
+    #expect(metricRowCount(path: path) == 1)
+}
+
+@Test func nonMonotonicCumulativeAllowsNegativeDelta() async throws {
+    let (db, _) = try await makeDatabase()
+    let session = UUID()
+
+    await insertCost(db, session: session, value: 100, isMonotonic: false)
+    await insertCost(db, session: session, value: 60, isMonotonic: false)
+
+    let analytics = await db.sessionAnalytics(for: session)
+    #expect(analytics.totalCost == 60)  // 100 + (-40): SUM reconstructs last value
+    await db.close()
+}
+
+@Test func sumTemporalityDecodesFromOTLPJSON() throws {
+    let json = """
+        {
+            "resourceMetrics": [{
+                "scopeMetrics": [{
+                    "metrics": [{
+                        "name": "claude_code.token.usage",
+                        "sum": {
+                            "aggregationTemporality": 2,
+                            "isMonotonic": true,
+                            "dataPoints": [{"asInt": "1234", "attributes": [{"key": "type", "value": {"stringValue": "input"}}]}]
+                        }
+                    }, {
+                        "name": "claude_code.cost.usage",
+                        "sum": {
+                            "aggregationTemporality": 1,
+                            "isMonotonic": true,
+                            "dataPoints": [{"asDouble": 0.5}]
+                        }
+                    }]
+                }]
+            }]
+        }
+        """
+    let payload = try JSONDecoder().decode(OTLPMetricsPayload.self, from: Data(json.utf8))
+    let metrics = payload.resourceMetrics[0].scopeMetrics?[0].metrics
+    #expect(metrics?[0].sum?.temporality == .cumulative)
+    #expect(metrics?[1].sum?.temporality == .delta)
+    #expect(metrics?[0].sum?.dataPoints?[0].numericValue == 1234)
+}


### PR DESCRIPTION
Closes #689. ADR 0008 follow-up 1/11 (refs #648, design PR #657) — v1-blocking; makes the token/cost metrics the scorecard grades on trustworthy. Unblocks trustworthy values in #690's SessionAnalytics snapshot.

## Approach: (a) normalize cumulative → deltas at ingest

Chosen over (b) persisting a temporality column because it needs **no schema change or migration machinery** (the repo has none — `createTables()` is pure `CREATE TABLE IF NOT EXISTS`, and user DBs at `~/Library/Application Support/crow/telemetry.db` would need an upgrade path) and keeps every existing `SUM()` reader correct unchanged. For pure counters the deltas are the raw fidelity that matters.

## What changed

- **`OTLPModels.swift`**: typed `OTLPAggregationTemporality` enum (0/1/2 per metrics.proto) + `OTLPSum.temporality` accessor.
- **`TelemetryDatabase.swift`**: `insertMetric` gains defaulted `temporality`/`isMonotonic` params. For CUMULATIVE datapoints it stores the **delta** against the last cumulative value seen for that series (session + metric + sorted-keys attributes JSON), tracked in-memory inside the actor (race-free — read-prev/insert/update-prev is one actor hop). After an app restart the baseline is recovered from the stored series sum (stored deltas sum to the last cumulative value seen). Monotonic resets (value decreases, e.g. Claude Code restarted mid-session) store the new value instead of a negative delta; non-monotonic (UpDownCounter) series keep legitimate negative deltas. Zero-delta rows (exporter heartbeats/retries) are skipped.
- **`OTLPReceiver.swift`**: `processMetrics` splits the previously-flattened sum/gauge loop and threads `temporality`/`isMonotonic` through for sums; gauges unchanged.
- **Tests**: new `CrowTelemetryTests` suite (10 tests — the target was declared in Package.swift but had no sources): cumulative no-double-count, delta regression, gauge/unspecified passthrough, reset, first datapoint, restart baseline recovery, per-attribute-set series separation, zero-delta skip, non-monotonic negative delta, OTLP JSON temporality decode.

## Why this matters

Claude Code is launched with no `OTEL_..._TEMPORALITY_PREFERENCE`, so its SDK emits **CUMULATIVE** counters — the double-count was the live behavior for every token/cost number, not an edge case.

## Verified end-to-end

Booted the real `TelemetryService` in a harness and drove `/v1/metrics` over HTTP with curl: cumulative cost stream 1.0→2.5→4.0 + duplicate export + reset to 0.5 stored as rows `1.0, 1.5, 1.5, 0.5` (total **4.5**; old behavior would have reported **12.0**); delta/gauge/no-temporality payloads stored raw; process restart on the same db recovered the baseline exactly (cumulative 5.0 → delta 0.5). `swift test --package-path Packages/CrowTelemetry`: 10/10 pass; full `make test` green except pre-existing unrelated CrowGit sandbox failures (missing git identity).

## Accepted limitations (documented in code comments)

- Counter-reset immediately followed by an app restart can over-count once, bounded by the counter value at restart — avoiding it needs a persisted per-series state table, not worth the schema surface.
- Rows already written by old builds are inflated and can't be retroactively distinguished (telemetry is off by default, pre-v1); an upgrade mid-live-session self-corrects after one clamped reset.
- `isMonotonic == nil` is treated as monotonic (all claude_code counters are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)