### PR TITLE
Persist PR→session attribution store (Crow-Session trailer) + merged-per-window counts (closes #693)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/PRSessionAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRSessionAttribution.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Durable PR → session attribution record, persisted whenever a PR's
+/// commits are fetched and their `Crow-Session:` trailers parsed.
+///
+/// This is ADR 0008 follow-up 5: the trailer parse used to be a
+/// discard-after-use auto-merge gate; this record retains the mapping so
+/// the scorecard can count PRs merged per session per window (and, in
+/// follow-up 6, merge rate). Records deliberately outlive session
+/// deletion — window counts must survive the retention reaper — and
+/// include unknown-session UUIDs: attribution is ground truth even when
+/// the session isn't (or is no longer) known locally.
+///
+/// Extension point: add future fields — e.g. `authorLogin: String?` —
+/// as OPTIONALS on this struct so previously persisted records keep
+/// decoding.
+public struct PRSessionAttribution: Codable, Equatable, Sendable {
+    public var prURL: String
+    public var repoNameWithOwner: String
+    public var prNumber: Int
+    /// Every UUID parsed from `Crow-Session:` trailers on the PR's commits,
+    /// deduped, in first-seen order. Monotonic: once observed an ID is never
+    /// removed, even if a later rebase drops the commit that carried it.
+    public var sessionIDs: [UUID]
+    /// Last observed PR state: "OPEN" / "MERGED" / "CLOSED".
+    public var state: String
+    /// When Crow first observed the PR in MERGED state; never overwritten.
+    /// Crow-observed (no backend surfaces the real merge timestamp yet), so
+    /// it can lag the actual merge by up to a poll interval or app downtime.
+    /// A future API-sourced value can replace it without a schema change.
+    public var mergedAt: Date?
+    public var firstSeenAt: Date
+    public var updatedAt: Date
+
+    public init(
+        prURL: String,
+        repoNameWithOwner: String,
+        prNumber: Int,
+        sessionIDs: [UUID],
+        state: String,
+        mergedAt: Date? = nil,
+        firstSeenAt: Date,
+        updatedAt: Date
+    ) {
+        self.prURL = prURL
+        self.repoNameWithOwner = repoNameWithOwner
+        self.prNumber = prNumber
+        self.sessionIDs = sessionIDs
+        self.state = state
+        self.mergedAt = mergedAt
+        self.firstSeenAt = firstSeenAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -24,6 +24,11 @@ public struct StoreData: Codable, Sendable {
     /// as `hookStates`. Entries deliberately outlive session deletion — the
     /// scorecard's trailing-4-week baseline must survive the retention reaper.
     public var analyticsSnapshots: [String: SessionAnalyticsSnapshot]?
+    /// Durable PR→session attribution per PR, keyed by PR URL (#693,
+    /// ADR 0008 follow-up 5). Optional for the same backward-compat reason
+    /// as `hookStates`. Entries deliberately outlive session deletion —
+    /// merged-PR-per-window counts must survive the retention reaper.
+    public var prAttributions: [String: PRSessionAttribution]?
 
     public init(
         sessions: [Session] = [],
@@ -31,7 +36,8 @@ public struct StoreData: Codable, Sendable {
         links: [SessionLink] = [],
         terminals: [SessionTerminal] = [],
         hookStates: [String: PersistedHookState]? = nil,
-        analyticsSnapshots: [String: SessionAnalyticsSnapshot]? = nil
+        analyticsSnapshots: [String: SessionAnalyticsSnapshot]? = nil,
+        prAttributions: [String: PRSessionAttribution]? = nil
     ) {
         self.sessions = sessions
         self.worktrees = worktrees
@@ -39,6 +45,7 @@ public struct StoreData: Codable, Sendable {
         self.terminals = terminals
         self.hookStates = hookStates
         self.analyticsSnapshots = analyticsSnapshots
+        self.prAttributions = prAttributions
     }
 }
 

--- a/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/PRAttributionRepository.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/PRAttributionRepository.swift
@@ -1,0 +1,32 @@
+import Foundation
+import CrowCore
+
+/// Repository for PR→session attribution queries (#693, ADR 0008
+/// follow-up 5). Read side of the attribution store; writes happen in
+/// `IssueTracker`, which owns the trailer parse.
+public struct PRAttributionRepository: Sendable {
+    private let store: JSONStore
+
+    public init(store: JSONStore) {
+        self.store = store
+    }
+
+    public func attribution(prURL: String) -> PRSessionAttribution? {
+        store.data.prAttributions?[prURL]
+    }
+
+    /// Every PR attributed to `sessionID`, in no guaranteed order.
+    public func attributions(for sessionID: UUID) -> [PRSessionAttribution] {
+        (store.data.prAttributions ?? [:]).values.filter { $0.sessionIDs.contains(sessionID) }
+    }
+
+    /// Count of PRs attributed to `sessionID` whose merge was observed
+    /// inside `window`. A PR carrying multiple session trailers counts once
+    /// for each of its sessions.
+    public func mergedPRCount(for sessionID: UUID, in window: DateInterval) -> Int {
+        attributions(for: sessionID).count { attribution in
+            guard attribution.state == "MERGED", let mergedAt = attribution.mergedAt else { return false }
+            return window.contains(mergedAt)
+        }
+    }
+}

--- a/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/SessionRepository.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/SessionRepository.swift
@@ -30,6 +30,8 @@ public struct SessionRepository: Sendable {
     /// Delete a session and all related data (worktrees, links, terminals) in a single atomic mutation.
     /// `analyticsSnapshots` is deliberately NOT cascaded: the scorecard's
     /// trailing-4-week baseline must survive session deletion (ADR 0008, #690).
+    /// `prAttributions` is likewise NOT cascaded: merged-PR-per-window counts
+    /// must survive session deletion (ADR 0008, #693).
     public func delete(id: UUID) {
         store.mutate { data in
             data.sessions.removeAll { $0.id == id }

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/PRAttributionRepositoryTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/PRAttributionRepositoryTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import CrowPersistence
+@testable import CrowCore
+
+// #693 (ADR 0008 follow-up 5): durable PR→session attribution store —
+// round-trip persistence, forward compat, delete-cascade exclusion, and
+// the merged-PR-per-window rollup.
+
+private func makeAttribution(
+    prURL: String = "https://github.com/corveil/crow/pull/42",
+    repo: String = "corveil/crow",
+    number: Int = 42,
+    sessionIDs: [UUID],
+    state: String = "OPEN",
+    mergedAt: Date? = nil
+) -> PRSessionAttribution {
+    PRSessionAttribution(
+        prURL: prURL,
+        repoNameWithOwner: repo,
+        prNumber: number,
+        sessionIDs: sessionIDs,
+        state: state,
+        mergedAt: mergedAt,
+        firstSeenAt: Date(timeIntervalSince1970: 1_752_000_000),
+        updatedAt: Date(timeIntervalSince1970: 1_752_000_100)
+    )
+}
+
+@Test func attributionPersistsAcrossRelaunch() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sessionID = UUID()
+    let attribution = makeAttribution(
+        sessionIDs: [sessionID],
+        state: "MERGED",
+        mergedAt: Date(timeIntervalSince1970: 1_752_100_000)
+    )
+    let store = JSONStore(directory: dir)
+    store.mutate { data in
+        data.prAttributions = [attribution.prURL: attribution]
+    }
+
+    // A new store over the same directory simulates an app relaunch.
+    let reloaded = JSONStore(directory: dir)
+    let repo = PRAttributionRepository(store: reloaded)
+    #expect(repo.attribution(prURL: attribution.prURL) == attribution)
+    #expect(repo.attributions(for: sessionID) == [attribution])
+}
+
+@Test func storeWithoutAttributionKeyDecodesCleanly() throws {
+    // Older store.json files predate the prAttributions key; decoding must
+    // leave the field nil and every other field intact.
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let legacy = """
+    {
+      "sessions": [],
+      "worktrees": [],
+      "links": [],
+      "terminals": []
+    }
+    """
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try legacy.write(to: dir.appendingPathComponent("store.json"), atomically: true, encoding: .utf8)
+
+    let store = JSONStore(directory: dir)
+    #expect(store.data.prAttributions == nil)
+    #expect(store.data.sessions.isEmpty)
+    let repo = PRAttributionRepository(store: store)
+    #expect(repo.attribution(prURL: "https://example.com/pr/1") == nil)
+    #expect(repo.mergedPRCount(for: UUID(), in: DateInterval(start: .distantPast, end: .distantFuture)) == 0)
+}
+
+// Like analyticsSnapshots (#690), attribution records are scorecard history
+// and must survive the retention reaper deleting the session.
+@Test func deleteDoesNotCascadePRAttributions() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let store = JSONStore(directory: dir)
+    let sessionRepo = SessionRepository(store: store)
+
+    let sessionID = UUID()
+    sessionRepo.save(Session(id: sessionID, name: "reaped"))
+    let attribution = makeAttribution(sessionIDs: [sessionID])
+    store.mutate { data in
+        data.prAttributions = [attribution.prURL: attribution]
+    }
+
+    sessionRepo.delete(id: sessionID)
+
+    #expect(sessionRepo.find(id: sessionID) == nil)
+    #expect(store.data.prAttributions?[attribution.prURL] == attribution)
+}
+
+@Test func mergedPRCountFiltersBySessionStateAndWindow() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sessionID = UUID()
+    let otherSession = UUID()
+    let window = DateInterval(
+        start: Date(timeIntervalSince1970: 1_752_000_000),
+        end: Date(timeIntervalSince1970: 1_752_604_800)
+    )
+    let insideWindow = window.start.addingTimeInterval(3_600)
+
+    let counted = makeAttribution(
+        prURL: "https://github.com/corveil/crow/pull/1", number: 1,
+        sessionIDs: [sessionID], state: "MERGED", mergedAt: insideWindow)
+    let mergedOutsideWindow = makeAttribution(
+        prURL: "https://github.com/corveil/crow/pull/2", number: 2,
+        sessionIDs: [sessionID], state: "MERGED",
+        mergedAt: window.end.addingTimeInterval(3_600))
+    let stillOpen = makeAttribution(
+        prURL: "https://github.com/corveil/crow/pull/3", number: 3,
+        sessionIDs: [sessionID], state: "OPEN")
+    let otherSessionsPR = makeAttribution(
+        prURL: "https://github.com/corveil/crow/pull/4", number: 4,
+        sessionIDs: [otherSession], state: "MERGED", mergedAt: insideWindow)
+
+    let store = JSONStore(directory: dir)
+    store.mutate { data in
+        data.prAttributions = Dictionary(
+            uniqueKeysWithValues: [counted, mergedOutsideWindow, stillOpen, otherSessionsPR].map { ($0.prURL, $0) })
+    }
+
+    let repo = PRAttributionRepository(store: store)
+    #expect(repo.mergedPRCount(for: sessionID, in: window) == 1)
+    #expect(repo.mergedPRCount(for: otherSession, in: window) == 1)
+    #expect(repo.mergedPRCount(for: UUID(), in: window) == 0)
+}
+
+@Test func multiSessionPRCountsForEachSession() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let a = UUID()
+    let b = UUID()
+    let window = DateInterval(
+        start: Date(timeIntervalSince1970: 1_752_000_000),
+        end: Date(timeIntervalSince1970: 1_752_604_800)
+    )
+    let attribution = makeAttribution(
+        sessionIDs: [a, b], state: "MERGED",
+        mergedAt: window.start.addingTimeInterval(60))
+
+    let store = JSONStore(directory: dir)
+    store.mutate { data in
+        data.prAttributions = [attribution.prURL: attribution]
+    }
+
+    let repo = PRAttributionRepository(store: store)
+    #expect(repo.mergedPRCount(for: a, in: window) == 1)
+    #expect(repo.mergedPRCount(for: b, in: window) == 1)
+    #expect(repo.attributions(for: a) == [attribution])
+    #expect(repo.attributions(for: b) == [attribution])
+}

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -750,7 +750,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Start issue tracker
-        let tracker = IssueTracker(appState: appState, providerManager: providerManager)
+        let tracker = IssueTracker(appState: appState, providerManager: providerManager, store: store)
         tracker.onNewReviewRequests = { [weak self] newRequests in
             for request in newRequests {
                 self?.notificationManager?.notifyReviewRequest(request)

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -18,6 +18,12 @@ import CrowProvider
 final class IssueTracker {
     private let appState: AppState
     private let providerManager: ProviderManager
+    /// Shared store instance (injected by AppDelegate). PR attributions have
+    /// no `appState` mirror, so they MUST be written through the same
+    /// `JSONStore` that `SessionService` mutates — an ad-hoc `JSONStore()`
+    /// write would be clobbered by the next mutation of the shared
+    /// instance's older in-memory snapshot.
+    private let store: JSONStore
     private var timer: Timer?
     private let pollInterval: TimeInterval = 60 // 1 minute
     private var isRefreshing = false
@@ -211,9 +217,10 @@ final class IssueTracker {
     /// Below this many remaining GraphQL points we proactively skip a cycle.
     private let rateLimitThreshold = 50
 
-    init(appState: AppState, providerManager: ProviderManager) {
+    init(appState: AppState, providerManager: ProviderManager, store: JSONStore = JSONStore()) {
         self.appState = appState
         self.providerManager = providerManager
+        self.store = store
     }
 
     func start() {
@@ -495,6 +502,7 @@ final class IssueTracker {
             let allKnownPRs = Self.dedupedByURL(ghResult.viewerPRs + stalePRs)
 
             applyPRStatuses(viewerPRs: allKnownPRs)
+            updatePRAttributions(viewerPRs: allKnownPRs)
 
             // Review requests (search result) + cross-reference with review sessions
             appState.isLoadingReviews = true
@@ -1796,6 +1804,102 @@ final class IssueTracker {
         return false
     }
 
+    /// Merge freshly parsed trailer UUIDs into the PR's attribution record
+    /// (#693). Returns the record to persist, or nil when no write is
+    /// needed: no trailers and no existing record, or nothing material
+    /// changed since the last capture. `sessionIDs` is a monotonic ordered
+    /// union — IDs observed once are never dropped, even if a rebase removes
+    /// the commit that carried them. All parsed UUIDs are kept, known
+    /// session or not; the auto-merge gate's known-session filter is a
+    /// separate concern (`crowAuthored`). Pure so unit tests can exercise
+    /// the merge without spinning up an `IssueTracker`.
+    nonisolated static func capturedAttribution(
+        existing: PRSessionAttribution?,
+        pr: ViewerPR,
+        parsedSessionIDs: [UUID],
+        now: Date
+    ) -> PRSessionAttribution? {
+        guard var attribution = existing else {
+            guard !parsedSessionIDs.isEmpty else { return nil }
+            var deduped: [UUID] = []
+            for id in parsedSessionIDs where !deduped.contains(id) { deduped.append(id) }
+            return PRSessionAttribution(
+                prURL: pr.url,
+                repoNameWithOwner: pr.repoNameWithOwner,
+                prNumber: pr.number,
+                sessionIDs: deduped,
+                state: pr.state,
+                mergedAt: pr.state == "MERGED" ? now : nil,
+                firstSeenAt: now,
+                updatedAt: now
+            )
+        }
+        for id in parsedSessionIDs where !attribution.sessionIDs.contains(id) {
+            attribution.sessionIDs.append(id)
+        }
+        attribution.state = pr.state
+        if pr.state == "MERGED" && attribution.mergedAt == nil {
+            attribution.mergedAt = now
+        }
+        guard attribution.sessionIDs != existing?.sessionIDs
+            || attribution.state != existing?.state
+            || attribution.mergedAt != existing?.mergedAt else { return nil }
+        attribution.updatedAt = now
+        return attribution
+    }
+
+    /// Refresh the state of already-attributed PRs from a polled PR list
+    /// (#693). Returns only the entries that changed; `mergedAt` is stamped
+    /// once, at the first MERGED observation, and never moved. Never creates
+    /// entries — attribution requires a trailer parse, which happens in
+    /// `recordPRAttribution`. Pure for testability.
+    nonisolated static func attributionStateUpdates(
+        existing: [String: PRSessionAttribution],
+        prs: [ViewerPR],
+        now: Date
+    ) -> [String: PRSessionAttribution] {
+        var updates: [String: PRSessionAttribution] = [:]
+        for pr in prs {
+            guard let updated = capturedAttribution(
+                existing: existing[pr.url], pr: pr, parsedSessionIDs: [], now: now
+            ) else { continue }
+            updates[pr.url] = updated
+        }
+        return updates
+    }
+
+    /// Persist the PR→session mapping parsed from `commitMessages` (#693).
+    /// Called from `prHasCrowAuthoredCommit` so attribution rides along with
+    /// the existing trailer parse; the gate's boolean result is unaffected.
+    func recordPRAttribution(pr: ViewerPR, commitMessages: [String], now: Date = Date()) {
+        let parsed = commitMessages.flatMap(Self.extractCrowSessionUUIDs)
+        let existing = store.data.prAttributions?[pr.url]
+        guard let attribution = Self.capturedAttribution(
+            existing: existing, pr: pr, parsedSessionIDs: parsed, now: now
+        ) else { return }
+        store.mutate { data in
+            var attributions = data.prAttributions ?? [:]
+            attributions[pr.url] = attribution
+            data.prAttributions = attributions
+        }
+    }
+
+    /// Update stored attribution state from a refresh cycle's PR list
+    /// (#693). Once merged, a PR leaves the auto-merge/rebase flow (the
+    /// only place commits are fetched), so state transitions — and the
+    /// observed merge timestamp — are recorded here instead.
+    func updatePRAttributions(viewerPRs: [ViewerPR], now: Date = Date()) {
+        let existing = store.data.prAttributions ?? [:]
+        guard !existing.isEmpty else { return }
+        let updates = Self.attributionStateUpdates(existing: existing, prs: viewerPRs, now: now)
+        guard !updates.isEmpty else { return }
+        store.mutate { data in
+            var attributions = data.prAttributions ?? [:]
+            for (url, attribution) in updates { attributions[url] = attribution }
+            data.prAttributions = attributions
+        }
+    }
+
     /// Per-refresh entry point. Picks candidate (session, PR) pairs and
     /// kicks off the async enable flow once each. No-op when the global
     /// `autoMergeWatcherEnabled` setting is off.
@@ -1926,6 +2030,7 @@ final class IssueTracker {
             return false
         }
         let messages = commits.map(\.message)
+        recordPRAttribution(pr: pr, commitMessages: messages)
         let knownIDs = Set(appState.sessions.map(\.id))
         return Self.crowAuthored(commitMessages: messages, knownSessionIDs: knownIDs)
     }

--- a/Tests/CrowTests/IssueTrackerNeedsRefineTests.swift
+++ b/Tests/CrowTests/IssueTrackerNeedsRefineTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowPersistence
 import CrowProvider
 @testable import Crow
 
@@ -20,6 +21,12 @@ import CrowProvider
 @Suite("IssueTracker stateless needsRefine (CROW-508)")
 @MainActor
 struct IssueTrackerNeedsRefineTests {
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-needs-refine-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
     private let prURL = "https://github.com/foo/bar/pull/123"
     private let shaA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     private let reviewAt = Date(timeIntervalSince1970: 1_700_000_000)
@@ -52,7 +59,7 @@ struct IssueTrackerNeedsRefineTests {
         state.terminalReadiness[terminal.id] = readiness
         state.hookState(for: session.id).activityState = activityState
 
-        let tracker = IssueTracker(appState: state, providerManager: ProviderManager())
+        let tracker = IssueTracker(appState: state, providerManager: ProviderManager(), store: Self.tempStore())
         tracker.respondToChangesRequestedProvider = { respondToChangesRequested }
 
         let captured = TransitionCapture()
@@ -317,7 +324,7 @@ struct IssueTrackerNeedsRefineTests {
         state.terminalReadiness[termA.id] = .agentLaunched
         state.terminalReadiness[termB.id] = .agentLaunched
 
-        let tracker = IssueTracker(appState: state, providerManager: ProviderManager())
+        let tracker = IssueTracker(appState: state, providerManager: ProviderManager(), store: Self.tempStore())
         tracker.respondToChangesRequestedProvider = { true }
         let captured = TransitionCapture()
         tracker.onPRStatusTransitions = { captured.append($0) }

--- a/Tests/CrowTests/IssueTrackerPRAttributionTests.swift
+++ b/Tests/CrowTests/IssueTrackerPRAttributionTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowProvider
+@testable import Crow
+
+/// PR→session attribution persistence (#693, ADR 0008 follow-up 5).
+/// Tests drive `recordPRAttribution` / `updatePRAttributions` directly with
+/// explicit `now:` values, so there is no timing dependence, and read back
+/// through the store / `PRAttributionRepository` to prove durability.
+@MainActor
+@Suite("IssueTracker PR→session attribution store")
+struct IssueTrackerPRAttributionTests {
+
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-pr-attribution-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private func makeTracker(store: JSONStore, appState: AppState = AppState()) -> IssueTracker {
+        IssueTracker(appState: appState, providerManager: ProviderManager(), store: store)
+    }
+
+    private func makePR(
+        url: String = "https://github.com/corveil/crow/pull/42",
+        number: Int = 42,
+        state: String = "OPEN",
+        repo: String = "corveil/crow"
+    ) -> IssueTracker.ViewerPR {
+        IssueTracker.ViewerPR(
+            number: number,
+            url: url,
+            state: state,
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "APPROVED",
+            isDraft: false,
+            headRefName: "feature/x",
+            headRefOid: "abc1234",
+            baseRefName: "main",
+            repoNameWithOwner: repo,
+            labels: [],
+            linkedIssueReferences: [],
+            checksState: "SUCCESS",
+            failedCheckNames: [],
+            latestReviewStates: ["APPROVED"]
+        )
+    }
+
+    private func message(for uuid: UUID) -> String {
+        "feat: thing\n\nCrow-Session: \(uuid.uuidString)\n"
+    }
+
+    private let t0 = Date(timeIntervalSince1970: 1_752_000_000)
+    private let t1 = Date(timeIntervalSince1970: 1_752_000_600)
+
+    // MARK: - Capture (recordPRAttribution)
+
+    @Test func multipleTrailersAcrossCommitsMapToOneEntry() {
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+        let a = UUID()
+        let b = UUID()
+        let pr = makePR()
+
+        tracker.recordPRAttribution(
+            pr: pr,
+            commitMessages: [message(for: a), "fix: no trailer\n", message(for: b), message(for: a)],
+            now: t0)
+
+        let attribution = store.data.prAttributions?[pr.url]
+        #expect(attribution?.sessionIDs == [a, b])   // deduped, first-seen order
+        #expect(attribution?.state == "OPEN")
+        #expect(attribution?.prNumber == pr.number)
+        #expect(attribution?.repoNameWithOwner == pr.repoNameWithOwner)
+        #expect(attribution?.mergedAt == nil)
+        #expect(attribution?.firstSeenAt == t0)
+    }
+
+    @Test func noTrailerCommitsCreateNoEntry() {
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+
+        tracker.recordPRAttribution(
+            pr: makePR(),
+            commitMessages: ["fix: external contribution\n\nCo-Authored-By: Someone\n"],
+            now: t0)
+
+        #expect(store.data.prAttributions?.isEmpty ?? true)
+    }
+
+    @Test func unknownSessionTrailerIsPersistedWhileGateStaysFalse() {
+        // Attribution is ground truth (the session may live on another
+        // machine or have been reaped); the auto-merge gate's known-session
+        // filter is a separate concern and must keep rejecting it.
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+        let unknown = UUID()
+        let pr = makePR()
+        let messages = [message(for: unknown)]
+
+        tracker.recordPRAttribution(pr: pr, commitMessages: messages, now: t0)
+
+        #expect(store.data.prAttributions?[pr.url]?.sessionIDs == [unknown])
+        #expect(!IssueTracker.crowAuthored(commitMessages: messages, knownSessionIDs: [UUID()]))
+    }
+
+    @Test func recaptureMergesNewIDsAndNeverDropsSeenOnes() {
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+        let a = UUID()
+        let b = UUID()
+        let pr = makePR()
+
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: a)], now: t0)
+        // A rebase dropped the commit carrying `a`; a new commit carries `b`.
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: b)], now: t1)
+
+        let attribution = store.data.prAttributions?[pr.url]
+        #expect(attribution?.sessionIDs == [a, b])
+        #expect(attribution?.firstSeenAt == t0)
+        #expect(attribution?.updatedAt == t1)
+    }
+
+    @Test func noChangeRecaptureWritesNothing() {
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+        let a = UUID()
+        let pr = makePR()
+
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: a)], now: t0)
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: a)], now: t1)
+
+        // Nothing material changed, so updatedAt must still be the first write.
+        #expect(store.data.prAttributions?[pr.url]?.updatedAt == t0)
+    }
+
+    // MARK: - State updates (updatePRAttributions)
+
+    @Test func mergeObservationSetsStateAndStampsMergedAtOnce() {
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+        let pr = makePR()
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: UUID())], now: t0)
+
+        tracker.updatePRAttributions(viewerPRs: [makePR(state: "MERGED")], now: t1)
+        var attribution = store.data.prAttributions?[pr.url]
+        #expect(attribution?.state == "MERGED")
+        #expect(attribution?.mergedAt == t1)
+
+        // A later poll observing MERGED again must not move the timestamp.
+        tracker.updatePRAttributions(viewerPRs: [makePR(state: "MERGED")], now: t1.addingTimeInterval(600))
+        attribution = store.data.prAttributions?[pr.url]
+        #expect(attribution?.mergedAt == t1)
+        #expect(attribution?.updatedAt == t1)
+    }
+
+    @Test func closeObservationLeavesMergedAtNil() {
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+        let pr = makePR()
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: UUID())], now: t0)
+
+        tracker.updatePRAttributions(viewerPRs: [makePR(state: "CLOSED")], now: t1)
+
+        let attribution = store.data.prAttributions?[pr.url]
+        #expect(attribution?.state == "CLOSED")
+        #expect(attribution?.mergedAt == nil)
+    }
+
+    @Test func stateUpdatesNeverCreateEntries() {
+        // Attribution requires a trailer parse; a polled PR that was never
+        // captured must not gain an entry from state updates alone.
+        let store = Self.tempStore()
+        let tracker = makeTracker(store: store)
+
+        tracker.updatePRAttributions(viewerPRs: [makePR(state: "MERGED")], now: t0)
+
+        #expect(store.data.prAttributions?.isEmpty ?? true)
+    }
+
+    // MARK: - End-to-end rollup
+
+    @Test func mergedPRIsCountableInWindowRollupAfterRelaunch() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-pr-attribution-\(UUID().uuidString)")
+        let store = JSONStore(directory: dir)
+        let tracker = makeTracker(store: store)
+        let sessionID = UUID()
+        let pr = makePR()
+
+        tracker.recordPRAttribution(pr: pr, commitMessages: [message(for: sessionID)], now: t0)
+        tracker.updatePRAttributions(viewerPRs: [makePR(state: "MERGED")], now: t1)
+
+        // Reload from disk to prove the rollup works across relaunch.
+        let repo = PRAttributionRepository(store: JSONStore(directory: dir))
+        let window = DateInterval(start: t0, end: t1.addingTimeInterval(3_600))
+        #expect(repo.mergedPRCount(for: sessionID, in: window) == 1)
+        #expect(repo.mergedPRCount(for: sessionID, in: DateInterval(start: t1.addingTimeInterval(3_600), duration: 3_600)) == 0)
+    }
+}


