### PR TITLE
feat(web): efficiency scorecard pane (ADR 0008 parity)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/ScorecardDTO.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/ScorecardDTO.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+/// A flat, `Codable`, JS-friendly projection of `ScorecardModel` for the web
+/// client (ADR 0008 web parity, #721). The macOS `ScorecardView` reads
+/// `ScorecardModel` directly; the web has no Swift value types, so `crowd`
+/// builds the model server-side and ships this DTO over `get-scorecard`. The
+/// web renders it verbatim — the grade, throughput, combined score, and
+/// baseline are all computed by the one Core `ScorecardModel.build(...)`, so
+/// web and desktop can never diverge on the numbers.
+///
+/// Flattening rules that keep the wire shape trivial for JavaScript:
+/// - The `GradeResult` / `CombinedScore.WeeklyResult` / `CostPerShipped`
+///   enums-with-payloads collapse to structs with optional fields and a
+///   discriminator (`graded`, `scored`) — a `nil` payload field means the
+///   other case.
+/// - Dates are epoch **milliseconds** (`Double`), not `Date` — `new Date(ms)`
+///   in JS, and no `JSONEncoder.dateEncodingStrategy` coupling with the
+///   `JSONValue` transport used by `get-state`.
+/// - The current week carries its derived rates inline so the web can draw the
+///   baseline comparison without re-deriving them from raws.
+public struct ScorecardDTO: Codable, Sendable, Equatable {
+    /// `config.telemetry.enabled` at build time — lets the web split the empty
+    /// state into "telemetry off" vs. "on but nothing shipped yet".
+    public let telemetryEnabled: Bool
+    /// Total persisted snapshots. Zero ⇒ the desktop's `analyticsSnapshots
+    /// .isEmpty` empty state.
+    public let snapshotCount: Int
+    public let currentWeek: WeeklyDTO
+    /// Trailing weeks that had snapshots, newest first (absence is not a zero).
+    public let priorWeeks: [WeeklyDTO]
+    public let baseline: BaselineDTO
+    /// Current week's per-session drill-down rows, newest first.
+    public let sessions: [SessionRowDTO]
+
+    // Tuning constants the web needs for its "baseline building" / "insufficient
+    // data" copy, so those thresholds live in Core, not duplicated in JS.
+    public let minimumBaselineWeeks: Int
+    public let baselineWeekCount: Int
+    public let minimumGradablePromptCount: Int
+
+    public init(
+        _ model: ScorecardModel,
+        telemetryEnabled: Bool,
+        snapshotCount: Int
+    ) {
+        self.telemetryEnabled = telemetryEnabled
+        self.snapshotCount = snapshotCount
+        self.currentWeek = WeeklyDTO(model.currentWeek)
+        self.priorWeeks = model.priorWeeks.map(WeeklyDTO.init)
+        self.baseline = BaselineDTO(model.baseline)
+        self.sessions = model.currentWeekSessions.map(SessionRowDTO.init)
+        self.minimumBaselineWeeks = EfficiencyGrading.Tuning.minimumBaselineWeeks
+        self.baselineWeekCount = EfficiencyGrading.Tuning.baselineWeekCount
+        self.minimumGradablePromptCount = EfficiencyGrading.Tuning.minimumGradablePromptCount
+    }
+}
+
+/// One week: the A–F grade, the separate sessions-shipped surface, the v2
+/// combined score, the displayed-not-graded context stats, and the current
+/// week's derived rates for baseline comparison.
+public struct WeeklyDTO: Codable, Sendable, Equatable {
+    public let weekStartMillis: Double
+    public let grade: GradeDTO
+    public let sessionsShipped: Int
+    /// `Σ totalCost / sessionsShipped`; `nil` = insufficient outcomes (nothing
+    /// shipped), never a fallback division.
+    public let costPerShipped: Double?
+    public let sessionCount: Int
+    public let totalCost: Double
+    public let activeTimeSeconds: Double
+    public let commitCount: Int
+    public let churnHint: Double
+    public let combined: CombinedDTO
+
+    // Derived rates (for the current week's baseline comparison rows).
+    public let compactionsPerActiveHour: Double
+    public let inputTokensPerPrompt: Double
+    public let cacheHitRatio: Double
+    public let apiErrorRate: Double
+
+    init(_ week: WeeklyScorecard) {
+        self.weekStartMillis = week.weekStart.millis
+        self.grade = GradeDTO(week.result)
+        self.sessionsShipped = week.sessionsShipped
+        if case .graded(let cost) = week.costPerShipped {
+            self.costPerShipped = cost
+        } else {
+            self.costPerShipped = nil
+        }
+        self.sessionCount = week.sessionCount
+        self.totalCost = week.totalCost
+        self.activeTimeSeconds = week.activeTimeSeconds
+        self.commitCount = week.commitCount
+        self.churnHint = week.churnHint
+        self.combined = CombinedDTO(week.combined)
+        self.compactionsPerActiveHour = week.input.compactionsPerActiveHour
+        self.inputTokensPerPrompt = week.input.inputTokensPerPrompt
+        self.cacheHitRatio = week.input.cacheHitRatio
+        self.apiErrorRate = week.input.apiErrorRate
+    }
+}
+
+/// A grade result: `graded` carries score/letter/deductions; otherwise
+/// `promptCount` is the below-floor count for the "insufficient data" copy.
+public struct GradeDTO: Codable, Sendable, Equatable {
+    public let graded: Bool
+    public let score: Int?
+    public let letter: String?
+    public let deductions: [DeductionDTO]
+    /// Set only when `graded == false`.
+    public let promptCount: Int?
+
+    init(_ result: EfficiencyGrading.GradeResult) {
+        switch result {
+        case .graded(let score, let letter, let deductions):
+            self.graded = true
+            self.score = score
+            self.letter = letter.rawValue
+            self.deductions = deductions.map(DeductionDTO.init)
+            self.promptCount = nil
+        case .insufficientData(let prompts):
+            self.graded = false
+            self.score = nil
+            self.letter = nil
+            self.deductions = []
+            self.promptCount = prompts
+        }
+    }
+}
+
+public struct DeductionDTO: Codable, Sendable, Equatable {
+    /// `EfficiencyGrading.Metric` raw value — the web keys its coaching hint off
+    /// this (`compactions`, `contextPressure`, `cacheHitRatio`, `apiErrorRate`,
+    /// `costPerShipped`).
+    public let metric: String
+    public let points: Int
+    public let label: String
+
+    init(_ deduction: EfficiencyGrading.Deduction) {
+        self.metric = deduction.metric.rawValue
+        self.points = deduction.points
+        self.label = deduction.label
+    }
+}
+
+/// The v2 combined score: `scored` carries the decomposed factors; otherwise
+/// it passes through the weekly grade's minimum-sample floor.
+public struct CombinedDTO: Codable, Sendable, Equatable {
+    public let scored: Bool
+    public let value: Double?
+    public let shippedCount: Int?
+    public let alignmentFactor: Double?
+    public let efficiencyMultiplier: Double?
+    public let gradeScore: Int?
+    public let hygieneFactor: Double?
+    public let revertCount: Int?
+    public let postMergeFixCount: Int?
+    /// merged / (merged + closed-without-merge); `nil` when nothing resolved
+    /// (neutral, never a fake 0 or 1).
+    public let mergeRate: Double?
+    /// Set only when `scored == false`.
+    public let promptCount: Int?
+
+    init(_ result: CombinedScore.WeeklyResult) {
+        switch result {
+        case .scored(let f):
+            self.scored = true
+            self.value = f.value
+            self.shippedCount = f.shippedCount
+            self.alignmentFactor = f.alignmentFactor
+            self.efficiencyMultiplier = f.efficiencyMultiplier
+            self.gradeScore = f.gradeScore
+            self.hygieneFactor = f.hygieneFactor
+            self.revertCount = f.rework.revertCount
+            self.postMergeFixCount = f.rework.postMergeFixCount
+            self.mergeRate = f.rework.mergeRate
+            self.promptCount = nil
+        case .insufficientData(let prompts):
+            self.scored = false
+            self.value = nil
+            self.shippedCount = nil
+            self.alignmentFactor = nil
+            self.efficiencyMultiplier = nil
+            self.gradeScore = nil
+            self.hygieneFactor = nil
+            self.revertCount = nil
+            self.postMergeFixCount = nil
+            self.mergeRate = nil
+            self.promptCount = prompts
+        }
+    }
+}
+
+/// The trailing-4-week median baseline. `nil` medians mean no graded prior week
+/// supplied that value.
+public struct BaselineDTO: Codable, Sendable, Equatable {
+    public let weeksAvailable: Int
+    public let medianScore: Double?
+    public let medianCompactionsPerActiveHour: Double?
+    public let medianInputTokensPerPrompt: Double?
+    public let medianCacheHitRatio: Double?
+    public let medianApiErrorRate: Double?
+    public let medianCostPerShipped: Double?
+    public let medianCombinedScore: Double?
+
+    init(_ baseline: ScorecardBaseline) {
+        self.weeksAvailable = baseline.weeksAvailable
+        self.medianScore = baseline.medianScore
+        self.medianCompactionsPerActiveHour = baseline.medianCompactionsPerActiveHour
+        self.medianInputTokensPerPrompt = baseline.medianInputTokensPerPrompt
+        self.medianCacheHitRatio = baseline.medianCacheHitRatio
+        self.medianApiErrorRate = baseline.medianApiErrorRate
+        self.medianCostPerShipped = baseline.medianCostPerShipped
+        self.medianCombinedScore = baseline.medianCombinedScore
+    }
+}
+
+/// One per-session drill-down row for the current week.
+public struct SessionRowDTO: Codable, Sendable, Equatable {
+    public let sessionID: String
+    public let endedAtMillis: Double
+    public let shipped: Bool
+    public let grade: GradeDTO
+    public let totalCost: Double
+    public let activeTimeSeconds: Double
+    public let wallClockDurationSeconds: Double?
+
+    init(_ row: SessionGradeRow) {
+        self.sessionID = row.sessionID.uuidString
+        self.endedAtMillis = row.endedAt.millis
+        self.shipped = row.shipped
+        self.grade = GradeDTO(row.result)
+        self.totalCost = row.analytics.totalCost
+        self.activeTimeSeconds = row.analytics.activeTimeSeconds
+        self.wallClockDurationSeconds = row.wallClockDurationSeconds
+    }
+}
+
+private extension Date {
+    /// Epoch milliseconds — the JS-native `Date` unit, so the web never has to
+    /// know Swift's date-encoding strategy.
+    var millis: Double { timeIntervalSince1970 * 1000 }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/ScorecardDTOTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ScorecardDTOTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #721 (ADR 0008 web parity): the `ScorecardDTO` is a lossless, JS-friendly
+// projection of `ScorecardModel`. These pin that the DTO carries exactly the
+// numbers the desktop `ScorecardView` reads — building server-side is what lets
+// the web match Core without re-implementing grading in JavaScript.
+
+private let utc: Calendar = {
+    var calendar = Calendar(identifier: .iso8601)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+}()
+
+private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 12) -> Date {
+    utc.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+}
+
+private let now = date(2026, 7, 15) // Wed of ISO week Mon 2026-07-13 … Sun 2026-07-19
+
+private func snapshot(
+    endedAt: Date,
+    status: SessionStatus = .completed,
+    compactions: Int? = 0,
+    activeSeconds: Double = 3600,
+    prompts: Int = 10,
+    inputTokens: Int = 0,
+    apiErrors: Int = 0,
+    apiRequests: Int = 0,
+    cost: Double = 0
+) -> SessionAnalyticsSnapshot {
+    SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: endedAt,
+        status: status,
+        analytics: SessionAnalytics(
+            totalCost: cost,
+            inputTokens: inputTokens,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            activeTimeSeconds: activeSeconds,
+            linesAdded: 0,
+            linesRemoved: 0,
+            commitCount: 0,
+            promptCount: prompts,
+            apiRequestCount: apiRequests,
+            apiErrorCount: apiErrors
+        ),
+        compactionCount: compactions
+    )
+}
+
+@Test func dtoMirrorsCurrentWeekGradeAndThroughput() {
+    // Current week: two shipped sessions, one with a compaction penalty.
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), compactions: 3, activeSeconds: 3600, prompts: 10, cost: 4),
+        snapshot(endedAt: date(2026, 7, 14), compactions: 0, activeSeconds: 3600, prompts: 8, cost: 6),
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    let dto = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: snapshots.count)
+
+    guard case .graded(let score, let letter, let deductions) = model.currentWeek.result else {
+        Issue.record("expected a graded current week"); return
+    }
+    #expect(dto.currentWeek.grade.graded)
+    #expect(dto.currentWeek.grade.score == score)
+    #expect(dto.currentWeek.grade.letter == letter.rawValue)
+    #expect(dto.currentWeek.grade.deductions.count == deductions.count)
+    #expect(dto.currentWeek.grade.deductions.first?.metric == deductions.first?.metric.rawValue)
+
+    #expect(dto.currentWeek.sessionsShipped == model.currentWeek.sessionsShipped)
+    #expect(dto.currentWeek.sessionsShipped == 2)
+    // costPerShipped graded ⇒ present.
+    if case .graded(let cost) = model.currentWeek.costPerShipped {
+        #expect(dto.currentWeek.costPerShipped == cost)
+    } else {
+        Issue.record("expected graded cost-per-shipped")
+    }
+    // Derived rates carried inline for the baseline comparison.
+    #expect(dto.currentWeek.compactionsPerActiveHour == model.currentWeek.input.compactionsPerActiveHour)
+    #expect(dto.currentWeek.cacheHitRatio == model.currentWeek.input.cacheHitRatio)
+    #expect(dto.sessions.count == model.currentWeekSessions.count)
+    #expect(dto.snapshotCount == 2)
+    #expect(dto.telemetryEnabled)
+}
+
+@Test func dtoMirrorsCombinedScoreDecomposition() {
+    let snapshots = [snapshot(endedAt: date(2026, 7, 13), prompts: 10, cost: 3)]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    let dto = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: 1)
+
+    guard case .scored(let factors) = model.currentWeek.combined else {
+        Issue.record("expected a scored combined result"); return
+    }
+    #expect(dto.currentWeek.combined.scored)
+    #expect(dto.currentWeek.combined.value == factors.value)
+    #expect(dto.currentWeek.combined.shippedCount == factors.shippedCount)
+    #expect(dto.currentWeek.combined.efficiencyMultiplier == factors.efficiencyMultiplier)
+    #expect(dto.currentWeek.combined.gradeScore == factors.gradeScore)
+    // No attributions ⇒ neutral hygiene, nil merge rate (never a fake 0/1).
+    #expect(dto.currentWeek.combined.hygieneFactor == 1.0)
+    #expect(dto.currentWeek.combined.mergeRate == nil)
+}
+
+@Test func dtoFlattensInsufficientData() {
+    // Below the minimum-sample floor ⇒ not graded, not scored.
+    let snapshots = [snapshot(endedAt: date(2026, 7, 13), prompts: 2)]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    let dto = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: 1)
+
+    #expect(!dto.currentWeek.grade.graded)
+    #expect(dto.currentWeek.grade.score == nil)
+    #expect(dto.currentWeek.grade.promptCount == 2)
+    #expect(!dto.currentWeek.combined.scored)
+    #expect(dto.currentWeek.combined.promptCount == 2)
+}
+
+@Test func dtoCarriesBaselineWhenPriorWeeksExist() {
+    // Four graded prior weeks + the current week ⇒ a full baseline.
+    var snapshots: [SessionAnalyticsSnapshot] = []
+    for offset in 0...4 {
+        let day = date(2026, 7, 13 - offset * 7)
+        snapshots.append(snapshot(endedAt: day, compactions: offset, prompts: 10, cost: 5))
+    }
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    let dto = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: snapshots.count)
+
+    #expect(dto.priorWeeks.count == model.priorWeeks.count)
+    #expect(dto.baseline.weeksAvailable == model.baseline.weeksAvailable)
+    #expect(dto.baseline.medianScore == model.baseline.medianScore)
+    #expect(dto.minimumBaselineWeeks == EfficiencyGrading.Tuning.minimumBaselineWeeks)
+    #expect(dto.baselineWeekCount == EfficiencyGrading.Tuning.baselineWeekCount)
+}
+
+@Test func dtoRoundTripsThroughJSON() throws {
+    let snapshots = [snapshot(endedAt: date(2026, 7, 13), compactions: 2, prompts: 10, cost: 8)]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    let dto = ScorecardDTO(model, telemetryEnabled: false, snapshotCount: 1)
+
+    let data = try JSONEncoder().encode(dto)
+    let decoded = try JSONDecoder().decode(ScorecardDTO.self, from: data)
+    #expect(decoded == dto)
+    // Week start survives as epoch millis (JS `new Date(ms)`).
+    #expect(decoded.currentWeek.weekStartMillis == model.currentWeek.weekStart.timeIntervalSince1970 * 1000)
+}
+
+@Test func dtoEmptyStateFlags() {
+    let model = ScorecardModel.build(snapshots: [], now: now, calendar: utc)
+    let off = ScorecardDTO(model, telemetryEnabled: false, snapshotCount: 0)
+    #expect(off.snapshotCount == 0)
+    #expect(!off.telemetryEnabled)
+    #expect(off.sessions.isEmpty)
+    #expect(off.priorWeeks.isEmpty)
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -704,6 +704,41 @@ func makeCommandRouter(
             }
         },
 
