### PR TITLE
fix(crow-daemon): port reviewer-side re-review (shaAdvanced kickoff) (#756)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -443,15 +443,40 @@ public enum CrowDaemon {
         // startup are picked up; deduped by a (request, headSHA) fingerprint plus
         // the persisted reviewSessionID, and serialized so a burst can't race
         // duplicate clones. `onNewReviewRequests` is notification-only → dropped.
+        //
+        // Two kickoff conditions, ported from the legacy `AppDelegate` the
+        // headless migration dropped (ADR 0008 / CROW-756): (A) no session yet →
+        // create; (B) a linked session's `lastReviewedHeadSha` is stale vs. the
+        // PR's current head → complete the stale round and re-review the new head
+        // (force-push, or round-2 commits landing before Signal A —
+        // `decideReviewCompletions` rule 1 — completed round 1). The SHA-keyed
+        // fingerprint makes each head its own round so B isn't blocked by A.
         var autoReviewed: Set<String> = []
         tracker.onReviewRequestsRefreshed = { requests in
             let patterns = (config()?.workspaces ?? []).flatMap { $0.autoReviewRepos }
             guard !patterns.isEmpty else { return }
             for request in requests {
-                guard request.reviewSessionID == nil else { continue }
                 guard repoMatchesPatterns(request.repo, patterns: patterns) else { continue }
+                let linkedSession = request.reviewSessionID.flatMap { id in
+                    appState.sessions.first(where: { $0.id == id })
+                }
+                let action = IssueTracker.reviewKickoffAction(
+                    reviewSessionID: request.reviewSessionID,
+                    headRefOid: request.headRefOid,
+                    linkedSession: linkedSession,
+                    existingByPRSessionID: appState.existingReviewSession(forPRURL: request.url)?.id
+                )
+                guard action != .skip else { continue }
+                // SHA-keyed dedup: a new head is a fresh round; an unchanged head
+                // never re-kicks (also guards the in-flight clone window before
+                // the session's link/reviewSessionID land).
                 let fingerprint = "\(request.id)\n\(request.headRefOid ?? "")"
                 guard autoReviewed.insert(fingerprint).inserted else { continue }
+                // B-fallback: tear down the stale round-1 session before enqueuing
+                // so `reviewSessions` doesn't double up for this PR.
+                if case let .reReview(staleID) = action {
+                    appState.onCompleteSession?(staleID)
+                }
                 let url = request.url
                 Task { _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) } }
             }

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -2779,6 +2779,59 @@ public final class IssueTracker {
         return CompletionResult(completions: decisions, floorGuardTriggered: false)
     }
 
