### PR TITLE
fix(web): report PR quick-action skips instead of a false "dispatched" (#730)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/QuickAction.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/QuickAction.swift
@@ -18,3 +18,31 @@ public enum QuickAction: String, Sendable, Equatable {
     /// `isReadyToMerge` — merge the PR.
     case mergePR
 }
+
+/// Outcome of a manual `dispatchManual(action:sessionID:)` attempt. Lets callers
+/// (the daemon `quick-action` handler, the web UI) report honestly instead of
+/// assuming success: `dispatchManual` silently skips — NSLog only — when there's
+/// no managed terminal, the terminal surface isn't ready, or the session has no
+/// PR link, which previously surfaced as a false "dispatched" echo (#730).
+public enum QuickActionDispatchResult: Sendable, Equatable {
+    /// The prompt was pasted into the session's managed agent terminal.
+    case sent
+    /// The session has no managed terminal to send the prompt to.
+    case noManagedTerminal
+    /// The managed terminal exists but its surface isn't initialized yet.
+    case surfaceNotReady
+    /// The session has no `.pr` link, so there's no PR to act on.
+    case noPRLink
+
+    public var isSent: Bool { self == .sent }
+
+    /// User-facing reason a manual dispatch was skipped; `nil` when actually sent.
+    public var skipReason: String? {
+        switch self {
+        case .sent:              return nil
+        case .noManagedTerminal: return "no active agent terminal for this session"
+        case .surfaceNotReady:   return "the agent terminal isn't ready yet"
+        case .noPRLink:          return "this session has no linked PR"
+        }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -427,7 +427,14 @@ func makeCommandRouter(
             guard let actionStr = params["action"]?.stringValue, let action = QuickAction(rawValue: actionStr) else {
                 throw DaemonRPCError.invalidParams("action required (fixConflicts, addressChanges, fixChecks, mergePR)")
             }
-            await MainActor.run { autoRespond.dispatchManual(action: action, sessionID: id) }
+            // `dispatchManual` silently skips (no managed terminal / surface not
+            // ready / no PR link); report that faithfully as `dispatched:false`
+            // + a reason instead of a false success, so the web UI can surface an
+            // actionable message rather than echoing "dispatched" (#730).
+            let result = await MainActor.run { autoRespond.dispatchManual(action: action, sessionID: id) }
+            if let reason = result.skipReason {
+                return ["dispatched": .bool(false), "action": .string(action.rawValue), "reason": .string(reason)]
+            }
             return ["dispatched": .bool(true), "action": .string(action.rawValue)]
         },
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1530,10 +1530,19 @@ function actionBtn(label, iconName, variant, onclick) {
   return btn;
 }
 
-// Dispatch a PR quick-action (forwarded to the app's agent terminal).
+// Dispatch a PR quick-action (forwarded to the app's agent terminal). Echo
+// "dispatched" ONLY when the prompt actually reached the agent: the daemon
+// returns `dispatched:false` + a reason when it silently skips (no managed
+// terminal / surface not ready / no PR link), so show that instead of a false
+// success. Genuine RPC failures (app/tmux down, bad action) hit the catch (#730).
 async function quickAction(id, action, label) {
   try {
-    await rpc('quick-action', { session_id: id, action });
+    const res = await rpc('quick-action', { session_id: id, action });
+    if (res && res.dispatched === false) {
+      const reason = res.reason || 'no active agent terminal for this session';
+      if (term) term.write('\r\n\x1b[33m[crow] ' + label + " couldn't run — " + reason + '\x1b[0m\r\n');
+      return;
+    }
     if (term) term.write('\r\n\x1b[33m[crow] dispatched: ' + label + '\x1b[0m\r\n');
   } catch (e) {
     if (term) term.write('\r\n\x1b[31m[crow] ' + label + ' failed: ' + (e.message || e) + '\x1b[0m\r\n');

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
@@ -249,9 +249,9 @@ import CrowPersistence
         #expect(resp.error?.code == RPCErrorCode.invalidParams)   // missing/invalid action
     }
 
-    @Test @MainActor func quickActionDispatchesLocallyWhenCoordinatorPresent() async {
-        // No managed terminal → dispatchManual silently skips, but the handler
-        // still returns the dispatched shape (the app behaves identically).
+    @Test @MainActor func quickActionReportsSkipWhenNoManagedTerminal() async {
+        // No managed terminal → dispatchManual skips; the handler must report that
+        // faithfully as dispatched:false + a reason, not a false "dispatched" (#730).
         let appState = AppState()
         let session = Session(name: "s", kind: .work, agentKind: .claudeCode)
         appState.sessions = [session]
@@ -262,7 +262,8 @@ import CrowPersistence
             id: 1, method: "quick-action",
             params: ["session_id": .string(session.id.uuidString), "action": .string("mergePR")]))
         #expect(resp.error == nil)
-        #expect(resp.result?["dispatched"]?.boolValue == true)
+        #expect(resp.result?["dispatched"]?.boolValue == false)
+        #expect(resp.result?["reason"]?.stringValue?.isEmpty == false)
         #expect(resp.result?["action"]?.stringValue == "mergePR")
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
@@ -78,23 +78,26 @@ public final class AutoRespondCoordinator {
     /// Manually dispatch a quick action triggered by a session-card button click.
     /// Mirrors `dispatch(_:)` but bypasses the `AutoRespondSettings` toggle —
     /// the click is the user's explicit consent. Resolves the PR URL/number
-    /// from the session's `.pr` link.
-    public func dispatchManual(action: QuickAction, sessionID: UUID) {
+    /// from the session's `.pr` link. Returns whether the prompt was actually
+    /// sent (or why it was skipped) so callers report honestly instead of
+    /// assuming success (#730).
+    @discardableResult
+    public func dispatchManual(action: QuickAction, sessionID: UUID) -> QuickActionDispatchResult {
         let terminals = appState.terminals(for: sessionID)
         guard let terminal = terminals.first(where: { $0.isManaged }) else {
             NSLog("[QuickAction] Skipping %@ for session %@: no managed terminal",
                   action.rawValue, sessionID.uuidString)
-            return
+            return .noManagedTerminal
         }
         guard TerminalRouter.canSend(terminal) else {
             NSLog("[QuickAction] Skipping %@ for session %@: terminal surface not initialized",
                   action.rawValue, sessionID.uuidString)
-            return
+            return .surfaceNotReady
         }
         guard let prLink = appState.links(for: sessionID).first(where: { $0.linkType == .pr }) else {
             NSLog("[QuickAction] Skipping %@ for session %@: no PR link",
                   action.rawValue, sessionID.uuidString)
-            return
+            return .noPRLink
         }
 
         let prNumber = QuickActionPrompts.parsePRNumber(from: prLink.url)
@@ -107,6 +110,7 @@ public final class AutoRespondCoordinator {
         NSLog("[QuickAction] Sending %@ prompt to terminal %@ (%d chars)",
               action.rawValue, terminal.id.uuidString, prompt.count)
         TerminalRouter.send(terminal, text: prompt)
+        return .sent
     }
 
     /// Resolve the `CodeBackend` to use for a session's prompt rendering.

--- a/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
@@ -53,3 +53,29 @@ struct QuickActionPromptsTests {
         #expect(prompt.hasSuffix("\n"))
     }
 }
+
+/// A manual quick action must report whether it actually reached the agent so
+/// the web UI stops echoing a false "dispatched" for silent no-ops (#730).
+@Suite("AutoRespondCoordinator.dispatchManual")
+@MainActor
+struct DispatchManualResultTests {
+
+    @Test func skipsWithNoManagedTerminalWhenSessionHasNone() {
+        let appState = AppState()
+        let session = Session(name: "s", kind: .work, agentKind: .claudeCode)
+        appState.sessions = [session]
+        let coordinator = AutoRespondCoordinator(
+            appState: appState, providerManager: ProviderManager(),
+            settingsProvider: { AutoRespondSettings() })
+        #expect(coordinator.dispatchManual(action: .mergePR, sessionID: session.id) == .noManagedTerminal)
+    }
+
+    @Test func skipReasonIsNilOnlyWhenSent() {
+        #expect(QuickActionDispatchResult.sent.isSent)
+        #expect(QuickActionDispatchResult.sent.skipReason == nil)
+        for result in [QuickActionDispatchResult.noManagedTerminal, .surfaceNotReady, .noPRLink] {
+            #expect(!result.isSent)
+            #expect(result.skipReason?.isEmpty == false)
+        }
+    }
+}


### PR DESCRIPTION
Closes #730

## Problem
Clicking a PR quick-action button in the web UI (**Fix Checks**, **Rebase & Fix Conflicts**, **Address Review**, **Merge PR**) always echoed `[crow] dispatched: <label>` — even when nothing reached the agent. `dispatchManual` returns `Void` and *silently skips* (NSLog only) when there's no managed terminal, the terminal surface isn't ready, or the session has no PR link, while the daemon handler returned `{"dispatched": true}` unconditionally and `app.js` echoed success whenever the RPC didn't throw. Users saw a false "success" for a no-op.

## Fix
Thread a typed result end-to-end so the echo is honest:

- **CrowCore** — new `QuickActionDispatchResult` (`.sent` / `.noManagedTerminal` / `.surfaceNotReady` / `.noPRLink`) with a user-facing `skipReason` (nil only when sent).
- **CrowEngine** — `dispatchManual` returns it. Marked `@discardableResult`, so the fire-and-forget auto-rebase caller (`CrowDaemon.swift onAutoRebaseConflicts`) is unchanged.
- **CrowDaemon** — the `quick-action` handler returns `{"dispatched": false, "action": …, "reason": …}` on a skip. This is a legitimate outcome, kept distinct from genuine RPC errors (app/tmux unavailable → `applicationError`; bad params → `invalidParams`).
- **Web** — `quickAction` echoes "dispatched" only on a real send; on a skip it writes `[crow] <label> couldn't run — <reason>` (yellow, actionable); genuine RPC failures stay on the existing red `catch`.

All four actions route through the same handler + `dispatchManual`, so behavior is consistent by construction.

## Tests
- Updated the daemon skip test (`quickActionReportsSkipWhenNoManagedTerminal`) to assert `dispatched:false` + a non-empty `reason` instead of the old false-success.
- Added a CrowEngine test: `dispatchManual` with no terminals returns `.noManagedTerminal`, and only `.sent` has a nil `skipReason`.
- `swift test` green for CrowEngine and CrowDaemon quick-action suites.

## Notes / out of scope
- `EngineRouter.swift` has a parallel `quick-action` handler using the app's `onQuickAction` hook (fire-and-forget, returns `dispatched:true`). Per ADR 0008 the macOS app is removed and crowd + web is the only client, so that path is legacy/unused and left untouched — possible follow-up if it's ever revived.
- The "offer to launch/attach an agent when none is running" nice-to-have is deferred; this PR scopes to honest reporting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016psD8Wj2mLRcZnT56vn46B