### PR TITLE
fix(crow-desktop): expose WKWebView a11y tree so voice dictation pastes into sessions (CROW-750)

### DIFF
--- a/crow-desktop/src-tauri/Cargo.lock
+++ b/crow-desktop/src-tauri/Cargo.lock
@@ -572,6 +572,8 @@ name = "crow"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "objc2",
+ "objc2-app-kit",
  "serde",
  "serde_json",
  "tauri",

--- a/crow-desktop/src-tauri/Cargo.toml
+++ b/crow-desktop/src-tauri/Cargo.toml
@@ -29,3 +29,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 libc = "0.2"
 
+# macOS only: force-enable the WKWebView's out-of-process accessibility tree so
+# AX-based dictation/assistive tools (Wispr Flow) can find the focused editable
+# field (CROW-750). Both are already in the lockfile via wry's deps.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+# Only NSApplication is needed (we set one accessibility flag on it), so trim the
+# default AppKit feature surface to keep the build lean.
+objc2-app-kit = { version = "0.3", default-features = false, features = ["NSApplication", "NSResponder"] }
+

--- a/crow-desktop/src-tauri/src/lib.rs
+++ b/crow-desktop/src-tauri/src/lib.rs
@@ -90,6 +90,54 @@ fn wait_for_port(timeout: Duration) -> bool {
     false
 }
 
+/// Force-enable this app's accessibility so the embedded WKWebView exposes its
+/// web-content accessibility tree to the macOS Accessibility (AX) API (CROW-750).
+///
+/// The web UI runs in a WKWebView, which builds its AX tree out-of-process and
+/// only *lazily* — WebKit (like Chromium/Gecko) waits until the host app's
+/// `NSApplication.accessibilityEnhancedUserInterface` is set (the flag VoiceOver
+/// flips) before it exposes the DOM to the AX API. Safari sets this proactively;
+/// a bare wry WKWebView never does. So AX-based dictation tools (Wispr Flow) and
+/// other non-VoiceOver assistive clients see *no* focused text field and fall
+/// back to "click where to paste" instead of pasting on mic release. In a plain
+/// browser the tree is exposed, which is why dictation only breaks in the app.
+///
+/// We set the flag directly on our own `NSApplication` (the internal AppKit
+/// setter — self-targeting needs no accessibility permission). Note: driving the
+/// *same* attribute through the AX API against our own pid returns
+/// `kAXErrorNotImplemented` (that path is only meant for a second process like
+/// VoiceOver), so the direct property setter is the one that actually takes.
+///
+/// Must run on the main thread (it touches `NSApplication`). Known trade-off:
+/// this attribute also nudges some window-manager/zoom behavior once (it
+/// disables a couple of window animations) — benign for a single-window app.
+#[cfg(target_os = "macos")]
+fn enable_webkit_accessibility() {
+    use objc2::msg_send;
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        eprintln!("[crow-desktop] a11y enable skipped: not on the main thread");
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    // Safety: `app` is the live shared NSApplication; the selector takes a BOOL.
+    unsafe {
+        let _: () = msg_send![&app, setAccessibilityEnhancedUserInterface: true];
+        // Opt-in readback for verifying the flag actually took at runtime
+        // (`CROW_AX_DEBUG=1`); silent otherwise.
+        if std::env::var_os("CROW_AX_DEBUG").is_some() {
+            let on: bool = msg_send![&app, isAccessibilityEnhancedUserInterface];
+            eprintln!("[crow-desktop][a11y] accessibilityEnhancedUserInterface = {on}");
+        }
+    }
+}
+
+/// No-op on non-macOS: the AX/WKWebView plumbing this addresses is macOS-only.
+#[cfg(not(target_os = "macos"))]
+fn enable_webkit_accessibility() {}
+
 /// Native menu: a Crow app menu, standard Edit (so copy/paste shortcuts work in
 /// the web UI), a View menu with Reload (handy for a web frontend), and Window.
 fn build_menu(app: &tauri::App) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
