### PR TITLE
Reinstate the per-launch dev-root scaffold on the daemon startup path

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -86,6 +86,18 @@ public enum CrowDaemon {
         // same store-backed binary overrides (CROW-581, M-B).
         await registerAgents(devRoot: options.devRoot)
 
+        // Refresh the dev-root scaffold — bundled skills, CLAUDE.md,
+        // settings.local.json, .claude/bin symlinks — on every launch, the way
+        // the retired app's `AppDelegate.launchMainApp` used to (#766). Runs
+        // AFTER `registerAgents` (the per-agent branches gate on the registry
+        // and on `BinaryOverrides`) and synchronously BEFORE `startBoardPoll`,
+        // whose first tick calls `ensureManagerSession` — so the Manager agent
+        // sees `.claude/skills/` on first paint. Bounded by
+        // `Scaffolder.corveilInstallTimeout` in the worst case.
+        let scaffoldWarning = LaunchScaffold.run(
+            devRoot: options.devRoot, configured: options.devRootConfigured)
+        await MainActor.run { appState.corveilSkillInstallWarning = scaffoldWarning }
+
         // Providers back both the board tracker (M-C) and the spawn engine
         // (M-E2). Zero-config at construction — it reads gh/glab/config lazily.
         let providerManager = ProviderManager()
@@ -712,7 +724,8 @@ public enum CrowDaemon {
         }
     }
 
