### PR TITLE
Persist SessionAnalytics snapshot at session end (v1-blocking scorecard foundation) (closes #690)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -285,6 +285,14 @@ public final class AppState {
         return new
     }
 
+    /// Look up a session's hook state without creating one. Use this for
+    /// read-only paths (e.g. snapshotting analytics at session end) so idle
+    /// sessions don't get empty `SessionHookState` objects instantiated —
+    /// which would also leak idle entries into `allHookStateSnapshots()`.
+    public func existingHookState(for sessionID: UUID) -> SessionHookState? {
+        _sessionState[sessionID]
+    }
+
     /// Remove hook state for a deleted session.
     public func removeHookState(for sessionID: UUID) {
         _sessionState.removeValue(forKey: sessionID)

--- a/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalytics.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalytics.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Aggregated analytics data for a single Crow session, computed from OTLP telemetry.
-public struct SessionAnalytics: Sendable {
+public struct SessionAnalytics: Codable, Equatable, Sendable {
     /// Total cost in USD (from `claude_code.cost.usage`).
     public var totalCost: Double
     /// Input tokens (from `claude_code.token.usage` where type=input).
@@ -33,6 +33,12 @@ public struct SessionAnalytics: Sendable {
     public var totalTokens: Int {
         inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens
     }
+
+    /// True when no telemetry has been recorded for the session. The SQL
+    /// aggregation (`COALESCE(SUM(value), 0)`) returns an all-zeros aggregate
+    /// for a session with no rows, so callers persisting snapshots must treat
+    /// an empty aggregate as "no data", not as a real measurement.
+    public var isEmpty: Bool { self == SessionAnalytics() }
 
     public init(
         totalCost: Double = 0,

--- a/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Durable per-session analytics record, persisted when a session reaches a
+/// terminal status (`.completed` / `.archived`).
+///
+/// This is the persistence backbone for ADR 0008's scorecard: weekly rollups
+/// re-aggregate these snapshots, and the trailing-4-week self-comparison
+/// baseline is derived from them. Snapshots deliberately outlive session
+/// deletion — the retention reaper deletes completed/archived sessions (and
+/// their telemetry rows) after a configurable window, and the baseline must
+/// survive that cleanup. That is also why the terminal `status` is recorded
+/// here rather than looked up on the session: "sessions shipped" is counted
+/// from snapshots after the session record is gone.
+///
+/// Extension point (ADR 0008 follow-up 3): add future fields — e.g.
+/// `compactionCount: Int?` — as OPTIONALS on this struct, not on
+/// `SessionAnalytics`, so previously persisted snapshots keep decoding.
+public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
+    public var sessionID: UUID
+    /// When the session reached its terminal status. Weekly rollups bucket by
+    /// this date.
+    public var endedAt: Date
+    /// Terminal status at snapshot time. `.completed` is ADR 0008's outcome
+    /// flag ("shipped"); `.archived` is ended without shipping. A session that
+    /// is reactivated and ends again overwrites its snapshot with the newer
+    /// status and aggregate.
+    public var status: SessionStatus
+    public var analytics: SessionAnalytics
+
+    public init(
+        sessionID: UUID,
+        endedAt: Date,
+        status: SessionStatus,
+        analytics: SessionAnalytics
+    ) {
+        self.sessionID = sessionID
+        self.endedAt = endedAt
+        self.status = status
+        self.analytics = analytics
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #690 (ADR 0008 follow-up 2): the durable end-of-session analytics record.
+
+@Test func sessionAnalyticsIsEmptySemantics() {
+    #expect(SessionAnalytics().isEmpty)
+    #expect(SessionAnalytics(totalCost: 0.01).isEmpty == false)
+    #expect(SessionAnalytics(promptCount: 1).isEmpty == false)
+    #expect(SessionAnalytics(activeTimeSeconds: 2.5).isEmpty == false)
+}
+
+@Test func snapshotJSONRoundTrip() throws {
+    // Whole-second date: the store's ISO8601 strategy drops sub-second
+    // precision, and this test locks in the same encoder configuration.
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(
+            totalCost: 1.23, inputTokens: 100, outputTokens: 200,
+            cacheReadTokens: 300, cacheCreationTokens: 40,
+            activeTimeSeconds: 360, linesAdded: 12, linesRemoved: 3,
+            commitCount: 2, promptCount: 7, toolCallCount: 21,
+            apiRequestCount: 30, apiErrorCount: 1
+        )
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let decoded = try decoder.decode(
+        SessionAnalyticsSnapshot.self, from: encoder.encode(snapshot))
+    #expect(decoded == snapshot)
+    #expect(decoded.analytics.totalTokens == 640)
+}
+
+// Locks in the follow-up-3 extension-point contract: future fields (e.g. the
+// compaction counter) arrive as optionals on the snapshot, and snapshots
+// carrying keys this app version doesn't know must still decode — Codable
+// synthesis ignores unknown keys.
+@Test func snapshotDecodingIgnoresUnknownFutureKeys() throws {
+    let json = """
+    {
+      "sessionID": "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+      "endedAt": "2026-07-13T00:00:00Z",
+      "status": "archived",
+      "analytics": {
+        "totalCost": 0, "inputTokens": 42, "outputTokens": 0,
+        "cacheReadTokens": 0, "cacheCreationTokens": 0, "activeTimeSeconds": 0,
+        "linesAdded": 0, "linesRemoved": 0, "commitCount": 0,
+        "promptCount": 0, "toolCallCount": 0, "apiRequestCount": 0,
+        "apiErrorCount": 0
+      },
+      "compactionCount": 3
+    }
+    """
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(SessionAnalyticsSnapshot.self, from: Data(json.utf8))
+    #expect(decoded.status == .archived)
+    #expect(decoded.analytics.inputTokens == 42)
+    #expect(decoded.analytics.isEmpty == false)
+}

--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -19,19 +19,26 @@ public struct StoreData: Codable, Sendable {
     /// synthesized `Codable` tolerates a missing optional, keeping us backward
     /// compatible and avoiding the corrupt-store backup path.
     public var hookStates: [String: PersistedHookState]?
+    /// Durable analytics snapshot per ended session, keyed by session UUID
+    /// string (#690, ADR 0008). Optional for the same backward-compat reason
+    /// as `hookStates`. Entries deliberately outlive session deletion — the
+    /// scorecard's trailing-4-week baseline must survive the retention reaper.
+    public var analyticsSnapshots: [String: SessionAnalyticsSnapshot]?
 
     public init(
         sessions: [Session] = [],
         worktrees: [SessionWorktree] = [],
         links: [SessionLink] = [],
         terminals: [SessionTerminal] = [],
-        hookStates: [String: PersistedHookState]? = nil
+        hookStates: [String: PersistedHookState]? = nil,
+        analyticsSnapshots: [String: SessionAnalyticsSnapshot]? = nil
     ) {
         self.sessions = sessions
         self.worktrees = worktrees
         self.links = links
         self.terminals = terminals
         self.hookStates = hookStates
+        self.analyticsSnapshots = analyticsSnapshots
     }
 }
 

--- a/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/SessionRepository.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/SessionRepository.swift
@@ -28,6 +28,8 @@ public struct SessionRepository: Sendable {
     }
 
     /// Delete a session and all related data (worktrees, links, terminals) in a single atomic mutation.
+    /// `analyticsSnapshots` is deliberately NOT cascaded: the scorecard's
+    /// trailing-4-week baseline must survive session deletion (ADR 0008, #690).
     public func delete(id: UUID) {
         store.mutate { data in
             data.sessions.removeAll { $0.id == id }

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
@@ -249,3 +249,88 @@ import Testing
     let store = JSONStore(directory: dir)
     #expect(store.data.sessions.isEmpty)
 }
+
+// MARK: - Analytics snapshots (#690, ADR 0008)
+
+// The ticket's headline requirement: a persisted end-of-session snapshot
+// survives a simulated relaunch (new store instance over the same directory).
+@Test func analyticsSnapshotsRoundTripAcrossReload() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sessionID = UUID()
+    // Whole-second date: the store encodes dates as ISO8601 (no sub-second).
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: sessionID,
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(
+            totalCost: 4.2, inputTokens: 1_000, outputTokens: 2_000,
+            activeTimeSeconds: 900, promptCount: 12
+        )
+    )
+
+    let store = JSONStore(directory: dir)
+    store.mutate { data in
+        data.analyticsSnapshots = [sessionID.uuidString: snapshot]
+    }
+
+    let reloaded = JSONStore(directory: dir)
+    #expect(reloaded.data.analyticsSnapshots?[sessionID.uuidString] == snapshot)
+}
+
+// Optional-field backward compat, same contract as `hookStates`: an older
+// store.json without the key must decode with the field nil, never trip the
+// corrupt-store backup path.
+@Test func storeDataDecodesWithoutAnalyticsSnapshotsField() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    let legacyJSON = """
+    {
+      "sessions": [],
+      "worktrees": [],
+      "links": [],
+      "terminals": []
+    }
+    """
+    try legacyJSON.data(using: .utf8)!.write(to: dir.appendingPathComponent("store.json"))
+
+    let store = JSONStore(directory: dir)
+    #expect(store.data.analyticsSnapshots == nil)
+    #expect(store.data.sessions.isEmpty)
+}
+
+// `SessionService.persistState()` rewrites the live-state fields wholesale on
+// quit; snapshots are not part of live AppState and must survive that rewrite.
+@Test func liveStateRewriteDoesNotClobberAnalyticsSnapshots() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sessionID = UUID()
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: sessionID,
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .archived,
+        analytics: SessionAnalytics(promptCount: 3)
+    )
+
+    let store = JSONStore(directory: dir)
+    store.mutate { data in
+        data.analyticsSnapshots = [sessionID.uuidString: snapshot]
+    }
+
+    // Mirror persistState: rewrite every live-state field, touch nothing else.
+    store.mutate { data in
+        data.sessions = [Session(name: "fresh")]
+        data.worktrees = []
+        data.links = []
+        data.terminals = []
+        data.hookStates = [:]
+    }
+
+    let reloaded = JSONStore(directory: dir)
+    #expect(reloaded.data.analyticsSnapshots?[sessionID.uuidString] == snapshot)
+    #expect(reloaded.data.sessions.count == 1)
+}

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/SessionRepositoryTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/SessionRepositoryTests.swift
@@ -254,6 +254,35 @@ import Testing
     #expect(repo.links(for: otherSessionID).count == 1)
 }
 
+// #690 (ADR 0008): the analytics snapshot is the scorecard's durable history
+// and must survive session deletion — the retention reaper deletes
+// completed/archived sessions routinely, and cascading would destroy the
+// trailing-4-week baseline.
+@Test func deleteDoesNotCascadeAnalyticsSnapshot() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let store = JSONStore(directory: dir)
+    let repo = SessionRepository(store: store)
+
+    let sessionID = UUID()
+    repo.save(Session(id: sessionID, name: "reaped"))
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: sessionID,
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(promptCount: 5)
+    )
+    store.mutate { data in
+        data.analyticsSnapshots = [sessionID.uuidString: snapshot]
+    }
+
+    repo.delete(id: sessionID)
+
+    #expect(repo.find(id: sessionID) == nil)
+    #expect(store.data.analyticsSnapshots?[sessionID.uuidString] == snapshot)
+}
+
 @Test func deleteIdempotent() throws {
     let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     defer { try? FileManager.default.removeItem(at: dir) }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -585,8 +585,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.defaultAgentKind = config.defaultAgentKind
         appState.agentsByKind = config.agentsByKind
 
-        // Create session service and hydrate state
-        let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil, providerManager: providerManager)
+        // Create session service and hydrate state. The analytics provider
+        // resolves telemetryService lazily — it is created later in launch —
+        // and returns nil when telemetry is disabled, so the snapshot writer
+        // falls back to the in-memory aggregate (#690).
+        let service = SessionService(
+            store: store,
+            appState: appState,
+            telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil,
+            providerManager: providerManager,
+            analyticsProvider: { [weak self] id in
+                await self?.telemetryService?.analytics(for: id)
+            })
         service.hydrateState()
         self.sessionService = service
         NSLog("[Crow] Session state hydrated (%d sessions)", appState.sessions.count)