+    /// The reviewer-side auto-kickoff decision for a single review request,
+    /// mirroring the legacy `AppDelegate.onReviewRequestsRefreshed` guard
+    /// (retired in the headless-engine migration, ADR 0008). Pure so the
+    /// daemon's imperative shell (repo-pattern filter, SHA fingerprint dedup,
+    /// clone serializer) stays thin and this branch is unit-testable.
+    ///
+    /// - `.create`: no session exists for this PR yet — spawn a review session.
+    /// - `.reReview`: a linked session exists but the PR head advanced past the
+    ///   SHA it last reviewed (author pushed / force-pushed after a first pass).
+    ///   The stale session is completed and a fresh one spun up against the new
+    ///   head (CROW-290 keys each head as its own round; CROW-406's
+    ///   `existingByPR` guards the clone window). Carries the stale session ID
+    ///   so the caller tears it down before enqueuing.
+    /// - `.skip`: a session already covers this PR at the current head.
+    public enum ReviewKickoffAction: Equatable {
+        case skip
+        case create
+        case reReview(staleSessionID: UUID)
+    }
+
+    /// - Parameters:
+    ///   - reviewSessionID: the `ReviewRequest`'s cross-referenced session, or
+    ///     nil until `IssueTracker` repopulates it (lags the actual session by
+    ///     up to one refresh).
+    ///   - headRefOid: the PR's current head SHA (nil when unfetched — never
+    ///     re-reviews on a missing head).
+    ///   - linkedSession: the session resolved from `reviewSessionID`.
+    ///   - existingByPRSessionID: `AppState.existingReviewSession(forPRURL:)` —
+    ///     the authoritative link-based lookup that catches an in-flight kickoff
+    ///     before `reviewSessionID` is written back.
+    nonisolated public static func reviewKickoffAction(
+        reviewSessionID: UUID?,
+        headRefOid: String?,
+        linkedSession: Session?,
+        existingByPRSessionID: UUID?
+    ) -> ReviewKickoffAction {
+        // B-fallback: linked session exists but its last-reviewed head is
+        // stale relative to the PR's current head → re-review the new head.
+        let shaAdvanced = linkedSession != nil
+            && headRefOid != nil
+            && linkedSession?.lastReviewedHeadSha != headRefOid
+        if shaAdvanced, let staleID = reviewSessionID {
+            return .reReview(staleSessionID: staleID)
+        }
+        // Create only when nothing already covers this PR (belt-and-suspenders:
+        // the lagging `reviewSessionID` cross-ref plus the authoritative
+        // link-based lookup, so the ~10s clone window can't double-kick).
+        if reviewSessionID == nil && existingByPRSessionID == nil {
+            return .create
+        }
+        return .skip
+    }
+
     /// Decide which review sessions should be auto-completed. Three rules:
     ///   1. Viewer has submitted a formal review (APPROVED / CHANGES_REQUESTED
     ///      / DISMISSED) at a time strictly after `session.createdAt`. This

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReviewKickoffTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReviewKickoffTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowEngine
+
+/// Reviewer-side auto re-review decision (CROW-756). Covers the `shaAdvanced`
+/// branch and stale-session teardown the headless migration (ADR 0008) dropped
+/// when it ported `AppDelegate.onReviewRequestsRefreshed`.
+@Suite("IssueTracker review kickoff decisions")
+struct IssueTrackerReviewKickoffTests {
+
+    private func makeSession(
+        id: UUID = UUID(),
+        lastReviewedHeadSha: String? = nil
+    ) -> Session {
+        Session(
+            id: id,
+            name: "review",
+            status: .active,
+            kind: .review,
+            createdAt: Date(),
+            updatedAt: Date(),
+            lastReviewedHeadSha: lastReviewedHeadSha
+        )
+    }
+
+    // No session, no existing-by-PR → create a fresh review session.
+    @Test
+    func noExistingSessionCreates() {
+        let action = IssueTracker.reviewKickoffAction(
+            reviewSessionID: nil,
+            headRefOid: "sha-a",
+            linkedSession: nil,
+            existingByPRSessionID: nil
+        )
+        #expect(action == .create)
+    }
+
+    // Linked session whose last-reviewed head matches the PR head → nothing to
+    // do. This is the regression guard: an unchanged head must NOT re-kick.
+    @Test
+    func linkedSessionAtSameHeadSkips() {
+        let session = makeSession(lastReviewedHeadSha: "sha-a")
+        let action = IssueTracker.reviewKickoffAction(
+            reviewSessionID: session.id,
+            headRefOid: "sha-a",
+            linkedSession: session,
+            existingByPRSessionID: session.id
+        )
+        #expect(action == .skip)
+    }
+
+    // Author pushed a new head after the reviewer's first pass → complete the
+    // stale round-1 session and re-review the advanced head.
+    @Test
+    func advancedHeadReReviewsAndCarriesStaleID() {
+        let session = makeSession(lastReviewedHeadSha: "sha-a")
+        let action = IssueTracker.reviewKickoffAction(
+            reviewSessionID: session.id,
+            headRefOid: "sha-b",
+            linkedSession: session,
+            existingByPRSessionID: session.id
+        )
+        #expect(action == .reReview(staleSessionID: session.id))
+    }
+
+    // A round-1 session created before `lastReviewedHeadSha` existed (nil) must
+    // still re-review once the head is known, rather than sit idle forever.
+    @Test
+    func nilLastReviewedHeadReReviews() {
+        let session = makeSession(lastReviewedHeadSha: nil)
+        let action = IssueTracker.reviewKickoffAction(
+            reviewSessionID: session.id,
+            headRefOid: "sha-b",
+            linkedSession: session,
+            existingByPRSessionID: session.id
+        )
+        #expect(action == .reReview(staleSessionID: session.id))
+    }
+
+    // Head SHA not yet fetched → never re-review on a missing head (would
+    // otherwise thrash every session with a nil `headRefOid`).
+    @Test
+    func missingHeadDoesNotReReview() {
+        let session = makeSession(lastReviewedHeadSha: "sha-a")
+        let action = IssueTracker.reviewKickoffAction(
+            reviewSessionID: session.id,
+            headRefOid: nil,
+            linkedSession: session,
+            existingByPRSessionID: session.id
+        )
+        #expect(action == .skip)
+    }
+
+    // Clone window: the session + PR link exist (existingByPR resolves) but the
+    // lagging `reviewSessionID` cross-ref hasn't been written back yet. Must not
+    // double-kick a create.
+    @Test
+    func existingByPRWithoutReviewSessionIDSkips() {
+        let session = makeSession(lastReviewedHeadSha: "sha-a")
+        let action = IssueTracker.reviewKickoffAction(
+            reviewSessionID: nil,
+            headRefOid: "sha-a",
+            linkedSession: nil,
+            existingByPRSessionID: session.id
+        )
+        #expect(action == .skip)
+    }
+}


