### PR TITLE
Isolate tests from the live store; trap default-path JSONStore under tests (#764)

### DIFF
--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
@@ -19,7 +19,7 @@ import CrowPersistence
     private func offlineRouter() -> CommandRouter {
         makeCommandRouter(
             appState: AppState(),
-            store: JSONStore(),
+            store: JSONStore.temporary(),
             git: GitManager(),
             devRoot: NSTemporaryDirectory(),
             cockpit: nil)
@@ -115,7 +115,7 @@ import CrowPersistence
         AgentRegistry.shared.register(ClaudeCodeAgent())
 
         let router = makeCommandRouter(
-            appState: AppState(), store: JSONStore(), git: GitManager(),
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
             devRoot: NSTemporaryDirectory(), cockpit: nil)
 
         let resp = await router.handle(request: JSONRPCRequest(id: 1, method: "list-agents"))
@@ -142,9 +142,9 @@ import CrowPersistence
                 url: "https://github.com/acme/api/issues/7", repo: "acme/api",
                 provider: .github, projectStatus: .backlog),
         ]
-        let tracker = IssueTracker(appState: appState, providerManager: ProviderManager())
+        let tracker = IssueTracker(appState: appState, providerManager: ProviderManager(), store: .temporary())
         let router = makeCommandRouter(
-            appState: appState, store: JSONStore(), git: GitManager(),
+            appState: appState, store: JSONStore.temporary(), git: GitManager(),
             devRoot: NSTemporaryDirectory(), cockpit: nil, tracker: tracker)
 
         let resp = await router.handle(request: JSONRPCRequest(id: 1, method: "list-tickets"))
@@ -159,7 +159,7 @@ import CrowPersistence
         appState.allowEntries = [AllowEntry(pattern: "Bash(npm test:*)", sources: [.global])]
         let allowList = AllowListService(appState: appState, devRoot: NSTemporaryDirectory())
         let router = makeCommandRouter(
-            appState: appState, store: JSONStore(), git: GitManager(),
+            appState: appState, store: JSONStore.temporary(), git: GitManager(),
             devRoot: NSTemporaryDirectory(), cockpit: nil, allowList: allowList)
 
         let resp = await router.handle(request: JSONRPCRequest(id: 1, method: "list-allowlist"))
@@ -188,7 +188,7 @@ import CrowPersistence
     @MainActor
     private func offlineRouter(devRoot: String) -> CommandRouter {
         makeCommandRouter(
-            appState: AppState(), store: JSONStore(), git: GitManager(),
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
             devRoot: devRoot, cockpit: nil)
     }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -198,7 +198,7 @@ import CrowPersistence
     @MainActor
     private func router() -> CommandRouter {
         makeCommandRouter(
-            appState: AppState(), store: JSONStore(), git: GitManager(),
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
             devRoot: NSTemporaryDirectory(), cockpit: nil)
     }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/JSONStore+Temporary.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/JSONStore+Temporary.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CrowPersistence