@@ -1656,6 +1666,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             data.sessions[i].updatedAt = Date()
                         }
                     }
+                    // This handler mutates status directly (deliberately not
+                    // routed through updateSessionStatus, which would add a
+                    // manager-session guard the RPC never had), so it must
+                    // trigger the end-of-session analytics snapshot itself.
+                    capturedService.scheduleAnalyticsSnapshot(for: id, status: status)
                     return ["session_id": .string(idStr), "status": .string(statusStr)]
                 }
             },

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -16,12 +16,23 @@ final class SessionService {
     /// Backend factory for ticket/PR lookups during recovery. Optional so unit-tests
     /// that don't exercise recovery paths needn't construct one. See ADR 0005.
     private let providerManager: ProviderManager?
+    /// Fresh session aggregate from telemetry.db, used when persisting the
+    /// end-of-session analytics snapshot (#690). Optional so unit tests and
+    /// telemetry-off launches fall back to the in-memory aggregate.
+    private let analyticsProvider: (@Sendable (UUID) async -> SessionAnalytics?)?
 
-    init(store: JSONStore, appState: AppState, telemetryPort: UInt16? = nil, providerManager: ProviderManager? = nil) {
+    init(
+        store: JSONStore,
+        appState: AppState,
+        telemetryPort: UInt16? = nil,
+        providerManager: ProviderManager? = nil,
+        analyticsProvider: (@Sendable (UUID) async -> SessionAnalytics?)? = nil
+    ) {
         self.store = store
         self.appState = appState
         self.telemetryPort = telemetryPort
         self.providerManager = providerManager
+        self.analyticsProvider = analyticsProvider
     }
 
     /// Upgrade the well-known primary Manager session from `.work` (how it was
@@ -2347,6 +2358,45 @@ final class SessionService {
                 data.sessions[idx].updatedAt = Date()
             }
         }
+
+        scheduleAnalyticsSnapshot(for: id, status: status)
+    }
+
+    // MARK: - Analytics Snapshot (#690, ADR 0008)
+
+    /// Fire-and-forget trigger for the end-of-session analytics snapshot.
+    /// Internal (not private) because the `set-status` RPC handler mutates
+    /// status directly, bypassing `updateSessionStatus`, and must trigger the
+    /// snapshot itself.
+    func scheduleAnalyticsSnapshot(for id: UUID, status: SessionStatus) {
+        guard status == .completed || status == .archived else { return }
+        Task { await writeAnalyticsSnapshot(for: id, status: status) }
+    }
+
+    /// Persist a durable `SessionAnalyticsSnapshot` when a session reaches a
+    /// terminal status. Prefers a fresh aggregate from telemetry.db — covering
+    /// the relaunch-then-complete gap where the in-memory aggregate is still
+    /// nil — and falls back to `SessionHookState.analytics`. Skips entirely,
+    /// preserving any existing snapshot, when both are nil or empty (telemetry
+    /// disabled, or a session that never produced data — the SQL aggregate is
+    /// all-zeros for unknown sessions, so `isEmpty` is the real guard).
+    func writeAnalyticsSnapshot(for id: UUID, status: SessionStatus) async {
+        guard status == .completed || status == .archived else { return }
+        guard !appState.isManagerSession(id) else { return }
+
+        let fresh = await analyticsProvider?(id)
+        let analytics = (fresh?.isEmpty == false)
+            ? fresh
+            : appState.existingHookState(for: id)?.analytics
+        guard let analytics, !analytics.isEmpty else { return }
+
+        let snapshot = SessionAnalyticsSnapshot(
+            sessionID: id, endedAt: Date(), status: status, analytics: analytics)
+        store.mutate { data in
+            var snapshots = data.analyticsSnapshots ?? [:]
+            snapshots[id.uuidString] = snapshot
+            data.analyticsSnapshots = snapshots
+        }
     }
 
     /// Lock or unlock a session to exempt it from (or restore it to) the
