### PR TITLE
Count GitLab closed issues in done-ticket throughput (GitLab parity) (closes #697)

### DIFF
--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
@@ -47,10 +47,7 @@ public struct GitLabTaskBackend: TaskBackend {
 
     public func listAssigned(includeClosed: Bool) async throws -> AssignedListing {
         // GitLab has no consolidated batched endpoint. One REST call for open;
-        // a second only when `includeClosed` is true (the GitHub-driven
-        // closed-issue diff in IssueTracker doesn't consume the GitLab half,
-        // so the default GitLab caller passes false to skip the wasted
-        // round-trip every poll).
+        // a second only when `includeClosed` is true.
         // Use `glab api` rather than `glab issue list` — the latter shells out
         // to `git` even when no repo is involved and aborts with "fatal: not
         // a git repository" when cwd isn't a git working tree.
@@ -71,16 +68,15 @@ public struct GitLabTaskBackend: TaskBackend {
             return AssignedListing(open: open, closed: [])
         }
 
-        // `closed` is a single `per_page=50` page and `closedTotalCount` falls
-        // back to its length — if this path ever feeds a done-count badge, the
-        // total must come from the `X-Total` header (`glab api -i`) instead,
-        // per the #562/#572 cap fixes. Today IssueTracker only calls GitLab
-        // with `includeClosed: false` and never badges its closed count.
+        // `closed` is a single `per_page=50` page that feeds the done-count
+        // badge (#697), so `closedTotalCount` must be the true window total,
+        // not the capped page length — read it from the `X-Total` response
+        // header (`glab api -i`), per the #562/#572 cap fixes.
         let updatedAfter = Self.updatedAfterString()
         let closedOut: String
         do {
             closedOut = try await shellRunner.run(
-                args: ["glab", "api", "issues?scope=assigned_to_me&state=closed&per_page=50&updated_after=\(updatedAfter)"],
+                args: ["glab", "api", "-i", "issues?scope=assigned_to_me&state=closed&per_page=50&updated_after=\(updatedAfter)"],
                 env: env(),
                 cwd: NSHomeDirectory()
             )
@@ -88,8 +84,31 @@ public struct GitLabTaskBackend: TaskBackend {
             // If the closed query fails, fall back to whatever open we got.
             return AssignedListing(open: open, closed: [])
         }
-        let closed = Self.parseIssues(closedOut, host: host ?? "", projectStatusOverride: .done)
-        return AssignedListing(open: open, closed: closed)
+        let (total, body) = Self.splitTotalHeader(closedOut)
+        let closed = Self.parseIssues(body, host: host ?? "", projectStatusOverride: .done)
+        return AssignedListing(
+            open: open,
+            closed: closed,
+            closedTotalCount: total.map { max($0, closed.count) }
+        )
+    }
+
+    /// Split a `glab api -i` response into the `X-Total` header value and the
+    /// body. Headers end at the first blank line; GitLab omits `X-Total` for
+    /// very expensive counts, in which case (or with no header block at all)
+    /// `total` is nil and `AssignedListing` falls back to the page length.
+    nonisolated static func splitTotalHeader(_ output: String) -> (total: Int?, body: String) {
+        let normalized = output.replacingOccurrences(of: "\r\n", with: "\n")
+        guard let sep = normalized.range(of: "\n\n") else { return (nil, output) }
+        var total: Int?
+        for line in normalized[..<sep.lowerBound].split(separator: "\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            if parts.count == 2,
+               parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "x-total" {
+                total = Int(parts[1].trimmingCharacters(in: .whitespaces))
+            }
+        }
+        return (total, String(normalized[sep.upperBound...]))
     }
 
     public func setLabels(url: String, add: [String], remove: [String]) async throws {

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -758,7 +758,8 @@ final class BackendsTests: XCTestCase {
         [{"iid":3,"title":"Closed","web_url":"https://gitlab.example.com/g/p/-/issues/3","state":"closed",
           "labels":[],"references":{"full":"g/p#3"}}]
         """
-        fake.responses = [.success(openJSON), .success(closedJSON)]
+        let closedResponse = "HTTP/2.0 200 OK\nContent-Type: application/json\nX-Total: 137\n\n" + closedJSON
+        fake.responses = [.success(openJSON), .success(closedResponse)]
         let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")
         let listing = try await backend.listAssigned()
         XCTAssertEqual(listing.open.count, 1)
@@ -766,14 +767,58 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(listing.open[0].state, "open")
         XCTAssertEqual(listing.closed.count, 1)
         XCTAssertEqual(listing.closed[0].projectStatus, .done)
+        // #697: the done badge uses the X-Total window total, not the capped page.
+        XCTAssertEqual(listing.closedTotalCount, 137)
         XCTAssertNil(listing.rateLimit)  // GitLab doesn't have rate-limit JSON in this shape
         XCTAssertEqual(fake.calls.count, 2)
+        XCTAssertTrue(fake.calls[1].args.contains("-i"))
+    }
+
+    func testGitLabTaskBackendClosedTotalFallsBackToPageCountWithoutHeader() async throws {
+        let fake = FakeShellRunner()
+        let openJSON = "[]"
+        let closedJSON = #"[{"iid":3,"title":"Closed","web_url":"https://gl/g/p/-/issues/3","state":"closed","labels":[],"references":{"full":"g/p#3"}}]"#
+        // Headers present but no X-Total (GitLab omits it for expensive counts).
+        let closedResponse = "HTTP/2.0 200 OK\nContent-Type: application/json\n\n" + closedJSON
+        fake.responses = [.success(openJSON), .success(closedResponse)]
+        let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closedTotalCount, 1)
+    }
+
+    func testGitLabTaskBackendClosedCallFailureKeepsOpen() async throws {
+        let fake = FakeShellRunner()
+        let openJSON = #"[{"iid":7,"title":"Open","web_url":"https://gl/g/p/-/issues/7","state":"opened","labels":[],"references":{"full":"g/p#7"}}]"#
+        fake.responses = [.success(openJSON), .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "boom"))]
+        let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.open.count, 1)
+        XCTAssertEqual(listing.closed.count, 0)
+        XCTAssertEqual(listing.closedTotalCount, 0)
+    }
+
+    func testGitLabSplitTotalHeader() {
+        // CRLF endings + case-insensitive header name.
+        let crlf = "HTTP/2.0 200 OK\r\nx-total: 42\r\n\r\n[{\"iid\":1}]"
+        let parsedCRLF = GitLabTaskBackend.splitTotalHeader(crlf)
+        XCTAssertEqual(parsedCRLF.total, 42)
+        XCTAssertEqual(parsedCRLF.body, "[{\"iid\":1}]")
+
+        // No blank line → treated as bare body, no total.
+        let bare = #"[{"iid":1}]"#
+        let parsedBare = GitLabTaskBackend.splitTotalHeader(bare)
+        XCTAssertNil(parsedBare.total)
+        XCTAssertEqual(parsedBare.body, bare)
+
+        // Non-numeric X-Total is ignored.
+        let junk = "HTTP/2.0 200 OK\nX-Total: lots\n\n[]"
+        XCTAssertNil(GitLabTaskBackend.splitTotalHeader(junk).total)
     }
 
     func testGitLabTaskBackendListAssignedSkipsClosedCallWhenNotRequested() async throws {
         // Regression guard: passing includeClosed: false must skip the second
-        // REST round-trip. The IssueTracker GitLab path uses this to avoid a
-        // wasted call every 60s — the closed-diff logic is GitHub-only.
+        // REST round-trip for callers that only need the open list.
         let fake = FakeShellRunner()
         let openJSON = #"[{"iid":7,"title":"Open","web_url":"https://gl/g/p/-/issues/7","state":"opened","labels":[],"references":{"full":"g/p#7"}}]"#
         fake.responses = [.success(openJSON)]

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -453,10 +453,13 @@ final class IssueTracker {
             doneCount += ghResult.closedTotalCount
         }
 
-        // GitLab — unchanged fan-out (one call per host)
+        // GitLab — one call per host; includes the recently-closed half (#697)
+        // so GitLab-backed workspaces count toward doneIssuesLast24h, mirroring
+        // GitHub's open + deduped-closed merge.
         for host in gitLabHosts {
-            let issues = await fetchGitLabIssues(host: host)
-            allIssues.append(contentsOf: issues)
+            let merged = Self.mergeListing(await fetchGitLabIssues(host: host))
+            allIssues.append(contentsOf: merged.issues)
+            doneCount += merged.doneCount
         }
 
         // Jira — one search per distinct config (best-effort, like GitLab).
@@ -466,7 +469,7 @@ final class IssueTracker {
         // `assignedIssues`. Mirror GitHub's open + deduped-closed merge.
         for cfg in jiraConfigs {
             let listing = await fetchJiraIssues(config: cfg)
-            let merged = Self.mergeJiraListing(listing)
+            let merged = Self.mergeListing(listing)
             allIssues.append(contentsOf: merged.issues)
             doneCount += merged.doneCount
         }
@@ -2876,24 +2879,20 @@ final class IssueTracker {
 
     // MARK: - GitLab
 
-    private func fetchGitLabIssues(host: String) async -> [AssignedIssue] {
+    /// Fetch assigned GitLab issues for one host, including the recently-closed
+    /// half (#697) so GitLab-backed workspaces feed the done-count badge.
+    /// Best-effort: degrades to an empty listing on failure, mirroring the
+    /// Jira / Corveil paths.
+    private func fetchGitLabIssues(host: String) async -> AssignedListing {
         let backend = providerManager.taskBackend(for: .gitlab, host: host)
         do {
-            // Pass includeClosed: false so we don't fire a wasted closed-issues
-            // REST call every 60s — only the open list is consumed by refresh()
-            // for the GitLab path (the closed-diff logic is GitHub-only today).
-            let listing = try await backend.listAssigned(includeClosed: false)
-            return listing.open
+            return try await backend.listAssigned(includeClosed: true)
         } catch {
             print("[IssueTracker] fetchGitLabIssues(host: \(host)) failed: \(error)")
-            return []
+            return AssignedListing(open: [], closed: [])
         }
     }
 
-    /// Fetch open Jira work items assigned to the user for one workspace config.
-    /// Best-effort (the backend itself degrades to empty on failure), mirroring
-    /// the GitLab path — `includeClosed: false` skips the wasted closed query
-    /// since refresh()'s closed-issue diff is GitHub-only today.
     /// Find the configured Jira workspace whose project key (then exact site host,
     /// then sole-candidate fallback) matches `ticketURL`. Shared by the status-map
     /// and full-config resolvers so the matching can never drift. `candidates`
@@ -2968,14 +2967,15 @@ final class IssueTracker {
         }
     }
 
-    /// Merge a Jira `AssignedListing` into the board's flat issue list: open
-    /// issues plus the closed (Done) issues deduped by `id` against the open
-    /// set, mirroring the GitHub closed-issue merge. `doneCount` is the
-    /// backend-reported window total (`closedTotalCount`), not the length of
-    /// the capped closed page, so the badge doesn't saturate at the 50-item
-    /// page cap (#572, mirroring GitHub's #562 fix) — and it counts the window,
-    /// not just the post-dedup remainder, matching GitHub's semantics.
-    nonisolated static func mergeJiraListing(_ listing: AssignedListing) -> (issues: [AssignedIssue], doneCount: Int) {
+    /// Merge an `AssignedListing` (Jira #536, GitLab #697) into the board's
+    /// flat issue list: open issues plus the closed (Done) issues deduped by
+    /// `id` against the open set, mirroring the GitHub closed-issue merge.
+    /// `doneCount` is the backend-reported window total (`closedTotalCount`),
+    /// not the length of the capped closed page, so the badge doesn't saturate
+    /// at the 50-item page cap (#572, mirroring GitHub's #562 fix) — and it
+    /// counts the window, not just the post-dedup remainder, matching GitHub's
+    /// semantics.
+    nonisolated static func mergeListing(_ listing: AssignedListing) -> (issues: [AssignedIssue], doneCount: Int) {
         let openIDs = Set(listing.open.map(\.id))
         let uniqueDone = listing.closed.filter { !openIDs.contains($0.id) }
         return (listing.open + uniqueDone, listing.closedTotalCount)

--- a/Tests/CrowTests/IssueTrackerGitLabDoneTests.swift
+++ b/Tests/CrowTests/IssueTrackerGitLabDoneTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowProvider
+@testable import Crow
+
+/// CROW-697: GitLab closed issues must count toward `doneIssuesLast24h` for
+/// throughput parity with GitHub/Jira. The backend's closed fetch + `X-Total`
+/// window total are covered by `BackendsTests` in CrowProvider; these cover
+/// IssueTracker's merge of a GitLab `AssignedListing` into the flat issue
+/// list + the recently-done count.
+@Suite("IssueTracker GitLab Done merge")
+struct IssueTrackerGitLabDoneTests {
+
+    private func issue(_ ref: String, number: Int, status: TicketStatus, state: String) -> AssignedIssue {
+        AssignedIssue(
+            id: "gitlab:gitlab.example.com:\(ref)",
+            number: number,
+            title: ref,
+            state: state,
+            url: "https://gitlab.example.com/g/p/-/issues/\(number)",
+            repo: "g/p",
+            provider: .gitlab,
+            projectStatus: status
+        )
+    }
+
+    @Test func closedIssuesContributeToDoneCount() {
+        let listing = AssignedListing(
+            open: [issue("g/p#7", number: 7, status: .unknown, state: "open")],
+            closed: [
+                issue("g/p#3", number: 3, status: .done, state: "closed"),
+                issue("g/p#4", number: 4, status: .done, state: "closed"),
+            ]
+        )
+
+        let merged = IssueTracker.mergeListing(listing)
+
+        // Both closed issues land in the flat list so the board can group them.
+        #expect(merged.issues.count == 3)
+        #expect(merged.issues.filter { $0.projectStatus == .done }.map(\.id).sorted()
+            == ["gitlab:gitlab.example.com:g/p#3", "gitlab:gitlab.example.com:g/p#4"])
+        // N issues closed in the last 24h contribute N (mirrors GitHub semantics).
+        #expect(merged.doneCount == 2)
+    }
+
+    @Test func dedupesClosedAgainstOpenButStillCountsTheWindow() {
+        // An issue present in both halves (defensive: the open/closed queries
+        // are disjoint by state, but mirror GitHub's id dedup).
+        let listing = AssignedListing(
+            open: [issue("g/p#7", number: 7, status: .unknown, state: "open")],
+            closed: [issue("g/p#7", number: 7, status: .done, state: "closed")]
+        )
+
+        let merged = IssueTracker.mergeListing(listing)
+
+        // Not double-counted in the issue list...
+        #expect(merged.issues.count == 1)
+        #expect(merged.issues[0].id == "gitlab:gitlab.example.com:g/p#7")
+        // ...but the done window count still reflects the closed result.
+        #expect(merged.doneCount == 1)
+    }
+
+    @Test func emptyListingContributesZero() {
+        // A workspace whose GitLab fetch degraded to empty contributes 0,
+        // no error — the no-backend / broken-glab path.
+        let merged = IssueTracker.mergeListing(AssignedListing(open: [], closed: []))
+        #expect(merged.issues.isEmpty)
+        #expect(merged.doneCount == 0)
+    }
+
+    /// The badge must reflect the `X-Total` window total, not the length of
+    /// the capped `per_page=50` page — 96 closed issues must badge as 96,
+    /// mirroring GitHub's #562 / Jira's #572 cap fixes.
+    @Test func doneCountUsesBackendTotalOverPageCount() {
+        let listing = AssignedListing(
+            open: [issue("g/p#7", number: 7, status: .unknown, state: "open")],
+            closed: [
+                issue("g/p#3", number: 3, status: .done, state: "closed"),
+                issue("g/p#4", number: 4, status: .done, state: "closed"),
+            ],
+            closedTotalCount: 96
+        )
+
+        let merged = IssueTracker.mergeListing(listing)
+
+        // The flat list still only carries the fetched page…
+        #expect(merged.issues.count == 3)
+        // …but the done window count is the header total, uncapped.
+        #expect(merged.doneCount == 96)
+    }
+}

--- a/Tests/CrowTests/IssueTrackerJiraDoneTests.swift
+++ b/Tests/CrowTests/IssueTrackerJiraDoneTests.swift
@@ -33,7 +33,7 @@ struct IssueTrackerJiraDoneTests {
             ]
         )
 
-        let merged = IssueTracker.mergeJiraListing(listing)
+        let merged = IssueTracker.mergeListing(listing)
 
         // Both Done issues land in the flat list so the board can group them.
         #expect(merged.issues.count == 3)
@@ -52,7 +52,7 @@ struct IssueTrackerJiraDoneTests {
             closed: [issue("PROJ-1", status: .done, state: "closed")]
         )
 
-        let merged = IssueTracker.mergeJiraListing(listing)
+        let merged = IssueTracker.mergeListing(listing)
 
         // Not double-counted in the issue list...
         #expect(merged.issues.count == 1)
@@ -62,7 +62,7 @@ struct IssueTrackerJiraDoneTests {
     }
 
     @Test func emptyListingYieldsNothing() {
-        let merged = IssueTracker.mergeJiraListing(AssignedListing(open: [], closed: []))
+        let merged = IssueTracker.mergeListing(AssignedListing(open: [], closed: []))
         #expect(merged.issues.isEmpty)
         #expect(merged.doneCount == 0)
     }
@@ -80,7 +80,7 @@ struct IssueTrackerJiraDoneTests {
             closedTotalCount: 96
         )
 
-        let merged = IssueTracker.mergeJiraListing(listing)
+        let merged = IssueTracker.mergeListing(listing)
 
         // The flat list still only carries the fetched page…
         #expect(merged.issues.count == 3)


### PR DESCRIPTION
Closes #697. ADR 0008 follow-up 9/11 (refs #648, design PR #657). Builds on the TaskBackend protocol (ADR 0005).

## What

`IssueTracker.refresh()` counted GitHub `state:closed` + Jira `statusCategory=Done` toward `doneIssuesLast24h`, but the GitLab path fetched with `includeClosed: false` and contributed nothing — undercounting throughput for GitLab-backed workspaces.

- **IssueTracker**: `fetchGitLabIssues` now returns the full `AssignedListing` (`includeClosed: true`); the GitLab block in `refresh()` merges open + deduped-closed and adds the window total to `doneCount`, structurally identical to the Jira block. `mergeJiraListing` → `mergeListing` (the 3-line dedup+count logic is provider-agnostic; shared by both paths).
- **GitLabTaskBackend**: the closed fetch now uses `glab api -i` and reads the true 24h window total from the `X-Total` response header instead of the capped `per_page=50` page (per the #562/#572 cap fixes), falling back to the page length when the header is absent (GitLab omits it for expensive counts).
- **Additive**: GitHub + Jira counting unchanged; best-effort error semantics preserved, so a non-GitLab setup or broken `glab` contributes 0 with no error.

## Notes

- Each poll now fires the closed-issues REST call per GitLab host (previously skipped) — same cost Jira accepted in #536; it's the point of the ticket.
- GitLab closed issues now appear in the board's Done section, matching how Jira closed issues already flow.
- Per the ADR 0008 coordination note: this feeds the board badge/throughput count only — `doneIssuesLast24h` stays out of the v1 scorecard inputs (#710).

## Tests

- `BackendsTests` (CrowProvider): X-Total parsed → `closedTotalCount` uncapped; header absent → falls back to page count; closed-call failure keeps open half; `splitTotalHeader` unit coverage (CRLF, case-insensitive, bare body); `includeClosed: false` still skips the second round-trip.
- New `IssueTrackerGitLabDoneTests`: N closed → doneCount N; id-dedup against open without losing the window count; empty listing → 0; backend total (96) wins over page length.
- `IssueTrackerJiraDoneTests` renamed call sites only — assertions unchanged (Jira counting unregressed).
- `make test` green (all packages + root, 373 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)