### PR TITLE
feat(web): org-goal tagging on sessions (#723)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ crow delete-session --session <uuid>            → {"deleted":true}
 ### Metadata Commands
 ```
 crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]
+crow set-goal --session <uuid> --goal "..." | --clear                  → tag the session's org goal/KPI (feeds alignment weight; exactly one of --goal/--clear)
 crow add-link --session <uuid> --label "Issue" --url "..." --type ticket|pr|repo|custom
 crow list-links --session <uuid>
 crow transition-ticket --session <uuid> --to inProgress|inReview|done   → moves the linked ticket to a pipeline status (Jira honors jiraStatusMap)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -157,6 +157,14 @@ func makeCommandRouter(
                         "ticket_badge": session.ticketBadgeLabel.map { .string($0) } ?? .null,
                         "provider": session.provider.map { .string($0.rawValue) } ?? .null,
                         "review_author": session.reviewAuthor.map { .string($0) } ?? .null,
+                        // Org-goal tag + alignment inputs (#723; ADR 0008
+                        // follow-up 8). `org_goal` drives the web tag display;
+                        // `ticket_priority` and the computed `alignment_weight`
+                        // are surfaced for parity with the model (untagged
+                        // sessions weight exactly 1.0).
+                        "org_goal": session.orgGoal.map { .string($0) } ?? .null,
+                        "ticket_priority": session.ticketPriority.map { .string($0.rawValue) } ?? .null,
+                        "alignment_weight": .double(session.alignmentWeight),
                     ]
                     if let worktree = appState.primaryWorktree(for: session.id) {
                         object["repo"] = .string(worktree.repoName)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -157,14 +157,14 @@ func makeCommandRouter(
                         "ticket_badge": session.ticketBadgeLabel.map { .string($0) } ?? .null,
                         "provider": session.provider.map { .string($0.rawValue) } ?? .null,
                         "review_author": session.reviewAuthor.map { .string($0) } ?? .null,
-                        // Org-goal tag + alignment inputs (#723; ADR 0008
-                        // follow-up 8). `org_goal` drives the web tag display;
-                        // `ticket_priority` and the computed `alignment_weight`
-                        // are surfaced for parity with the model (untagged
-                        // sessions weight exactly 1.0).
+                        // Org-goal tag (#723; ADR 0008 follow-up 8) — drives the
+                        // web tag display (sidebar badge + detail header). The
+                        // computed `alignment_weight` / `ticket_priority` are
+                        // intentionally NOT sent: nothing on the web renders
+                        // them today, so shipping them in every poll to every
+                        // client was dead payload. A future consumer (scorecard
+                        // / session strip) can add them back alongside its use.
                         "org_goal": session.orgGoal.map { .string($0) } ?? .null,
-                        "ticket_priority": session.ticketPriority.map { .string($0.rawValue) } ?? .null,
-                        "alignment_weight": .double(session.alignmentWeight),
                     ]
                     if let worktree = appState.primaryWorktree(for: session.id) {
                         object["repo"] = .string(worktree.repoName)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -199,8 +199,9 @@ html, body {
 .activity-badge { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; }
 /* Org-goal tag (#723): the sidebar glyph reuses .badge sizing (non-clickable);
    the detail-header .meta-goal row shows the full text and turns gold on hover
-   to read as clickable. `cursor` inherits, so the clickable header pill needs
-   its own `pointer` to beat the sidebar glyph's `default` below. */
+   to read as clickable. The header pill needs its own `pointer` because the
+   base `.goal-badge { cursor: default }` (below) would otherwise apply to it —
+   `.meta-goal .goal-badge` (0,2,0) wins on specificity over `.goal-badge` (0,1,0). */
 .goal-badge { cursor: default; }
 .meta-goal { display: flex; align-items: center; }
 .meta-goal .goal-badge { color: var(--gold); background: rgba(221, 196, 130, 0.14); border-radius: 10px; padding: 2px 8px; font-size: 11px; cursor: pointer; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -197,11 +197,13 @@ html, body {
   font-size: 10px; font-weight: 600; border: 1px solid; background: var(--bg-surface);
 }
 .activity-badge { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; }
-/* Org-goal tag (#723): the sidebar glyph reuses .badge sizing; the detail-header
-   .meta-goal row shows the full text and turns gold on hover to read as clickable. */
+/* Org-goal tag (#723): the sidebar glyph reuses .badge sizing (non-clickable);
+   the detail-header .meta-goal row shows the full text and turns gold on hover
+   to read as clickable. `cursor` inherits, so the clickable header pill needs
+   its own `pointer` to beat the sidebar glyph's `default` below. */
 .goal-badge { cursor: default; }
 .meta-goal { display: flex; align-items: center; }
-.meta-goal .goal-badge { color: var(--gold); background: rgba(221, 196, 130, 0.14); border-radius: 10px; padding: 2px 8px; font-size: 11px; }
+.meta-goal .goal-badge { color: var(--gold); background: rgba(221, 196, 130, 0.14); border-radius: 10px; padding: 2px 8px; font-size: 11px; cursor: pointer; }
 .meta-goal:hover .goal-badge { background: rgba(221, 196, 130, 0.24); }
 .empty { color: var(--text-muted); padding: 20px 6px; }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -197,6 +197,12 @@ html, body {
   font-size: 10px; font-weight: 600; border: 1px solid; background: var(--bg-surface);
 }
 .activity-badge { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; }
+/* Org-goal tag (#723): the sidebar glyph reuses .badge sizing; the detail-header
+   .meta-goal row shows the full text and turns gold on hover to read as clickable. */
+.goal-badge { cursor: default; }
+.meta-goal { display: flex; align-items: center; }
+.meta-goal .goal-badge { color: var(--gold); background: rgba(221, 196, 130, 0.14); border-radius: 10px; padding: 2px 8px; font-size: 11px; }
+.meta-goal:hover .goal-badge { background: rgba(221, 196, 130, 0.24); }
 .empty { color: var(--text-muted); padding: 20px 6px; }
 
 /* ---- Sidebar skeleton (first paint before list-sessions, CROW-613) ---- */

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1682,11 +1682,8 @@ async function setSessionGoal(id, current) {
   const raw = await textPrompt(current ? 'Edit org goal' : 'Set org goal', current || '',
     { placeholder: 'e.g. Q3 latency KPI', okLabel: 'Save' });
   if (raw == null) return; // cancelled
-  const goal = raw.trim();
   try {
-    await rpc('set-goal', goal ? { session_id: id, goal } : { session_id: id, clear: true });
-    const s = sessions.find((x) => x.id === id);
-    if (s) { s.org_goal = goal || null; renderSidebar(); if (id === selectedId) renderHeader(s); }
+    await applyOrgGoal(id, raw.trim());
   } catch (e) {
     alertModal('Set goal failed: ' + (e.message || e));
   }
@@ -1694,12 +1691,21 @@ async function setSessionGoal(id, current) {
 
 async function clearSessionGoal(id) {
   try {
-    await rpc('set-goal', { session_id: id, clear: true });
-    const s = sessions.find((x) => x.id === id);
-    if (s) { s.org_goal = null; renderSidebar(); if (id === selectedId) renderHeader(s); }
+    await applyOrgGoal(id, '');
   } catch (e) {
     alertModal('Clear goal failed: ' + (e.message || e));
   }
+}
+
+// Shared org-goal mutation: a non-empty `goal` sets it, an empty string clears
+// it (RPC gets `{goal}` or `{clear:true}` — never a blank goal, which the
+// handler rejects). Reflects the change locally so the sidebar + header update
+// without a refetch; `alignment_weight` is server-computed and refreshes on the
+// next `list-sessions` poll (nothing renders it client-side).
+async function applyOrgGoal(id, goal) {
+  await rpc('set-goal', goal ? { session_id: id, goal } : { session_id: id, clear: true });
+  const s = sessions.find((x) => x.id === id);
+  if (s) { s.org_goal = goal || null; renderSidebar(); if (id === selectedId) renderHeader(s); }
 }
 
 async function deleteSession(id, name) {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1047,6 +1047,13 @@ function sessionRow(s) {
 
   const badges = el('div', 'row-badges');
   if (s.ticket_badge) badges.appendChild(el('span', 'badge', s.ticket_badge));
+  // Light org-goal indicator (#723) — glyph only to keep the card compact; the
+  // full goal text lives in the tooltip and the detail header.
+  if (s.org_goal) {
+    const g = el('span', 'badge goal-badge', '🎯');
+    g.title = 'Goal: ' + s.org_goal;
+    badges.appendChild(g);
+  }
   // PR badge — shown whenever a PR link exists (stored, or live from the app
   // when it's only in memory); colored by live status when available.
   const prLink = (s.links || []).find((l) => l.type === 'pr') || liveFor(s.id).pr_link;
@@ -1205,6 +1212,13 @@ function sessionMenuItems(s) {
   if (s.ticket_url) items.push({ label: 'Copy issue link', action: () => copyToClipboard(s.ticket_url) });
   if (prUrl) items.push({ label: 'Copy PR link', action: () => copyToClipboard(prUrl) });
   if (s.ticket_url || prUrl) items.push({ sep: true });
+  // Org-goal tagging (#723) — any non-manager session can ladder its work up to
+  // an org KPI/goal. Managers are excluded from PR/issue tracking, so no goal.
+  if (s.kind !== 'manager') {
+    items.push({ label: s.org_goal ? 'Edit org goal…' : 'Set org goal…', action: () => setSessionGoal(s.id, s.org_goal) });
+    if (s.org_goal) items.push({ label: 'Clear org goal', action: () => clearSessionGoal(s.id) });
+    items.push({ sep: true });
+  }
   const hasPR = (s.links || []).some((l) => l.type === 'pr');
   if (s.kind === 'manager') {
     // Maintenance actions (restart manager / reload tmux) live in Settings → About;
@@ -1404,6 +1418,16 @@ function renderHeader(s) {
   root.appendChild(top);
 
   if (s.ticket_title) root.appendChild(el('div', 'subtle', s.ticket_title));
+  // Org-goal tag (#723) — click to edit/clear. Only rendered when tagged; the
+  // menu's "Set org goal…" is the entry point for untagged sessions.
+  if (s.org_goal) {
+    const goalRow = el('div', 'meta meta-goal');
+    goalRow.appendChild(el('span', 'goal-badge', '🎯 ' + s.org_goal));
+    goalRow.title = 'Org goal — click to edit';
+    goalRow.style.cursor = 'pointer';
+    goalRow.onclick = (ev) => { ev.stopPropagation(); setSessionGoal(s.id, s.org_goal); };
+    root.appendChild(goalRow);
+  }
   // Review sessions: surface the PR author. Prefer the live review request
   // (Reviews board), but fall back to the author persisted on the session at
   // review-creation so it still shows when the board is empty (CROW-593).
@@ -1648,6 +1672,33 @@ async function renameSession(id, current) {
     if (s) { s.name = name; renderSidebar(); if (id === selectedId) renderHeader(s); }
   } catch (e) {
     if (term) term.write('\r\n\x1b[31m[crow] rename failed: ' + (e.message || e) + '\x1b[0m\r\n');
+  }
+}
+
+// Set or update a session's org-goal tag (#723). Prompts free-text; an empty
+// value clears the tag (parity with `crow set-goal --clear`). Updates the local
+// session so the sidebar badge + detail header reflect it without a refetch.
+async function setSessionGoal(id, current) {
+  const raw = await textPrompt(current ? 'Edit org goal' : 'Set org goal', current || '',
+    { placeholder: 'e.g. Q3 latency KPI', okLabel: 'Save' });
+  if (raw == null) return; // cancelled
+  const goal = raw.trim();
+  try {
+    await rpc('set-goal', goal ? { session_id: id, goal } : { session_id: id, clear: true });
+    const s = sessions.find((x) => x.id === id);
+    if (s) { s.org_goal = goal || null; renderSidebar(); if (id === selectedId) renderHeader(s); }
+  } catch (e) {
+    alertModal('Set goal failed: ' + (e.message || e));
+  }
+}
+
+async function clearSessionGoal(id) {
+  try {
+    await rpc('set-goal', { session_id: id, clear: true });
+    const s = sessions.find((x) => x.id === id);
+    if (s) { s.org_goal = null; renderSidebar(); if (id === selectedId) renderHeader(s); }
+  } catch (e) {
+    alertModal('Clear goal failed: ' + (e.message || e));
   }
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1700,8 +1700,7 @@ async function clearSessionGoal(id) {
 // Shared org-goal mutation: a non-empty `goal` sets it, an empty string clears
 // it (RPC gets `{goal}` or `{clear:true}` — never a blank goal, which the
 // handler rejects). Reflects the change locally so the sidebar + header update
-// without a refetch; `alignment_weight` is server-computed and refreshes on the
-// next `list-sessions` poll (nothing renders it client-side).
+// without a refetch.
 async function applyOrgGoal(id, goal) {
   await rpc('set-goal', goal ? { session_id: id, goal } : { session_id: id, clear: true });
   const s = sessions.find((x) => x.id === id);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1682,8 +1682,10 @@ async function setSessionGoal(id, current) {
   const raw = await textPrompt(current ? 'Edit org goal' : 'Set org goal', current || '',
     { placeholder: 'e.g. Q3 latency KPI', okLabel: 'Save' });
   if (raw == null) return; // cancelled
+  const goal = raw.trim();
+  if (goal === (current || '')) return; // unchanged (or empty on an untagged session) — skip the write
   try {
-    await applyOrgGoal(id, raw.trim());
+    await applyOrgGoal(id, goal);
   } catch (e) {
     alertModal('Set goal failed: ' + (e.message || e));
   }

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -592,6 +592,31 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                     return ["session_id": .string(idStr)]
                 }
             },
+            // Set or clear the org-goal tag on a session (#723; ADR 0008
+            // follow-up 8). The data model + `SessionService.setOrgGoal` and the
+            // `crow set-goal` CLI shipped with #696, but no RPC ever routed the
+            // method — this wires the CLI socket *and* the web WebSocket (both
+            // share this router) to the mutator. `clear` wins over `goal`; a
+            // blank/whitespace goal is treated as a clear so an empty tag can't
+            // buy the on-goal alignment multiplier.
+            "set-goal": { @Sendable params in
+                guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
+                    throw RPCError.invalidParams("session_id required")
+                }
+                let clear = params["clear"]?.boolValue ?? false
+                let goal: String? = {
+                    if clear { return nil }
+                    let trimmed = (params["goal"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }()
+                return try await MainActor.run {
+                    guard capturedAppState.sessions.contains(where: { $0.id == id }) else {
+                        throw RPCError.applicationError("Session not found")
+                    }
+                    capturedService.setOrgGoal(id: id, goal: goal)
+                    return ["session_id": .string(idStr), "org_goal": goal.map { .string($0) } ?? .null]
+                }
+            },
             "transition-ticket": { @Sendable params in
                 // CROW-529: transition a session's linked ticket to a pipeline
                 // status (honoring jiraStatusMap for Jira). `setup.sh` calls this

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -596,22 +596,43 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
             // follow-up 8). The data model + `SessionService.setOrgGoal` and the
             // `crow set-goal` CLI shipped with #696, but no RPC ever routed the
             // method — this wires the CLI socket *and* the web WebSocket (both
-            // share this router) to the mutator. `clear` wins over `goal`; a
-            // blank/whitespace goal is treated as a clear so an empty tag can't
-            // buy the on-goal alignment multiplier.
+            // share this router) to the mutator.
+            //
+            // Enforcement mirrors the CLI's `validateSetGoal` (CrowCLI
+            // Validation.swift) so the two surfaces agree on ONE contract:
+            // reject both, neither, and a blank goal. The CLI's `validate()`
+            // guards only the CLI path, so for the web this RPC is the sole
+            // enforcement point — a missing/typo'd param must error, not
+            // silently wipe an existing tag. (The web only ever sends `{goal}`
+            // or `{clear:true}` — app.js `setSessionGoal` — so this rejects
+            // nothing it emits.) Managers are excluded per the same product
+            // rule the web menu applies: orchestration sessions don't ladder up
+            // to an org KPI, so the goal doesn't apply.
             "set-goal": { @Sendable params in
                 guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
                     throw RPCError.invalidParams("session_id required")
                 }
                 let clear = params["clear"]?.boolValue ?? false
-                let goal: String? = {
-                    if clear { return nil }
-                    let trimmed = (params["goal"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                    return trimmed.isEmpty ? nil : trimmed
-                }()
+                let rawGoal = params["goal"]?.stringValue
+                switch (rawGoal, clear) {
+                case (.some, true):
+                    throw RPCError.invalidParams("`goal` and `clear` are mutually exclusive")
+                case (nil, false):
+                    throw RPCError.invalidParams("Exactly one of `goal` or `clear` is required")
+                case (.some(let g), false) where g.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+                    throw RPCError.invalidParams("`goal` must not be blank")
+                default:
+                    break
+                }
+                let goal: String? = clear
+                    ? nil
+                    : rawGoal!.trimmingCharacters(in: .whitespacesAndNewlines)
                 return try await MainActor.run {
-                    guard capturedAppState.sessions.contains(where: { $0.id == id }) else {
+                    guard let session = capturedAppState.sessions.first(where: { $0.id == id }) else {
                         throw RPCError.applicationError("Session not found")
+                    }
+                    guard session.kind != .manager else {
+                        throw RPCError.applicationError("Org goals don't apply to the manager session")
                     }
                     capturedService.setOrgGoal(id: id, goal: goal)
                     return ["session_id": .string(idStr), "org_goal": goal.map { .string($0) } ?? .null]

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -197,10 +197,17 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // Legacy alias (CROW-569 named this `pinned`); kept for
                         // one release so existing scripts keep working.
                         "pinned": .bool(s.locked),
-                        // Org-goal tag (#723) — surfaced here so `crow
-                        // get-session` reflects a goal set from the web (read
-                        // parity for the write path this PR wired).
+                        // Org-goal tag + alignment inputs (#723; ADR 0008
+                        // follow-up 8) — surfaced here so `crow get-session`
+                        // reflects a goal set from the web and matches the
+                        // documented read-back contract (docs/cli-reference.md).
+                        // Unlike the web `list-sessions` poll (which sends only
+                        // `org_goal`), this is a deliberate single-session read,
+                        // so the computed `alignment_weight` + `ticket_priority`
+                        // ride along too.
                         "org_goal": s.orgGoal.map { .string($0) } ?? .null,
+                        "ticket_priority": s.ticketPriority.map { .string($0.rawValue) } ?? .null,
+                        "alignment_weight": .double(s.alignmentWeight),
                     ]
                 }
             },
