### PR TITLE
Reland: route job agent-kind config→state sync through one choke point (CROW-739)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -90,6 +90,16 @@ public final class AppState {
         return agentsByKind[sessionKind.rawValue] ?? defaultAgentKind
     }
 
+    /// Mirror the agent-selection config (`defaultAgentKind` + `agentsByKind`)
+    /// into runtime state so `agentKind(for:)` resolves the just-saved value
+    /// without a config reload (CROW-733). The single choke point every
+    /// config→state sync site funnels through, so no save path can leave the
+    /// mirror stale.
+    public func applyAgentConfig(_ config: AppConfig) {
+        defaultAgentKind = config.defaultAgentKind
+        agentsByKind = config.agentsByKind
+    }
+
     /// Terminal IDs whose Claude Code was launched with `--rc` — drives the
     /// per-session indicator badge. Survives toggle changes so existing sessions
     /// keep showing the badge until they're restarted.

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppStateAgentConfigSyncTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppStateAgentConfigSyncTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// CROW-733: changing the per-action agent (e.g. "Agent for scheduled jobs")
+// must apply to the very next launched session without an app restart or a
+// config reload from disk. Jobs resolve their agent live via
+// `AppState.agentKind(for:)`, so the invariant under test is that
+// `AppState.applyAgentConfig(_:)` — the single choke point every config→state
+// sync site funnels through — makes the just-saved value observable immediately.
+
+@MainActor @Test func applyAgentConfigPropagatesJobOverrideUpdateWithoutReload() {
+    let state = AppState()
+    var config = AppConfig()
+
+    // First selection: Cursor for jobs.
+    config.agentsByKind["job"] = .cursor
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .cursor)
+
+    // Re-select in the same running app (no disk reload): Claude Code.
+    config.agentsByKind["job"] = .claudeCode
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .claudeCode)
+}
+
+@MainActor @Test func applyAgentConfigClearingJobOverrideFallsBackToDefault() {
+    let state = AppState()
+    var config = AppConfig()
+
+    // Override in place → resolves to the override.
+    config.defaultAgentKind = .claudeCode
+    config.agentsByKind["job"] = .cursor
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .cursor)
+
+    // "Use default" removes the override → resolves to defaultAgentKind.
+    config.agentsByKind.removeValue(forKey: "job")
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .claudeCode)
+    #expect(state.agentsByKind["job"] == nil)
+}
+
+@MainActor @Test func applyAgentConfigPropagatesDefaultAgentChange() {
+    let state = AppState()
+    var config = AppConfig()
+
+    // No per-kind override → resolution tracks defaultAgentKind.
+    config.defaultAgentKind = .cursor
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .cursor)
+
+    config.defaultAgentKind = .claudeCode
+    state.applyAgentConfig(config)
+    #expect(state.agentKind(for: .job) == .claudeCode)
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -617,8 +617,10 @@ public enum CrowDaemon {
         // resolves the built-in default (.claudeCode) via appState.agentKind(for:),
         // so the Settings manager/coder agent pickers are ignored on
         // restart/respawn even though they persist to config (CROW-433 / CROW-581).
-        appState.defaultAgentKind = config.defaultAgentKind
-        appState.agentsByKind = config.agentsByKind
+        // Route through the single choke point so no field is silently missed on
+        // any sync path and the next launched job resolves the just-saved agent
+        // without a config reload (CROW-733).
+        appState.applyAgentConfig(config)
     }
 
     /// Poll `store.json`'s mtime and reload when the desktop app writes it, so

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -247,7 +247,9 @@ import CrowPersistence
             remoteControlEnabled: true,          // AppState default: false
             managerAutoPermissionMode: false,    // AppState default: true
             jobsAutoPermissionMode: false,       // AppState default: true
-            coderViewAutoPermissionMode: true)   // AppState default: false
+            coderViewAutoPermissionMode: true,   // AppState default: false
+            defaultAgentKind: .cursor,           // AppState default: .claudeCode
+            agentsByKind: ["job": .codex])       // AppState default: [:]
         try ConfigStore.saveConfig(cfg, devRoot: devRoot)
 
         let appState = AppState()
@@ -260,6 +262,15 @@ import CrowPersistence
         #expect(appState.managerAutoPermissionMode == false)
         #expect(appState.jobsAutoPermissionMode == false)
         #expect(appState.coderViewAutoPermissionMode == true)
+        // Agent selection must land too, via the `applyAgentConfig` choke point
+        // wired into `applyConfigToAppState`. This is the guard for CROW-733: a
+        // launched job resolves its agent live through `agentKind(for: .job)`, so
+        // deleting that daemon call site reintroduces the stale-agent bug — and
+        // only this disk→config→state assertion (not the direct-setter unit tests)
+        // fails when it is removed.
+        #expect(appState.defaultAgentKind == .cursor)
+        #expect(appState.agentsByKind == ["job": .codex])
+        #expect(appState.agentKind(for: .job) == .codex)
 
         // The board the daemon serializes is `filteredAssignedIssues`; with the
         // field populated it now drops the excluded repos (exact + glob) — the


### PR DESCRIPTION
Re-lands #735 (CROW-733) onto `feature/crow-593-web-ui-parity` after that PR was merged to `main` by mistake and reverted there. **Base is the parity branch, not `main`.**

## What
- **`AppState.applyAgentConfig(_:)`** (CrowCore) — the single choke point every config→state agent sync site funnels through, so no save path can leave the runtime mirror (`agentKind(for:)`) stale.
- Route the mirror site through it. The original #735 target was the macOS app's two `AppDelegate` sites; on this parity branch those are **deleted under ADR 0008** and collapsed into one static choke point, **`CrowDaemon.applyConfigToAppState`** — the sole writer of these fields, called at boot and on every board tick, so runtime Settings edits take effect within one poll. That is the site rerouted here.
- **`AppStateAgentConfigSyncTests`** — locks the invariant with no disk reload.

## Drift vs. #735
`Sources/Crow/App/AppDelegate.swift` no longer exists on this branch, so the cherry-pick's AppDelegate hunk was dropped and its intent relanded at the daemon choke point instead. CrowCore additions applied unchanged.

## Verification
- `make build` succeeds.
- `swift test --package-path Packages/CrowCore --filter 'AppStateAgentConfigSync|AppConfigAgentKind|SessionAgentKind'` — 17/17 pass (incl. the 3 new `applyAgentConfig*` regression tests).

## Acceptance criteria (CROW-733)
- [x] Next launched job uses the new agent, no restart — live `agentKind(for: .job)` resolve + daemon re-runs `applyConfigToAppState` → `applyAgentConfig` within one poll.
- [x] Per-kind override update **and** clearing back to Use default — tests 1 & 2.
- [x] Reflected in both `config.json` (disk write unchanged) and `appState.agentKind(for: .job)`.
- [x] Regression guard with no disk reload — `AppStateAgentConfigSyncTests`.
- [x] Build passes; CrowCore tests green.

Closes #739