### PR TITLE
v1 read-only efficiency scorecard (A–F grade + sessions shipped, weekly) (closes #710)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -120,6 +120,9 @@ public final class AppState {
     /// purged on load (multiple Manager sessions replaced standalone terminals).
     nonisolated public static let globalTerminalSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
 
+    /// Fixed UUID for the efficiency scorecard tab (ADR 0008 v1, #710).
+    nonisolated public static let scorecardSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+
     /// The primary (back-compat) Manager session identified by the well-known UUID.
     public var managerSession: Session? {
         sessions.first { $0.id == Self.managerSessionID }
@@ -157,6 +160,15 @@ public final class AppState {
 
     /// Sort order for the ticket board.
     public var ticketSortOrder: TicketSortOrder = .updatedDesc
+
+    // MARK: - Scorecard (ADR 0008)
+
+    /// Read-only mirror of the store's persisted per-session analytics
+    /// snapshots, keyed by session UUID string — hydrated by SessionService on
+    /// load and kept in sync as snapshots are written. The efficiency
+    /// scorecard (#710) computes entirely from this; CrowUI cannot read the
+    /// store directly.
+    public var analyticsSnapshots: [String: SessionAnalyticsSnapshot] = [:]
 
     // MARK: - Allowlist
 
@@ -433,7 +445,8 @@ public final class AppState {
     public var selectedSession: Session? {
         guard selectedSessionID != Self.ticketBoardSessionID,
               selectedSessionID != Self.allowListSessionID,
-              selectedSessionID != Self.reviewBoardSessionID else { return nil }
+              selectedSessionID != Self.reviewBoardSessionID,
+              selectedSessionID != Self.scorecardSessionID else { return nil }
         return sessions.first { $0.id == selectedSessionID }
     }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyGrading.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyGrading.swift
@@ -1,0 +1,378 @@
+import Foundation
+
+/// ADR 0008 v1 efficiency grading: a penalty-point deduction from 100 within a
+/// single unit, mapped to A–F bands. Every deduction is labeled with its cause
+/// so the grade is a coachable sentence, not a number.
+///
+/// There is exactly ONE grading function, and it takes raw numerators and
+/// denominators (`GradeInput`), never grades: the per-session grade is
+/// `grade(input(for: snapshot))` and the weekly grade is
+/// `grade(weeklyInput(summing: snapshots))`. Averaging per-session grades is
+/// structurally impossible here — no API accepts grades as input — which is
+/// how the ADR's anti-session-splitting rollup rule is enforced.
+///
+/// The grade and the sessions-shipped throughput count are separate surfaces;
+/// no combined number exists in v1 (ADR 0008).
+public enum EfficiencyGrading {
+
+    // MARK: - Tuning
+
+    /// Grade bands and penalty weights. Every value here is a starting
+    /// heuristic (ADR 0008) — a tunable prior under the binding 4-week
+    /// calibration period. If real data says a threshold punishes legitimately
+    /// hard sessions, the threshold moves; revise against real distributions,
+    /// not taste.
+    public enum Tuning {
+        /// Sessions (or weekly sums) with fewer prompts than this are shown as
+        /// "insufficient data", not graded — the anti-farming minimum-sample
+        /// floor ("< ~5 prompts" in the ADR).
+        public static let minimumGradablePromptCount = 5
+
+        /// Letter cutoffs: score ≥ 90 → A, ≥ 80 → B, ≥ 70 → C, ≥ 60 → D, else F.
+        public static let gradeACutoff = 90
+        public static let gradeBCutoff = 80
+        public static let gradeCCutoff = 70
+        public static let gradeDCutoff = 60
+
+        /// Compactions are the heaviest penalty, normalized per active hour
+        /// (`activeTimeSeconds` is the authoritative clock — never wall-clock,
+        /// never per-session, never per-outcome). Calibrated to the ADR's
+        /// canonical example: 3 compactions in ~1 active hour → −15.
+        public static let pointsPerCompactionPerActiveHour = 5.0
+        public static let compactionDeductionCap = 30
+        /// Floor (in hours) for the active-time denominator so a compaction in
+        /// a minutes-long session doesn't produce an absurd rate, and so zero
+        /// recorded active time never divides by zero.
+        public static let activeHoursFloor = 0.25
+
+        /// Context pressure (`inputTokens / max(1, promptCount)`): a
+        /// per-session average threshold until per-turn data exists (ADR 0008
+        /// follow-up 7).
+        public static let contextPressureLightThreshold = 20_000.0  // above → −5
+        public static let contextPressureMediumThreshold = 50_000.0 // above → −10
+        public static let contextPressureHeavyThreshold = 100_000.0 // above → −15
+        public static let contextPressureLightPoints = 5
+        public static let contextPressureMediumPoints = 10
+        public static let contextPressureHeavyPoints = 15
+
+        /// Cache hit ratio (`cacheRead / max(1, input + cacheCreation)`),
+        /// higher = better: a high cache-read share means context is carried
+        /// via prompt cache instead of re-sent as fresh input. ADR: > 0.7 good.
+        public static let cacheRatioGoodThreshold = 0.7   // at or above → 0
+        public static let cacheRatioFairThreshold = 0.5   // at or above → −5
+        public static let cacheRatioPoorThreshold = 0.3   // at or above → −10, below → −15
+        public static let cacheRatioFairPoints = 5
+        public static let cacheRatioPoorPoints = 10
+        public static let cacheRatioBadPoints = 15
+
+        /// API error rate: < 2% clean, > 10% heavy (ADR). The heavy value is
+        /// pinned by the ADR's own example: "12% API error rate (−10)".
+        public static let apiErrorRateCleanThreshold = 0.02
+        public static let apiErrorRateHeavyThreshold = 0.10
+        public static let apiErrorRateModeratePoints = 5
+        public static let apiErrorRateHeavyPoints = 10
+
+        /// Cost per shipped session — graded at weekly grain only
+        /// (`Σ totalCost / sessionsShipped`). Pure prior with no ADR anchor;
+        /// calibration will move these.
+        public static let costPerShippedLightThreshold = 5.0   // above → −5
+        public static let costPerShippedMediumThreshold = 15.0 // above → −10
+        public static let costPerShippedHeavyThreshold = 30.0  // above → −15
+        public static let costPerShippedLightPoints = 5
+        public static let costPerShippedMediumPoints = 10
+        public static let costPerShippedHeavyPoints = 15
+
+        /// Trailing weeks below this count render the self-comparison baseline
+        /// as "building" instead of a comparison (ADR cold-start consequence).
+        public static let minimumBaselineWeeks = 2
+        /// The baseline window: the user's own trailing 4-week median.
+        public static let baselineWeekCount = 4
+    }
+
+    // MARK: - Types
+
+    /// The graded metrics. Cost-per-shipped-session participates at weekly
+    /// grain only.
+    public enum Metric: String, Codable, Sendable, CaseIterable {
+        case compactions
+        case contextPressure
+        case cacheHitRatio
+        case apiErrorRate
+        case costPerShipped
+    }
+
+    public enum LetterGrade: String, Codable, Sendable, CaseIterable {
+        case a = "A", b = "B", c = "C", d = "D", f = "F"
+    }
+
+    /// One labeled, coachable penalty. The view renders "label (−points)",
+    /// e.g. "3 compactions (3.0/active hr) −15".
+    public struct Deduction: Equatable, Sendable {
+        public let metric: Metric
+        public let points: Int
+        public let label: String
+
+        public init(metric: Metric, points: Int, label: String) {
+            self.metric = metric
+            self.points = points
+            self.label = label
+        }
+    }
+
+    /// Raw numerators and denominators — the only input grading accepts.
+    /// Session grain: one snapshot's raws with `costContext == nil` (cost is
+    /// weekly-grain-only). Weekly grain: sums across the week's snapshots plus
+    /// a `CostContext`.
+    public struct GradeInput: Equatable, Sendable {
+        public var compactionCount: Int
+        /// The authoritative penalty clock (telemetry active time). Wall-clock
+        /// duration is display-only and must never appear here.
+        public var activeTimeSeconds: Double
+        public var inputTokens: Int
+        public var promptCount: Int
+        public var cacheReadTokens: Int
+        public var cacheCreationTokens: Int
+        public var apiErrorCount: Int
+        public var apiRequestCount: Int
+        /// Present at weekly grain only.
+        public var costContext: CostContext?
+
+        public struct CostContext: Equatable, Sendable {
+            /// Σ totalCost across the week's snapshots.
+            public var totalCost: Double
+            /// Count of outcome-flagged (`.completed`) snapshots in the week.
+            public var sessionsShipped: Int
+
+            public init(totalCost: Double, sessionsShipped: Int) {
+                self.totalCost = totalCost
+                self.sessionsShipped = sessionsShipped
+            }
+        }
+
+        public init(
+            compactionCount: Int = 0,
+            activeTimeSeconds: Double = 0,
+            inputTokens: Int = 0,
+            promptCount: Int = 0,
+            cacheReadTokens: Int = 0,
+            cacheCreationTokens: Int = 0,
+            apiErrorCount: Int = 0,
+            apiRequestCount: Int = 0,
+            costContext: CostContext? = nil
+        ) {
+            self.compactionCount = compactionCount
+            self.activeTimeSeconds = activeTimeSeconds
+            self.inputTokens = inputTokens
+            self.promptCount = promptCount
+            self.cacheReadTokens = cacheReadTokens
+            self.cacheCreationTokens = cacheCreationTokens
+            self.apiErrorCount = apiErrorCount
+            self.apiRequestCount = apiRequestCount
+            self.costContext = costContext
+        }
+
+        // MARK: Derived rates (shared by grading, baselines, and display)
+
+        public var activeHours: Double { activeTimeSeconds / 3600 }
+
+        /// Compactions per active hour, with the denominator floored so short
+        /// or zero active time never explodes the rate.
+        public var compactionsPerActiveHour: Double {
+            Double(compactionCount) / max(activeHours, Tuning.activeHoursFloor)
+        }
+
+        public var inputTokensPerPrompt: Double {
+            Double(inputTokens) / Double(max(1, promptCount))
+        }
+
+        public var cacheHitRatio: Double {
+            Double(cacheReadTokens) / Double(max(1, inputTokens + cacheCreationTokens))
+        }
+
+        public var apiErrorRate: Double {
+            Double(apiErrorCount) / Double(max(1, apiRequestCount))
+        }
+    }
+
+    public enum GradeResult: Equatable, Sendable {
+        case graded(score: Int, letter: LetterGrade, deductions: [Deduction])
+        /// Below the minimum-sample floor — shown as "insufficient data".
+        case insufficientData(promptCount: Int)
+    }
+
+    // MARK: - Input builders
+
+    /// Session-grain input from one persisted snapshot. `costContext` stays
+    /// nil: cost per shipped session is graded at weekly grain only.
+    public static func input(for snapshot: SessionAnalyticsSnapshot) -> GradeInput {
+        let analytics = snapshot.analytics
+        return GradeInput(
+            compactionCount: snapshot.compactionCount ?? 0,
+            activeTimeSeconds: analytics.activeTimeSeconds,
+            inputTokens: analytics.inputTokens,
+            promptCount: analytics.promptCount,
+            cacheReadTokens: analytics.cacheReadTokens,
+            cacheCreationTokens: analytics.cacheCreationTokens,
+            apiErrorCount: analytics.apiErrorCount,
+            apiRequestCount: analytics.apiRequestCount
+        )
+    }
+
+    /// Weekly-grain input: re-aggregates raw numerators and denominators
+    /// across the week's snapshots (Σ compactions / Σ active hours, Σ input
+    /// tokens / Σ prompts, …) — never an average of per-session grades.
+    /// Sub-floor sessions' raws still sum in (the floor gates only the graded
+    /// result), so splitting one long session into many short ones neither
+    /// resets a denominator nor dodges a numerator.
+    public static func weeklyInput(summing snapshots: [SessionAnalyticsSnapshot]) -> GradeInput {
+        var input = GradeInput()
+        var totalCost = 0.0
+        var shipped = 0
+        for snapshot in snapshots {
+            let analytics = snapshot.analytics
+            input.compactionCount += snapshot.compactionCount ?? 0
+            input.activeTimeSeconds += analytics.activeTimeSeconds
+            input.inputTokens += analytics.inputTokens
+            input.promptCount += analytics.promptCount
+            input.cacheReadTokens += analytics.cacheReadTokens
+            input.cacheCreationTokens += analytics.cacheCreationTokens
+            input.apiErrorCount += analytics.apiErrorCount
+            input.apiRequestCount += analytics.apiRequestCount
+            totalCost += analytics.totalCost
+            if snapshot.status == .completed { shipped += 1 }
+        }
+        input.costContext = GradeInput.CostContext(totalCost: totalCost, sessionsShipped: shipped)
+        return input
+    }
+
+    // MARK: - Grading
+
+    /// The single grading function. Deductions are sorted heaviest-first;
+    /// zero-point metrics emit no deduction. The cost metric is evaluated only
+    /// when a `costContext` is present AND at least one session shipped — a
+    /// zero-shipped week is "insufficient outcomes", never divided by a
+    /// fallback.
+    public static func grade(_ input: GradeInput) -> GradeResult {
+        guard input.promptCount >= Tuning.minimumGradablePromptCount else {
+            return .insufficientData(promptCount: input.promptCount)
+        }
+
+        var deductions: [Deduction] = []
+        if let deduction = compactionDeduction(input) { deductions.append(deduction) }
+        if let deduction = contextPressureDeduction(input) { deductions.append(deduction) }
+        if let deduction = cacheRatioDeduction(input) { deductions.append(deduction) }
+        if let deduction = apiErrorDeduction(input) { deductions.append(deduction) }
+        if let deduction = costPerShippedDeduction(input) { deductions.append(deduction) }
+
+        deductions.sort { lhs, rhs in
+            if lhs.points != rhs.points { return lhs.points > rhs.points }
+            return metricOrder(lhs.metric) < metricOrder(rhs.metric)
+        }
+        let score = max(0, 100 - deductions.reduce(0) { $0 + $1.points })
+        return .graded(score: score, letter: letter(forScore: score), deductions: deductions)
+    }
+
+    public static func letter(forScore score: Int) -> LetterGrade {
+        switch score {
+        case Tuning.gradeACutoff...: return .a
+        case Tuning.gradeBCutoff...: return .b
+        case Tuning.gradeCCutoff...: return .c
+        case Tuning.gradeDCutoff...: return .d
+        default: return .f
+        }
+    }
+
+    // MARK: - Per-metric deductions
+
+    private static func compactionDeduction(_ input: GradeInput) -> Deduction? {
+        guard input.compactionCount > 0 else { return nil }
+        let rate = input.compactionsPerActiveHour
+        let points = min(
+            Tuning.compactionDeductionCap,
+            Int((rate * Tuning.pointsPerCompactionPerActiveHour).rounded())
+        )
+        guard points > 0 else { return nil }
+        let noun = input.compactionCount == 1 ? "compaction" : "compactions"
+        let label = String(format: "%d %@ (%.1f/active hr)", input.compactionCount, noun, rate)
+        return Deduction(metric: .compactions, points: points, label: label)
+    }
+
+    private static func contextPressureDeduction(_ input: GradeInput) -> Deduction? {
+        let perPrompt = input.inputTokensPerPrompt
+        guard perPrompt > Tuning.contextPressureLightThreshold else { return nil }
+        let points: Int
+        if perPrompt <= Tuning.contextPressureMediumThreshold {
+            points = Tuning.contextPressureLightPoints
+        } else if perPrompt <= Tuning.contextPressureHeavyThreshold {
+            points = Tuning.contextPressureMediumPoints
+        } else {
+            points = Tuning.contextPressureHeavyPoints
+        }
+        let label = String(format: "%@ input tokens/prompt", abbreviatedCount(perPrompt))
+        return Deduction(metric: .contextPressure, points: points, label: label)
+    }
+
+    private static func cacheRatioDeduction(_ input: GradeInput) -> Deduction? {
+        // No context carried at all → nothing to cache; the metric doesn't
+        // apply (avoids penalizing sessions whose telemetry recorded prompts
+        // but no token traffic).
+        guard input.inputTokens + input.cacheCreationTokens > 0 else { return nil }
+        let ratio = input.cacheHitRatio
+        let points: Int
+        switch ratio {
+        case Tuning.cacheRatioGoodThreshold...: return nil
+        case Tuning.cacheRatioFairThreshold...: points = Tuning.cacheRatioFairPoints
+        case Tuning.cacheRatioPoorThreshold...: points = Tuning.cacheRatioPoorPoints
+        default: points = Tuning.cacheRatioBadPoints
+        }
+        let label = String(format: "%@ cache hit ratio", percentString(ratio))
+        return Deduction(metric: .cacheHitRatio, points: points, label: label)
+    }
+
+    private static func apiErrorDeduction(_ input: GradeInput) -> Deduction? {
+        let rate = input.apiErrorRate
+        guard rate >= Tuning.apiErrorRateCleanThreshold else { return nil }
+        let points = rate > Tuning.apiErrorRateHeavyThreshold
+            ? Tuning.apiErrorRateHeavyPoints
+            : Tuning.apiErrorRateModeratePoints
+        let label = String(format: "%@ API error rate", percentString(rate))
+        return Deduction(metric: .apiErrorRate, points: points, label: label)
+    }
+
+    private static func costPerShippedDeduction(_ input: GradeInput) -> Deduction? {
+        guard let cost = input.costContext, cost.sessionsShipped > 0 else { return nil }
+        let perShipped = cost.totalCost / Double(cost.sessionsShipped)
+        let points: Int
+        switch perShipped {
+        case ...Tuning.costPerShippedLightThreshold: return nil
+        case ...Tuning.costPerShippedMediumThreshold: points = Tuning.costPerShippedLightPoints
+        case ...Tuning.costPerShippedHeavyThreshold: points = Tuning.costPerShippedMediumPoints
+        default: points = Tuning.costPerShippedHeavyPoints
+        }
+        let label = String(format: "$%.2f per shipped session", perShipped)
+        return Deduction(metric: .costPerShipped, points: points, label: label)
+    }
+
+    private static func metricOrder(_ metric: Metric) -> Int {
+        Metric.allCases.firstIndex(of: metric) ?? 0
+    }
+
+    // MARK: - Label formatting (String(format:) only — Linux-safe, no FormatStyle)
+
+    static func percentString(_ fraction: Double) -> String {
+        let percent = fraction * 100
+        if percent == percent.rounded() {
+            return String(format: "%.0f%%", percent)
+        }
+        return String(format: "%.1f%%", percent)
+    }
+
+    static func abbreviatedCount(_ value: Double) -> String {
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", value / 1_000_000)
+        } else if value >= 1_000 {
+            return String(format: "%.1fK", value / 1_000)
+        }
+        return String(format: "%.0f", value)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyScorecard.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyScorecard.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+/// Cost per shipped session — the only outcome-touching grade input, computed
+/// at weekly grain only (ADR 0008). A week that shipped nothing is
+/// "insufficient outcomes"; the total is never divided by a fallback.
+public enum CostPerShipped: Equatable, Sendable {
+    case graded(Double)
+    case insufficientOutcomes
+}
+
+/// One week of the scorecard: the re-aggregated efficiency grade, the
+/// sessions-shipped throughput count, and the displayed-not-graded context
+/// stats. Grade and throughput are separate surfaces — nothing here combines
+/// them (no combined number exists in v1, ADR 0008).
+public struct WeeklyScorecard: Equatable, Sendable {
+    public let weekStart: Date
+    /// Grade over the week's summed raws (`EfficiencyGrading.weeklyInput`),
+    /// never an average of per-session grades.
+    public let result: EfficiencyGrading.GradeResult
+    /// The summed raws behind `result`; exposes the derived rates for the
+    /// self-comparison baseline and display.
+    public let input: EfficiencyGrading.GradeInput
+    /// Throughput headline: count of outcome-flagged (`.completed`) snapshots.
+    public let sessionsShipped: Int
+    public let costPerShipped: CostPerShipped
+    public let sessionCount: Int
+    // Displayed, not graded (Σ over the week):
+    public let totalCost: Double
+    public let activeTimeSeconds: Double
+    public let commitCount: Int
+    /// `Σ linesRemoved / max(1, Σ linesAdded)` — informational only, too weak
+    /// as a rework proxy to grade (ADR 0008).
+    public let churnHint: Double
+}
+
+/// The user's own trailing 4-week medians — the private "this week vs. your
+/// normal" comparison. Nil fields mean no graded prior weeks supplied a value.
+public struct ScorecardBaseline: Equatable, Sendable {
+    /// Graded prior weeks found (0...4). Below
+    /// `EfficiencyGrading.Tuning.minimumBaselineWeeks` the view shows
+    /// "baseline building" instead of comparisons.
+    public let weeksAvailable: Int
+    public let medianScore: Double?
+    public let medianCompactionsPerActiveHour: Double?
+    public let medianInputTokensPerPrompt: Double?
+    public let medianCacheHitRatio: Double?
+    public let medianApiErrorRate: Double?
+    /// Median over prior weeks that actually shipped (zero-shipped weeks have
+    /// no cost-per-shipped value to enter the median).
+    public let medianCostPerShipped: Double?
+
+    public static let empty = ScorecardBaseline(
+        weeksAvailable: 0,
+        medianScore: nil,
+        medianCompactionsPerActiveHour: nil,
+        medianInputTokensPerPrompt: nil,
+        medianCacheHitRatio: nil,
+        medianApiErrorRate: nil,
+        medianCostPerShipped: nil
+    )
+}
+
+/// Per-session drill-down row for the current week.
+public struct SessionGradeRow: Equatable, Sendable, Identifiable {
+    public var id: UUID { sessionID }
+    public let sessionID: UUID
+    public let endedAt: Date
+    /// `status == .completed` — the ADR 0008 outcome flag.
+    public let shipped: Bool
+    public let result: EfficiencyGrading.GradeResult
+    /// For the displayed-not-graded chips (cost, active time, commits, churn).
+    public let analytics: SessionAnalytics
+    /// Display-only context; never a grading denominator.
+    public let wallClockDurationSeconds: Double?
+}
+
+/// The read-only scorecard model (ADR 0008 v1): built from persisted
+/// `SessionAnalyticsSnapshot`s, pure and deterministic — `now` and the
+/// calendar's time zone are injected, and nothing here reads a store or a
+/// clock.
+public struct ScorecardModel: Equatable, Sendable {
+    public let currentWeek: WeeklyScorecard
+    /// Up to the trailing 4 weeks, newest first; weeks with no snapshots are
+    /// omitted (absence is not a zero).
+    public let priorWeeks: [WeeklyScorecard]
+    public let baseline: ScorecardBaseline
+    /// Current week's sessions, newest first.
+    public let currentWeekSessions: [SessionGradeRow]
+
+    /// Buckets snapshots into ISO-8601 weeks (Monday start, locale-stable so
+    /// the historical baseline doesn't shift with the user's locale) in the
+    /// injected calendar's time zone, grades the current week over summed
+    /// raws, and computes the trailing-4-week median baseline from the prior
+    /// weeks.
+    public static func build(
+        snapshots: [SessionAnalyticsSnapshot],
+        now: Date,
+        calendar: Calendar
+    ) -> ScorecardModel {
+        var iso = Calendar(identifier: .iso8601)
+        iso.timeZone = calendar.timeZone
+
+        let currentInterval = iso.dateInterval(of: .weekOfYear, for: now)
+            ?? DateInterval(start: now, duration: 7 * 86_400)
+
+        let currentSnapshots = snapshots.filter { contains(currentInterval, $0.endedAt) }
+        let currentWeek = weeklyScorecard(weekStart: currentInterval.start, snapshots: currentSnapshots)
+
+        var priorWeeks: [WeeklyScorecard] = []
+        for offset in 1...EfficiencyGrading.Tuning.baselineWeekCount {
+            guard
+                let weekDate = iso.date(byAdding: .weekOfYear, value: -offset, to: currentInterval.start),
+                let interval = iso.dateInterval(of: .weekOfYear, for: weekDate)
+            else { continue }
+            let weekSnapshots = snapshots.filter { contains(interval, $0.endedAt) }
+            guard !weekSnapshots.isEmpty else { continue }
+            priorWeeks.append(weeklyScorecard(weekStart: interval.start, snapshots: weekSnapshots))
+        }
+
+        let rows = currentSnapshots
+            .sorted { $0.endedAt > $1.endedAt }
+            .map { snapshot in
+                SessionGradeRow(
+                    sessionID: snapshot.sessionID,
+                    endedAt: snapshot.endedAt,
+                    shipped: snapshot.status == .completed,
+                    result: EfficiencyGrading.grade(EfficiencyGrading.input(for: snapshot)),
+                    analytics: snapshot.analytics,
+                    wallClockDurationSeconds: snapshot.wallClockDurationSeconds
+                )
+            }
+
+        return ScorecardModel(
+            currentWeek: currentWeek,
+            priorWeeks: priorWeeks,
+            baseline: baseline(from: priorWeeks),
+            currentWeekSessions: rows
+        )
+    }
+
+    /// Half-open week membership: `DateInterval.contains` is end-inclusive,
+    /// which would put a snapshot ending exactly at Monday 00:00 into two
+    /// adjacent week buckets.
+    private static func contains(_ interval: DateInterval, _ date: Date) -> Bool {
+        date >= interval.start && date < interval.end
+    }
+
+    // MARK: - Weekly rollup
+
+    static func weeklyScorecard(weekStart: Date, snapshots: [SessionAnalyticsSnapshot]) -> WeeklyScorecard {
+        let input = EfficiencyGrading.weeklyInput(summing: snapshots)
+        let shipped = input.costContext?.sessionsShipped ?? 0
+        let totalCost = input.costContext?.totalCost ?? 0
+
+        let costPerShipped: CostPerShipped = shipped > 0
+            ? .graded(totalCost / Double(shipped))
+            : .insufficientOutcomes
+
+        let linesAdded = snapshots.reduce(0) { $0 + $1.analytics.linesAdded }
+        let linesRemoved = snapshots.reduce(0) { $0 + $1.analytics.linesRemoved }
+
+        return WeeklyScorecard(
+            weekStart: weekStart,
+            result: EfficiencyGrading.grade(input),
+            input: input,
+            sessionsShipped: shipped,
+            costPerShipped: costPerShipped,
+            sessionCount: snapshots.count,
+            totalCost: totalCost,
+            activeTimeSeconds: input.activeTimeSeconds,
+            commitCount: snapshots.reduce(0) { $0 + $1.analytics.commitCount },
+            churnHint: Double(linesRemoved) / Double(max(1, linesAdded))
+        )
+    }
+
+    // MARK: - Baseline
+
+    /// Medians over the graded prior weeks only — an ungraded (sub-floor) or
+    /// absent week contributes nothing rather than a zero.
+    static func baseline(from priorWeeks: [WeeklyScorecard]) -> ScorecardBaseline {
+        var scores: [Double] = []
+        var compactionRates: [Double] = []
+        var contextPressures: [Double] = []
+        var cacheRatios: [Double] = []
+        var errorRates: [Double] = []
+        var costsPerShipped: [Double] = []
+
+        for week in priorWeeks {
+            guard case .graded(let score, _, _) = week.result else { continue }
+            scores.append(Double(score))
+            compactionRates.append(week.input.compactionsPerActiveHour)
+            contextPressures.append(week.input.inputTokensPerPrompt)
+            cacheRatios.append(week.input.cacheHitRatio)
+            errorRates.append(week.input.apiErrorRate)
+            if case .graded(let cost) = week.costPerShipped {
+                costsPerShipped.append(cost)
+            }
+        }
+
+        return ScorecardBaseline(
+            weeksAvailable: scores.count,
+            medianScore: median(scores),
+            medianCompactionsPerActiveHour: median(compactionRates),
+            medianInputTokensPerPrompt: median(contextPressures),
+            medianCacheHitRatio: median(cacheRatios),
+            medianApiErrorRate: median(errorRates),
+            medianCostPerShipped: median(costsPerShipped)
+        )
+    }
+
+    /// Standard median: middle element, or the mean of the middle two for an
+    /// even count. Nil for no values.
+    static func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let mid = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[mid - 1] + sorted[mid]) / 2
+        }
+        return sorted[mid]
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/EfficiencyGradingTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/EfficiencyGradingTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #710 (ADR 0008 v1): the single penalty-point grading function. Session and
+// weekly grades share it — it only ever takes raw numerators/denominators.
+
+private func deduction(
+    _ result: EfficiencyGrading.GradeResult,
+    _ metric: EfficiencyGrading.Metric
+) -> EfficiencyGrading.Deduction? {
+    guard case .graded(_, _, let deductions) = result else { return nil }
+    return deductions.first { $0.metric == metric }
+}
+
+private func score(_ result: EfficiencyGrading.GradeResult) -> Int? {
+    guard case .graded(let score, _, _) = result else { return nil }
+    return score
+}
+
+@Test func cleanSessionGradesAWithNoDeductions() {
+    let input = EfficiencyGrading.GradeInput(
+        activeTimeSeconds: 3600,
+        inputTokens: 5_000,
+        promptCount: 10,
+        cacheReadTokens: 80_000,
+        cacheCreationTokens: 5_000,
+        apiErrorCount: 0,
+        apiRequestCount: 100
+    )
+    guard case .graded(let score, let letter, let deductions) = EfficiencyGrading.grade(input) else {
+        Issue.record("expected graded result")
+        return
+    }
+    #expect(score == 100)
+    #expect(letter == .a)
+    #expect(deductions.isEmpty)
+}
+
+// The ADR's canonical coachable sentence: "C — 3 compactions (−15), 12% API
+// error rate (−10)". 100 − 15 − 10 = 75 → C. This fixture is the calibration
+// anchor for the tuning constants.
+@Test func adrCanonicalExampleGradesC() {
+    let input = EfficiencyGrading.GradeInput(
+        compactionCount: 3,
+        activeTimeSeconds: 3600, // 1 active hour
+        inputTokens: 10_000,
+        promptCount: 10,
+        cacheReadTokens: 80_000,
+        cacheCreationTokens: 5_000,
+        apiErrorCount: 12,
+        apiRequestCount: 100
+    )
+    guard case .graded(let score, let letter, let deductions) = EfficiencyGrading.grade(input) else {
+        Issue.record("expected graded result")
+        return
+    }
+    #expect(score == 75)
+    #expect(letter == .c)
+    #expect(deductions.count == 2)
+    #expect(deductions[0] == EfficiencyGrading.Deduction(
+        metric: .compactions, points: 15, label: "3 compactions (3.0/active hr)"))
+    #expect(deductions[1] == EfficiencyGrading.Deduction(
+        metric: .apiErrorRate, points: 10, label: "12% API error rate"))
+}
+
+// Compactions are normalized per ACTIVE hour, not per session: the same 3
+// compactions cost half as much over twice the active time.
+@Test func compactionsNormalizedPerActiveHour() {
+    func input(activeSeconds: Double) -> EfficiencyGrading.GradeInput {
+        EfficiencyGrading.GradeInput(
+            compactionCount: 3, activeTimeSeconds: activeSeconds, promptCount: 10)
+    }
+    let overTwoHours = deduction(EfficiencyGrading.grade(input(activeSeconds: 7200)), .compactions)
+    #expect(overTwoHours?.points == 8) // 1.5/hr × 5, rounded
+
+    let overHalfHour = deduction(EfficiencyGrading.grade(input(activeSeconds: 1800)), .compactions)
+    #expect(overHalfHour?.points == EfficiencyGrading.Tuning.compactionDeductionCap) // 6/hr × 5 = 30
+}
+
+// Zero recorded active time uses the denominator floor — capped deduction, no
+// division by zero, no infinite rate.
+@Test func zeroActiveTimeUsesFloor() {
+    let input = EfficiencyGrading.GradeInput(
+        compactionCount: 4, activeTimeSeconds: 0, promptCount: 10)
+    let compaction = deduction(EfficiencyGrading.grade(input), .compactions)
+    #expect(compaction?.points == EfficiencyGrading.Tuning.compactionDeductionCap)
+    #expect(input.compactionsPerActiveHour == 16) // 4 / 0.25h floor
+}
+
+@Test func zeroCompactionsEmitNoDeduction() {
+    let input = EfficiencyGrading.GradeInput(activeTimeSeconds: 60, promptCount: 10)
+    #expect(deduction(EfficiencyGrading.grade(input), .compactions) == nil)
+}
+
+@Test func contextPressureBands() {
+    func input(tokensPerPrompt: Int) -> EfficiencyGrading.GradeInput {
+        EfficiencyGrading.GradeInput(
+            activeTimeSeconds: 3600, inputTokens: tokensPerPrompt * 5, promptCount: 5)
+    }
+    #expect(deduction(EfficiencyGrading.grade(input(tokensPerPrompt: 20_000)), .contextPressure) == nil)
+
+    let light = deduction(EfficiencyGrading.grade(input(tokensPerPrompt: 20_001)), .contextPressure)
+    #expect(light?.points == 5)
+    #expect(light?.label == "20.0K input tokens/prompt")
+
+    #expect(deduction(EfficiencyGrading.grade(input(tokensPerPrompt: 50_000)), .contextPressure)?.points == 5)
+    #expect(deduction(EfficiencyGrading.grade(input(tokensPerPrompt: 50_001)), .contextPressure)?.points == 10)
+    #expect(deduction(EfficiencyGrading.grade(input(tokensPerPrompt: 100_001)), .contextPressure)?.points == 15)
+}
+
+// Higher cache-read share of carried context is BETTER (ADR 0008 deliberately
+// grades the opposite polarity of #648's original framing).
+@Test func cacheHitRatioBandsHigherIsBetter() {
+    func input(cacheRead: Int) -> EfficiencyGrading.GradeInput {
+        EfficiencyGrading.GradeInput(
+            activeTimeSeconds: 3600, inputTokens: 1_000, promptCount: 10,
+            cacheReadTokens: cacheRead, cacheCreationTokens: 0)
+    }
+    #expect(deduction(EfficiencyGrading.grade(input(cacheRead: 700)), .cacheHitRatio) == nil) // 0.7 good
+
+    let fair = deduction(EfficiencyGrading.grade(input(cacheRead: 500)), .cacheHitRatio)
+    #expect(fair?.points == 5)
+    #expect(fair?.label == "50% cache hit ratio")
+
+    #expect(deduction(EfficiencyGrading.grade(input(cacheRead: 300)), .cacheHitRatio)?.points == 10)
+    #expect(deduction(EfficiencyGrading.grade(input(cacheRead: 0)), .cacheHitRatio)?.points == 15)
+}
+
+// A session whose telemetry recorded prompts but no token traffic has no
+// context to cache — the metric doesn't apply, rather than penalizing a 0%.
+@Test func cacheRatioSkippedWithNoTokenTraffic() {
+    let input = EfficiencyGrading.GradeInput(activeTimeSeconds: 3600, promptCount: 10)
+    #expect(deduction(EfficiencyGrading.grade(input), .cacheHitRatio) == nil)
+}
+
+@Test func apiErrorRateBands() {
+    func input(errors: Int) -> EfficiencyGrading.GradeInput {
+        EfficiencyGrading.GradeInput(
+            activeTimeSeconds: 3600, promptCount: 10,
+            apiErrorCount: errors, apiRequestCount: 100)
+    }
+    #expect(deduction(EfficiencyGrading.grade(input(errors: 1)), .apiErrorRate) == nil) // < 2% clean
+
+    let moderate = deduction(EfficiencyGrading.grade(input(errors: 2)), .apiErrorRate)
+    #expect(moderate?.points == 5)
+    #expect(moderate?.label == "2% API error rate")
+
+    #expect(deduction(EfficiencyGrading.grade(input(errors: 10)), .apiErrorRate)?.points == 5) // 10% is not > 10%
+    #expect(deduction(EfficiencyGrading.grade(input(errors: 11)), .apiErrorRate)?.points == 10)
+}
+
+@Test func costPerShippedBandsAtWeeklyGrain() {
+    func input(totalCost: Double, shipped: Int = 1) -> EfficiencyGrading.GradeInput {
+        EfficiencyGrading.GradeInput(
+            activeTimeSeconds: 3600, promptCount: 10,
+            costContext: .init(totalCost: totalCost, sessionsShipped: shipped))
+    }
+    #expect(deduction(EfficiencyGrading.grade(input(totalCost: 5)), .costPerShipped) == nil)
+
+    let light = deduction(EfficiencyGrading.grade(input(totalCost: 10)), .costPerShipped)
+    #expect(light?.points == 5)
+    #expect(light?.label == "$10.00 per shipped session")
+
+    #expect(deduction(EfficiencyGrading.grade(input(totalCost: 20)), .costPerShipped)?.points == 10)
+    #expect(deduction(EfficiencyGrading.grade(input(totalCost: 31)), .costPerShipped)?.points == 15)
+    // Σ / shipped, not per session: $40 across 8 shipped = $5 → clean.
+    #expect(deduction(EfficiencyGrading.grade(input(totalCost: 40, shipped: 8)), .costPerShipped) == nil)
+}
+
+// Cost is weekly-grain-only: session-grain inputs carry no cost context, so
+// even an expensive session takes no cost deduction.
+@Test func costMetricSkippedAtSessionGrain() {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .completed,
+        analytics: SessionAnalytics(
+            totalCost: 500, activeTimeSeconds: 3600, promptCount: 10))
+    let input = EfficiencyGrading.input(for: snapshot)
+    #expect(input.costContext == nil)
+    #expect(deduction(EfficiencyGrading.grade(input), .costPerShipped) == nil)
+}
+
+// A zero-shipped week is "insufficient outcomes" — the cost metric is skipped
+// entirely, never divided by a fallback.
+@Test func zeroShippedWeekSkipsCostMetric() {
+    let input = EfficiencyGrading.GradeInput(
+        activeTimeSeconds: 3600, promptCount: 10,
+        costContext: .init(totalCost: 1_000, sessionsShipped: 0))
+    #expect(deduction(EfficiencyGrading.grade(input), .costPerShipped) == nil)
+}
+
+// The anti-farming minimum-sample floor: < 5 prompts is not graded.
+@Test func underFivePromptsIsInsufficientData() {
+    let four = EfficiencyGrading.grade(EfficiencyGrading.GradeInput(promptCount: 4))
+    #expect(four == .insufficientData(promptCount: 4))
+
+    let five = EfficiencyGrading.grade(EfficiencyGrading.GradeInput(promptCount: 5))
+    #expect(score(five) == 100)
+}
+
+// Pre-#691 snapshots have no compaction counter; nil is zero, not a penalty.
+@Test func nilCompactionCountTreatedAsZero() {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+        status: .archived,
+        analytics: SessionAnalytics(activeTimeSeconds: 3600, promptCount: 10),
+        compactionCount: nil)
+    let input = EfficiencyGrading.input(for: snapshot)
+    #expect(input.compactionCount == 0)
+    #expect(deduction(EfficiencyGrading.grade(input), .compactions) == nil)
+}
+
+// No combined number, behaviorally: throughput never scales the grade. With
+// cost in the clean band, shipping 1 vs 5 sessions yields the identical grade.
+@Test func throughputNeverScalesTheGrade() {
+    func input(shipped: Int) -> EfficiencyGrading.GradeInput {
+        EfficiencyGrading.GradeInput(
+            compactionCount: 3, activeTimeSeconds: 3600, promptCount: 10,
+            costContext: .init(totalCost: 4, sessionsShipped: shipped))
+    }
+    #expect(EfficiencyGrading.grade(input(shipped: 1)) == EfficiencyGrading.grade(input(shipped: 5)))
+}
+
+@Test func letterCutoffs() {
+    #expect(EfficiencyGrading.letter(forScore: 100) == .a)
+    #expect(EfficiencyGrading.letter(forScore: 90) == .a)
+    #expect(EfficiencyGrading.letter(forScore: 89) == .b)
+    #expect(EfficiencyGrading.letter(forScore: 80) == .b)
+    #expect(EfficiencyGrading.letter(forScore: 79) == .c)
+    #expect(EfficiencyGrading.letter(forScore: 70) == .c)
+    #expect(EfficiencyGrading.letter(forScore: 69) == .d)
+    #expect(EfficiencyGrading.letter(forScore: 60) == .d)
+    #expect(EfficiencyGrading.letter(forScore: 59) == .f)
+    #expect(EfficiencyGrading.letter(forScore: 0) == .f)
+}
+
+// Deductions are ordered heaviest-first so the worst coaching lands on top.
+@Test func deductionsSortedHeaviestFirst() {
+    let input = EfficiencyGrading.GradeInput(
+        compactionCount: 3, activeTimeSeconds: 3600,
+        inputTokens: 300_000, promptCount: 5, // 60K/prompt → −10
+        apiErrorCount: 2, apiRequestCount: 100) // 2% → −5
+    guard case .graded(_, _, let deductions) = EfficiencyGrading.grade(input) else {
+        Issue.record("expected graded result")
+        return
+    }
+    let points = deductions.map(\.points)
+    #expect(points == points.sorted(by: >))
+    #expect(deductions.first?.metric == .compactions)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/EfficiencyScorecardTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/EfficiencyScorecardTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #710 (ADR 0008 v1): week bucketing, Σ-based weekly rollup, sessions-shipped
+// throughput, and the trailing-4-week self-comparison baseline.
+
+/// Fixed UTC ISO-8601 calendar so bucketing is deterministic on any machine
+/// (including Linux CI).
+private let utc: Calendar = {
+    var calendar = Calendar(identifier: .iso8601)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+}()
+
+private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 12, _ minute: Int = 0) -> Date {
+    utc.date(from: DateComponents(year: year, month: month, day: day, hour: hour, minute: minute))!
+}
+
+/// Mid-week "now": Wednesday 2026-07-15. The current ISO week runs Monday
+/// 2026-07-13 00:00 UTC through Sunday 2026-07-19.
+private let now = date(2026, 7, 15)
+private let currentWeekMonday = date(2026, 7, 13, 0)
+
+private func snapshot(
+    endedAt: Date,
+    status: SessionStatus = .archived,
+    compactions: Int? = 0,
+    activeSeconds: Double = 3600,
+    prompts: Int = 10,
+    inputTokens: Int = 0,
+    cacheRead: Int = 0,
+    cacheCreation: Int = 0,
+    apiErrors: Int = 0,
+    apiRequests: Int = 0,
+    cost: Double = 0,
+    linesAdded: Int = 0,
+    linesRemoved: Int = 0,
+    commits: Int = 0
+) -> SessionAnalyticsSnapshot {
+    SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: endedAt,
+        status: status,
+        analytics: SessionAnalytics(
+            totalCost: cost,
+            inputTokens: inputTokens,
+            cacheReadTokens: cacheRead,
+            cacheCreationTokens: cacheCreation,
+            activeTimeSeconds: activeSeconds,
+            linesAdded: linesAdded,
+            linesRemoved: linesRemoved,
+            commitCount: commits,
+            promptCount: prompts,
+            apiRequestCount: apiRequests,
+            apiErrorCount: apiErrors
+        ),
+        compactionCount: compactions
+    )
+}
+
+private func weeklyScore(_ week: WeeklyScorecard) -> Int? {
+    guard case .graded(let score, _, _) = week.result else { return nil }
+    return score
+}
+
+// The ADR's core anti-dilution rule: the weekly grade re-aggregates raw
+// numerators/denominators (Σ compactions / Σ active hours) — one disastrous
+// session cannot be laundered by surrounding it with many short clean ones,
+// which averaging per-session grades would allow.
+@Test func weeklyRollupSumsRawsNotAverages() {
+    var snapshots = [
+        // Disaster: 6 compactions in half an active hour.
+        snapshot(endedAt: date(2026, 7, 13), compactions: 6, activeSeconds: 1800, prompts: 5)
+    ]
+    // Five short clean sessions (0.1 active hours each).
+    for day in 14...18 {
+        snapshots.append(snapshot(endedAt: date(2026, 7, day), activeSeconds: 360, prompts: 5))
+    }
+
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+
+    // Σ = 6 compactions over 1.0 total active hours → 6.0/hr → capped −30.
+    guard case .graded(let weekScore, _, let deductions) = model.currentWeek.result else {
+        Issue.record("expected graded week")
+        return
+    }
+    #expect(deductions == [EfficiencyGrading.Deduction(
+        metric: .compactions,
+        points: EfficiencyGrading.Tuning.compactionDeductionCap,
+        label: "6 compactions (6.0/active hr)")])
+    #expect(weekScore == 70)
+
+    // The mean of per-session scores (5×100 + 1×70 = 95) would have diluted
+    // the disaster; the Σ-based weekly score must sit strictly below it.
+    let sessionScores = model.currentWeekSessions.compactMap { row -> Int? in
+        guard case .graded(let s, _, _) = row.result else { return nil }
+        return s
+    }
+    #expect(sessionScores.count == 6)
+    let mean = Double(sessionScores.reduce(0, +)) / Double(sessionScores.count)
+    #expect(Double(weekScore) < mean)
+}
+
+// ISO-8601 weeks: Monday 00:00 starts a new bucket.
+@Test func weekBucketingSplitsOnISOMonday() {
+    let sundayNight = snapshot(endedAt: date(2026, 7, 12, 23, 59))
+    let mondayMorning = snapshot(endedAt: date(2026, 7, 13, 0, 1))
+
+    let model = ScorecardModel.build(
+        snapshots: [sundayNight, mondayMorning], now: now, calendar: utc)
+
+    #expect(model.currentWeek.weekStart == currentWeekMonday)
+    #expect(model.currentWeek.sessionCount == 1)
+    #expect(model.currentWeekSessions.first?.sessionID == mondayMorning.sessionID)
+    #expect(model.priorWeeks.count == 1)
+    #expect(model.priorWeeks[0].sessionCount == 1)
+}
+
+// Sessions shipped counts `.completed` snapshots only — the ADR 0008 outcome
+// flag, not `doneIssuesLast24h`.
+@Test func sessionsShippedCountsCompletedOnly() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .completed),
+        snapshot(endedAt: date(2026, 7, 14), status: .completed),
+        snapshot(endedAt: date(2026, 7, 15), status: .archived)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.currentWeek.sessionsShipped == 2)
+    #expect(model.currentWeekSessions.filter(\.shipped).count == 2)
+}
+
+@Test func zeroShippedWeekIsInsufficientOutcomes() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .archived, cost: 12),
+        snapshot(endedAt: date(2026, 7, 14), status: .archived, cost: 30)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.currentWeek.costPerShipped == .insufficientOutcomes)
+    // The spend still displays, and no cost deduction sneaks into the grade.
+    #expect(model.currentWeek.totalCost == 42)
+    if case .graded(_, _, let deductions) = model.currentWeek.result {
+        #expect(!deductions.contains { $0.metric == .costPerShipped })
+    }
+}
+
+@Test func costPerShippedIsWeeklySigmaOverShippedCount() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .completed, cost: 10),
+        snapshot(endedAt: date(2026, 7, 14), status: .completed, cost: 20),
+        snapshot(endedAt: date(2026, 7, 15), status: .archived, cost: 5)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    // Σ cost (35, including the unshipped session's spend) / 2 shipped.
+    #expect(model.currentWeek.costPerShipped == .graded(17.5))
+}
+
+// Baseline = the user's own trailing-4-week median; even count → mean of the
+// middle two.
+@Test func baselineIsMedianOfTrailingFourWeeks() throws {
+    var snapshots: [SessionAnalyticsSnapshot] = []
+    // Week −1: clean → 100. Week −2: 2% errors → 95. Week −3: 12% errors →
+    // 90. Week −4: 12% errors → 90.
+    let errorsByWeek = [0, 2, 12, 12]
+    for (index, errors) in errorsByWeek.enumerated() {
+        let monday = utc.date(byAdding: .weekOfYear, value: -(index + 1), to: currentWeekMonday)!
+        snapshots.append(snapshot(
+            endedAt: monday.addingTimeInterval(3600),
+            status: .completed,
+            apiErrors: errors, apiRequests: 100, cost: 4))
+    }
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+
+    #expect(model.priorWeeks.count == 4)
+    #expect(model.baseline.weeksAvailable == 4)
+    #expect(model.baseline.medianScore == 92.5) // (95 + 90) / 2
+    let medianErrorRate = try #require(model.baseline.medianApiErrorRate)
+    #expect(abs(medianErrorRate - 0.07) < 1e-9) // (0.02 + 0.12) / 2
+    #expect(model.baseline.medianCompactionsPerActiveHour == 0)
+    #expect(model.baseline.medianCostPerShipped == 4)
+}
+
+@Test func baselineMedianOddCountTakesMiddle() {
+    #expect(ScorecardModel.median([90, 100, 95]) == 95)
+    #expect(ScorecardModel.median([]) == nil)
+}
+
+// A week with no snapshots is absent, not a zero — it neither appears in
+// priorWeeks nor drags the baseline.
+@Test func datalessWeeksExcludedFromBaseline() {
+    let snapshots = [
+        snapshot(
+            endedAt: utc.date(byAdding: .weekOfYear, value: -1, to: currentWeekMonday)!,
+            status: .completed),
+        snapshot(
+            endedAt: utc.date(byAdding: .weekOfYear, value: -3, to: currentWeekMonday)!,
+            status: .completed)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.priorWeeks.count == 2)
+    #expect(model.baseline.weeksAvailable == 2)
+    #expect(model.baseline.medianScore == 100)
+}
+
+// An ungraded (sub-floor) prior week is present in the list but contributes
+// nothing to the baseline medians.
+@Test func insufficientDataWeeksExcludedFromBaselineMedians() {
+    let snapshots = [
+        snapshot(
+            endedAt: utc.date(byAdding: .weekOfYear, value: -1, to: currentWeekMonday)!,
+            prompts: 2),
+        snapshot(
+            endedAt: utc.date(byAdding: .weekOfYear, value: -2, to: currentWeekMonday)!,
+            status: .completed, prompts: 10)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.priorWeeks.count == 2)
+    #expect(model.baseline.weeksAvailable == 1)
+}
+
+// The minimum-sample floor applies at weekly grain through the same function:
+// a week whose summed prompts are below the floor is insufficient data, while
+// sessions-shipped (a plain count on a separate surface) still reports.
+@Test func weeklySigmaUnderFivePromptsIsInsufficientData() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .completed, prompts: 2),
+        snapshot(endedAt: date(2026, 7, 14), prompts: 2)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.currentWeek.result == .insufficientData(promptCount: 4))
+    #expect(model.currentWeek.sessionsShipped == 1)
+}
+
+// Sub-floor sessions' raws still sum into the weekly denominators and
+// numerators — splitting work into tiny sessions can't dodge the rollup.
+@Test func subFloorSessionRawsStillSumIntoWeek() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), compactions: 4, activeSeconds: 1800, prompts: 2),
+        snapshot(endedAt: date(2026, 7, 14), compactions: 0, activeSeconds: 1800, prompts: 10)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    // Σ prompts = 12 ≥ floor; Σ = 4 compactions / 1.0 active hour → −20.
+    guard case .graded(let score, _, let deductions) = model.currentWeek.result else {
+        Issue.record("expected graded week")
+        return
+    }
+    #expect(deductions.first?.points == 20)
+    #expect(score == 80)
+}
+
+@Test func emptySnapshotsBuildEmptyModel() {
+    let model = ScorecardModel.build(snapshots: [], now: now, calendar: utc)
+    #expect(model.currentWeek.result == .insufficientData(promptCount: 0))
+    #expect(model.currentWeek.sessionsShipped == 0)
+    #expect(model.currentWeek.costPerShipped == .insufficientOutcomes)
+    #expect(model.currentWeek.sessionCount == 0)
+    #expect(model.priorWeeks.isEmpty)
+    #expect(model.baseline == .empty)
+    #expect(model.currentWeekSessions.isEmpty)
+}
+
+// Displayed-not-graded stats are Σ over the week; churn is Σ removed / Σ added.
+@Test func displayedStatsSumAcrossTheWeek() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), cost: 1.5, linesAdded: 100, linesRemoved: 40, commits: 2),
+        snapshot(endedAt: date(2026, 7, 14), cost: 2.5, linesAdded: 100, linesRemoved: 10, commits: 3)
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.currentWeek.totalCost == 4)
+    #expect(model.currentWeek.activeTimeSeconds == 7200)
+    #expect(model.currentWeek.commitCount == 5)
+    #expect(model.currentWeek.churnHint == 0.25)
+}

