### PR TITLE
Restore session-detail Open in VS Code / Open Terminal + parity gates (CROW-749)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -76,6 +76,21 @@ private func prStatusJSON(_ pr: PRStatus) -> [String: JSONValue] {
     ]
 }
 
+/// Launch a detached GUI process on the daemon host (open the worktree in VS
+/// Code / a Terminal window). Fire-and-forget: we don't wait for the app to
+/// exit, we only surface a launch failure. Backs the `open-in-vscode` /
+/// `open-terminal` RPCs, which restore the retired native `SessionDetailView`'s
+/// "Open in VS Code" / "Open Terminal" buttons now that the web UI is the sole
+/// client (ADR 0007). The daemon uses a `NoopHostBridge`, so the old
+/// `SessionService.openInVSCode/openTerminal` do nothing here — the handler
+/// launches the process itself (CROW-749).
+private func launchHostProcess(_ executable: String, _ arguments: [String]) throws {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: executable)
+    proc.arguments = arguments
+    try proc.run()
+}
+
 /// Builds the daemon's `CommandRouter`. Handlers mirror the corresponding
 /// closures in the macOS app's `AppDelegate.startSocketServer`, but operate
 /// purely on `AppState` + `JSONStore` (+ `GitManager` / the tmux `cockpit`)
@@ -165,6 +180,10 @@ func makeCommandRouter(
                         // client was dead payload. A future consumer (scorecard
                         // / session strip) can add them back alongside its use.
                         "org_goal": session.orgGoal.map { .string($0) } ?? .null,
+                        // Project-board "In Review" permission gate — mirrors the
+                        // retired native `canSetProjectStatus(for:)` (GitHub/Jira
+                        // yes, GitLab no). Gates the web "In Review" button (CROW-749).
+                        "can_set_project_status": .bool(tracker?.canSetProjectStatus(for: session) ?? false),
                     ]
                     if let worktree = appState.primaryWorktree(for: session.id) {
                         object["repo"] = .string(worktree.repoName)
@@ -446,6 +465,53 @@ func makeCommandRouter(
             return ["dispatched": .bool(true), "action": .string(action.rawValue)]
         },
 
+        // Open the session's primary worktree in VS Code on the daemon host —
+        // restores the retired native "Open in VS Code" button (CROW-749). Gated
+        // to loopback callers in `RPCWebSocketHandler.localOnlyDenial` since it
+        // launches a GUI app on the host. Shown by the web only when the `code`
+        // CLI is present (see `vs_code_available` in get-config).
+        "open-in-vscode": { params in
+            guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
+                throw DaemonRPCError.invalidParams("session_id required")
+            }
+            let path = await MainActor.run { appState.primaryWorktree(for: id)?.worktreePath }
+            guard let path else {
+                throw DaemonRPCError.applicationError("No worktree for session")
+            }
+            guard let code = SessionService.findVSCodeBinary() else {
+                throw DaemonRPCError.applicationError("VS Code CLI not found")
+            }
+            do {
+                try launchHostProcess(code, [path])
+            } catch {
+                throw DaemonRPCError.applicationError("Failed to launch VS Code: \(error.localizedDescription)")
+            }
+            return ["opened": .bool(true)]
+        },
+
+        // Open a host Terminal window at the session's primary worktree —
+        // restores the retired native "Open Terminal" button (CROW-749). macOS
+        // only (native used NSWorkspace); loopback-gated like `open-in-vscode`.
+        "open-terminal": { params in
+            guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
+                throw DaemonRPCError.invalidParams("session_id required")
+            }
+            let path = await MainActor.run { appState.primaryWorktree(for: id)?.worktreePath }
+            guard let path else {
+                throw DaemonRPCError.applicationError("No worktree for session")
+            }
+            #if os(macOS)
+            do {
+                try launchHostProcess("/usr/bin/open", ["-a", "Terminal", path])
+            } catch {
+                throw DaemonRPCError.applicationError("Failed to open Terminal: \(error.localizedDescription)")
+            }
+            return ["opened": .bool(true)]
+            #else
+            throw DaemonRPCError.applicationError("Opening a host terminal is only supported on macOS")
+            #endif
+        },
+
         // Board data (Ticket Board / Reviews / Allowlist) is in-memory on the app
         // (IssueTracker / AllowListService), so these reads are forward-only.
         // Coding agents are registered in the daemon's own AgentRegistry at
