### PR TITLE
Alignment/KPI mapping: Jira priority + epic-parent, org-goal tagging, alignment weight (closes #696)

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/MetadataCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/MetadataCommands.swift
@@ -4,21 +4,23 @@ import Foundation
 
 // MARK: - Metadata Commands
 
-/// Set ticket metadata (URL, title, number) for a session.
+/// Set ticket metadata (URL, title, number, priority) for a session.
 ///
-/// At least one of `--url`, `--title`, or `--number` must be provided.
+/// At least one of `--url`, `--title`, `--number`, or `--priority` must be provided.
 public struct SetTicket: ParsableCommand {
     public static let configuration = CommandConfiguration(commandName: "set-ticket", abstract: "Set ticket metadata")
     @Option(name: .long, help: "Session UUID") var session: String
     @Option(name: .long, help: "Ticket URL") var url: String?
     @Option(name: .long, help: "Ticket title") var title: String?
     @Option(name: .long, help: "Ticket number") var number: Int?
+    @Option(name: .long, help: "Ticket priority: highest, high, medium, low, or lowest") var priority: String?
 
     public init() {}
 
     public func validate() throws {
         try validateUUID(session, label: "session UUID")
-        try validateSetTicketHasField(url: url, title: title, number: number)
+        try validateSetTicketHasField(url: url, title: title, number: number, priority: priority)
+        if let priority { try validateTicketPriority(priority) }
     }
 
     public func run() throws {
@@ -26,7 +28,35 @@ public struct SetTicket: ParsableCommand {
         if let url { params["url"] = .string(url) }
         if let title { params["title"] = .string(title) }
         if let number { params["number"] = .int(number) }
+        if let priority { params["priority"] = .string(priority) }
         let result = try rpc("set-ticket", params: params)
+        printJSON(result)
+    }
+}
+
+/// Set or clear the org-goal tag on a session (#696, ADR 0008 follow-up 8).
+///
+/// The tag marks which org goal/KPI the session's work ladders up to; it feeds
+/// the session's alignment weight. Exactly one of `--goal` or `--clear` is
+/// required.
+public struct SetGoal: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "set-goal", abstract: "Set or clear the org-goal tag on a session")
+    @Option(name: .long, help: "Session UUID") var session: String
+    @Option(name: .long, help: "Org goal/KPI this session's work ladders up to") var goal: String?
+    @Flag(name: .long, help: "Clear the org-goal tag") var clear: Bool = false
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(session, label: "session UUID")
+        try validateSetGoal(goal: goal, clear: clear)
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["session_id": .string(session)]
+        if let goal { params["goal"] = .string(goal) }
+        if clear { params["clear"] = .bool(true) }
+        let result = try rpc("set-goal", params: params)
         printJSON(result)
     }
 }

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -21,6 +21,7 @@ public struct CrowCommand: ParsableCommand {
             SetPinned.self,
             DeleteSession.self,
             SetTicket.self,
+            SetGoal.self,
             Job.self,
             AddWorktree.self,
             ListWorktrees.self,

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -60,9 +60,43 @@ func validateJobName(_ value: String) throws {
 
 /// Validate that at least one optional field is provided for set-ticket.
 ///
-/// - Throws: `ValidationError` if all three fields are nil.
-func validateSetTicketHasField(url: String?, title: String?, number: Int?) throws {
-    guard url != nil || title != nil || number != nil else {
-        throw ValidationError("At least one of --url, --title, or --number is required.")
+/// - Throws: `ValidationError` if all four fields are nil.
+func validateSetTicketHasField(url: String?, title: String?, number: Int?, priority: String? = nil) throws {
+    guard url != nil || title != nil || number != nil || priority != nil else {
+        throw ValidationError("At least one of --url, --title, --number, or --priority is required.")
+    }
+}
+
+/// Valid ticket priority values accepted by `set-ticket --priority` (#696).
+/// Matches CrowCore's `TicketPriority` ladder minus `unknown` (clearing back
+/// to unknown isn't a CLI operation).
+let validTicketPriorities = ["highest", "high", "medium", "low", "lowest"]
+
+/// Validate that a string is a recognized ticket priority, case-insensitively.
+///
+/// - Throws: `ValidationError` if not one of: highest, high, medium, low, lowest.
+func validateTicketPriority(_ value: String) throws {
+    guard validTicketPriorities.contains(value.lowercased()) else {
+        throw ValidationError("'\(value)' is not a valid priority. Expected one of: \(validTicketPriorities.joined(separator: ", "))")
+    }
+}
+
+/// Validate the set-goal argument shape: exactly one of `--goal`/`--clear`,
+/// and a provided goal must not be blank (a whitespace goal would silently
+/// fail to earn the on-goal alignment multiplier).
+///
+/// - Throws: `ValidationError` on both, neither, or a blank goal.
+func validateSetGoal(goal: String?, clear: Bool) throws {
+    switch (goal, clear) {
+    case (.some, true):
+        throw ValidationError("--goal and --clear are mutually exclusive.")
+    case (nil, false):
+        throw ValidationError("Exactly one of --goal or --clear is required.")
+    case (.some(let goal), false):
+        guard !goal.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw ValidationError("--goal must not be blank.")
+        }
+    case (nil, true):
+        break
     }
 }

--- a/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
@@ -75,6 +75,58 @@ private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     #expect(cmd.type == "custom")
 }
 
+// MARK: - set-ticket --priority + set-goal (#696)
+
+@Test func setTicketParsesPriority() throws {
+    let cmd = try SetTicket.parse(["--session", validUUID, "--priority", "high"])
+    #expect(cmd.session == validUUID)
+    try cmd.validate() // --priority alone satisfies the has-field rule
+}
+
+@Test func setTicketAcceptsCaseInsensitivePriority() throws {
+    let cmd = try SetTicket.parse(["--session", validUUID, "--priority", "Highest"])
+    try cmd.validate()
+}
+
+@Test func setTicketRejectsBogusPriority() {
+    #expect(throws: (any Error).self) {
+        let cmd = try SetTicket.parse(["--session", validUUID, "--priority", "urgent"])
+        try cmd.validate()
+    }
+}
+
+@Test func setGoalParsesGoal() throws {
+    let cmd = try SetGoal.parse(["--session", validUUID, "--goal", "Q3 latency KPI"])
+    #expect(cmd.session == validUUID)
+    try cmd.validate()
+}
+
+@Test func setGoalParsesClear() throws {
+    let cmd = try SetGoal.parse(["--session", validUUID, "--clear"])
+    try cmd.validate()
+}
+
+@Test func setGoalRejectsGoalWithClear() {
+    #expect(throws: (any Error).self) {
+        let cmd = try SetGoal.parse(["--session", validUUID, "--goal", "x", "--clear"])
+        try cmd.validate()
+    }
+}
+
+@Test func setGoalRejectsNoArgs() {
+    #expect(throws: (any Error).self) {
+        let cmd = try SetGoal.parse(["--session", validUUID])
+        try cmd.validate()
+    }
+}
+
+@Test func setGoalRejectsInvalidUUID() {
+    #expect(throws: (any Error).self) {
+        let cmd = try SetGoal.parse(["--session", "not-a-uuid", "--goal", "x"])
+        try cmd.validate()
+    }
+}
+
 // MARK: - transition-ticket (#529)
 
 @Test func transitionTicketParsesValidArgs() throws {

--- a/Packages/CrowCLI/Tests/CrowCLITests/ValidationTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ValidationTests.swift
@@ -104,3 +104,60 @@ import Foundation
         try validateSetTicketHasField(url: nil, title: nil, number: nil)
     }
 }
