### PR TITLE
v2 combined multiplicative score (alignment-weighted throughput × efficiency) (closes #699)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AlignmentWeight.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AlignmentWeight.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 /// Alignment-weight priors (ADR 0008 follow-up 8, category C: does the work
-/// ladder up to an org KPI/goal). The weight is the future multiplicand of the
-/// v2 score (`throughput × efficiency-multiplier × alignment-weight`,
-/// follow-up 11) — this type only *produces* the value; nothing combines it
-/// into a live score yet.
+/// ladder up to an org KPI/goal). The weight is the alignment multiplicand of
+/// the v2 combined score (follow-up 11, #699): `CombinedScore` sums it over a
+/// week's shipped snapshots to form the alignment-weighted throughput factor.
+/// This type only *produces* the value.
 ///
 /// Scheme: bonus-above-neutral. Untagged/unknown work scores exactly
 /// `neutral` (1.0), so every pre-existing session is unaffected; any explicit

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -170,6 +170,13 @@ public final class AppState {
     /// store directly.
     public var analyticsSnapshots: [String: SessionAnalyticsSnapshot] = [:]
 
+    /// Read-only mirror of the store's persisted PR→session attributions
+    /// (#693/#694), keyed by PR URL — hydrated by SessionService on load and
+    /// resynced by IssueTracker after every attribution write. The v2
+    /// combined score (#699) computes its weekly rework/hygiene factor from
+    /// this; CrowUI cannot read the store directly.
+    public var prAttributions: [String: PRSessionAttribution] = [:]
+
     // MARK: - Allowlist
 
     /// Aggregated allow-list entries from all worktrees.

--- a/Packages/CrowCore/Sources/CrowCore/Models/CombinedScore.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/CombinedScore.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// ADR 0008 v2 combined multiplicative score (follow-up 11, #699):
+/// `alignment-weighted throughput × efficiency multiplier`, computed at
+/// **weekly grain only**. There is deliberately no session-grain API — at
+/// session grain the throughput factor is usually zero, producing the
+/// unstable, unexplainable scores the ADR rejects.
+///
+/// Multiplicative is the point: an additive combination lets high throughput
+/// mask terrible hygiene, recreating the raw-spend-leaderboard failure. Here
+/// the efficiency multiplier is provably ≤ 1, so waste can only shrink a
+/// week's score — it cannot be bought back with volume.
+///
+/// The score is an ADDITIONAL surface on the weekly scorecard; the v1 A–F
+/// grade and the sessions-shipped count remain their own separate surfaces.
+/// It decomposes into inspectable factors —
+/// `shipped count × alignment factor × efficiency multiplier` — so it stays
+/// a coachable sentence, not an opaque number. Private self-comparison
+/// posture per the ADR: no leaderboard unless a later ADR supersedes it.
+public enum CombinedScore {
+
+    // MARK: - Tuning
+
+    /// Hygiene-penalty priors. Like `EfficiencyGrading.Tuning`, every value is
+    /// a starting heuristic under the ADR's binding 4-week calibration period
+    /// — revise against real distributions, not taste.
+    public enum Tuning {
+        /// Hygiene fraction removed per detected revert: ×(1 − 0.25) each.
+        /// A revert is the strongest shipped-then-unshipped signal, so one
+        /// revert costs more than any single grade deduction — but the decay
+        /// is geometric, never zeroing a week: waste is expensive, not
+        /// annihilating.
+        public static let revertHygienePenalty: Double = 0.25
+        /// Per detected post-merge fix: ×(1 − 0.10). Lighter than a revert
+        /// because the 48h file-overlap heuristic can catch legitimate
+        /// follow-on work, not just repair.
+        public static let postMergeFixHygienePenalty: Double = 0.10
+        /// Merge-rate blend weight: factor = 1 − w × (1 − mergeRate). At
+        /// w = 0.5 a 0%-merge-rate week bottoms out at ×0.5 rather than ×0 —
+        /// closed-without-merge is ambiguous (superseded branches,
+        /// exploration), unlike a revert. A nil merge rate (nothing resolved)
+        /// is fully neutral.
+        public static let mergeRateHygieneWeight: Double = 0.5
+    }
+
+    // MARK: - Weekly rework rollup
+
+    /// Whole-machine rework counts for one scorecard week, rolled up from the
+    /// persisted PR attributions (#693/#694). Deliberately NOT per-session —
+    /// the v2 unit is per-user-per-week, and on this single-user app
+    /// "per-user" is every attribution on the machine. (CrowPersistence's
+    /// `SessionReworkMetrics` is the per-session drill-down counterpart.)
+    public struct WeeklyRework: Equatable, Sendable {
+        /// PRs whose current state is MERGED with `mergedAt` in the week.
+        public let mergedCount: Int
+        /// PRs whose current state is CLOSED with `closedAt` in the week —
+        /// a reopened-then-merged PR counts as merged, never closed.
+        public let closedWithoutMergeCount: Int
+        /// Reverts detected (`detectedAt`) in the week.
+        public let revertCount: Int
+        /// Post-merge fixes detected (`detectedAt`) in the week.
+        public let postMergeFixCount: Int
+
+        /// merged / (merged + closed-without-merge); nil when the week
+        /// resolved nothing — neutral, never a fake 0 or 1.
+        public var mergeRate: Double? {
+            let resolved = mergedCount + closedWithoutMergeCount
+            guard resolved > 0 else { return nil }
+            return Double(mergedCount) / Double(resolved)
+        }
+
+        public static let empty = WeeklyRework(
+            mergedCount: 0,
+            closedWithoutMergeCount: 0,
+            revertCount: 0,
+            postMergeFixCount: 0
+        )
+
+        public init(mergedCount: Int, closedWithoutMergeCount: Int, revertCount: Int, postMergeFixCount: Int) {
+            self.mergedCount = mergedCount
+            self.closedWithoutMergeCount = closedWithoutMergeCount
+            self.revertCount = revertCount
+            self.postMergeFixCount = postMergeFixCount
+        }
+    }
+
+    /// Rolls the attribution store up into one week's rework counts.
+    /// Membership is half-open (`>= start && < end`) to match
+    /// `ScorecardModel`'s week bucketing — NOT `DateInterval.contains`,
+    /// which is end-inclusive and would double-count a Monday-00:00 event
+    /// into two adjacent weeks.
+    public static func weeklyRework(
+        attributions: [PRSessionAttribution],
+        week: DateInterval
+    ) -> WeeklyRework {
+        var merged = 0
+        var closed = 0
+        var reverts = 0
+        var fixes = 0
+
+        for attribution in attributions {
+            if attribution.state == "MERGED", let mergedAt = attribution.mergedAt, contains(week, mergedAt) {
+                merged += 1
+            }
+            if attribution.state == "CLOSED", let closedAt = attribution.closedAt, contains(week, closedAt) {
+                closed += 1
+            }
+            reverts += (attribution.reverts ?? []).filter { contains(week, $0.detectedAt) }.count
+            fixes += (attribution.postMergeFixes ?? []).filter { contains(week, $0.detectedAt) }.count
+        }
+
+        return WeeklyRework(
+            mergedCount: merged,
+            closedWithoutMergeCount: closed,
+            revertCount: reverts,
+            postMergeFixCount: fixes
+        )
+    }
+
+    private static func contains(_ interval: DateInterval, _ date: Date) -> Bool {
+        date >= interval.start && date < interval.end
+    }
+
+    // MARK: - Factors
+
+    /// Every input and intermediate of one week's combined score, so the
+    /// number decomposes into an explainable sentence:
+    /// `value == shippedCount × alignmentFactor × efficiencyMultiplier`
+    /// (within floating-point epsilon; the exact identity is
+    /// `weightedThroughput × efficiencyMultiplier`).
+    public struct Factors: Equatable, Sendable {
+        /// Raw throughput count: `.completed` snapshots in the week.
+        public let shippedCount: Int
+        /// Σ alignment weight over shipped snapshots (nil weight = neutral
+        /// 1.0, so pre-#696 snapshots count exactly as an unweighted count).
+        public let weightedThroughput: Double
+        /// The week's v1 grade score (0–100) — the grade half of the
+        /// efficiency multiplier.
+        public let gradeScore: Int
+        /// The rework half of the efficiency multiplier, in (0, 1].
+        public let hygieneFactor: Double
+        /// The rework counts behind `hygieneFactor`, for display.
+        public let rework: WeeklyRework
+
+        /// Average alignment weight of the week's shipped work; neutral 1.0
+        /// for a zero-shipped week (keeps the decomposition identity
+        /// `0 × 1.0 × E = 0` instead of dividing by zero).
+        public var alignmentFactor: Double {
+            shippedCount > 0 ? weightedThroughput / Double(shippedCount) : AlignmentWeight.neutral
+        }
+        public var gradeFactor: Double { Double(gradeScore) / 100 }
+        /// Grade × hygiene, clamped to [0, 1]: both halves are already ≤ 1 by
+        /// construction, so the clamp is defensive. Hygiene can only shrink a
+        /// score — a perfect week multiplies by exactly 1.
+        public var efficiencyMultiplier: Double { min(1, max(0, gradeFactor * hygieneFactor)) }
+        /// The combined score.
+        public var value: Double { weightedThroughput * efficiencyMultiplier }
+
+        public init(
+            shippedCount: Int,
+            weightedThroughput: Double,
+            gradeScore: Int,
+            hygieneFactor: Double,
+            rework: WeeklyRework
+        ) {
+            self.shippedCount = shippedCount
+            self.weightedThroughput = weightedThroughput
+            self.gradeScore = gradeScore
+            self.hygieneFactor = hygieneFactor
+            self.rework = rework
+        }
+    }
+
+    public enum WeeklyResult: Equatable, Sendable {
+        case scored(Factors)
+        /// Passthrough of the weekly grade's minimum-sample floor: no grade →
+        /// no efficiency multiplier → no combined score. (A graded week that
+        /// shipped nothing IS scored — value 0 is a legitimate weekly-grain
+        /// zero, not the session-grain degeneracy the ADR rejects.)
+        case insufficientData(promptCount: Int)
+    }
+
+    // MARK: - Scoring
+
+    /// `(1 − revertPenalty)^reverts × (1 − fixPenalty)^fixes ×
+    /// (1 − w × (1 − mergeRate))`, clamped to [0, 1] defensively. Each factor
+    /// is in (0, 1] by construction, so a week with no attributions — or no
+    /// resolved PRs — is fully neutral at 1.0: absence of data is never
+    /// punished (the `AlignmentWeight` principle).
+    public static func hygieneFactor(rework: WeeklyRework) -> Double {
+        let revertFactor = pow(1 - Tuning.revertHygienePenalty, Double(rework.revertCount))
+        let fixFactor = pow(1 - Tuning.postMergeFixHygienePenalty, Double(rework.postMergeFixCount))
+        let mergeRateFactor: Double
+        if let mergeRate = rework.mergeRate {
+            mergeRateFactor = 1 - Tuning.mergeRateHygieneWeight * (1 - mergeRate)
+        } else {
+            mergeRateFactor = 1
+        }
+        return min(1, max(0, revertFactor * fixFactor * mergeRateFactor))
+    }
+
+    /// One week's combined score from the week's snapshots, its already
+    /// computed v1 grade, and its rework rollup. The grade is passed in, not
+    /// recomputed, so the combined score is guaranteed to be built on exactly
+    /// the number the grade card shows.
+    public static func weeklyScore(
+        snapshots: [SessionAnalyticsSnapshot],
+        gradeResult: EfficiencyGrading.GradeResult,
+        rework: WeeklyRework
+    ) -> WeeklyResult {
+        switch gradeResult {
+        case .insufficientData(let promptCount):
+            return .insufficientData(promptCount: promptCount)
+        case .graded(let score, _, _):
+            let shipped = snapshots.filter { $0.status == .completed }
+            let weightedThroughput = shipped.reduce(0.0) {
+                $0 + ($1.alignmentWeight ?? AlignmentWeight.neutral)
+            }
+            return .scored(Factors(
+                shippedCount: shipped.count,
+                weightedThroughput: weightedThroughput,
+                gradeScore: score,
+                hygieneFactor: hygieneFactor(rework: rework),
+                rework: rework
+            ))
+        }
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyGrading.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyGrading.swift
@@ -11,8 +11,11 @@ import Foundation
 /// structurally impossible here — no API accepts grades as input — which is
 /// how the ADR's anti-session-splitting rollup rule is enforced.
 ///
-/// The grade and the sessions-shipped throughput count are separate surfaces;
-/// no combined number exists in v1 (ADR 0008).
+/// The grade and the sessions-shipped throughput count are separate surfaces.
+/// The v2 combined score (#699, `CombinedScore`) is an additional weekly
+/// surface built ON these — it consumes the weekly grade's score, never
+/// changes how it is computed, and the anti-averaging invariant above still
+/// holds.
 public enum EfficiencyGrading {
 
     // MARK: - Tuning

--- a/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyScorecard.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/EfficiencyScorecard.swift
@@ -9,9 +9,11 @@ public enum CostPerShipped: Equatable, Sendable {
 }
 
 /// One week of the scorecard: the re-aggregated efficiency grade, the
-/// sessions-shipped throughput count, and the displayed-not-graded context
-/// stats. Grade and throughput are separate surfaces — nothing here combines
-/// them (no combined number exists in v1, ADR 0008).
+/// sessions-shipped throughput count, the displayed-not-graded context
+/// stats, and — since #699 — the v2 combined score. Grade and throughput
+/// remain their own separate surfaces (the v1 anti-averaging invariants
+/// still hold); the combined score is an ADDITIONAL surface built on top of
+/// them, never a replacement (ADR 0008 follow-up 11).
 public struct WeeklyScorecard: Equatable, Sendable {
     public let weekStart: Date
     /// Grade over the week's summed raws (`EfficiencyGrading.weeklyInput`),
@@ -31,6 +33,9 @@ public struct WeeklyScorecard: Equatable, Sendable {
     /// `Σ linesRemoved / max(1, Σ linesAdded)` — informational only, too weak
     /// as a rework proxy to grade (ADR 0008).
     public let churnHint: Double
+    /// The v2 combined multiplicative score (#699):
+    /// alignment-weighted throughput × efficiency multiplier, weekly grain.
+    public let combined: CombinedScore.WeeklyResult
 }
 
 /// The user's own trailing 4-week medians — the private "this week vs. your
@@ -48,6 +53,10 @@ public struct ScorecardBaseline: Equatable, Sendable {
     /// Median over prior weeks that actually shipped (zero-shipped weeks have
     /// no cost-per-shipped value to enter the median).
     public let medianCostPerShipped: Double?
+    /// Median combined score over the scored prior weeks (#699). Unlike
+    /// cost-per-shipped, a scored zero-shipped week contributes its 0 — a
+    /// present zero IS a combined score.
+    public let medianCombinedScore: Double?
 
     public static let empty = ScorecardBaseline(
         weeksAvailable: 0,
@@ -56,7 +65,8 @@ public struct ScorecardBaseline: Equatable, Sendable {
         medianInputTokensPerPrompt: nil,
         medianCacheHitRatio: nil,
         medianApiErrorRate: nil,
-        medianCostPerShipped: nil
+        medianCostPerShipped: nil,
+        medianCombinedScore: nil
     )
 }
 
@@ -74,10 +84,10 @@ public struct SessionGradeRow: Equatable, Sendable, Identifiable {
     public let wallClockDurationSeconds: Double?
 }
 
-/// The read-only scorecard model (ADR 0008 v1): built from persisted
-/// `SessionAnalyticsSnapshot`s, pure and deterministic — `now` and the
-/// calendar's time zone are injected, and nothing here reads a store or a
-/// clock.
+/// The read-only scorecard model (ADR 0008; v1 surfaces plus the v2 combined
+/// score): built from persisted `SessionAnalyticsSnapshot`s and PR
+/// attributions, pure and deterministic — `now` and the calendar's time zone
+/// are injected, and nothing here reads a store or a clock.
 public struct ScorecardModel: Equatable, Sendable {
     public let currentWeek: WeeklyScorecard
     /// Up to the trailing 4 weeks, newest first; weeks with no snapshots are
@@ -91,9 +101,12 @@ public struct ScorecardModel: Equatable, Sendable {
     /// the historical baseline doesn't shift with the user's locale) in the
     /// injected calendar's time zone, grades the current week over summed
     /// raws, and computes the trailing-4-week median baseline from the prior
-    /// weeks.
+    /// weeks. `attributions` (the persisted PR→session store, #693/#694)
+    /// feeds only the v2 combined score's hygiene factor — every v1 surface
+    /// is computed exactly as before, with or without it.
     public static func build(
         snapshots: [SessionAnalyticsSnapshot],
+        attributions: [PRSessionAttribution] = [],
         now: Date,
         calendar: Calendar
     ) -> ScorecardModel {
@@ -104,7 +117,9 @@ public struct ScorecardModel: Equatable, Sendable {
             ?? DateInterval(start: now, duration: 7 * 86_400)
 
         let currentSnapshots = snapshots.filter { contains(currentInterval, $0.endedAt) }
-        let currentWeek = weeklyScorecard(weekStart: currentInterval.start, snapshots: currentSnapshots)
+        let currentWeek = weeklyScorecard(
+            week: currentInterval, snapshots: currentSnapshots, attributions: attributions
+        )
 
         var priorWeeks: [WeeklyScorecard] = []
         for offset in 1...EfficiencyGrading.Tuning.baselineWeekCount {
@@ -114,7 +129,9 @@ public struct ScorecardModel: Equatable, Sendable {
             else { continue }
             let weekSnapshots = snapshots.filter { contains(interval, $0.endedAt) }
             guard !weekSnapshots.isEmpty else { continue }
-            priorWeeks.append(weeklyScorecard(weekStart: interval.start, snapshots: weekSnapshots))
+            priorWeeks.append(weeklyScorecard(
+                week: interval, snapshots: weekSnapshots, attributions: attributions
+            ))
         }
 
         let rows = currentSnapshots
@@ -147,8 +164,13 @@ public struct ScorecardModel: Equatable, Sendable {
 
     // MARK: - Weekly rollup
 
-    static func weeklyScorecard(weekStart: Date, snapshots: [SessionAnalyticsSnapshot]) -> WeeklyScorecard {
+    static func weeklyScorecard(
+        week: DateInterval,
+        snapshots: [SessionAnalyticsSnapshot],
+        attributions: [PRSessionAttribution]
+    ) -> WeeklyScorecard {
         let input = EfficiencyGrading.weeklyInput(summing: snapshots)
+        let result = EfficiencyGrading.grade(input)
         let shipped = input.costContext?.sessionsShipped ?? 0
         let totalCost = input.costContext?.totalCost ?? 0
 
@@ -160,8 +182,8 @@ public struct ScorecardModel: Equatable, Sendable {
         let linesRemoved = snapshots.reduce(0) { $0 + $1.analytics.linesRemoved }
 
         return WeeklyScorecard(
-            weekStart: weekStart,
-            result: EfficiencyGrading.grade(input),
+            weekStart: week.start,
+            result: result,
             input: input,
             sessionsShipped: shipped,
             costPerShipped: costPerShipped,
@@ -169,7 +191,12 @@ public struct ScorecardModel: Equatable, Sendable {
             totalCost: totalCost,
             activeTimeSeconds: input.activeTimeSeconds,
             commitCount: snapshots.reduce(0) { $0 + $1.analytics.commitCount },
-            churnHint: Double(linesRemoved) / Double(max(1, linesAdded))
+            churnHint: Double(linesRemoved) / Double(max(1, linesAdded)),
+            combined: CombinedScore.weeklyScore(
+                snapshots: snapshots,
+                gradeResult: result,
+                rework: CombinedScore.weeklyRework(attributions: attributions, week: week)
+            )
         )
     }
 
@@ -184,6 +211,7 @@ public struct ScorecardModel: Equatable, Sendable {
         var cacheRatios: [Double] = []
         var errorRates: [Double] = []
         var costsPerShipped: [Double] = []
+        var combinedScores: [Double] = []
 
         for week in priorWeeks {
             guard case .graded(let score, _, _) = week.result else { continue }
@@ -195,6 +223,9 @@ public struct ScorecardModel: Equatable, Sendable {
             if case .graded(let cost) = week.costPerShipped {
                 costsPerShipped.append(cost)
             }
+            if case .scored(let factors) = week.combined {
+                combinedScores.append(factors.value)
+            }
         }
 
         return ScorecardBaseline(
@@ -204,7 +235,8 @@ public struct ScorecardModel: Equatable, Sendable {
             medianInputTokensPerPrompt: median(contextPressures),
             medianCacheHitRatio: median(cacheRatios),
             medianApiErrorRate: median(errorRates),
-            medianCostPerShipped: median(costsPerShipped)
+            medianCostPerShipped: median(costsPerShipped),
+            medianCombinedScore: median(combinedScores)
         )
     }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/CombinedScoreTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CombinedScoreTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #699 (ADR 0008 v2, follow-up 11): the combined multiplicative score —
+// alignment-weighted throughput × efficiency multiplier, weekly grain only.
+
+/// Fixed UTC ISO-8601 calendar so windowing is deterministic on any machine
+/// (including Linux CI). Duplicated from EfficiencyScorecardTests, where the
+/// helpers are file-private.
+private let utc: Calendar = {
+    var calendar = Calendar(identifier: .iso8601)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+}()
+
+private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 12, _ minute: Int = 0) -> Date {
+    utc.date(from: DateComponents(year: year, month: month, day: day, hour: hour, minute: minute))!
+}
+
+/// The ISO week Monday 2026-07-13 00:00 UTC ..< Monday 2026-07-20 00:00 UTC.
+private let week = DateInterval(start: date(2026, 7, 13, 0), end: date(2026, 7, 20, 0))
+
+private func snapshot(
+    status: SessionStatus = .completed,
+    alignmentWeight: Double? = nil,
+    prompts: Int = 10
+) -> SessionAnalyticsSnapshot {
+    SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: date(2026, 7, 15),
+        status: status,
+        analytics: SessionAnalytics(activeTimeSeconds: 3600, promptCount: prompts),
+        compactionCount: 0,
+        alignmentWeight: alignmentWeight
+    )
+}
+
+private func attribution(
+    prURL: String,
+    state: String = "MERGED",
+    mergedAt: Date? = nil,
+    closedAt: Date? = nil,
+    reverts: [PRRevertRecord]? = nil,
+    postMergeFixes: [PostMergeFixRecord]? = nil
+) -> PRSessionAttribution {
+    PRSessionAttribution(
+        prURL: prURL,
+        repoNameWithOwner: "corveil/crow",
+        prNumber: 1,
+        sessionIDs: [UUID()],
+        state: state,
+        mergedAt: mergedAt,
+        firstSeenAt: date(2026, 7, 1),
+        updatedAt: date(2026, 7, 15),
+        closedAt: closedAt,
+        reverts: reverts,
+        postMergeFixes: postMergeFixes
+    )
+}
+
+private func fix(detectedAt: Date) -> PostMergeFixRecord {
+    PostMergeFixRecord(fixPRURL: "https://github.com/corveil/crow/pull/999", overlappingFileCount: 1, detectedAt: detectedAt)
+}
+
+private func graded(_ score: Int) -> EfficiencyGrading.GradeResult {
+    .graded(score: score, letter: EfficiencyGrading.letter(forScore: score), deductions: [])
+}
+
+private func factors(_ result: CombinedScore.WeeklyResult) -> CombinedScore.Factors? {
+    guard case .scored(let factors) = result else { return nil }
+    return factors
+}
+
+// The reason the score is multiplicative (ADR 0008): a high-throughput week
+// with terrible hygiene must score BELOW a modest clean week — waste cannot
+// be bought back with volume, which an additive combination would allow.
+@Test func multiplicativeDragDownBeatsVolume() throws {
+    let distinctReverts = (1...4).map { index in
+        PRRevertRecord(revertedCommitSHA: "sha\(index)", revertCommitSHA: "rev\(index)", detectedAt: date(2026, 7, 15))
+    }
+    let dirty = CombinedScore.weeklyRework(
+        attributions: [attribution(
+            prURL: "https://github.com/corveil/crow/pull/1",
+            mergedAt: date(2026, 7, 14),
+            reverts: distinctReverts
+        )],
+        week: week
+    )
+    #expect(dirty.revertCount == 4)
+
+    let highVolumeBadHygiene = CombinedScore.weeklyScore(
+        snapshots: (1...10).map { _ in snapshot() },
+        gradeResult: graded(70),
+        rework: dirty
+    )
+    let modestClean = CombinedScore.weeklyScore(
+        snapshots: (1...3).map { _ in snapshot() },
+        gradeResult: graded(95),
+        rework: .empty
+    )
+
+    let dirtyValue = try #require(factors(highVolumeBadHygiene)).value
+    let cleanValue = try #require(factors(modestClean)).value
+    // 10 × (0.70 × 0.75⁴ ≈ 0.2215) ≈ 2.21 < 3 × 0.95 = 2.85. An additive
+    // combination of the same inputs would rank the dirty week first.
+    #expect(dirtyValue < cleanValue)
+}
+
+// Alignment weight raises on-goal work: same shipped count, higher weight →
+// strictly higher score.
+@Test func alignmentRaisesOnGoalWork() throws {
+    let onGoal = CombinedScore.weeklyScore(
+        snapshots: (1...3).map { _ in
+            snapshot(alignmentWeight: AlignmentWeight.highPriorityBase * AlignmentWeight.onGoalMultiplier)
+        },
+        gradeResult: graded(90),
+        rework: .empty
+    )
+    let untagged = CombinedScore.weeklyScore(
+        snapshots: (1...3).map { _ in snapshot(alignmentWeight: nil) },
+        gradeResult: graded(90),
+        rework: .empty
+    )
+
+    let onGoalFactors = try #require(factors(onGoal))
+    let untaggedFactors = try #require(factors(untagged))
+    #expect(onGoalFactors.value > untaggedFactors.value)
+    #expect(abs(onGoalFactors.alignmentFactor - 1.95) < 1e-9)
+    #expect(untaggedFactors.alignmentFactor == AlignmentWeight.neutral)
+}
+
+// The score must stay explainable: it decomposes into the three inspectable
+// factors shown on the card.
+@Test func decompositionIdentity() throws {
+    let result = CombinedScore.weeklyScore(
+        snapshots: [
+            snapshot(alignmentWeight: 1.5),
+            snapshot(alignmentWeight: 1.2),
+            snapshot(alignmentWeight: nil),
+            snapshot(status: .archived, alignmentWeight: 2.1) // not shipped — excluded
+        ],
+        gradeResult: graded(85),
+        rework: CombinedScore.WeeklyRework(
+            mergedCount: 3, closedWithoutMergeCount: 1, revertCount: 1, postMergeFixCount: 2)
+    )
+    let f = try #require(factors(result))
+    #expect(f.shippedCount == 3)
+    #expect(abs(f.weightedThroughput - 3.7) < 1e-9)
+    #expect(abs(f.value - f.weightedThroughput * f.efficiencyMultiplier) < 1e-12)
+    #expect(abs(f.value - Double(f.shippedCount) * f.alignmentFactor * f.efficiencyMultiplier) < 1e-9)
+}
+
+// nil alignment weight (pre-#696 snapshots) is exactly neutral — a nil-weight
+// week scores identically to an explicit-1.0 week.
+@Test func nilAlignmentWeightIsNeutral() throws {
+    let nilWeight = CombinedScore.weeklyScore(
+        snapshots: [snapshot(alignmentWeight: nil)], gradeResult: graded(90), rework: .empty)
+    let explicitNeutral = CombinedScore.weeklyScore(
+        snapshots: [snapshot(alignmentWeight: 1.0)], gradeResult: graded(90), rework: .empty)
+    #expect(nilWeight == explicitNeutral)
+}
+
+// A graded week that shipped nothing is a legitimate zero at weekly grain —
+// scored, value 0, with a neutral alignment factor so the decomposition
+// identity holds without dividing by zero.
+@Test func zeroShippedWeekScoresZero() throws {
+    let result = CombinedScore.weeklyScore(
+        snapshots: [snapshot(status: .archived)], gradeResult: graded(100), rework: .empty)
+    let f = try #require(factors(result))
+    #expect(f.shippedCount == 0)
+    #expect(f.value == 0)
+    #expect(f.alignmentFactor == AlignmentWeight.neutral)
+}
+
+// No grade → no efficiency multiplier → no combined score. The weekly grade's
+// minimum-sample floor passes straight through.
+@Test func insufficientDataPassthrough() {
+    let result = CombinedScore.weeklyScore(
+        snapshots: [snapshot(prompts: 3)],
+        gradeResult: .insufficientData(promptCount: 3),
+        rework: .empty
+    )
+    #expect(result == .insufficientData(promptCount: 3))
+}
+
+// Absence of data is never punished: no attributions (and therefore a nil
+// merge rate) leave hygiene fully neutral.
+@Test func hygieneNeutralWithNoAttributions() {
+    #expect(CombinedScore.WeeklyRework.empty.mergeRate == nil)
+    #expect(CombinedScore.hygieneFactor(rework: .empty) == 1.0)
+}
+
+// Exact hygiene formula, and its bounds: each factor is in (0, 1], so even a
+// pathological week stays strictly above 0 and never above 1.
+@Test func hygieneFactorFormulaAndBounds() {
+    let rework = CombinedScore.WeeklyRework(
+        mergedCount: 1, closedWithoutMergeCount: 1, revertCount: 1, postMergeFixCount: 2)
+    // (1−0.25)¹ × (1−0.10)² × (1 − 0.5×(1−0.5)) = 0.75 × 0.81 × 0.75
+    let expected = 0.75 * 0.81 * 0.75
+    #expect(abs(CombinedScore.hygieneFactor(rework: rework) - expected) < 1e-12)
+
+    let pathological = CombinedScore.WeeklyRework(
+        mergedCount: 0, closedWithoutMergeCount: 5, revertCount: 10, postMergeFixCount: 10)
+    let factor = CombinedScore.hygieneFactor(rework: pathological)
+    #expect(factor > 0)
+    #expect(factor <= 1)
+}
+
+// Weekly rework windowing: half-open week membership matching the scorecard's
+// bucketing, current-state gating for merged vs. closed, nil merge rate when
+// nothing resolved.
+@Test func weeklyReworkWindowing() {
+    let attributions = [
+        // Merged inside the week; revert detected at the exact week start
+        // (included) and another at the exact week end (excluded).
+        attribution(
+            prURL: "https://github.com/corveil/crow/pull/1",
+            mergedAt: date(2026, 7, 13, 0, 0),
+            reverts: [
+                PRRevertRecord(revertedCommitSHA: "in", revertCommitSHA: "r1", detectedAt: week.start),
+                PRRevertRecord(revertedCommitSHA: "out", revertCommitSHA: "r2", detectedAt: week.end)
+            ]
+        ),
+        // Merged the week before — outside.
+        attribution(prURL: "https://github.com/corveil/crow/pull/2", mergedAt: date(2026, 7, 10)),
+        // Reopened-then-merged: state MERGED with a stale closedAt in-window —
+        // counts as merged only, never closed.
+        attribution(
+            prURL: "https://github.com/corveil/crow/pull/3",
+            mergedAt: date(2026, 7, 16),
+            closedAt: date(2026, 7, 14)
+        ),
+        // Currently CLOSED, closed in-window.
+        attribution(
+            prURL: "https://github.com/corveil/crow/pull/4",
+            state: "CLOSED",
+            closedAt: date(2026, 7, 15),
+            postMergeFixes: [fix(detectedAt: date(2026, 7, 15))]
+        )
+    ]
+
+    let rework = CombinedScore.weeklyRework(attributions: attributions, week: week)
+    #expect(rework.mergedCount == 2)
+    #expect(rework.closedWithoutMergeCount == 1)
+    #expect(rework.revertCount == 1)
+    #expect(rework.postMergeFixCount == 1)
+    #expect(rework.mergeRate == 2.0 / 3.0)
+
+    // A week that resolved nothing has no merge rate — neutral, not 0 or 1.
+    let quietWeek = DateInterval(start: date(2026, 6, 1, 0), end: date(2026, 6, 8, 0))
+    #expect(CombinedScore.weeklyRework(attributions: attributions, week: quietWeek).mergeRate == nil)
+}
+
+// The efficiency multiplier is a pure discount: a perfect week multiplies by
+// exactly 1, and nothing can push it above 1.
+@Test func efficiencyMultiplierNeverExceedsOne() throws {
+    let perfect = CombinedScore.weeklyScore(
+        snapshots: [snapshot()], gradeResult: graded(100), rework: .empty)
+    let f = try #require(factors(perfect))
+    #expect(f.efficiencyMultiplier == 1.0)
+    #expect(f.value == f.weightedThroughput)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/EfficiencyScorecardTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/EfficiencyScorecardTests.swift
@@ -259,6 +259,144 @@ private func weeklyScore(_ week: WeeklyScorecard) -> Int? {
     #expect(model.currentWeekSessions.isEmpty)
 }
 
+// MARK: - v2 combined score wiring (#699)
+
+private func mergedAttribution(
+    prURL: String,
+    mergedAt: Date,
+    reverts: [PRRevertRecord]? = nil
+) -> PRSessionAttribution {
+    PRSessionAttribution(
+        prURL: prURL,
+        repoNameWithOwner: "corveil/crow",
+        prNumber: 1,
+        sessionIDs: [UUID()],
+        state: "MERGED",
+        mergedAt: mergedAt,
+        firstSeenAt: mergedAt.addingTimeInterval(-86_400),
+        updatedAt: mergedAt,
+        reverts: reverts
+    )
+}
+
+// The combined score appears on the current week, built from the week's
+// shipped snapshots and the attributions' rework signals.
+@Test func combinedScoreAppearsOnCurrentWeek() throws {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .completed),
+        snapshot(endedAt: date(2026, 7, 14), status: .archived)
+    ]
+    let attributions = [mergedAttribution(
+        prURL: "https://github.com/corveil/crow/pull/1",
+        mergedAt: date(2026, 7, 14),
+        reverts: [PRRevertRecord(
+            revertedCommitSHA: "abc1234", revertCommitSHA: "def5678",
+            detectedAt: date(2026, 7, 15))]
+    )]
+    let model = ScorecardModel.build(
+        snapshots: snapshots, attributions: attributions, now: now, calendar: utc)
+
+    guard case .scored(let factors) = model.currentWeek.combined else {
+        Issue.record("expected scored combined result")
+        return
+    }
+    #expect(factors.shippedCount == 1)
+    #expect(factors.rework.mergedCount == 1)
+    #expect(factors.rework.revertCount == 1)
+    #expect(factors.gradeScore == 100)
+    // hygiene = (1−0.25)¹ × mergeRate factor (rate 1.0 → 1.0) = 0.75
+    #expect(abs(factors.hygieneFactor - 0.75) < 1e-12)
+    #expect(abs(factors.value - 0.75) < 1e-12)
+}
+
+// The v1 surfaces are computed identically with and without attributions —
+// the combined score is an additional surface, never an input to the grade,
+// the shipped count, or their baselines.
+@Test func v1SurfacesUnchangedByAttributions() {
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .completed, apiErrors: 12, apiRequests: 100, cost: 10),
+        snapshot(
+            endedAt: utc.date(byAdding: .weekOfYear, value: -1, to: currentWeekMonday)!,
+            status: .completed)
+    ]
+    let attributions = [mergedAttribution(
+        prURL: "https://github.com/corveil/crow/pull/1",
+        mergedAt: date(2026, 7, 14),
+        reverts: [PRRevertRecord(
+            revertedCommitSHA: "abc1234", revertCommitSHA: "def5678",
+            detectedAt: date(2026, 7, 15))]
+    )]
+
+    let with = ScorecardModel.build(
+        snapshots: snapshots, attributions: attributions, now: now, calendar: utc)
+    let without = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+
+    #expect(with.currentWeek.result == without.currentWeek.result)
+    #expect(with.currentWeek.input == without.currentWeek.input)
+    #expect(with.currentWeek.sessionsShipped == without.currentWeek.sessionsShipped)
+    #expect(with.currentWeek.costPerShipped == without.currentWeek.costPerShipped)
+    #expect(with.baseline.medianScore == without.baseline.medianScore)
+    #expect(with.baseline.medianCostPerShipped == without.baseline.medianCostPerShipped)
+    #expect(with.currentWeekSessions == without.currentWeekSessions)
+}
+
+// Weekly grain isolation: an attribution event lands in exactly the week that
+// contains it, not in every week the record is visible from.
+@Test func combinedScoreWeeklyGrainIsolation() throws {
+    let priorMonday = utc.date(byAdding: .weekOfYear, value: -1, to: currentWeekMonday)!
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), status: .completed),
+        snapshot(endedAt: priorMonday.addingTimeInterval(3600), status: .completed)
+    ]
+    // Merged and reverted in the PRIOR week only.
+    let attributions = [mergedAttribution(
+        prURL: "https://github.com/corveil/crow/pull/1",
+        mergedAt: priorMonday.addingTimeInterval(7200),
+        reverts: [PRRevertRecord(
+            revertedCommitSHA: "abc1234", revertCommitSHA: "def5678",
+            detectedAt: priorMonday.addingTimeInterval(10_800))]
+    )]
+    let model = ScorecardModel.build(
+        snapshots: snapshots, attributions: attributions, now: now, calendar: utc)
+
+    let current = try #require({
+        guard case .scored(let f) = model.currentWeek.combined else { return nil }
+        return f
+    }() as CombinedScore.Factors?)
+    #expect(current.rework == .empty)
+    #expect(current.hygieneFactor == 1.0)
+
+    let prior = try #require({
+        guard case .scored(let f) = model.priorWeeks[0].combined else { return nil }
+        return f
+    }() as CombinedScore.Factors?)
+    #expect(prior.rework.mergedCount == 1)
+    #expect(prior.rework.revertCount == 1)
+}
+
+// The baseline's median combined score includes a scored zero-shipped week —
+// a present zero IS a combined score (unlike cost-per-shipped, which has no
+// value for such a week).
+@Test func baselineMedianCombinedScoreIncludesZeroShippedWeeks() throws {
+    var snapshots: [SessionAnalyticsSnapshot] = []
+    // Week −1: 2 shipped (clean grade 100 → value 2.0). Week −2: 0 shipped
+    // (graded, value 0). Week −3: 1 shipped (value 1.0).
+    for (offset, shippedCount) in [(1, 2), (2, 0), (3, 1)] {
+        let monday = utc.date(byAdding: .weekOfYear, value: -offset, to: currentWeekMonday)!
+        if shippedCount == 0 {
+            snapshots.append(snapshot(endedAt: monday.addingTimeInterval(3600), status: .archived))
+        } else {
+            for index in 0..<shippedCount {
+                snapshots.append(snapshot(
+                    endedAt: monday.addingTimeInterval(Double(index + 1) * 3600),
+                    status: .completed))
+            }
+        }
+    }
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    #expect(model.baseline.medianCombinedScore == 1.0) // median of {2, 0, 1}
+}
+
 // Displayed-not-graded stats are Σ over the week; churn is Σ removed / Σ added.
 @Test func displayedStatsSumAcrossTheWeek() {
     let snapshots = [

--- a/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/PRAttributionRepository.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/Repositories/PRAttributionRepository.swift
@@ -68,11 +68,13 @@ public struct PRAttributionRepository: Sendable {
 }
 
 /// Per-session rework/merge-rate read values over a window (#694, ADR 0008
-/// follow-up 6). Category-A efficiency signal inputs for the scorecard and
-/// the v2 combined score (follow-up 11) — this type only carries the
-/// numbers; grading/weighting lives with the (future) consumer. The churn
-/// hint (`SessionAnalytics.linesAdded/linesRemoved`) intentionally stays
-/// separate and informational-only.
+/// follow-up 6). Category-A efficiency signal inputs — this type only
+/// carries the numbers; grading/weighting lives with the consumer. The v2
+/// combined score (follow-up 11, #699) consumes the same attribution records
+/// at whole-machine weekly grain via `CombinedScore.weeklyRework` in CrowCore
+/// (this per-session type is the drill-down counterpart). The churn hint
+/// (`SessionAnalytics.linesAdded/linesRemoved`) intentionally stays separate
+/// and informational-only.
 public struct SessionReworkMetrics: Equatable, Sendable {
     /// Attributed PRs whose merge was observed inside the window.
     public let mergedCount: Int

--- a/Packages/CrowUI/Sources/CrowUI/ScorecardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ScorecardView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 import CrowCore
 
-// MARK: - Scorecard View (ADR 0008 v1, #710)
+// MARK: - Scorecard View (ADR 0008, #710 v1 + #699 v2 combined score)
 
 /// Full-pane private efficiency scorecard: the weekly A–F grade with its
-/// coachable deductions, the sessions-shipped throughput count, and the
-/// self-comparison against the user's own trailing 4-week median. Read-only —
-/// computed from the persisted snapshots mirrored on
-/// `appState.analyticsSnapshots`. The grade and the shipped count are separate
-/// surfaces; nothing on this screen combines them into one number.
+/// coachable deductions, the sessions-shipped throughput count, the v2
+/// combined multiplicative score, and the self-comparison against the user's
+/// own trailing 4-week median. Read-only — computed from the persisted
+/// snapshots mirrored on `appState.analyticsSnapshots` plus the PR
+/// attributions on `appState.prAttributions`. The grade and the shipped count
+/// remain separate surfaces; the combined score is an additional card that
+/// decomposes into its factors rather than replacing either.
 public struct ScorecardView: View {
     @Bindable var appState: AppState
 
@@ -19,6 +21,7 @@ public struct ScorecardView: View {
     private var model: ScorecardModel {
         ScorecardModel.build(
             snapshots: Array(appState.analyticsSnapshots.values),
+            attributions: Array(appState.prAttributions.values),
             now: Date(),
             calendar: .current
         )
@@ -72,6 +75,7 @@ public struct ScorecardView: View {
                     shippedCard(model.currentWeek)
                 }
 
+                combinedCard(model.currentWeek)
                 baselineSection(model)
                 displayedStatsSection(model.currentWeek)
 
@@ -188,6 +192,58 @@ public struct ScorecardView: View {
         }
     }
 
+    // MARK: Combined score (ADR 0008 v2, #699)
+
+    /// The v2 multiplicative score, always shown WITH its decomposition —
+    /// the number is only trustworthy while it stays explainable.
+    private func combinedCard(_ week: WeeklyScorecard) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Combined Score (v2)")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+
+                switch week.combined {
+                case .scored(let factors):
+                    Text(String(format: "%.1f", factors.value))
+                        .font(.system(size: 44, weight: .bold, design: .rounded))
+                        .foregroundStyle(CorveilTheme.gold)
+
+                    Text("\(factors.shippedCount) shipped × \(String(format: "%.2f", factors.alignmentFactor)) alignment × \(String(format: "%.2f", factors.efficiencyMultiplier)) efficiency")
+                        .font(.system(size: 12, weight: .medium))
+                        .monospacedDigit()
+
+                    Text("efficiency = grade \(factors.gradeScore)/100 × hygiene \(String(format: "%.2f", factors.hygieneFactor))\(Self.hygieneDetail(factors.rework))")
+                        .font(.caption2)
+                        .monospacedDigit()
+                        .foregroundStyle(CorveilTheme.textMuted)
+
+                    Text("Alignment-weighted throughput × efficiency, weekly grain — bad hygiene multiplies the score down and can't be bought back with volume. Same private self-comparison posture and tunable priors as the grade.")
+                        .font(.caption2)
+                        .foregroundStyle(CorveilTheme.textMuted)
+                case .insufficientData(let prompts):
+                    insufficientDataBlock(prompts: prompts)
+                }
+            }
+        }
+    }
+
+    /// Compact rework readout appended to the hygiene line — empty when the
+    /// week has no rework signals, so a clean week reads clean.
+    static func hygieneDetail(_ rework: CombinedScore.WeeklyRework) -> String {
+        var parts: [String] = []
+        if rework.revertCount > 0 {
+            parts.append("\(rework.revertCount) revert\(rework.revertCount == 1 ? "" : "s")")
+        }
+        if rework.postMergeFixCount > 0 {
+            parts.append("\(rework.postMergeFixCount) post-merge fix\(rework.postMergeFixCount == 1 ? "" : "es")")
+        }
+        if let mergeRate = rework.mergeRate, mergeRate < 1 {
+            parts.append(String(format: "%.0f%% merge rate", mergeRate * 100))
+        }
+        return parts.isEmpty ? "" : "  (\(parts.joined(separator: ", ")))"
+    }
+
     // MARK: Baseline (vs. your normal)
 
     @ViewBuilder
@@ -241,6 +297,12 @@ public struct ScorecardView: View {
                             comparisonRow(
                                 name: "Cost/shipped", current: cost, baseline: median,
                                 higherIsBetter: false) { AnalyticsFormatting.cost($0) }
+                        }
+                        if let median = baseline.medianCombinedScore,
+                           case .scored(let factors) = model.currentWeek.combined {
+                            comparisonRow(
+                                name: "Combined score", current: factors.value, baseline: median,
+                                higherIsBetter: true) { String(format: "%.1f", $0) }
                         }
                     }
                 }
@@ -318,6 +380,16 @@ public struct ScorecardView: View {
                             .font(.system(size: 12))
                             .monospacedDigit()
                             .foregroundStyle(CorveilTheme.textSecondary)
+                        Text({
+                            if case .scored(let factors) = week.combined {
+                                return String(format: "%.1f", factors.value)
+                            }
+                            return "—"
+                        }())
+                            .font(.system(size: 12))
+                            .monospacedDigit()
+                            .foregroundStyle(CorveilTheme.textMuted)
+                            .help("Combined score (v2)")
                         Text(AnalyticsFormatting.cost(week.totalCost))
                             .font(.system(size: 12))
                             .monospacedDigit()

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -18,11 +18,13 @@ import CrowProvider
 final class IssueTracker {
     private let appState: AppState
     private let providerManager: ProviderManager
-    /// Shared store instance (injected by AppDelegate). PR attributions have
-    /// no `appState` mirror, so they MUST be written through the same
-    /// `JSONStore` that `SessionService` mutates — an ad-hoc `JSONStore()`
-    /// write would be clobbered by the next mutation of the shared
-    /// instance's older in-memory snapshot.
+    /// Shared store instance (injected by AppDelegate). PR attributions MUST
+    /// be written through the same `JSONStore` that `SessionService` mutates
+    /// — an ad-hoc `JSONStore()` write would be clobbered by the next
+    /// mutation of the shared instance's older in-memory snapshot. Every
+    /// attribution write is followed by `syncPRAttributionMirror()` so the
+    /// read-only `appState.prAttributions` mirror (the v2 combined score's
+    /// input, #699) stays current.
     private let store: JSONStore
     private var timer: Timer?
     private let pollInterval: TimeInterval = 60 // 1 minute
@@ -1915,6 +1917,12 @@ final class IssueTracker {
         return updates
     }
 
+    /// Resync the read-only AppState mirror after a `prAttributions`
+    /// mutation, so the scorecard's v2 combined score (#699) sees the write.
+    private func syncPRAttributionMirror() {
+        appState.prAttributions = store.data.prAttributions ?? [:]
+    }
+
     /// Persist the PR→session mapping parsed from the PR's commits (#693).
     /// Called from `prHasCrowAuthoredCommit` so attribution rides along with
     /// the existing trailer parse; the gate's boolean result is unaffected.
@@ -1952,6 +1960,7 @@ final class IssueTracker {
             }
             data.prAttributions = attributions
         }
+        syncPRAttributionMirror()
     }
 
     /// Update stored attribution state from a refresh cycle's PR list
@@ -1968,6 +1977,7 @@ final class IssueTracker {
             for (url, attribution) in updates { attributions[url] = attribution }
             data.prAttributions = attributions
         }
+        syncPRAttributionMirror()
     }
 
     // MARK: - Rework / merge-rate metrics (#694, ADR 0008 follow-up 6)
@@ -2181,6 +2191,7 @@ final class IssueTracker {
                 attributions[attribution.prURL] = target
                 data.prAttributions = attributions
             }
+            syncPRAttributionMirror()
         }
     }
 
@@ -2232,6 +2243,7 @@ final class IssueTracker {
                 }
                 data.prAttributions = attributions
             }
+            syncPRAttributionMirror()
         }
     }
 
