### PR TITLE
fix(web): batch "Start Working (N)" dispatches one /crow-batch-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 
 ### Web UI
 
+- #752 — Multi-select "Start Working (N)" on the tickets board now fires a single `batch-work-on-issues` RPC, so the Manager runs one `/crow-batch-workspace url1 url2 …` (parallel setup) instead of N separate `/crow-workspace` submissions.
 - #613 — Left pane paints chrome + skeleton (or cached last-known) session rows on first load before `list-sessions` returns, then swaps in real rows without a blank flash.
 
 ### Automation

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -34,6 +34,16 @@ enum DaemonRPCError: Error, LocalizedError, RPCErrorCoded {
 /// `DaemonRPCError` on an app-level error; rethrows the underlying socket error
 /// (connection refused → app not running) so callers can fall back to local
 /// handling (CROW-581).
+/// A ticket/PR URL is sent verbatim as Manager keystrokes, so accept only a
+/// plain http(s) URL with no whitespace or control characters — otherwise a
+/// crafted url could inject extra submitted lines into the agent (review #4).
+/// Shared by `work-on-issue` and `batch-work-on-issues` so the two can't drift.
+func isSafeIssueURL(_ url: String) -> Bool {
+    guard !url.isEmpty,
+          url.range(of: #"^https?://[^\s]+$"#, options: .regularExpression) != nil else { return false }
+    return !url.unicodeScalars.contains { $0.value < 0x20 || $0.value == 0x7F }
+}
+
 /// App-down local path for the `session.status` transitions (mark-in-review /
 /// complete-session / set-session-active): write the status to both the
 /// observable `appState` and the persisted `store`, exactly like `set-status`.
@@ -677,11 +687,7 @@ func makeCommandRouter(
             guard let url = params["url"]?.stringValue, !url.isEmpty else {
                 throw DaemonRPCError.invalidParams("url required")
             }
-            // Sent verbatim as Manager keystrokes below — reject anything that
-            // isn't a plain http(s) URL, so newlines/control chars can't inject
-            // extra submitted lines into the agent (review #4).
-            guard url.range(of: #"^https?://[^\s]+$"#, options: .regularExpression) != nil,
-                  !url.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F }) else {
+            guard isSafeIssueURL(url) else {
                 throw DaemonRPCError.invalidParams("url must be a well-formed http(s) URL with no control characters")
             }
             return try await MainActor.run {
@@ -690,6 +696,49 @@ func makeCommandRouter(
                 }
                 TerminalRouter.send(managerTerminal, text: "/crow-workspace \(url)\n")
                 return ["ok": .bool(true)]
+            }
+        },
+        // Batch counterpart of work-on-issue (#752): types ONE
+        // `/crow-batch-workspace <url1> <url2> …` line, so the Manager runs the
+        // parallel batch skill once instead of N sequential `/crow-workspace`
+        // submissions. Single-line by construction — TerminalRouter turns
+        // newlines into Enter presses, so an embedded newline would split the
+        // prompt (cf. #161). Unsafe URLs are dropped and reported back in
+        // `rejected` rather than failing the whole batch, so one bad ticket
+        // can't block the rest.
+        "batch-work-on-issues": { params in
+            guard sessionService != nil else {
+                throw DaemonRPCError.applicationError(
+                    "Working on an issue requires tmux on the daemon host")
+            }
+            guard let arr = params["urls"]?.arrayValue, !arr.isEmpty else {
+                throw DaemonRPCError.invalidParams("urls array required")
+            }
+            var valid: [String] = []
+            var rejected: [String] = []
+            for value in arr {
+                let url = value.stringValue ?? ""
+                if isSafeIssueURL(url) {
+                    if !valid.contains(url) { valid.append(url) }
+                } else {
+                    rejected.append(url)
+                }
+            }
+            guard !valid.isEmpty else {
+                throw DaemonRPCError.invalidParams("urls must be well-formed http(s) URLs with no control characters")
+            }
+            return try await MainActor.run {
+                guard let managerTerminal = appState.terminals[AppState.managerSessionID]?.first else {
+                    throw DaemonRPCError.applicationError("The Manager is still starting — try again in a moment")
+                }
+                TerminalRouter.send(
+                    managerTerminal,
+                    text: "/crow-batch-workspace \(valid.joined(separator: " "))\n")
+                return [
+                    "ok": .bool(true),
+                    "sent": .int(valid.count),
+                    "rejected": .array(rejected.map { .string($0) }),
+                ]
             }
         },
         // Starting a review forwards to the app when it's running; with the app

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2688,9 +2688,10 @@ function toggleIssueSelect(url) {
   renderBoard();
 }
 
-// Batch "Start Working (N)": dispatch work-on-issue for each selected ticket
-// (mirrors the native batch action's per-issue dispatch), then clear selection
-// and exit selection mode.
+// Batch "Start Working (N)": ONE batch-work-on-issues call with every selected
+// ticket, so the Manager runs a single `/crow-batch-workspace url1 url2 …` (the
+// batch skill sets them up in parallel) instead of N separate `/crow-workspace`
+// submissions (#752). Then clear selection and exit selection mode.
 async function startWorkingSelected(btn) {
   const urls = ((boardData.tickets && boardData.tickets.issues) || [])
     .filter((i) => !i.linked_session_id && selectedIssueIDs.has(i.url))
@@ -2698,16 +2699,19 @@ async function startWorkingSelected(btn) {
   if (!urls.length) return;
   btn.disabled = true;
   btn.textContent = 'Starting…';
-  let failed = 0;
-  for (const url of urls) {
-    try { await rpc('work-on-issue', { url }); selectedIssueIDs.delete(url); }
-    catch (_) { failed++; }
+  let problem = '';
+  try {
+    const res = await rpc('batch-work-on-issues', { urls });
+    const rejected = (res && res.rejected) || [];
+    if (rejected.length) problem = rejected.length + ' ticket(s) could not be started.';
+  } catch (e) {
+    problem = 'Start Working failed: ' + (e.message || e);
   }
   selectedIssueIDs.clear();
   ticketSelectionMode = false;
   refreshTickets();
   renderBoard();
-  if (failed) alertModal(failed + ' ticket(s) could not be started.');
+  if (problem) alertModal(problem);
 }
 
 async function refreshTickets() {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
@@ -53,7 +53,8 @@ import CrowPersistence
         // mark-in-review / complete-session / set-session-active — now run
         // locally, so they're covered by LocalStatusTests instead.)
         let actions = [
-            "work-on-issue", "start-review", "promote-allowlist", "refresh-tickets", "refresh-allowlist",
+            "work-on-issue", "batch-work-on-issues", "start-review", "promote-allowlist",
+            "refresh-tickets", "refresh-allowlist",
             "create-manager", "mark-issue-done", "add-merge-label",
         ]
         for method in actions {
@@ -61,6 +62,36 @@ import CrowPersistence
             #expect(resp.error != nil, "\(method) should error when the app is down")
             #expect(resp.error?.code == RPCErrorCode.applicationError, "\(method) should be an application error")
         }
+    }
+}
+
+/// #752: the web board's batch "Start Working (N)" dispatches a single
+/// `batch-work-on-issues` RPC, which types one `/crow-batch-workspace url1 url2 …`
+/// line into the Manager. These pin the URL contract — the URLs reach the agent
+/// as keystrokes, so anything that isn't a plain http(s) URL must be dropped.
+@Suite struct BatchWorkOnIssuesTests {
+    @Test func acceptsPlainHTTPURLsOnly() {
+        #expect(isSafeIssueURL("https://github.com/acme/api/issues/7"))
+        #expect(isSafeIssueURL("http://gitlab.example.com/org/repo/-/issues/42"))
+
+        #expect(!isSafeIssueURL(""))
+        #expect(!isSafeIssueURL("javascript:alert(1)"))
+        #expect(!isSafeIssueURL("ftp://example.com/x"))
+        #expect(!isSafeIssueURL("https://example.com/a b"))            // whitespace
+        #expect(!isSafeIssueURL("https://example.com/x\n/crow-workspace evil"))  // newline injection
+        #expect(!isSafeIssueURL("https://example.com/x\u{7F}"))        // DEL
+    }
+
+    /// Params validation is reached only once tmux is available; with the app
+    /// down the applicationError guard fires first (same ordering as
+    /// `work-on-issue`), which `boardActionsErrorWhenAppDown` already pins.
+    @Test @MainActor func missingURLsErrorsWhenTmuxUnavailable() async {
+        let router = makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: NSTemporaryDirectory(), cockpit: nil)
+        let resp = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "batch-work-on-issues", params: ["urls": .array([])]))
+        #expect(resp.error?.code == RPCErrorCode.applicationError)
     }
 }
 


