### PR TITLE
docs(adr): flip ADR 0008 status Proposed → Accepted (closes #726)

### DIFF
--- a/docs/adr/0008-ai-usage-efficiency-scorecard.md
+++ b/docs/adr/0008-ai-usage-efficiency-scorecard.md
@@ -1,6 +1,6 @@
 # 0008 — AI-usage efficiency scorecard (rate usage by efficiency + outcomes, not spend)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-10
 - **Deciders:** @dhilgaertner, @dgershman
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,4 +44,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0005 | [TaskBackend and CodeBackend protocols](./0005-task-and-code-backend-protocols.md) | Proposed | 2026-06-03 |
 | 0006 | [xterm.js terminal renderer (Intel support)](./0006-universal-macos-binary.md) | Accepted | 2026-07-01 |
 | 0007 | [Swift CI runs on Linux, not macOS](./0007-linux-ci-swift.md) | Accepted | 2026-07-10 |
-| 0008 | [AI-usage efficiency scorecard](./0008-ai-usage-efficiency-scorecard.md) | Proposed | 2026-07-10 |
+| 0008 | [AI-usage efficiency scorecard](./0008-ai-usage-efficiency-scorecard.md) | Accepted | 2026-07-10 |


### PR DESCRIPTION
Closes #726. ADR 0008 (AI usage efficiency scorecard) is fully implemented — v1 data layer + scorecard surface + v2 combined score shipped (#689–#697, #699, #700, #710), design PR #657 merged, RFC #648 closed — so its status is now earned. Docs-only: Status Proposed → Accepted in the ADR + the README index row. Out of scope (noted on the ticket): #698 stays unbuilt (private-scorecard constraint stands), and the 4-week calibration of the grade bands (~2026-08-10) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)