### PR TITLE
Enforce a single writer for store.json via a store-scoped flock

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -48,6 +48,23 @@ public enum CrowDaemon {
             exit(1)
         }
 
+        // Store-writer guard: the socket lock above is keyed to the socket, but
+        // `store.json` lives at a fixed app-support path regardless of --socket,
+        // so two daemons on DIFFERENT sockets would still both write it — and
+        // because every mutate rewrites the whole file, the loser's sessions
+        // vanish silently. Lock the store itself (fail closed) so exactly one
+        // crowd may write it, whatever --socket each was launched with (#759).
+        let storeDirectory = JSONStore.defaultDirectory
+        guard acquireStoreWriterLock(storeDirectory: storeDirectory) else {
+            log("FATAL: another process already holds the store writer lock for "
+                + "\(storeDirectory.path) — refusing to start. Only ONE crowd may write store.json, "
+                + "regardless of --socket. Stop the other daemon first (a second writer silently "
+                + "clobbers every session the first one knew about).")
+            exit(1)
+        }
+
+        log("started: pid \(getpid()); socket \(options.socketPath); store \(storeDirectory.appendingPathComponent("store.json").path)")
+
         let store = JSONStore()
         let git = GitManager()
         let appState = await seedAppState(from: store)
@@ -316,6 +333,13 @@ public enum CrowDaemon {
         if singleInstanceLockFD >= 0 {
             close(singleInstanceLockFD)
             singleInstanceLockFD = -1
+        }
+        // Same rationale for the store lock (#759): an inherited fd keeps the
+        // flock held, so the re-exec'd image's fail-closed store guard would
+        // refuse to start.
+        if storeWriterLockFD >= 0 {
+            close(storeWriterLockFD)
+            storeWriterLockFD = -1
         }
         guard let argv0 = argv.first, !argv0.isEmpty else {
             log("re-exec failed: empty argv")
@@ -717,6 +741,50 @@ public enum CrowDaemon {
             return false
         }
         singleInstanceLockFD = fd
+        return true
+    }
+
+    /// Held for the process lifetime once acquired — closing the fd drops the
+    /// `flock`. Separate from `singleInstanceLockFD` because it guards a
+    /// different resource: the STORE, not the socket. `nonisolated(unsafe)`:
+    /// written once during single-threaded startup, then only kept alive.
+    nonisolated(unsafe) private static var storeWriterLockFD: Int32 = -1
+
+    /// Enforce ONE writer of `store.json` regardless of `--socket`, via an
+    /// advisory `flock` on `<storeDirectory>/store.json.writer.lock`.
+    ///
+    /// The socket lock (`acquireSingleInstanceLock`) is keyed to the socket
+    /// path, but `store.json` lives at a fixed app-support location no matter
+    /// which `--socket` a daemon uses — so two daemons on different sockets both
+    /// pass the socket guard and then race the same file. Because
+    /// `JSONStore.mutate` rewrites the entire `StoreData`, a stale full-file
+    /// write silently clobbers every session the other writer knew about
+    /// ("all my sessions disappeared" — #759). This store-scoped lock closes
+    /// that gap.
+    ///
+    /// Unlike the socket lock, this one **fails CLOSED**: if the lock file can't
+    /// even be opened we refuse to run rather than write unguarded, because the
+    /// blast radius of a lost race is the user's entire session history.
+    /// Returns false when another live crowd already holds the store lock.
+    static func acquireStoreWriterLock(storeDirectory: URL) -> Bool {
+        // `open(O_CREAT)` needs the parent dir; on a fresh install it doesn't
+        // exist yet (JSONStore.init creates it, but we lock BEFORE constructing
+        // the store). Create it here so a first-run daemon locks cleanly instead
+        // of failing closed on ENOENT.
+        try? FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+        let lockPath = storeDirectory.appendingPathComponent("store.json.writer.lock").path
+        let fd = lockPath.withCString { open($0, O_CREAT | O_RDWR, 0o600) }
+        guard fd >= 0 else {
+            log("FATAL: could not open store writer lock \(lockPath) "
+                + "(\(String(cString: strerror(errno)))); refusing to start (fail closed) rather "
+                + "than write store.json unguarded and risk clobbering another writer's sessions.")
+            return false
+        }
+        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            close(fd)
+            return false
+        }
+        storeWriterLockFD = fd
         return true
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -192,6 +192,39 @@ import CrowPersistence
     }
 }
 