### PR DESCRIPTION
Closes #752

## Problem

On the tickets board, multi-selecting tickets and clicking **Start Working (N)** looped `rpc("work-on-issue", {url})` once per ticket, so the Manager got N separate `/crow-workspace <url>` submissions instead of a single parallel batch run.

## Change

- **`RPCHandlers.swift`** — new `batch-work-on-issues` RPC next to `work-on-issue`: same tmux/Manager-terminal guards, validates each URL, dedupes, and types **one** `/crow-batch-workspace <url1> <url2> …` line. Returns `{ok, sent, rejected}` — unsafe URLs are dropped and reported rather than failing the whole batch. Single-line by construction (newlines become Enter presses, cf. #161).
- **`app.js`** — `startWorkingSelected()` makes one batch call with the full selection; still surfaces how many tickets could not be started. Single-ticket "Start Working" is untouched.
- **`isSafeIssueURL`** — the plain-http(s)/no-control-char check (URLs reach the agent as keystrokes) extracted and shared by both handlers so they cannot drift.
- Tests: `batch-work-on-issues` added to the app-down board-actions contract, plus a URL-validation suite (rejects `javascript:`, embedded newline, whitespace, DEL).

## Notes

- `AppState.onBatchWorkOnIssues` referenced by the ticket is **never assigned** anywhere in the repo (CrowUI is analytics-only; crowd is the sole spawner per ADR 0009), so no EngineRouter counterpart was added — it would fire a callback no host sets. The daemon path is the live one.
- Based on `main`: the ticket's `feature/crow-593-web-ui-parity` base is stale — that work merged as `eb7a489`.

## Verification

- `swift build` clean; `swift test --package-path Packages/CrowDaemon --filter "BoardForwarderTests|BatchWorkOnIssuesTests"` → 15 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ex9C49frwCB63DU9c9q9Xj