### PR TITLE
Persist per-session compaction counter (PostCompact) on the analytics snapshot (closes #691)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -693,6 +693,9 @@ public final class SessionHookState {
     public var lastToolActivity: ToolActivity?
     public var hookEvents: [HookEvent] = []
     public var analytics: SessionAnalytics?
+    /// Completed compactions this app run (ADR 0008 follow-up 3). Persisted at
+    /// session end on `SessionAnalyticsSnapshot`, NOT on `PersistedHookState`.
+    public var compactionCount: Int = 0
     /// Timestamp of the most recent top-level Stop / StopFailure for this session.
     /// Used to suppress state elevation from background activity (e.g. the
     /// `awaySummaryEnabled` recap subagent in Claude Code ≥ 2.1.108) that
@@ -701,6 +704,13 @@ public final class SessionHookState {
     public var lastTopLevelStopAt: Date?
 
     public init() {}
+
+    /// ADR 0008: count completed compactions only. `PreCompact` (and any
+    /// failed/aborted compaction, which never emits `PostCompact`) is not
+    /// graded waste.
+    public func noteCompactionEvent(_ eventName: String) {
+        if eventName == "PostCompact" { compactionCount += 1 }
+    }
 }
 
 /// Codable, value-type snapshot of the *color-driving* subset of

--- a/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
@@ -12,8 +12,8 @@ import Foundation
 /// here rather than looked up on the session: "sessions shipped" is counted
 /// from snapshots after the session record is gone.
 ///
-/// Extension point (ADR 0008 follow-up 3): add future fields — e.g.
-/// `compactionCount: Int?` — as OPTIONALS on this struct, not on
+/// Extension point (ADR 0008 follow-ups): add future fields — like
+/// `compactionCount` below — as OPTIONALS on this struct, not on
 /// `SessionAnalytics`, so previously persisted snapshots keep decoding.
 public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
     public var sessionID: UUID
@@ -26,16 +26,22 @@ public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
     /// status and aggregate.
     public var status: SessionStatus
     public var analytics: SessionAnalytics
+    /// Completed compactions (`PostCompact` events) over the session's life
+    /// (ADR 0008 follow-up 3 — the scorecard's heaviest-weighted penalty).
+    /// `nil` in snapshots persisted before #691; treat as 0.
+    public var compactionCount: Int?
 
     public init(
         sessionID: UUID,
         endedAt: Date,
         status: SessionStatus,
-        analytics: SessionAnalytics
+        analytics: SessionAnalytics,
+        compactionCount: Int? = nil
     ) {
         self.sessionID = sessionID
         self.endedAt = endedAt
         self.status = status
         self.analytics = analytics
+        self.compactionCount = compactionCount
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
@@ -38,10 +38,10 @@ import Testing
     #expect(decoded.analytics.totalTokens == 640)
 }
 
-// Locks in the follow-up-3 extension-point contract: future fields (e.g. the
-// compaction counter) arrive as optionals on the snapshot, and snapshots
-// carrying keys this app version doesn't know must still decode — Codable
-// synthesis ignores unknown keys.
+// Locks in the extension-point contract: future fields arrive as optionals on
+// the snapshot (compactionCount, once the follow-up-3 example, is now real and
+// must decode), and snapshots carrying keys this app version doesn't know must
+// still decode — Codable synthesis ignores unknown keys.
 @Test func snapshotDecodingIgnoresUnknownFutureKeys() throws {
     let json = """
     {
@@ -55,7 +55,8 @@ import Testing
         "promptCount": 0, "toolCallCount": 0, "apiRequestCount": 0,
         "apiErrorCount": 0
       },
-      "compactionCount": 3
+      "compactionCount": 3,
+      "someFutureScorecardField": true
     }
     """
     let decoder = JSONDecoder()
@@ -64,4 +65,71 @@ import Testing
     #expect(decoded.status == .archived)
     #expect(decoded.analytics.inputTokens == 42)
     #expect(decoded.analytics.isEmpty == false)
+    #expect(decoded.compactionCount == 3)
+}
+
+// #691 (ADR 0008 follow-up 3): the per-session compaction counter.
+
+// Completed compactions only: PostCompact increments; PreCompact (and a
+// failed/aborted compaction, which never emits PostCompact) does not.
+@MainActor
+@Test func noteCompactionEventCountsPostCompactOnly() {
+    let state = SessionHookState()
+    #expect(state.compactionCount == 0)
+
+    state.noteCompactionEvent("PreCompact")
+    #expect(state.compactionCount == 0)
+
+    state.noteCompactionEvent("PostCompact")
+    state.noteCompactionEvent("PostCompact")
+    #expect(state.compactionCount == 2)
+
+    state.noteCompactionEvent("PreCompact")
+    state.noteCompactionEvent("Stop")
+    state.noteCompactionEvent("StopFailure")
+    #expect(state.compactionCount == 2)
+}
+
+@Test func snapshotCompactionCountRoundTrips() throws {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(promptCount: 1),
+        compactionCount: 2
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let decoded = try decoder.decode(
+        SessionAnalyticsSnapshot.self, from: encoder.encode(snapshot))
+    #expect(decoded == snapshot)
+    #expect(decoded.compactionCount == 2)
+}
+
+// Snapshots persisted before #691 have no compactionCount key — they must
+// keep decoding, with the absent field surfacing as nil (treated as 0).
+@Test func snapshotWithoutCompactionCountDecodesAsNil() throws {
+    let json = """
+    {
+      "sessionID": "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+      "endedAt": "2026-07-13T00:00:00Z",
+      "status": "completed",
+      "analytics": {
+        "totalCost": 0, "inputTokens": 42, "outputTokens": 0,
+        "cacheReadTokens": 0, "cacheCreationTokens": 0, "activeTimeSeconds": 0,
+        "linesAdded": 0, "linesRemoved": 0, "commitCount": 0,
+        "promptCount": 0, "toolCallCount": 0, "apiRequestCount": 0,
+        "apiErrorCount": 0
+      }
+    }
+    """
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(SessionAnalyticsSnapshot.self, from: Data(json.utf8))
+    #expect(decoded.compactionCount == nil)
+    #expect(decoded.compactionCount ?? 0 == 0)
 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -2185,6 +2185,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // real change (keeps sidebar colors correct after relaunch — #367).
                     let snapshotBefore = state.persistedSnapshot
 
+                    // Count completed compactions (PostCompact only) for the
+                    // end-of-session analytics snapshot (ADR 0008, #691).
+                    state.noteCompactionEvent(eventName)
+
                     // Append to ring buffer (keep last 50 events per session)
                     state.hookEvents.append(event)
                     if state.hookEvents.count > 50 { state.hookEvents.removeFirst(state.hookEvents.count - 50) }

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -2390,8 +2390,12 @@ final class SessionService {
             : appState.existingHookState(for: id)?.analytics
         guard let analytics, !analytics.isEmpty else { return }
 
+        // Compaction count only exists on the in-memory hook state — telemetry.db
+        // has no compaction rows — so read it there even when `analytics` came
+        // from the DB provider (#691).
         let snapshot = SessionAnalyticsSnapshot(
-            sessionID: id, endedAt: Date(), status: status, analytics: analytics)
+            sessionID: id, endedAt: Date(), status: status, analytics: analytics,
+            compactionCount: appState.existingHookState(for: id)?.compactionCount ?? 0)
         store.mutate { data in
             var snapshots = data.analyticsSnapshots ?? [:]
             snapshots[id.uuidString] = snapshot
@@ -2458,7 +2462,9 @@ final class SessionService {
                 var snapshots = data.analyticsSnapshots ?? [:]
                 snapshots[key] = SessionAnalyticsSnapshot(
                     sessionID: session.id, endedAt: session.updatedAt,
-                    status: session.status, analytics: analytics)
+                    status: session.status, analytics: analytics,
+                    compactionCount: appState.existingHookState(for: session.id)?
+                        .compactionCount ?? 0)
                 data.analyticsSnapshots = snapshots
             }
         }

--- a/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
+++ b/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
@@ -183,6 +183,47 @@ struct SessionServiceAnalyticsSnapshotTests {
         #expect(snapshot?.status == .completed)
     }
 
+    // #691: two completed compactions persist as 2 on the snapshot and read
+    // back after a simulated relaunch. Routed through noteCompactionEvent —
+    // the hook-handler seam — so PreCompact is exercised as a non-increment.
+    @Test
+    func compactionCountPersistsAndSurvivesSimulatedRelaunch() async {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-compaction-relaunch-\(UUID().uuidString)")
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "compacted-twice")]
+        let hookState = appState.hookState(for: id)
+        hookState.noteCompactionEvent("PreCompact")
+        hookState.noteCompactionEvent("PostCompact")
+        hookState.noteCompactionEvent("PreCompact")
+        hookState.noteCompactionEvent("PostCompact")
+        let service = SessionService(
+            store: JSONStore(directory: dir), appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let reloaded = JSONStore(directory: dir)
+        #expect(reloaded.data.analyticsSnapshots?[id.uuidString]?.compactionCount == 2)
+    }
+
+    // #691: a session that never compacted persists an explicit 0.
+    @Test
+    func zeroCompactionsPersistsZero() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "never-compacted")]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        #expect(store.data.analyticsSnapshots?[id.uuidString]?.compactionCount == 0)
+    }
+
     // Quit-race backfill: a terminal transition's async snapshot write can be
     // beaten by a fast quit; persistState backfills from the in-memory
     // aggregate — but never overwrites an existing snapshot.