### PR DESCRIPTION
Closes #756

## Problem

A `crow:auto` **review session** never re-reviewed when the PR author pushed new commits after the reviewer's first pass — it sat idle on the stale head (repro: review-crow-753 idle after a new head landed following `CHANGES_REQUESTED`).

Regression from the headless-engine migration (ADR 0008): legacy `AppDelegate.onReviewRequestsRefreshed` had **two** kickoff conditions, but the daemon port kept only the create-once path and dropped the `shaAdvanced` re-kick. `Session.lastReviewedHeadSha` was written (`SessionService`) but **never read** on this branch — its only reader lived in the deleted `AppDelegate`.

## Fix

- **Extract `IssueTracker.reviewKickoffAction`** — a pure `.skip / .create / .reReview(staleSessionID:)` decision mirroring the legacy guard. Keeps the branch unit-testable and the daemon's imperative shell (repo-pattern filter, SHA fingerprint dedup, clone serializer) thin.
- **Wire it into `CrowDaemon.onReviewRequestsRefreshed`:** resolve the linked session (via `reviewSessionID`) + `existingReviewSession(forPRURL:)`, and on `shaAdvanced` (linked session's `lastReviewedHeadSha` != PR head) **complete the stale round-1 session** (`appState.onCompleteSession`, already wired) before enqueuing a fresh review against the new head.
- **Keep the SHA-keyed `(request, head)` fingerprint** so each head is its own round (an unchanged head never re-kicks) and the ~10s clone window can't double-create.

Model matches legacy: complete the old review session + spin up a **new** one for the new head. Agent-agnostic — works for review sessions of any `AgentKind` (reported case was Cursor). Signal A (`decideReviewCompletions` rule 1) is already ported; this adds Signal B, which covers force-push / round-2-before-A on its own.

## Tests

New `IssueTrackerReviewKickoffTests` (6 cases): create / skip-unchanged-head / reReview-advanced-head / reReview-nil-last-head / skip-missing-head / skip-clone-window. `make daemon` clean; full CrowEngine (303) + CrowDaemon (114) suites green.

## Sibling

Pairs with **#757** (manual "Re-review" button reusing this mechanism) — this lands the automated path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)