### PR TITLE
Persist session wall-clock duration (display-only; activeTimeSeconds stays the penalty clock) (closes #692)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -41,6 +41,17 @@ public struct Session: Identifiable, Codable, Sendable {
     // `false`; the decoder also reads the legacy `pinned` key so sessions locked
     // under CROW-569 stay locked after upgrade.
     public var locked: Bool
+    // Agent wall-clock lifecycle stamps (#692, ADR 0008 follow-up 4), recorded
+    // from `SessionStart`/`SessionEnd` hook arrival. DISPLAY-ONLY context:
+    // telemetry's `SessionAnalytics.activeTimeSeconds` is the authoritative
+    // clock for all penalty normalization — never use `wallClockDuration` as a
+    // grading denominator (an idle-overnight session must not launder its
+    // compactions through an inflated denominator).
+    // First `SessionStart` wins; resume/clear/compact starts don't move the origin.
+    public var agentSessionStartedAt: Date?
+    // Last `SessionEnd` wins; cleared by a new `SessionStart` so a resumed
+    // agent never displays a stale finished duration.
+    public var agentSessionEndedAt: Date?
 
     /// Whether this session is a Manager (orchestration) session. Managers run
     /// Claude Code in the devRoot and are excluded from PR/issue tracking.
@@ -61,6 +72,30 @@ public struct Session: Identifiable, Codable, Sendable {
         return nil
     }
 
+    /// Wall-clock span from first `SessionStart` to last `SessionEnd`, or `nil`
+    /// while the session is open-ended (no end yet, non-Claude agents that never
+    /// send `SessionEnd`, or clock skew putting the end before the start).
+    /// DISPLAY-ONLY per ADR 0008: `SessionAnalytics.activeTimeSeconds` is the
+    /// authoritative clock for penalty normalization, never this.
+    public var wallClockDuration: TimeInterval? {
+        guard let start = agentSessionStartedAt, let end = agentSessionEndedAt,
+              end >= start else { return nil }
+        return end.timeIntervalSince(start)
+    }
+
+    /// Stamp a `SessionStart` hook arrival. The first start is the origin and
+    /// is never moved (SessionStart also fires on resume/clear/compact); any
+    /// stale end is cleared so a running agent reads as open-ended again.
+    public mutating func recordAgentSessionStart(at date: Date = Date()) {
+        if agentSessionStartedAt == nil { agentSessionStartedAt = date }
+        agentSessionEndedAt = nil
+    }
+
+    /// Stamp a `SessionEnd` hook arrival. Latest end wins.
+    public mutating func recordAgentSessionEnd(at date: Date = Date()) {
+        agentSessionEndedAt = date
+    }
+
     public init(
         id: UUID = UUID(),
         name: String,
@@ -77,7 +112,9 @@ public struct Session: Identifiable, Codable, Sendable {
         reviewPromptDispatched: Bool = false,
         lastReviewedHeadSha: String? = nil,
         autoMergeEnabledAt: Date? = nil,
-        locked: Bool = false
+        locked: Bool = false,
+        agentSessionStartedAt: Date? = nil,
+        agentSessionEndedAt: Date? = nil
     ) {
         self.id = id
         self.name = name
@@ -95,6 +132,8 @@ public struct Session: Identifiable, Codable, Sendable {
         self.lastReviewedHeadSha = lastReviewedHeadSha
         self.autoMergeEnabledAt = autoMergeEnabledAt
         self.locked = locked
+        self.agentSessionStartedAt = agentSessionStartedAt
+        self.agentSessionEndedAt = agentSessionEndedAt
     }
 
     /// Parse a GitHub PR URL (`https://github.com/<owner>/<repo>/pull/<number>`)
@@ -131,6 +170,8 @@ public struct Session: Identifiable, Codable, Sendable {
         reviewPromptDispatched = try container.decodeIfPresent(Bool.self, forKey: .reviewPromptDispatched) ?? true
         lastReviewedHeadSha = try container.decodeIfPresent(String.self, forKey: .lastReviewedHeadSha)
         autoMergeEnabledAt = try container.decodeIfPresent(Date.self, forKey: .autoMergeEnabledAt)
+        agentSessionStartedAt = try container.decodeIfPresent(Date.self, forKey: .agentSessionStartedAt)
+        agentSessionEndedAt = try container.decodeIfPresent(Date.self, forKey: .agentSessionEndedAt)
         // CROW-573 renamed `pinned` → `locked`. Prefer the new key, but fall
         // back to the legacy `pinned` key so sessions locked under CROW-569
         // remain locked after upgrade.

--- a/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
@@ -30,18 +30,29 @@ public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
     /// (ADR 0008 follow-up 3 — the scorecard's heaviest-weighted penalty).
     /// `nil` in snapshots persisted before #691; treat as 0.
     public var compactionCount: Int?
+    /// Wall-clock span from first `SessionStart` to last `SessionEnd` hook,
+    /// copied from the session's lifecycle stamps at snapshot time (#692, ADR
+    /// 0008 follow-up 4). DISPLAY-ONLY context: `analytics.activeTimeSeconds`
+    /// is the authoritative clock for all penalty normalization — this must
+    /// never be a grading denominator. `nil` for open-ended sessions (no
+    /// `SessionEnd` — e.g. non-Claude agents never send one) and for snapshots
+    /// persisted before this field existed. Telemetry-off sessions get no
+    /// snapshot at all, so their duration lives only on the `Session` row.
+    public var wallClockDurationSeconds: Double?
 
     public init(
         sessionID: UUID,
         endedAt: Date,
         status: SessionStatus,
         analytics: SessionAnalytics,
-        compactionCount: Int? = nil
+        compactionCount: Int? = nil,
+        wallClockDurationSeconds: Double? = nil
     ) {
         self.sessionID = sessionID
         self.endedAt = endedAt
         self.status = status
         self.analytics = analytics
         self.compactionCount = compactionCount
+        self.wallClockDurationSeconds = wallClockDurationSeconds
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
@@ -66,6 +66,9 @@ import Testing
     #expect(decoded.analytics.inputTokens == 42)
     #expect(decoded.analytics.isEmpty == false)
     #expect(decoded.compactionCount == 3)
+    // #692 landed after some snapshots were persisted: the wall-clock field is
+    // optional and absent keys decode to nil (open-ended, no bogus duration).
+    #expect(decoded.wallClockDurationSeconds == nil)
 }
 
 // #691 (ADR 0008 follow-up 3): the per-session compaction counter.
@@ -132,4 +135,30 @@ import Testing
     let decoded = try decoder.decode(SessionAnalyticsSnapshot.self, from: Data(json.utf8))
     #expect(decoded.compactionCount == nil)
     #expect(decoded.compactionCount ?? 0 == 0)
+}
+
+// #692 (ADR 0008 follow-up 4): the display-only wall-clock scalar rides the
+// snapshot's documented optional-extension point.
+@Test func snapshotWallClockRoundTrip() throws {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(activeTimeSeconds: 300),
+        wallClockDurationSeconds: 28_800
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let decoded = try decoder.decode(
+        SessionAnalyticsSnapshot.self, from: encoder.encode(snapshot))
+    #expect(decoded == snapshot)
+    // Role separation (ADR 0008): wall-clock is display-only context; the
+    // penalty-normalization clock is analytics.activeTimeSeconds. Both persist
+    // independently and an idle-heavy session keeps them far apart.
+    #expect(decoded.wallClockDurationSeconds == 28_800)
+    #expect(decoded.analytics.activeTimeSeconds == 300)
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionWallClockDurationTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionWallClockDurationTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #692 (ADR 0008 follow-up 4): agent wall-clock lifecycle stamps on Session.
+// Wall-clock duration is DISPLAY-ONLY context — SessionAnalytics.activeTimeSeconds
+// is the authoritative clock for penalty normalization, and these tests lock in
+// the boundary semantics that keep the two roles distinct.
+
+private func makeSession() -> Session {
+    Session(name: "wall-clock")
+}
+
+@Test func firstSessionStartWins() {
+    var session = makeSession()
+    let first = Date(timeIntervalSince1970: 1_752_000_000)
+    session.recordAgentSessionStart(at: first)
+    // A resume/clear/compact SessionStart must not move the origin.
+    session.recordAgentSessionStart(at: first.addingTimeInterval(600))
+    #expect(session.agentSessionStartedAt == first)
+}
+
+@Test func sessionStartClearsStaleEnd() {
+    var session = makeSession()
+    let start = Date(timeIntervalSince1970: 1_752_000_000)
+    session.recordAgentSessionStart(at: start)
+    session.recordAgentSessionEnd(at: start.addingTimeInterval(1_200))
+    // The agent resumes: a finished-looking duration would be a lie, so the
+    // session reads as open-ended again until the next SessionEnd.
+    session.recordAgentSessionStart(at: start.addingTimeInterval(7_200))
+    #expect(session.agentSessionEndedAt == nil)
+    #expect(session.wallClockDuration == nil)
+    #expect(session.agentSessionStartedAt == start)
+}
+
+@Test func lastSessionEndWins() {
+    var session = makeSession()
+    let start = Date(timeIntervalSince1970: 1_752_000_000)
+    session.recordAgentSessionStart(at: start)
+    session.recordAgentSessionEnd(at: start.addingTimeInterval(60))
+    session.recordAgentSessionEnd(at: start.addingTimeInterval(3_600))
+    #expect(session.wallClockDuration == 3_600)
+}
+
+@Test func durationNilWithoutEnd() {
+    var session = makeSession()
+    session.recordAgentSessionStart(at: Date(timeIntervalSince1970: 1_752_000_000))
+    // Open-ended: no SessionEnd yet, or an agent (Codex/Cursor/OpenCode) that
+    // never sends one. No fabricated duration.
+    #expect(session.wallClockDuration == nil)
+}
+
+@Test func durationNilWithoutStart() {
+    var session = makeSession()
+    session.recordAgentSessionEnd(at: Date(timeIntervalSince1970: 1_752_000_000))
+    #expect(session.wallClockDuration == nil)
+}
+
+@Test func durationNilWhenEndBeforeStart() {
+    // Host clock skew must not render a negative duration.
+    var session = makeSession()
+    let start = Date(timeIntervalSince1970: 1_752_000_000)
+    session.recordAgentSessionStart(at: start)
+    session.agentSessionEndedAt = start.addingTimeInterval(-30)
+    #expect(session.wallClockDuration == nil)
+}
+
+@Test func wallClockDistinctFromActiveTime() {
+    // The ADR's core split: an idle-overnight session has a huge wall-clock
+    // span but tiny active time. The two must never be conflated — wall-clock
+    // is display-only, activeTimeSeconds is the penalty denominator.
+    var session = makeSession()
+    let start = Date(timeIntervalSince1970: 1_752_000_000)
+    session.recordAgentSessionStart(at: start)
+    session.recordAgentSessionEnd(at: start.addingTimeInterval(28_800)) // 8h wall-clock
+    let analytics = SessionAnalytics(activeTimeSeconds: 300) // 5m active
+    #expect(session.wallClockDuration == 28_800)
+    #expect(analytics.activeTimeSeconds == 300)
+    #expect(session.wallClockDuration != analytics.activeTimeSeconds)
+}
+
+@Test func sessionWallClockJSONRoundTrip() throws {
+    // Whole-second dates: the store's ISO8601 strategy drops sub-second
+    // precision, and this test locks in the same encoder configuration.
+    let start = Date(timeIntervalSince1970: 1_752_000_000)
+    let session = Session(
+        name: "round-trip",
+        agentSessionStartedAt: start,
+        agentSessionEndedAt: start.addingTimeInterval(4_500)
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let decoded = try decoder.decode(Session.self, from: encoder.encode(session))
+    #expect(decoded.agentSessionStartedAt == start)
+    #expect(decoded.agentSessionEndedAt == start.addingTimeInterval(4_500))
+    #expect(decoded.wallClockDuration == 4_500)
+}
+
+@Test func sessionBackwardCompatDecodingWithoutWallClockFields() throws {
+    // Persisted state.json predating #692 has no lifecycle stamps. Decode
+    // must succeed and default both fields to nil (open-ended, no bogus
+    // duration).
+    let id = UUID()
+    let date = Date()
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let dateStr = formatter.string(from: date)
+    let json: [String: Any] = [
+        "id": id.uuidString,
+        "name": "legacy",
+        "status": "active",
+        "kind": "work",
+        "createdAt": dateStr,
+        "updatedAt": dateStr,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let session = try decoder.decode(Session.self, from: data)
+    #expect(session.agentSessionStartedAt == nil)
+    #expect(session.agentSessionEndedAt == nil)
+    #expect(session.wallClockDuration == nil)
+}

--- a/Packages/CrowUI/Sources/CrowUI/SessionAnalyticsStrip.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionAnalyticsStrip.swift
@@ -4,6 +4,10 @@ import CrowCore
 /// Compact horizontal strip of session analytics metrics shown in the session header.
 struct SessionAnalyticsStrip: View {
     let analytics: SessionAnalytics
+    /// Wall-clock span from agent SessionStart to SessionEnd (#692). Display-only
+    /// context beside "Active" — never a grading input. Nil hides the chip
+    /// (open-ended session or agent that never sends SessionEnd).
+    var wallClockDuration: TimeInterval? = nil
 
     var body: some View {
         HStack(spacing: 12) {
@@ -11,6 +15,9 @@ struct SessionAnalyticsStrip: View {
             StatChip(icon: "text.word.spacing", label: "Tokens", value: formatCount(analytics.totalTokens))
             StatChip(icon: "wrench", label: "Tools", value: "\(analytics.toolCallCount)")
             StatChip(icon: "clock", label: "Active", value: formatTime(analytics.activeTimeSeconds))
+            if let wallClockDuration {
+                StatChip(icon: "timer", label: "Duration", value: formatTime(wallClockDuration))
+            }
             if analytics.linesAdded > 0 || analytics.linesRemoved > 0 {
                 StatChip(
                     icon: "chevron.left.forwardslash.chevron.right",

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -233,7 +233,7 @@ public struct SessionDetailView: View {
             // Row 4: Session Analytics (if telemetry data exists)
             if let analytics = appState.hookState(for: session.id).analytics {
                 Divider().overlay(CorveilTheme.borderSubtle).padding(.horizontal, 16)
-                SessionAnalyticsStrip(analytics: analytics)
+                SessionAnalyticsStrip(analytics: analytics, wallClockDuration: session.wallClockDuration)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 6)
             }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1642,6 +1642,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         "provider": s.provider.map { .string($0.rawValue) } ?? .null,
                         "created_at": .string(fmt.string(from: s.createdAt)),
                         "updated_at": .string(fmt.string(from: s.updatedAt)),
+                        // Agent wall-clock lifecycle (#692). Display-only —
+                        // grading normalizes by telemetry's activeTimeSeconds.
+                        "agent_session_started_at": s.agentSessionStartedAt.map { .string(fmt.string(from: $0)) } ?? .null,
+                        "agent_session_ended_at": s.agentSessionEndedAt.map { .string(fmt.string(from: $0)) } ?? .null,
+                        "wall_clock_seconds": s.wallClockDuration.map { .double($0) } ?? .null,
                         "locked": .bool(s.locked),
                         // Legacy alias (CROW-569 named this `pinned`); kept for
                         // one release so existing scripts keep working.
@@ -2230,6 +2235,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         case .set(let date):
                             state.lastTopLevelStopAt = date
                         }
+                    }
+
+                    // Wall-clock lifecycle stamps (#692, ADR 0008 follow-up 4).
+                    // Display-only context — telemetry's activeTimeSeconds
+                    // remains the authoritative penalty-normalization clock.
+                    if eventName == "SessionStart" || eventName == "SessionEnd" {
+                        capturedService.recordAgentLifecycleEvent(
+                            sessionID: sessionID, eventName: eventName)
                     }
 
                     // Trigger notification/sound for this event

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -2362,6 +2362,32 @@ final class SessionService {
         scheduleAnalyticsSnapshot(for: id, status: status)
     }
 
+    /// Stamp agent `SessionStart`/`SessionEnd` wall-clock timestamps on the
+    /// session (#692, ADR 0008 follow-up 4). Display-only context —
+    /// `activeTimeSeconds` from telemetry stays the penalty-normalization
+    /// clock. Like `setLocked`, deliberately leaves `updatedAt` untouched so
+    /// the retention clock is unaffected. These events are rare (agent
+    /// launch/exit), so the unconditional store write is cheap.
+    func recordAgentLifecycleEvent(sessionID: UUID, eventName: String, at date: Date = Date()) {
+        guard eventName == "SessionStart" || eventName == "SessionEnd" else { return }
+
+        func apply(_ session: inout Session) {
+            if eventName == "SessionStart" {
+                session.recordAgentSessionStart(at: date)
+            } else {
+                session.recordAgentSessionEnd(at: date)
+            }
+        }
+        if let idx = appState.sessions.firstIndex(where: { $0.id == sessionID }) {
+            apply(&appState.sessions[idx])
+        }
+        store.mutate { data in
+            if let idx = data.sessions.firstIndex(where: { $0.id == sessionID }) {
+                apply(&data.sessions[idx])
+            }
+        }
+    }
+
     // MARK: - Analytics Snapshot (#690, ADR 0008)
 
     /// Fire-and-forget trigger for the end-of-session analytics snapshot.
@@ -2395,7 +2421,9 @@ final class SessionService {
         // from the DB provider (#691).
         let snapshot = SessionAnalyticsSnapshot(
             sessionID: id, endedAt: Date(), status: status, analytics: analytics,
-            compactionCount: appState.existingHookState(for: id)?.compactionCount ?? 0)
+            compactionCount: appState.existingHookState(for: id)?.compactionCount ?? 0,
+            wallClockDurationSeconds: appState.sessions
+                .first(where: { $0.id == id })?.wallClockDuration)
         store.mutate { data in
             var snapshots = data.analyticsSnapshots ?? [:]
             snapshots[id.uuidString] = snapshot
@@ -2464,7 +2492,8 @@ final class SessionService {
                     sessionID: session.id, endedAt: session.updatedAt,
                     status: session.status, analytics: analytics,
                     compactionCount: appState.existingHookState(for: session.id)?
-                        .compactionCount ?? 0)
+                        .compactionCount ?? 0,
+                    wallClockDurationSeconds: session.wallClockDuration)
                 data.analyticsSnapshots = snapshots
             }
         }

--- a/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
+++ b/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
@@ -268,4 +268,106 @@ struct SessionServiceAnalyticsSnapshotTests {
         // Non-terminal sessions never snapshot.
         #expect(snapshots?[stillActive.id.uuidString] == nil)
     }
+
+    // MARK: - Wall-clock duration (#692, ADR 0008 follow-up 4)
+
+    // The ADR's role separation: wall-clock duration is display-only context;
+    // analytics.activeTimeSeconds is the authoritative penalty-normalization
+    // clock. An idle-overnight session (8h wall-clock, 20m active) persists
+    // both values distinctly — neither substitutes for the other.
+    @Test
+    func snapshotCarriesWallClockDistinctFromActiveTime() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+        appState.sessions = [Session(
+            id: id, name: "idle-overnight",
+            agentSessionStartedAt: start,
+            agentSessionEndedAt: start.addingTimeInterval(28_800))]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let snapshot = store.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot?.wallClockDurationSeconds == 28_800)
+        #expect(snapshot?.analytics.activeTimeSeconds == Self.sampleAnalytics.activeTimeSeconds)
+        #expect(snapshot?.wallClockDurationSeconds != snapshot?.analytics.activeTimeSeconds)
+    }
+
+    // A session that never saw a SessionEnd (non-Claude agents don't send one;
+    // or the agent was killed) still snapshots its analytics — with a nil
+    // wall-clock, never a fabricated one.
+    @Test
+    func openEndedSessionSnapshotsNilWallClock() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(
+            id: id, name: "open-ended",
+            agentSessionStartedAt: Date(timeIntervalSince1970: 1_752_000_000))]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let snapshot = store.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot != nil)
+        #expect(snapshot?.wallClockDurationSeconds == nil)
+    }
+
+    // The quit-race backfill path carries the duration too.
+    @Test
+    func persistStateBackfillCarriesWallClock() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+        var ended = Session(
+            id: UUID(), name: "ended-then-quit",
+            agentSessionStartedAt: start,
+            agentSessionEndedAt: start.addingTimeInterval(4_500))
+        ended.status = .completed
+        appState.sessions = [ended]
+        appState.hookState(for: ended.id).analytics = Self.sampleAnalytics
+
+        let service = SessionService(store: store, appState: appState)
+        service.persistState()
+
+        #expect(store.data.analyticsSnapshots?[ended.id.uuidString]?
+            .wallClockDurationSeconds == 4_500)
+    }
+
+    // Both the session's lifecycle stamps and the snapshot's duration copy
+    // must read back after a simulated relaunch.
+    @Test
+    func wallClockSurvivesSimulatedRelaunch() async {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-wallclock-relaunch-\(UUID().uuidString)")
+        let appState = AppState()
+        let id = UUID()
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+        let session = Session(
+            id: id, name: "durable-duration",
+            agentSessionStartedAt: start,
+            agentSessionEndedAt: start.addingTimeInterval(3_600))
+        appState.sessions = [session]
+        let store = JSONStore(directory: dir)
+        store.mutate { $0.sessions = [session] }
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let reloaded = JSONStore(directory: dir)
+        let restored = reloaded.data.sessions.first(where: { $0.id == id })
+        #expect(restored?.agentSessionStartedAt == start)
+        #expect(restored?.agentSessionEndedAt == start.addingTimeInterval(3_600))
+        #expect(restored?.wallClockDuration == 3_600)
+        #expect(reloaded.data.analyticsSnapshots?[id.uuidString]?
+            .wallClockDurationSeconds == 3_600)
+    }
 }