+
+extension JSONStore {
+    /// A `JSONStore` isolated to a unique temp directory, so a test never opens
+    /// or mutates the live `~/Library/Application Support/crow/store.json`
+    /// (#764, ADR 0012). Mirrors `LocalStatusTests.seededRouter`'s pattern.
+    /// Always prefer this over a bare `JSONStore()` in tests — the bare form now
+    /// traps under a test process.
+    static func temporary() -> JSONStore {
+        JSONStore(directory: URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-test-\(UUID().uuidString)"))
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
@@ -21,7 +21,7 @@ import CrowPersistence
     @MainActor
     private func offlineRouter(appState: AppState) -> CommandRouter {
         makeCommandRouter(
-            appState: appState, store: JSONStore(), git: GitManager(),
+            appState: appState, store: JSONStore.temporary(), git: GitManager(),
             devRoot: NSTemporaryDirectory(), cockpit: nil)
     }
 
@@ -110,7 +110,7 @@ import CrowPersistence
         jobScheduler: JobScheduler? = nil
     ) -> CommandRouter {
         makeCommandRouter(
-            appState: appState, store: JSONStore(), git: GitManager(),
+            appState: appState, store: JSONStore.temporary(), git: GitManager(),
             devRoot: NSTemporaryDirectory(), cockpit: nil,
             tracker: tracker, sessionService: sessionService, autoRespond: autoRespond,
             jobScheduler: jobScheduler)
@@ -130,7 +130,7 @@ import CrowPersistence
         // Tracker present → the local path is entered; a missing session_id is
         // then a param error (proves we didn't stop at the tracker guard).
         let appState = AppState()
-        let tracker = IssueTracker(appState: appState, providerManager: ProviderManager())
+        let tracker = IssueTracker(appState: appState, providerManager: ProviderManager(), store: .temporary())
         for method in ["mark-issue-done", "add-merge-label"] {
             let resp = await router(appState: appState, tracker: tracker)
                 .handle(request: JSONRPCRequest(id: 1, method: method))
@@ -149,7 +149,7 @@ import CrowPersistence
     @Test @MainActor func deleteSessionRejectsManagerSession() async {
         let appState = AppState()
         let service = SessionService(
-            store: JSONStore(), appState: appState,
+            store: JSONStore.temporary(), appState: appState,
             providerManager: ProviderManager(), hostBridge: NoopHostBridge())
         let resp = await router(appState: appState, sessionService: service).handle(request: JSONRPCRequest(
             id: 1, method: "delete-session",
@@ -172,7 +172,7 @@ import CrowPersistence
         // param error (proves we didn't stop at the scheduler guard).
         let appState = AppState()
         let service = SessionService(
-            store: JSONStore(), appState: appState,
+            store: JSONStore.temporary(), appState: appState,
             providerManager: ProviderManager(), hostBridge: NoopHostBridge())
         let scheduler = JobScheduler(appState: appState, sessionService: service)
         let resp = await router(appState: appState, jobScheduler: scheduler)
@@ -299,8 +299,11 @@ import CrowPersistence
         AgentRegistry.shared.register(ClaudeCodeAgent())
         // A session that completed before this daemon started: its snapshot lives
         // in store.json, but a fresh appState is empty until reseed mirrors it.
-        let session = Session(name: "s", kind: .work, agentKind: .claudeCode)
-        let store = JSONStore()
+        // Sentinel fixture name (#764): if this ever reached a real store despite
+        // the guardrail, the stray record names itself as test data instead of
+        // masquerading as corruption (the lone survivor here was named "s").
+        let session = Session(name: "__TEST__SessionAnalyticsStrip", kind: .work, agentKind: .claudeCode)
+        let store = JSONStore.temporary()
         store.mutate { data in
             data.sessions = [session]
             data.analyticsSnapshots = [session.id.uuidString: snapshot(for: session.id)]
@@ -324,7 +327,7 @@ import CrowPersistence
         let session = Session(name: "s", kind: .work, agentKind: .claudeCode)
         let appState = AppState()
         appState.sessions = [session]
-        let resp = await router(appState: appState, store: JSONStore())
+        let resp = await router(appState: appState, store: JSONStore.temporary())
             .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
         let entry = resp.result?["sessions"]?.objectValue?[session.id.uuidString]?.objectValue
         #expect(entry != nil)
@@ -337,7 +340,7 @@ import CrowPersistence
         let appState = AppState()
         appState.sessions = [manager]
         appState.analyticsSnapshots[manager.id.uuidString] = snapshot(for: manager.id)
-        let resp = await router(appState: appState, store: JSONStore())
+        let resp = await router(appState: appState, store: JSONStore.temporary())
             .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
         let entry = resp.result?["sessions"]?.objectValue?[manager.id.uuidString]?.objectValue
         #expect(entry != nil)

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -233,7 +233,7 @@ public final class IssueTracker {
     /// fails; a restart retries, which is the desired recovery path.
     private var changedFilesFetchAttempted: Set<String> = []
 
-    public init(appState: AppState, providerManager: ProviderManager, store: JSONStore = JSONStore()) {
+    public init(appState: AppState, providerManager: ProviderManager, store: JSONStore) {
         self.appState = appState
         self.providerManager = providerManager
         self.store = store

--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -115,7 +115,21 @@ public final class JSONStore: Sendable {
     }
 
     public init(directory: URL? = nil) {
-        let dir = directory ?? AppSupportDirectory.url
+        let dir: URL
+        if let directory {
+            dir = directory
+        } else {
+            // Test-isolation guardrail (#764, ADR 0012): a bare `JSONStore()`
+            // under a test process would open the LIVE store
+            // (~/Library/Application Support/crow/store.json) and a subsequent
+            // full-snapshot `mutate` would wipe the developer's real sessions —
+            // exactly the incident this ticket fixed. Trap loudly instead of
+            // silently mutating live data. Only the default (nil-directory) path
+            // is gated, so explicit-temp-dir test stores and production `crowd`
+            // (never run under a test runner) are both unaffected.
+            Self.trapIfConstructingLivePathUnderTests()
+            dir = AppSupportDirectory.url
+        }
 
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.fileURL = dir.appendingPathComponent("store.json")
@@ -137,6 +151,41 @@ public final class JSONStore: Sendable {
         } else {
             self._data = StoreData()
         }
+    }
+
+    /// Fail-fast when a `JSONStore()` with no explicit `directory:` is built
+    /// inside a test process. Covers the runners Crow's suites actually use:
+    ///
+    /// - **swift-testing via SwiftPM** (`swift test` / `make test`, the path in
+    ///   #764): the host executable is `swiftpm-testing-helper`; XCTest is *not*
+    ///   linked and no XCTest env vars are set, so we key off the runner name.
+    /// - **XCTest / Xcode**: `XCTestCase` is linked into the test bundle, and the
+    ///   host runs from an `.xctest` bundle with `XCTestConfigurationFilePath` set.
+    ///
+    /// None of these signals are present in the shipping `crowd`/app binaries, so
+    /// production is never gated. See `docs/adr/0012-tests-never-touch-live-data.md`.
+    private static func isRunningUnderTests() -> Bool {
+        if NSClassFromString("XCTestCase") != nil { return true }
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestConfigurationFilePath"] != nil || env["XCTestBundlePath"] != nil { return true }
+        let arg0 = CommandLine.arguments.first
+        let runnerNames: Set<String> = ["swiftpm-testing-helper", "xctest"]
+        if let base = (arg0 as NSString?)?.lastPathComponent, runnerNames.contains(base) { return true }
+        if runnerNames.contains(ProcessInfo.processInfo.processName) { return true }
+        if arg0?.contains(".xctest") == true { return true }
+        return false
+    }
+
+    private static func trapIfConstructingLivePathUnderTests() {
+        guard isRunningUnderTests() else { return }
+        fatalError("""
+            JSONStore() was constructed with the default LIVE store path \
+            (\(AppSupportDirectory.url.appendingPathComponent("store.json").path)) \
+            under a test process. A full-store `mutate` would clobber the \
+            developer's real sessions (#764). Inject an explicit temp directory \
+            instead — e.g. `JSONStore.temporary()` or \
+            `JSONStore(directory: NSTemporaryDirectory()…)`. See ADR 0012.
+            """)
     }
 
     public func mutate(_ transform: (inout StoreData) -> Void) {

--- a/docs/adr/0012-tests-never-touch-live-data.md
+++ b/docs/adr/0012-tests-never-touch-live-data.md
@@ -1,0 +1,90 @@
+# 0012 — Tests must never touch live application data
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+- **Deciders:** @dgershman
+
+## Context
+
+Crow persists sessions, worktrees, terminals, and links to a single JSON file at
+`~/Library/Application Support/crow/store.json`, owned by `JSONStore`. `JSONStore`
+defaults its directory to that live App Support path when constructed with no
+`directory:` argument (`JSONStore(directory: URL? = nil)`), and `mutate` is a
+read-modify-write of the *entire* `StoreData` snapshot.
+
+Those two facts combined are a footgun for tests. `SessionAnalyticsStripLiveTests`
+constructed a bare `JSONStore()` and did `data.sessions = [session]` inside
+`mutate` — reading the developer's N real sessions and replacing them with one
+throwaway fixture named `"s"`. Running `swift test --package-path Packages/CrowDaemon`
+(and therefore `make test`) on a machine with a real Crow install silently wiped
+the session list; the suite still passed green (#764). This is the same
+full-snapshot-overwrite class as the intra-process clobber (#728) and the
+cross-process lock gap (#759), but a third variant: **a test opening the live
+store path**.
+
+Convention ("tests should pass a temp `directory:`") had already been followed by
+most suites, but one slip destroyed live data with no signal. The offending
+fixture's single-letter name (`"s"`) read like corrupted data rather than test
+output, so it wasn't even obvious a *test* had done it — costing investigation
+time.
+
+## Decision
+
+Tests never read or write the live data store. This is enforced structurally, not
+by convention:
+
+1. **`JSONStore.init` traps under a test process** when constructed with the
+   default (nil) directory. Detection covers the runners Crow's suites use: the
+   swift-testing SwiftPM host (`swift test` / `make test`) runs as
+   `swiftpm-testing-helper`, and XCTest/Xcode hosts link `XCTestCase`, set
+   `XCTestConfigurationFilePath`, and run from an `.xctest` bundle. None of those
+   signals appear in the shipping `crowd`/app binaries. Only the default path is
+   gated — explicit `directory:` constructions and production are unaffected.
+2. **No production API defaults its store to the live path.** `IssueTracker`'s
+   `store: JSONStore = JSONStore()` default is removed; callers inject explicitly
+   (production already does; tests pass a temp store). Compile-time enforcement is
+   preferred over relying on the runtime trap.
+3. **Tests inject an isolated temp store**, via the `JSONStore.temporary()` helper
+   (a unique `NSTemporaryDirectory()/crow-test-<uuid>` directory).
+4. **Persisted test fixtures use self-identifying sentinel names** (e.g.
+   `__TEST__SessionAnalyticsStrip`), so any record that ever reaches a real store
+   despite the guardrail names itself as test data and points at its suite, rather
+   than masquerading as corruption.
+
+## Consequences
+
+- A bare `JSONStore()` in a test now fails loudly and immediately with an
+  actionable message, instead of silently mutating live data. Reintroducing the
+  bug is impossible to miss.
+- New test authors get a compile error (missing `store:` on `IssueTracker`) or a
+  fatal error (bare `JSONStore()`) that both point at the right fix.
+- The guardrail is a heuristic on "am I under a test runner," not a hard
+  capability boundary. It relies on production binaries never running as
+  `swiftpm-testing-helper`/`xctest` nor linking XCTest — true today for `crowd`
+  and the app. A future target that runs tests through a different host would need
+  to extend the detector.
+- One extra indirection in tests (`JSONStore.temporary()` instead of
+  `JSONStore()`), which also makes the isolation intent explicit at the call site.
+
+## Alternatives considered
+
+- **Convention only ("remember to pass a temp dir").** This is what we had; one
+  slip wiped live data with a green suite. Rejected — the failure mode is silent
+  and destructive.
+- **A separate test-only `JSONStore` subclass/type.** More surface area and a
+  parallel type to keep in sync; the nil-directory trap achieves the same
+  guarantee against the real type callers actually use.
+- **Redirect App Support to a temp dir for the whole test process (env/`HOME`
+  override).** Fragile across runners and hides the real defect (a test reaching
+  for the live path at all); the trap makes that reach an error rather than
+  quietly relocating it.
+
+## References
+
+- PR: https://github.com/corveil/crow/pull/765
+- Ticket: https://github.com/corveil/crow/issues/764
+- Related: #728 (intra-process throwaway clobber), #759 (cross-process store lock)
+- Code:
+  - `Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift` (init guardrail)
+  - `Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift` (dropped live-store default)
+  - `Packages/CrowDaemon/Tests/CrowDaemonTests/JSONStore+Temporary.swift` (`temporary()` helper)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0009 | [crowd is the sole authority; every UI is a pure client](./0009-crowd-sole-authority-clients-only.md) | Accepted | 2026-07-05 |
 | 0010 | [Retire the macOS app; the web UI is the only client](./0010-retire-the-macos-app.md) | Accepted | 2026-07-07 |
 | 0011 | [Mid-session agent handoff preserves Crow identity, not chat history](./0011-agent-handoff-preserves-session-not-chat.md) | Accepted | 2026-07-09 |
+| 0012 | [Tests must never touch live application data](./0012-tests-never-touch-live-data.md) | Accepted | 2026-07-19 |


### PR DESCRIPTION
Closes #764

## Problem

Running the CrowDaemon suite (`swift test --package-path Packages/CrowDaemon`, and therefore `make test`) **overwrote the developer's live `~/Library/Application Support/crow/store.json`**, wiping real sessions down to one throwaway named `"s"`. `SessionAnalyticsStripLiveTests` constructed a bare `JSONStore()` (default directory = the live path) and did `data.sessions = [session]` inside a full-snapshot `mutate`, replacing the real N sessions with one fixture. The suite passed green — silent data loss. Same overwrite class as #728 (intra-process) and #759 (cross-process); this is the **test-isolation** variant.

## Fix

1. **Guardrail in `JSONStore.init`** — when built with the default (nil) `directory:` under a test runner, `fatalError` with an actionable message instead of opening the live store. Detects the swift-testing SwiftPM host (`swiftpm-testing-helper`, the exact runner in #764) and XCTest/Xcode hosts (`XCTestCase` linked / `XCTestConfigurationFilePath` / `.xctest` bundle). None of these fire in the shipping `crowd`/app binaries. Only the nil-directory path is gated — explicit temp dirs and production are unaffected.
2. **Drop `IssueTracker`'s `store: JSONStore = JSONStore()` default** so callers inject explicitly (compile-time enforcement). Production already injects (`CrowDaemon.swift:83`); the two test sites now pass a temp store.
3. **Convert every bare `JSONStore()` in CrowDaemon tests** to an injected temp dir via a new `JSONStore.temporary()` helper (LocalLiveActionTests, BoardForwarderTests, DaemonSecurityTests).
4. **Sentinel fixture name** — the offending persisted fixture `"s"` → `"__TEST__SessionAnalyticsStrip"`, so any record that ever reaches a real store despite the guardrail names itself as test data instead of masquerading as corruption.
5. **ADR 0012** documents the invariant: tests never touch live application data.

## Verification

- Full **CrowDaemon suite green (114 tests)**; the live `store.json` mtime + size + session count were **byte-identical** before and after the run (`sessions=2 ['Manager', 'crow-764-test-store-isolation']`). Before this fix, that run reduced it to 1 session named `"s"`.
- A **reintroduced bare `JSONStore()`** traps loudly under the swift-testing runner:
  `Fatal error: JSONStore() was constructed with the default LIVE store path (…/store.json) under a test process … Inject an explicit temp directory … See ADR 0012.`
- **CrowPersistence (45)** and **CrowEngine (297)** suites also green (dropped default + guardrail break neither).

## Related

- #728 (intra-process throwaway clobber — fixed)
- #759 (cross-process store lock — open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)