-    private static func log(_ message: String) {
+    // Internal (not private): `LaunchScaffold` logs through the same prefix.
+    static func log(_ message: String) {
         FileHandle.standardError.write(Data("[crowd] \(message)\n".utf8))
     }
 
@@ -822,6 +835,12 @@ struct DaemonOptions {
     var host: String = "127.0.0.1"
     var socketPath: String = DaemonOptions.defaultDaemonSocketPath()
     var devRoot: String = FileManager.default.currentDirectoryPath
+    /// Whether `devRoot` came from an explicit override (`--dev-root` /
+    /// `CROW_DEV_ROOT`) or the App Support pointer — as opposed to the bare
+    /// current-working-directory fallback below. Gates the launch-time scaffold
+    /// (#766): re-materializing `.claude/skills/` is right for a configured dev
+    /// root and wrong for whatever directory `crowd` happened to start in.
+    var devRootConfigured: Bool = false
     /// When set, serve web UI files live from this source directory instead of
     /// the compiled bundle (`--web-dir` / `CROW_WEB_DIR`) — edit + refresh.
     var webDir: String?
@@ -884,9 +903,12 @@ struct DaemonOptions {
         if !devRootExplicit {
             if let configured = ConfigStore.loadDevRoot() {
                 options.devRoot = configured
+                options.devRootConfigured = true
             } else {
                 options.devRoot = FileManager.default.currentDirectoryPath
             }
+        } else {
+            options.devRootConfigured = true
         }
         return options
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -860,10 +860,12 @@ struct DaemonOptions {
     static func parse(_ arguments: [String]) -> DaemonOptions {
         var options = DaemonOptions()
         var devRootExplicit = false
-        // An empty `CROW_DEV_ROOT=` is treated as unset, not as an explicit
-        // override of "" — otherwise it would count as a configured root and
-        // open the launch-time scaffold gate on a nonsense path (#766 review).
-        if let envRoot = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"], !envRoot.isEmpty {
+        // An empty / whitespace-only `CROW_DEV_ROOT=` is treated as unset, not
+        // as an explicit override of "" — otherwise it would count as a
+        // configured root and open the launch-time scaffold gate on a nonsense
+        // path (#766 review).
+        if let envRoot = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"]?
+            .trimmingCharacters(in: .whitespaces), !envRoot.isEmpty {
             options.devRoot = envRoot
             devRootExplicit = true
         }
@@ -874,6 +876,8 @@ struct DaemonOptions {
         while index < arguments.count {
             let flag = arguments[index]
             let next = index + 1 < arguments.count ? arguments[index + 1] : nil
+            // An empty / whitespace-only value read as its trimmed self, or nil.
+            let trimmedNext = next?.trimmingCharacters(in: .whitespaces)
             switch flag {
             case "--http-port":
                 if let value = next {
@@ -888,7 +892,13 @@ struct DaemonOptions {
             case "--host": if let value = next { options.host = value }; index += 1
             case "--socket", "--socket-path": if let value = next { options.socketPath = value }; index += 1
             case "--dev-root":
-                if let value = next {
+                // Same guard as empty `CROW_DEV_ROOT=`: an empty or
+                // whitespace-only `--dev-root ""` must NOT count as a configured
+                // root. `NSString("").appendingPathComponent(".claude")`
+                // resolves to a relative `.claude`, so honoring it would scaffold
+                // into the process CWD — the exact footgun `devRootConfigured`
+                // exists to prevent (#766 review).
+                if let value = trimmedNext, !value.isEmpty {
                     options.devRoot = value
                     devRootExplicit = true
                 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -860,7 +860,10 @@ struct DaemonOptions {
     static func parse(_ arguments: [String]) -> DaemonOptions {
         var options = DaemonOptions()
         var devRootExplicit = false
-        if let envRoot = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"] {
+        // An empty `CROW_DEV_ROOT=` is treated as unset, not as an explicit
+        // override of "" — otherwise it would count as a configured root and
+        // open the launch-time scaffold gate on a nonsense path (#766 review).
+        if let envRoot = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"], !envRoot.isEmpty {
             options.devRoot = envRoot
             devRootExplicit = true
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -1,0 +1,123 @@
+import CrowClaude
+import CrowCodex
+import CrowCore
+import CrowCursor
+import CrowEngine
+import CrowOpenCode
+import CrowPersistence
+import Foundation
+
+/// The per-launch dev-root scaffold: bundled skills, `CLAUDE.md`,
+/// `settings.local.json`, the `.claude/bin` symlinks, and the per-agent
+/// (Codex / Cursor / OpenCode) dev-root + global hook configs.
+///
+/// This used to run on every `applicationDidFinishLaunching` in the macOS app's
+/// `AppDelegate.launchMainApp`. That file was deleted when the native app was
+/// retired for Web UI parity (`eb7a489`, ADR 0007) and nothing on the daemon
+/// startup path replaced it, so a fresh install came up with an empty
+/// `{devRoot}/.claude/skills/` and the Manager had no knowledge of
+/// `/crow-workspace` (#766). The only surviving `Scaffolder.scaffold(...)` call
+/// was the one-shot `run-setup` wizard, which is rejected once a dev-root
+/// pointer exists — so upgrades never refreshed their skills either.
+///
+/// `CrowDaemon.run` calls this synchronously before `startBoardPoll`, whose
+/// first tick calls `SessionService.ensureManagerSession` — so the files are on
+/// disk before the Manager agent is spawned.
+enum LaunchScaffold {
+
+    /// Re-materialize the dev-root scaffold. Idempotent by construction:
+    /// `Scaffolder` merges `settings.local.json`, preserves the user's
+    /// `## Known Issues / Corrections` block in `CLAUDE.md`, and only owns its
+    /// own symlinks — so this is safe (and intended) to run on every launch.
+    ///
+    /// `configured` gates the whole thing. `DaemonOptions.parse` falls back to
+    /// the current working directory when no dev root is configured, and
+    /// scaffolding *that* would scatter `.claude/skills/` into whatever
+    /// directory `crowd` happened to be started from. Only an explicitly
+    /// configured root (App Support pointer, `--dev-root`, or `CROW_DEV_ROOT`)
+    /// is scaffolded.
+    ///
+    /// Never throws: a scaffold failure is logged and boot continues. Returns
+    /// the non-fatal `corveil skill install` warning (`nil` when unconfigured or
+    /// successful), which the caller mirrors into
+    /// `AppState.corveilSkillInstallWarning`.
+    @discardableResult
+    static func run(devRoot: String, configured: Bool) -> String? {
+        guard configured else { return nil }
+
+        let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+
+        var warning: String?
+        do {
+            let result = try Scaffolder(devRoot: devRoot).scaffold(
+                workspaceNames: config.workspaces.map(\.name),
+                managerAgentKind: config.agentKind(for: .manager),
+                corveilBinaryPath: config.defaults.binaries["corveil"],
+                binaryOverrides: config.defaults.binaries)
+            warning = result.warning
+            CrowDaemon.log("dev-root scaffold refreshed at \(devRoot)")
+        } catch {
+            CrowDaemon.log("WARNING: dev-root scaffold failed: \(error.localizedDescription)")
+        }
+
+        scaffoldAgents(devRoot: devRoot)
+        return warning
+    }
+
+    /// Per-agent dev-root files and global hook configs, each gated on the agent
+    /// actually being registered (i.e. its binary resolved on PATH or via a
+    /// `defaults.binaries.*` override) — so a user without Codex installed never
+    /// gets a `~/.codex`. `AGENTS.md` is shared by all three scaffolders; all are
+    /// idempotent and preserve the user-edited `## Known Issues / Corrections`
+    /// section, so co-existence is safe.
+    private static func scaffoldAgents(devRoot: String) {
+        let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot)
+        let env = ProcessInfo.processInfo.environment
+
+        if AgentRegistry.shared.agent(for: .codex) != nil {
+            attempt("Codex scaffold") { try CodexScaffolder.scaffold(devRoot: devRoot) }
+            if let crowPath {
+                let codexHome = env["CODEX_HOME"] ?? NSString(string: "~/.codex").expandingTildeInPath
+                attempt("Codex global config install") {
+                    try CodexHookConfigWriter.installGlobalConfig(codexHome: codexHome, crowPath: crowPath)
+                    try CodexHookConfigWriter.installGlobalTomlConfig(codexHome: codexHome, crowPath: crowPath)
+                }
+            }
+        }
+
+        if AgentRegistry.shared.agent(for: .cursor) != nil {
+            attempt("Cursor scaffold") { try CursorScaffolder.scaffold(devRoot: devRoot) }
+            if let crowPath {
+                let cursorHome = env["CURSOR_CONFIG_DIR"] ?? NSString(string: "~/.cursor").expandingTildeInPath
+                attempt("Cursor global config install") {
+                    try CursorHookConfigWriter.installGlobalConfig(cursorHome: cursorHome, crowPath: crowPath)
+                }
+            }
+        }
+
+        if AgentRegistry.shared.agent(for: .openCode) != nil {
+            attempt("OpenCode scaffold") { try OpenCodeScaffolder.scaffold(devRoot: devRoot) }
+            if let crowPath {
+                // XDG spec: an empty `XDG_CONFIG_HOME` is treated as unset, so
+                // fall through to ~/.config/opencode rather than a relative path.
+                let xdg = env["XDG_CONFIG_HOME"]
+                let configHome = (xdg?.isEmpty == false ? xdg : nil)
+                    .map { ($0 as NSString).appendingPathComponent("opencode") }
+                    ?? NSString(string: "~/.config/opencode").expandingTildeInPath
+                attempt("OpenCode global config install") {
+                    try OpenCodeHookConfigWriter.installGlobalConfig(configHome: configHome, crowPath: crowPath)
+                }
+            }
+        }
+    }
+
+    /// Run one optional scaffold step, logging (never propagating) its failure —
+    /// none of these are worth aborting daemon boot over.
+    private static func attempt(_ label: String, _ body: () throws -> Void) {
+        do {
+            try body()
+        } catch {
+            CrowDaemon.log("WARNING: \(label) failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -72,12 +72,15 @@ enum LaunchScaffold {
     /// section, so co-existence is safe.
     private static func scaffoldAgents(devRoot: String) {
         let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot)
-        let env = ProcessInfo.processInfo.environment
 
         if AgentRegistry.shared.agent(for: .codex) != nil {
             attempt("Codex scaffold") { try CodexScaffolder.scaffold(devRoot: devRoot) }
             if let crowPath {
-                let codexHome = env["CODEX_HOME"] ?? NSString(string: "~/.codex").expandingTildeInPath
+                // An empty `CODEX_HOME=` is treated as unset — otherwise
+                // `appendingPathComponent("hooks.json")` on "" is a relative path
+                // and the config writes into the process CWD, matching the empty
+                // `XDG_CONFIG_HOME` guard below (#766 review).
+                let codexHome = nonEmptyEnv("CODEX_HOME") ?? NSString(string: "~/.codex").expandingTildeInPath
                 attempt("Codex global config install") {
                     try CodexHookConfigWriter.installGlobalConfig(codexHome: codexHome, crowPath: crowPath)
                     try CodexHookConfigWriter.installGlobalTomlConfig(codexHome: codexHome, crowPath: crowPath)
@@ -88,7 +91,9 @@ enum LaunchScaffold {
         if AgentRegistry.shared.agent(for: .cursor) != nil {
             attempt("Cursor scaffold") { try CursorScaffolder.scaffold(devRoot: devRoot) }
             if let crowPath {
-                let cursorHome = env["CURSOR_CONFIG_DIR"] ?? NSString(string: "~/.cursor").expandingTildeInPath
+                // Empty `CURSOR_CONFIG_DIR=` treated as unset, same reason as
+                // `CODEX_HOME` above.
+                let cursorHome = nonEmptyEnv("CURSOR_CONFIG_DIR") ?? NSString(string: "~/.cursor").expandingTildeInPath
                 attempt("Cursor global config install") {
                     try CursorHookConfigWriter.installGlobalConfig(cursorHome: cursorHome, crowPath: crowPath)
                 }
@@ -100,8 +105,7 @@ enum LaunchScaffold {
             if let crowPath {
                 // XDG spec: an empty `XDG_CONFIG_HOME` is treated as unset, so
                 // fall through to ~/.config/opencode rather than a relative path.
-                let xdg = env["XDG_CONFIG_HOME"]
-                let configHome = (xdg?.isEmpty == false ? xdg : nil)
+                let configHome = nonEmptyEnv("XDG_CONFIG_HOME")
                     .map { ($0 as NSString).appendingPathComponent("opencode") }
                     ?? NSString(string: "~/.config/opencode").expandingTildeInPath
                 attempt("OpenCode global config install") {
@@ -109,6 +113,14 @@ enum LaunchScaffold {
                 }
             }
         }
+    }
+
+    /// The value of environment variable `name`, or `nil` when it is unset or
+    /// empty. An empty config-home var must never survive to
+    /// `appendingPathComponent`, where "" yields a CWD-relative path.
+    private static func nonEmptyEnv(_ name: String) -> String? {
+        guard let value = ProcessInfo.processInfo.environment[name], !value.isEmpty else { return nil }
+        return value
     }
 
     /// Run one optional scaffold step, logging (never propagating) its failure —

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -160,6 +160,25 @@ import CrowPersistence
         }
     }
 
+    /// An empty (or whitespace-only) `--dev-root ""` must NOT count as a
+    /// configured root: `NSString("").appendingPathComponent(".claude")`
+    /// resolves to a CWD-relative `.claude`, so honoring it would scaffold into
+    /// the process working directory — the exact footgun the gate prevents
+    /// (#766 review). It must fall through to the App Support / CWD resolution
+    /// exactly as if the flag were absent.
+    @Test func emptyDevRootFlagIsTreatedAsUnset() {
+        let empty = DaemonOptions.parse(["crowd", "--dev-root", ""])
+        let whitespace = DaemonOptions.parse(["crowd", "--dev-root", "   "])
+        let baseline = DaemonOptions.parse(["crowd"])
+
+        for options in [empty, whitespace] {
+            #expect(options.devRootConfigured == baseline.devRootConfigured)
+            #expect(options.devRoot == baseline.devRoot)
+            // Never a relative `.claude` root.
+            #expect(!options.devRoot.isEmpty)
+        }
+    }
+
     /// An empty `CROW_DEV_ROOT=` must read as unset rather than as an explicit
     /// override of `""` — otherwise the launch-time scaffold gate would open on
     /// a nonsense path. Exercised through the parse helper's env read.

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -117,7 +117,9 @@ import CrowPersistence
     }
 }
 
-@Suite struct DaemonOptionsTests {
+/// `.serialized`: two of these tests read `CROW_DEV_ROOT` and one mutates it,
+/// so they must not run concurrently with each other.
+@Suite(.serialized) struct DaemonOptionsTests {
     @Test func parsesAllFlags() {
         let options = DaemonOptions.parse([
             "crowd", "--http-port", "9001", "--host", "0.0.0.0",
@@ -127,6 +129,51 @@ import CrowPersistence
         #expect(options.host == "0.0.0.0")
         #expect(options.socketPath == "/tmp/crowd.sock")
         #expect(options.devRoot == "/tmp/dev")
+        // An explicit --dev-root is a configured root, so the launch-time
+        // scaffold gate opens (#766).
+        #expect(options.devRootConfigured)
+    }
+
+    /// `LaunchScaffold` refuses to scaffold unless `devRootConfigured` is set,
+    /// so the parse-side wiring of that flag is the other half of the #766
+    /// safety property: an unconfigured `crowd` must never scatter
+    /// `.claude/skills/` into whatever directory it was started from.
+    ///
+    /// With no flags the answer depends on the host — this machine may or may
+    /// not have an App Support dev-root pointer, and `CROW_DEV_ROOT` may be
+    /// exported into the test process — so assert the invariant that holds
+    /// either way: configured ⇔ an explicit env override or a pointer exists,
+    /// and the unconfigured case falls back to the current working directory.
+    @Test func devRootConfiguredTracksTheAppSupportPointer() {
+        let options = DaemonOptions.parse(["crowd"])
+        let envRoot = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"]
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let pointer = ConfigStore.loadDevRoot()
+
+        #expect(options.devRootConfigured == (envRoot != nil || pointer != nil))
+        if let envRoot {
+            #expect(options.devRoot == envRoot)
+        } else if let pointer {
+            #expect(options.devRoot == pointer)
+        } else {
+            #expect(options.devRoot == FileManager.default.currentDirectoryPath)
+        }
+    }
+
+    /// An empty `CROW_DEV_ROOT=` must read as unset rather than as an explicit
+    /// override of `""` — otherwise the launch-time scaffold gate would open on
+    /// a nonsense path. Exercised through the parse helper's env read.
+    @Test func emptyDevRootEnvIsTreatedAsUnset() {
+        let prior = ProcessInfo.processInfo.environment["CROW_DEV_ROOT"]
+        setenv("CROW_DEV_ROOT", "", 1)
+        defer {
+            if let prior { setenv("CROW_DEV_ROOT", prior, 1) } else { unsetenv("CROW_DEV_ROOT") }
+        }
+
+        let options = DaemonOptions.parse(["crowd"])
+
+        #expect(!options.devRoot.isEmpty)
+        #expect(options.devRootConfigured == (ConfigStore.loadDevRoot() != nil))
     }
 
     @Test func malformedPortKeepsDefault() {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LaunchScaffoldTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LaunchScaffoldTests.swift
@@ -1,0 +1,116 @@
+import CrowCore
+import Foundation
+import Testing
+@testable import CrowDaemon
+
+/// Regression coverage for #766: the per-launch dev-root scaffold was lost when
+/// `AppDelegate` was deleted (`eb7a489`), so a fresh install brought up a Manager
+/// with an empty `{devRoot}/.claude/skills/` and no knowledge of
+/// `/crow-workspace`. `LaunchScaffold.run` is the daemon-side replacement,
+/// called from `CrowDaemon.run` before `startBoardPoll` ensures the Manager.
+@Suite("LaunchScaffold — per-launch dev-root scaffold")
+struct LaunchScaffoldTests {
+
+    private static func makeTempDevRoot() throws -> String {
+        let unique = "crow-766-\(UUID().uuidString)"
+        let path = (NSTemporaryDirectory() as NSString).appendingPathComponent(unique)
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return path
+    }
+
+    /// Every bundled skill file the Manager relies on, relative to `.claude/`.
+    private static let expectedSkillFiles = [
+        "skills/crow-workspace/SKILL.md",
+        "skills/crow-workspace/setup.sh",
+        "skills/crow-review-pr/SKILL.md",
+        "skills/crow-batch-workspace/SKILL.md",
+        "skills/crow-create-ticket/SKILL.md",
+        "skills/crow-show-image/SKILL.md",
+        "skills/crow-attribution/FOOTER.md",
+    ]
+
+    @Test func configuredDevRootGetsSkillsAndClaudeMD() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // Fresh install shape: the dev root exists but `.claude/` does not.
+        let claudeDir = (devRoot as NSString).appendingPathComponent(".claude")
+
+        LaunchScaffold.run(devRoot: devRoot, configured: true)
+
+        let fm = FileManager.default
+        for relative in Self.expectedSkillFiles {
+            let path = (claudeDir as NSString).appendingPathComponent(relative)
+            #expect(fm.fileExists(atPath: path), "missing bundled skill file: \(relative)")
+        }
+        #expect(fm.fileExists(atPath: (claudeDir as NSString).appendingPathComponent("CLAUDE.md")))
+        #expect(fm.fileExists(atPath: (claudeDir as NSString).appendingPathComponent("settings.local.json")))
+        #expect(fm.fileExists(atPath: (claudeDir as NSString).appendingPathComponent("commands/crow-image.md")))
+    }
+
+    /// The upgrade case: an existing dev root whose skills are stale must be
+    /// refreshed to the latest bundled version, not left alone.
+    @Test func staleSkillsAreRefreshed() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let skillPath = (devRoot as NSString)
+            .appendingPathComponent(".claude/skills/crow-workspace/SKILL.md")
+        try FileManager.default.createDirectory(
+            atPath: (skillPath as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true)
+        try "# stale from an older Crow\n".write(toFile: skillPath, atomically: true, encoding: .utf8)
+
+        LaunchScaffold.run(devRoot: devRoot, configured: true)
+
+        let refreshed = try String(contentsOfFile: skillPath, encoding: .utf8)
+        #expect(!refreshed.contains("stale from an older Crow"))
+        #expect(refreshed.contains("crow-workspace"))
+    }
+
+    /// `DaemonOptions.parse` falls back to the current working directory when
+    /// nothing is configured. Scaffolding that would scatter `.claude/skills/`
+    /// into whatever directory `crowd` was started from, so the unconfigured
+    /// case must be a complete no-op.
+    @Test func unconfiguredDevRootIsNotScaffolded() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let warning = LaunchScaffold.run(devRoot: devRoot, configured: false)
+
+        #expect(warning == nil)
+        #expect(!FileManager.default.fileExists(
+            atPath: (devRoot as NSString).appendingPathComponent(".claude")))
+    }
+
+    /// Running on every launch is only safe if it is genuinely idempotent: the
+    /// user's `## Known Issues / Corrections` block in `CLAUDE.md` and their
+    /// hand-added `settings.local.json` permissions must survive a second pass
+    /// (`Scaffolder.mergeSettings`, covered in depth by
+    /// `ScaffolderSettingsMergeTests`).
+    @Test func rerunPreservesUserCorrectionsAndSettings() throws {
+        let devRoot = try Self.makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let claudeDir = (devRoot as NSString).appendingPathComponent(".claude")
+
+        LaunchScaffold.run(devRoot: devRoot, configured: true)
+
+        // Simulate the user editing both files between launches.
+        let claudeMDPath = (claudeDir as NSString).appendingPathComponent("CLAUDE.md")
+        let base = try String(contentsOfFile: claudeMDPath, encoding: .utf8)
+        let marker = "- `crow send` needs a trailing newline to submit."
+        try (base + "\n\(marker)\n").write(toFile: claudeMDPath, atomically: true, encoding: .utf8)
+
+        let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.local.json")
+        var settings = try String(contentsOfFile: settingsPath, encoding: .utf8)
+        settings = settings.replacingOccurrences(
+            of: "\"allow\": [", with: "\"allow\": [\n      \"Bash(npm test:*)\",")
+        try settings.write(toFile: settingsPath, atomically: true, encoding: .utf8)
+
+        LaunchScaffold.run(devRoot: devRoot, configured: true)
+
+        let claudeMDAfter = try String(contentsOfFile: claudeMDPath, encoding: .utf8)
+        #expect(claudeMDAfter.contains("## Known Issues / Corrections"))
+        #expect(claudeMDAfter.contains(marker))
+        let settingsAfter = try String(contentsOfFile: settingsPath, encoding: .utf8)
+        #expect(settingsAfter.contains("Bash(npm test:*)"))
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LaunchScaffoldTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LaunchScaffoldTests.swift
@@ -45,6 +45,16 @@ struct LaunchScaffoldTests {
         #expect(fm.fileExists(atPath: (claudeDir as NSString).appendingPathComponent("CLAUDE.md")))
         #expect(fm.fileExists(atPath: (claudeDir as NSString).appendingPathComponent("settings.local.json")))
         #expect(fm.fileExists(atPath: (claudeDir as NSString).appendingPathComponent("commands/crow-image.md")))
+        // The `.claude/bin` PATH-precedence anchor is materialized too. Only the
+        // directory is asserted here: which links land inside depends on
+        // `defaults.binaries` and on `ClaudeHookConfigWriter.appCrowBinary()`
+        // resolving in the host process, and the link contents are already
+        // covered with an injected binary by `ScaffolderBinarySymlinkTests`.
+        var isDirectory: ObjCBool = false
+        #expect(fm.fileExists(
+            atPath: (claudeDir as NSString).appendingPathComponent("bin"),
+            isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
     }
 
     /// The upgrade case: an existing dev root whose skills are stale must be

--- a/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
@@ -396,9 +396,10 @@ public struct Scaffolder {
     }
 
     /// Wall-clock budget for the per-launch `corveil skill install` run. Tight
-    /// because `Scaffolder.scaffold(...)` runs on the main thread before the
-    /// app window is shown — a hung corveil binary delays first paint by this
-    /// many seconds. 5s is generous for a local subprocess that only writes
+    /// because `Scaffolder.scaffold(...)` runs synchronously on the daemon
+    /// launch path (`CrowDaemon.run` → `LaunchScaffold.run`) before the Manager
+    /// session is ensured — a hung corveil binary delays the Manager's spawn by
+    /// this many seconds. 5s is generous for a local subprocess that only writes
     /// one ~10KB file.
     static let corveilInstallTimeout: TimeInterval = 5.0
 

--- a/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
@@ -317,21 +317,19 @@ public struct Scaffolder {
     /// user-facing warning string on failure; `nil` on success or when the
     /// feature is unconfigured (empty/nil path).
     ///
-    /// `Scaffolder.scaffold(...)` runs on the main thread during
-    /// `applicationDidFinishLaunching`, so a hung corveil binary (wrong
-    /// executable, stdin prompt, etc.) would freeze app startup with no
-    /// window drawn yet. The hard wall-clock timeout bounds the worst case:
-    /// after `corveilInstallTimeout` seconds the process is sent SIGTERM and
-    /// the install reports a warning rather than blocking forever.
+    /// `Scaffolder.scaffold(...)` runs synchronously on the daemon's launch
+    /// path (`CrowDaemon.run` → `LaunchScaffold.run`, before the Manager
+    /// session is ensured), so a hung corveil binary (wrong executable, stdin
+    /// prompt, etc.) would stall startup before the Manager comes up. The hard
+    /// wall-clock timeout bounds the worst case: after `corveilInstallTimeout`
+    /// seconds the process is sent SIGTERM and the install reports a warning
+    /// rather than blocking forever.
     ///
-    /// Internal, not private — Settings calls this directly via callbacks
-    /// wired in `AppDelegate.launchMainApp`: when the user picks a new
-    /// corveil binary (CROW-490) and when the user clicks "Reinstall skill"
-    /// (CROW-491). Both avoid the "must restart Crow" gap of the per-launch
-    /// path. SettingsView itself lives in CrowUI and cannot import the app
-    /// target, so closure injection through `AppState` is the only path.
-    /// Settings-side callers dispatch off the main thread (`Task.detached`)
-    /// so the 5s worst-case doesn't freeze the Settings window.
+    /// Public, not private — it is also the "reinstall without restarting Crow"
+    /// entry point for a corveil binary the user just picked (CROW-490) or
+    /// clicked Reinstall on (CROW-491). Callers on that path must dispatch off
+    /// the main thread (`Task.detached`) so the worst case doesn't freeze the
+    /// settings UI.
     public func installCorveilSkill(_ corveilBinaryPath: String?) -> String? {
         guard let path = corveilBinaryPath?.trimmingCharacters(in: .whitespacesAndNewlines),
               !path.isEmpty else {


### PR DESCRIPTION
Closes #766

## Problem

A fresh install brought up a Manager with an empty `{devRoot}/.claude/skills/` — no `/crow-workspace`, `/crow-batch-workspace`, `/crow-create-ticket`, `/crow-review-pr`, `/crow-show-image` — and `CLAUDE.md` / `settings.local.json` / the `.claude/bin` symlinks were never refreshed, so upgrades never picked up newer bundled skills either.

`Scaffolder.scaffold(...)` is idempotent and was designed to run on every launch, but its only per-launch call site was `AppDelegate.launchMainApp`, deleted in `eb7a489` (#594) when the native app was retired for Web UI parity (ADR 0007). The only surviving production call is the one-shot `run-setup` wizard (`RPCHandlers.swift:962`), which is rejected once a dev-root pointer exists — and the daemon's Manager path (`startBoardPoll` → `ensureManagerSession`) never scaffolded.

## Fix

- New `Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift` — `LaunchScaffold.run(devRoot:configured:)`, called from `CrowDaemon.run` **after** `registerAgents` (the per-agent branches gate on the registry and `BinaryOverrides`) and synchronously **before** `startBoardPoll`, whose first tick ensures the Manager. Skills are on disk before the Manager agent is spawned.
- **Gate:** `DaemonOptions.parse` falls back to the current working directory when no dev root is configured; scaffolding that would scatter `.claude/skills/` into whatever directory `crowd` started in. The new `DaemonOptions.devRootConfigured` is true only for an explicit `--dev-root` / `CROW_DEV_ROOT` or the App Support pointer.
- Every step is logged-not-thrown — a scaffold failure must not abort daemon boot. The corveil-install warning is mirrored into `AppState.corveilSkillInstallWarning` as before.
- `run-setup` is **untouched** and stays one-shot; its re-exec now boots through this path.
- Stale `applicationDidFinishLaunching` / `AppDelegate.launchMainApp` docstrings in `Scaffolder.swift` corrected (they outlived both call sites — `installCorveilSkill` is also `public`, not "internal, not private").

### Beyond the ticket

`CodexScaffolder` / `CursorScaffolder` / `OpenCodeScaffolder` and the three global hook-config writers (`~/.codex`, `~/.cursor`, `~/.config/opencode`) lost their call site in the *same* commit and had **zero** remaining production callers. They're restored alongside, each still gated on the agent actually being registered, so a user without Codex installed never gets a `~/.codex`.

## Tests

`Packages/CrowDaemon/Tests/CrowDaemonTests/LaunchScaffoldTests.swift` — 4 tests, all passing:

- configured dev root with no `.claude/` → all six bundled skills + `CLAUDE.md` + `settings.local.json` + `commands/crow-image.md` written
- stale `crow-workspace/SKILL.md` → refreshed to the bundled version (the upgrade case)
- `configured: false` → complete no-op, `.claude/` is never created
- second run preserves a hand-edited `## Known Issues / Corrections` block and a user-added `settings.local.json` permission (on top of the existing `ScaffolderSettingsMergeTests`)

`make test`: everything passes except `CrowTerminal`'s `retryReadinessEmitsTimedOutWhenSentinelMissing`, which **fails identically on a stashed clean tree** — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZ3dA8YcCdjQxxBKQRMj8d