@@ -151,6 +199,12 @@ pub fn run() {
         .setup(|app| {
             let menu = build_menu(app)?;
             app.set_menu(menu)?;
+
+            // Enable accessibility before the real UI loads so the WKWebView's
+            // WebContent process inherits the enabled state and exposes its AX
+            // tree to dictation/assistive tools (CROW-750). Re-asserted after
+            // navigate() below as belt-and-suspenders.
+            enable_webkit_accessibility();
 
             // Reuse an already-running crowd; otherwise spawn our own sidecar.
             // Only reuse a listener that identifies as crowd (review #7).
@@ -219,6 +273,13 @@ pub fn run() {
                     match format!("http://127.0.0.1:{}", port()).parse() {
                         Ok(url) => {
                             let _ = win.navigate(url);
+                            // Re-assert accessibility for the freshly navigated
+                            // document's WebContent process (CROW-750). The flag
+                            // is app-global, but re-setting it is cheap and keeps
+                            // the guarantee independent of process (re)spawn order.
+                            // We're on a worker thread here; the NSApplication
+                            // setter must run on the main thread.
+                            let _ = handle.run_on_main_thread(enable_webkit_accessibility);
                         }
                         Err(e) => eprintln!("[crow-desktop] bad crowd url: {e}"),
                     }


### PR DESCRIPTION
Closes #750

## Symptom

In the **desktop app**, dictating with Wispr Flow into a focused session terminal does nothing on mic release — Wispr behaves as if no text field is focused and asks you to click a paste target (its "can't find a focused field" / Scratchpad fallback). The **same web UI in a plain browser works fine.**

## Root cause (the browser-vs-app clue cracked it)

It's the desktop shell's **webview**, not the web page or xterm.

- The desktop app (`crow-desktop`, Tauri v2 / wry 0.55.1) spawns `crowd` and navigates its single window to `http://127.0.0.1:8787` (`crow-desktop/src-tauri/src/lib.rs`), so the web UI runs inside a **macOS WKWebView**. Per ADR 0010 the AppKit app is retired and this Tauri shell is now *the* native surface.
- Wispr Flow finds the focused editable field via the macOS **Accessibility (AX) API**. WKWebView builds its web-content AX tree **out-of-process and lazily** — WebKit (like Chromium/Gecko) waits until the host app's `NSApplication.accessibilityEnhancedUserInterface` flag is set (the flag VoiceOver flips) before it exposes the DOM to the AX API. Safari sets it proactively; a bare wry WKWebView never does. So non-VoiceOver AX clients (dictation tools, window managers — cf. Mozilla bug 1664992, Electron #7206) see no focused text field and fall back to click-to-paste.
- In a real browser the tree is exposed, so dictation works — exactly matching the observed behavior.

Ruled out (the ticket's original guesses): there is **no iframe** (xterm mounts in the top-level, same-origin document; `activeTerminal.window` is a *tmux* window; `index.html` even sets `frame-ancestors 'none'`), and xterm's hidden `.xterm-helper-textarea` is not the blocker — it works fine in a browser. A composer-overlay/`<textarea>` fix would **not** have helped, since it'd live in the same un-exposed WKWebView.

## Fix

Set `accessibilityEnhancedUserInterface = true` on our own `NSApplication` at startup, and re-assert it after the runtime `navigate(...)` to the crowd UI (via `objc2`/AppKit). Self-targeting needs no accessibility permission.

Two mechanisms were tried (empirically):

- ❌ Driving the same attribute through the **AX API** against our own pid (`AXUIElementSetAttributeValue`) returns `kAXErrorNotImplemented (-25208)` — that path is only meant for a *second* process like VoiceOver.
- ✅ The **direct AppKit property setter** (`-[NSApplication setAccessibilityEnhancedUserInterface:]`) takes; a gated `CROW_AX_DEBUG=1` readback confirms `accessibilityEnhancedUserInterface = true` at runtime.

### Trade-offs

- Setting this flag can nudge some window-manager/zoom behavior once at launch (it disables a couple of window animations — Apple forum 659755, Rectangle #129). Benign for this single-window app; watch for any launch-time window reposition.
- It's the same flag VoiceOver sets, so the app now behaves (accessibility-wise) as if an assistive client is attached. That's the intent — it's what makes the web content reachable to dictation/assistive tools generally, not just Wispr.

### Scope

macOS-only, additive, fails safe (it only sets an accessibility flag; if the set were ever a no-op, existing behavior is unchanged). No web-UI changes. Adds `objc2` + `objc2-app-kit` (`NSApplication` feature only) as macOS-only deps — both already in the lockfile via wry, so lockfile churn is just two dep entries.

## Files

- `crow-desktop/src-tauri/src/lib.rs` — `enable_webkit_accessibility()`; called in `setup()` and re-asserted (on the main thread) after `navigate(...)`.
- `crow-desktop/src-tauri/Cargo.toml` / `Cargo.lock` — macOS-only `objc2`/`objc2-app-kit` deps.

## Verification

- ✅ **Runtime readback** (this branch): `CROW_AX_DEBUG=1 ./crow-desktop/src-tauri/target/debug/Crow` logs `accessibilityEnhancedUserInterface = true` at both call sites; no errors; app starts/stops cleanly.
- ⏳ **Wispr Flow (behavioral, reviewer):** on a build of this branch (`make run`), select a session, focus the terminal, hold the Wispr mic, dictate, release — text should paste into the session input **with no extra click**.
- Optional: **Accessibility Inspector** (Xcode) targeting the `Crow` app → the focused terminal element resolves to an `AXTextArea` inside the web area (vs. not reachable before the fix).
- Regression sanity: normal typing, `Cmd+V`, right-click paste, and drag-drop file paste into the terminal still work; window behaves normally at launch.

## Follow-up

If Wispr still can't reach the field on some setups, the next lever is a WKWebView-scoped enable via Tauri's `with_webview` + `objc2-web-kit`; noted here rather than pre-emptively added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WEErRk9rgsvpM5e37Tj2j