@@ -2392,6 +2442,25 @@ final class SessionService {
             data.terminals = appState.terminals.values.flatMap { $0 }
             data.hookStates = Dictionary(
                 uniqueKeysWithValues: hookSnapshots.map { ($0.key.uuidString, $0.value) })
+
+            // Analytics-snapshot quit-race backfill (#690): a terminal status
+            // transition spawns the snapshot write asynchronously, so a fast
+            // quit can beat it. Backfill synchronously from the in-memory
+            // aggregate — but never overwrite an existing snapshot, which is
+            // DB-derived and at least as fresh.
+            for session in appState.sessions
+            where (session.status == .completed || session.status == .archived)
+                && !session.isManager {
+                let key = session.id.uuidString
+                guard data.analyticsSnapshots?[key] == nil,
+                      let analytics = appState.existingHookState(for: session.id)?.analytics,
+                      !analytics.isEmpty else { continue }
+                var snapshots = data.analyticsSnapshots ?? [:]
+                snapshots[key] = SessionAnalyticsSnapshot(
+                    sessionID: session.id, endedAt: session.updatedAt,
+                    status: session.status, analytics: analytics)
+                data.analyticsSnapshots = snapshots
+            }
         }
     }
 

--- a/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
+++ b/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+@testable import Crow
+
+/// End-of-session analytics snapshot persistence (#690, ADR 0008 follow-up 2).
+/// Tests drive the awaitable `writeAnalyticsSnapshot` / `persistState`
+/// directly rather than the fire-and-forget `Task {}` trigger, so there is no
+/// timing dependence.
+@MainActor
+@Suite("SessionService analytics snapshot")
+struct SessionServiceAnalyticsSnapshotTests {
+
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-analytics-snap-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private nonisolated static let sampleAnalytics = SessionAnalytics(
+        totalCost: 2.5, inputTokens: 500, outputTokens: 900,
+        activeTimeSeconds: 1_200, promptCount: 9, toolCallCount: 30
+    )
+
+    @Test
+    func completedSessionWithProviderPersistsSnapshot() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "shipped")]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let snapshot = store.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot?.sessionID == id)
+        #expect(snapshot?.status == .completed)
+        #expect(snapshot?.analytics == Self.sampleAnalytics)
+    }
+
+    // Telemetry's SQL aggregate is all-zeros for a session with no rows —
+    // that must never become a persisted snapshot, and it must not clobber
+    // a real one written earlier.
+    @Test
+    func emptyProviderAggregateWritesNothingAndPreservesExisting() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "no-data")]
+        let existing = SessionAnalyticsSnapshot(
+            sessionID: id, endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+            status: .completed, analytics: Self.sampleAnalytics)
+        store.mutate { $0.analyticsSnapshots = [id.uuidString: existing] }
+
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in SessionAnalytics() })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        #expect(store.data.analyticsSnapshots?[id.uuidString] == existing)
+    }
+
+    // Telemetry disabled (nil provider): fall back to the in-memory aggregate.
+    @Test
+    func nilProviderFallsBackToInMemoryAnalytics() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "in-memory")]
+        appState.hookState(for: id).analytics = Self.sampleAnalytics
+        let service = SessionService(store: store, appState: appState)
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        #expect(store.data.analyticsSnapshots?[id.uuidString]?.analytics == Self.sampleAnalytics)
+    }
+
+    // The relaunch-then-complete gap: in-memory analytics is nil after a
+    // relaunch until new telemetry arrives, but telemetry.db still has the
+    // session's rows — the fresh provider aggregate wins.
+    @Test
+    func providerWinsWhenInMemoryIsNil() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "post-relaunch")]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .archived)
+
+        let snapshot = store.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot?.analytics == Self.sampleAnalytics)
+        #expect(snapshot?.status == .archived)
+    }
+
+    // A session with no telemetry at all ends gracefully: no crash, no entry.
+    @Test
+    func noTelemetryAnywhereWritesNothing() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "telemetry-off")]
+        let service = SessionService(store: store, appState: appState)
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        #expect(store.data.analyticsSnapshots?[id.uuidString] == nil)
+    }
+
+    // Re-ending a session (resume → end again) updates the one entry rather
+    // than duplicating — and records the newest status and aggregate.
+    @Test
+    func reEndingUpdatesInsteadOfDuplicating() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "resumed")]
+        let firstRun = Self.sampleAnalytics
+        var secondRun = Self.sampleAnalytics
+        secondRun.promptCount = 20
+
+        let firstEnd = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in firstRun })
+        await firstEnd.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let secondEnd = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { [secondRun] _ in secondRun })
+        await secondEnd.writeAnalyticsSnapshot(for: id, status: .archived)
+
+        let snapshots = store.data.analyticsSnapshots
+        #expect(snapshots?.count == 1)
+        #expect(snapshots?[id.uuidString]?.status == .archived)
+        #expect(snapshots?[id.uuidString]?.analytics.promptCount == 20)
+    }
+
+    @Test
+    func nonTerminalStatusAndManagerWriteNothing() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let workID = UUID()
+        appState.sessions = [
+            Session(id: workID, name: "in-flight"),
+            Session(id: AppState.managerSessionID, name: "Manager", kind: .manager),
+        ]
+        appState.hookState(for: workID).analytics = Self.sampleAnalytics
+        appState.hookState(for: AppState.managerSessionID).analytics = Self.sampleAnalytics
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: workID, status: .active)
+        await service.writeAnalyticsSnapshot(for: workID, status: .inReview)
+        await service.writeAnalyticsSnapshot(for: AppState.managerSessionID, status: .completed)
+
+        #expect(store.data.analyticsSnapshots == nil)
+    }
+
+    // The persisted snapshot must read back after a simulated relaunch.
+    @Test
+    func snapshotSurvivesSimulatedRelaunch() async {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-analytics-relaunch-\(UUID().uuidString)")
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "durable")]
+        let service = SessionService(
+            store: JSONStore(directory: dir), appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let reloaded = JSONStore(directory: dir)
+        let snapshot = reloaded.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot?.analytics == Self.sampleAnalytics)
+        #expect(snapshot?.status == .completed)
+    }
+
+    // Quit-race backfill: a terminal transition's async snapshot write can be
+    // beaten by a fast quit; persistState backfills from the in-memory
+    // aggregate — but never overwrites an existing snapshot.
+    @Test
+    func persistStateBackfillsMissingSnapshotOnly() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+
+        var ended = Session(id: UUID(), name: "ended-then-quit")
+        ended.status = .completed
+        ended.updatedAt = Date(timeIntervalSince1970: 1_752_100_000)
+
+        var alreadySnapshotted = Session(id: UUID(), name: "already-done")
+        alreadySnapshotted.status = .completed
+
+        var stillActive = Session(id: UUID(), name: "active")
+        stillActive.status = .active
+
+        appState.sessions = [ended, alreadySnapshotted, stillActive]
+        appState.hookState(for: ended.id).analytics = Self.sampleAnalytics
+        appState.hookState(for: alreadySnapshotted.id).analytics = Self.sampleAnalytics
+        appState.hookState(for: stillActive.id).analytics = Self.sampleAnalytics
+
+        let existing = SessionAnalyticsSnapshot(
+            sessionID: alreadySnapshotted.id,
+            endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+            status: .archived, analytics: SessionAnalytics(promptCount: 1))
+        store.mutate { $0.analyticsSnapshots = [alreadySnapshotted.id.uuidString: existing] }
+
+        let service = SessionService(store: store, appState: appState)
+        service.persistState()
+
+        let snapshots = store.data.analyticsSnapshots
+        // Backfilled for the ended session, stamped with its transition time.
+        #expect(snapshots?[ended.id.uuidString]?.analytics == Self.sampleAnalytics)
+        #expect(snapshots?[ended.id.uuidString]?.endedAt == ended.updatedAt)
+        // Existing snapshot untouched (DB-derived, at least as fresh).
+        #expect(snapshots?[alreadySnapshotted.id.uuidString] == existing)
+        // Non-terminal sessions never snapshot.
+        #expect(snapshots?[stillActive.id.uuidString] == nil)
+    }
+}