+        // Private efficiency scorecard (ADR 0008; web parity #721). The desktop
+        // `ScorecardView` reads `ScorecardModel` off `appState.analyticsSnapshots`
+        // + `appState.prAttributions` directly; the web has no Swift value types,
+        // so we build the ONE Core `ScorecardModel.build(...)` here and ship its
+        // flattened `ScorecardDTO`. Building server-side is what guarantees the
+        // web grade/throughput/combined/baseline can never drift from desktop —
+        // there is no JS re-implementation of the grading to keep in sync.
+        // Read-only and always local (same posture as get-state).
+        "get-scorecard": { _ in
+            let dto = await MainActor.run { () -> ScorecardDTO in
+                let model = ScorecardModel.build(
+                    snapshots: Array(appState.analyticsSnapshots.values),
+                    attributions: Array(appState.prAttributions.values),
+                    now: Date(),
+                    calendar: .current
+                )
+                let telemetryEnabled = ConfigStore.loadConfig(devRoot: devRoot)?.telemetry.enabled ?? false
+                return ScorecardDTO(
+                    model,
+                    telemetryEnabled: telemetryEnabled,
+                    snapshotCount: appState.analyticsSnapshots.count
+                )
+            }
+            do {
+                guard case .object(let dict) = try JSONValue(encoding: dto) else {
+                    throw DaemonRPCError.applicationError("scorecard did not encode to an object")
+                }
+                return dict
+            } catch let error as DaemonRPCError {
+                throw error
+            } catch {
+                throw DaemonRPCError.applicationError("Failed to encode scorecard: \(error)")
+            }
+        },
+
         // App config (the web Settings modal). Forward to the app when it's
         // running so its `saveSettings` side effects run (AppState mirror,
         // notification settings); read/write `{devRoot}/.claude/config.json`

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -1063,3 +1063,105 @@ html, body {
   margin-bottom: 6px;
 }
 @keyframes wizard-spin { to { transform: rotate(360deg); } }