### PR DESCRIPTION
Closes #693. ADR 0008 follow-up 5/11 (refs #648, design PR #657). Unblocks PR-based throughput metrics + is a v2 trigger condition; blocks follow-up 6 (rework/merge-rate).

## What

The `Crow-Session:` trailer parse (`IssueTracker.extractCrowSessionUUIDs`) was a discard-after-use auto-merge eligibility gate. This PR retains the mapping durably and adds the rollup the scorecard needs:

- **`PRSessionAttribution`** (CrowCore) — PR url/number/repo, all trailer session UUIDs (deduped, monotonic), state, `mergedAt`, first-seen/updated timestamps.
- **`StoreData.prAttributions`** — optional dict keyed by PR URL, exactly the #690 `analyticsSnapshots` backward-compat pattern; deliberately excluded from the `SessionRepository.delete` cascade so window counts survive the retention reaper.
- **Capture** rides the existing parse in `prHasCrowAuthoredCommit` (reuses `extractCrowSessionUUIDs`, no fork). ALL parsed UUIDs persist, known session or not — attribution is ground truth; the gate's known-session filter is a separate concern and its boolean is unchanged by construction (the `return Self.crowAuthored(...)` line is untouched).
- **State updates** hook the refresh flow right after `applyPRStatuses`: once merged, a PR leaves the gate path, so OPEN→MERGED/CLOSED transitions are recorded there. `mergedAt` is stamped once at first MERGED observation.
- **Read API**: `PRAttributionRepository` with `attribution(prURL:)`, `attributions(for:)`, and `mergedPRCount(for:in:)` — the merged-PR-per-window rollup follow-up 6 consumes.
- **Wiring**: `IssueTracker` now takes the shared `JSONStore`. This is load-bearing — `prAttributions` has no `appState` mirror, so a write through an ad-hoc `JSONStore()` instance would be silently clobbered by the next mutation of the shared instance's older in-memory snapshot.

