### PR TITLE
Route job agent-kind config→state sync through one testable choke point (closes #733)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -84,6 +84,16 @@ public final class AppState {
         return agentsByKind[sessionKind.rawValue] ?? defaultAgentKind
     }
 
+    /// Mirror the agent-selection config (`defaultAgentKind` + `agentsByKind`)
+    /// into runtime state so `agentKind(for:)` resolves the just-saved value
+    /// without a config reload (CROW-733). The single choke point every
+    /// config→state sync site funnels through, so no save path can leave the
+    /// mirror stale.
+    public func applyAgentConfig(_ config: AppConfig) {
+        defaultAgentKind = config.defaultAgentKind
+        agentsByKind = config.agentsByKind
+    }
+
     /// Terminal IDs whose Claude Code was launched with `--rc` — drives the
     /// per-session indicator badge. Survives toggle changes so existing sessions
     /// keep showing the badge until they're restarted.

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppStateAgentConfigSyncTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppStateAgentConfigSyncTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// CROW-733: changing the per-action agent (e.g. "Agent for scheduled jobs")
+// must apply to the very next launched session without an app restart or a
+// config reload from disk. Jobs resolve their agent live via
+// `AppState.agentKind(for:)`, so the invariant under test is that
+// `AppState.applyAgentConfig(_:)` — the single choke point every config→state
+// sync site funnels through — makes the just-saved value observable immediately.
+
+@MainActor @Test func applyAgentConfigPropagatesJobOverrideUpdateWithoutReload() {
+    let state = AppState()
+    var config = AppConfig()
+
+    // First selection: Cursor for jobs.
+    config.agentsByKind["job"] = .cursor
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .cursor)
+
+    // Re-select in the same running app (no disk reload): Claude Code.
+    config.agentsByKind["job"] = .claudeCode
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .claudeCode)
+}
+
+@MainActor @Test func applyAgentConfigClearingJobOverrideFallsBackToDefault() {
+    let state = AppState()
+    var config = AppConfig()
+
+    // Override in place → resolves to the override.
+    config.defaultAgentKind = .claudeCode
+    config.agentsByKind["job"] = .cursor
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .cursor)
+
+    // "Use default" removes the override → resolves to defaultAgentKind.
+    config.agentsByKind.removeValue(forKey: "job")
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .claudeCode)
+    #expect(state.agentsByKind["job"] == nil)
+}
+
+@MainActor @Test func applyAgentConfigPropagatesDefaultAgentChange() {
+    let state = AppState()
+    var config = AppConfig()
+
+    // No per-kind override → resolution tracks defaultAgentKind.
+    config.defaultAgentKind = .cursor
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .cursor)
+
+    config.defaultAgentKind = .claudeCode
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .claudeCode)
+}

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -582,8 +582,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
-        appState.defaultAgentKind = config.defaultAgentKind
-        appState.agentsByKind = config.agentsByKind
+        appState.applyAgentConfig(config)
 
         // Create session service and hydrate state. The analytics provider
         // resolves telemetryService lazily — it is created later in launch —
@@ -1313,8 +1312,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
-        appState.defaultAgentKind = config.defaultAgentKind
-        appState.agentsByKind = config.agentsByKind
+        appState.applyAgentConfig(config)
     }
 
     /// Record a job's run time in the canonical `appConfig` and persist it, so


### PR DESCRIPTION
Closes #733

## Finding

Changing **Agent for scheduled jobs** (e.g. Cursor → Claude Code) and launching a job — the ticket's prime hypothesis was an `AppConfig.agentsByKind` ↔ `AppState.agentsByKind` sync gap. On current `main` that propagation **already works**:

- `saveSettings` mirrors `defaultAgentKind` + `agentsByKind` into `AppState` (`AppDelegate.swift`, added June 2026).
- Jobs resolve the agent **live** at run time: `SessionService.runJob` → `agentKind: appState.agentKind(for: .job)` → the terminal launches `AgentRegistry.shared.agent(for: session.agentKind)`.
- `JobScheduler` captures **no** agent (the alternative hypothesis is false), and the Settings picker is the only writer of agent config (no CLI/RPC path).

The real gap: the config→state mirroring was **duplicated inline** in two `AppDelegate` sites in the macOS `Crow` target (effectively un-unit-testable), with **no regression guard**. That "remember to mirror every field on each save path" fragility is what could silently reintroduce the bug.

## Change

The ticket's own suggested fix — one source of truth:

- **`AppState.applyAgentConfig(_:)`** (CrowCore): a single choke point every config→state sync site funnels through, so no save path can leave the runtime mirror stale.
- Route both sync sites (startup hydrate + `saveSettings`) through it.
- **`AppStateAgentConfigSyncTests`** (swift-testing): locks the invariant with no disk reload — per-kind override update applies immediately, clearing the override falls back to `defaultAgentKind`, and a default-agent change propagates.

## Acceptance criteria

- [x] Next launched job uses the new agent, no restart — live resolve + synced state, guaranteed by the single choke point.
- [x] Works for a per-kind override **and** clearing back to Use default — covered by tests 1 & 2.
- [x] Reflected in both `config.json` (disk write unchanged) and `appState.agentKind(for: .job)`.
- [x] Regression test: update job agent → `agentKind(for: .job)` returns the new value without reloading config from disk.

## Verification

- `make build` succeeds.
- `swift test --package-path Packages/CrowCore --filter AppStateAgentConfigSync` — 3/3 pass.
- Existing agent tests (`AppConfigAgentKindTests`, `SessionAgentKindTests`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4grWhwkj5ZgDsYJJfhb7w