@@ -678,6 +744,10 @@ func makeCommandRouter(
                     var entry: [String: JSONValue] = [
                         "remote_control_active": .bool(rcActive),
                         "remote_control_available": .bool(available),
+                        // PR quick-actions need a managed Claude Code terminal to
+                        // dispatch into — mirrors native `canDispatchQuickAction`.
+                        // The web disables the quick-action buttons when false (CROW-749).
+                        "can_dispatch": .bool(appState.terminals(for: id).contains { $0.isManaged }),
                     ]
                     entry["pr"] = appState.prStatus[id].map { .object(prStatusJSON($0)) }
                         ?? .object(["has_pr": .bool(false)])
@@ -805,6 +875,11 @@ func makeCommandRouter(
                 "app_running": .bool(false),
                 "configured": .bool(ConfigStore.loadDevRoot() != nil),
                 "default_dev_root": .string(defaultDevRoot),
+                // Host capability: is the VS Code `code` CLI installed? Gates the
+                // web "Open in VS Code" button, mirroring native `vsCodeAvailable`.
+                // Computed here (not off `sessionService`) so it's independent of
+                // tmux presence (CROW-749).
+                "vs_code_available": .bool(SessionService.findVSCodeBinary() != nil),
             ]
         },
         // Non-secret settings write. `defaults.binaries` is held to the same

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -88,6 +88,12 @@ private func launchHostProcess(_ executable: String, _ arguments: [String]) thro
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: executable)
     proc.arguments = arguments
+    // Reap the child: `code` / `/usr/bin/open` exit almost immediately, and
+    // Foundation only harvests the zombie once a `terminationHandler` or
+    // `waitUntilExit()` is attached. Without this the long-lived `crowd`
+    // daemon would accumulate defunct entries (matches the `terminationHandler`
+    // pattern already used in TmuxController / SessionService — review Yellow).
+    proc.terminationHandler = { _ in }
     try proc.run()
 }
 