## Notes / accepted limitations

- **`mergedAt` is Crow-observed** (no backend surfaces the real merge timestamp today; `PRRecord` has no such field). Error is bounded by the poll interval or app downtime — negligible for weekly windows. A future API-sourced value drops in without a schema change; documented on the field.
- **Coverage**: capture fires where commits are already fetched (the auto-merge/rebase flow). Manually merged PRs that never enter that flow aren't attributed — a cheap later extension when follow-up 6 needs fuller merge-rate denominators.
- Pre-existing ad-hoc `JSONStore()` writes in IssueTracker (fields with appState mirrors) were left as-is; possible follow-up cleanup.

## Tests

- `PRAttributionRepositoryTests` (CrowPersistence): relaunch round-trip, legacy-store forward compat, delete-cascade exclusion, window rollup filters (state/window/session), multi-session PR counts for each session.
- `IssueTrackerPRAttributionTests` (CrowTests): multi-trailer → one entry both UUIDs; no-trailer → no entry; unknown-session trailer persisted while `crowAuthored` stays false; monotonic re-capture; no-change re-capture writes nothing; OPEN→MERGED stamps `mergedAt` once; OPEN→CLOSED leaves it nil; state updates never create entries; end-to-end record → merge → `mergedPRCount` across relaunch.
- `IssueTrackerAutoMergeTests` untouched and passing (gate regression).
- `swift build` + `make test`: 335 root tests + all package tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)