### PR TITLE
feat(crow-daemon): auto-resume sessions after reboot (recreate tmux windows + relaunch every agent) (CROW-747)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -466,10 +466,13 @@ public enum CrowDaemon {
     /// Broadcasts a `changed` nudge after each poll so clients re-fetch the
     /// boards reactively (M-D).
     ///
-    /// Also performs the terminal TAKEOVER: on the first tick it adopts every
+    /// Also performs the terminal TAKEOVER: on the first tick it restores every
     /// persisted tmux window into this process (so `TerminalRouter.send` /
-    /// `isRegistered` works) and ensures the Manager. Runs before `refresh()` so
-    /// automation dispatches have a live, registered Manager to reach.
+    /// `isRegistered` works) and ensures the Manager. On a warm crowd restart
+    /// the windows are still alive and it adopts them; on a cold start (reboot /
+    /// `tmux kill-server`) it recreates them and relaunches each session's agent
+    /// (CROW-747). Runs before `refresh()` so automation dispatches have a live,
+    /// registered Manager to reach.
     private static func startBoardPoll(
         tracker: IssueTracker,
         eventHub: EventHub,
@@ -488,16 +491,31 @@ public enum CrowDaemon {
                 if let sessionService {
                     if !didTakeOver {
                         await MainActor.run {
-                            sessionService.rebuildAllSurfaces()
+                            // CROW-747: on a genuine cold start (machine reboot
+                            // or `tmux kill-server`) the cockpit session and
+                            // every agent are gone; recreate each persisted
+                            // terminal's window and relaunch its session's agent
+                            // (Claude `--continue`, Cursor/Codex/OpenCode
+                            // equivalents). On a warm crowd restart the windows
+                            // are still live and this adopts them in place —
+                            // gated on the cockpit-alive probe so a live pane is
+                            // never re-registered or double-launched.
+                            sessionService.takeOverTerminalSurfaces()
                             sessionService.ensureManagerSession(devRoot: devRoot)
                         }
                         didTakeOver = true
+                        // Skip reconcile on the takeover tick: the per-terminal
+                        // window recreate above is dispatched as async @MainActor
+                        // tasks whose fresh bindings haven't landed yet, so
+                        // pruning now would drop the very records we're about to
+                        // resurrect (CROW-747). Reconcile runs on every
+                        // subsequent tick, once those tasks have settled.
+                    } else {
+                        // Reconcile terminals ↔ tmux windows each tick: prune
+                        // terminal records whose window is gone and reap orphaned
+                        // windows (targeted-auto, Manager-safe).
+                        await MainActor.run { sessionService.reconcileTerminalSurfaces() }
                     }
-                    // Reconcile terminals ↔ tmux windows each tick: prune terminal
-                    // records whose window is gone and reap orphaned windows
-                    // (targeted-auto, Manager-safe). Runs after `rebuildAllSurfaces`
-                    // on the takeover tick so adopted windows are in the keep-set.
-                    await MainActor.run { sessionService.reconcileTerminalSurfaces() }
                 }
                 await tracker.refresh()
                 await eventHub.broadcast()

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -380,6 +380,48 @@ public final class SessionService {
         }
     }
 
+    /// Cold-start terminal takeover for the headless daemon (CROW-747). Probes
+    /// whether the tmux cockpit session survived, then restores accordingly:
+    ///
+    ///   - **Cockpit alive** — a warm `crowd` restart: the daemon process
+    ///     bounced but tmux and its windows kept running, so each agent is still
+    ///     live in its pane. Adopt the surviving windows in place via
+    ///     `rebuildAllSurfaces(forceRegister: false)`; nothing is relaunched.
+    ///   - **Cockpit gone** — a machine reboot or `tmux kill-server`: the server
+    ///     and every window (and the agent process inside each) were destroyed,
+    ///     but session metadata persisted to disk. Recreate each persisted
+    ///     terminal's window and relaunch its session's agent via
+    ///     `rebuildAllSurfaces(forceRegister: true)` — the same
+    ///     recreate-and-relaunch machinery the mid-run crash auto-recovery uses
+    ///     (#588). The relaunch routes through `launchAgent →
+    ///     agent.autoLaunchCommand` keyed on the session's `agentKind`, so every
+    ///     supported agent resumes per its own rules (Claude via `--continue`,
+    ///     Cursor/Codex/OpenCode via their equivalents; branches an agent marks
+    ///     unsupported simply stay unlaunched).
+    ///
+    /// Correct against the warm-restart regression the ticket warns about:
+    /// `forceRegister: true` is gated on the server actually being gone, so a
+    /// live pane is never re-registered and no agent is double-launched into a
+    /// running one. Returns whether the recreate path was taken (for tests).
+    @MainActor
+    @discardableResult
+    public func takeOverTerminalSurfaces() -> Bool {
+        let recreate = Self.shouldRecreateSurfacesOnTakeover(
+            cockpitSessionIsLive: TmuxBackend.shared.cockpitSessionIsLive())
+        NSLog(recreate
+            ? "[CrowTelemetry takeover:recreate] tmux cockpit gone (reboot/kill-server) — recreating windows + relaunching agents (CROW-747)"
+            : "[CrowTelemetry takeover:adopt] tmux cockpit alive — adopting surviving surfaces in place")
+        rebuildAllSurfaces(forceRegister: recreate)
+        return recreate
+    }
+
+    /// Pure takeover policy (CROW-747): recreate + relaunch when the cockpit
+    /// session did NOT survive (reboot / server kill), adopt when it did (warm
+    /// crowd restart). Split out so the decision is unit-testable without tmux.
+    nonisolated static func shouldRecreateSurfacesOnTakeover(cockpitSessionIsLive: Bool) -> Bool {
+        !cockpitSessionIsLive
+    }
+
     /// Commit the result of a per-terminal rehydration task back to
     /// `appState.terminals`, locating the row by ID since the array may
     /// have shifted while the task awaited. If the `tmuxBinding` changed

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceTakeoverPolicyTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceTakeoverPolicyTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import CrowEngine
+
+/// Pure-policy tests for the CROW-747 cold-start terminal takeover decision.
+/// `takeOverTerminalSurfaces` itself drives real tmux + agents, but its branch
+/// is factored into `shouldRecreateSurfacesOnTakeover(cockpitSessionIsLive:)`
+/// so the adopt-vs-recreate choice is testable without a tmux server.
+@Suite("SessionService takeover policy (CROW-747)")
+struct SessionServiceTakeoverPolicyTests {
+
+    /// Cockpit gone (machine reboot / `tmux kill-server`) → recreate windows and
+    /// relaunch each session's agent (`forceRegister: true`).
+    @Test func recreatesWhenCockpitGone() {
+        #expect(SessionService.shouldRecreateSurfacesOnTakeover(cockpitSessionIsLive: false))
+    }
+
+    /// Cockpit alive (warm crowd restart, windows + agents still running) →
+    /// adopt in place (`forceRegister: false`); never relaunch into a live pane.
+    @Test func adoptsWhenCockpitAlive() {
+        #expect(!SessionService.shouldRecreateSurfacesOnTakeover(cockpitSessionIsLive: true))
+    }
+}

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -143,6 +143,30 @@ public final class TmuxBackend {
     /// quit left the server running at the stable socket — see #330.
     public var isRunning: Bool { controller?.hasSession() ?? false }
 
+    /// Probe whether the cockpit tmux session is live on the socket *right now*,
+    /// WITHOUT creating it — unlike `ensureRunningServer`, which resurrects an
+    /// empty cockpit as a side effect. Used at daemon cold start to choose
+    /// between adopting surviving windows (warm `crowd` restart) and recreating
+    /// + relaunching them (machine reboot / `tmux kill-server`) — CROW-747.
+    ///
+    /// Distinct from `isRunning`: that reads the *cached* `controller`, which is
+    /// `nil` at daemon boot even when the server is alive, so it can't answer
+    /// the cold-start question. This constructs a throwaway `TmuxController`
+    /// when none is cached and runs `has-session` against the socket directly.
+    /// The throwaway is deliberately NOT cached — populating `controller` with a
+    /// session-less handle would make the next `ensureRunningServer` spuriously
+    /// fire `onServerLost` (it treats a cached controller whose session vanished
+    /// as a mid-run crash). Returns `false` when tmux wasn't configured this run.
+    public func cockpitSessionIsLive() -> Bool {
+        guard !tmuxBinary.isEmpty, !socketPath.isEmpty else { return false }
+        let ctrl = controller ?? TmuxController(
+            tmuxBinary: tmuxBinary,
+            socketPath: socketPath,
+            sessionName: TmuxBackend.cockpitSessionName
+        )
+        return ctrl.hasSession()
+    }
+
     /// Detach this Crow process from the tmux backend, resetting in-memory
     /// state. Used by app quit and by the crash-watchdog (PROD #5).
     ///

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -798,6 +798,68 @@ struct TmuxBackendTests {
         #expect(backend.activeTerminalID == nil)
         #expect(backend.isRunning)  // server untouched
     }
+
+    // MARK: - CROW-747 cold-start takeover signal
+
+    /// `cockpitSessionIsLive()` is the adopt-vs-recreate probe the daemon uses
+    /// at cold start. It must track the real server state on the socket, not the
+    /// cached controller: false before anything is created, true once the cockpit
+    /// exists, and false again after the server is killed out-of-band (the
+    /// machine-reboot / `tmux kill-server` case that CROW-747 recreates from).
+    @Test func cockpitSessionIsLiveReflectsServerState() throws {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        // Nothing created yet → no cockpit session on the socket.
+        #expect(!backend.cockpitSessionIsLive())
+
+        _ = try backend.registerTerminal(
+            id: UUID(), name: "probe", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        #expect(backend.cockpitSessionIsLive())
+
+        // Server killed out-of-band (reboot proxy) → probe reports gone without
+        // resurrecting it (unlike `ensureRunningServer`).
+        killLeftoverServer(socket: backend.socketPath)
+        #expect(!backend.cockpitSessionIsLive())
+    }
+
+    /// A fresh backend (no cached controller — the daemon-boot case) still reads
+    /// the socket directly: it reports the cockpit live when a prior process left
+    /// the server running (warm crowd restart → adopt), and gone once that server
+    /// is torn down (cold start → recreate). Guards `isRunning`'s blind spot,
+    /// which is false at boot regardless because `controller` is nil.
+    @Test func cockpitSessionIsLiveOnFreshBackendReadsSocket() throws {
+        let socket = sharedSocketPath()
+        let backendA = makeBackend(socket: socket)
+        _ = try backendA.registerTerminal(
+            id: UUID(), name: "persist", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        // Warm restart: leave the server running.
+        backendA.shutdown(killServer: false)
+
+        // Brand-new backend on the same socket, controller not yet created.
+        let backendB = makeBackend(socket: socket)
+        #expect(backendB.isRunning == false)          // cached-controller view is blind at boot
+        #expect(backendB.cockpitSessionIsLive())      // socket probe sees the live server
+
+        // Cold start: tear the server down out-of-band (the probe never cached a
+        // controller, so `backendB.shutdown` couldn't — that non-side-effect is
+        // the point). A fresh backend must then see the cockpit gone.
+        killLeftoverServer(socket: socket)
+        let backendC = makeBackend(socket: socket)
+        defer { backendC.shutdown() }
+        #expect(!backendC.cockpitSessionIsLive())
+    }
+
+    /// Not-configured backends never claim a live cockpit — `takeOverTerminalSurfaces`
+    /// falls back to the recreate branch, which no-ops safely when tmux is absent.
+    @Test func cockpitSessionIsLiveFalseWhenUnconfigured() {
+        let backend = TmuxBackend()  // no configure(...)
+        #expect(!backend.cockpitSessionIsLive())
+    }
 }
 
 // MARK: - CROW-487 crowBinDir propagation


### PR DESCRIPTION
Closes #747

## Problem

After a machine reboot (or any `tmux kill-server`), the tmux server and every window — plus the coding-agent process inside each — are destroyed. Crow persists session **metadata** (JSONStore), so sessions still render, but on daemon cold start the takeover only **adopted** existing windows and never recreated the missing ones: terminals came back dead and no agent (`claude` / `cursor` / `codex` / `opencode`) resumed.

## Fix

Route the daemon's first-tick takeover through the **existing** recreate-and-relaunch machinery when the cockpit session is genuinely gone, while keeping the cheap **adopt** path for a warm `crowd` restart where windows are still alive. The two are distinguished by a new non-mutating socket probe — the same server-crashed-vs-missing-window distinction the crash-recovery path (#588) already relies on.

- **`TmuxBackend.cockpitSessionIsLive()`** — non-mutating probe (throwaway controller when none is cached, so it never spuriously trips `onServerLost`) that answers *"did the server survive?"* at boot. `isRunning` can't: its cached `controller` is `nil` at daemon boot regardless of the real server state.
- **`SessionService.takeOverTerminalSurfaces()`** — probe + branch:
  - cockpit **alive** → `rebuildAllSurfaces(forceRegister: false)` — adopt in place, nothing relaunched;
  - cockpit **gone** → `rebuildAllSurfaces(forceRegister: true)` — recreate each persisted terminal's window and relaunch its session's agent via `launchAgent → agent.autoLaunchCommand` keyed on `agentKind` (Claude `--continue`, Cursor/Codex/OpenCode equivalents; each agent's unsupported review/job/manager branches stay unlaunched).
  - The recreate is **gated on the server actually being gone**, so a live pane is never re-registered and no agent is double-launched — the warm-restart regression the ticket calls out. The decision is factored into the pure, unit-tested `shouldRecreateSurfacesOnTakeover(cockpitSessionIsLive:)`.
- **`CrowDaemon.startBoardPoll`** — call `takeOverTerminalSurfaces()` instead of `rebuildAllSurfaces()` on the takeover tick, and **defer** `reconcileTerminalSurfaces()` to subsequent ticks: the per-terminal recreate runs as async `@MainActor` tasks whose fresh bindings haven't landed yet, so pruning on the same tick would drop the very records being resurrected (constraint #3).

The Manager returns via the unchanged `ensureManagerSession`; its window is recreated from the persisted command on the `forceRegister` path. No agent files were touched — the per-agent resume rules already live in each `autoLaunchCommand`.

## Verification

- **Unit / integration (added):** `TmuxBackend.cockpitSessionIsLive()` — alive→gone transition, fresh-backend-reads-socket (warm restart) case, unconfigured; pure `SessionService` takeover-policy tests.
- **Regression:** full **CrowTerminal (91)**, **CrowDaemon (113)**, and CrowEngine takeover suites green; `swift build` clean.
- **Manual (per ticket test plan):** start crowd with sessions on different agents, `tmux kill-server`, restart crowd → each terminal comes back with its agent resumed per `agentKind`; a plain crowd restart (no kill) still adopts and does **not** relaunch into live panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)