### PR TITLE
fix(crow-desktop): serve frozen bundle web assets under make run (CROW-737)

### DIFF
--- a/crow-desktop/src-tauri/src/lib.rs
+++ b/crow-desktop/src-tauri/src/lib.rs
@@ -178,14 +178,10 @@ pub fn run() {
                         cmd.arg("--socket").arg(sock);
                     }
                 }
-                // Dev: serve web assets live from source so UI edits show on reload
-                // (matches `make crowd-dev`). Skipped when the source tree isn't
-                // present (e.g. a release install), where crowd uses its bundle.
-                let web = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../../Packages/CrowDaemon/Sources/CrowDaemon/Resources/web");
-                if web.is_dir() {
-                    cmd.arg("--web-dir").arg(&web);
-                }
+                // No --web-dir: the sidecar serves the frozen web assets baked
+                // into crowd's resource bundle at `make daemon` time, so UI edits
+                // don't show until an explicit rebuild. For live-from-source web
+                // editing, use `make crowd-dev` (which passes --web-dir).
                 match cmd.spawn() {
                     Ok(child) => {
                         eprintln!(

--- a/scripts/crowd-dev.sh
+++ b/scripts/crowd-dev.sh
@@ -10,9 +10,9 @@
 # Note: Swift can't be hot-swapped into a running process, so `--watch` tears
 # down and respawns the daemon on every change — the same "the server restarts"
 # tradeoff as the Tauri dev loop. Prefer the default (no --watch) when you want a
-# daemon that stays up across edits. And note `make run` already spawns `crowd`
-# with live web assets as a sidecar, so for most UI work you don't need this
-# script at all.
+# daemon that stays up across edits. Note that `make run` spawns its `crowd`
+# sidecar serving the *frozen* bundle-baked web assets (no live reload), so this
+# script is what you want when you need live-from-source web editing.
 #
 # Always binds 127.0.0.1 (loopback only) — front it with an HTTPS reverse proxy
 # for remote access. Env overrides: CROW_HTTP_PORT (8787),


### PR DESCRIPTION
## Problem

In a dev checkout, `make run`'s Tauri window spawned a sidecar `crowd` with `--web-dir` pointed at the source web folder whenever it existed. The desktop app therefore served the web UI **live from source** — editing `app.js`/CSS/HTML and reloading the window reflected the change with no rebuild.

We don't want `make run` doing live web reloads. It should serve the **frozen, bundle-baked** assets (the copy baked into crowd's resource bundle at `make daemon` time) so nothing updates until an explicit rebuild.

## Fix

- `crow-desktop/src-tauri/src/lib.rs` — remove the `--web-dir` block so the sidecar `crowd` is always spawned **without** `--web-dir`. crowd falls back to its compiled resource bundle (`StaticAssets.webResponse` serves from the bundle when `webDir` is `nil`).
- `scripts/crowd-dev.sh` — update the stale header comment that claimed `make run` already serves live web assets. `make crowd-dev` (still passing `--web-dir`) is now the explicit path for live-from-source web editing.

Release installs are unaffected — the block was already skipped when the source tree isn't present.

## Verification

- [x] `cargo check` on the Tauri crate compiles clean.
- `make app && make run`, edit `app.js`, reload window → change must **not** appear (frozen).
- Spawned crowd log line (`[crow-desktop] spawned crowd …`) has no `--web-dir`.
- `make crowd-dev` still serves live web.
- `make daemon` + relaunch → edit now appears.

Base: `feature/crow-593-web-ui-parity` (integration branch, not `main`).

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EEynTgL9b4vdFBrSwaWpR