--- a/Tests/CrowTests/SessionServiceLifecycleEventTests.swift
+++ b/Tests/CrowTests/SessionServiceLifecycleEventTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+@testable import Crow
+
+/// Agent lifecycle stamping (#692, ADR 0008 follow-up 4): the hook-event
+/// handler routes `SessionStart`/`SessionEnd` to
+/// `SessionService.recordAgentLifecycleEvent`, which stamps wall-clock
+/// timestamps on the Session in memory and in the store. Display-only —
+/// telemetry's activeTimeSeconds stays the penalty-normalization clock.
+@MainActor
+@Suite("SessionService lifecycle events")
+struct SessionServiceLifecycleEventTests {
+
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-lifecycle-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private static func makeFixture() -> (JSONStore, AppState, SessionService, UUID) {
+        let store = tempStore()
+        let appState = AppState()
+        let session = Session(name: "lifecycle")
+        appState.sessions = [session]
+        store.mutate { $0.sessions = [session] }
+        let service = SessionService(store: store, appState: appState)
+        return (store, appState, service, session.id)
+    }
+
+    @Test
+    func sessionStartStampsMemoryAndStoreWithoutTouchingUpdatedAt() {
+        let (store, appState, service, id) = Self.makeFixture()
+        let updatedAtBefore = appState.sessions[0].updatedAt
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+
+        service.recordAgentLifecycleEvent(sessionID: id, eventName: "SessionStart", at: start)
+
+        #expect(appState.sessions[0].agentSessionStartedAt == start)
+        #expect(store.data.sessions[0].agentSessionStartedAt == start)
+        // The retention reaper keys off updatedAt — lifecycle stamps must not
+        // extend a session's retention (same contract as setLocked).
+        #expect(appState.sessions[0].updatedAt == updatedAtBefore)
+        #expect(store.data.sessions[0].updatedAt == updatedAtBefore)
+    }
+
+    @Test
+    func startThenEndYieldsDurationPersistedInStore() {
+        let (store, appState, service, id) = Self.makeFixture()
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+
+        service.recordAgentLifecycleEvent(sessionID: id, eventName: "SessionStart", at: start)
+        service.recordAgentLifecycleEvent(
+            sessionID: id, eventName: "SessionEnd", at: start.addingTimeInterval(1_800))
+
+        #expect(appState.sessions[0].wallClockDuration == 1_800)
+        #expect(store.data.sessions[0].wallClockDuration == 1_800)
+    }
+
+    // SessionStart also fires on resume/clear/compact: the origin must not
+    // move, but a stale end is cleared so the resumed session reads as
+    // open-ended until the next SessionEnd.
+    @Test
+    func resumeStartKeepsOriginAndClearsEnd() {
+        let (store, appState, service, id) = Self.makeFixture()
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+
+        service.recordAgentLifecycleEvent(sessionID: id, eventName: "SessionStart", at: start)
+        service.recordAgentLifecycleEvent(
+            sessionID: id, eventName: "SessionEnd", at: start.addingTimeInterval(1_200))
+        service.recordAgentLifecycleEvent(
+            sessionID: id, eventName: "SessionStart", at: start.addingTimeInterval(7_200))
+
+        for session in [appState.sessions[0], store.data.sessions[0]] {
+            #expect(session.agentSessionStartedAt == start)
+            #expect(session.agentSessionEndedAt == nil)
+            #expect(session.wallClockDuration == nil)
+        }
+    }
+
+    @Test
+    func secondEndOverwritesFirst() {
+        let (_, appState, service, id) = Self.makeFixture()
+        let start = Date(timeIntervalSince1970: 1_752_000_000)
+
+        service.recordAgentLifecycleEvent(sessionID: id, eventName: "SessionStart", at: start)
+        service.recordAgentLifecycleEvent(
+            sessionID: id, eventName: "SessionEnd", at: start.addingTimeInterval(60))
+        service.recordAgentLifecycleEvent(
+            sessionID: id, eventName: "SessionEnd", at: start.addingTimeInterval(3_600))
+
+        #expect(appState.sessions[0].wallClockDuration == 3_600)
+    }
+
+    // A session missing its end hook stays open-ended: no bogus duration.
+    @Test
+    func missingEndHookLeavesDurationNil() {
+        let (store, appState, service, id) = Self.makeFixture()
+
+        service.recordAgentLifecycleEvent(
+            sessionID: id, eventName: "SessionStart",
+            at: Date(timeIntervalSince1970: 1_752_000_000))
+
+        #expect(appState.sessions[0].wallClockDuration == nil)
+        #expect(store.data.sessions[0].wallClockDuration == nil)
+    }
+
+    @Test
+    func nonLifecycleEventsAndUnknownSessionsAreNoOps() {
+        let (store, appState, service, id) = Self.makeFixture()
+
+        service.recordAgentLifecycleEvent(sessionID: id, eventName: "PostToolUse")
+        service.recordAgentLifecycleEvent(sessionID: id, eventName: "Stop")
+        service.recordAgentLifecycleEvent(sessionID: UUID(), eventName: "SessionStart")
+
+        #expect(appState.sessions[0].agentSessionStartedAt == nil)
+        #expect(appState.sessions[0].agentSessionEndedAt == nil)
+        #expect(store.data.sessions[0].agentSessionStartedAt == nil)
+    }
+}


