### PR TITLE
Revert #734 from main (merged to wrong base; relands in #738)

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/CorveilTheme.swift
+++ b/Packages/CrowUI/Sources/CrowUI/CorveilTheme.swift
@@ -154,18 +154,6 @@ extension TicketStatus {
         case .unknown: .secondary
         }
     }
-
-    /// Canonical SF Symbol for each pipeline stage.
-    public var icon: String {
-        switch self {
-        case .backlog: "tray"
-        case .ready: "flag.fill"
-        case .inProgress: "bolt.fill"
-        case .inReview: "eye.fill"
-        case .done: "checkmark.circle.fill"
-        case .unknown: "questionmark.circle"
-        }
-    }
 }
 
 extension SessionStatus {

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -268,7 +268,7 @@ struct AllPipelineSegment: View {
         Button(action: action) {
             HStack(spacing: 6) {
                 Image(systemName: "square.grid.2x2")
-                    .font(.callout)
+                    .font(.system(size: 8))
                     .foregroundStyle(CorveilTheme.gold)
                 Text("All")
                     .font(.callout)
@@ -301,9 +301,9 @@ struct PipelineSegment: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
-                Image(systemName: status.icon)
-                    .font(.callout)
-                    .foregroundStyle(status.color)
+                Circle()
+                    .fill(status.color)
+                    .frame(width: 8, height: 8)
                 Text(status.rawValue)
                     .font(.callout)
                     .fontWeight(isSelected ? .semibold : .regular)
@@ -613,11 +613,11 @@ public struct TicketBoardSidebarRow: View {
             }
             HStack(spacing: 8) {
                 Spacer(minLength: 0)
-                StatusCount(status: .backlog, count: appState.issueCount(for: .backlog))
-                StatusCount(status: .ready, count: appState.issueCount(for: .ready))
-                StatusCount(status: .inProgress, count: appState.issueCount(for: .inProgress))
-                StatusCount(status: .inReview, count: appState.issueCount(for: .inReview))
-                StatusCount(status: .done, count: appState.doneIssuesLast24h)
+                StatusCount(icon: "tray", color: CorveilTheme.textMuted, count: appState.issueCount(for: .backlog))
+                StatusCount(icon: "flag.fill", color: .blue, count: appState.issueCount(for: .ready))
+                StatusCount(icon: "bolt.fill", color: .orange, count: appState.issueCount(for: .inProgress))
+                StatusCount(icon: "eye.fill", color: .purple, count: appState.issueCount(for: .inReview))
+                StatusCount(icon: "checkmark.circle.fill", color: .green, count: appState.doneIssuesLast24h)
                 Spacer(minLength: 0)
             }
         }
@@ -665,14 +665,6 @@ struct StatusCount: View {
     let icon: String
     let color: Color
     let count: Int
-
-    /// Derive icon + color from a single `TicketStatus` so the pair can't drift
-    /// — the same source-of-truth guarantee the pipeline row relies on.
-    init(status: TicketStatus, count: Int) {
-        self.icon = status.icon
-        self.color = status.color
-        self.count = count
-    }
 
     var body: some View {
         HStack(spacing: 3) {

--- a/Packages/CrowUI/Tests/CrowUITests/CrowUITests.swift
+++ b/Packages/CrowUI/Tests/CrowUITests/CrowUITests.swift
@@ -57,20 +57,6 @@ struct RunCorveilVersionTests {
     }
 }
 
-@Test func ticketStatusIcons() {
-    #expect(TicketStatus.backlog.icon == "tray")
-    #expect(TicketStatus.ready.icon == "flag.fill")
-    #expect(TicketStatus.inProgress.icon == "bolt.fill")
-    #expect(TicketStatus.inReview.icon == "eye.fill")
-    #expect(TicketStatus.done.icon == "checkmark.circle.fill")
-    #expect(TicketStatus.unknown.icon == "questionmark.circle")
-
-    // Each status must map to a distinct icon — catches a copy-paste bug
-    // (two statuses sharing a glyph) that exact-string matching alone can't.
-    let icons = TicketStatus.allCases.map(\.icon)
-    #expect(Set(icons).count == icons.count)
-}
-
 // MARK: - PR Check/Review Status Extensions
 
 @Test func checkStatusIcons() {


### PR DESCRIPTION
## Why

**PR #734** (closes #732) was merged into **`main`** by mistake — it should have targeted the web-UI-parity integration branch `feature/crow-593-web-ui-parity`. This PR reverts it from `main`.

This is a clean revert of the squash commit `90a3d54`; no code is lost. The same change is being re-landed on the correct base branch in **#738**.

## What

- Reverts `90a3d54` ("Unify per-category icons & colors across pipeline headings and sidebar (#734)").
- 3 files restored: `CorveilTheme.swift`, `TicketBoardView.swift`, and the added test.

## Follow-up

- Reland ticket (correct branch): #738
- Original issue: #732 · Mis-targeted PR: #734