+
+@Test func setTicketWithPriorityAloneAccepted() throws {
+    // #696: --priority alone satisfies the has-field rule.
+    try validateSetTicketHasField(url: nil, title: nil, number: nil, priority: "high")
+}
+
+// MARK: - Ticket Priority Validation (#696)
+
+@Test func allValidTicketPrioritiesAccepted() throws {
+    for priority in ["highest", "high", "medium", "low", "lowest"] {
+        try validateTicketPriority(priority)
+    }
+}
+
+@Test func ticketPriorityIsCaseInsensitive() throws {
+    try validateTicketPriority("Highest")
+    try validateTicketPriority("HIGH")
+}
+
+@Test func invalidTicketPriorityRejected() {
+    #expect(throws: (any Error).self) {
+        try validateTicketPriority("urgent")
+    }
+    #expect(throws: (any Error).self) {
+        // `unknown` is the internal neutral, not a CLI-settable rung.
+        try validateTicketPriority("unknown")
+    }
+}
+
+// MARK: - Set Goal Validation (#696)
+
+@Test func setGoalWithGoalAccepted() throws {
+    try validateSetGoal(goal: "Q3 latency KPI", clear: false)
+}
+
+@Test func setGoalClearAccepted() throws {
+    try validateSetGoal(goal: nil, clear: true)
+}
+
+@Test func setGoalRejectsGoalAndClearTogether() {
+    #expect(throws: (any Error).self) {
+        try validateSetGoal(goal: "Q3 latency KPI", clear: true)
+    }
+}
+
+@Test func setGoalRejectsNeitherGoalNorClear() {
+    #expect(throws: (any Error).self) {
+        try validateSetGoal(goal: nil, clear: false)
+    }
+}
+
+@Test func setGoalRejectsBlankGoal() {
+    // A whitespace goal would silently fail to earn the on-goal multiplier.
+    #expect(throws: (any Error).self) {
+        try validateSetGoal(goal: "   ", clear: false)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/AlignmentWeight.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AlignmentWeight.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Alignment-weight priors (ADR 0008 follow-up 8, category C: does the work
+/// ladder up to an org KPI/goal). The weight is the future multiplicand of the
+/// v2 score (`throughput × efficiency-multiplier × alignment-weight`,
+/// follow-up 11) — this type only *produces* the value; nothing combines it
+/// into a live score yet.
+///
+/// Scheme: bonus-above-neutral. Untagged/unknown work scores exactly
+/// `neutral` (1.0), so every pre-existing session is unaffected; any explicit
+/// priority signal sits above the neutral floor, and an org-goal tag
+/// multiplies on top. That yields the ordering the rubric requires:
+/// high-priority on-goal (1.3 × 1.5 = 1.95) > low-priority off-goal (1.1) >
+/// untagged-neutral (1.0). Demonstrated alignment is rewarded; absence of
+/// data is never punished (trackers without priorities shouldn't grade worse).
+///
+/// These constants are tunable priors in the ADR 0008 sense, not gospel —
+/// revisit once real scorecard data exists.
+public enum AlignmentWeight {
+    /// Weight for work with no priority and no org-goal tag. Also the exact
+    /// value every session created before #696 computes to.
+    public static let neutral: Double = 1.0
+    /// Multiplier applied when the session carries an org-goal tag.
+    public static let onGoalMultiplier: Double = 1.5
+
+    public static let lowestPriorityBase: Double = 1.05
+    public static let lowPriorityBase: Double = 1.1
+    public static let mediumPriorityBase: Double = 1.2
+    public static let highPriorityBase: Double = 1.3
+    public static let highestPriorityBase: Double = 1.4
+
+    /// Compute the alignment weight for a piece of work.
+    /// `nil` priority and `.unknown` are both the neutral base.
+    public static func weight(priority: TicketPriority?, hasOrgGoal: Bool) -> Double {
+        base(for: priority) * (hasOrgGoal ? onGoalMultiplier : 1.0)
+    }
+
+    private static func base(for priority: TicketPriority?) -> Double {
+        switch priority {
+        case .highest: return highestPriorityBase
+        case .high: return highPriorityBase
+        case .medium: return mediumPriorityBase
+        case .low: return lowPriorityBase
+        case .lowest: return lowestPriorityBase
+        case .unknown, .none: return neutral
+        }
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/JiraSearchClient.swift
+++ b/Packages/CrowCore/Sources/CrowCore/JiraSearchClient.swift
@@ -132,7 +132,7 @@ public enum JiraSearchClient {
         site: String,
         jql: String,
         authorization: String,
-        fields: [String] = ["key", "summary", "status", "labels"],
+        fields: [String] = ["key", "summary", "status", "labels", "priority", "parent"],
         maxResults: Int = 100,
         transport: (URLRequest) async throws -> (Data, URLResponse) = { try await URLSession.shared.data(for: $0) }
     ) async -> Result<[[String: Any]], FetchError> {

--- a/Packages/CrowCore/Sources/CrowCore/Models/AssignedIssue.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AssignedIssue.swift
@@ -15,6 +15,18 @@ public struct AssignedIssue: Identifiable, Codable, Sendable {
     /// URL of the linked pull request, if any.
     public var prURL: String?
     public var updatedAt: Date?
+    /// Normalized ticket priority (#696, ADR 0008 follow-up 8). Only Jira
+    /// surfaces one today; nil for GitHub/GitLab/Corveil issues and for
+    /// records persisted before this field existed.
+    public var priority: TicketPriority?
+    /// Raw tracker priority name (e.g. Jira "Critical"), preserved so custom
+    /// priority schemes that normalize to `.unknown` stay inspectable.
+    public var priorityName: String?
+    /// Epic/parent work-item key (Jira Cloud unified `parent` field). Fetched
+    /// for future epic-based goal inference; unused by the v1 alignment weight.
+    public var parentKey: String?
+    /// Epic/parent summary, when the tracker provides it.
+    public var parentSummary: String?
     /// Pipeline status from the GitHub/GitLab project board.
     public var projectStatus: TicketStatus
 
@@ -22,7 +34,9 @@ public struct AssignedIssue: Identifiable, Codable, Sendable {
         id: String, number: Int, title: String, state: String,
         url: String, repo: String, labels: [LabelInfo] = [],
         provider: Provider, prNumber: Int? = nil, prURL: String? = nil,
-        updatedAt: Date? = nil, projectStatus: TicketStatus = .unknown
+        updatedAt: Date? = nil, priority: TicketPriority? = nil,
+        priorityName: String? = nil, parentKey: String? = nil,
+        parentSummary: String? = nil, projectStatus: TicketStatus = .unknown
     ) {
         self.id = id
         self.number = number
@@ -35,6 +49,10 @@ public struct AssignedIssue: Identifiable, Codable, Sendable {
         self.prNumber = prNumber
         self.prURL = prURL
         self.updatedAt = updatedAt
+        self.priority = priority
+        self.priorityName = priorityName
+        self.parentKey = parentKey
+        self.parentSummary = parentSummary
         self.projectStatus = projectStatus
     }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -52,6 +52,19 @@ public struct Session: Identifiable, Codable, Sendable {
     // Last `SessionEnd` wins; cleared by a new `SessionStart` so a resumed
     // agent never displays a stale finished duration.
     public var agentSessionEndedAt: Date?
+    // Org goal/KPI this session's work ladders up to (#696, ADR 0008
+    // follow-up 8, category C). V1 is deliberately user-driven: a free-text
+    // tag set via `crow set-goal`. Inferring the goal from the ticket's
+    // epic/parent link is deferred — the Jira backend now fetches the parent
+    // key/summary so the data exists when inference lands. Nil (or blank)
+    // means untagged: the alignment weight stays neutral.
+    public var orgGoal: String?
+    // Normalized priority of the linked ticket, set via `crow set-ticket
+    // --priority` (#696). Captured once at set time — Jira-side priority
+    // changes don't sync back yet (noted follow-up in ADR 0008). Nil for
+    // sessions without a priority signal; the alignment weight treats nil
+    // and `.unknown` identically as the neutral base.
+    public var ticketPriority: TicketPriority?
 
     /// Whether this session is a Manager (orchestration) session. Managers run
     /// Claude Code in the devRoot and are excluded from PR/issue tracking.
@@ -81,6 +94,18 @@ public struct Session: Identifiable, Codable, Sendable {
         guard let start = agentSessionStartedAt, let end = agentSessionEndedAt,
               end >= start else { return nil }
         return end.timeIntervalSince(start)
+    }
+
+    /// Alignment weight for this session's work (#696, ADR 0008 follow-up 8):
+    /// the value the future v2 multiplicative score consumes (follow-up 11 —
+    /// nothing combines it into a live score yet). Derived from the ticket
+    /// priority and the org-goal tag via ``AlignmentWeight``; untagged
+    /// sessions compute exactly `AlignmentWeight.neutral` (1.0). A blank or
+    /// whitespace-only `orgGoal` counts as untagged, so an empty tag can't
+    /// buy the on-goal multiplier.
+    public var alignmentWeight: Double {
+        let goal = (orgGoal ?? "").trimmingCharacters(in: .whitespaces)
+        return AlignmentWeight.weight(priority: ticketPriority, hasOrgGoal: !goal.isEmpty)
     }
 
     /// Stamp a `SessionStart` hook arrival. The first start is the origin and
@@ -114,7 +139,9 @@ public struct Session: Identifiable, Codable, Sendable {
         autoMergeEnabledAt: Date? = nil,
         locked: Bool = false,
         agentSessionStartedAt: Date? = nil,
-        agentSessionEndedAt: Date? = nil
+        agentSessionEndedAt: Date? = nil,
+        orgGoal: String? = nil,
+        ticketPriority: TicketPriority? = nil
     ) {
         self.id = id
         self.name = name
@@ -134,6 +161,8 @@ public struct Session: Identifiable, Codable, Sendable {
         self.locked = locked
         self.agentSessionStartedAt = agentSessionStartedAt
         self.agentSessionEndedAt = agentSessionEndedAt
+        self.orgGoal = orgGoal
+        self.ticketPriority = ticketPriority
     }
 
     /// Parse a GitHub PR URL (`https://github.com/<owner>/<repo>/pull/<number>`)
@@ -172,6 +201,8 @@ public struct Session: Identifiable, Codable, Sendable {
         autoMergeEnabledAt = try container.decodeIfPresent(Date.self, forKey: .autoMergeEnabledAt)
         agentSessionStartedAt = try container.decodeIfPresent(Date.self, forKey: .agentSessionStartedAt)
         agentSessionEndedAt = try container.decodeIfPresent(Date.self, forKey: .agentSessionEndedAt)
+        orgGoal = try container.decodeIfPresent(String.self, forKey: .orgGoal)
+        ticketPriority = try container.decodeIfPresent(TicketPriority.self, forKey: .ticketPriority)
         // CROW-573 renamed `pinned` → `locked`. Prefer the new key, but fall
         // back to the legacy `pinned` key so sessions locked under CROW-569
         // remain locked after upgrade.

--- a/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsSnapshot.swift
@@ -39,6 +39,15 @@ public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
     /// persisted before this field existed. Telemetry-off sessions get no
     /// snapshot at all, so their duration lives only on the `Session` row.
     public var wallClockDurationSeconds: Double?
+    /// Alignment weight at snapshot time (#696, ADR 0008 follow-up 8) — the
+    /// multiplicand the v2 combined score consumes (follow-up 11; nothing
+    /// multiplies it yet). Copied from `Session.alignmentWeight`. `nil` in
+    /// snapshots persisted before #696; treat as neutral 1.0.
+    public var alignmentWeight: Double?
+    /// Org-goal tag at snapshot time (#696). Kept alongside the weight so
+    /// weekly rollups can group by goal after the session record is reaped.
+    /// `nil` = untagged or pre-#696 snapshot.
+    public var orgGoal: String?
 
     public init(
         sessionID: UUID,
@@ -46,7 +55,9 @@ public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
         status: SessionStatus,
         analytics: SessionAnalytics,
         compactionCount: Int? = nil,
-        wallClockDurationSeconds: Double? = nil
+        wallClockDurationSeconds: Double? = nil,
+        alignmentWeight: Double? = nil,
+        orgGoal: String? = nil
     ) {
         self.sessionID = sessionID
         self.endedAt = endedAt
@@ -54,5 +65,7 @@ public struct SessionAnalyticsSnapshot: Codable, Equatable, Sendable {
         self.analytics = analytics
         self.compactionCount = compactionCount
         self.wallClockDurationSeconds = wallClockDurationSeconds
+        self.alignmentWeight = alignmentWeight
+        self.orgGoal = orgGoal
     }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Models/TicketPriority.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/TicketPriority.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Normalized ticket priority ladder (ADR 0008 follow-up 8 — alignment/KPI
+/// mapping). Jira is the only backend that surfaces a priority today;
+/// GitHub/GitLab/Corveil tickets carry no priority and stay `nil` on the
+/// models, which the alignment weight treats the same as `.unknown`.
+public enum TicketPriority: String, Codable, Sendable, CaseIterable {
+    case highest
+    case high
+    case medium
+    case low
+    case lowest
+    case unknown
+
+    /// Map a Jira priority name onto the normalized ladder, case-insensitively.
+    /// Covers the modern Jira Cloud scheme (Highest…Lowest), the classic
+    /// scheme (Blocker/Critical/Major/Minor/Trivial), and the enum's own raw
+    /// values (so CLI input like `--priority high` maps directly).
+    /// `nil` or an unrecognized custom name → `.unknown`.
+    public init(jiraName: String?) {
+        switch jiraName?.lowercased() {
+        case "highest", "blocker": self = .highest
+        case "high", "critical": self = .high
+        case "medium", "major": self = .medium
+        case "low", "minor": self = .low
+        case "lowest", "trivial": self = .lowest
+        default: self = .unknown
+        }
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AlignmentWeightTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AlignmentWeightTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #696 (ADR 0008 follow-up 8, category C): the alignment-weight priors. The
+// weight is the future v2 multiplicand — these tests lock in the rubric's
+// required ordering and the no-regression neutral floor, not a live score.
+
+// The ordering the rubric requires: demonstrated alignment beats weaker
+// demonstrated alignment beats no alignment data at all.
+@Test func alignmentWeightRequiredOrdering() {
+    let highOnGoal = AlignmentWeight.weight(priority: .high, hasOrgGoal: true)
+    let lowOffGoal = AlignmentWeight.weight(priority: .low, hasOrgGoal: false)
+    let untagged = AlignmentWeight.weight(priority: nil, hasOrgGoal: false)
+    #expect(highOnGoal > lowOffGoal)
+    #expect(lowOffGoal > untagged)
+    // The neutral floor is exact: every pre-#696 session computes this value,
+    // so the capture cannot regress existing scores.
+    #expect(untagged == AlignmentWeight.neutral)
+    #expect(untagged == 1.0)
+}
+
+// nil priority and .unknown are the same neutral base — a tracker without a
+// priority concept must not grade differently from an unrecognized name.
+@Test func alignmentWeightNilAndUnknownAreNeutral() {
+    #expect(AlignmentWeight.weight(priority: .unknown, hasOrgGoal: false) == AlignmentWeight.neutral)
+    #expect(AlignmentWeight.weight(priority: nil, hasOrgGoal: false)
+        == AlignmentWeight.weight(priority: .unknown, hasOrgGoal: false))
+}
+
+// Bonus-above-neutral scheme: any explicit priority signal sits above the
+// untagged floor (absence of data is never punished, presence always counts).
+@Test func alignmentWeightEveryExplicitRungBeatsNeutral() {
+    for priority in TicketPriority.allCases where priority != .unknown {
+        #expect(AlignmentWeight.weight(priority: priority, hasOrgGoal: false) > AlignmentWeight.neutral)
+    }
+}
+
+// The priority ladder is strictly monotonic, on- and off-goal.
+@Test func alignmentWeightLadderIsMonotonic() {
+    let ladder: [TicketPriority] = [.lowest, .low, .medium, .high, .highest]
+    for hasGoal in [false, true] {
+        let weights = ladder.map { AlignmentWeight.weight(priority: $0, hasOrgGoal: hasGoal) }
+        #expect(weights == weights.sorted())
+        #expect(Set(weights).count == weights.count)
+    }
+}
+
+// A goal tag alone (no priority signal — e.g. a GitHub-tasked session) earns
+// exactly the on-goal multiplier over neutral.
+@Test func alignmentWeightGoalOnlyEarnsMultiplier() {
+    #expect(AlignmentWeight.weight(priority: nil, hasOrgGoal: true)
+        == AlignmentWeight.neutral * AlignmentWeight.onGoalMultiplier)
+}
+
+// The weight is priorityBase × goalMultiplier — lock in the compositional
+// shape the v2 score consumes (follow-up 11).
+@Test func alignmentWeightComposesMultiplicatively() {
+    for priority in TicketPriority.allCases {
+        let off = AlignmentWeight.weight(priority: priority, hasOrgGoal: false)
+        let on = AlignmentWeight.weight(priority: priority, hasOrgGoal: true)
+        #expect(on == off * AlignmentWeight.onGoalMultiplier)
+    }
+}
+
+// Session-level derivation: the computed property feeds from ticketPriority +
+// orgGoal, and a blank/whitespace goal cannot buy the multiplier.
+@Test func sessionAlignmentWeightDerivesFromPriorityAndGoal() {
+    var session = Session(name: "s")
+    #expect(session.alignmentWeight == AlignmentWeight.neutral)
+
+    session.ticketPriority = .high
+    session.orgGoal = "Q3 latency KPI"
+    #expect(session.alignmentWeight
+        == AlignmentWeight.weight(priority: .high, hasOrgGoal: true))
+
+    session.orgGoal = "   "
+    #expect(session.alignmentWeight
+        == AlignmentWeight.weight(priority: .high, hasOrgGoal: false))
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AssignedIssueTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AssignedIssueTests.swift
@@ -58,3 +58,44 @@ import Testing
     )
     #expect(issue.projectStatus == .unknown)
 }
+
+// #696: priority + epic/parent ride the model as additive optionals.
+
+@Test func assignedIssueRoundTripsPriorityAndParent() throws {
+    let issue = AssignedIssue(
+        id: "jira:MAXX-1", number: 1, title: "T", state: "open",
+        url: "https://acme.atlassian.net/browse/MAXX-1", repo: "MAXX",
+        provider: .jira,
+        priority: .high, priorityName: "Critical",
+        parentKey: "MAXX-100", parentSummary: "Q3 latency epic"
+    )
+    let data = try JSONEncoder().encode(issue)
+    let decoded = try JSONDecoder().decode(AssignedIssue.self, from: data)
+    #expect(decoded.priority == .high)
+    #expect(decoded.priorityName == "Critical")
+    #expect(decoded.parentKey == "MAXX-100")
+    #expect(decoded.parentSummary == "Q3 latency epic")
+}
+
+@Test func assignedIssueLegacyJSONWithoutAlignmentFieldsDecodes() throws {
+    // Persisted AppState predating #696 has none of the new keys; synthesized
+    // Codable must surface them as nil, not fail.
+    let json: [String: Any] = [
+        "id": "github:o/r#7",
+        "number": 7,
+        "title": "Legacy",
+        "state": "open",
+        "url": "https://github.com/o/r/issues/7",
+        "repo": "o/r",
+        "labels": [],
+        "provider": "github",
+        "projectStatus": "In Progress",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let decoded = try JSONDecoder().decode(AssignedIssue.self, from: data)
+    #expect(decoded.priority == nil)
+    #expect(decoded.priorityName == nil)
+    #expect(decoded.parentKey == nil)
+    #expect(decoded.parentSummary == nil)
+    #expect(decoded.projectStatus == .inProgress)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/JiraSearchClientTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JiraSearchClientTests.swift
@@ -84,6 +84,26 @@ import FoundationNetworking  // URLRequest/URLResponse live here on Linux
         #expect(issues.count == 2)
     }
 
+    @Test func fetchAssignedDefaultFieldsIncludePriorityAndParent() async {
+        // #696: the default field set must request priority + parent so the
+        // alignment capture rides the standard board read.
+        let result = await JiraSearchClient.fetchAssigned(
+            site: "acme.atlassian.net",
+            jql: "assignee = currentUser()",
+            authorization: "Basic creds",
+            transport: { request in
+                let query = request.url?.query ?? ""
+                #expect(query.contains("fields=key,summary,status,labels,priority,parent"))
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (Self.searchPayload, response)
+            }
+        )
+        guard case .success = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+    }
+
     @Test func fetchAssignedFailsOnNon2xx() async {
         let result = await JiraSearchClient.fetchAssigned(
             site: "acme.atlassian.net",

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsSnapshotTests.swift
@@ -162,3 +162,53 @@ import Testing
     #expect(decoded.wallClockDurationSeconds == 28_800)
     #expect(decoded.analytics.activeTimeSeconds == 300)
 }
+
+// #696 (ADR 0008 follow-up 8): alignment weight + org goal ride the snapshot's
+// documented optional-extension point.
+@Test func snapshotAlignmentFieldsRoundTrip() throws {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(promptCount: 1),
+        alignmentWeight: AlignmentWeight.weight(priority: .high, hasOrgGoal: true),
+        orgGoal: "Q3 latency KPI"
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let decoded = try decoder.decode(
+        SessionAnalyticsSnapshot.self, from: encoder.encode(snapshot))
+    #expect(decoded == snapshot)
+    #expect(decoded.alignmentWeight
+        == AlignmentWeight.weight(priority: .high, hasOrgGoal: true))
+    #expect(decoded.orgGoal == "Q3 latency KPI")
+}
+
+// Snapshots persisted before #696 have neither key — they must keep decoding,
+// with the absent weight surfacing as nil (treated as neutral 1.0).
+@Test func snapshotWithoutAlignmentFieldsDecodesAsNil() throws {
+    let json = """
+    {
+      "sessionID": "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+      "endedAt": "2026-07-13T00:00:00Z",
+      "status": "completed",
+      "analytics": {
+        "totalCost": 0, "inputTokens": 42, "outputTokens": 0,
+        "cacheReadTokens": 0, "cacheCreationTokens": 0, "activeTimeSeconds": 0,
+        "linesAdded": 0, "linesRemoved": 0, "commitCount": 0,
+        "promptCount": 0, "toolCallCount": 0, "apiRequestCount": 0,
+        "apiErrorCount": 0
+      }
+    }
+    """
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(SessionAnalyticsSnapshot.self, from: Data(json.utf8))
+    #expect(decoded.alignmentWeight == nil)
+    #expect(decoded.orgGoal == nil)
+    #expect(decoded.alignmentWeight ?? AlignmentWeight.neutral == 1.0)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
@@ -170,6 +170,46 @@ import Testing
     #expect(decoded.locked == true)
 }
 
+@Test func sessionBackwardCompatDecodingWithoutAlignmentFields() throws {
+    // Persisted state.json predating #696 has neither `orgGoal` nor
+    // `ticketPriority`. Decode must succeed with nils, and the derived
+    // alignment weight must be exactly neutral — the no-regression guarantee.
+    let id = UUID()
+    let date = Date()
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let dateStr = formatter.string(from: date)
+    let json: [String: Any] = [
+        "id": id.uuidString,
+        "name": "legacy",
+        "status": "active",
+        "kind": "work",
+        "createdAt": dateStr,
+        "updatedAt": dateStr,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let session = try decoder.decode(Session.self, from: data)
+    #expect(session.orgGoal == nil)
+    #expect(session.ticketPriority == nil)
+    #expect(session.alignmentWeight == AlignmentWeight.neutral)
+}
+
+@Test func sessionRoundTripsOrgGoalAndTicketPriority() throws {
+    let session = Session(
+        name: "aligned",
+        orgGoal: "Q3 latency KPI",
+        ticketPriority: .high
+    )
+    let data = try JSONEncoder().encode(session)
+    let decoded = try JSONDecoder().decode(Session.self, from: data)
+    #expect(decoded.orgGoal == "Q3 latency KPI")
+    #expect(decoded.ticketPriority == .high)
+    #expect(decoded.alignmentWeight
+        == AlignmentWeight.weight(priority: .high, hasOrgGoal: true))
+}
+
 @Test func sessionManagerKindRoundTrip() throws {
     let session = Session(name: "Manager 2", kind: .manager)
     #expect(session.isManager)

--- a/Packages/CrowCore/Tests/CrowCoreTests/TicketPriorityTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TicketPriorityTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #696: the normalized priority ladder and its Jira-name mapper.
+
+@Test func ticketPriorityMapsModernJiraLadder() {
+    #expect(TicketPriority(jiraName: "Highest") == .highest)
+    #expect(TicketPriority(jiraName: "High") == .high)
+    #expect(TicketPriority(jiraName: "Medium") == .medium)
+    #expect(TicketPriority(jiraName: "Low") == .low)
+    #expect(TicketPriority(jiraName: "Lowest") == .lowest)
+}
+
+@Test func ticketPriorityMapsClassicJiraScheme() {
+    #expect(TicketPriority(jiraName: "Blocker") == .highest)
+    #expect(TicketPriority(jiraName: "Critical") == .high)
+    #expect(TicketPriority(jiraName: "Major") == .medium)
+    #expect(TicketPriority(jiraName: "Minor") == .low)
+    #expect(TicketPriority(jiraName: "Trivial") == .lowest)
+}
+
+@Test func ticketPriorityMappingIsCaseInsensitive() {
+    #expect(TicketPriority(jiraName: "HIGHEST") == .highest)
+    #expect(TicketPriority(jiraName: "critical") == .high)
+    #expect(TicketPriority(jiraName: "mEdIuM") == .medium)
+}
+
+// Custom per-project priority schemes normalize to .unknown (neutral weight);
+// the raw name is preserved separately on the models for inspection.
+@Test func ticketPriorityUnrecognizedAndNilAreUnknown() {
+    #expect(TicketPriority(jiraName: "P0 — Drop Everything") == .unknown)
+    #expect(TicketPriority(jiraName: "") == .unknown)
+    #expect(TicketPriority(jiraName: nil) == .unknown)
+}
+
+@Test func ticketPriorityRawValueRoundTrip() throws {
+    for priority in TicketPriority.allCases {
+        #expect(TicketPriority(rawValue: priority.rawValue) == priority)
+        // The mapper also accepts raw values, so CLI input maps directly.
+        if priority != .unknown {
+            #expect(TicketPriority(jiraName: priority.rawValue) == priority)
+        }
+        let data = try JSONEncoder().encode([priority])
+        let decoded = try JSONDecoder().decode([TicketPriority].self, from: data)
+        #expect(decoded == [priority])
+    }
+}

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/SessionRepositoryTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/SessionRepositoryTests.swift
@@ -157,7 +157,9 @@ import Testing
         ticketTitle: "Fix the bug",
         ticketNumber: 42,
         provider: .github,
-        codeProvider: .gitlab
+        codeProvider: .gitlab,
+        orgGoal: "Q3 latency KPI",
+        ticketPriority: .high
     )
     repo.save(session)
 
@@ -168,6 +170,10 @@ import Testing
     #expect(found?.provider == .github)
     #expect(found?.codeProvider == .gitlab)
     #expect(found?.status == .inReview)
+    // #696: the org-goal tag + ticket priority persist and read back.
+    #expect(found?.orgGoal == "Q3 latency KPI")
+    #expect(found?.ticketPriority == .high)
+    #expect(found?.alignmentWeight == AlignmentWeight.weight(priority: .high, hasOrgGoal: true))
 }
 
 @Test func statusUpdateRoundTrip() throws {

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
@@ -91,7 +91,7 @@ public struct JiraTaskBackend: TaskBackend {
         }
         let output = try await run([
             "acli", "jira", "workitem", "view", parsed.key,
-            "--json", "--fields", "summary,status,description,comment,assignee",
+            "--json", "--fields", "summary,status,description,comment,assignee,priority,parent",
         ])
         let fields = Self.firstFields(output)
         let title = (fields?["summary"] as? String) ?? "Ticket \(parsed.key)"
@@ -102,7 +102,9 @@ public struct JiraTaskBackend: TaskBackend {
             org: parsed.project,
             url: browseURL(for: parsed.key) ?? url,
             provider: .jira,
-            isMR: false
+            isMR: false,
+            priority: Self.priorityName(fields).map { TicketPriority(jiraName: $0) },
+            parentKey: Self.parentInfo(fields).key
         )
     }
 
@@ -297,7 +299,7 @@ public struct JiraTaskBackend: TaskBackend {
             "acli", "jira", "workitem", "search",
             "--jql", jql,
             "--json",
-            "--fields", "key,summary,status,assignee,labels",
+            "--fields", "key,summary,status,assignee,labels,priority,parent",
             "--limit", "\(limit)",
         ])
     }
@@ -370,6 +372,23 @@ public struct JiraTaskBackend: TaskBackend {
         return nil
     }
 
+    /// Priority name from a work item's `fields` dict (`fields.priority.name`).
+    /// Nil-safe: absent for GitHub-style payloads, pre-#696 fixtures, and Jira
+    /// projects without a priority field.
+    static func priorityName(_ fields: [String: Any]?) -> String? {
+        (fields?["priority"] as? [String: Any])?["name"] as? String
+    }
+
+    /// Epic/parent link from a work item's `fields` dict (#696). On Jira Cloud
+    /// `parent` is the unified field for both team- and company-managed
+    /// projects (classic "Epic Link" customfields were migrated into it);
+    /// Server/DC classic epic links don't surface here and degrade to nil.
+    static func parentInfo(_ fields: [String: Any]?) -> (key: String?, summary: String?) {
+        guard let parent = fields?["parent"] as? [String: Any] else { return (nil, nil) }
+        let summary = (parent["fields"] as? [String: Any])?["summary"] as? String
+        return (parent["key"] as? String, summary)
+    }
+
     /// Leniently pull the first integer out of `acli … --count` output, whose
     /// exact shape isn't contract ("96", "96 work items", `{"count":96}` all parse).
     static func firstInt(_ output: String) -> Int? {
@@ -428,6 +447,8 @@ public struct JiraTaskBackend: TaskBackend {
             // Jira labels are plain strings (no color); surface them so
             // label-driven flows (e.g. auto-create) work for Jira too.
             let labels = (fields?["labels"] as? [String] ?? []).map { LabelInfo(name: $0) }
+            let priorityName = Self.priorityName(fields)
+            let parent = Self.parentInfo(fields)
             let url = site.flatMap { s -> String? in
                 let host = s.hasPrefix("http") ? s : "https://\(s)"
                 return "\(host)/browse/\(parsed.key)"
@@ -441,6 +462,10 @@ public struct JiraTaskBackend: TaskBackend {
                 repo: parsed.project,
                 labels: labels,
                 provider: .jira,
+                priority: priorityName.map { TicketPriority(jiraName: $0) },
+                priorityName: priorityName,
+                parentKey: parent.key,
+                parentSummary: parent.summary,
                 projectStatus: status
             )
         }

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -382,6 +382,28 @@ public struct TicketInfo: Sendable {
     public let url: String
     public let provider: Provider
     public let isMR: Bool
+    /// Normalized ticket priority (#696, ADR 0008 follow-up 8). Only Jira
+    /// surfaces one today; nil for GitHub/GitLab/Corveil tickets.
+    public let priority: TicketPriority?
+    /// Epic/parent work-item key (Jira Cloud unified `parent` field). Fetched
+    /// for future epic-based goal inference; unused by the v1 alignment weight.
+    public let parentKey: String?
+
+    public init(
+        number: Int, title: String, repo: String, org: String, url: String,
+        provider: Provider, isMR: Bool,
+        priority: TicketPriority? = nil, parentKey: String? = nil
+    ) {
+        self.number = number
+        self.title = title
+        self.repo = repo
+        self.org = org
+        self.url = url
+        self.provider = provider
+        self.isMR = isMR
+        self.priority = priority
+        self.parentKey = parentKey
+    }
 }
 
 public enum ProviderError: Error {

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -49,6 +49,10 @@ final class BackendsTests: XCTestCase {
         XCTAssertFalse(info.isMR)
         XCTAssertEqual(fake.calls.first?.args.first, "gh")
         XCTAssertTrue(fake.calls.first?.args.contains("issue") ?? false)
+        // #696: GitHub carries no ticket priority/epic — the fields default to
+        // nil without any backend change (neutral alignment weight downstream).
+        XCTAssertNil(info.priority)
+        XCTAssertNil(info.parentKey)
     }
 
     func testGitHubTaskBackendRejectsPullRequestURL() async {
@@ -670,6 +674,9 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(info.provider, .gitlab)
         XCTAssertEqual(fake.calls.first?.args.first, "glab")
         XCTAssertEqual(fake.calls.first?.env["GITLAB_HOST"], "gitlab.internal.io")
+        // #696: GitLab carries no ticket priority/epic — nil, not an error.
+        XCTAssertNil(info.priority)
+        XCTAssertNil(info.parentKey)
     }
 
     func testGitLabTaskBackendListAssignedIssuesParses() async throws {

--- a/Packages/CrowProvider/Tests/CrowProviderTests/CorveilTaskBackendTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/CorveilTaskBackendTests.swift
@@ -75,6 +75,9 @@ final class CorveilTaskBackendTests: XCTestCase {
         XCTAssertEqual(Array(args.prefix(3)), ["corveil", "task", "get"])
         XCTAssertTrue(args.contains("42"))
         XCTAssertTrue(args.contains("--json"))
+        // #696: Corveil carries no ticket priority/epic — nil, not an error.
+        XCTAssertNil(info.priority)
+        XCTAssertNil(info.parentKey)
     }
 
     func testFetchTaskFallsBackToHostBuiltURLWhenJSONOmitsURL() async throws {

--- a/Packages/CrowProvider/Tests/CrowProviderTests/JiraTaskBackendTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/JiraTaskBackendTests.swift
@@ -72,6 +72,78 @@ final class JiraTaskBackendTests: XCTestCase {
         XCTAssertTrue(args.contains("--fields"))
     }
 
+    // MARK: - Priority + epic/parent read (#696, ADR 0008 follow-up 8)
+
+    func testFetchTaskRequestsAndParsesPriorityAndParent() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("""
+        [{"key":"PROJ-42","fields":{
+          "summary":"Fix the thing",
+          "priority":{"name":"Critical"},
+          "parent":{"key":"PROJ-100","fields":{"summary":"Q3 latency epic"}}
+        }}]
+        """)]
+        let b = backend(fake, config: JiraConfig(site: "acme.atlassian.net"))
+        let info = try await b.fetchTask(url: "https://acme.atlassian.net/browse/PROJ-42")
+
+        XCTAssertEqual(info.priority, .high) // classic "Critical" normalizes to high
+        XCTAssertEqual(info.parentKey, "PROJ-100")
+
+        let args = fake.calls.first?.args ?? []
+        let fields = args[args.firstIndex(of: "--fields")! + 1]
+        XCTAssertTrue(fields.contains("priority"), "view --fields must request priority; got \(fields)")
+        XCTAssertTrue(fields.contains("parent"), "view --fields must request parent; got \(fields)")
+    }
+
+    func testFetchTaskWithoutPriorityOrParentIsNil() async throws {
+        // Pre-#696-shaped payload (and projects without priority/epics):
+        // absent fields degrade to nil, never throw.
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"[{"key":"PROJ-42","fields":{"summary":"Fix the thing"}}]"#)]
+        let info = try await backend(fake).fetchTask(url: "PROJ-42")
+        XCTAssertNil(info.priority)
+        XCTAssertNil(info.parentKey)
+    }
+
+    func testListAssignedAcliParsesPriorityAndParent() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("""
+        [
+          {"key":"PROJ-1","fields":{
+            "summary":"Aligned one",
+            "status":{"name":"In Progress","statusCategory":{"key":"indeterminate"}},
+            "priority":{"name":"Highest"},
+            "parent":{"key":"PROJ-100","fields":{"summary":"Q3 latency epic"}}
+          }},
+          {"key":"PROJ-2","fields":{
+            "summary":"Custom-scheme two",
+            "status":{"name":"To Do","statusCategory":{"key":"new"}},
+            "priority":{"name":"P0 — Drop Everything"}
+          }}
+        ]
+        """)]
+        let listing = try await backend(fake).listAssigned(includeClosed: false)
+
+        let first = listing.open[0]
+        XCTAssertEqual(first.priority, .highest)
+        XCTAssertEqual(first.priorityName, "Highest")
+        XCTAssertEqual(first.parentKey, "PROJ-100")
+        XCTAssertEqual(first.parentSummary, "Q3 latency epic")
+
+        // An unrecognized custom priority name normalizes to .unknown but the
+        // raw name is preserved; no parent → nil.
+        let second = listing.open[1]
+        XCTAssertEqual(second.priority, .unknown)
+        XCTAssertEqual(second.priorityName, "P0 — Drop Everything")
+        XCTAssertNil(second.parentKey)
+        XCTAssertNil(second.parentSummary)
+
+        let args = fake.calls[0].args
+        let fields = args[args.firstIndex(of: "--fields")! + 1]
+        XCTAssertTrue(fields.contains("priority"), "search --fields must request priority; got \(fields)")
+        XCTAssertTrue(fields.contains("parent"), "search --fields must request parent; got \(fields)")
+    }
+
     func testFetchTaskRejectsUnparseableURL() async {
         do {
             _ = try await backend(FakeShellRunner()).fetchTask(url: "https://acme.atlassian.net/browse/")
@@ -231,7 +303,7 @@ final class JiraTaskBackendTests: XCTestCase {
             statusMap: ["In Progress": "In Development"],
             authorization: "Basic creds"
         )
-        let payload = #"{"issues":[{"key":"MAXX-1","fields":{"summary":"Dev one","status":{"name":"In Development","statusCategory":{"key":"indeterminate"}},"labels":["bug"]}}]}"#.data(using: .utf8)!
+        let payload = #"{"issues":[{"key":"MAXX-1","fields":{"summary":"Dev one","status":{"name":"In Development","statusCategory":{"key":"indeterminate"}},"labels":["bug"],"priority":{"name":"High"},"parent":{"key":"MAXX-90","fields":{"summary":"Epic"}}}}]}"#.data(using: .utf8)!
         let b = JiraTaskBackend(shellRunner: fake, config: cfg, transport: { request in
             sawGET.set(true)
             XCTAssertEqual(request.httpMethod, "GET")
@@ -247,6 +319,11 @@ final class JiraTaskBackendTests: XCTestCase {
         XCTAssertEqual(listing.open[0].projectStatus, .inProgress)
         XCTAssertEqual(listing.open[0].url, "https://acme.atlassian.net/browse/MAXX-1")
         XCTAssertEqual(listing.open[0].labels.map(\.name), ["bug"])
+        // #696: priority + parent ride the REST read too.
+        XCTAssertEqual(listing.open[0].priority, .high)
+        XCTAssertEqual(listing.open[0].priorityName, "High")
+        XCTAssertEqual(listing.open[0].parentKey, "MAXX-90")
+        XCTAssertEqual(listing.open[0].parentSummary, "Epic")
     }
 
     /// A REST failure degrades to an empty listing (like GitLab) without throwing.

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1647,6 +1647,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         "agent_session_started_at": s.agentSessionStartedAt.map { .string(fmt.string(from: $0)) } ?? .null,
                         "agent_session_ended_at": s.agentSessionEndedAt.map { .string(fmt.string(from: $0)) } ?? .null,
                         "wall_clock_seconds": s.wallClockDuration.map { .double($0) } ?? .null,
+                        // Alignment/KPI mapping (#696). `alignment_weight` is a
+                        // read value for the future v2 score — nothing combines
+                        // it into a live score yet (ADR 0008 follow-up 11).
+                        "org_goal": s.orgGoal.map { .string($0) } ?? .null,
+                        "ticket_priority": s.ticketPriority.map { .string($0.rawValue) } ?? .null,
+                        "alignment_weight": .double(s.alignmentWeight),
                         "locked": .bool(s.locked),
                         // Legacy alias (CROW-569 named this `pinned`); kept for
                         // one release so existing scripts keep working.
@@ -1742,10 +1748,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                     if let title = params["title"]?.stringValue { capturedAppState.sessions[idx].ticketTitle = title }
                     if let num = params["number"]?.intValue { capturedAppState.sessions[idx].ticketNumber = num }
+                    if let priority = params["priority"]?.stringValue {
+                        capturedAppState.sessions[idx].ticketPriority = TicketPriority(jiraName: priority)
+                    }
                     capturedStore.mutate { data in
                         if let i = data.sessions.firstIndex(where: { $0.id == id }) { data.sessions[i] = capturedAppState.sessions[idx] }
                     }
                     return ["session_id": .string(idStr)]
+                }
+            },
+            "set-goal": { @Sendable params in
+                // #696 (ADR 0008 follow-up 8): tag a session with the org
+                // goal/KPI its work ladders up to, feeding the alignment weight.
+                guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
+                    throw RPCError.invalidParams("session_id required")
+                }
+                let clear = params["clear"]?.boolValue ?? false
+                let goal = params["goal"]?.stringValue?.trimmingCharacters(in: .whitespaces)
+                guard clear || !(goal ?? "").isEmpty else {
+                    throw RPCError.invalidParams("goal (non-blank) or clear required")
+                }
+                return try await MainActor.run {
+                    guard capturedAppState.sessions.contains(where: { $0.id == id }) else {
+                        throw RPCError.applicationError("Session not found")
+                    }
+                    let newGoal = clear ? nil : goal
+                    capturedService.setOrgGoal(id: id, goal: newGoal)
+                    return ["session_id": .string(idStr), "goal": newGoal.map { .string($0) } ?? .null]
                 }
             },
             "transition-ticket": { @Sendable params in

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -2419,11 +2419,13 @@ final class SessionService {
         // Compaction count only exists on the in-memory hook state — telemetry.db
         // has no compaction rows — so read it there even when `analytics` came
         // from the DB provider (#691).
+        let session = appState.sessions.first(where: { $0.id == id })
         let snapshot = SessionAnalyticsSnapshot(
             sessionID: id, endedAt: Date(), status: status, analytics: analytics,
             compactionCount: appState.existingHookState(for: id)?.compactionCount ?? 0,
-            wallClockDurationSeconds: appState.sessions
-                .first(where: { $0.id == id })?.wallClockDuration)
+            wallClockDurationSeconds: session?.wallClockDuration,
+            alignmentWeight: session?.alignmentWeight,
+            orgGoal: session?.orgGoal)
         store.mutate { data in
             var snapshots = data.analyticsSnapshots ?? [:]
             snapshots[id.uuidString] = snapshot
@@ -2443,6 +2445,23 @@ final class SessionService {
         store.mutate { data in
             if let idx = data.sessions.firstIndex(where: { $0.id == id }) {
                 data.sessions[idx].locked = locked
+            }
+        }
+    }
+
+    /// Set or clear the session's org-goal tag (#696, ADR 0008 follow-up 8).
+    /// `nil` clears the tag back to untagged/neutral. The tag feeds
+    /// `Session.alignmentWeight`, which is copied onto the analytics snapshot
+    /// when the session reaches a terminal status.
+    func setOrgGoal(id: UUID, goal: String?) {
+        if let idx = appState.sessions.firstIndex(where: { $0.id == id }) {
+            appState.sessions[idx].orgGoal = goal
+            appState.sessions[idx].updatedAt = Date()
+        }
+        store.mutate { data in
+            if let idx = data.sessions.firstIndex(where: { $0.id == id }) {
+                data.sessions[idx].orgGoal = goal
+                data.sessions[idx].updatedAt = Date()
             }
         }
     }
@@ -2493,7 +2512,9 @@ final class SessionService {
                     status: session.status, analytics: analytics,
                     compactionCount: appState.existingHookState(for: session.id)?
                         .compactionCount ?? 0,
-                    wallClockDurationSeconds: session.wallClockDuration)
+                    wallClockDurationSeconds: session.wallClockDuration,
+                    alignmentWeight: session.alignmentWeight,
+                    orgGoal: session.orgGoal)
                 data.analyticsSnapshots = snapshots
             }
         }

--- a/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
+++ b/Tests/CrowTests/SessionServiceAnalyticsSnapshotTests.swift
@@ -370,4 +370,90 @@ struct SessionServiceAnalyticsSnapshotTests {
         #expect(reloaded.data.analyticsSnapshots?[id.uuidString]?
             .wallClockDurationSeconds == 3_600)
     }
+
+    // MARK: - Alignment weight + org goal (#696, ADR 0008 follow-up 8)
+
+    // A tagged, high-priority session snapshots its alignment weight (the
+    // future v2 multiplicand) and goal at session end.
+    @Test
+    func snapshotCarriesAlignmentWeightAndOrgGoal() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(
+            id: id, name: "aligned",
+            orgGoal: "Q3 latency KPI", ticketPriority: .high)]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let snapshot = store.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot?.alignmentWeight
+            == AlignmentWeight.weight(priority: .high, hasOrgGoal: true))
+        #expect(snapshot?.orgGoal == "Q3 latency KPI")
+    }
+
+    // An untagged session snapshots the exact neutral weight — the
+    // "done ≠ value" fix cannot regress anyone who never tags.
+    @Test
+    func untaggedSessionSnapshotsNeutralWeight() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "untagged")]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        let snapshot = store.data.analyticsSnapshots?[id.uuidString]
+        #expect(snapshot?.alignmentWeight == AlignmentWeight.neutral)
+        #expect(snapshot?.orgGoal == nil)
+    }
+
+    // The quit-race backfill path carries the alignment fields too.
+    @Test
+    func persistStateBackfillCarriesAlignmentFields() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        var ended = Session(
+            id: UUID(), name: "aligned-then-quit",
+            orgGoal: "Q3 latency KPI", ticketPriority: .highest)
+        ended.status = .completed
+        appState.sessions = [ended]
+        appState.hookState(for: ended.id).analytics = Self.sampleAnalytics
+
+        let service = SessionService(store: store, appState: appState)
+        service.persistState()
+
+        let snapshot = store.data.analyticsSnapshots?[ended.id.uuidString]
+        #expect(snapshot?.alignmentWeight
+            == AlignmentWeight.weight(priority: .highest, hasOrgGoal: true))
+        #expect(snapshot?.orgGoal == "Q3 latency KPI")
+    }
+
+    // setOrgGoal mutates both live state and the store; clearing goes back to
+    // nil (not empty string) so the weight returns to neutral.
+    @Test
+    func setOrgGoalPersistsAndClears() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        let session = Session(id: id, name: "taggable")
+        appState.sessions = [session]
+        store.mutate { $0.sessions = [session] }
+        let service = SessionService(store: store, appState: appState)
+
+        service.setOrgGoal(id: id, goal: "Q3 latency KPI")
+        #expect(appState.sessions[0].orgGoal == "Q3 latency KPI")
+        #expect(store.data.sessions.first(where: { $0.id == id })?.orgGoal == "Q3 latency KPI")
+
+        service.setOrgGoal(id: id, goal: nil)
+        #expect(appState.sessions[0].orgGoal == nil)
+        #expect(store.data.sessions.first(where: { $0.id == id })?.orgGoal == nil)
+        #expect(appState.sessions[0].alignmentWeight == AlignmentWeight.neutral)
+    }
 }

