### PR TITLE
Label-based ticket status fallback (crow:in-review) for issues not on a GitHub Project (closes #706)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -94,6 +94,12 @@ public enum TicketStatus: String, Codable, Sendable, CaseIterable {
     /// The pipeline stages shown in the UI (including Done).
     public static let pipelineStatuses: [TicketStatus] = [.backlog, .ready, .inProgress, .inReview, .done]
 
+    /// Fallback status label applied to issues that aren't on a Project board
+    /// (#706). Presence of this label ⇒ the ticket is In Review; the
+    /// Projects-v2 Status field stays authoritative whenever the issue IS on
+    /// a board, and the label is ignored there.
+    public static let inReviewFallbackLabel = "crow:in-review"
+
     /// Initialize from a GitHub/GitLab project board status name (case-insensitive).
     public init(projectBoardName name: String) {
         switch name.lowercased().trimmingCharacters(in: .whitespaces) {

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -156,12 +156,22 @@ public struct GitHubTaskBackend: TaskBackend {
         }
 
         guard let resolved = Self.resolveProjectFieldOption(queryOut, target: status) else {
-            // No project board attached to the issue, OR no matching option
-            // for the requested status. Treat as unimplemented so callers can
-            // distinguish "feature genuinely not available here" from "shell
-            // failed".
+            if !Self.hasProjectItems(queryOut) {
+                // No project board attached to the issue: represent pipeline
+                // status with the `crow:in-review` fallback label instead
+                // (#706). The label only encodes In Review — any other target
+                // status just clears it (Done is signaled by closing the
+                // issue; In Progress by the active session).
+                try await setInReviewFallbackLabel(
+                    url: url, repo: "\(parsed.org)/\(parsed.repo)", applied: status == .inReview
+                )
+                return
+            }
+            // On a project, but no matching option for the requested status.
+            // Treat as unimplemented so callers can distinguish "feature
+            // genuinely not available here" from "shell failed".
             throw ProviderError.unimplemented(
-                "GitHubTaskBackend.setTaskStatus: issue has no project board or no '\(status.rawValue)' status option"
+                "GitHubTaskBackend.setTaskStatus: issue has no '\(status.rawValue)' status option"
             )
         }
 
@@ -275,6 +285,55 @@ public struct GitHubTaskBackend: TaskBackend {
             return .insufficientScope("read:project")
         }
         return .commandFailed(stderr)
+    }
+
+    /// Apply or clear the `crow:in-review` fallback label on an issue that has
+    /// no project board (#706).
+    private func setInReviewFallbackLabel(url: String, repo: String, applied: Bool) async throws {
+        let label = TicketStatus.inReviewFallbackLabel
+        if applied {
+            try await ensureInReviewLabel(repo: repo)
+            try await setLabels(url: url, add: [label], remove: [])
+        } else {
+            do {
+                try await setLabels(url: url, add: [], remove: [label])
+            } catch ShellRunnerError.nonZeroExit(_, let output)
+                where output.localizedCaseInsensitiveContains("not found") {
+                // Label doesn't exist in the repo (never entered review here);
+                // removal is best-effort.
+            }
+        }
+    }
+
+    /// Ensure the `crow:in-review` fallback label exists in `repo`, mirroring
+    /// `GitHubCodeBackend.ensureMergeLabel`.
+    private func ensureInReviewLabel(repo: String) async throws {
+        do {
+            _ = try await shellRunner.run(
+                "gh", "label", "create", TicketStatus.inReviewFallbackLabel,
+                "--repo", repo,
+                "--color", "FBCA04",
+                "--description", "Crow: in review (no-project status fallback)"
+            )
+        } catch ShellRunnerError.nonZeroExit(_, let output) where output.localizedCaseInsensitiveContains("already exists") {
+            return
+        }
+    }
+
+    /// Whether the project-item lookup response shows the issue on at least
+    /// one Project board. Distinguishes "no board at all" (→ label fallback)
+    /// from "on a board but no matching Status option" (→ unimplemented).
+    static func hasProjectItems(_ output: String) -> Bool {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any],
+              let repo = dataObj["repository"] as? [String: Any],
+              let issue = repo["issue"] as? [String: Any],
+              let projectItems = issue["projectItems"] as? [String: Any],
+              let nodes = projectItems["nodes"] as? [[String: Any]] else {
+            return false
+        }
+        return !nodes.isEmpty
     }
 
     /// Walk the project-item lookup response and find the (itemID, projectID,
@@ -539,6 +598,13 @@ public struct GitHubTaskBackend: TaskBackend {
                         break
                     }
                 }