@@ -502,7 +508,9 @@ func makeCommandRouter(
             }
             #if os(macOS)
             do {
-                try launchHostProcess("/usr/bin/open", ["-a", "Terminal", path])
+                // `--` terminates option parsing so an unusual worktree path can
+                // never be read as an `open` flag (defense in depth; review Green).
+                try launchHostProcess("/usr/bin/open", ["-a", "Terminal", "--", path])
             } catch {
                 throw DaemonRPCError.applicationError("Failed to open Terminal: \(error.localizedDescription)")
             }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -112,6 +112,8 @@ enum RPCWebSocketHandler {
     /// - `set-config` when `defaults.binaries` change: absolute local binary paths
     ///   that execute at the next agent launch (persistent RCE on an
     ///   unauthenticated non-loopback bind). Other `set-config` fields flow through.
+    /// - `open-in-vscode` / `open-terminal`: launch a GUI app on the daemon host
+    ///   at the worktree path — a remote peer must not spawn host processes (CROW-749).
     ///
     /// Scheduled `jobs` are intentionally NOT gated here (CROW-665): the Jobs
     /// editor is a core web-Settings surface, so an authenticated remote session
@@ -122,6 +124,11 @@ enum RPCWebSocketHandler {
         switch request.method {
         case "run-setup":
             return "run-setup is local-only"
+        case "open-in-vscode", "open-terminal":
+            // These launch a GUI app on the daemon host (VS Code / Terminal at
+            // the worktree path). Restrict to loopback callers — a remote web
+            // session must not spawn host processes (CROW-749).
+            return "opening host apps is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
             return "set-config binaries is local-only"

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -1073,6 +1073,17 @@ html, body {
 }
 @keyframes wizard-spin { to { transform: rotate(360deg); } }
 
+/* In-flight spinner for detail-header action buttons (In Review; CROW-749). */
+.action-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--gold);
+  border-radius: 50%;
+  animation: wizard-spin 0.7s linear infinite;
+}
+
 /* ---- Scorecard (ADR 0008 web parity, #721) ---- */
 .score-weeklabel { color: var(--text-secondary); font-size: 12px; }
 .score-banner {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -105,7 +105,7 @@ function onServerChanged() {
 // `changed`, so we load this on boot and re-load it when the Settings modal
 // saves (via `window.reloadUIConfig`). Mirrors the desktop's
 // `appState.hideSessionDetails`.
-const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false };
+const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false, vsCodeAvailable: false };
 async function loadUIConfig() {
   try {
     const res = await rpc('get-config');
@@ -114,6 +114,9 @@ async function loadUIConfig() {
     uiConfig.notifications = parseNotificationSettings(cfg.notifications);
     // Presence of the (secret-stripped) webAuth block means a web password is set.
     uiConfig.webPasswordSet = !!cfg.webAuth;
+    // Host capability: whether the VS Code `code` CLI is installed. Gates the
+    // "Open in VS Code" detail-header button (CROW-749).
+    uiConfig.vsCodeAvailable = !!(res && res.vs_code_available);
     // First-run gate: pointer absent → show the setup wizard (CROW-605).
     if (res && res.configured === false && !document.getElementById('wizard')) {
       showWizard(res.default_dev_root || '');
@@ -975,6 +978,8 @@ const ICONS = {
   wrench: '<path d="M11.8 2.4a2.8 2.8 0 0 0-3.3 3.7L2.9 11.7a1.3 1.3 0 0 0 1.8 1.8l5.6-5.6a2.8 2.8 0 0 0 3.7-3.3l-1.9 1.9-1.6-.4-.4-1.6z"/>',
   logout: '<path d="M6.5 3.5H3.5v9h3"/><path d="M12.5 8H6.5"/><path d="M10 5.5 12.5 8 10 10.5"/>',
   help: '<circle cx="8" cy="8" r="5.8"/><path d="M6.3 6.5a1.7 1.7 0 1 1 2.4 1.6c-.5.3-.7.6-.7 1.1v.3"/><path d="M8 11.3v.15"/>',
+  code: '<path d="M6 5 2.5 8 6 11"/><path d="M10 5l3.5 3-3.5 3"/>',
+  terminal: '<rect x="2" y="3" width="12" height="10" rx="1.5"/><path d="M4.5 6.5 6.5 8l-2 1.5"/><path d="M8 9.5h3"/>',
 };
 function icon(name, size) {
   const span = el('span', 'ico');
@@ -1253,7 +1258,7 @@ function sessionMenuItems(s) {
     items.push({ label: 'Delete', danger: true, action: () => deleteSession(s.id, s.name) });
     return items;
   }
-  if (s.status === 'active' && s.ticket_url) {
+  if (s.status === 'active' && s.ticket_url && s.can_set_project_status) {
     items.push({ label: 'Mark as In Review', action: () => sessionAction('mark-in-review', s.id) });
   }
   if ((s.status === 'active' || s.status === 'inReview') && s.ticket_url) {
@@ -1316,6 +1321,26 @@ async function openHandoffAgentMenu(session, anchorEl) {
 async function sessionAction(method, id, extra) {
   try { await rpc(method, Object.assign({ session_id: id }, extra || {})); }
   catch (e) { alertModal(method + ' failed: ' + (e.message || e)); }
+}
+
+// "In Review" with an in-flight spinner — mirrors native's ProgressView swap
+// while `isMarkingInReview` (CROW-749). On success the status transition pushes
+// a re-render that drops the button (status leaves `active`); on error we
+// restore the button and surface the failure.
+async function markInReviewAction(btn, id) {
+  if (!btn || btn.disabled) return;
+  btn.disabled = true;
+  const saved = btn.innerHTML;
+  btn.innerHTML = '';
+  btn.appendChild(el('span', 'action-spinner'));
+  try {
+    await rpc('mark-in-review', { session_id: id });
+    // Leave the button disabled: the ensuing state push re-renders the header.
+  } catch (e) {
+    btn.disabled = false;
+    btn.innerHTML = saved;
+    alertModal('mark-in-review failed: ' + (e.message || e));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1510,14 +1535,32 @@ function renderHeader(s) {
   // Right-aligned action cluster: PR quick-actions, then status transitions + delete.
   const actions = el('div', 'actions-cluster');
   if (pr && pr.has_pr && !pr.is_merged) {
-    if (pr.merge === 'conflicting') actions.appendChild(qaButton('Rebase & Fix Conflicts', 'fixConflicts', s.id, 'danger', 'merge'));
-    if (pr.review === 'changesRequested') actions.appendChild(qaButton('Address Review', 'addressChanges', s.id, 'danger', 'pencil'));
-    if (pr.checks === 'failing') actions.appendChild(qaButton('Fix Checks', 'fixChecks', s.id, 'danger', 'warning'));
-    if (pr.ready_to_merge) actions.appendChild(qaButton('Merge PR', 'mergePR', s.id, 'primary', 'merge'));
+    // Quick-actions dispatch a prompt into the session's managed Claude Code
+    // terminal — disable them when there is none (native `canDispatchQuickAction`;
+    // CROW-749). `can_dispatch` is absent until the daemon ships it, so treat only
+    // an explicit `false` as "no terminal".
+    const canDispatch = liveFor(s.id).can_dispatch !== false;
+    const qaOpts = { disabled: !canDispatch, title: canDispatch ? '' : 'No managed Claude Code terminal in this session' };
+    if (pr.merge === 'conflicting') actions.appendChild(qaButton('Rebase & Fix Conflicts', 'fixConflicts', s.id, 'danger', 'merge', qaOpts));
+    if (pr.review === 'changesRequested') actions.appendChild(qaButton('Address Review', 'addressChanges', s.id, 'danger', 'pencil', qaOpts));
+    if (pr.checks === 'failing') actions.appendChild(qaButton('Fix Checks', 'fixChecks', s.id, 'danger', 'warning', qaOpts));
+    if (pr.ready_to_merge) actions.appendChild(qaButton('Merge PR', 'mergePR', s.id, 'primary', 'merge', qaOpts));
   }
   if (s.kind !== 'manager') {
-    if (s.status === 'active' && s.ticket_url) {
-      actions.appendChild(actionBtn('In Review', 'eye', null, () => sessionAction('mark-in-review', s.id)));
+    // Open the primary worktree on the host (native "Open in VS Code" / "Open
+    // Terminal"; CROW-749). VS Code needs the `code` CLI installed; both need a
+    // worktree. Loopback-gated on the daemon.
+    if (s.worktree_path && uiConfig.vsCodeAvailable) {
+      actions.appendChild(actionBtn('Open in VS Code', 'code', null, () => sessionAction('open-in-vscode', s.id)));
+    }
+    if (s.worktree_path) {
+      actions.appendChild(actionBtn('Open Terminal', 'terminal', null, () => sessionAction('open-terminal', s.id)));
+    }
+    // In Review — active + linked ticket + a project-board-capable provider
+    // (native `canSetProjectStatus`). In-flight: swap to a spinner until the
+    // status transition lands and the re-render drops the button (CROW-749).
+    if (s.status === 'active' && s.ticket_url && s.can_set_project_status) {
+      actions.appendChild(actionBtn('In Review', 'eye', null, (ev) => markInReviewAction(ev.currentTarget, s.id)));
     }
     if (s.status === 'active' || s.status === 'inReview') {
       actions.appendChild(actionBtn('Mark as Completed', 'check', null, () => sessionAction('complete-session', s.id)));
@@ -1587,11 +1630,15 @@ function prStatusPart(text, color) {
   return part;
 }
 
-function qaButton(label, action, id, variant, iconName) {
+function qaButton(label, action, id, variant, iconName, opts) {
   const btn = el('button', 'action-btn' + (variant ? ' action-' + variant : ''), '');
   if (iconName) btn.appendChild(icon(iconName));
   btn.appendChild(el('span', null, label));
   btn.onclick = () => quickAction(id, action, label);
+  // Disabled state (no managed Claude Code terminal to dispatch into) mirrors
+  // native's `canDispatchQuickAction` gate; `.action-btn:disabled` styles it.
+  if (opts && opts.disabled) btn.disabled = true;
+  if (opts && opts.title) btn.title = opts.title;
   return btn;
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -105,7 +105,7 @@ function onServerChanged() {
 // `changed`, so we load this on boot and re-load it when the Settings modal
 // saves (via `window.reloadUIConfig`). Mirrors the desktop's
 // `appState.hideSessionDetails`.
-const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false, vsCodeAvailable: false };
+const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false, vsCodeAvailable: false, isLocal: false };
 async function loadUIConfig() {
   try {
     const res = await rpc('get-config');
@@ -117,6 +117,14 @@ async function loadUIConfig() {
     // Host capability: whether the VS Code `code` CLI is installed. Gates the
     // "Open in VS Code" detail-header button (CROW-749).
     uiConfig.vsCodeAvailable = !!(res && res.vs_code_available);
+    // Is this a local-direct connection? The host-action buttons (Open in VS
+    // Code / Open Terminal) launch apps on the daemon host and are loopback-gated
+    // server-side, so hide them from proxied/remote sessions where they'd only
+    // fail — same `/auth/context` signal the Settings secret editors use (CROW-749).
+    try {
+      const cr = await fetch('/auth/context', { cache: 'no-store' });
+      uiConfig.isLocal = cr.ok ? !!(await cr.json()).local : false;
+    } catch (_) { uiConfig.isLocal = false; }
     // First-run gate: pointer absent → show the setup wizard (CROW-605).
     if (res && res.configured === false && !document.getElementById('wizard')) {
       showWizard(res.default_dev_root || '');
@@ -1548,12 +1556,13 @@ function renderHeader(s) {
   }
   if (s.kind !== 'manager') {
     // Open the primary worktree on the host (native "Open in VS Code" / "Open
-    // Terminal"; CROW-749). VS Code needs the `code` CLI installed; both need a
-    // worktree. Loopback-gated on the daemon.
-    if (s.worktree_path && uiConfig.vsCodeAvailable) {
+    // Terminal"; CROW-749). These launch apps on the daemon host, so they're
+    // loopback-gated server-side and only shown to a local-direct session. VS
+    // Code additionally needs the `code` CLI installed; both need a worktree.
+    if (uiConfig.isLocal && s.worktree_path && uiConfig.vsCodeAvailable) {
       actions.appendChild(actionBtn('Open in VS Code', 'code', null, () => sessionAction('open-in-vscode', s.id)));
     }
-    if (s.worktree_path) {
+    if (uiConfig.isLocal && s.worktree_path) {
       actions.appendChild(actionBtn('Open Terminal', 'terminal', null, () => sessionAction('open-terminal', s.id)));
     }
     // In Review — active + linked ticket + a project-board-capable provider

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -714,6 +714,18 @@ import CrowPersistence
             == "run-setup is local-only")
     }
 
+    @Test func openHostAppsAreLocalOnly() {
+        // The host-launch RPCs spawn a GUI app (`code` / `/usr/bin/open`) on the
+        // daemon host — a remote `/rpc` peer must never reach them (CROW-749).
+        for method in ["open-in-vscode", "open-terminal"] {
+            let req = JSONRPCRequest(id: 1, method: method, params: [
+                "session_id": .string(UUID().uuidString),
+            ])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
+                == "opening host apps is local-only")
+        }
+    }
+
     @Test func setConfigBinariesChangeIsLocalOnly() throws {
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -1190,6 +1190,16 @@ public final class IssueTracker {
         return providerManager.codeBackend(for: provider)?.capabilities.contains(.autoMergeLabel) ?? false
     }
 
+    /// Whether `session` may be moved to a project-board "In Review" status —
+    /// i.e. its **task** backend declares `.projectBoardStatus`. Mirrors the
+    /// retired native `AppState.canSetProjectStatus(for:)` (GitHub Projects v2 /
+    /// Jira: yes; GitLab: no — ADR 0005), which gated the "In Review" button.
+    /// Restores that gate for the web UI (CROW-749).
+    public func canSetProjectStatus(for session: Session) -> Bool {
+        guard let provider = session.provider else { return false }
+        return providerManager.taskBackend(for: provider).capabilities.contains(.projectBoardStatus)
+    }
+
     /// For each non-archived, non-review session missing a `.pr` link with a
     /// resolvable (repoSlug, branch), query the provider directly and upsert
     /// a link when a PR exists on that branch. Runs once per refresh cycle

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -1194,10 +1194,17 @@ public final class IssueTracker {
     /// i.e. its **task** backend declares `.projectBoardStatus`. Mirrors the
     /// retired native `AppState.canSetProjectStatus(for:)` (GitHub Projects v2 /
     /// Jira: yes; GitLab: no — ADR 0005), which gated the "In Review" button.
-    /// Restores that gate for the web UI (CROW-749).
-    public func canSetProjectStatus(for session: Session) -> Bool {
+    /// Restores that gate for the web UI (CROW-749). Pure — unit-tested like
+    /// `canAddMergeLabel`.
+    public nonisolated static func canSetProjectStatus(session: Session, providerManager: ProviderManager) -> Bool {
         guard let provider = session.provider else { return false }
         return providerManager.taskBackend(for: provider).capabilities.contains(.projectBoardStatus)
+    }
+
+    /// Instance convenience over ``canSetProjectStatus(session:providerManager:)``
+    /// using this tracker's provider manager — the daemon's `list-sessions` gate.
+    public func canSetProjectStatus(for session: Session) -> Bool {
+        Self.canSetProjectStatus(session: session, providerManager: providerManager)
     }
 
     /// For each non-archived, non-review session missing a `.pr` link with a

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -2873,8 +2873,9 @@ public final class SessionService {
 
     // MARK: - VS Code Integration
 
-    /// Find the VS Code `code` CLI binary.
-    static func findVSCodeBinary() -> String? {
+    /// Find the VS Code `code` CLI binary. Pure (no actor state), so `nonisolated`
+    /// — the headless daemon calls it off the main actor to gate/launch VS Code.
+    public nonisolated static func findVSCodeBinary() -> String? {
         let candidates = [
             "/usr/local/bin/code",
             "/opt/homebrew/bin/code",

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
@@ -346,3 +346,33 @@ struct CanAddMergeLabelTests {
         #expect(!IssueTracker.canAddMergeLabel(session: s, providerManager: providerManager))
     }
 }
+
+/// CROW-749: the "In Review" button gates on the session's **task** backend
+/// declaring `.projectBoardStatus` — GitHub Projects v2 / Jira yes, GitLab no
+/// (ADR 0005). Restores the retired native `canSetProjectStatus` gate.
+@Suite("canSetProjectStatus — gates on task backend project-board capability")
+struct CanSetProjectStatusTests {
+    private let providerManager = ProviderManager()
+
+    private func session(provider: Provider?) -> Session {
+        Session(id: UUID(), name: "s", provider: provider)
+    }
+
+    @Test func gitHubTaskCanSetStatus() {
+        #expect(IssueTracker.canSetProjectStatus(session: session(provider: .github), providerManager: providerManager))
+    }
+
+    @Test func jiraTaskCanSetStatus() {
+        #expect(IssueTracker.canSetProjectStatus(session: session(provider: .jira), providerManager: providerManager))
+    }
+
+    @Test func gitLabTaskCannotSetStatus() {
+        // GitLab declares no `.projectBoardStatus` capability.
+        #expect(!IssueTracker.canSetProjectStatus(session: session(provider: .gitlab), providerManager: providerManager))
+    }
+
+    @Test func noProviderCannotSetStatus() {
+        // A provider-less session (e.g. the Manager) is never eligible.
+        #expect(!IssueTracker.canSetProjectStatus(session: session(provider: nil), providerManager: providerManager))
+    }
+}


### PR DESCRIPTION
Closes #749

## What & why

The web UI is now the sole client (ADR 0007), but its session-detail header had dropped two action buttons the retired native `SessionDetailView` rendered — **Open in VS Code** and **Open Terminal** — and two surviving buttons had lost conditional logic. This restores full parity. Cut from and targeting `feature/crow-593-web-ui-parity`.

## Changes

**New buttons (host actions)**
- **Open in VS Code** — new `open-in-vscode` daemon RPC launches `code <worktree>` on the host. Gate: primary worktree present **and** VS Code CLI installed. Availability is surfaced as `vs_code_available` on `get-config` (mirrors native `vsCodeAvailable`).
- **Open Terminal** — new `open-terminal` RPC opens Terminal.app at the worktree (macOS only). Gate: worktree present.
- Both RPCs are **loopback-gated** in `localOnlyDenial` since they spawn host processes. The daemon uses `NoopHostBridge`, so the handlers launch via `Process` directly rather than the dead `AppState.onOpenInVSCode/onOpenTerminal` hooks.

**Parity nits**
- **In Review** now also requires the provider's task backend to support `.projectBoardStatus` (new `IssueTracker.canSetProjectStatus(for:)`, surfaced as `can_set_project_status` per session — GitHub Projects v2 / Jira yes, GitLab no) and shows an **in-flight spinner** while the transition lands. Mirrors native `canSetProjectStatus` + `isMarkingInReview`. The context-menu entry gets the same gate.
- **PR quick-actions** are now **disabled** (with a tooltip) when the session has no managed Claude Code terminal, surfaced as `can_dispatch` on `list-sessions-live` (native `canDispatchQuickAction`).

`SessionService.findVSCodeBinary()` is made `public nonisolated` so the headless daemon reuses it for both the availability signal and the launch.

## Verification

`swift build` clean (only a pre-existing unrelated warning). `node --check` on `app.js`. Ran the freshly-built `crowd` against the live store and probed the RPC surface:
- `get-config.vs_code_available` → `true`
- `list-sessions.can_set_project_status` → `true` for GitHub work sessions, `false` for manager sessions (no provider)
- `list-sessions-live.can_dispatch` → `true` only for sessions with a managed terminal, `false` for the manager
- `open-terminal` / `open-in-vscode` reachable over the local socket with the expected error paths (`session_id required`, `No worktree for session`)

## Acceptance criteria
- [x] Web renders **Open in VS Code** (worktree + VS Code available) and **Open Terminal** (worktree), matching native gates
- [x] A daemon RPC backs each action to open the editor/terminal on the host
- [x] **In Review** replicates native's permission gate + in-flight spinner
- [x] PR quick-actions disabled when the session has no managed terminal
- [x] Branched from `feature/crow-593-web-ui-parity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbusPh4L5Mw6hW2HSb6ASg