@@ -203,6 +244,7 @@ struct SessionServiceAnalyticsSnapshotTests {
 
         appState.sessions = [ended, alreadySnapshotted, stillActive]
         appState.hookState(for: ended.id).analytics = Self.sampleAnalytics
+        appState.hookState(for: ended.id).noteCompactionEvent("PostCompact")
         appState.hookState(for: alreadySnapshotted.id).analytics = Self.sampleAnalytics
         appState.hookState(for: stillActive.id).analytics = Self.sampleAnalytics
 
@@ -216,9 +258,11 @@ struct SessionServiceAnalyticsSnapshotTests {
         service.persistState()
 
         let snapshots = store.data.analyticsSnapshots
-        // Backfilled for the ended session, stamped with its transition time.
+        // Backfilled for the ended session, stamped with its transition time,
+        // carrying the compaction count (#691).
         #expect(snapshots?[ended.id.uuidString]?.analytics == Self.sampleAnalytics)
         #expect(snapshots?[ended.id.uuidString]?.endedAt == ended.updatedAt)
+        #expect(snapshots?[ended.id.uuidString]?.compactionCount == 1)
         // Existing snapshot untouched (DB-derived, at least as fresh).
         #expect(snapshots?[alreadySnapshotted.id.uuidString] == existing)
         // Non-terminal sessions never snapshot.


### PR DESCRIPTION
Closes #691. ADR 0008 follow-up 3/11 (refs #648, design PR #657). Depends on #690 (SessionAnalytics snapshot — the counter's persistence home).

## #690 relationship

**#690 is merged (PR #704, commit cc027a7) and this builds directly on it** — the counter is added as `compactionCount: Int?` on `SessionAnalyticsSnapshot`, exactly per that struct's documented extension point (optionals on the snapshot, not `SessionAnalytics`, so pre-#691 snapshots keep decoding; absent = 0).

## What

- `SessionHookState` gains an in-memory `compactionCount` and a `noteCompactionEvent(_:)` seam that increments on **`PostCompact` only** — a completed compaction. `PreCompact` (and a failed/aborted compaction, which never emits `PostCompact`) is not graded waste.
- The existing `hook-event` RPC handler calls the seam next to the ring-buffer append — no new hook wiring (`PreCompact`/`PostCompact` were already registered in `ClaudeHookConfigWriter`).
- Both snapshot writers carry the count: `writeAnalyticsSnapshot` and the `persistState` quit-race backfill. The count always comes from in-memory hook state — telemetry.db has no compaction rows — regardless of whether the analytics aggregate came from the DB provider or the in-memory fallback.
- **`PersistedHookState` untouched** — its documented contract stays the color-driving UI subset (ADR 0008 mandate).

## Tests

- `noteCompactionEvent`: two `PostCompact` → 2; `PreCompact`/`Stop`/`StopFailure` don't increment; fresh state is 0.
- Snapshot JSON round-trip with the count; legacy snapshot without the key decodes with `compactionCount == nil` (treated as 0); unknown-future-key forward-compat test updated (it had used `compactionCount` as its example — now asserted to decode, with a new fake key covering forward-compat).
- Service level: 2 compactions persist as 2 and **survive a simulated relaunch** (fresh `JSONStore` over the same dir); zero compactions persist an explicit 0; the `persistState` backfill carries the count.
- Full gate: `make test` (all package suites + root `CrowTests`, 328 tests) passes.

## Known limitation

The live counter is in-memory only; an app relaunch mid-session resets it (analytics has a telemetry.db fallback for that gap; compaction events have no DB row). The ADR only mandates persistence with the end-of-session snapshot.

## Coordination

Shares the `CrowCore` analytics-model surface with #692 (session duration); this change touches only the new `compactionCount` field on the snapshot to minimize rebase friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)