+            }
+            // Label fallback (#706): when the board yields no status (issue
+            // not on any project), the `crow:in-review` label carries the
+            // In Review state. A board status, when present, wins above.
+            if projectStatusOverride == nil, projectStatus == .unknown,
+               labels.contains(where: { $0.name == TicketStatus.inReviewFallbackLabel }) {
+                projectStatus = .inReview
             }
             return AssignedIssue(
                 id: "github:\(repoName)#\(number)",

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -120,6 +120,46 @@ final class BackendsTests: XCTestCase {
         XCTAssertTrue(fake.calls.first?.args.contains("graphql") ?? false)
     }
 
+    func testGitHubTaskBackendParsesInReviewLabelFallback() async throws {
+        let fake = FakeShellRunner()
+        // Open issues: #1 has no project item but carries the fallback label →
+        // .inReview; #2 is on a board AND carries the label → the board wins;
+        // #3 has neither → .unknown. Closed #4 carries the label → .done (the
+        // closed override wins).
+        let json = """
+        {"data":{
+          "openIssues":{"nodes":[
+            {"number":1,"title":"Labelled","url":"https://github.com/a/b/issues/1","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"crow:in-review","color":"FBCA04"}]},
+             "projectItems":{"nodes":[]}},
+            {"number":2,"title":"On board","url":"https://github.com/a/b/issues/2","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"crow:in-review","color":"FBCA04"}]},
+             "projectItems":{"nodes":[{"fieldValueByName":{"name":"In Progress"}}]}},
+            {"number":3,"title":"Plain","url":"https://github.com/a/b/issues/3","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"bug","color":"red"}]},
+             "projectItems":{"nodes":[]}}
+          ]},
+          "closedIssues":{"issueCount":1,"nodes":[
+            {"number":4,"title":"Closed","url":"https://github.com/a/b/issues/4","state":"closed",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"crow:in-review","color":"FBCA04"}]}}
+          ]},
+          "rateLimit":{"remaining":4999,"limit":5000,"resetAt":"2026-01-01T00:00:00Z","cost":1}
+        }}
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.open.count, 3)
+        XCTAssertEqual(listing.open[0].projectStatus, .inReview)
+        XCTAssertEqual(listing.open[1].projectStatus, .inProgress)
+        XCTAssertEqual(listing.open[2].projectStatus, .unknown)
+        XCTAssertEqual(listing.closed[0].projectStatus, .done)
+    }
+
     func testGitHubTaskBackendClosedTotalFallsBackToNodeCount() async throws {
         let fake = FakeShellRunner()
         // No issueCount in the response — closedTotalCount falls back to the
@@ -271,8 +311,20 @@ final class BackendsTests: XCTestCase {
 
     func testGitHubTaskBackendSetTaskStatusThrowsWhenOptionMissing() async {
         let fake = FakeShellRunner()
-        // No matching option.
-        fake.responses = [.success(#"{"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}"#)]
+        // On a project board, but no option matching the target status — this
+        // stays an unimplemented throw (the label fallback is only for issues
+        // on no board at all).
+        let lookup = """
+        {"data":{"repository":{"issue":{"projectItems":{"nodes":[
+          {"id":"ITEM_1","project":{"id":"PROJ_1"},
+           "fieldValueByName":{"name":"Backlog",
+             "field":{"id":"FIELD_1","options":[
+               {"id":"OPT_BACKLOG","name":"Backlog"},
+               {"id":"OPT_DONE","name":"Done"}
+             ]}}}
+        ]}}}}}
+        """
+        fake.responses = [.success(lookup)]
         let backend = GitHubTaskBackend(shellRunner: fake)
         do {
             try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
@@ -282,6 +334,8 @@ final class BackendsTests: XCTestCase {
         } catch {
             XCTFail("unexpected error \(error)")
         }
+        // No label churn on the on-project path.
+        XCTAssertEqual(fake.calls.count, 1)
     }
 
     func testGitHubTaskBackendSetTaskStatusMatchesBareReviewAlias() async throws {
@@ -304,6 +358,65 @@ final class BackendsTests: XCTestCase {
         try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
         XCTAssertEqual(fake.calls.count, 2)
         XCTAssertTrue(fake.calls[1].args.contains("optionId=OPT_REVIEW"))
+    }
+
+    // No project board at all → the `crow:in-review` label carries the status
+    // instead of a Projects-v2 field (#706).
+    private static let noProjectLookup = #"{"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}"#
+
+    func testGitHubTaskBackendSetTaskStatusFallsBackToLabelWhenNoProject() async throws {
+        let fake = FakeShellRunner()
+        // Lookup (no project items) → label create → issue edit.
+        fake.responses = [.success(Self.noProjectLookup), .success(""), .success("")]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
+        XCTAssertEqual(fake.calls.count, 3)
+        let createArgs = fake.calls[1].args
+        XCTAssertEqual(Array(createArgs.prefix(4)), ["gh", "label", "create", "crow:in-review"])
+        XCTAssertTrue(createArgs.contains("a/b"))
+        let editArgs = fake.calls[2].args
+        XCTAssertTrue(editArgs.contains("--add-label"))
+        XCTAssertTrue(editArgs.contains("crow:in-review"))
+        XCTAssertFalse(editArgs.contains("--remove-label"))
+    }
+
+    func testGitHubTaskBackendSetTaskStatusFallbackToleratesExistingLabel() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [
+            .success(Self.noProjectLookup),
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "label 'crow:in-review' already exists")),
+            .success("")
+        ]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
+        XCTAssertEqual(fake.calls.count, 3)
+        XCTAssertTrue(fake.calls[2].args.contains("--add-label"))
+        XCTAssertTrue(fake.calls[2].args.contains("crow:in-review"))
+    }
+
+    func testGitHubTaskBackendSetTaskStatusFallbackRemovesLabelWhenLeavingReview() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(Self.noProjectLookup), .success("")]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inProgress)
+        // No label create on the way out — just the removal edit.
+        XCTAssertEqual(fake.calls.count, 2)
+        let editArgs = fake.calls[1].args
+        XCTAssertTrue(editArgs.contains("--remove-label"))
+        XCTAssertTrue(editArgs.contains("crow:in-review"))
+        XCTAssertFalse(editArgs.contains("--add-label"))
+    }
+
+    func testGitHubTaskBackendSetTaskStatusFallbackSwallowsMissingLabelOnRemove() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [
+            .success(Self.noProjectLookup),
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "'crow:in-review' not found"))
+        ]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        // Removal is best-effort: a repo that never entered review has no label.
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .done)
+        XCTAssertEqual(fake.calls.count, 2)
     }
 
     func testGitHubTaskBackendAssignInvokesGhIssueEdit() async throws {

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -2621,6 +2621,14 @@ final class IssueTracker {
             appState.assignedIssues[idx].projectStatus = .done
         }
 
+        // Cosmetic cleanup (#706): a closed issue reads as Done regardless, so
+        // drop a lingering no-project `crow:in-review` fallback label. Gated on
+        // the in-memory labels to avoid a gratuitous API call; best-effort.
+        if let issue = appState.assignedIssues.first(where: { $0.url == ticketURL }),
+           issue.labels.contains(where: { $0.name == TicketStatus.inReviewFallbackLabel }) {
+            try? await backend.setLabels(url: ticketURL, add: [], remove: [TicketStatus.inReviewFallbackLabel])
+        }
+
         print("[IssueTracker] Marked issue done: \(ticketURL)")
 
         // Flip the Crow session to .completed so the row reflects the closed issue.


### PR DESCRIPTION
Closes #706

When a GitHub issue isn't on a Projects-v2 board, Crow's pipeline status was a no-op (`setTaskStatus` threw `unimplemented`, the read path left `projectStatus == .unknown`). This adds a label fallback so the In-Review flow works with no Project board — e.g. on this very repo.

## Decisions (as delegated by the ticket)

- **Label name:** `crow:in-review`, following the existing `crow:auto` / `crow:merge` convention. Single documented constant: `TicketStatus.inReviewFallbackLabel` (CrowCore `Enums.swift`).
- **On-project behavior:** unchanged and authoritative. The label fallback is only used when the issue has **no project item**; when a board status exists it wins on read, the Projects-v2 mutation is used on write, and the label is **ignored** (not synced) — no label churn on the board path. "On a board but no matching Status option" still throws `unimplemented` as before.
- **setup.sh:** untouched — the no-project branch stays a clean skip for the session-start → In Progress transition (In Progress without a board is low value; the active session already implies it). No `crow:in-progress` in v1; the app owns the In-Review label transition on review kickoff.

## Changes

- **Write** (`GitHubTaskBackend.setTaskStatus`): when the project-item lookup shows no board at all, → In Review ensures the label exists (`gh label create`, mirroring `ensureMergeLabel`, tolerating "already exists") and adds it; any other target status removes it (best-effort — "not found" swallowed). Because this lives in the backend, `markInReview`, `transitionTicket`, and the `transition-ticket` CLI all get the fallback for free.
- **Read** (`GitHubTaskBackend.parseIssueNodes`): when the board yields no status, `crow:in-review` in the (already-fetched) labels ⇒ `projectStatus = .inReview`; closed issues keep the `.done` override. All downstream UI (In-Review board section, badges, `syncInReviewSessions` reconcile, session↔ticket linkage) keys off `projectStatus`, so it lights up with zero downstream changes.
- **Done cleanup** (`IssueTracker.markIssueDone`): after closing, drops a lingering fallback label (gated on in-memory labels; cosmetic — closed reads as Done regardless).

## Tests

New `BackendsTests` coverage: no-project + label parses `.inReview`; board status wins over the label; closed + label parses `.done`; fallback → In Review runs `gh label create` + `--add-label` (incl. "already exists" tolerance); leaving review runs `--remove-label` (incl. "not found" tolerance); on-project-but-option-missing still throws with no label calls.

`swift build` + `make test` green, except pre-existing `CrowGit/RebaseTests` failures on this machine (no global git identity — "Committer identity unknown"; fails on any branch, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)