+/// One writer of `store.json`, regardless of `--socket` (#759). The socket lock
+/// above is keyed to the socket path, but the store lives at a fixed app-support
+/// location — so a distinct `--socket` alone does NOT isolate the store. This
+/// store-scoped flock rejects a second acquirer for the same store directory,
+/// while two daemons pointed at genuinely separate store directories coexist.
+@Suite struct StoreWriterLockTests {
+    private func tmpStoreDir() -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-store-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func secondAcquireForSameStoreDirIsRefused() {
+        let dir = tmpStoreDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // First writer wins; a second one — even launched with a *distinct*
+        // --socket — is refused because it targets the same store directory.
+        #expect(CrowDaemon.acquireStoreWriterLock(storeDirectory: dir) == true)
+        #expect(CrowDaemon.acquireStoreWriterLock(storeDirectory: dir) == false)
+    }
+
+    @Test func separateStoreDirsCoexist() {
+        let a = tmpStoreDir(), b = tmpStoreDir()
+        defer {
+            try? FileManager.default.removeItem(at: a)
+            try? FileManager.default.removeItem(at: b)
+        }
+        #expect(CrowDaemon.acquireStoreWriterLock(storeDirectory: a) == true)
+        #expect(CrowDaemon.acquireStoreWriterLock(storeDirectory: b) == true)   // genuinely separate stores still coexist
+    }
+}
+
 /// add-worktree input hardening (CROW-581 review): option-injection and orphan
 /// rows. Both checks run before any git/fs work, so no tmux/app is needed.
 @Suite struct AddWorktreeValidationTests {

--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -82,6 +82,21 @@ public final class JSONStore: Sendable {
     private let writeLock = NSLock()
     /// Highest sequence already persisted, guarded by `writeLock`.
     private nonisolated(unsafe) var lastWrittenSeq: UInt64 = 0
+    /// (mtime, size) of `store.json` as of our own last write/reload, or nil
+    /// until we've touched it. Guarded by `writeLock`. Lets us notice a SECOND
+    /// process writing the file out from under us: `JSONStore.mutate` rewrites
+    /// the whole `StoreData`, so a stray external write silently clobbers our
+    /// view. The daemon enforces a single writer via an flock (#759); this is
+    /// the diagnostic tripwire that makes any future bypass attributable in the
+    /// console the user already tails.
+    private nonisolated(unsafe) var lastWrittenSignature: FileSignature?
+
+    /// A cheap fingerprint of `store.json` — enough to spot that *someone else*
+    /// rewrote it since we last did (#759).
+    private struct FileSignature: Equatable {
+        let modified: Date
+        let size: Int
+    }
 
     public var data: StoreData {
         lock.lock()
@@ -93,6 +108,11 @@ public final class JSONStore: Sendable {
     /// `crowd` daemon) can watch it for external writes and `reload()`
     /// (CROW-581).
     public var storeURL: URL { fileURL }
+
+    /// The default on-disk directory for `store.json` — the shared app-support
+    /// dir, fixed regardless of any `--socket`. The daemon locks a file beside
+    /// the store here to enforce a single store writer (#759).
+    public static var defaultDirectory: URL { AppSupportDirectory.url }
 
     /// Last-modification date of `store.json`, or nil if it doesn't exist yet.
     /// Cheap change-detection for a polling reloader.
@@ -109,6 +129,13 @@ public final class JSONStore: Sendable {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard let decoded = try? decoder.decode(StoreData.self, from: data) else { return }
+        // Adopting a disk copy we didn't write is exactly the single-writer
+        // violation the tripwire watches for; check + re-baseline before we
+        // overwrite our in-memory view (#759).
+        writeLock.lock()
+        detectExternalWrite(context: "reload")
+        lastWrittenSignature = currentSignature()
+        writeLock.unlock()
         lock.lock()
         _data = decoded
         lock.unlock()
@@ -160,8 +187,38 @@ public final class JSONStore: Sendable {
         writeLock.lock()
         defer { writeLock.unlock() }
         guard mySeq > lastWrittenSeq else { return }
+        // Before overwriting the whole file, notice if a second writer touched
+        // it since our last write — otherwise its records vanish silently (#759).
+        detectExternalWrite(context: "before write")
         lastWrittenSeq = mySeq
         Self.save(snapshot, to: fileURL)
+        lastWrittenSignature = currentSignature()
+    }
+
+    /// Current `(mtime, size)` fingerprint of `store.json`, or nil if it can't
+    /// be stat'd (missing file / error). Diagnostic-only (#759).
+    private func currentSignature() -> FileSignature? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let modified = attrs[.modificationDate] as? Date,
+              let size = attrs[.size] as? Int else { return nil }
+        return FileSignature(modified: modified, size: size)
+    }
+
+    /// If `store.json` changed since our last write/reload, a SECOND process is
+    /// writing it — log LOUD and pid-stamped so the bypass is immediately
+    /// attributable. Diagnostic only: it never alters behavior (the flock in
+    /// `crowd` is the actual enforcement — #759). No-op until we've written once
+    /// (`lastWrittenSignature == nil`). Must be called under `writeLock`.
+    private func detectExternalWrite(context: String) {
+        guard let expected = lastWrittenSignature, let actual = currentSignature(),
+              actual != expected else { return }
+        NSLog(
+            "[JSONStore] EXTERNAL WRITE DETECTED (%@): store.json at %@ changed under pid %d "
+                + "— a second writer is touching store.json (expected mtime=%@ size=%d, "
+                + "found mtime=%@ size=%d). Whole-file writes mean the losing writer's sessions "
+                + "vanish; only ONE crowd may write this store.",
+            context, fileURL.path, getpid(),
+            "\(expected.modified)", expected.size, "\(actual.modified)", actual.size)
     }
 
     private static func save(_ data: StoreData, to url: URL) {


### PR DESCRIPTION
Closes #759

## Problem
Crow's single-writer invariant for `store.json` isn't enforced. The daemon's single-instance guard flocks `<socketPath>.lock` — keyed to the **socket**, not the store. `AppSupportDirectory.url` is fixed regardless of `--socket`, so two `crowd` processes on different sockets both pass the guard and write the same `store.json`. Because `JSONStore.mutate` rewrites the **entire** `StoreData`, a stale full-file write from the second writer silently clobbers every session the first knew about → "all my sessions disappeared" (children linger as orphans).

## Change
- **Store-scoped flock** (`acquireStoreWriterLock(storeDirectory:)`): locks `store.json.writer.lock` beside the store, acquired at startup **in addition** to the socket lock. A second `crowd` for the same store dir — any `--socket` — refuses to start. **Fails closed**: if the lock file can't be opened we refuse to run rather than write unguarded (blast radius = the user's whole session history). The socket lock's per-socket fail-*open* behavior is untouched.
- **External-writer tripwire** in `JSONStore`: remembers `(mtime, size)` after each write/`reload()`; before the next write and in `reload()`, stats the file and — if it changed under us — logs LOUD, pid-stamped `EXTERNAL WRITE DETECTED`. Diagnostic only; the flock is the enforcement.
- **Startup log line**: `pid` + socket + store path, so a second instance is obvious.
- `reexec` closes the store lock fd (no `O_CLOEXEC`) so the re-exec'd image can reacquire it instead of tripping its own fail-closed guard.
- On fresh installs the app-support dir is created before locking (we lock before constructing `JSONStore`, which normally creates it), so a first-run daemon doesn't fail closed on ENOENT.

## Tests
New `StoreWriterLockTests`: a second acquirer for the same store dir is refused; genuinely separate store dirs coexist. Existing `SingleInstanceLockTests` (socket) unchanged. All CrowPersistence + these daemon tests pass locally.

## Out of scope (separate follow-ups, per ticket)
Orphan GC for children of wiped sessions; a `deleteSession` guard refusing to force-destroy uncommitted work; decode-failure recovery from the newest good timestamped backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)