### PR DESCRIPTION
Closes #690. ADR 0008 follow-up **2 of 11** (refs #648, design PR #657). **v1-blocking.**

Persists a durable `SessionAnalyticsSnapshot` when a session reaches a terminal status, so the scorecard's weekly rollups and trailing-4-week self-comparison baseline survive relaunch — and survive the retention reaper, which routinely deletes completed/archived sessions along with their telemetry rows.

## Key decisions

- **Trigger**: status transition to `.completed` or `.archived` (both are treated as terminal everywhere else in the codebase). Two paths are covered, because they don't share a funnel:
  - `SessionService.updateSessionStatus` (used by `completeSession` → IssueTracker `markIssueDone`/auto-merge, JobScheduler);
  - the `set-status` RPC handler in `AppDelegate`, which mutates status directly. It deliberately keeps its direct mutation (routing it through `updateSessionStatus` would silently add a manager-session guard the RPC never had) and triggers the snapshot itself.
- **Data source**: prefers a fresh aggregate from `telemetry.db` via an injected async provider — this covers the relaunch-then-complete gap where `SessionHookState.analytics` is still nil — and falls back to the in-memory aggregate. When both are nil/empty it skips entirely, preserving any existing snapshot. `TelemetryDatabase.sessionAnalytics` returns **all-zeros** for a session with no rows (`COALESCE(SUM,0)`), so a new `SessionAnalytics.isEmpty` guard prevents bogus zero snapshots (the telemetry-off case ends gracefully: no crash, no entry).
- **Storage shape**: a new optional `analyticsSnapshots: [String: SessionAnalyticsSnapshot]?` field on `StoreData` in the existing `JSONStore` (`store.json`), keyed by session UUID string — exactly the `hookStates` backward-compat pattern (#367). No new store. Old `store.json` files decode with the field nil.
- **Idempotency**: dict keying means a session that resumes and ends again *updates* its snapshot (newest status + aggregate), never duplicates.
- **Lifecycle**: snapshots are **not** cascade-deleted with sessions — the auto-cleanup reaper deletes completed/archived sessions after `retentionHours`, and cascading would destroy the 4-week baseline. Unbounded growth is a known trade-off (records are tiny); pruning by `endedAt` can ride a follow-up.
- **Quit race**: the terminal transition fires the snapshot write asynchronously; `persistState()` (clean quit) backfills synchronously from the in-memory aggregate, never overwriting an existing (DB-derived, at-least-as-fresh) snapshot.
- **Terminal status recorded on the snapshot** (`completed` vs `archived`): the ADR derives "sessions shipped" from these snapshots *after* the session record is gone, so the outcome flag has to live here.
- **Not on `PersistedHookState`** — per the ADR, its contract stays the color-driving UI subset.

## Extension point for follow-up 3 (compaction counter)

Future fields ride `SessionAnalyticsSnapshot` as **optionals** (e.g. `compactionCount: Int?`) so previously persisted snapshots keep decoding — documented on the model and locked in by a decode-unknown-keys test. They should *not* go on `SessionAnalytics` (13 non-optional stored fields; a required addition would break old snapshots).

## Sibling dependency

#689 (telemetry temporality-at-ingest, follow-up 1) makes the token/cost numbers in these snapshots trustworthy — today cumulative datapoints are over-summed. The snapshot *mechanism* here is valid regardless; the *values* firm up once #689 lands. Not blocked on it (different package, low collision).

## Tests

- CrowCore: `isEmpty` semantics; snapshot ISO8601 JSON round-trip; unknown-future-key decode (extension-point contract).
- CrowPersistence: snapshot round-trip across a simulated relaunch (new `JSONStore` over the same directory); legacy `store.json` without the field decodes; a `persistState`-style live-state rewrite doesn't clobber snapshots; `SessionRepository.delete` cascades everything *except* snapshots.
- App target: provider-sourced snapshot on completion (+ survives reload); all-zeros aggregate writes nothing and preserves existing; nil provider falls back to in-memory; provider wins when in-memory is nil (relaunch gap); re-end updates instead of duplicating; non-terminal statuses and manager sessions never write; `persistState` backfills missing snapshots only.

`make test`: all packages + root suite pass (`CrowCore` 338, `CrowPersistence` 34, root 326). The only failures are pre-existing/environmental: `CrowGit` `RebaseTests` fail on machines with no global git identity ("Committer identity unknown" in the tests' temp repos) — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)