### PR TITLE
feat(web): per-session analytics strip (CROW-722)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsDTO.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/SessionAnalyticsDTO.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// A flat, `Codable`, JS-friendly projection of a single session's analytics for
+/// the web per-session strip (CROW-722; ADR 0008 web parity, sibling to the
+/// `ScorecardDTO` surface). The desktop `SessionAnalyticsStrip` reads a
+/// `SessionAnalytics` value directly; the web has no Swift value types, so
+/// `crowd` resolves the best available source per session — the live in-memory
+/// hook aggregate for an open session, else the durable end-of-session snapshot —
+/// and ships this DTO inside `list-sessions-live`. The web renders it verbatim
+/// with the same `fmt*` helpers the scorecard chips use, so web and desktop can't
+/// drift on the numbers or their formatting.
+public struct SessionAnalyticsDTO: Codable, Sendable, Equatable {
+    /// Which source produced these numbers: `"live"` = the in-memory hook
+    /// aggregate for an open session; `"snapshot"` = the durable end-of-session
+    /// record. Lets the web distinguish live-updating vs. final without a second
+    /// lookup (currently informational — the strip renders both identically).
+    public let source: String
+    public let totalCost: Double
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheReadTokens: Int
+    public let cacheCreationTokens: Int
+    public let totalTokens: Int
+    public let activeTimeSeconds: Double
+    public let toolCallCount: Int
+    public let linesAdded: Int
+    public let linesRemoved: Int
+    public let apiErrorCount: Int
+    /// Wall-clock span (first `SessionStart` → last `SessionEnd`). Display-only
+    /// context beside "Active", never a grading input. `nil` hides the chip
+    /// (open-ended session, or an agent that never sends `SessionEnd`).
+    public let wallClockDurationSeconds: Double?
+
+    private init(source: String, analytics: SessionAnalytics, wallClockDurationSeconds: Double?) {
+        self.source = source
+        self.totalCost = analytics.totalCost
+        self.inputTokens = analytics.inputTokens
+        self.outputTokens = analytics.outputTokens
+        self.cacheReadTokens = analytics.cacheReadTokens
+        self.cacheCreationTokens = analytics.cacheCreationTokens
+        self.totalTokens = analytics.totalTokens
+        self.activeTimeSeconds = analytics.activeTimeSeconds
+        self.toolCallCount = analytics.toolCallCount
+        self.linesAdded = analytics.linesAdded
+        self.linesRemoved = analytics.linesRemoved
+        self.apiErrorCount = analytics.apiErrorCount
+        self.wallClockDurationSeconds = wallClockDurationSeconds
+    }
+
+    /// Live in-memory hook aggregate for an open session. `wallClockDuration`
+    /// comes from the session's lifecycle stamps (`nil` while the session hasn't
+    /// ended, or for agents that never send `SessionEnd`).
+    public init(live analytics: SessionAnalytics, wallClockDuration: TimeInterval? = nil) {
+        self.init(source: "live", analytics: analytics, wallClockDurationSeconds: wallClockDuration)
+    }
+
+    /// Durable end-of-session snapshot (terminal sessions). Snapshots are only
+    /// written for non-empty aggregates, so a snapshot is always meaningful.
+    public init(snapshot: SessionAnalyticsSnapshot) {
+        self.init(
+            source: "snapshot",
+            analytics: snapshot.analytics,
+            wallClockDurationSeconds: snapshot.wallClockDurationSeconds
+        )
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsDTOTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionAnalyticsDTOTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// CROW-722 (ADR 0008 web parity): `SessionAnalyticsDTO` is a lossless, JS-friendly
+// projection of a session's analytics — either the live in-memory hook aggregate
+// or the durable end-of-session snapshot. These pin that both inits carry exactly
+// the numbers the desktop `SessionAnalyticsStrip` reads, so the web strip can't
+// drift from Core.
+
+@Test func liveInitCarriesEveryFieldAndComputesTotalTokens() {
+    let analytics = SessionAnalytics(
+        totalCost: 1.23,
+        inputTokens: 100,
+        outputTokens: 200,
+        cacheReadTokens: 300,
+        cacheCreationTokens: 400,
+        activeTimeSeconds: 3600,
+        linesAdded: 10,
+        linesRemoved: 4,
+        commitCount: 2,
+        promptCount: 5,
+        toolCallCount: 42,
+        apiRequestCount: 7,
+        apiErrorCount: 3
+    )
+    let dto = SessionAnalyticsDTO(live: analytics, wallClockDuration: 5400)
+
+    #expect(dto.source == "live")
+    #expect(dto.totalCost == 1.23)
+    #expect(dto.inputTokens == 100)
+    #expect(dto.outputTokens == 200)
+    #expect(dto.cacheReadTokens == 300)
+    #expect(dto.cacheCreationTokens == 400)
+    #expect(dto.totalTokens == 1000) // 100 + 200 + 300 + 400
+    #expect(dto.activeTimeSeconds == 3600)
+    #expect(dto.toolCallCount == 42)
+    #expect(dto.linesAdded == 10)
+    #expect(dto.linesRemoved == 4)
+    #expect(dto.apiErrorCount == 3)
+    #expect(dto.wallClockDurationSeconds == 5400)
+}
+
+@Test func liveInitWithoutWallClockOmitsDuration() {
+    let dto = SessionAnalyticsDTO(live: SessionAnalytics(totalCost: 0.5))
+    #expect(dto.source == "live")
+    #expect(dto.wallClockDurationSeconds == nil)
+}
+
+@Test func snapshotInitCarriesAnalyticsAndWallClock() {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(),
+        status: .completed,
+        analytics: SessionAnalytics(totalCost: 2.5, inputTokens: 50, outputTokens: 50, toolCallCount: 9),
+        compactionCount: 1,
+        wallClockDurationSeconds: 7200
+    )
+    let dto = SessionAnalyticsDTO(snapshot: snapshot)
+
+    #expect(dto.source == "snapshot")
+    #expect(dto.totalCost == 2.5)
+    #expect(dto.totalTokens == 100)
+    #expect(dto.toolCallCount == 9)
+    #expect(dto.wallClockDurationSeconds == 7200)
+}
+
+@Test func snapshotInitWithoutWallClockOmitsDuration() {
+    let snapshot = SessionAnalyticsSnapshot(
+        sessionID: UUID(),
+        endedAt: Date(),
+        status: .archived,
+        analytics: SessionAnalytics(totalCost: 1.0)
+    )
+    let dto = SessionAnalyticsDTO(snapshot: snapshot)
+    #expect(dto.source == "snapshot")
+    #expect(dto.wallClockDurationSeconds == nil)
+}
+
+@Test func encodesToFlatJSONObjectForTheWeb() throws {
+    let dto = SessionAnalyticsDTO(
+        live: SessionAnalytics(totalCost: 0.01, inputTokens: 1, outputTokens: 1, toolCallCount: 3),
+        wallClockDuration: 60
+    )
+    let data = try JSONEncoder().encode(dto)
+    let object = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+    #expect(object["source"] as? String == "live")
+    #expect(object["totalTokens"] as? Int == 2)
+    #expect(object["toolCallCount"] as? Int == 3)
+    #expect(object["wallClockDurationSeconds"] as? Double == 60)
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -564,7 +564,7 @@ public enum CrowDaemon {
     /// `SessionService.hydrateState` — hook state, migrations, agent wiring — is
     /// AppKit-bound and out of scope for the daemon.)
     @MainActor
-    private static func reseed(_ appState: AppState, from store: JSONStore) {
+    static func reseed(_ appState: AppState, from store: JSONStore) {
         let data = store.data
         appState.sessions = data.sessions
         appState.worktrees = [:]
@@ -584,6 +584,13 @@ public enum CrowDaemon {
                 appState.restoreHookState(snapshot, for: sid)
             }
         }
+        // Mirror persisted analytics snapshots so the per-session strip
+        // (CROW-722) and the scorecard (#724) survive a daemon restart. Both read
+        // `appState.analyticsSnapshots`, and nothing else populates it in crowd —
+        // `SessionService.hydrateState` (the app's fuller restore) is AppKit-bound
+        // and never runs here, so without this the snapshot fallback is dead for
+        // any session that completed before this daemon process started (#736 review).
+        appState.analyticsSnapshots = data.analyticsSnapshots ?? [:]
     }
 
     /// Mirror the config-derived `AppState` fields the desktop app syncs in

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -676,6 +676,26 @@ func makeCommandRouter(
                     if let prLink = appState.links(for: id).first(where: { $0.linkType == .pr }) {
                         entry["pr_link"] = .object(["label": .string(prLink.label), "url": .string(prLink.url)])
                     }
+                    // Per-session analytics strip (CROW-722). Prefer the live
+                    // in-memory hook aggregate (open sessions); fall back to the
+                    // durable end-of-session snapshot (terminal sessions). Mirrors
+                    // `writeAnalyticsSnapshot`'s own source preference. Never for the
+                    // Manager, and never an all-zeros aggregate — the web renders
+                    // the strip only when this key is present (chips-only empty
+                    // state), so absence IS the empty state.
+                    if !appState.isManagerSession(id) {
+                        let dto: SessionAnalyticsDTO?
+                        if let live = appState.existingHookState(for: id)?.analytics, !live.isEmpty {
+                            dto = SessionAnalyticsDTO(live: live, wallClockDuration: session.wallClockDuration)
+                        } else if let snapshot = appState.analyticsSnapshots[id.uuidString] {
+                            dto = SessionAnalyticsDTO(snapshot: snapshot)
+                        } else {
+                            dto = nil
+                        }
+                        if let dto, let encoded = try? JSONValue(encoding: dto) {
+                            entry["analytics"] = encoded
+                        }
+                    }
                     out[id.uuidString] = .object(entry)
                 }
                 return ["sessions": .object(out)]

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -1128,6 +1128,18 @@ html, body {
 .score-chip-label { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
 .score-chip-value { font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
+/* Per-session analytics strip in the detail header (CROW-722). Reuses the
+   scorecard's statChipEl DOM but renders compact and unboxed — matching the
+   desktop SessionAnalyticsStrip and the header's .meta density, not the boxed
+   scorecard cards. */
+.analytics-strip { display: flex; gap: 14px; flex-wrap: wrap; align-items: baseline; margin-top: 6px; }
+.analytics-strip .score-chip {
+  flex-direction: row; align-items: baseline; gap: 4px;
+  background: none; border: none; border-radius: 0; padding: 0; min-width: 0;
+}
+.analytics-strip .score-chip-value { font-size: 11px; }
+.analytics-strip .chip-error .score-chip-value { color: var(--red); }
+
 .score-prior { display: flex; flex-direction: column; gap: 6px; }
 .score-prior-row { display: flex; align-items: center; gap: 10px; font-size: 12px; }
 .score-prior-week { color: var(--text-secondary); }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1432,6 +1432,11 @@ function renderHeader(s) {
     agentMeta.onclick = (ev) => { ev.stopPropagation(); openHandoffAgentMenu(s, agentMeta); };
   }
 
+  // Per-session analytics strip (CROW-722): cost / tokens / tools / active time,
+  // mirroring the desktop SessionAnalyticsStrip. Sits between the session context
+  // rows and the links/actions row.
+  renderSessionAnalyticsStrip(s, root);
+
   // Links + actions on ONE row (issue/PR/repo chips + inline PR status on the
   // left, action buttons trailing) — matching the desktop detail header.
   const links = (s.links || []).slice();
@@ -1483,6 +1488,34 @@ function renderHeader(s) {
   }
   if (actions.children.length) headerRow.appendChild(actions);
   if (headerRow.children.length) root.appendChild(headerRow);
+}
+
+// Per-session analytics strip (CROW-722) — cost / tokens / tools / active time,
+// mirroring the desktop SessionAnalyticsStrip. Chips-only: appends nothing when
+// there's no analytics (telemetry off, or nothing recorded yet) or for the
+// Manager session, so absence is the empty state. Source (live hook aggregate vs.
+// end-of-session snapshot) is resolved server-side in list-sessions-live.
+function renderSessionAnalyticsStrip(s, root) {
+  if (s.kind === 'manager') return;
+  const a = liveFor(s.id).analytics;
+  if (!a) return;
+  const strip = el('div', 'analytics-strip');
+  strip.appendChild(statChipEl('Cost', fmtCost(a.totalCost)));
+  strip.appendChild(statChipEl('Tokens', fmtCount(a.totalTokens)));
+  strip.appendChild(statChipEl('Tools', String(a.toolCallCount)));
+  strip.appendChild(statChipEl('Active', fmtTime(a.activeTimeSeconds)));
+  if (a.wallClockDurationSeconds != null) {
+    strip.appendChild(statChipEl('Duration', fmtTime(a.wallClockDurationSeconds)));
+  }
+  if (a.linesAdded || a.linesRemoved) {
+    strip.appendChild(statChipEl('Lines', '+' + a.linesAdded + ' −' + a.linesRemoved));
+  }
+  if (a.apiErrorCount > 0) {
+    const chip = statChipEl('Errors', String(a.apiErrorCount));
+    chip.classList.add('chip-error');
+    strip.appendChild(chip);
+  }
+  root.appendChild(strip);
 }
 
 // Inline PR status, mirroring the desktop PRStatusDetail.

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
@@ -267,3 +267,80 @@ import CrowPersistence
         #expect(resp.result?["action"]?.stringValue == "mergePR")
     }
 }
+
+/// CROW-722: `list-sessions-live` carries a per-session analytics strip resolved
+/// server-side (live hook aggregate → durable snapshot). These pin the resolution
+/// branch the DTO's own tests don't reach — the empty-state omission, the Manager
+/// exclusion, and that `CrowDaemon.reseed` mirrors persisted snapshots so a
+/// session that completed before this daemon process started still renders its
+/// strip (the snapshot half was dead before #736's reseed fix).
+@Suite struct SessionAnalyticsStripLiveTests {
+    @MainActor
+    private func router(appState: AppState, store: JSONStore) -> CommandRouter {
+        makeCommandRouter(
+            appState: appState, store: store, git: GitManager(),
+            devRoot: NSTemporaryDirectory(), cockpit: nil)
+    }
+
+    private func snapshot(for id: UUID, cost: Double = 2.5) -> SessionAnalyticsSnapshot {
+        SessionAnalyticsSnapshot(
+            sessionID: id, endedAt: Date(), status: .completed,
+            analytics: SessionAnalytics(totalCost: cost, inputTokens: 40, outputTokens: 60, toolCallCount: 9),
+            wallClockDurationSeconds: 7200)
+    }
+
+    /// JSONValue decodes whole-number Doubles as `.int` (Int is tried first), so
+    /// read numbers as int-or-double rather than pinning the case.
+    private func num(_ v: JSONValue?) -> Double? {
+        v?.doubleValue ?? v?.intValue.map(Double.init)
+    }
+
+    @Test @MainActor func reseedMirrorsSnapshotsSoStripRendersAfterRestart() async {
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        // A session that completed before this daemon started: its snapshot lives
+        // in store.json, but a fresh appState is empty until reseed mirrors it.
+        let session = Session(name: "s", kind: .work, agentKind: .claudeCode)
+        let store = JSONStore()
+        store.mutate { data in
+            data.sessions = [session]
+            data.analyticsSnapshots = [session.id.uuidString: snapshot(for: session.id)]
+        }
+        let appState = AppState()
+        CrowDaemon.reseed(appState, from: store)
+        #expect(appState.analyticsSnapshots[session.id.uuidString] != nil)
+
+        let resp = await router(appState: appState, store: store)
+            .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
+        let a = resp.result?["sessions"]?.objectValue?[session.id.uuidString]?.objectValue?["analytics"]?.objectValue
+        #expect(a?["source"]?.stringValue == "snapshot")
+        #expect(num(a?["totalCost"]) == 2.5)
+        #expect(num(a?["totalTokens"]) == 100) // 40 + 60
+        #expect(num(a?["toolCallCount"]) == 9)
+        #expect(num(a?["wallClockDurationSeconds"]) == 7200)
+    }
+
+    @Test @MainActor func omitsAnalyticsWhenNoLiveOrSnapshot() async {
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        let session = Session(name: "s", kind: .work, agentKind: .claudeCode)
+        let appState = AppState()
+        appState.sessions = [session]
+        let resp = await router(appState: appState, store: JSONStore())
+            .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
+        let entry = resp.result?["sessions"]?.objectValue?[session.id.uuidString]?.objectValue
+        #expect(entry != nil)
+        #expect(entry?["analytics"] == nil) // absence IS the empty state
+    }
+
+    @Test @MainActor func excludesManagerEvenWithSnapshot() async {
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        let manager = Session(name: "m", kind: .manager, agentKind: .claudeCode)
+        let appState = AppState()
+        appState.sessions = [manager]
+        appState.analyticsSnapshots[manager.id.uuidString] = snapshot(for: manager.id)
+        let resp = await router(appState: appState, store: JSONStore())
+            .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
+        let entry = resp.result?["sessions"]?.objectValue?[manager.id.uuidString]?.objectValue
+        #expect(entry != nil)
+        #expect(entry?["analytics"] == nil)
+    }
+}


### PR DESCRIPTION
Closes #722

Adds a **per-session analytics strip** to the web session header, matching main's desktop `SessionAnalyticsStrip` — the parity gap called out in the ticket (web headers show review author etc. but no analytics).

## What
- **New `SessionAnalyticsDTO`** (CrowCore): a flat, JS-friendly projection of a session's analytics, built from either the **live** in-memory hook aggregate (open sessions) or the **snapshot** (terminal sessions), with a `source` discriminator. Sibling to `ScorecardDTO`.
- **`list-sessions-live`** now attaches a per-session `analytics` object, resolved server-side (live → snapshot fallback, mirroring `writeAnalyticsSnapshot`'s preference). No new RPC: `refreshLive()` already re-renders the selected header each poll, so the strip updates on the same cadence as the PR/RC badges.
- **Web strip** (`app.js`/`app.css`): `renderSessionAnalyticsStrip` shows Cost · Tokens · Tools · Active, plus Duration / Lines / Errors chips when present, reusing the scorecard's `fmt*` + `statChipEl` helpers scoped to a compact, unboxed `.analytics-strip` (keeps header density; no card forest).

## Source decision (live vs snapshot)
Per session, in priority order: live hook aggregate (non-empty) → durable end-of-session snapshot → nothing.

## Empty state
**Chips-only** (per review preference): the strip renders only when analytics data exists — absent when telemetry is off or nothing was recorded, and never for the Manager. Absence *is* the empty state.

## Note — surface parity over dormant infra
The analytics ingestion pipeline is still dormant on the parity branch (`TelemetryService` is never instantiated; `hookState.analytics` is never written at runtime), so today the strip is absent by default. This is the same posture as the #724 scorecard: it's built to consume the data and lights up **unchanged** once telemetry ingestion is wired. Wiring that ingestion is intentionally **out of scope** here.

## Base
Stacked on **`feature/crow-593-web-ui-parity`** (sibling to #725), not main.

## Test plan
- [x] `make build` green (daemon + desktop)
- [x] `swift test` — new `SessionAnalyticsDTOTests` (5 cases: live/snapshot inits, totalTokens, wall-clock passthrough, flat JSON encode) pass
- [x] `node --check app.js`
- [x] Telemetry off (current default): strip absent, header density unchanged, no console errors
- [ ] With a snapshot present: `list-sessions-live` returns the `analytics` object and the strip renders chips (covers "completed session shows last snapshot")