+
+/* ---- Scorecard (ADR 0008 web parity, #721) ---- */
+.score-weeklabel { color: var(--text-secondary); font-size: 12px; }
+.score-banner {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  margin-bottom: 14px;
+}
+.score-wrap { display: flex; flex-direction: column; gap: 14px; padding-bottom: 24px; }
+.score-row { display: flex; gap: 12px; flex-wrap: wrap; }
+.score-row > .score-card { flex: 1 1 220px; }
+.score-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 12px;
+}
+.score-card-label { color: var(--text-secondary); font-size: 12px; margin-bottom: 10px; }
+.score-sub { color: var(--text-secondary); font-size: 12px; margin-top: 6px; }
+.score-muted { color: var(--text-muted); font-size: 12px; margin-top: 6px; line-height: 1.45; }
+
+.score-grade-row { display: flex; align-items: baseline; gap: 10px; }
+.score-grade-letter { font-size: 44px; font-weight: 800; line-height: 1; }
+.score-grade-num { font-size: 15px; font-weight: 500; color: var(--text-secondary); }
+.score-big-gold { font-size: 44px; font-weight: 800; color: var(--gold); line-height: 1.05; }
+
+.score-deductions { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; }
+.score-deduction-line { display: flex; align-items: baseline; gap: 8px; }
+.score-deduction-label { font-size: 12px; font-weight: 500; flex: 1; }
+.score-deduction-points { font-size: 12px; font-weight: 700; color: var(--red); font-variant-numeric: tabular-nums; }
+.score-deduction-hint { font-size: 11px; color: var(--text-muted); margin-top: 1px; line-height: 1.4; }
+
+.score-decomp { font-size: 12px; font-weight: 500; margin-top: 8px; font-variant-numeric: tabular-nums; }
+.score-decomp-sub { font-size: 11px; color: var(--text-muted); margin-top: 4px; font-variant-numeric: tabular-nums; }
+
+.score-insufficient { margin-top: 4px; }
+.score-insufficient-title { font-size: 20px; font-weight: 600; color: var(--text-secondary); }
+
+.score-comparisons { display: flex; flex-direction: column; gap: 6px; }
+.score-comparison { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.score-comparison-name { color: var(--text-secondary); flex: 1; }
+.score-comparison-current { font-weight: 600; font-variant-numeric: tabular-nums; }
+.score-comparison-baseline { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.score-comparison-arrow { font-size: 11px; font-weight: 700; }
+.score-comparison-arrow.good { color: var(--green); }
+.score-comparison-arrow.bad { color: var(--red); }
+.score-comparison-arrow.flat { color: var(--text-muted); }
+
+.score-chips { display: flex; gap: 12px; flex-wrap: wrap; }
+.score-chip {
+  display: flex; flex-direction: column; gap: 2px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 6px 10px;
+  min-width: 72px;
+}
+.score-chip-label { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+.score-chip-value { font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums; }
+
+.score-prior { display: flex; flex-direction: column; gap: 6px; }
+.score-prior-row { display: flex; align-items: center; gap: 10px; font-size: 12px; }
+.score-prior-week { color: var(--text-secondary); }
+.score-prior-shipped { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--text-secondary); }
+.score-prior-combined { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 30px; text-align: right; }
+.score-prior-cost { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 56px; text-align: right; }
+
+.score-sessions { display: flex; flex-direction: column; gap: 8px; }
+.score-session { display: flex; flex-direction: column; gap: 3px; padding: 2px 0; }
+.score-session-line { display: flex; align-items: center; gap: 8px; }
+.score-session-date { font-size: 12px; color: var(--text-secondary); }
+.score-session-spacer { flex: 1; }
+.score-session-stat { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.score-session-deductions { font-size: 11px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.score-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 5px;
+  font-size: 12px; font-weight: 700;
+  background: var(--bg-surface);
+}
+.score-badge.muted { color: var(--text-muted); }
+.score-shipped-pill {
+  font-size: 10px; font-weight: 500;
+  padding: 1px 6px; border-radius: 10px;
+  background: rgba(52, 199, 89, 0.15); color: var(--green);
+}
+
+.score-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 10px; text-align: center;
+  padding: 48px 24px;
+  color: var(--text-secondary);
+}
+.score-empty-title { font-size: 16px; font-weight: 600; color: var(--text-primary); }
+.score-empty-msg { font-size: 13px; max-width: 460px; line-height: 1.5; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -456,8 +456,8 @@ let liveById = {};
 // Boards (Ticket Board / Reviews / Allowlist), mirroring the desktop's
 // full-pane boards. Data is forwarded to the desktop app, so it's empty when
 // the app isn't running.
-let selectedBoard = null; // 'tickets' | 'reviews' | 'allowlist' | null
-const boardData = { tickets: null, reviews: null, allowlist: null };
+let selectedBoard = null; // 'tickets' | 'reviews' | 'allowlist' | 'scorecard' | null
+const boardData = { tickets: null, reviews: null, allowlist: null, scorecard: null };
 
 // Last-known sidebar layout (sessions + ticket/review badge counts) so first
 // paint isn't blank while /rpc connects (CROW-613).
@@ -873,6 +873,8 @@ function navPillRow() {
   row.appendChild(rev);
 
   row.appendChild(navPill('Allowlist', selectedBoard === 'allowlist', () => selectBoard('allowlist')));
+
+  row.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
 
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
@@ -1773,7 +1775,10 @@ function selectBoard(key) {
 // Fetch one board; only re-render when the data actually changed so polling
 // doesn't reset scroll/selection while idle.
 async function refreshBoard(key) {
-  const method = key === 'tickets' ? 'list-tickets' : key === 'reviews' ? 'list-reviews' : 'list-allowlist';
+  const method = key === 'tickets' ? 'list-tickets'
+    : key === 'reviews' ? 'list-reviews'
+    : key === 'scorecard' ? 'get-scorecard'
+    : 'list-allowlist';
   let data;
   try { data = await rpc(method); } catch (_) { return; }
   const changed = JSON.stringify(boardData[key]) !== JSON.stringify(data);
@@ -1796,6 +1801,311 @@ function renderBoard() {
   if (selectedBoard === 'tickets') renderTicketBoard(root);
   else if (selectedBoard === 'reviews') renderReviewBoard(root);
   else if (selectedBoard === 'allowlist') renderAllowlist(root);
+  else if (selectedBoard === 'scorecard') renderScorecard(root);
+}
+
+// ===== Scorecard (ADR 0008 web parity, #721) =====
+// Private weekly efficiency scorecard, mirroring the desktop `ScorecardView`.
+// Everything is computed by the one Core `ScorecardModel` on the daemon and
+// shipped as a flat `ScorecardDTO` over `get-scorecard`; this only renders it,
+// so web and desktop can never disagree on a number.
+
+// Formatters mirroring CrowUI's `AnalyticsFormatting` so the web reads the same
+// as the desktop cards.
+function fmtCost(cost) {
+  if (cost > 0 && cost < 0.01) return '<$0.01';
+  return '$' + Number(cost).toFixed(2);
+}
+function fmtCount(n) {
+  n = Number(n);
+  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+  return String(Math.round(n));
+}
+function fmtTime(seconds) {
+  const s = Math.floor(Number(seconds) || 0);
+  if (s >= 3600) return Math.floor(s / 3600) + 'h ' + Math.floor((s % 3600) / 60) + 'm';
+  if (s >= 60) return Math.floor(s / 60) + 'm';
+  return s + 's';
+}
+function fmtPct(fraction) {
+  const p = Number(fraction) * 100;
+  return (p === Math.round(p) ? p.toFixed(0) : p.toFixed(1)) + '%';
+}
+function scoreWeekLabel(millis) {
+  const start = new Date(millis);
+  const end = new Date(millis + 6 * 86400 * 1000);
+  const fmt = (d) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return 'Week of ' + fmt(start) + ' – ' + fmt(end);
+}
+const GRADE_COLORS = { A: '#4ade80', B: '#6ee7b7', C: '#facc15', D: '#fb923c', F: '#f87171' };
+function gradeColor(letter) { return GRADE_COLORS[letter] || 'var(--text-muted)'; }
+// One coachable sentence per metric — the view-layer copy from the desktop.
+const COACHING = {
+  compactions: 'Compacting mid-session means the context filled — clear between tasks or split unrelated work.',
+  contextPressure: 'Heavy input per prompt suggests bloated context — reset more often or narrow what gets loaded.',
+  cacheHitRatio: 'Low cache reuse means context is re-sent as fresh input — steadier sessions cache better.',
+  apiErrorRate: 'Frequent API errors burn time and tokens — check connectivity, rate limits, or the agent setup.',
+  costPerShipped: 'High spend per shipped session — smaller scoped sessions that finish tend to cost less per outcome.',
+};
+
+function scoreCard(children) {
+  const c = el('div', 'score-card');
+  for (const child of children) if (child) c.appendChild(child);
+  return c;
+}
+function scoreLabel(text) { return el('div', 'score-card-label', text); }
+
+function renderScorecard(root) {
+  const head = el('div', 'board-head');
+  head.appendChild(el('div', 'board-title', 'Scorecard'));
+  const data = boardData.scorecard;
+  if (data) {
+    const wk = el('div', 'score-weeklabel', scoreWeekLabel(data.currentWeek.weekStartMillis));
+    head.appendChild(wk);
+  }
+  const refresh = el('button', 'action-btn', 'Refresh');
+  refresh.onclick = () => refreshBoard('scorecard');
+  head.appendChild(refresh);
+  root.appendChild(head);
+
+  const banner = el('div', 'score-banner',
+    'Private efficiency scorecard — this week vs. your own trailing 4-week normal. ' +
+    'Grade thresholds are starting heuristics under a 4-week calibration period; expect them to move.');
+  root.appendChild(banner);
+
+  if (!data) {
+    root.appendChild(el('div', 'score-empty', 'Loading…'));
+    return;
+  }
+  if (!data.snapshotCount) {
+    root.appendChild(scorecardEmpty(data));
+    return;
+  }
+
+  const wrap = el('div', 'score-wrap');
+  const top = el('div', 'score-row');
+  top.appendChild(gradeCardEl(data.currentWeek));
+  top.appendChild(shippedCardEl(data.currentWeek));
+  wrap.appendChild(top);
+
+  wrap.appendChild(combinedCardEl(data.currentWeek));
+  wrap.appendChild(baselineCardEl(data));
+  wrap.appendChild(displayedStatsEl(data.currentWeek));
+  if (data.priorWeeks.length) wrap.appendChild(priorWeeksEl(data.priorWeeks));
+  if (data.sessions.length) wrap.appendChild(sessionsEl(data.sessions));
+  root.appendChild(wrap);
+}
+
+function scorecardEmpty(data) {
+  const box = el('div', 'score-empty');
+  box.appendChild(el('div', 'score-empty-title', 'No Session Data Yet'));
+  const msg = el('div', 'score-empty-msg', data.telemetryEnabled
+    ? 'The scorecard is computed from analytics snapshots written when sessions complete or archive. Telemetry is on — finish a session and it will appear here.'
+    : 'The scorecard is computed from analytics snapshots written when sessions complete or archive. Snapshots require Claude Code telemetry, which is off by default.');
+  box.appendChild(msg);
+  if (!data.telemetryEnabled) {
+    const btn = el('button', 'action-btn action-primary', 'Open Settings');
+    btn.onclick = () => { if (window.openSettings) window.openSettings(); };
+    box.appendChild(btn);
+  }
+  return box;
+}
+
+function insufficientDataEl(promptCount, minPrompts) {
+  const box = el('div', 'score-insufficient');
+  box.appendChild(el('div', 'score-insufficient-title', 'Insufficient data'));
+  box.appendChild(el('div', 'score-sub',
+    promptCount + ' prompt' + (promptCount === 1 ? '' : 's') + ' this week — grading starts at ' + minPrompts + '.'));
+  return box;
+}
+
+function gradeCardEl(week) {
+  const body = [scoreLabel("This Week's Grade")];
+  const g = week.grade;
+  if (g.graded) {
+    const big = el('div', 'score-grade-row');
+    const letter = el('span', 'score-grade-letter', g.letter);
+    letter.style.color = gradeColor(g.letter);
+    big.appendChild(letter);
+    big.appendChild(el('span', 'score-grade-num', g.score + '/100'));
+    body.push(big);
+    if (!g.deductions.length) {
+      body.push(el('div', 'score-muted', 'No deductions — clean week.'));
+    } else {
+      const list = el('div', 'score-deductions');
+      for (const d of g.deductions) list.appendChild(deductionRowEl(d));
+      body.push(list);
+    }
+  } else {
+    body.push(insufficientDataEl(g.promptCount, boardData.scorecard.minimumGradablePromptCount));
+  }
+  return scoreCard(body);
+}
+
+function deductionRowEl(d) {
+  const row = el('div', 'score-deduction');
+  const line = el('div', 'score-deduction-line');
+  line.appendChild(el('span', 'score-deduction-label', d.label));
+  line.appendChild(el('span', 'score-deduction-points', '−' + d.points));
+  row.appendChild(line);
+  row.appendChild(el('div', 'score-deduction-hint', COACHING[d.metric] || ''));
+  return row;
+}
+
+function shippedCardEl(week) {
+  const body = [scoreLabel('Sessions Shipped')];
+  const big = el('div', 'score-big-gold', String(week.sessionsShipped));
+  body.push(big);
+  if (week.costPerShipped != null) {
+    body.push(el('div', 'score-sub', fmtCost(week.costPerShipped) + ' per shipped session'));
+  } else {
+    body.push(el('div', 'score-muted', 'Insufficient outcomes — nothing shipped this week.'));
+  }
+  return scoreCard(body);
+}
+
+function combinedCardEl(week) {
+  const body = [scoreLabel('Combined Score (v2)')];
+  const c = week.combined;
+  if (c.scored) {
+    body.push(el('div', 'score-big-gold', Number(c.value).toFixed(1)));
+    body.push(el('div', 'score-decomp',
+      c.shippedCount + ' shipped × ' + Number(c.alignmentFactor).toFixed(2) + ' alignment × ' +
+      Number(c.efficiencyMultiplier).toFixed(2) + ' efficiency'));
+    body.push(el('div', 'score-decomp-sub',
+      'efficiency = grade ' + c.gradeScore + '/100 × hygiene ' + Number(c.hygieneFactor).toFixed(2) +
+      hygieneDetail(c)));
+    body.push(el('div', 'score-muted',
+      'Alignment-weighted throughput × efficiency, weekly grain — bad hygiene multiplies the score down and ' +
+      "can't be bought back with volume. Same private self-comparison posture and tunable priors as the grade."));
+  } else {
+    body.push(insufficientDataEl(c.promptCount, boardData.scorecard.minimumGradablePromptCount));
+  }
+  return scoreCard(body);
+}
+
+function hygieneDetail(c) {
+  const parts = [];
+  if (c.revertCount > 0) parts.push(c.revertCount + ' revert' + (c.revertCount === 1 ? '' : 's'));
+  if (c.postMergeFixCount > 0) parts.push(c.postMergeFixCount + ' post-merge fix' + (c.postMergeFixCount === 1 ? '' : 'es'));
+  if (c.mergeRate != null && c.mergeRate < 1) parts.push(Math.round(c.mergeRate * 100) + '% merge rate');
+  return parts.length ? '  (' + parts.join(', ') + ')' : '';
+}
+
+function baselineCardEl(data) {
+  const b = data.baseline;
+  const body = [scoreLabel('vs. Your Normal (trailing 4-week median)')];
+  if (b.weeksAvailable < data.minimumBaselineWeeks) {
+    body.push(el('div', 'score-muted',
+      'Baseline building — ' + b.weeksAvailable + ' of ' + data.baselineWeekCount + ' weeks of history.'));
+    return scoreCard(body);
+  }
+  const wk = data.currentWeek;
+  const rows = el('div', 'score-comparisons');
+  const add = (name, current, baseline, higherIsBetter, fmt) => {
+    if (baseline == null || current == null) return;
+    rows.appendChild(comparisonRowEl(name, current, baseline, higherIsBetter, fmt));
+  };
+  if (wk.grade.graded) add('Score', wk.grade.score, b.medianScore, true, (v) => v.toFixed(0));
+  add('Compactions/active hr', wk.compactionsPerActiveHour, b.medianCompactionsPerActiveHour, false, (v) => v.toFixed(1));
+  add('Input tokens/prompt', wk.inputTokensPerPrompt, b.medianInputTokensPerPrompt, false, (v) => fmtCount(Math.round(v)));
+  add('Cache hit ratio', wk.cacheHitRatio, b.medianCacheHitRatio, true, (v) => (v * 100).toFixed(0) + '%');
+  add('API error rate', wk.apiErrorRate, b.medianApiErrorRate, false, (v) => (v * 100).toFixed(1) + '%');
+  add('Cost/shipped', wk.costPerShipped, b.medianCostPerShipped, false, fmtCost);
+  if (wk.combined.scored) add('Combined score', wk.combined.value, b.medianCombinedScore, true, (v) => v.toFixed(1));
+  body.push(rows);
+  return scoreCard(body);
+}
+
+function comparisonRowEl(name, current, baseline, higherIsBetter, fmt) {
+  const delta = current - baseline;
+  const isFlat = Math.abs(delta) < 0.0001;
+  const isBetter = higherIsBetter ? delta > 0 : delta < 0;
+  const row = el('div', 'score-comparison');
+  row.appendChild(el('span', 'score-comparison-name', name));
+  row.appendChild(el('span', 'score-comparison-current', fmt(current)));
+  const arrow = el('span', 'score-comparison-arrow ' + (isFlat ? 'flat' : isBetter ? 'good' : 'bad'),
+    isFlat ? '–' : delta > 0 ? '↑' : '↓');
+  row.appendChild(arrow);
+  row.appendChild(el('span', 'score-comparison-baseline', fmt(baseline)));
+  return row;
+}
+
+function displayedStatsEl(week) {
+  const body = [scoreLabel('This Week (context only — not graded)')];
+  const chips = el('div', 'score-chips');
+  chips.appendChild(statChipEl('Cost', fmtCost(week.totalCost)));
+  chips.appendChild(statChipEl('Active', fmtTime(week.activeTimeSeconds)));
+  chips.appendChild(statChipEl('Commits', String(week.commitCount)));
+  chips.appendChild(statChipEl('Churn', Number(week.churnHint).toFixed(2)));
+  body.push(chips);
+  return scoreCard(body);
+}
+
+function statChipEl(label, value) {
+  const chip = el('div', 'score-chip');
+  chip.appendChild(el('span', 'score-chip-label', label));
+  chip.appendChild(el('span', 'score-chip-value', value));
+  return chip;
+}
+
+function priorWeeksEl(weeks) {
+  const body = [scoreLabel('Previous Weeks')];
+  const list = el('div', 'score-prior');
+  for (const w of weeks) {
+    const row = el('div', 'score-prior-row');
+    row.appendChild(el('span', 'score-prior-week', scoreWeekLabel(w.weekStartMillis)));
+    row.appendChild(gradeBadgeEl(w.grade));
+    row.appendChild(el('span', 'score-prior-shipped', w.sessionsShipped + ' shipped'));
+    row.appendChild(el('span', 'score-prior-combined',
+      w.combined.scored ? Number(w.combined.value).toFixed(1) : '—'));
+    row.appendChild(el('span', 'score-prior-cost', fmtCost(w.totalCost)));
+    list.appendChild(row);
+  }
+  body.push(list);
+  return scoreCard(body);
+}
+
+function sessionsEl(rows) {
+  const body = [scoreLabel("This Week's Sessions")];
+  const list = el('div', 'score-sessions');
+  for (const r of rows) list.appendChild(sessionRowEl(r));
+  body.push(list);
+  return scoreCard(body);
+}
+
+function sessionRowEl(r) {
+  const row = el('div', 'score-session');
+  const line = el('div', 'score-session-line');
+  line.appendChild(gradeBadgeEl(r.grade));
+  line.appendChild(el('span', 'score-session-date', new Date(r.endedAtMillis).toLocaleDateString()));
+  if (r.shipped) line.appendChild(el('span', 'score-shipped-pill', 'Shipped'));
+  const spacer = el('span', 'score-session-spacer');
+  line.appendChild(spacer);
+  line.appendChild(el('span', 'score-session-stat', fmtCost(r.totalCost)));
+  line.appendChild(el('span', 'score-session-stat', fmtTime(r.activeTimeSeconds)));
+  if (r.wallClockDurationSeconds != null) {
+    line.appendChild(el('span', 'score-session-stat muted', '(' + fmtTime(r.wallClockDurationSeconds) + ' wall)'));
+  }
+  row.appendChild(line);
+  if (r.grade.graded && r.grade.deductions.length) {
+    row.appendChild(el('div', 'score-session-deductions',
+      r.grade.deductions.map((d) => d.label + ' −' + d.points).join('  ·  ')));
+  }
+  return row;
+}
+
+function gradeBadgeEl(grade) {
+  if (grade.graded) {
+    const badge = el('span', 'score-badge', grade.letter);
+    badge.style.color = gradeColor(grade.letter);
+    badge.style.background = gradeColor(grade.letter) + '26'; // ~15% alpha
+    return badge;
+  }
+  const badge = el('span', 'score-badge muted', '—');
+  badge.title = 'Insufficient data';
+  return badge;
 }
 
 // -- shared card helpers --


### PR DESCRIPTION
Closes #721

Ports main's private **efficiency scorecard** to the web UI / `crowd` client. On `main`, CrowUI ships `ScorecardView`; the parity branch already has the Core models (`ScorecardModel`, grading, combined score, snapshots) but no web pane, no RPC, and `get-state` never exposed scorecard data. This wires it end-to-end in the web assets under CrowDaemon — **CrowUI is not resurrected** as a product surface.

## Approach: build server-side, render on the web
The desktop `ScorecardView` reads `ScorecardModel` directly. The web has no Swift value types, so rather than re-implement grading in JavaScript (and risk drift), `crowd` builds the **one** Core `ScorecardModel.build(...)` and ships a flat, JS-friendly `ScorecardDTO` over a new `get-scorecard` RPC. The web just renders it — so web and desktop can never disagree on a number (directly satisfies the test-plan parity requirement).

## Changes
- **CrowCore** — `ScorecardDTO` (+ `WeeklyDTO`/`GradeDTO`/`CombinedDTO`/`BaselineDTO`/`SessionRowDTO`): a lossless Codable projection of `ScorecardModel`. Enums-with-payloads (`GradeResult`, `CombinedScore.WeeklyResult`, `CostPerShipped`) collapse to structs with a discriminator + optional fields; dates are epoch **millis** (JS-native, no `dateEncodingStrategy` coupling with the `JSONValue` transport). Current week carries its derived rates inline for the baseline comparison.
- **CrowDaemon** — `get-scorecard` RPC: builds `ScorecardModel` from `appState.analyticsSnapshots` + `appState.prAttributions` (both already hydrated by SessionService/IssueTracker), encodes the DTO via the same `JSONValue(encoding:)` path as `get-state`. Carries `telemetryEnabled` + `snapshotCount` so the empty state can distinguish "telemetry off" from "on but nothing shipped".
- **Web** — `Scorecard` nav pill + full pane mirroring the desktop cards: weekly A–F grade with coachable per-metric deductions, the separate sessions-shipped surface, the v2 combined-score decomposition, the trailing-4-week "vs. your normal" baseline, context-only stats, prior weeks, and per-session drill-down. Empty state links to Settings when telemetry is off. JS formatters mirror `AnalyticsFormatting`.
- **Tests** — `ScorecardDTOTests`: DTO⇄model parity (grade, throughput, combined decomposition, baseline, insufficient-data flattening, empty-state flags) + JSON round-trip.

## Verification
- `CrowCore` builds; 6 `ScorecardDTO` tests pass.
- `CrowDaemon` builds clean (RPC handler compiles).
- `app.js` passes `node --check`.

> Note: the full workspace test suite / `make build` was not run locally — the data volume was at 100% (1.9 GB free of 926 GB), so I limited local builds to the two affected packages. CI runs the authoritative full build.

## Test plan (from #721)
- [x] With telemetry enabled + completed sessions that have snapshots, the web scorecard matches Core `ScorecardModel` for the current week (guaranteed by server-side build; pinned by `ScorecardDTOTests`).
- [x] Telemetry off / no snapshots → clear empty state (`snapshotCount == 0`; distinct copy + Settings link when telemetry off).
- [ ] Mobile layout usable (cards use flex-wrap; needs a device check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188oPqbomM2HxETxJmUHuEN