### PR TITLE
docs: repoint stale radiusmethod/crow links to corveil/crow after org migration (closes #700)

### DIFF
--- a/docs/adr/0001-tmux-only-terminal-backend.md
+++ b/docs/adr/0001-tmux-only-terminal-backend.md
@@ -43,7 +43,7 @@ A single-instance lock at `$TMPDIR/crow-instance.lock` prevents two Crow process
 
 ## References
 
-- PRs: [#229](https://github.com/radiusmethod/crow/pull/229) (feature flag), [#302](https://github.com/radiusmethod/crow/pull/302) (default backend), [#334](https://github.com/radiusmethod/crow/pull/334) (remove legacy Ghostty path), [#324](https://github.com/radiusmethod/crow/pull/324) (Manager on tmux), [#353](https://github.com/radiusmethod/crow/pull/353) (persist across restarts), [#377](https://github.com/radiusmethod/crow/pull/377) (restart-server menu)
+- PRs: [#229](https://github.com/corveil/crow/pull/229) (feature flag), [#302](https://github.com/corveil/crow/pull/302) (default backend), [#334](https://github.com/corveil/crow/pull/334) (remove legacy Ghostty path), [#324](https://github.com/corveil/crow/pull/324) (Manager on tmux), [#353](https://github.com/corveil/crow/pull/353) (persist across restarts), [#377](https://github.com/corveil/crow/pull/377) (restart-server menu)
 - Research: [`docs/terminal-runtime-research.md`](../terminal-runtime-research.md)
 - Code:
   - `Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift`

--- a/docs/adr/0003-worktree-per-task-model.md
+++ b/docs/adr/0003-worktree-per-task-model.md
@@ -39,7 +39,7 @@ The Manager session and other fixed-UUID virtual sessions are exempt from cleanu
 
 ## References
 
-- PRs: [#261](https://github.com/radiusmethod/crow/pull/261) (auto-cleanup of completed sessions)
+- PRs: [#261](https://github.com/corveil/crow/pull/261) (auto-cleanup of completed sessions)
 - Code:
   - `skills/crow-workspace/setup.sh` (creates the worktree and enforces the naming convention)
   - `Packages/CrowCore/Sources/CrowCore/Models/Worktree.swift`

--- a/docs/adr/0004-manager-auto-permission-mode.md
+++ b/docs/adr/0004-manager-auto-permission-mode.md
@@ -38,7 +38,7 @@ The trust scope is explicit: only the Manager. The user can disable Manager auto
 
 ## References
 
-- PRs: [#189](https://github.com/radiusmethod/crow/pull/189) (introduce `managerAutoPermissionMode`, default `true`)
+- PRs: [#189](https://github.com/corveil/crow/pull/189) (introduce `managerAutoPermissionMode`, default `true`)
 - Code:
   - `Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift`
   - `Packages/CrowCore/Sources/CrowCore/AppState.swift`

--- a/docs/adr/0005-task-and-code-backend-protocols.md
+++ b/docs/adr/0005-task-and-code-backend-protocols.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Crow integrates with two ticket/PR providers today (`gh` for GitHub, `glab` for GitLab) by shelling out from many call sites scattered across `IssueTracker.swift`, `SessionService.swift`, and `ProviderManager.swift`. An audit in [#410](https://github.com/radiusmethod/crow/issues/410) found three coexisting patterns:
+Crow integrates with two ticket/PR providers today (`gh` for GitHub, `glab` for GitLab) by shelling out from many call sites scattered across `IssueTracker.swift`, `SessionService.swift`, and `ProviderManager.swift`. An audit in [#410](https://github.com/corveil/crow/issues/410) found three coexisting patterns:
 
 1. **Switch-at-callsite**: `switch provider { gh / glab }` inline (e.g. `IssueTracker.swift:493`).
 2. **Parallel implementations**: one fat GitHub function and one fat GitLab function sitting in the same file — conceptually one operation, two halves (e.g. assigned-issue fetch at `IssueTracker.swift:703` and `:2509`).
@@ -127,7 +127,7 @@ After #454, `rg '"gh"|"glab"|gh api|glab api' Sources/Crow/App/IssueTracker.swif
 
 ## References
 
-- Tickets: [#410](https://github.com/radiusmethod/crow/issues/410) (foundation, closed via #411), [#454](https://github.com/radiusmethod/crow/issues/454) (migration), [#495](https://github.com/radiusmethod/crow/issues/495) (real Corveil backend)
+- Tickets: [#410](https://github.com/corveil/crow/issues/410) (foundation, closed via #411), [#454](https://github.com/corveil/crow/issues/454) (migration), [#495](https://github.com/corveil/crow/issues/495) (real Corveil backend)
 - PRs: #411 (foundation), the PR closing #454 (migration)
 - Code:
   - `Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift`

--- a/docs/adr/0007-linux-ci-swift.md
+++ b/docs/adr/0007-linux-ci-swift.md
@@ -6,9 +6,9 @@
 
 ## Context
 
-PR CI (`ci.yml`) and the per-`main`-push cache warm (`cache-warm.yml`) ran on `macos-15` with Xcode 16, purely to get a Swift toolchain. macOS GitHub Actions minutes are billed at ~10× Linux, so every PR and every push to `main` paid the macOS premium for Swift work that is mostly Foundation-only. Crow is [web-app-first over a headless daemon](https://github.com/radiusmethod/crow/issues/581), and #118 already began shifting macOS-only cost toward the release pipeline; issue [#647](https://github.com/radiusmethod/crow/issues/647) finishes the job for day-to-day CI.
+PR CI (`ci.yml`) and the per-`main`-push cache warm (`cache-warm.yml`) ran on `macos-15` with Xcode 16, purely to get a Swift toolchain. macOS GitHub Actions minutes are billed at ~10× Linux, so every PR and every push to `main` paid the macOS premium for Swift work that is mostly Foundation-only. Crow is [web-app-first over a headless daemon](https://github.com/corveil/crow/issues/581), and #118 already began shifting macOS-only cost toward the release pipeline; issue [#647](https://github.com/corveil/crow/issues/647) finishes the job for day-to-day CI.
 
-Constraint on the current tree: the daemon Linux build ([#645](https://github.com/radiusmethod/crow/issues/645)) is **not merged**, so there is no `crowd` product here. The root `Package.swift` is `platforms: [.macOS(.v14)]` and its only executables are the AppKit GUI (`Crow`/`CrowApp`) and the `crow` CLI. A root `swift build` therefore compiles the GUI and cannot run on Linux. However, 10 of the 13 sub-packages (`CrowCore`, `CrowIPC`, `CrowClaude`, `CrowCodex`, `CrowCursor`, `CrowGit`, `CrowOpenCode`, `CrowPersistence`, `CrowProvider`, `CrowCLI`) are Foundation-only — they import only Foundation / ArgumentParser / each other, with Darwin↔Glibc socket code already `#if canImport`-guarded — and depend on nothing that reaches AppKit.
+Constraint on the current tree: the daemon Linux build ([#645](https://github.com/corveil/crow/issues/645)) is **not merged**, so there is no `crowd` product here. The root `Package.swift` is `platforms: [.macOS(.v14)]` and its only executables are the AppKit GUI (`Crow`/`CrowApp`) and the `crow` CLI. A root `swift build` therefore compiles the GUI and cannot run on Linux. However, 10 of the 13 sub-packages (`CrowCore`, `CrowIPC`, `CrowClaude`, `CrowCodex`, `CrowCursor`, `CrowGit`, `CrowOpenCode`, `CrowPersistence`, `CrowProvider`, `CrowCLI`) are Foundation-only — they import only Foundation / ArgumentParser / each other, with Darwin↔Glibc socket code already `#if canImport`-guarded — and depend on nothing that reaches AppKit.
 
 ## Decision
 
@@ -32,6 +32,6 @@ PR CI and cache-warm run on `ubuntu-latest` inside the official `swift:6` contai
 
 ## References
 
-- PR: https://github.com/radiusmethod/crow/pull/651 (issue #647)
+- PR: https://github.com/corveil/crow/pull/651 (issue #647)
 - Related ADRs: [0006](./0006-universal-macos-binary.md)
 - Code: `.github/workflows/ci.yml`, `.github/workflows/cache-warm.yml`, `.github/workflows/release.yml`, `scripts/generate-build-info.sh`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ This guide walks you from a fresh clone to a running Crow app with GitHub (or Gi
 ## 1. Clone the Repository
 
 ```bash
-git clone https://github.com/radiusmethod/crow.git
+git clone https://github.com/corveil/crow.git
 cd crow
 ```
 
@@ -214,7 +214,7 @@ Builds from source are unsigned. If macOS quarantines the bundle on first launch
 xattr -cr /Applications/Crow.app
 ```
 
-Official signed/notarized builds are available on the [Releases](https://github.com/radiusmethod/crow/releases) page and install without Gatekeeper warnings.
+Official signed/notarized builds are available on the [Releases](https://github.com/corveil/crow/releases) page and install without Gatekeeper warnings.
 
 ## Next Steps
 

--- a/docs/terminal-runtime-research.md
+++ b/docs/terminal-runtime-research.md
@@ -5,7 +5,7 @@
 > WKWebView over a tmux-backed PTY — see [ADR 0006](adr/0006-universal-macos-binary.md).
 > Kept as-is for the historical record.
 
-**Issue:** [#103 — Investigate: Terminal Alternatives to Ghostty for Background Execution](https://github.com/radiusmethod/crow/issues/103)
+**Issue:** [#103 — Investigate: Terminal Alternatives to Ghostty for Background Execution](https://github.com/corveil/crow/issues/103)
 **Date:** 2026-04-06
 
 ## Executive Summary


### PR DESCRIPTION
Closes #700. Docs-only link sweep; ADR 0008 already handled in PR #657. Example-workspace-name prose left as-is (out of scope).

**Files:** `docs/getting-started.md` (clone URL + Releases), `docs/terminal-runtime-research.md` (issue #103), ADRs 0001/0003/0004/0005/0007 (issue/PR reference links). Issue/PR numbers unchanged — only the org in the URLs.

**Verified:** `rg -in "radiusmethod/crow" docs/` returns nothing; remaining `RadiusMethod` hits in docs/ are illustrative workspace-name prose only. No code files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)