@@ -623,21 +630,28 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }
                 let clear = params["clear"]?.boolValue ?? false
                 let rawGoal = params["goal"]?.stringValue
+                // Bind `goal` in-pattern (no force-unwrap): the switch is
+                // exhaustive over (goal?, clear), and the only arm that yields a
+                // value validates it — blank rejected, then the same
+                // `isValidSessionName` bound (≤256 chars, no control chars) the
+                // sibling free-text handlers keep.
+                let goal: String?
                 switch (rawGoal, clear) {
                 case (.some, true):
                     throw RPCError.invalidParams("`goal` and `clear` are mutually exclusive")
                 case (nil, false):
                     throw RPCError.invalidParams("Exactly one of `goal` or `clear` is required")
-                case (.some(let g), false) where g.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
-                    throw RPCError.invalidParams("`goal` must not be blank")
-                default:
-                    break
-                }
-                let goal: String? = clear
-                    ? nil
-                    : rawGoal!.trimmingCharacters(in: .whitespacesAndNewlines)
-                if let goal, !Validation.isValidSessionName(goal) {
-                    throw RPCError.invalidParams("Invalid goal (max \(Validation.maxSessionNameLength) chars, no control characters)")
+                case (.some(let g), false):
+                    let trimmed = g.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else {
+                        throw RPCError.invalidParams("`goal` must not be blank")
+                    }
+                    guard Validation.isValidSessionName(trimmed) else {
+                        throw RPCError.invalidParams("Invalid goal (max \(Validation.maxSessionNameLength) chars, no control characters)")
+                    }
+                    goal = trimmed
+                case (nil, true):
+                    goal = nil
                 }
                 return try await MainActor.run {
                     guard let session = capturedAppState.sessions.first(where: { $0.id == id }) else {

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -197,6 +197,10 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // Legacy alias (CROW-569 named this `pinned`); kept for
                         // one release so existing scripts keep working.
                         "pinned": .bool(s.locked),
+                        // Org-goal tag (#723) — surfaced here so `crow
+                        // get-session` reflects a goal set from the web (read
+                        // parity for the write path this PR wired).
+                        "org_goal": s.orgGoal.map { .string($0) } ?? .null,
                     ]
                 }
             },