@@ -2254,6 +2266,7 @@ final class IssueTracker {
             }
             data.prAttributions = attributions
         }
+        syncPRAttributionMirror()
     }
 
     /// Per-refresh entry point. Picks candidate (session, PR) pairs and

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -56,6 +56,9 @@ final class SessionService {
         // Mirror persisted analytics snapshots for the scorecard (#710) —
         // CrowUI can't read the store, so the view computes from this.
         appState.analyticsSnapshots = data.analyticsSnapshots ?? [:]
+        // Same for PR attributions: the v2 combined score's hygiene factor
+        // (#699) reads this mirror; IssueTracker resyncs it after writes.
+        appState.prAttributions = data.prAttributions ?? [:]
 
         // Migrate a legacy primary Manager (persisted as `.work` before
         // SessionKind.manager existed) to `.manager` BEFORE the per-session loop.

--- a/Tests/CrowTests/PRAttributionMirrorWiringTests.swift
+++ b/Tests/CrowTests/PRAttributionMirrorWiringTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowProvider
+@testable import Crow
+
+/// #699: the v2 combined score reads PR attributions through the read-only
+/// `AppState.prAttributions` mirror (CrowUI cannot import CrowPersistence).
+/// These tests lock in that the mirror is hydrated on load and resynced by
+/// every IssueTracker attribution write path — the same contract
+/// `ScorecardWiringTests` locks in for analytics snapshots.
+@MainActor
+@Suite("PR attribution mirror wiring")
+struct PRAttributionMirrorWiringTests {
+
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-pr-attribution-mirror-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private func makeTracker(store: JSONStore, appState: AppState) -> IssueTracker {
+        IssueTracker(appState: appState, providerManager: ProviderManager(), store: store)
+    }
+
+    private func makePR(
+        url: String = "https://github.com/corveil/crow/pull/42",
+        number: Int = 42,
+        state: String = "OPEN",
+        repo: String = "corveil/crow"
+    ) -> IssueTracker.ViewerPR {
+        IssueTracker.ViewerPR(
+            number: number,
+            url: url,
+            state: state,
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "APPROVED",
+            isDraft: false,
+            headRefName: "feature/x",
+            headRefOid: "abc1234",
+            baseRefName: "main",
+            repoNameWithOwner: repo,
+            labels: [],
+            linkedIssueReferences: [],
+            checksState: "SUCCESS",
+            failedCheckNames: [],
+            latestReviewStates: ["APPROVED"]
+        )
+    }
+
+    private func mergedAttribution(
+        url: String,
+        number: Int,
+        firstSeenAt: Date,
+        mergedAt: Date?,
+        files: [String]?
+    ) -> PRSessionAttribution {
+        PRSessionAttribution(
+            prURL: url,
+            repoNameWithOwner: "corveil/crow",
+            prNumber: number,
+            sessionIDs: [UUID()],
+            state: mergedAt != nil ? "MERGED" : "OPEN",
+            mergedAt: mergedAt,
+            firstSeenAt: firstSeenAt,
+            updatedAt: firstSeenAt,
+            changedFiles: files
+        )
+    }
+
+    private let t0 = Date(timeIntervalSince1970: 1_752_000_000)
+    private let t1 = Date(timeIntervalSince1970: 1_752_000_600)
+    private let t2 = Date(timeIntervalSince1970: 1_752_001_200)
+
+    @Test
+    func hydrateStatePopulatesPRAttributionMirror() {
+        let store = Self.tempStore()
+        let persisted = mergedAttribution(
+            url: "https://github.com/corveil/crow/pull/1", number: 1,
+            firstSeenAt: t0, mergedAt: t1, files: nil)
+        store.mutate { $0.prAttributions = [persisted.prURL: persisted] }
+
+        let appState = AppState()
+        let service = SessionService(store: store, appState: appState)
+        service.hydrateState()
+
+        #expect(appState.prAttributions == [persisted.prURL: persisted])
+    }
+
+    @Test
+    func hydrateStateWithNoAttributionsLeavesMirrorEmpty() {
+        let appState = AppState()
+        let service = SessionService(store: Self.tempStore(), appState: appState)
+        service.hydrateState()
+        #expect(appState.prAttributions.isEmpty)
+    }
+
+    @Test
+    func recordPRAttributionSyncsMirror() {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let tracker = makeTracker(store: store, appState: appState)
+        let pr = makePR()
+        let sessionID = UUID()
+
+        tracker.recordPRAttribution(
+            pr: pr,
+            commits: [CommitInfo(sha: "abc1234", message: "feat: thing\n\nCrow-Session: \(sessionID.uuidString)\n")],
+            now: t0)
+
+        #expect(appState.prAttributions == (store.data.prAttributions ?? [:]))
+        #expect(appState.prAttributions[pr.url]?.sessionIDs == [sessionID])
+    }
+
+    @Test
+    func updatePRAttributionsSyncsMirrorOnStateTransition() {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let tracker = makeTracker(store: store, appState: appState)
+        let pr = makePR()
+        let sessionID = UUID()
+        tracker.recordPRAttribution(
+            pr: pr,
+            commits: [CommitInfo(sha: "abc1234", message: "feat: thing\n\nCrow-Session: \(sessionID.uuidString)\n")],
+            now: t0)
+
+        tracker.updatePRAttributions(viewerPRs: [makePR(state: "MERGED")], now: t1)
+
+        #expect(appState.prAttributions == (store.data.prAttributions ?? [:]))
+        #expect(appState.prAttributions[pr.url]?.state == "MERGED")
+        #expect(appState.prAttributions[pr.url]?.mergedAt == t1)
+    }
+
+    @Test
+    func detectPostMergeFixesSyncsMirror() {
+        let store = Self.tempStore()
+        let appState = AppState()
+        let tracker = makeTracker(store: store, appState: appState)
+        let fixed = mergedAttribution(
+            url: "https://github.com/corveil/crow/pull/1", number: 1,
+            firstSeenAt: t0, mergedAt: t0, files: ["Sources/App/Foo.swift"])
+        let fix = mergedAttribution(
+            url: "https://github.com/corveil/crow/pull/2", number: 2,
+            firstSeenAt: t1, mergedAt: t2, files: ["Sources/App/Foo.swift"])
+        store.mutate { $0.prAttributions = [fixed.prURL: fixed, fix.prURL: fix] }
+
+        tracker.detectPostMergeFixes(now: t2)
+
+        #expect(appState.prAttributions == (store.data.prAttributions ?? [:]))
+        #expect(appState.prAttributions[fixed.prURL]?.postMergeFixes?.first?.fixPRURL == fix.prURL)
+    }
+}

--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -110,7 +110,7 @@ Deferred guardrails (explicit non-goals until their data exists): trivial-PR far
 | 8 | Alignment / KPI mapping | Extend `JiraTaskBackend` to read priority + epic/parent; org-goal tagging on sessions; alignment weight. Greenfield. | v2 |
 | 9 | GitLab throughput parity | Include GitLab in done-ticket counting. | — |
 | 10 | Cross-machine aggregation + team surface | Prerequisite for any leaderboard; out of scope here. | — |
-| 11 | Combined multiplicative score (v2) | `alignment-weighted throughput × efficiency multiplier`, per-user-per-week. | blocked on 5, 6, 8 |
+| 11 | Combined multiplicative score (v2) | `alignment-weighted throughput × efficiency multiplier`, per-user-per-week. *Implemented (#699):* see the follow-up 11 addendum below. | blocked on 5, 6, 8 — all landed |
 
 No prototype ships with this ADR: the smallest useful one requires persisting the compaction counter (a write-path model change, follow-up 3), which exceeds the read-only bar for a design PR.
 
@@ -122,6 +122,16 @@ The alignment capture shipped with these decisions:
 - **Priority** rides `AssignedIssue`/`TicketInfo` from the Jira read (both the REST and `acli` paths), normalized to `TicketPriority` (modern Highest…Lowest and classic Blocker…Trivial ladders; unrecognized custom schemes → `.unknown` with the raw name preserved). It reaches the session via `crow set-ticket --priority`; automatic Jira-side priority sync (via IssueTracker's existing ticketURL↔session matching) is a noted follow-up. Jira Cloud's unified `parent` field covers team- and company-managed projects; Server/DC classic epic-link customfields aren't fetched and degrade to nil.
 - **Weight priors** live in `AlignmentWeight` (CrowCore) as named constants — a bonus-above-neutral scheme: untagged/unknown = exactly 1.0 (no pre-existing session regresses), each explicit priority rung > 1.0, an org-goal tag multiplies (×1.5). This yields the rubric ordering high-priority-on-goal > low-priority-off-goal > untagged-neutral: demonstrated alignment is rewarded, absence of data is never punished. Tunable priors, per the grade-bands principle above.
 - **Read-only exposure**: `Session.alignmentWeight` (computed) and `SessionAnalyticsSnapshot.alignmentWeight`/`orgGoal` (persisted at session end, nil = neutral in pre-#696 snapshots). Nothing multiplies it into a live score — that remains follow-up 11.
+
+### Follow-up 11 addendum (implemented in #699)
+
+The v2 combined score shipped with these decisions (`CombinedScore` in CrowCore):
+
+- **Formula**: `value = weightedThroughput × efficiencyMultiplier`, decomposing for display as `shipped count × alignment factor × efficiency multiplier`. **Weekly grain only** — there is no session-grain API, by construction (the same structural enforcement `EfficiencyGrading` uses against grade-averaging).
+- **Throughput factor**: Σ `SessionAnalyticsSnapshot.alignmentWeight` (nil = neutral 1.0) over the week's `.completed` snapshots — the alignment-weighted sessions-shipped count. Merged-PR counts were deliberately NOT added to the throughput unit (they'd double-count the session that shipped them); attribution data enters through hygiene instead.
+- **Efficiency multiplier (provably ≤ 1)**: `(weekly grade score / 100) × hygieneFactor`. The grade half reuses the exact score the grade card shows. The hygiene half rolls the #693/#694 attribution records up **whole-machine per week** (half-open ISO-week membership, matching `ScorecardModel` bucketing): `(1 − 0.25)^reverts × (1 − 0.10)^postMergeFixes × (1 − 0.5 × (1 − mergeRate))`, with a nil merge rate (nothing resolved) fully neutral. Constants are tunable priors in `CombinedScore.Tuning`, same calibration rule as the grade bands.
+- **Degenerate cases**: a weekly grade of *insufficient data* passes through (no grade → no multiplier → no score); a graded zero-shipped week scores 0 (a legitimate weekly-grain zero, with a neutral alignment factor so the decomposition identity holds); absence of attribution/alignment data never penalizes.
+- **Surface**: an additional card on the weekly scorecard, always rendered WITH its decomposition; the v1 grade and shipped cards are unchanged. The trailing-4-week baseline gains a median combined score (scored zero-shipped weeks contribute their 0 — a present zero IS a score, unlike cost-per-shipped). Private self-comparison posture unchanged; the view reads a new read-only `AppState.prAttributions` mirror.
 
 ## Consequences
 


### PR DESCRIPTION
Closes #699. ADR 0008 follow-up 11/11 (refs #648, design PR #657). Built on #693 (attribution) + #694 (rework) + #696 (alignment) + #710 (v1 scorecard).

## Readiness gate

The ticket was hard-blocked on #693/#694/#696 — all three (plus #710's v1 surface) verified merged on `main` (PRs #707, #713, #711, #712) before implementation.

## What this adds

`CombinedScore` (CrowCore, pure): the v2 score at **weekly grain only** — no session-grain API exists, by construction (same structural enforcement `EfficiencyGrading` uses against grade-averaging).

```
value = weightedThroughput × efficiencyMultiplier
      ≈ shipped count × alignment factor × efficiency multiplier   (inspectable decomposition)

weightedThroughput   = Σ (snapshot.alignmentWeight ?? neutral) over .completed snapshots in the ISO week
efficiencyMultiplier = (weekly grade score / 100) × hygieneFactor        — provably ≤ 1
hygieneFactor        = (1−0.25)^reverts × (1−0.10)^postMergeFixes × (1 − 0.5×(1−mergeRate))
```

- **Multiplicative, so waste is un-buyable with volume** — the headline test proves a 10-shipped/4-revert/grade-70 week scores below a 3-shipped clean grade-95 week.
- **Throughput unit = sessions shipped** (alignment-weighted); merged-PR data enters via the hygiene penalty instead of the count, avoiding double-counting one outcome.
- **Neutral-when-no-data everywhere**: nil alignment weight, nil merge rate, no attributions → factor 1.0 (the `AlignmentWeight` principle). Weekly grade insufficient-data passes through.
- **Rework rollup is whole-machine per week** (per-user-per-week on a single-user app), half-open ISO-week membership matching `ScorecardModel` bucketing.
- **Placement**: an additional card on the weekly scorecard, always rendered with its decomposition; the v1 A–F grade + sessions-shipped cards are untouched (locked by a with/without-attributions equality test). Baseline gains a median combined score. Private self-comparison posture unchanged.
- New read-only `AppState.prAttributions` mirror (CrowUI can't import CrowPersistence), hydrated on load and resynced after all five IssueTracker attribution write sites.
- ADR 0008: follow-up 11 addendum + table row marked implemented; stale "no combined score yet" doc comments updated.

## Tests

- `CombinedScoreTests` (10): multiplicative drag-down, alignment raises on-goal work, decomposition identity, nil-weight neutrality, zero-shipped week scores 0, insufficient-data passthrough, hygiene neutrality/exact formula/bounds, half-open rework windowing (incl. reopened-then-merged), multiplier ≤ 1.
- `EfficiencyScorecardTests` (+4): combined on current week, **v1 surfaces identical with/without attributions**, weekly-grain isolation, baseline median includes zero-shipped weeks.
- `PRAttributionMirrorWiringTests` (5): hydrate + record/update/detect resync paths.

`swift build` + root suite (374), CrowCore (414), CrowPersistence (43) all pass; CrowUI builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)