### PR DESCRIPTION
Closes #692. ADR 0008 follow-up 4/11 (refs #648, design PR #657). **v1-blocking.**

## Where duration is persisted

**Home: the `Session` model** (the ADR-literal, lower-collision path) — `agentSessionStartedAt` / `agentSessionEndedAt` are stamped on `SessionStart`/`SessionEnd` hook arrival (the payload carries no timestamp, so the app stamps `Date()` on receipt) and persisted immediately via the store, so they survive relaunch. `wallClockDuration` is a computed span from first start to last end.

**Plus** a `wallClockDurationSeconds: Double?` scalar copied onto the #690 `SessionAnalyticsSnapshot` at write time (both the terminal-status write and the quit-race backfill), following the snapshot's documented optional-extension point, so the display context survives the retention reaper alongside the rest of the scorecard data.

## Wall-clock is display-only

Per the ADR: telemetry's `activeTimeSeconds` (already durably persisted inside the snapshot since #690) remains the **sole penalty-normalization clock**. No grading path exists yet, so the role split is enforced by:
- doc comments on every new field/property stating "display-only, never a penalty denominator";
- `snapshotCarriesWallClockDistinctFromActiveTime` — an idle-overnight session (8h wall-clock, 20m active) persists both values independently and unequal, so wall-clock can't launder compactions.