@@ -598,16 +602,21 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
             // method — this wires the CLI socket *and* the web WebSocket (both
             // share this router) to the mutator.
             //
-            // Enforcement mirrors the CLI's `validateSetGoal` (CrowCLI
-            // Validation.swift) so the two surfaces agree on ONE contract:
-            // reject both, neither, and a blank goal. The CLI's `validate()`
-            // guards only the CLI path, so for the web this RPC is the sole
-            // enforcement point — a missing/typo'd param must error, not
-            // silently wipe an existing tag. (The web only ever sends `{goal}`
-            // or `{clear:true}` — app.js `setSessionGoal` — so this rejects
-            // nothing it emits.) Managers are excluded per the same product
-            // rule the web menu applies: orchestration sessions don't ladder up
-            // to an org KPI, so the goal doesn't apply.
+            // The goal/clear/blank rules mirror the CLI's `validateSetGoal`
+            // (CrowCLI Validation.swift) so the two surfaces agree on ONE
+            // contract: reject both, neither, and a blank goal. The CLI's
+            // `validate()` guards only the CLI path, so for the web this RPC is
+            // the sole enforcement point — a missing/typo'd param must error,
+            // not silently wipe an existing tag. (The web only ever sends
+            // `{goal}` or `{clear:true}` — app.js `setSessionGoal` — so this
+            // rejects nothing it emits.) The goal string is additionally held to
+            // the same `isValidSessionName` bound (≤256 chars, no control
+            // characters) as the sibling free-text handlers (`new-session`
+            // above, `rename-session` via `SessionService`), since this newly
+            // exposes a free-text field to an authenticated *remote* web client
+            // that gets re-broadcast in every `list-sessions` payload. Managers
+            // are excluded — a server-side-only rule (not from the CLI) matching
+            // the web menu: orchestration sessions don't ladder up to an org KPI.
             "set-goal": { @Sendable params in
                 guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
                     throw RPCError.invalidParams("session_id required")
@@ -627,6 +636,9 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 let goal: String? = clear
                     ? nil
                     : rawGoal!.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let goal, !Validation.isValidSessionName(goal) {
+                    throw RPCError.invalidParams("Invalid goal (max \(Validation.maxSessionNameLength) chars, no control characters)")
+                }
                 return try await MainActor.run {
                     guard let session = capturedAppState.sessions.first(where: { $0.id == id }) else {
                         throw RPCError.applicationError("Session not found")

--- a/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
@@ -89,4 +89,72 @@ struct EngineRouterSmokeTests {
         // traversal guard — proving cwd was derived from the primary worktree.
         #expect(response.error?.message == "Terminal cwd must be within the configured devRoot")
     }
+
+    /// #723 (ADR 0008 follow-up 8): the `set-goal` data model, `SessionService`
+    /// mutator, and `crow set-goal` CLI all shipped with #696, but no RPC ever
+    /// routed the method — so the whole path silently no-op'd with nothing to
+    /// catch it. This locks in the newly-wired route (`EngineRouter.swift`),
+    /// including the two normalization rules a missing test would let regress:
+    /// `clear` wins over `goal`, and a blank/whitespace goal is treated as a
+    /// clear (so an empty tag can't buy the on-goal alignment multiplier).
+    @Test("set-goal reaches the mutator; clear wins over goal; blank goal clears")
+    func setGoalRoutesToMutator() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-engine-smoke-\(UUID().uuidString)")
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+
+        let session = Session(name: "goal-test")   // orgGoal defaults to nil
+        appState.sessions.append(session)
+        let id = session.id
+
+        let ctx = EngineContext(
+            appState: appState,
+            store: store,
+            sessionService: service,
+            issueTracker: nil,
+            telemetryPort: nil,
+            devRoot: tmp.path,
+            hostBridge: NoopHostBridge(),
+            loadConfig: { nil },
+            applyConfig: { _ in nil }
+        )
+        let router = makeEngineRouter(ctx)
+
+        func handle(_ params: [String: JSONValue]) async -> JSONRPCResponse {
+            await router.handle(request: JSONRPCRequest(id: 1, method: "set-goal", params: params))
+        }
+        func currentGoal() -> String? {
+            appState.sessions.first(where: { $0.id == id })?.orgGoal
+        }
+
+        // 1. Route reaches the mutator: a goal is set on the session.
+        let set = await handle(["session_id": .string(id.uuidString), "goal": .string("Q3 revenue")])
+        #expect(set.error == nil)
+        #expect(currentGoal() == "Q3 revenue")
+
+        // 2. `clear` wins over `goal`, even when both are supplied.
+        let cleared = await handle([
+            "session_id": .string(id.uuidString),
+            "clear": .bool(true),
+            "goal": .string("ignored"),
+        ])
+        #expect(cleared.error == nil)
+        #expect(currentGoal() == nil)
+
+        // 3. A blank/whitespace goal normalizes to a clear (re-set first so the
+        //    nil assertion proves the blank cleared it, not that it was already nil).
+        _ = await handle(["session_id": .string(id.uuidString), "goal": .string("temp")])
+        #expect(currentGoal() == "temp")
+        let blanked = await handle(["session_id": .string(id.uuidString), "goal": .string("   ")])
+        #expect(blanked.error == nil)
+        #expect(currentGoal() == nil)
+
+        // 4. An unknown session is rejected before mutating (the guard's
+        //    `applicationError` path), not silently no-op'd.
+        let missing = await handle(["session_id": .string(UUID().uuidString), "goal": .string("x")])
+        #expect(missing.error != nil)
+        #expect(missing.error?.message == "Session not found")
+    }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
@@ -93,11 +93,11 @@ struct EngineRouterSmokeTests {
     /// #723 (ADR 0008 follow-up 8): the `set-goal` data model, `SessionService`
     /// mutator, and `crow set-goal` CLI all shipped with #696, but no RPC ever
     /// routed the method — so the whole path silently no-op'd with nothing to
-    /// catch it. This locks in the newly-wired route (`EngineRouter.swift`),
-    /// including the two normalization rules a missing test would let regress:
-    /// `clear` wins over `goal`, and a blank/whitespace goal is treated as a
-    /// clear (so an empty tag can't buy the on-goal alignment multiplier).
-    @Test("set-goal reaches the mutator; clear wins over goal; blank goal clears")
+    /// catch it. This locks in the newly-wired route (`EngineRouter.swift`) and
+    /// its contract, which mirrors the CLI's `validateSetGoal`: reject both /
+    /// neither / a blank goal (so a missing or typo'd param can't silently wipe
+    /// an existing tag), and exclude the manager session.
+    @Test("set-goal routes to the mutator and enforces the CLI's validation contract")
     func setGoalRoutesToMutator() async throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("crow-engine-smoke-\(UUID().uuidString)")
@@ -105,9 +105,12 @@ struct EngineRouterSmokeTests {
         let store = JSONStore(directory: tmp)
         let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
 
-        let session = Session(name: "goal-test")   // orgGoal defaults to nil
+        let session = Session(name: "goal-test")   // default kind .work; orgGoal nil
         appState.sessions.append(session)
         let id = session.id
+        // A manager session — org goals don't apply to orchestration sessions.
+        let manager = Session(name: "manager", kind: .manager)
+        appState.sessions.append(manager)
 
         let ctx = EngineContext(
             appState: appState,
@@ -129,32 +132,47 @@ struct EngineRouterSmokeTests {
             appState.sessions.first(where: { $0.id == id })?.orgGoal
         }
 
-        // 1. Route reaches the mutator: a goal is set on the session.
+        // Route reaches the mutator: a goal is set on the session.
         let set = await handle(["session_id": .string(id.uuidString), "goal": .string("Q3 revenue")])
         #expect(set.error == nil)
         #expect(currentGoal() == "Q3 revenue")
 
-        // 2. `clear` wins over `goal`, even when both are supplied.
-        let cleared = await handle([
-            "session_id": .string(id.uuidString),
-            "clear": .bool(true),
-            "goal": .string("ignored"),
-        ])
+        // `clear: true` clears the tag.
+        let cleared = await handle(["session_id": .string(id.uuidString), "clear": .bool(true)])
         #expect(cleared.error == nil)
         #expect(currentGoal() == nil)
 
-        // 3. A blank/whitespace goal normalizes to a clear (re-set first so the
-        //    nil assertion proves the blank cleared it, not that it was already nil).
-        _ = await handle(["session_id": .string(id.uuidString), "goal": .string("temp")])
-        #expect(currentGoal() == "temp")
-        let blanked = await handle(["session_id": .string(id.uuidString), "goal": .string("   ")])
-        #expect(blanked.error == nil)
-        #expect(currentGoal() == nil)
+        // Contract (mirrors CLI `validateSetGoal`) — each malformed shape is
+        // rejected *without* mutating. Re-set a goal so we can prove the
+        // rejected calls leave it untouched rather than clearing it.
+        _ = await handle(["session_id": .string(id.uuidString), "goal": .string("keep me")])
+        #expect(currentGoal() == "keep me")
 
-        // 4. An unknown session is rejected before mutating (the guard's
-        //    `applicationError` path), not silently no-op'd.
+        // both goal + clear → mutually exclusive.
+        let both = await handle([
+            "session_id": .string(id.uuidString), "clear": .bool(true), "goal": .string("x"),
+        ])
+        #expect(both.error != nil)
+        #expect(currentGoal() == "keep me")
+
+        // neither goal nor clear → exactly-one-required (the silent-wipe bug).
+        let neither = await handle(["session_id": .string(id.uuidString)])
+        #expect(neither.error != nil)
+        #expect(currentGoal() == "keep me")
+
+        // blank/whitespace goal → rejected (an empty tag can't buy the on-goal
+        // alignment multiplier).
+        let blank = await handle(["session_id": .string(id.uuidString), "goal": .string("   ")])
+        #expect(blank.error != nil)
+        #expect(currentGoal() == "keep me")
+
+        // Unknown session → applicationError, not a silent no-op.
         let missing = await handle(["session_id": .string(UUID().uuidString), "goal": .string("x")])
-        #expect(missing.error != nil)
         #expect(missing.error?.message == "Session not found")
+
+        // Manager session → rejected; org goals don't apply to orchestration.
+        let mgr = await handle(["session_id": .string(manager.id.uuidString), "goal": .string("x")])
+        #expect(mgr.error != nil)
+        #expect(appState.sessions.first(where: { $0.id == manager.id })?.orgGoal == nil)
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
@@ -166,6 +166,22 @@ struct EngineRouterSmokeTests {
         #expect(blank.error != nil)
         #expect(currentGoal() == "keep me")
 
+        // Over-length goal → rejected by the same `isValidSessionName` bound the
+        // sibling handlers keep (a remote web client can't persist a
+        // multi-megabyte tag that rides every list-sessions payload).
+        let tooLong = await handle([
+            "session_id": .string(id.uuidString), "goal": .string(String(repeating: "a", count: 257)),
+        ])
+        #expect(tooLong.error != nil)
+        #expect(currentGoal() == "keep me")
+
+        // Control characters in the goal → rejected (no escape sequences).
+        let control = await handle([
+            "session_id": .string(id.uuidString), "goal": .string("bad\u{07}goal"),
+        ])
+        #expect(control.error != nil)
+        #expect(currentGoal() == "keep me")
+
         // Unknown session → applicationError, not a silent no-op.
         let missing = await handle(["session_id": .string(UUID().uuidString), "goal": .string("x")])
         #expect(missing.error?.message == "Session not found")

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -21,6 +21,7 @@ crow delete-session --session <uuid>            → {"deleted":true}
 ### Metadata Commands
 ```
 crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]
+crow set-goal --session <uuid> --goal "..." | --clear
 crow add-link --session <uuid> --label "Issue" --url "..." --type ticket|pr|repo|custom
 crow list-links --session <uuid>
 ```


### PR DESCRIPTION
Closes #723

## What

Exposes **org-goal tagging** in the web UI (ADR 0008 follow-up 8 / #696) and fixes the missing RPC that made `crow set-goal` a dead call.

The org-goal data model (`Session.orgGoal` / `ticketPriority` / `alignmentWeight`), `SessionService.setOrgGoal`, and the `crow set-goal` CLI all shipped with #696 — but **no RPC ever routed the `set-goal` method**, so both the CLI and the web had no reachable path to it.

## Changes

- **`EngineRouter.swift`** — register the missing `set-goal` handler. The daemon's Unix socket (CLI) and web WebSocket share one `commandRouter`, so this single handler wires both. Validation mirrors the CLI's `validateSetGoal` so the two surfaces enforce one contract — reject **both** / **neither** / a **blank** goal (a missing or typo'd param errors instead of silently wiping the tag), and hold the goal to the same `isValidSessionName` bound (≤256 chars, no control chars) the sibling free-text handlers keep. The manager session is excluded server-side. Delegates to the existing `SessionService.setOrgGoal`.
- **`EngineRouter.swift` (`get-session`)** — include `org_goal`, `ticket_priority`, and the computed `alignment_weight`, so a goal set from the web reads back via `crow get-session` (matches `docs/cli-reference.md`).
- **`RPCHandlers.swift`** — include **`org_goal`** in the web `list-sessions` payload (the source the web renders sessions from). `ticket_priority` / `alignment_weight` are intentionally **not** sent here — nothing on the web renders them, so shipping them in every poll to every client would be dead payload; they're surfaced via `get-session` instead.
- **`app.js` / `app.css`** — set / edit / clear the org goal from the session context menu (non-manager sessions), a clickable 🎯 goal row in the detail header, and a light 🎯 badge on sidebar cards when tagged. Reuses the existing `textPrompt`, `rpc`, and re-render helpers (modeled on `renameSession`, including its no-op guard).
- **Docs** — document `crow set-goal` in `docs/cli-reference.md` and `CLAUDE.md`'s Metadata Commands.

## Tests

- **`EngineRouterSmokeTests.swift`** — a headless router test locks in the newly-wired `set-goal` route *and* its full contract: route reaches the mutator, `clear`, and every rejection shape (both / neither / blank / over-length / control-char / unknown-session / manager) asserted to leave the tag **unchanged**.

## Test plan (from #723)

- [x] `make build` — `crow` + `crowd` compile/link cleanly.
- [x] `set-goal` RPC route + validation contract covered by `EngineRouterSmokeTests` (3/3 green).
- [ ] Set goal in web → 🎯 shows in header + sidebar; persists across reload / get-state. *(manual browser round-trip)*
- [ ] Clear goal in web → tag removed. *(manual)*
- [ ] `crow set-goal --session <id> --goal "X"` then reload web → shows "X" (CLI/web parity, now that the RPC exists). *(manual)*
- [ ] `crow set-goal --session <id> --clear` → tag gone. *(manual)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gci8z5vL1jBv3YNn8eUD5f
