### PR TITLE
feat(web): per-kind PR quick action — Re-review on review sessions (#757)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/QuickAction.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/QuickAction.swift
@@ -17,6 +17,25 @@ public enum QuickAction: String, Sendable, Equatable {
     case fixChecks
     /// `isReadyToMerge` — merge the PR.
     case mergePR
+    /// `reviewStatus == .changesRequested` on a **review** session — re-run the
+    /// review on the author's latest head and post a fresh verdict. The
+    /// reviewer-side counterpart to `addressChanges`; never edits code (#757).
+    /// Manual counterpart to the automatic head-advance re-review (#756) —
+    /// both share `QuickActionPrompts.reReviewPrompt` so they can't drift.
+    case reReview
+
+    /// Whether this action modifies the code under review — commits/pushes to
+    /// the PR branch. A reviewer must never do this to the branch they review
+    /// (CROW-551), so `dispatchManual` refuses these on review sessions,
+    /// mirroring `AutoRespondCoordinator.shouldSkipReviewSession` on the manual
+    /// path (#757). `reReview` and `mergePR` are not code-modifying in this
+    /// sense and stay allowed.
+    public var modifiesCodeUnderReview: Bool {
+        switch self {
+        case .addressChanges, .fixChecks, .fixConflicts: return true
+        case .mergePR, .reReview:                        return false
+        }
+    }
 }
 
 /// Outcome of a manual `dispatchManual(action:sessionID:)` attempt. Lets callers
@@ -33,16 +52,21 @@ public enum QuickActionDispatchResult: Sendable, Equatable {
     case surfaceNotReady
     /// The session has no `.pr` link, so there's no PR to act on.
     case noPRLink
+    /// The action modifies the code under review but the session is a **review**
+    /// (reviewer) session — refused so the reviewer never commits to the branch
+    /// under review, mirroring `shouldSkipReviewSession` on the manual path (#757).
+    case forbiddenOnReviewSession
 
     public var isSent: Bool { self == .sent }
 
     /// User-facing reason a manual dispatch was skipped; `nil` when actually sent.
     public var skipReason: String? {
         switch self {
-        case .sent:              return nil
-        case .noManagedTerminal: return "no active agent terminal for this session"
-        case .surfaceNotReady:   return "the agent terminal isn't ready yet"
-        case .noPRLink:          return "this session has no linked PR"
+        case .sent:                     return nil
+        case .noManagedTerminal:        return "no active agent terminal for this session"
+        case .surfaceNotReady:          return "the agent terminal isn't ready yet"
+        case .noPRLink:                 return "this session has no linked PR"
+        case .forbiddenOnReviewSession: return "a reviewer can't modify the branch under review — use Re-review instead"
         }
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -458,7 +458,7 @@ func makeCommandRouter(
                 throw DaemonRPCError.invalidParams("session_id required")
             }
             guard let actionStr = params["action"]?.stringValue, let action = QuickAction(rawValue: actionStr) else {
-                throw DaemonRPCError.invalidParams("action required (fixConflicts, addressChanges, fixChecks, mergePR)")
+                throw DaemonRPCError.invalidParams("action required (fixConflicts, addressChanges, fixChecks, mergePR, reReview)")
             }
             // `dispatchManual` silently skips (no managed terminal / surface not
             // ready / no PR link); report that faithfully as `dispatched:false`

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1564,7 +1564,18 @@ function renderHeader(s) {
     const canDispatch = liveFor(s.id).can_dispatch !== false;
     const qaOpts = { disabled: !canDispatch, title: canDispatch ? '' : 'No managed Claude Code terminal in this session' };
     if (pr.merge === 'conflicting') actions.appendChild(qaButton('Rebase & Fix Conflicts', 'fixConflicts', s.id, 'danger', 'merge', qaOpts));
-    if (pr.review === 'changesRequested') actions.appendChild(qaButton('Address Review', 'addressChanges', s.id, 'danger', 'pencil', qaOpts));
+    if (pr.review === 'changesRequested') {
+      // Per-kind split (CROW-757): a reviewer must never modify the branch
+      // under review, so review sessions get "Re-review" (re-run the review on
+      // the author's latest head; never edits code) instead of "Address Review"
+      // (author fixes code + pushes). The daemon also refuses the code-changing
+      // actions on review sessions server-side (`dispatchManual` guard).
+      if (s.kind === 'review') {
+        actions.appendChild(qaButton('Re-review', 'reReview', s.id, 'primary', 'eye', qaOpts));
+      } else {
+        actions.appendChild(qaButton('Address Review', 'addressChanges', s.id, 'danger', 'pencil', qaOpts));
+      }
+    }
     if (pr.checks === 'failing') actions.appendChild(qaButton('Fix Checks', 'fixChecks', s.id, 'danger', 'warning', qaOpts));
     if (pr.ready_to_merge) actions.appendChild(qaButton('Merge PR', 'mergePR', s.id, 'primary', 'merge', qaOpts));
   }

--- a/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
@@ -83,6 +83,20 @@ public final class AutoRespondCoordinator {
     /// assuming success (#730).
     @discardableResult
     public func dispatchManual(action: QuickAction, sessionID: UUID) -> QuickActionDispatchResult {
+        let session = appState.sessions.first(where: { $0.id == sessionID })
+
+        // Reviewer policy on the manual path (#757). The auto path already gates
+        // this via `shouldSkipReviewSession`; `dispatchManual` never did, so a
+        // reviewer clicking "Address Review" would have Crow committing to the
+        // branch under review — exactly what CROW-551 forbids. Refuse the
+        // code-modifying actions on review sessions; `reReview` is the correct
+        // reviewer affordance and stays allowed.
+        if session?.kind == .review, action.modifiesCodeUnderReview {
+            NSLog("[QuickAction] Refusing %@ for session %@: review session must not modify the branch under review",
+                  action.rawValue, sessionID.uuidString)
+            return .forbiddenOnReviewSession
+        }
+
         let terminals = appState.terminals(for: sessionID)
         guard let terminal = terminals.first(where: { $0.isManaged }) else {
             NSLog("[QuickAction] Skipping %@ for session %@: no managed terminal",
@@ -105,7 +119,8 @@ public final class AutoRespondCoordinator {
             action: action,
             codeBackend: resolveCodeBackend(forSessionID: sessionID),
             prURL: prLink.url,
-            prNumber: prNumber
+            prNumber: prNumber,
+            lastReviewedHeadSha: session?.lastReviewedHeadSha
         )
         NSLog("[QuickAction] Sending %@ prompt to terminal %@ (%d chars)",
               action.rawValue, terminal.id.uuidString, prompt.count)
@@ -184,7 +199,7 @@ public enum AutoRespondPrompts {
 /// `addressChanges` and `fixChecks` cases delegate to `AutoRespondPrompts`
 /// so the auto and manual paths share a single source of truth.
 public enum QuickActionPrompts {
-    static func build(action: QuickAction, codeBackend: CodeBackend, prURL: String, prNumber: Int?) -> String {
+    static func build(action: QuickAction, codeBackend: CodeBackend, prURL: String, prNumber: Int?, lastReviewedHeadSha: String? = nil) -> String {
         let prRef = prNumber.map { "PR #\($0)" } ?? "the PR"
         let cli = codeBackend.cliName
 
@@ -228,7 +243,56 @@ public enum QuickActionPrompts {
                 mergeHint = "Run `\(cli) pr view \(prURL)` to verify the PR is in the expected state, then `cd \"$TMPDIR\" && \(cli) pr merge \(prURL) --squash --delete-branch` to merge. The `cd` keeps `gh`'s post-merge git cleanup (which runs in the CWD) from tripping when `main` is checked out in another worktree. If the repo uses a different merge strategy, adjust accordingly."
             }
             return "Merge \(prRef) (\(prURL)). \(mergeHint)\n"
+
+        case .reReview:
+            // Delegate to the shared re-review prompt so the manual button and
+            // #756's automatic head-advance re-review can't drift.
+            return reReviewPrompt(
+                codeBackend: codeBackend,
+                prURL: prURL,
+                prNumber: prNumber,
+                lastReviewedHeadSha: lastReviewedHeadSha
+            )
         }
+    }
+
+    /// Shared reviewer re-review prompt. Used by BOTH the manual **Re-review**
+    /// quick action (#757, via `build(action: .reReview, …)`) and the automatic
+    /// head-advance re-review (#756) — a single source of truth so the two paths
+    /// can't drift. Re-runs the review on the author's latest head and posts a
+    /// fresh verdict, exactly like `crow-review-pr`.
+    ///
+    /// Agent-agnostic (Cursor is the live repro, PR #753) and CLI-driven rather
+    /// than a slash command, so it works for agents without a Crow command
+    /// engine. Explicitly forbids editing code / committing / pushing: a
+    /// reviewer must never touch the branch under review (CROW-551).
+    ///
+    /// `lastReviewedHeadSha` scopes the diff to what changed since the previous
+    /// review when known; falls back to the full PR when it's `nil`.
+    static func reReviewPrompt(codeBackend: CodeBackend, prURL: String, prNumber: Int?, lastReviewedHeadSha: String?) -> String {
+        let prRef = prNumber.map { "PR #\($0)" } ?? "the PR"
+        let cli = codeBackend.cliName
+
+        // Scope-to-new-changes hint, only when we know the prior head.
+        let sinceHint: String
+        if let sha = lastReviewedHeadSha, !sha.isEmpty {
+            let short = String(sha.prefix(12))
+            sinceHint = "Focus on what changed since your last review with `git diff \(short)..HEAD` (review the whole PR if that range is empty or the SHA is missing locally)."
+        } else {
+            sinceHint = "Review the whole PR."
+        }
+
+        let syncHint: String
+        let reviewHint: String
+        if codeBackend.provider == .gitlab {
+            syncHint = "Run `\(cli) mr checkout \(prURL)` (then `git pull`) to sync your local checkout to the author's latest head."
+            reviewHint = "Post a fresh verdict with `\(cli) mr note`/approval per the crow-review-pr skill — never a bare comment."
+        } else {
+            syncHint = "Run `\(cli) pr checkout \(prURL)` to sync your local checkout to the author's latest head."
+            reviewHint = "Post a fresh verdict with `\(cli) pr review \(prURL) --request-changes` or `--approve` (never `--comment`), following the crow-review-pr skill's format and verdict rules."
+        }
+
+        return "The author pushed new changes to \(prRef) (\(prURL)) since your last review. Re-review it. \(syncHint) \(sinceHint) \(reviewHint) You are the reviewer: do NOT modify code, commit, or push — never touch the branch under review; only read, review, and post the review.\n"
     }
 
     /// Extract the trailing numeric segment from a PR/MR URL (e.g.

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -235,15 +235,15 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }
             },
             // CROW-581: trigger a PR-status quick action (fixConflicts /
-            // addressChanges / fixChecks / mergePR) — reuses the existing
-            // `onQuickAction` hook, which pastes the deterministic prompt into
-            // the session's managed agent terminal.
+            // addressChanges / fixChecks / mergePR / reReview) — reuses the
+            // existing `onQuickAction` hook, which pastes the deterministic
+            // prompt into the session's managed agent terminal.
             "quick-action": { @Sendable params in
                 guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
                     throw RPCError.invalidParams("session_id required")
                 }
                 guard let actionStr = params["action"]?.stringValue, let action = QuickAction(rawValue: actionStr) else {
-                    throw RPCError.invalidParams("action required (fixConflicts, addressChanges, fixChecks, mergePR)")
+                    throw RPCError.invalidParams("action required (fixConflicts, addressChanges, fixChecks, mergePR, reReview)")
                 }
                 await MainActor.run {
                     capturedAppState.onQuickAction?(id, action)

--- a/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
@@ -54,6 +54,70 @@ struct QuickActionPromptsTests {
     }
 }
 
+/// The reviewer-side re-review prompt (#757) must re-run the review on the
+/// author's latest head, post a verdict, and NEVER instruct the agent to edit
+/// code — that's the CROW-551 policy the manual button now honors. Shared with
+/// #756's automatic head-advance re-review via `QuickActionPrompts.reReviewPrompt`.
+@Suite("QuickActionPrompts.reReview")
+struct ReReviewPromptTests {
+
+    @Test func neverInstructsCodeChangesAndAlwaysPostsAVerdict() {
+        let prompt = QuickActionPrompts.build(
+            action: .reReview,
+            codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
+            prURL: "https://github.com/radiusmethod/crow/pull/753",
+            prNumber: 753,
+            lastReviewedHeadSha: "abcdef0123456789"
+        )
+        // Never touch the branch under review.
+        #expect(prompt.contains("do NOT modify code, commit, or push"))
+        // Re-runs the review + posts a verdict (not a bare comment).
+        #expect(prompt.contains("gh pr review https://github.com/radiusmethod/crow/pull/753 --request-changes"))
+        #expect(prompt.contains("--approve"))
+        #expect(prompt.contains("never `--comment`"))
+        // Single-line contract.
+        #expect(prompt.hasSuffix("\n"))
+        #expect(!prompt.dropLast().contains("\n"))
+    }
+
+    @Test func scopesDiffToLastReviewedHeadWhenKnown() {
+        let prompt = QuickActionPrompts.build(
+            action: .reReview,
+            codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
+            prURL: "https://github.com/radiusmethod/crow/pull/753",
+            prNumber: 753,
+            lastReviewedHeadSha: "abcdef0123456789deadbeef"
+        )
+        // Short SHA (12 chars) scopes the incremental diff.
+        #expect(prompt.contains("git diff abcdef012345..HEAD"))
+    }
+
+    @Test func fallsBackToFullPRWhenNoLastReviewedHead() {
+        let prompt = QuickActionPrompts.build(
+            action: .reReview,
+            codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
+            prURL: "https://github.com/radiusmethod/crow/pull/753",
+            prNumber: 753,
+            lastReviewedHeadSha: nil
+        )
+        #expect(prompt.contains("Review the whole PR."))
+        #expect(!prompt.contains("git diff"))
+    }
+
+    @Test func gitlabUsesGlabCli() {
+        let prompt = QuickActionPrompts.build(
+            action: .reReview,
+            codeBackend: FakeCodeBackend(provider: .gitlab, cliName: "glab"),
+            prURL: "https://gitlab.example.com/org/repo/-/merge_requests/45",
+            prNumber: 45,
+            lastReviewedHeadSha: nil
+        )
+        #expect(prompt.contains("glab mr checkout https://gitlab.example.com/org/repo/-/merge_requests/45"))
+        #expect(prompt.contains("do NOT modify code, commit, or push"))
+        #expect(prompt.hasSuffix("\n"))
+    }
+}
+
 /// A manual quick action must report whether it actually reached the agent so
 /// the web UI stops echoing a false "dispatched" for silent no-ops (#730).
 @Suite("AutoRespondCoordinator.dispatchManual")
@@ -73,9 +137,57 @@ struct DispatchManualResultTests {
     @Test func skipReasonIsNilOnlyWhenSent() {
         #expect(QuickActionDispatchResult.sent.isSent)
         #expect(QuickActionDispatchResult.sent.skipReason == nil)
-        for result in [QuickActionDispatchResult.noManagedTerminal, .surfaceNotReady, .noPRLink] {
+        for result in [QuickActionDispatchResult.noManagedTerminal, .surfaceNotReady, .noPRLink, .forbiddenOnReviewSession] {
             #expect(!result.isSent)
             #expect(result.skipReason?.isEmpty == false)
         }
+    }
+
+    /// #757 — the manual path must mirror `shouldSkipReviewSession`: a reviewer
+    /// clicking a code-changing action on a review session is refused before any
+    /// terminal work, so Crow never commits to the branch under review.
+    @Test func refusesCodeChangingActionsOnReviewSession() {
+        let appState = AppState()
+        let review = Session(name: "review-crow-753", kind: .review, agentKind: .cursor)
+        appState.sessions = [review]
+        let coordinator = AutoRespondCoordinator(
+            appState: appState, providerManager: ProviderManager(),
+            settingsProvider: { AutoRespondSettings() })
+        for action in [QuickAction.addressChanges, .fixChecks, .fixConflicts] {
+            #expect(coordinator.dispatchManual(action: action, sessionID: review.id) == .forbiddenOnReviewSession)
+        }
+    }
+
+    /// `reReview` is the reviewer's affordance — it must NOT be refused on a
+    /// review session. With no managed terminal it falls through to the normal
+    /// skip result rather than the review guard.
+    @Test func reReviewIsAllowedOnReviewSession() {
+        let appState = AppState()
+        let review = Session(name: "review-crow-753", kind: .review, agentKind: .cursor)
+        appState.sessions = [review]
+        let coordinator = AutoRespondCoordinator(
+            appState: appState, providerManager: ProviderManager(),
+            settingsProvider: { AutoRespondSettings() })
+        #expect(coordinator.dispatchManual(action: .reReview, sessionID: review.id) == .noManagedTerminal)
+    }
+
+    /// Author/work sessions are unaffected — code-changing actions still flow
+    /// through (here they reach the no-terminal skip, not the review guard).
+    @Test func doesNotRefuseCodeChangingActionsOnWorkSession() {
+        let appState = AppState()
+        let work = Session(name: "feature-crow-789", kind: .work, agentKind: .claudeCode)
+        appState.sessions = [work]
+        let coordinator = AutoRespondCoordinator(
+            appState: appState, providerManager: ProviderManager(),
+            settingsProvider: { AutoRespondSettings() })
+        #expect(coordinator.dispatchManual(action: .addressChanges, sessionID: work.id) == .noManagedTerminal)
+    }
+
+    @Test func modifiesCodeUnderReviewFlagsOnlyCodeChangingActions() {
+        #expect(QuickAction.addressChanges.modifiesCodeUnderReview)
+        #expect(QuickAction.fixChecks.modifiesCodeUnderReview)
+        #expect(QuickAction.fixConflicts.modifiesCodeUnderReview)
+        #expect(!QuickAction.reReview.modifiesCodeUnderReview)
+        #expect(!QuickAction.mergePR.modifiesCodeUnderReview)
     }
 }


### PR DESCRIPTION
Closes #757

## Summary

On a `changesRequested` PR, the quick action was rendered identically for **every** session kind, so a **reviewer** could click **Address Review** and have Crow commit to the branch under review — exactly what CROW-551 forbids. That policy was only ever enforced on the **auto** path (`shouldSkipReviewSession`); the **manual** `dispatchManual` path never gated it, in legacy `main` or crow-593.

This splits the action by session kind and closes the reviewer-policy gap on the manual path.

| session kind | button | action |
|---|---|---|
| work / job (author) | **Address Review** | `addressChanges` → fix code + push (**unchanged**) |
| review (reviewer) | **Re-review** | `reReview` → re-run the review on the author's latest head, post a verdict; **never edits code** |

## Changes

- **`QuickAction`** — add `case reReview` + `modifiesCodeUnderReview` (true for `addressChanges`/`fixChecks`/`fixConflicts`). New `QuickActionDispatchResult.forbiddenOnReviewSession` with a user-facing skip reason.
- **`dispatchManual`** — refuse the code-modifying actions on review sessions before any terminal work, mirroring `shouldSkipReviewSession`. `reReview`/`mergePR` stay allowed. Resolves + threads `lastReviewedHeadSha` into the prompt.
- **`QuickActionPrompts.reReviewPrompt`** — shared, agent-agnostic, CLI-driven re-review prompt. Scopes the diff to `lastReviewedHeadSha` when known (falls back to the full PR), tells the agent to post a fresh `--request-changes`/`--approve` verdict per the `crow-review-pr` rules, and **explicitly forbids editing code / committing / pushing**. Single source of truth so this ticket's manual button and **#756**'s automatic head-advance re-review can't drift — #756 can converge onto `reReviewPrompt`.
- **`app.js`** — render **Re-review** (`reReview`, eye icon) for `s.kind === 'review'`, else **Address Review**.
- **quick-action RPC validation** — `RPCHandlers.swift` + `EngineRouter.swift` action-list strings now include `reReview`.

## Relationship to #756

Pairs with **#756** (automatic reviewer re-review). This is the UI + manual-override sibling: the button, the per-kind split, and the never-touch-code guard. Both branch off `main` independently; the shared `reReviewPrompt` is written so #756 converges onto it (user manages merge order).

## Verification

- `swift build` clean; every `QuickAction` switch stayed exhaustive.
- 16 CrowEngine tests pass (new `QuickActionPrompts.reReview` suite + dispatchManual review-guard tests) — covers: never instructs code changes / always posts a verdict, diff scoped to `lastReviewedHeadSha`, full-PR fallback, GitLab CLI variant, `addressChanges`/`fixChecks`/`fixConflicts` refused on review sessions, `reReview` allowed on review sessions, work sessions unaffected.
- CrowDaemon `LocalLiveActionTests` (20 tests) pass; no test asserted the old validation string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)