## Semantics / edge cases

- **First `SessionStart` wins** — resume/clear/compact starts don't move the origin.
- **Last `SessionEnd` wins**; a new `SessionStart` clears a stale end so a resumed agent reads as open-ended rather than showing a finished-looking duration.
- **Missing end hook** (non-Claude agents never send `SessionEnd`; kill -9): duration stays nil — nothing fabricated from `updatedAt`.
- **`end < start`** (clock skew): nil, never negative.
- Lifecycle stamps deliberately **don't bump `updatedAt`** (retention-reaper clock; same contract as `setLocked`).
- Legacy `store.json` without the new keys decodes to nils (locked in by tests).

Also exposed via `get-session` RPC (`agent_session_started_at` / `agent_session_ended_at` / `wall_clock_seconds`, CLI picks them up via passthrough) and a "Duration" chip beside "Active" in the session analytics strip, making the wall-clock-vs-active-time contrast visible.

## Coordination

Shares the `SessionAnalyticsSnapshot` optional-extension surface with **#691** (compaction counter, not yet started) — both add an optional field per the snapshot's documented pattern, so merge order doesn't matter (trivial at worst). Distinct from #693. Branch is based on latest `main` including #690 (`cc027a7`) and #689.

## Tests

20 new tests: model semantics + Codable round-trip + legacy-decode compat (`SessionWallClockDurationTests`, CrowCore), snapshot round-trip/forward-compat extensions, service-level distinctness / open-ended / backfill / simulated-relaunch (`SessionServiceAnalyticsSnapshotTests`), and lifecycle stamping incl. `updatedAt` untouched and no-op guards (`SessionServiceLifecycleEventTests`).

`make build` + `make test`: all packages green except two **pre-existing** `CrowGit` `RebaseTests` failures ("Committer identity unknown" — environmental, package untouched by this PR and identical to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)