--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -114,6 +114,15 @@ Deferred guardrails (explicit non-goals until their data exists): trivial-PR far
 
 No prototype ships with this ADR: the smallest useful one requires persisting the compaction counter (a write-path model change, follow-up 3), which exceeds the read-only bar for a design PR.
 
+### Follow-up 8 addendum (implemented in #696)
+
+The alignment capture shipped with these decisions:
+
+- **Org-goal tag is user-set for v1**: a free-text `Session.orgGoal` set/cleared via `crow set-goal`. Epic-based goal inference is deliberately deferred — but `JiraTaskBackend` now fetches the epic/parent link (`parentKey`/`parentSummary` on `AssignedIssue`, `parentKey` on `TicketInfo`) so the data exists when inference lands.
+- **Priority** rides `AssignedIssue`/`TicketInfo` from the Jira read (both the REST and `acli` paths), normalized to `TicketPriority` (modern Highest…Lowest and classic Blocker…Trivial ladders; unrecognized custom schemes → `.unknown` with the raw name preserved). It reaches the session via `crow set-ticket --priority`; automatic Jira-side priority sync (via IssueTracker's existing ticketURL↔session matching) is a noted follow-up. Jira Cloud's unified `parent` field covers team- and company-managed projects; Server/DC classic epic-link customfields aren't fetched and degrade to nil.
+- **Weight priors** live in `AlignmentWeight` (CrowCore) as named constants — a bonus-above-neutral scheme: untagged/unknown = exactly 1.0 (no pre-existing session regresses), each explicit priority rung > 1.0, an org-goal tag multiplies (×1.5). This yields the rubric ordering high-priority-on-goal > low-priority-off-goal > untagged-neutral: demonstrated alignment is rewarded, absence of data is never punished. Tunable priors, per the grade-bands principle above.
+- **Read-only exposure**: `Session.alignmentWeight` (computed) and `SessionAnalyticsSnapshot.alignmentWeight`/`orgGoal` (persisted at session end, nil = neutral in pre-#696 snapshots). Nothing multiplies it into a live score — that remains follow-up 11.
+
 ## Consequences
 
 - **Goodhart risk is inherent.** Any graded metric will be optimized; the compaction penalty may discourage legitimately long, hard sessions. The tunable-priors + calibration-period framing is the mitigation, and it is binding, not decorative.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -107,10 +107,11 @@ Deletes the session metadata. Sessions on protected branches (main/master/develo
 
 ### `crow set-ticket`
 
-Attach ticket metadata (URL, title, number) to a session. At least one of `--url`, `--title`, or `--number` must be provided.
+Attach ticket metadata (URL, title, number, priority) to a session. At least one of `--url`, `--title`, `--number`, or `--priority` must be provided.
 
 ```bash
 crow set-ticket --session <uuid> --url "https://github.com/org/repo/issues/123" --title "Fix bug" --number 123
+crow set-ticket --session <uuid> --priority high
 ```
 
 | Flag         | Required | Description    |
@@ -119,8 +120,26 @@ crow set-ticket --session <uuid> --url "https://github.com/org/repo/issues/123" 
 | `--url`      | no¹      | Ticket URL     |
 | `--title`    | no¹      | Ticket title   |
 | `--number`   | no¹      | Ticket number  |
+| `--priority` | no¹      | Ticket priority: `highest`, `high`, `medium`, `low`, or `lowest` (case-insensitive). Feeds the session's alignment weight (ADR 0008 follow-up 8). |
 
-¹ At least one of `--url`, `--title`, `--number` is required.
+¹ At least one of `--url`, `--title`, `--number`, `--priority` is required.
+
+### `crow set-goal`
+
+Set or clear the org-goal tag on a session — the org goal/KPI the session's work ladders up to (ADR 0008 follow-up 8). The tag feeds the session's alignment weight, read back via `crow get-session` (`org_goal`, `ticket_priority`, `alignment_weight`). Exactly one of `--goal` or `--clear` is required.
+
+```bash
+crow set-goal --session <uuid> --goal "Q3 latency KPI"
+crow set-goal --session <uuid> --clear
+```
+
+| Flag        | Required | Description                                  |
+| ----------- | -------- | -------------------------------------------- |
+| `--session` | yes      | Session UUID                                 |
+| `--goal`    | no²      | Org goal/KPI tag (free text, non-blank)      |
+| `--clear`   | no²      | Clear the tag (back to neutral weight)       |
+
+² Exactly one of `--goal`, `--clear` is required.
 
 ### `crow add-link`
 


### PR DESCRIPTION
Closes #696. ADR 0008 follow-up 8/11 (refs #648, design PR #657) — greenfield alignment capture; blocks v2; fixes 'done ≠ value'. Builds on ADR 0005 backend protocols.

## What's here

**Backend read (Jira only; others return nil):**
- `JiraTaskBackend` now requests + parses `priority` and `parent` (epic link) on both fetch paths: the REST `search/jql` default fields and the `acli --fields` lists (`search` + `view`).
- New optional fields: `AssignedIssue.priority/priorityName/parentKey/parentSummary`, `TicketInfo.priority/parentKey` (explicit defaulted init, so GitHub/GitLab/Corveil backends compile untouched and return nil — no protocol change needed).
- New `TicketPriority` enum normalizes both Jira ladders (Highest…Lowest and classic Blocker…Trivial, case-insensitive); unrecognized custom schemes → `.unknown` with the raw name preserved.

**Org-goal tagging on sessions (user-driven for v1):**
- `Session.orgGoal` free-text tag, set/cleared via new `crow set-goal --goal|--clear`; `Session.ticketPriority` via `crow set-ticket --priority`. Epic-based goal inference is deliberately deferred — the parent key/summary is fetched now so the data exists when inference lands (documented in the ADR addendum).

**Alignment weight (category C of #648's rubric):**
- `AlignmentWeight` (CrowCore): named priors, bonus-above-neutral scheme — untagged/unknown = exactly **1.0** (no pre-existing session regresses), priority rungs 1.05–1.4, on-goal ×1.5. Ordering: high-priority on-goal (1.95) > low-priority off-goal (1.1) > untagged-neutral (1.0).
- Exposed as a read value only: `Session.alignmentWeight` (computed), `get-session` output (`org_goal`/`ticket_priority`/`alignment_weight`), and persisted onto `SessionAnalyticsSnapshot` at session end (nil = neutral in pre-#696 snapshots). **Not** wired into any combined score — that's follow-up 11.

## Backward compatibility
All model additions are optionals with `decodeIfPresent`/synthesized-Codable defaults; legacy store.json/AppState data decodes to nil → neutral weight. Locked in by tests (legacy-JSON decode fixtures for Session, AssignedIssue, snapshot).

## Tests
- `AlignmentWeightTests` (required ordering, neutral floor exactness, monotonic ladder, multiplicative shape), `TicketPriorityTests` (both ladders, case-insensitivity, unknown fallback).
- Jira: acli argv + REST default-fields assertions; fixtures parse priority/parent; absent fields → nil. GitHub/GitLab/Corveil `fetchTask` asserts nil priority/parent.
- Session/snapshot/repository round-trips + legacy decode; CLI parsing/validation for `set-goal` and `set-ticket --priority`; `SessionService` snapshot write + quit-race backfill carry weight/goal; `setOrgGoal` set/clear.

`make test` green across packages (the pre-existing `CrowGit` RebaseTests failures are environmental — no global git identity on this machine — and untouched by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)