--- a/Packages/CrowUI/Sources/CrowUI/AnalyticsFormatting.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AnalyticsFormatting.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Shared display formatting for analytics values (cost, token counts,
+/// durations) — used by the session analytics strip and the scorecard.
+enum AnalyticsFormatting {
+    static func cost(_ cost: Double) -> String {
+        if cost < 0.01 && cost > 0 {
+            return "<$0.01"
+        }
+        return String(format: "$%.2f", cost)
+    }
+
+    static func count(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1_000 {
+            return String(format: "%.1fK", Double(count) / 1_000)
+        }
+        return "\(count)"
+    }
+
+    static func time(_ seconds: Double) -> String {
+        let totalSeconds = Int(seconds)
+        if totalSeconds >= 3600 {
+            let hours = totalSeconds / 3600
+            let mins = (totalSeconds % 3600) / 60
+            return "\(hours)h \(mins)m"
+        } else if totalSeconds >= 60 {
+            return "\(totalSeconds / 60)m"
+        } else {
+            return "\(totalSeconds)s"
+        }
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
@@ -20,6 +20,8 @@ public struct MainContentView: View {
                 AllowListView(appState: appState)
             } else if appState.selectedSessionID == AppState.reviewBoardSessionID {
                 ReviewBoardView(appState: appState)
+            } else if appState.selectedSessionID == AppState.scorecardSessionID {
+                ScorecardView(appState: appState)
             } else if let session = appState.selectedSession {
                 SessionDetailView(session: session, appState: appState)
             } else {

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -362,12 +362,42 @@ public struct ManagerReviewsAllowListRow: View {
         HStack(spacing: 6) {
             reviewButton
             allowListButton
+            scorecardButton
             if appState.managerSession != nil {
                 managerButton
                 newManagerButton
             }
         }
         .padding(.vertical, 2)
+    }
+
+    /// Compact icon pill (same footprint as the "+" pill — the row is too
+    /// narrow for a fifth text pill) opening the efficiency scorecard (#710).
+    private var scorecardButton: some View {
+        let isActive = appState.selectedSessionID == AppState.scorecardSessionID
+        return Button {
+            appState.selectedSessionID = AppState.scorecardSessionID
+        } label: {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+                .frame(width: 28)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(
+                                    isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
+                                    lineWidth: 1
+                                )
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help("Scorecard")
+        .accessibilityLabel("Scorecard")
     }
 
     private var managerNeedsAttention: Bool {

--- a/Packages/CrowUI/Sources/CrowUI/ScorecardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ScorecardView.swift
@@ -1,0 +1,459 @@
+import SwiftUI
+import CrowCore
+
+// MARK: - Scorecard View (ADR 0008 v1, #710)
+
+/// Full-pane private efficiency scorecard: the weekly A–F grade with its
+/// coachable deductions, the sessions-shipped throughput count, and the
+/// self-comparison against the user's own trailing 4-week median. Read-only —
+/// computed from the persisted snapshots mirrored on
+/// `appState.analyticsSnapshots`. The grade and the shipped count are separate
+/// surfaces; nothing on this screen combines them into one number.
+public struct ScorecardView: View {
+    @Bindable var appState: AppState
+
+    public init(appState: AppState) {
+        self.appState = appState
+    }
+
+    private var model: ScorecardModel {
+        ScorecardModel.build(
+            snapshots: Array(appState.analyticsSnapshots.values),
+            now: Date(),
+            calendar: .current
+        )
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            SectionHelpBanner(
+                description: "Private efficiency scorecard — this week vs. your own trailing 4-week normal. Grade thresholds are starting heuristics under a 4-week calibration period; expect them to move.",
+                storageKey: "helpDismissed_scorecard"
+            )
+            Divider()
+            if appState.analyticsSnapshots.isEmpty {
+                emptyState
+            } else {
+                content
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.background)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack {
+            Text("Scorecard")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(CorveilTheme.gold)
+
+            Spacer()
+
+            Text(Self.weekRangeLabel(model.currentWeek.weekStart))
+                .font(.caption)
+                .foregroundStyle(CorveilTheme.textSecondary)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(CorveilTheme.bgSurface)
+    }
+
+    // MARK: Content
+
+    private var content: some View {
+        let model = self.model
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(alignment: .top, spacing: 12) {
+                    gradeCard(model.currentWeek)
+                    shippedCard(model.currentWeek)
+                }
+
+                baselineSection(model)
+                displayedStatsSection(model.currentWeek)
+
+                if !model.priorWeeks.isEmpty {
+                    priorWeeksSection(model.priorWeeks)
+                }
+
+                if !model.currentWeekSessions.isEmpty {
+                    sessionsSection(model.currentWeekSessions)
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Session Data Yet", systemImage: "chart.bar.xaxis")
+        } description: {
+            Text("The scorecard is computed from analytics snapshots written when sessions complete or archive. Snapshots require Claude Code telemetry, which is off by default — enable it in Settings, then finish a session.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Weekly grade card
+
+    private func gradeCard(_ week: WeeklyScorecard) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("This Week's Grade")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+
+                switch week.result {
+                case .graded(let score, let letter, let deductions):
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(letter.rawValue)
+                            .font(.system(size: 44, weight: .bold, design: .rounded))
+                            .foregroundStyle(Self.gradeColor(letter))
+                        Text("\(score)/100")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(CorveilTheme.textSecondary)
+                    }
+                    if deductions.isEmpty {
+                        Text("No deductions — clean week.")
+                            .font(.caption)
+                            .foregroundStyle(CorveilTheme.textMuted)
+                    } else {
+                        VStack(alignment: .leading, spacing: 6) {
+                            ForEach(deductions, id: \.metric) { deduction in
+                                deductionRow(deduction)
+                            }
+                        }
+                    }
+                case .insufficientData(let prompts):
+                    insufficientDataBlock(prompts: prompts)
+                }
+            }
+        }
+    }
+
+    private func deductionRow(_ deduction: EfficiencyGrading.Deduction) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(deduction.label)
+                    .font(.system(size: 12, weight: .medium))
+                Spacer()
+                Text("−\(deduction.points)")
+                    .font(.system(size: 12, weight: .bold))
+                    .monospacedDigit()
+                    .foregroundStyle(.red)
+            }
+            Text(Self.coachingHint(deduction.metric))
+                .font(.caption2)
+                .foregroundStyle(CorveilTheme.textMuted)
+        }
+    }
+
+    private func insufficientDataBlock(prompts: Int) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Insufficient data")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(CorveilTheme.textSecondary)
+            Text("\(prompts) prompt\(prompts == 1 ? "" : "s") this week — grading starts at \(EfficiencyGrading.Tuning.minimumGradablePromptCount).")
+                .font(.caption)
+                .foregroundStyle(CorveilTheme.textMuted)
+        }
+    }
+
+    // MARK: Sessions-shipped card (separate surface — never combined)
+
+    private func shippedCard(_ week: WeeklyScorecard) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Sessions Shipped")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+
+                Text("\(week.sessionsShipped)")
+                    .font(.system(size: 44, weight: .bold, design: .rounded))
+                    .foregroundStyle(CorveilTheme.gold)
+
+                switch week.costPerShipped {
+                case .graded(let cost):
+                    Text("\(AnalyticsFormatting.cost(cost)) per shipped session")
+                        .font(.caption)
+                        .foregroundStyle(CorveilTheme.textSecondary)
+                case .insufficientOutcomes:
+                    Text("Insufficient outcomes — nothing shipped this week.")
+                        .font(.caption)
+                        .foregroundStyle(CorveilTheme.textMuted)
+                }
+            }
+        }
+    }
+
+    // MARK: Baseline (vs. your normal)
+
+    @ViewBuilder
+    private func baselineSection(_ model: ScorecardModel) -> some View {
+        let baseline = model.baseline
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("vs. Your Normal (trailing 4-week median)")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+
+                if baseline.weeksAvailable < EfficiencyGrading.Tuning.minimumBaselineWeeks {
+                    Text("Baseline building — \(baseline.weeksAvailable) of \(EfficiencyGrading.Tuning.baselineWeekCount) weeks of history.")
+                        .font(.caption)
+                        .foregroundStyle(CorveilTheme.textMuted)
+                } else {
+                    let input = model.currentWeek.input
+                    VStack(alignment: .leading, spacing: 5) {
+                        if case .graded(let score, _, _) = model.currentWeek.result,
+                           let median = baseline.medianScore {
+                            comparisonRow(
+                                name: "Score", current: Double(score), baseline: median,
+                                higherIsBetter: true) { String(format: "%.0f", $0) }
+                        }
+                        if let median = baseline.medianCompactionsPerActiveHour {
+                            comparisonRow(
+                                name: "Compactions/active hr",
+                                current: input.compactionsPerActiveHour, baseline: median,
+                                higherIsBetter: false) { String(format: "%.1f", $0) }
+                        }
+                        if let median = baseline.medianInputTokensPerPrompt {
+                            comparisonRow(
+                                name: "Input tokens/prompt",
+                                current: input.inputTokensPerPrompt, baseline: median,
+                                higherIsBetter: false) { AnalyticsFormatting.count(Int($0)) }
+                        }
+                        if let median = baseline.medianCacheHitRatio {
+                            comparisonRow(
+                                name: "Cache hit ratio",
+                                current: input.cacheHitRatio, baseline: median,
+                                higherIsBetter: true) { String(format: "%.0f%%", $0 * 100) }
+                        }
+                        if let median = baseline.medianApiErrorRate {
+                            comparisonRow(
+                                name: "API error rate",
+                                current: input.apiErrorRate, baseline: median,
+                                higherIsBetter: false) { String(format: "%.1f%%", $0 * 100) }
+                        }
+                        if let median = baseline.medianCostPerShipped,
+                           case .graded(let cost) = model.currentWeek.costPerShipped {
+                            comparisonRow(
+                                name: "Cost/shipped", current: cost, baseline: median,
+                                higherIsBetter: false) { AnalyticsFormatting.cost($0) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func comparisonRow(
+        name: String,
+        current: Double,
+        baseline: Double,
+        higherIsBetter: Bool,
+        format: (Double) -> String
+    ) -> some View {
+        let delta = current - baseline
+        let isBetter = higherIsBetter ? delta > 0 : delta < 0
+        let isFlat = abs(delta) < 0.0001
+        return HStack {
+            Text(name)
+                .font(.system(size: 12))
+                .foregroundStyle(CorveilTheme.textSecondary)
+            Spacer()
+            Text(format(current))
+                .font(.system(size: 12, weight: .semibold))
+                .monospacedDigit()
+            Image(systemName: isFlat ? "minus" : (delta > 0 ? "arrow.up" : "arrow.down"))
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(isFlat ? CorveilTheme.textMuted : (isBetter ? .green : .red))
+            Text(format(baseline))
+                .font(.system(size: 12))
+                .monospacedDigit()
+                .foregroundStyle(CorveilTheme.textMuted)
+        }
+    }
+
+    // MARK: Displayed, not graded
+
+    private func displayedStatsSection(_ week: WeeklyScorecard) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("This Week (context only — not graded)")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                HStack(spacing: 12) {
+                    StatChip(icon: "dollarsign.circle", label: "Cost",
+                             value: AnalyticsFormatting.cost(week.totalCost))
+                    StatChip(icon: "clock", label: "Active",
+                             value: AnalyticsFormatting.time(week.activeTimeSeconds))
+                    StatChip(icon: "arrow.up.circle", label: "Commits",
+                             value: "\(week.commitCount)")
+                    StatChip(icon: "arrow.triangle.2.circlepath", label: "Churn",
+                             value: String(format: "%.2f", week.churnHint))
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    // MARK: Prior weeks
+
+    private func priorWeeksSection(_ weeks: [WeeklyScorecard]) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Previous Weeks")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                ForEach(weeks, id: \.weekStart) { week in
+                    HStack {
+                        Text(Self.weekRangeLabel(week.weekStart))
+                            .font(.system(size: 12))
+                            .foregroundStyle(CorveilTheme.textSecondary)
+                        gradeBadge(week.result)
+                        Spacer()
+                        Text("\(week.sessionsShipped) shipped")
+                            .font(.system(size: 12))
+                            .monospacedDigit()
+                            .foregroundStyle(CorveilTheme.textSecondary)
+                        Text(AnalyticsFormatting.cost(week.totalCost))
+                            .font(.system(size: 12))
+                            .monospacedDigit()
+                            .foregroundStyle(CorveilTheme.textMuted)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Per-session drill-down
+
+    private func sessionsSection(_ rows: [SessionGradeRow]) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("This Week's Sessions")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                ForEach(rows) { row in
+                    sessionRow(row)
+                }
+            }
+        }
+    }
+
+    private func sessionRow(_ row: SessionGradeRow) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                gradeBadge(row.result)
+                Text(row.endedAt, style: .date)
+                    .font(.system(size: 12))
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                if row.shipped {
+                    Text("Shipped")
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(Color.green.opacity(0.15))
+                        .foregroundStyle(.green)
+                        .clipShape(Capsule())
+                }
+                Spacer()
+                Text(AnalyticsFormatting.cost(row.analytics.totalCost))
+                    .font(.system(size: 11))
+                    .monospacedDigit()
+                    .foregroundStyle(CorveilTheme.textMuted)
+                Text(AnalyticsFormatting.time(row.analytics.activeTimeSeconds))
+                    .font(.system(size: 11))
+                    .monospacedDigit()
+                    .foregroundStyle(CorveilTheme.textMuted)
+                if let wallClock = row.wallClockDurationSeconds {
+                    Text("(\(AnalyticsFormatting.time(wallClock)) wall)")
+                        .font(.system(size: 11))
+                        .foregroundStyle(CorveilTheme.textMuted)
+                }
+            }
+            if case .graded(_, _, let deductions) = row.result, !deductions.isEmpty {
+                Text(deductions.map { "\($0.label) −\($0.points)" }.joined(separator: "  ·  "))
+                    .font(.caption2)
+                    .foregroundStyle(CorveilTheme.textMuted)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func gradeBadge(_ result: EfficiencyGrading.GradeResult) -> some View {
+        switch result {
+        case .graded(_, let letter, _):
+            Text(letter.rawValue)
+                .font(.system(size: 12, weight: .bold, design: .rounded))
+                .frame(width: 22, height: 22)
+                .background(Self.gradeColor(letter).opacity(0.15))
+                .foregroundStyle(Self.gradeColor(letter))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        case .insufficientData:
+            Text("—")
+                .font(.system(size: 12, weight: .bold))
+                .frame(width: 22, height: 22)
+                .background(CorveilTheme.bgSurface)
+                .foregroundStyle(CorveilTheme.textMuted)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .help("Insufficient data (fewer than \(EfficiencyGrading.Tuning.minimumGradablePromptCount) prompts)")
+        }
+    }
+
+    // MARK: Shared bits
+
+    private func card(@ViewBuilder content: () -> some View) -> some View {
+        content()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(CorveilTheme.bgCard)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
+                    )
+            )
+    }
+
+    static func gradeColor(_ letter: EfficiencyGrading.LetterGrade) -> Color {
+        switch letter {
+        case .a: return .green
+        case .b: return .mint
+        case .c: return .yellow
+        case .d: return .orange
+        case .f: return .red
+        }
+    }
+
+    /// One coachable sentence per metric, rendered under its deduction. Lives
+    /// in the view layer: the compute layer's labels state the measurement,
+    /// these state what to do about it.
+    static func coachingHint(_ metric: EfficiencyGrading.Metric) -> String {
+        switch metric {
+        case .compactions:
+            return "Compacting mid-session means the context filled — clear between tasks or split unrelated work."
+        case .contextPressure:
+            return "Heavy input per prompt suggests bloated context — reset more often or narrow what gets loaded."
+        case .cacheHitRatio:
+            return "Low cache reuse means context is re-sent as fresh input — steadier sessions cache better."
+        case .apiErrorRate:
+            return "Frequent API errors burn time and tokens — check connectivity, rate limits, or the agent setup."
+        case .costPerShipped:
+            return "High spend per shipped session — smaller scoped sessions that finish tend to cost less per outcome."
+        }
+    }
+
+    static func weekRangeLabel(_ weekStart: Date) -> String {
+        let end = weekStart.addingTimeInterval(6 * 86_400)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return "Week of \(formatter.string(from: weekStart)) – \(formatter.string(from: end))"
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/SessionAnalyticsStrip.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionAnalyticsStrip.swift
@@ -11,12 +11,12 @@ struct SessionAnalyticsStrip: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            StatChip(icon: "dollarsign.circle", label: "Cost", value: formatCost(analytics.totalCost))
-            StatChip(icon: "text.word.spacing", label: "Tokens", value: formatCount(analytics.totalTokens))
+            StatChip(icon: "dollarsign.circle", label: "Cost", value: AnalyticsFormatting.cost(analytics.totalCost))
+            StatChip(icon: "text.word.spacing", label: "Tokens", value: AnalyticsFormatting.count(analytics.totalTokens))
             StatChip(icon: "wrench", label: "Tools", value: "\(analytics.toolCallCount)")
-            StatChip(icon: "clock", label: "Active", value: formatTime(analytics.activeTimeSeconds))
+            StatChip(icon: "clock", label: "Active", value: AnalyticsFormatting.time(analytics.activeTimeSeconds))
             if let wallClockDuration {
-                StatChip(icon: "timer", label: "Duration", value: formatTime(wallClockDuration))
+                StatChip(icon: "timer", label: "Duration", value: AnalyticsFormatting.time(wallClockDuration))
             }
             if analytics.linesAdded > 0 || analytics.linesRemoved > 0 {
                 StatChip(
@@ -37,40 +37,10 @@ struct SessionAnalyticsStrip: View {
         }
     }
 
-    // MARK: - Formatting
-
-    private func formatCost(_ cost: Double) -> String {
-        if cost < 0.01 && cost > 0 {
-            return "<$0.01"
-        }
-        return String(format: "$%.2f", cost)
-    }
-
-    private func formatCount(_ count: Int) -> String {
-        if count >= 1_000_000 {
-            return String(format: "%.1fM", Double(count) / 1_000_000)
-        } else if count >= 1_000 {
-            return String(format: "%.1fK", Double(count) / 1_000)
-        }
-        return "\(count)"
-    }
-
-    private func formatTime(_ seconds: Double) -> String {
-        let totalSeconds = Int(seconds)
-        if totalSeconds >= 3600 {
-            let hours = totalSeconds / 3600
-            let mins = (totalSeconds % 3600) / 60
-            return "\(hours)h \(mins)m"
-        } else if totalSeconds >= 60 {
-            return "\(totalSeconds / 60)m"
-        } else {
-            return "\(totalSeconds)s"
-        }
-    }
 }
 
 /// A single stat chip with icon, label, and value.
-private struct StatChip: View {
+struct StatChip: View {
     let icon: String
     let label: String
     let value: String

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -2476,6 +2476,7 @@ final class IssueTracker {
         AppState.ticketBoardSessionID,
         AppState.allowListSessionID,
         AppState.reviewBoardSessionID,
+        AppState.scorecardSessionID,
     ]
 
     /// Pure decision function: returns session IDs eligible for auto-cleanup.

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -53,6 +53,9 @@ final class SessionService {
     func hydrateState() {
         let data = store.data
         appState.sessions = data.sessions
+        // Mirror persisted analytics snapshots for the scorecard (#710) —
+        // CrowUI can't read the store, so the view computes from this.
+        appState.analyticsSnapshots = data.analyticsSnapshots ?? [:]
 
         // Migrate a legacy primary Manager (persisted as `.work` before
         // SessionKind.manager existed) to `.manager` BEFORE the per-session loop.
@@ -2429,6 +2432,7 @@ final class SessionService {
             snapshots[id.uuidString] = snapshot
             data.analyticsSnapshots = snapshots
         }
+        appState.analyticsSnapshots[id.uuidString] = snapshot
     }
 
     /// Lock or unlock a session to exempt it from (or restore it to) the
@@ -2497,6 +2501,8 @@ final class SessionService {
                 data.analyticsSnapshots = snapshots
             }
         }
+        // Keep the scorecard mirror in sync with any quit-race backfills.
+        appState.analyticsSnapshots = store.data.analyticsSnapshots ?? [:]
     }
 
     // MARK: - Find Claude Binary

--- a/Tests/CrowTests/ScorecardWiringTests.swift
+++ b/Tests/CrowTests/ScorecardWiringTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+@testable import Crow
+
+/// #710: the scorecard reads persisted snapshots through the read-only
+/// `AppState.analyticsSnapshots` mirror (CrowUI cannot import CrowPersistence).
+/// These tests lock in that the mirror is hydrated on load and stays in sync
+/// with every snapshot write path.
+@MainActor
+@Suite("Scorecard snapshot mirror wiring")
+struct ScorecardWiringTests {
+
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-scorecard-wiring-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private nonisolated static let sampleAnalytics = SessionAnalytics(
+        totalCost: 2.5, inputTokens: 500, outputTokens: 900,
+        activeTimeSeconds: 1_200, promptCount: 9, toolCallCount: 30
+    )
+
+    @Test
+    func hydrateStatePopulatesTheMirror() {
+        let store = Self.tempStore()
+        let id = UUID()
+        let persisted = SessionAnalyticsSnapshot(
+            sessionID: id, endedAt: Date(timeIntervalSince1970: 1_752_000_000),
+            status: .completed, analytics: Self.sampleAnalytics)
+        store.mutate { $0.analyticsSnapshots = [id.uuidString: persisted] }
+
+        let appState = AppState()
+        let service = SessionService(store: store, appState: appState)
+        service.hydrateState()
+
+        #expect(appState.analyticsSnapshots == [id.uuidString: persisted])
+    }
+
+    @Test
+    func hydrateStateWithNoSnapshotsLeavesMirrorEmpty() {
+        let appState = AppState()
+        let service = SessionService(store: Self.tempStore(), appState: appState)
+        service.hydrateState()
+        #expect(appState.analyticsSnapshots.isEmpty)
+    }
+
+    @Test
+    func writeAnalyticsSnapshotUpdatesTheMirror() async {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let id = UUID()
+        appState.sessions = [Session(id: id, name: "shipped")]
+        let service = SessionService(
+            store: store, appState: appState,
+            analyticsProvider: { _ in Self.sampleAnalytics })
+
+        await service.writeAnalyticsSnapshot(for: id, status: .completed)
+
+        #expect(appState.analyticsSnapshots[id.uuidString]
+            == store.data.analyticsSnapshots?[id.uuidString])
+        #expect(appState.analyticsSnapshots[id.uuidString]?.status == .completed)
+    }
+
+    @Test
+    func persistStateBackfillResyncsTheMirror() {
+        let store = Self.tempStore()
+        let appState = AppState()
+        var ended = Session(id: UUID(), name: "ended-then-quit")
+        ended.status = .completed
+        appState.sessions = [ended]
+        appState.hookState(for: ended.id).analytics = Self.sampleAnalytics
+
+        let service = SessionService(store: store, appState: appState)
+        service.persistState()
+
+        #expect(appState.analyticsSnapshots[ended.id.uuidString]?.analytics
+            == Self.sampleAnalytics)
+    }
+}


### PR DESCRIPTION
Closes #710. ADR 0008 v1 deliverable (refs #648). Read-only compute + view over the persisted snapshots from #689/#690/#691/#692.

## Prerequisite status
All four data-foundation prerequisites are **merged on `main`** and this branch is built directly on them: #689 temporality (badbe6d), #690 snapshot persistence (cc027a7), #691 compaction counter (4e469a2), #692 wall-clock duration (cc18fba). No new capture, no persistence changes, no migration.

## What's here
- **`CrowCore/Models/EfficiencyGrading.swift`** — the single penalty-point grading function. It only accepts raw numerators/denominators (`GradeInput`), so the weekly grade is `grade(Σ raws)` and averaging per-session grades is structurally impossible (the ADR's anti-session-splitting rule, enforced by API shape). Tuning constants are named priors under the binding 4-week calibration period; the ADR's canonical example ("C — 3 compactions (−15), 12% API error rate (−10)" → 75) is a test fixture.
- **`CrowCore/Models/EfficiencyScorecard.swift`** — ISO-8601 week bucketing (half-open intervals; a snapshot at Monday 00:00 lands in exactly one week), weekly rollup, trailing-4-week median baseline, per-session drill-down rows.
- **`CrowUI/ScorecardView.swift`** — weekly grade card (letter + score + coachable deduction sentences) and sessions-shipped card as two separate surfaces (no combined number anywhere), vs-your-normal comparison strip, displayed-not-graded chips (cost/active/commits/churn), prior weeks, per-session drill-down, telemetry-off empty state. Sidebar icon pill + `MainContentView` route on new fixed UUID `…005`.
- **Wiring** — `AppState.analyticsSnapshots` read-only mirror hydrated by `SessionService` (CrowUI can't import CrowPersistence); scorecard UUID added to the retention reaper's protected set.

## ADR guardrails implemented
- Penalties normalized **per active hour** (`activeTimeSeconds`); wall-clock is display-only.
- `< 5` prompts → "insufficient data" (session and weekly grain, same floor, same function).
- `sessionsShipped == 0` week → cost metric "insufficient outcomes", never a fallback divisor.
- Cost-per-shipped graded at weekly grain only; `doneIssuesLast24h` untouched (stays a board badge).
- Baseline = own trailing 4-week median; no leaderboard, no combined score.

## Tests
30 new CrowCore tests (grading bands/labels, per-active-hour normalization, Σ-not-average rollup no-dilution fixture, insufficient data/outcomes, median baseline incl. even-count, nil compactionCount) + 4 wiring tests for the AppState mirror. `make build` + `make test` green. Only failure is the pre-existing `CrowGit` RebaseTests environment issue (no git committer identity in sandbox) — fails identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)