### PR TITLE
De-brand Crow from RadiusMethod → Corveil (bundle ID, copyright, docs, fixtures)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,13 @@ git worktree add /path -b feature/name --no-track origin/main   # Retry
 ### Worktree Naming
 **Correct:** `{devRoot}/{workspace}/{repo}-{number}-{slug}` (same level as main repo)
 ```
-/Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash
+/Users/jane/Dev/Corveil/acme-api-197-fix-tab-url-hash
 ```
 
 **WRONG — never create subdirectories:**
 ```
-WRONG: /Users/jane/Dev/RadiusMethod/acme-api-worktrees/197-fix-tab
-WRONG: /Users/jane/Dev/RadiusMethod/worktrees/acme-api-197-fix-tab
+WRONG: /Users/jane/Dev/Corveil/acme-api-worktrees/197-fix-tab
+WRONG: /Users/jane/Dev/Corveil/worktrees/acme-api-197-fix-tab
 ```
 
 ### Always use `--no-track` for new branches

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [REDACTED_EMAIL]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by opening a [private report](https://github.com/corveil/crow/security/advisories/new) or contacting the maintainers directly. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the community leaders responsible for enforcement through [GitHub's private vulnerability reporting](https://github.com/corveil/crow/security/advisories/new) for this repository. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [REDACTED_EMAIL]. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@corveil.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the community leaders responsible for enforcement through [GitHub's private vulnerability reporting](https://github.com/corveil/crow/security/advisories/new) for this repository. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@radiusmethod.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@corveil.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please note that this project is released with a [Code of Conduct](CODE_OF_CONDU
 
 ## Reporting Bugs
 
-Open a [GitHub Issue](https://github.com/radiusmethod/crow/issues/new?template=bug_report.md) with:
+Open a [GitHub Issue](https://github.com/corveil/crow/issues/new?template=bug_report.md) with:
 
 - macOS version and hardware (Intel/Apple Silicon)
 - Xcode and Zig versions
@@ -16,14 +16,14 @@ Open a [GitHub Issue](https://github.com/radiusmethod/crow/issues/new?template=b
 
 ## Suggesting Features
 
-Open a [GitHub Issue](https://github.com/radiusmethod/crow/issues/new?template=feature_request.md) describing the use case and proposed solution.
+Open a [GitHub Issue](https://github.com/corveil/crow/issues/new?template=feature_request.md) describing the use case and proposed solution.
 
 ## Development Setup
 
 See [README.md](README.md#detailed-setup) for full build instructions. The short version:
 
 ```bash
-git clone https://github.com/radiusmethod/crow.git
+git clone https://github.com/corveil/crow.git
 cd crow
 make build
 ```

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -45,7 +45,7 @@ func validateRepoSlug(_ value: String) throws {
     let components = repo.split(separator: "/", omittingEmptySubsequences: false)
     guard components.count >= 2,
           components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
-        throw ValidationError("'\(value)' is not a valid repo. Expected an owner/repo slug (e.g. radiusmethod/crow); components must not be empty, '.', or '..'.")
+        throw ValidationError("'\(value)' is not a valid repo. Expected an owner/repo slug (e.g. corveil/crow); components must not be empty, '.', or '..'.")
     }
 }
 

--- a/Packages/CrowCLI/Tests/CrowCLITests/JobCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/JobCommandParsingTests.swift
@@ -10,8 +10,8 @@ private let jobUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 @Test func jobAddParsesFullArgs() throws {
     let cmd = try JobAdd.parse([
         "--name", "nightly triage",
-        "--workspace", "RadiusMethod",
-        "--repo", "radiusmethod/api",
+        "--workspace", "Corveil",
+        "--repo", "corveil/api",
         "--prompt", "first prompt",
         "--prompt", "second prompt",
         "--daily-at", "09:30",
@@ -19,8 +19,8 @@ private let jobUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         "--disabled",
     ])
     #expect(cmd.name == "nightly triage")
-    #expect(cmd.workspace == "RadiusMethod")
-    #expect(cmd.repo == "radiusmethod/api")
+    #expect(cmd.workspace == "Corveil")
+    #expect(cmd.repo == "corveil/api")
     #expect(cmd.prompt == ["first prompt", "second prompt"])
     #expect(cmd.dailyAt == "09:30")
     #expect(cmd.weekdays == "mon,fri")

--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Canonical Crow attribution footers for GitHub/GitLab artifacts and skill instructions.
 public enum CrowAttribution {
-    public static let repoURL = "https://github.com/radiusmethod/crow"
+    public static let repoURL = "https://github.com/corveil/crow"
 
     /// Human-readable agent label when kind/env is unknown (legacy installs).
     public static let defaultAgentDisplayName = "Claude Code"
@@ -103,12 +103,12 @@ public enum CrowAttribution {
     expression in attribution footers. The shell silently fails to expand it inside
     single-quoted heredocs and the literal text leaks into the artifact (#447).
 
-    The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
+    The link target is always `https://github.com/corveil/crow` — never a fork or a value from the local git remote.
 
     | Artifact | Footer |
     |----------|--------|
-    | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
-    | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
+    | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/corveil/crow)` |
+    | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/corveil/crow)` |
     | Committed (hand-authored commit message) | Trailer block at the end of the message: `Crow-Session: <session-uuid>` and `Co-Authored-By: Claude <noreply@anthropic.com>` on their own lines, separated from the body by a blank line. `setup.sh` installs a `prepare-commit-msg` hook (CROW-518) that idempotently fills them in if missing, but include them explicitly when writing the message — the hook is the safety net. |
 
     `<agent>` above is just a placeholder for *this document* — in the real footer lines

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -617,7 +617,7 @@ import Testing
 @Test func workspaceGatewayRoundTrip() throws {
     let config = AppConfig(workspaces: [
         WorkspaceInfo(
-            name: "RadiusMethod",
+            name: "Corveil",
             gateway: WorkspaceGateway(
                 baseURL: "https://corveil.io",
                 customHeaders: ["x-citadel-api-key": "op://Spotlight Prod/Citadel/api_key"]

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppStateReviewSessionLookupTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppStateReviewSessionLookupTests.swift
@@ -29,7 +29,7 @@ private func makeReviewSession(name: String = "review-crow-406", status: Session
 @Test func existingReviewSessionReturnsSessionWithMatchingPRLink() {
     let appState = AppState()
     let session = makeReviewSession()
-    let prURL = "https://github.com/radiusmethod/crow/pull/406"
+    let prURL = "https://github.com/corveil/crow/pull/406"
     appState.sessions = [session]
     appState.links[session.id] = [
         SessionLink(sessionID: session.id, label: "PR #406", url: prURL, linkType: .pr)
@@ -42,7 +42,7 @@ private func makeReviewSession(name: String = "review-crow-406", status: Session
 @Test func existingReviewSessionIgnoresCompletedSessions() {
     let appState = AppState()
     let session = makeReviewSession(status: .completed)
-    let prURL = "https://github.com/radiusmethod/crow/pull/406"
+    let prURL = "https://github.com/corveil/crow/pull/406"
     appState.sessions = [session]
     appState.links[session.id] = [
         SessionLink(sessionID: session.id, label: "PR #406", url: prURL, linkType: .pr)
@@ -55,7 +55,7 @@ private func makeReviewSession(name: String = "review-crow-406", status: Session
 @Test func existingReviewSessionIgnoresArchivedSessions() {
     let appState = AppState()
     let session = makeReviewSession(status: .archived)
-    let prURL = "https://github.com/radiusmethod/crow/pull/406"
+    let prURL = "https://github.com/corveil/crow/pull/406"
     appState.sessions = [session]
     appState.links[session.id] = [
         SessionLink(sessionID: session.id, label: "PR #406", url: prURL, linkType: .pr)
@@ -68,7 +68,7 @@ private func makeReviewSession(name: String = "review-crow-406", status: Session
 @Test func existingReviewSessionIgnoresNonPRLinkTypes() {
     let appState = AppState()
     let session = makeReviewSession()
-    let prURL = "https://github.com/radiusmethod/crow/pull/406"
+    let prURL = "https://github.com/corveil/crow/pull/406"
     appState.sessions = [session]
     // Same URL string but linked as `.repo`, not `.pr` — should not match.
     appState.links[session.id] = [
@@ -83,7 +83,7 @@ private func makeReviewSession(name: String = "review-crow-406", status: Session
     let appState = AppState()
     let first = makeReviewSession(name: "review-crow-406-a")
     let second = makeReviewSession(name: "review-crow-406-b")
-    let prURL = "https://github.com/radiusmethod/crow/pull/406"
+    let prURL = "https://github.com/corveil/crow/pull/406"
     appState.sessions = [first, second]
     appState.links[first.id] = [
         SessionLink(sessionID: first.id, label: "PR #406", url: prURL, linkType: .pr)

--- a/Packages/CrowCore/Tests/CrowCoreTests/AssignedIssueTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AssignedIssueTests.swift
@@ -7,29 +7,29 @@ import Testing
 @Test func assignedIssueCodableRoundTrip() throws {
     let date = Date(timeIntervalSince1970: 1_700_000_000)
     let issue = AssignedIssue(
-        id: "github:radiusmethod/crow#64",
+        id: "github:corveil/crow#64",
         number: 64,
         title: "Expand test coverage",
         state: "open",
-        url: "https://github.com/radiusmethod/crow/issues/64",
-        repo: "radiusmethod/crow",
+        url: "https://github.com/corveil/crow/issues/64",
+        repo: "corveil/crow",
         labels: [LabelInfo(name: "enhancement", color: "a2eeef"), LabelInfo(name: "testing")],
         provider: .github,
         prNumber: 100,
-        prURL: "https://github.com/radiusmethod/crow/pull/100",
+        prURL: "https://github.com/corveil/crow/pull/100",
         updatedAt: date,
         projectStatus: .inProgress
     )
     let data = try JSONEncoder().encode(issue)
     let decoded = try JSONDecoder().decode(AssignedIssue.self, from: data)
-    #expect(decoded.id == "github:radiusmethod/crow#64")
+    #expect(decoded.id == "github:corveil/crow#64")
     #expect(decoded.number == 64)
     #expect(decoded.title == "Expand test coverage")
     #expect(decoded.state == "open")
     #expect(decoded.labels == [LabelInfo(name: "enhancement", color: "a2eeef"), LabelInfo(name: "testing")])
     #expect(decoded.provider == .github)
     #expect(decoded.prNumber == 100)
-    #expect(decoded.prURL == "https://github.com/radiusmethod/crow/pull/100")
+    #expect(decoded.prURL == "https://github.com/corveil/crow/pull/100")
     #expect(decoded.updatedAt == date)
     #expect(decoded.projectStatus == .inProgress)
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -3,17 +3,17 @@ import Testing
 @testable import CrowCore
 
 @Test func crowAttributionRepoURLIsCanonical() {
-    #expect(CrowAttribution.repoURL == "https://github.com/radiusmethod/crow")
+    #expect(CrowAttribution.repoURL == "https://github.com/corveil/crow")
 }
 
 @Test func crowAttributionReviewLinkDefaultIsClaudeCode() {
     #expect(CrowAttribution.reviewMarkdownLink ==
-            "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)")
+            "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/corveil/crow)")
 }
 
 @Test func crowAttributionReviewLinkForCursor() {
     #expect(CrowAttribution.reviewMarkdownLink(agentDisplayName: "Cursor") ==
-            "[🐦‍⬛ Reviewed by Crow via Cursor](https://github.com/radiusmethod/crow)")
+            "[🐦‍⬛ Reviewed by Crow via Cursor](https://github.com/corveil/crow)")
 }
 
 @Test func crowAttributionReviewLinkEmbedsRepoURL() {
@@ -22,17 +22,17 @@ import Testing
 
 @Test func crowAttributionContainsNoForkReferences() {
     #expect(!CrowAttribution.reviewMarkdownLink.contains("nicholasgasior"))
-    #expect(!CrowAttribution.reviewMarkdownLink.lowercased().contains("corveil"))
+    #expect(!CrowAttribution.reviewMarkdownLink.lowercased().contains("radiusmethod"))
 }
 
 @Test func crowAttributionTicketLinkDefaultIsClaudeCode() {
     #expect(CrowAttribution.ticketMarkdownLink ==
-            "[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)")
+            "[🐦‍⬛ Created with Crow via Claude Code](https://github.com/corveil/crow)")
 }
 
 @Test func crowAttributionTicketLinkForCodex() {
     #expect(CrowAttribution.ticketMarkdownLink(agentDisplayName: "OpenAI Codex") ==
-            "[🐦‍⬛ Created with Crow via OpenAI Codex](https://github.com/radiusmethod/crow)")
+            "[🐦‍⬛ Created with Crow via OpenAI Codex](https://github.com/corveil/crow)")
 }
 
 @Test func crowAttributionTicketLinkEmbedsRepoURL() {
@@ -41,7 +41,7 @@ import Testing
 
 @Test func crowAttributionTicketLinkContainsNoForkReferences() {
     #expect(!CrowAttribution.ticketMarkdownLink.contains("nicholasgasior"))
-    #expect(!CrowAttribution.ticketMarkdownLink.lowercased().contains("corveil"))
+    #expect(!CrowAttribution.ticketMarkdownLink.lowercased().contains("radiusmethod"))
 }
 
 @Test func crowAttributionAgentDisplayNameKnownKinds() {
@@ -91,7 +91,7 @@ import Testing
 }
 
 @Test func crowAttributionExpandSkillBodyReplacesLegacyClaudeCodeWording() {
-    let body = "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
+    let body = "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/corveil/crow)"
     let expanded = CrowAttribution.expandSkillBody(body, agentKind: .codex)
     #expect(expanded.contains("via OpenAI Codex"))
     #expect(!expanded.contains("via Claude Code"))

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -20,7 +20,7 @@ import Testing
     #expect(CrowAttribution.reviewMarkdownLink.contains(CrowAttribution.repoURL))
 }
 
-@Test func crowAttributionContainsNoForkReferences() {
+@Test func crowAttributionContainsNoForkOrSupersededOrgReferences() {
     #expect(!CrowAttribution.reviewMarkdownLink.contains("nicholasgasior"))
     #expect(!CrowAttribution.reviewMarkdownLink.lowercased().contains("radiusmethod"))
 }
@@ -39,7 +39,7 @@ import Testing
     #expect(CrowAttribution.ticketMarkdownLink.contains(CrowAttribution.repoURL))
 }
 
-@Test func crowAttributionTicketLinkContainsNoForkReferences() {
+@Test func crowAttributionTicketLinkContainsNoForkOrSupersededOrgReferences() {
     #expect(!CrowAttribution.ticketMarkdownLink.contains("nicholasgasior"))
     #expect(!CrowAttribution.ticketMarkdownLink.lowercased().contains("radiusmethod"))
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
@@ -6,8 +6,8 @@ import Testing
     let config = AppConfig(jobs: [
         JobConfig(
             name: "Nightly Audit",
-            workspace: "RadiusMethod",
-            repo: "radiusmethod/api",
+            workspace: "Corveil",
+            repo: "corveil/api",
             prompts: ["Run the audit", "Summarize findings"],
             schedule: .interval(seconds: 3600),
             enabled: true
@@ -22,8 +22,8 @@ import Testing
     #expect(decoded.jobs.count == 1)
     let job = decoded.jobs[0]
     #expect(job.name == "Nightly Audit")
-    #expect(job.workspace == "RadiusMethod")
-    #expect(job.repo == "radiusmethod/api")
+    #expect(job.workspace == "Corveil")
+    #expect(job.repo == "corveil/api")
     #expect(job.prompts == ["Run the audit", "Summarize findings"])
     #expect(job.schedule == .interval(seconds: 3600))
     #expect(job.enabled == true)

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionParseReviewPRTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionParseReviewPRTests.swift
@@ -3,8 +3,8 @@ import Testing
 @testable import CrowCore
 
 @Test func parseReviewPRExtractsOwnerRepoAndNumber() {
-    let parsed = Session.parseReviewPR(url: "https://github.com/radiusmethod/crow/pull/406")
-    #expect(parsed?.owner == "radiusmethod")
+    let parsed = Session.parseReviewPR(url: "https://github.com/corveil/crow/pull/406")
+    #expect(parsed?.owner == "corveil")
     #expect(parsed?.repo == "crow")
     #expect(parsed?.number == 406)
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -1090,7 +1090,7 @@ public final class IssueTracker {
     struct ReconcileCandidate: Sendable, Equatable {
         let sessionID: UUID
         let provider: Provider
-        let repoSlug: String       // "corveil/corveil"
+        let repoSlug: String       // "corveil/crow"
         let branch: String
         let gitlabHost: String?    // nil for github.com
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -1090,7 +1090,7 @@ public final class IssueTracker {
     struct ReconcileCandidate: Sendable, Equatable {
         let sessionID: UUID
         let provider: Provider
-        let repoSlug: String       // "radiusmethod/corveil"
+        let repoSlug: String       // "corveil/corveil"
         let branch: String
         let gitlabHost: String?    // nil for github.com
     }
@@ -1522,7 +1522,7 @@ public final class IssueTracker {
         }
     }
 
-    /// Resolve the org/repo slug (e.g. "radiusmethod/citadel") from a worktree's git remote.
+    /// Resolve the org/repo slug (e.g. "corveil/citadel") from a worktree's git remote.
     private func resolveRepoSlug(worktree: SessionWorktree) -> String {
         return resolveRepoInfo(worktree: worktree).slug
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/JobRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/JobRPCSupport.swift
@@ -62,7 +62,7 @@ public enum JobRPC {
         guard components.count >= 2,
               components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
             throw RPCError.invalidParams(
-                "repo must be an owner/repo slug (e.g. \"radiusmethod/crow\"); components must not be empty, '.', or '..'"
+                "repo must be an owner/repo slug (e.g. \"corveil/crow\"); components must not be empty, '.', or '..'"
             )
         }
         return repo

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -2526,7 +2526,7 @@ public final class SessionService {
     }
 
     /// The local folder name for a job's repo: the slug's last component
-    /// (`radiusmethod/api` → `api`, GitLab `group/sub/proj` → `proj`), or the
+    /// (`corveil/api` → `api`, GitLab `group/sub/proj` → `proj`), or the
     /// value verbatim when it isn't a slug (legacy bare-name jobs).
     nonisolated static func jobRepoFolder(for repo: String) -> String {
         repo.contains("/") ? (repo as NSString).lastPathComponent : repo

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AgentHandoffTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AgentHandoffTests.swift
@@ -61,7 +61,7 @@ struct AgentHandoffPromptTests {
             name: "crow-627",
             kind: .work,
             agentKind: .claudeCode,
-            ticketURL: "https://github.com/radiusmethod/crow/issues/627"
+            ticketURL: "https://github.com/corveil/crow/issues/627"
         )
         let wt = SessionWorktree(
             sessionID: session.id,

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AutoRespondCoordinatorReviewSessionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AutoRespondCoordinatorReviewSessionTests.swift
@@ -28,7 +28,7 @@ struct AutoRespondCoordinatorReviewSessionTests {
         let t = PRStatusTransition(
             kind: .changesRequested,
             sessionID: review.id,
-            prURL: "https://github.com/radiusmethod/crow/pull/123",
+            prURL: "https://github.com/corveil/crow/pull/123",
             prNumber: 123
         )
         #expect(coord.shouldSkipReviewSession(t))
@@ -40,7 +40,7 @@ struct AutoRespondCoordinatorReviewSessionTests {
         let t = PRStatusTransition(
             kind: .checksFailing,
             sessionID: review.id,
-            prURL: "https://github.com/radiusmethod/crow/pull/456",
+            prURL: "https://github.com/corveil/crow/pull/456",
             prNumber: 456
         )
         #expect(coord.shouldSkipReviewSession(t))
@@ -52,7 +52,7 @@ struct AutoRespondCoordinatorReviewSessionTests {
         let t = PRStatusTransition(
             kind: .changesRequested,
             sessionID: work.id,
-            prURL: "https://github.com/radiusmethod/crow/pull/789",
+            prURL: "https://github.com/corveil/crow/pull/789",
             prNumber: 789
         )
         #expect(!coord.shouldSkipReviewSession(t))
@@ -66,7 +66,7 @@ struct AutoRespondCoordinatorReviewSessionTests {
         let t = PRStatusTransition(
             kind: .changesRequested,
             sessionID: UUID(),
-            prURL: "https://github.com/radiusmethod/crow/pull/1",
+            prURL: "https://github.com/corveil/crow/pull/1",
             prNumber: 1
         )
         #expect(!coord.shouldSkipReviewSession(t))

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
@@ -13,7 +13,7 @@ struct IssueTrackerAutoMergeTests {
     private static let otherLabel = LabelInfo(name: "documentation", color: "ffffff")
 
     private func makePR(
-        url: String = "https://github.com/radiusmethod/crow/pull/42",
+        url: String = "https://github.com/corveil/crow/pull/42",
         number: Int = 42,
         state: String = "OPEN",
         mergeable: String = "MERGEABLE",
@@ -21,7 +21,7 @@ struct IssueTrackerAutoMergeTests {
         reviewDecision: String = "APPROVED",
         isDraft: Bool = false,
         labels: [LabelInfo] = [crowMergeLabel],
-        repo: String = "radiusmethod/crow"
+        repo: String = "corveil/crow"
     ) -> IssueTracker.ViewerPR {
         IssueTracker.ViewerPR(
             number: number,

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoRebaseTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoRebaseTests.swift
@@ -21,7 +21,7 @@ struct IssueTrackerAutoRebaseTests {
     ) -> IssueTracker.ViewerPR {
         IssueTracker.ViewerPR(
             number: 42,
-            url: "https://github.com/radiusmethod/crow/pull/42",
+            url: "https://github.com/corveil/crow/pull/42",
             state: state,
             mergeable: mergeable,
             mergeStateStatus: mergeStateStatus,
@@ -30,7 +30,7 @@ struct IssueTrackerAutoRebaseTests {
             headRefName: "feature/x",
             headRefOid: "abc1234",
             baseRefName: "main",
-            repoNameWithOwner: "radiusmethod/crow",
+            repoNameWithOwner: "corveil/crow",
             labels: labels,
             linkedIssueReferences: [],
             checksState: "SUCCESS",

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
@@ -50,7 +50,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func collapsesExactDuplicates() {
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let prs = [
             makeViewerPR(url: url, state: "OPEN"),
             makeViewerPR(url: url, state: "OPEN"),
@@ -61,7 +61,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergedBeatsOpenRegardlessOfOrder() {
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let open = makeViewerPR(url: url, state: "OPEN")
         let merged = makeViewerPR(url: url, state: "MERGED")
 
@@ -75,14 +75,14 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergedWinnerBackfillsEmptyFieldsFromOpenLoser() {
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let open = makeViewerPR(
             url: url,
             state: "OPEN",
             reviewDecision: "APPROVED",
             headRefName: "feature/x",
             baseRefName: "main",
-            repoNameWithOwner: "radiusmethod/corveil",
+            repoNameWithOwner: "corveil/corveil",
             checksState: "SUCCESS",
             failedCheckNames: ["noop"],
             latestReviewStates: ["APPROVED"]
@@ -96,14 +96,14 @@ struct IssueTrackerDedupTests {
         #expect(pr.reviewDecision == "APPROVED")
         #expect(pr.headRefName == "feature/x")
         #expect(pr.baseRefName == "main")
-        #expect(pr.repoNameWithOwner == "radiusmethod/corveil")
+        #expect(pr.repoNameWithOwner == "corveil/corveil")
         #expect(pr.checksState == "SUCCESS")
         #expect(pr.failedCheckNames == ["noop"])
         #expect(pr.latestReviewStates == ["APPROVED"])
     }
 
     @Test func mergedWinsThreeWay() {
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let prs = [
             makeViewerPR(url: url, state: "OPEN"),
             makeViewerPR(url: url, state: "CLOSED"),
@@ -128,7 +128,7 @@ struct IssueTrackerDedupTests {
         // applyPRStatuses / autoCompleteFinishedSessions. If a future
         // refactor regresses dedup at the assembly site, these call sites
         // must still tolerate duplicates instead of trapping.
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let prs = [
             makeViewerPR(url: url, state: "OPEN"),
             makeViewerPR(url: url, state: "MERGED"),
@@ -148,7 +148,7 @@ struct IssueTrackerDedupTests {
         // Forward its lastChangesRequestedAt; fall back to loser's only when
         // winner's is nil so the stateless "needs refine" rule never loses
         // the anchor timestamp during merge.
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let openTs = Date(timeIntervalSince1970: 1_700_000_000)
         let mergedTs = Date(timeIntervalSince1970: 1_700_001_000)
         let open = makeViewerPR(url: url, state: "OPEN", lastChangesRequestedAt: openTs)
@@ -158,7 +158,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergePRRecordsBackfillsLastChangesRequestedAtWhenWinnerLacks() {
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let openTs = Date(timeIntervalSince1970: 1_700_000_000)
         let open = makeViewerPR(url: url, state: "OPEN", lastChangesRequestedAt: openTs)
         let mergedNoTs = makeViewerPR(url: url, state: "MERGED")
@@ -166,7 +166,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergePRRecordsBackfillsLastSubstantiveCommitAtWhenWinnerLacks() {
-        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let url = "https://github.com/corveil/corveil/pull/201"
         let openTs = Date(timeIntervalSince1970: 1_700_000_000)
         let open = makeViewerPR(url: url, state: "OPEN", lastSubstantiveCommitAt: openTs)
         let mergedNoTs = makeViewerPR(url: url, state: "MERGED")

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
@@ -50,7 +50,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func collapsesExactDuplicates() {
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let prs = [
             makeViewerPR(url: url, state: "OPEN"),
             makeViewerPR(url: url, state: "OPEN"),
@@ -61,7 +61,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergedBeatsOpenRegardlessOfOrder() {
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let open = makeViewerPR(url: url, state: "OPEN")
         let merged = makeViewerPR(url: url, state: "MERGED")
 
@@ -75,14 +75,14 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergedWinnerBackfillsEmptyFieldsFromOpenLoser() {
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let open = makeViewerPR(
             url: url,
             state: "OPEN",
             reviewDecision: "APPROVED",
             headRefName: "feature/x",
             baseRefName: "main",
-            repoNameWithOwner: "corveil/corveil",
+            repoNameWithOwner: "corveil/crow",
             checksState: "SUCCESS",
             failedCheckNames: ["noop"],
             latestReviewStates: ["APPROVED"]
@@ -96,14 +96,14 @@ struct IssueTrackerDedupTests {
         #expect(pr.reviewDecision == "APPROVED")
         #expect(pr.headRefName == "feature/x")
         #expect(pr.baseRefName == "main")
-        #expect(pr.repoNameWithOwner == "corveil/corveil")
+        #expect(pr.repoNameWithOwner == "corveil/crow")
         #expect(pr.checksState == "SUCCESS")
         #expect(pr.failedCheckNames == ["noop"])
         #expect(pr.latestReviewStates == ["APPROVED"])
     }
 
     @Test func mergedWinsThreeWay() {
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let prs = [
             makeViewerPR(url: url, state: "OPEN"),
             makeViewerPR(url: url, state: "CLOSED"),
@@ -128,7 +128,7 @@ struct IssueTrackerDedupTests {
         // applyPRStatuses / autoCompleteFinishedSessions. If a future
         // refactor regresses dedup at the assembly site, these call sites
         // must still tolerate duplicates instead of trapping.
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let prs = [
             makeViewerPR(url: url, state: "OPEN"),
             makeViewerPR(url: url, state: "MERGED"),
@@ -148,7 +148,7 @@ struct IssueTrackerDedupTests {
         // Forward its lastChangesRequestedAt; fall back to loser's only when
         // winner's is nil so the stateless "needs refine" rule never loses
         // the anchor timestamp during merge.
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let openTs = Date(timeIntervalSince1970: 1_700_000_000)
         let mergedTs = Date(timeIntervalSince1970: 1_700_001_000)
         let open = makeViewerPR(url: url, state: "OPEN", lastChangesRequestedAt: openTs)
@@ -158,7 +158,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergePRRecordsBackfillsLastChangesRequestedAtWhenWinnerLacks() {
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let openTs = Date(timeIntervalSince1970: 1_700_000_000)
         let open = makeViewerPR(url: url, state: "OPEN", lastChangesRequestedAt: openTs)
         let mergedNoTs = makeViewerPR(url: url, state: "MERGED")
@@ -166,7 +166,7 @@ struct IssueTrackerDedupTests {
     }
 
     @Test func mergePRRecordsBackfillsLastSubstantiveCommitAtWhenWinnerLacks() {
-        let url = "https://github.com/corveil/corveil/pull/201"
+        let url = "https://github.com/corveil/crow/pull/201"
         let openTs = Date(timeIntervalSince1970: 1_700_000_000)
         let open = makeViewerPR(url: url, state: "OPEN", lastSubstantiveCommitAt: openTs)
         let mergedNoTs = makeViewerPR(url: url, state: "MERGED")

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReconcileTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReconcileTests.swift
@@ -148,11 +148,11 @@ struct IssueTrackerReconcileProviderTests {
 @Suite("IssueTracker remote host extraction")
 struct IssueTrackerRemoteHostTests {
     @Test func parsesGitHubSSH() {
-        #expect(IssueTracker.extractHost(fromRemote: "git@github.com:radiusmethod/corveil") == "github.com")
+        #expect(IssueTracker.extractHost(fromRemote: "git@github.com:corveil/corveil") == "github.com")
     }
 
     @Test func parsesGitHubHTTPS() {
-        #expect(IssueTracker.extractHost(fromRemote: "https://github.com/radiusmethod/corveil") == "github.com")
+        #expect(IssueTracker.extractHost(fromRemote: "https://github.com/corveil/corveil") == "github.com")
     }
 
     @Test func parsesGitLabHTTPSCustomHost() {
@@ -172,11 +172,11 @@ struct IssueTrackerRemoteHostTests {
 @Suite("IssueTracker remote slug extraction")
 struct IssueTrackerRemoteSlugTests {
     @Test func parsesGitHubSSH() {
-        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:radiusmethod/corveil") == "radiusmethod/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:corveil/corveil") == "corveil/corveil")
     }
 
     @Test func parsesGitHubHTTPS() {
-        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/radiusmethod/corveil") == "radiusmethod/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/corveil/corveil") == "corveil/corveil")
     }
 
     @Test func parsesGitLabTwoLevel() {
@@ -202,8 +202,8 @@ struct IssueTrackerRemoteSlugTests {
     }
 
     @Test func stripsTrailingDotGit() {
-        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/radiusmethod/corveil.git") == "radiusmethod/corveil")
-        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:radiusmethod/corveil.git") == "radiusmethod/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/corveil/corveil.git") == "corveil/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:corveil/corveil.git") == "corveil/corveil")
         #expect(
             IssueTracker.extractSlug(
                 fromRemote: "https://gitlab.example.com/big-bang/product/packages/elasticsearch-kibana.git"

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReconcileTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReconcileTests.swift
@@ -148,11 +148,11 @@ struct IssueTrackerReconcileProviderTests {
 @Suite("IssueTracker remote host extraction")
 struct IssueTrackerRemoteHostTests {
     @Test func parsesGitHubSSH() {
-        #expect(IssueTracker.extractHost(fromRemote: "git@github.com:corveil/corveil") == "github.com")
+        #expect(IssueTracker.extractHost(fromRemote: "git@github.com:corveil/crow") == "github.com")
     }
 
     @Test func parsesGitHubHTTPS() {
-        #expect(IssueTracker.extractHost(fromRemote: "https://github.com/corveil/corveil") == "github.com")
+        #expect(IssueTracker.extractHost(fromRemote: "https://github.com/corveil/crow") == "github.com")
     }
 
     @Test func parsesGitLabHTTPSCustomHost() {
@@ -172,11 +172,11 @@ struct IssueTrackerRemoteHostTests {
 @Suite("IssueTracker remote slug extraction")
 struct IssueTrackerRemoteSlugTests {
     @Test func parsesGitHubSSH() {
-        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:corveil/corveil") == "corveil/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:corveil/crow") == "corveil/crow")
     }
 
     @Test func parsesGitHubHTTPS() {
-        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/corveil/corveil") == "corveil/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/corveil/crow") == "corveil/crow")
     }
 
     @Test func parsesGitLabTwoLevel() {
@@ -202,8 +202,8 @@ struct IssueTrackerRemoteSlugTests {
     }
 
     @Test func stripsTrailingDotGit() {
-        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/corveil/corveil.git") == "corveil/corveil")
-        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:corveil/corveil.git") == "corveil/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/corveil/crow.git") == "corveil/crow")
+        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:corveil/crow.git") == "corveil/crow")
         #expect(
             IssueTracker.extractSlug(
                 fromRemote: "https://gitlab.example.com/big-bang/product/packages/elasticsearch-kibana.git"

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerStalePRTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerStalePRTests.swift
@@ -181,7 +181,7 @@ struct IssueTrackerStalePRTests {
         // from a prior reconcile, once MERGED from this cycle's stale fetch)
         // collapses with MERGED winning.
         let mrURL = "https://repo1.dso.mil/big-bang/product/-/merge_requests/7"
-        let prURL = "https://github.com/radiusmethod/corveil/pull/201"
+        let prURL = "https://github.com/corveil/corveil/pull/201"
         let prs = [
             makeViewerPR(url: prURL, state: "OPEN"),
             makeViewerPR(url: mrURL, state: "OPEN"),

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerStalePRTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerStalePRTests.swift
@@ -181,7 +181,7 @@ struct IssueTrackerStalePRTests {
         // from a prior reconcile, once MERGED from this cycle's stale fetch)
         // collapses with MERGED winning.
         let mrURL = "https://repo1.dso.mil/big-bang/product/-/merge_requests/7"
-        let prURL = "https://github.com/corveil/corveil/pull/201"
+        let prURL = "https://github.com/corveil/crow/pull/201"
         let prs = [
             makeViewerPR(url: prURL, state: "OPEN"),
             makeViewerPR(url: mrURL, state: "OPEN"),

--- a/Packages/CrowEngine/Tests/CrowEngineTests/JobRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/JobRPCSupportTests.swift
@@ -68,7 +68,7 @@ struct JobRPCSupportTests {
     // MARK: - validateRepoSlug
 
     @Test func validateRepoSlugAcceptsSlugsAndNestedGroups() throws {
-        #expect(try JobRPC.validateRepoSlug("radiusmethod/crow") == "radiusmethod/crow")
+        #expect(try JobRPC.validateRepoSlug("corveil/crow") == "corveil/crow")
         #expect(try JobRPC.validateRepoSlug("group/sub/project") == "group/sub/project")
         #expect(try JobRPC.validateRepoSlug("  owner/repo  ") == "owner/repo")
     }
@@ -104,8 +104,8 @@ struct JobRPCSupportTests {
         let created = Date(timeIntervalSince1970: 1_750_000_000)
         let job = JobConfig(
             name: "triage",
-            workspace: "RadiusMethod",
-            repo: "radiusmethod/api",
+            workspace: "Corveil",
+            repo: "corveil/api",
             prompts: ["go"],
             schedule: .interval(seconds: 3600),
             enabled: true,
@@ -115,8 +115,8 @@ struct JobRPCSupportTests {
         let object = try #require(JobRPC.jobJSON(job).objectValue)
         #expect(object["id"] == .string(job.id.uuidString))
         #expect(object["name"] == .string("triage"))
-        #expect(object["workspace"] == .string("RadiusMethod"))
-        #expect(object["repo"] == .string("radiusmethod/api"))
+        #expect(object["workspace"] == .string("Corveil"))
+        #expect(object["repo"] == .string("corveil/api"))
         #expect(object["prompts"] == .array([.string("go")]))
         #expect(object["enabled"] == .bool(true))
         #expect(object["schedule"] == .object(["type": .string("interval"), "seconds": .int(3600)]))

--- a/Packages/CrowEngine/Tests/CrowEngineTests/JobRepoResolutionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/JobRepoResolutionTests.swift
@@ -10,7 +10,7 @@ import Testing
 struct JobRepoResolutionTests {
 
     @Test func repoFolderTakesSlugLastComponent() {
-        #expect(SessionService.jobRepoFolder(for: "radiusmethod/api") == "api")
+        #expect(SessionService.jobRepoFolder(for: "corveil/api") == "api")
     }
 
     @Test func repoFolderHandlesNestedGitLabGroups() {
@@ -24,10 +24,10 @@ struct JobRepoResolutionTests {
 
     @Test func worktreeLayoutComposesWorkspaceScopedPath() {
         let layout = SessionService.jobWorktreeLayout(
-            devRoot: "/dev", workspace: "RadiusMethod", repo: "radiusmethod/api"
+            devRoot: "/dev", workspace: "Corveil", repo: "corveil/api"
         )
-        #expect(layout.workspacePath == "/dev/RadiusMethod")
-        #expect(layout.repoPath == "/dev/RadiusMethod/api")
+        #expect(layout.workspacePath == "/dev/Corveil")
+        #expect(layout.repoPath == "/dev/Corveil/api")
         #expect(layout.repoFolder == "api")
     }
 

--- a/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
@@ -33,10 +33,10 @@ struct QuickActionPromptsTests {
         let prompt = QuickActionPrompts.build(
             action: .mergePR,
             codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
-            prURL: "https://github.com/radiusmethod/crow/pull/123",
+            prURL: "https://github.com/corveil/crow/pull/123",
             prNumber: 123
         )
-        #expect(prompt.contains("cd \"$TMPDIR\" && gh pr merge https://github.com/radiusmethod/crow/pull/123 --squash --delete-branch"))
+        #expect(prompt.contains("cd \"$TMPDIR\" && gh pr merge https://github.com/corveil/crow/pull/123 --squash --delete-branch"))
         #expect(prompt.contains("worktree"))
         #expect(prompt.hasSuffix("\n"))
     }
@@ -65,14 +65,14 @@ struct ReReviewPromptTests {
         let prompt = QuickActionPrompts.build(
             action: .reReview,
             codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
-            prURL: "https://github.com/radiusmethod/crow/pull/753",
+            prURL: "https://github.com/corveil/crow/pull/753",
             prNumber: 753,
             lastReviewedHeadSha: "abcdef0123456789"
         )
         // Never touch the branch under review.
         #expect(prompt.contains("do NOT modify code, commit, or push"))
         // Re-runs the review + posts a verdict (not a bare comment).
-        #expect(prompt.contains("gh pr review https://github.com/radiusmethod/crow/pull/753 --request-changes"))
+        #expect(prompt.contains("gh pr review https://github.com/corveil/crow/pull/753 --request-changes"))
         #expect(prompt.contains("--approve"))
         #expect(prompt.contains("never `--comment`"))
         // Single-line contract.
@@ -84,7 +84,7 @@ struct ReReviewPromptTests {
         let prompt = QuickActionPrompts.build(
             action: .reReview,
             codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
-            prURL: "https://github.com/radiusmethod/crow/pull/753",
+            prURL: "https://github.com/corveil/crow/pull/753",
             prNumber: 753,
             lastReviewedHeadSha: "abcdef0123456789deadbeef"
         )
@@ -96,7 +96,7 @@ struct ReReviewPromptTests {
         let prompt = QuickActionPrompts.build(
             action: .reReview,
             codeBackend: FakeCodeBackend(provider: .github, cliName: "gh"),
-            prURL: "https://github.com/radiusmethod/crow/pull/753",
+            prURL: "https://github.com/corveil/crow/pull/753",
             prNumber: 753,
             lastReviewedHeadSha: nil
         )

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
@@ -16,9 +16,9 @@ import CrowCore
 @Suite("Review prompt branch")
 struct SessionServiceReviewPromptTests {
 
-    private static let prURL = "https://github.com/radiusmethod/crow/pull/123"
+    private static let prURL = "https://github.com/corveil/crow/pull/123"
     private static let prTitle = "Some PR"
-    private static let repoSlug = "radiusmethod/crow"
+    private static let repoSlug = "corveil/crow"
     private static let prNumber = 123
 
     /// Minimal SKILL-shaped fixture. Avoids depending on
@@ -28,7 +28,7 @@ struct SessionServiceReviewPromptTests {
     # Crow Review PR
     Review PR $ARGUMENTS — checkout via `gh pr checkout $ARGUMENTS`.
 
-    [🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+    [🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/corveil/crow)
     """
 
     @Test func cursorPromptSubstitutesPRURLForArguments() {
@@ -61,7 +61,7 @@ struct SessionServiceReviewPromptTests {
         #expect(!prompt.contains("$CROW_AGENT_DISPLAY_NAME"))
         // The canonical URL must remain — only the agent-name segment is
         // swapped.
-        #expect(prompt.contains("https://github.com/radiusmethod/crow"))
+        #expect(prompt.contains("https://github.com/corveil/crow"))
     }
 
     @Test func buildReviewPromptCursorBranchUsesCursorHelper() {

--- a/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
@@ -28,10 +28,10 @@ import CrowCore
 // MARK: - RepoInfo
 
 @Test func repoInfoStoresAllProperties() {
-    let info = RepoInfo(name: "crow", path: "/dev/crow", workspace: "RadiusMethod", provider: "github", cli: "gh", host: "github.com")
+    let info = RepoInfo(name: "crow", path: "/dev/crow", workspace: "Corveil", provider: "github", cli: "gh", host: "github.com")
     #expect(info.name == "crow")
     #expect(info.path == "/dev/crow")
-    #expect(info.workspace == "RadiusMethod")
+    #expect(info.workspace == "Corveil")
     #expect(info.provider == "github")
     #expect(info.cli == "gh")
     #expect(info.host == "github.com")

--- a/Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift
+++ b/Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift
@@ -20,7 +20,7 @@ public final class SocketServer: @unchecked Sendable {
     private let router: CommandRouter
     private var serverFD: Int32 = -1
     private var running = false
-    private let queue = DispatchQueue(label: "com.radiusmethod.crow.socket", qos: .userInitiated)
+    private let queue = DispatchQueue(label: "com.corveil.crow.socket", qos: .userInitiated)
 
     /// Maximum size of a single JSON-RPC message (1 MB).
     static let maxMessageSize = 1_048_576

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
@@ -144,7 +144,7 @@ import Testing
     var config = AppConfig(
         workspaces: [
             WorkspaceInfo(
-                name: "RadiusMethod",
+                name: "Corveil",
                 gateway: WorkspaceGateway(
                     baseURL: "https://corveil.io",
                     customHeaders: ["x-citadel-api-key": "op://Spotlight Prod/Citadel/api_key"]

--- a/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
@@ -41,8 +41,8 @@ struct ProviderManagerTests {
     // MARK: - parseTicketURLComponents (static)
 
     @Test func parseGitHubIssueURL() {
-        let result = ProviderManager.parseTicketURLComponents("https://github.com/radiusmethod/crow/issues/74")
-        #expect(result?.org == "radiusmethod")
+        let result = ProviderManager.parseTicketURLComponents("https://github.com/corveil/crow/issues/74")
+        #expect(result?.org == "corveil")
         #expect(result?.repo == "crow")
         #expect(result?.number == 74)
         #expect(result?.isMR == false)
@@ -262,7 +262,7 @@ struct ProviderManagerTests {
     // MARK: - classifySpec (Jobs repo specs)
 
     @Test func classifySpecGlobExtractsOwner() {
-        #expect(ProviderManager.classifySpec("radiusmethod/*") == .glob(owner: "radiusmethod"))
+        #expect(ProviderManager.classifySpec("corveil/*") == .glob(owner: "corveil"))
     }
 
     @Test func classifySpecNestedGroupGlob() {
@@ -270,11 +270,11 @@ struct ProviderManagerTests {
     }
 
     @Test func classifySpecExplicitSlugPassesThrough() {
-        #expect(ProviderManager.classifySpec("radiusmethod/api") == .explicit(slug: "radiusmethod/api"))
+        #expect(ProviderManager.classifySpec("corveil/api") == .explicit(slug: "corveil/api"))
     }
 
     @Test func classifySpecTrimsWhitespace() {
-        #expect(ProviderManager.classifySpec("  radiusmethod/api  ") == .explicit(slug: "radiusmethod/api"))
+        #expect(ProviderManager.classifySpec("  corveil/api  ") == .explicit(slug: "corveil/api"))
     }
 
     @Test func classifySpecBareNameIsInvalid() {
@@ -298,7 +298,7 @@ struct ProviderManagerTests {
     }
 
     @Test func encodeGitLabGroupPathLeavesSimpleOwnerUnchanged() {
-        #expect(ProviderManager.encodeGitLabGroupPath("radiusmethod") == "radiusmethod")
+        #expect(ProviderManager.encodeGitLabGroupPath("corveil") == "corveil")
     }
 
     @Test func reposForSpecsKeepsExplicitSlugsSortedAndDeduped() async {
@@ -369,12 +369,12 @@ struct ProviderManagerTests {
     // MARK: - TicketInfo
 
     @Test func ticketInfoStoresAllProperties() {
-        let info = TicketInfo(number: 42, title: "Fix bug", repo: "crow", org: "radiusmethod", url: "https://github.com/radiusmethod/crow/issues/42", provider: .github, isMR: false)
+        let info = TicketInfo(number: 42, title: "Fix bug", repo: "crow", org: "corveil", url: "https://github.com/corveil/crow/issues/42", provider: .github, isMR: false)
         #expect(info.number == 42)
         #expect(info.title == "Fix bug")
         #expect(info.repo == "crow")
-        #expect(info.org == "radiusmethod")
-        #expect(info.url == "https://github.com/radiusmethod/crow/issues/42")
+        #expect(info.org == "corveil")
+        #expect(info.url == "https://github.com/corveil/crow/issues/42")
         #expect(info.provider == .github)
         #expect(info.isMR == false)
     }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
@@ -10,7 +10,7 @@ public final class OTLPReceiver: Sendable {
     private let port: UInt16
     private let listener: NWListener
     private let database: TelemetryDatabase
-    private let queue = DispatchQueue(label: "com.radiusmethod.crow.otlp-receiver")
+    private let queue = DispatchQueue(label: "com.corveil.crow.otlp-receiver")
 
     /// Callback invoked on the main actor when new data arrives for a Crow session.
     /// The UUID is the Crow session ID.

--- a/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
@@ -16,7 +16,7 @@ public final class PTYProcess: @unchecked Sendable {
     private var masterFD: Int32 = -1
     private var childPID: pid_t = -1
     private var readSource: DispatchSourceRead?
-    private let readQueue = DispatchQueue(label: "com.radiusmethod.crow.pty-read", qos: .userInteractive)
+    private let readQueue = DispatchQueue(label: "com.corveil.crow.pty-read", qos: .userInteractive)
     /// When true (default), `onOutput`/`onExit` fire on `DispatchQueue.main` —
     /// what the AppKit surface needs. The headless `crowd` daemon has no main
     /// run loop pumping that queue, so it constructs with `false` to receive

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/SmartDetectTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/SmartDetectTests.swift
@@ -10,10 +10,10 @@ struct SmartDetectTests {
 
     @Test func detectsHttpsURLInPlainSelection() {
         let url = SmartDetect.detectURL(
-            in: "https://github.com/radiusmethod/crow",
+            in: "https://github.com/corveil/crow",
             allowedSchemes: schemes
         )
-        #expect(url?.absoluteString == "https://github.com/radiusmethod/crow")
+        #expect(url?.absoluteString == "https://github.com/corveil/crow")
     }
 
     @Test func detectURLTolersWhitespace() {

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ flowchart TB
 
 ```bash
 # 1. Clone
-git clone https://github.com/radiusmethod/crow.git
+git clone https://github.com/corveil/crow.git
 cd crow
 
 # 2. Build the `crow` CLI and the `crowd` daemon (Swift toolchain only).

--- a/Resources/crow-attribution-FOOTER.md.template
+++ b/Resources/crow-attribution-FOOTER.md.template
@@ -10,12 +10,12 @@ line survives every quoting form (single-quoted heredocs, JSON files, Swift lite
 expression in attribution footers. The shell silently fails to expand it inside
 single-quoted heredocs and the literal text leaks into the artifact (#447).
 
-The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
+The link target is always `https://github.com/corveil/crow` — never a fork or a value from the local git remote.
 
 | Artifact | Footer |
 |----------|--------|
-| Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
-| Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
+| Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/corveil/crow)` |
+| Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/corveil/crow)` |
 | Committed (hand-authored commit message) | Trailer block at the end of the message: `Crow-Session: <session-uuid>` and `Co-Authored-By: Claude <noreply@anthropic.com>` on their own lines, separated from the body by a blank line. `setup.sh` installs a `prepare-commit-msg` hook (CROW-518) that idempotently fills them in if missing, but include them explicitly when writing the message — the hook is the safety net. |
 
 `<agent>` above is just a placeholder for *this document* — in the real footer lines

--- a/Resources/crow-batch-workspace-SKILL.md.template
+++ b/Resources/crow-batch-workspace-SKILL.md.template
@@ -42,16 +42,16 @@ One or more ticket URLs, separated by newlines:
 
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
-https://github.com/Corveil/acme-api/issues/45
-https://github.com/Corveil/crow/issues/99
+https://github.com/corveil/crow/issues/101
+https://github.com/corveil/acme-api/issues/45
+https://github.com/corveil/crow/issues/99
 ```
 
 Or a mix of ticket URLs and natural language:
 
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
+https://github.com/corveil/crow/issues/101
 "update acme-api authentication"
 https://gitlab.example.com/org/repo/-/issues/42
 ```
@@ -190,9 +190,9 @@ Same as `/crow-workspace`. See that skill for the full CLI reference.
 ### Three GitHub Issues
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
-https://github.com/Corveil/acme-api/issues/45
-https://github.com/Corveil/crow/issues/99
+https://github.com/corveil/crow/issues/101
+https://github.com/corveil/acme-api/issues/45
+https://github.com/corveil/crow/issues/99
 ```
 - Resolves all 3 sequentially (fetches tickets, detects PRs, generates names)
 - Fires 3 `setup.sh` calls simultaneously
@@ -201,7 +201,7 @@ https://github.com/Corveil/crow/issues/99
 ### Mixed Providers
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
+https://github.com/corveil/crow/issues/101
 https://gitlab.example.com/org/my-project/-/issues/42
 ```
 - Detects GitHub and GitLab providers from URLs
@@ -211,11 +211,11 @@ https://gitlab.example.com/org/my-project/-/issues/42
 ### Five Workspaces (Stress Test)
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
-https://github.com/Corveil/crow/issues/102
-https://github.com/Corveil/crow/issues/103
-https://github.com/Corveil/acme-api/issues/45
-https://github.com/Corveil/acme-api/issues/46
+https://github.com/corveil/crow/issues/101
+https://github.com/corveil/crow/issues/102
+https://github.com/corveil/crow/issues/103
+https://github.com/corveil/acme-api/issues/45
+https://github.com/corveil/acme-api/issues/46
 ```
 - 5 parallel `setup.sh` calls
 - Each blocks one GCD thread in the socket server (well within the 64+ thread pool)

--- a/Resources/crow-batch-workspace-SKILL.md.template
+++ b/Resources/crow-batch-workspace-SKILL.md.template
@@ -42,16 +42,16 @@ One or more ticket URLs, separated by newlines:
 
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
-https://github.com/RadiusMethod/acme-api/issues/45
-https://github.com/RadiusMethod/crow/issues/99
+https://github.com/Corveil/crow/issues/101
+https://github.com/Corveil/acme-api/issues/45
+https://github.com/Corveil/crow/issues/99
 ```
 
 Or a mix of ticket URLs and natural language:
 
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
+https://github.com/Corveil/crow/issues/101
 "update acme-api authentication"
 https://gitlab.example.com/org/repo/-/issues/42
 ```
@@ -190,9 +190,9 @@ Same as `/crow-workspace`. See that skill for the full CLI reference.
 ### Three GitHub Issues
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
-https://github.com/RadiusMethod/acme-api/issues/45
-https://github.com/RadiusMethod/crow/issues/99
+https://github.com/Corveil/crow/issues/101
+https://github.com/Corveil/acme-api/issues/45
+https://github.com/Corveil/crow/issues/99
 ```
 - Resolves all 3 sequentially (fetches tickets, detects PRs, generates names)
 - Fires 3 `setup.sh` calls simultaneously
@@ -201,7 +201,7 @@ https://github.com/RadiusMethod/crow/issues/99
 ### Mixed Providers
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
+https://github.com/Corveil/crow/issues/101
 https://gitlab.example.com/org/my-project/-/issues/42
 ```
 - Detects GitHub and GitLab providers from URLs
@@ -211,11 +211,11 @@ https://gitlab.example.com/org/my-project/-/issues/42
 ### Five Workspaces (Stress Test)
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
-https://github.com/RadiusMethod/crow/issues/102
-https://github.com/RadiusMethod/crow/issues/103
-https://github.com/RadiusMethod/acme-api/issues/45
-https://github.com/RadiusMethod/acme-api/issues/46
+https://github.com/Corveil/crow/issues/101
+https://github.com/Corveil/crow/issues/102
+https://github.com/Corveil/crow/issues/103
+https://github.com/Corveil/acme-api/issues/45
+https://github.com/Corveil/acme-api/issues/46
 ```
 - 5 parallel `setup.sh` calls
 - Each blocks one GCD thread in the socket server (well within the 64+ thread pool)

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -41,7 +41,7 @@ same file used by `/crow-workspace`. It maps each workspace to a provider/cli/ho
 {
   "devRoot": "/Users/name/Dev",
   "workspaces": {
-    "RadiusMethod": { "provider": "github", "cli": "gh" },
+    "Corveil": { "provider": "github", "cli": "gh" },
     "MyGitLab": { "provider": "gitlab", "cli": "glab", "host": "gitlab.example.com" }
   },
   "defaults": { "provider": "github", "cli": "gh" }
@@ -124,7 +124,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -137,7 +137,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -157,11 +157,11 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body pas
 followed by:
 
 ```
-[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)
 ```
 
 - Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the issue body).
-- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not modify the URL — the link target is always `https://github.com/corveil/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body — GitHub, GitLab, or Jira — and whether or not the user supplied any body text.
 

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -140,11 +140,11 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 `gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)
 ```
 
 - Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the review body).
-- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not modify the URL — the link target is always `https://github.com/corveil/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.
 

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -600,7 +600,7 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 
 ### GitHub Issue URL
 ```
-/crow-workspace https://github.com/Corveil/acme-api/issues/45
+/crow-workspace https://github.com/corveil/acme-api/issues/45
 ```
 → Fetches issue #45, matches acme-api in Corveil
 → Creates worktree at ~/Dev/Corveil/acme-api-45-jwt-validation

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -22,7 +22,7 @@ Configuration is at `{devRoot}/.claude/config.json` (managed by the Crow app). T
 {
   "devRoot": "/Users/name/Dev",
   "workspaces": {
-    "RadiusMethod": {
+    "Corveil": {
       "provider": "github",
       "cli": "gh",
       "customInstructions": "Always run `npm test` before committing."
@@ -195,18 +195,18 @@ Branch: `feature/{repo}-{ticket_number}-{brief_slug}`
 The brief slug is 2-4 key words from the ticket title.
 
 **Concrete example with full paths:**
-Given: devRoot=`/Users/jane/Dev`, workspace=`RadiusMethod`, repo=`acme-api` (cloned at `/Users/jane/Dev/RadiusMethod/acme-api`), ticket #197 "Fix tab URL hash routing"
+Given: devRoot=`/Users/jane/Dev`, workspace=`Corveil`, repo=`acme-api` (cloned at `/Users/jane/Dev/Corveil/acme-api`), ticket #197 "Fix tab URL hash routing"
 
 ```
-Worktree path: /Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash
+Worktree path: /Users/jane/Dev/Corveil/acme-api-197-fix-tab-url-hash
 Branch:        feature/acme-api-197-fix-tab-url-hash
-Git command:   git -C /Users/jane/Dev/RadiusMethod/acme-api worktree add /Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash -b feature/acme-api-197-fix-tab-url-hash --no-track origin/main
+Git command:   git -C /Users/jane/Dev/Corveil/acme-api worktree add /Users/jane/Dev/Corveil/acme-api-197-fix-tab-url-hash -b feature/acme-api-197-fix-tab-url-hash --no-track origin/main
 ```
 
 More examples:
 ```
 web-app #252 "Update deployment-guide.md"    → {devRoot}/MyGitLab/web-app-252-update-deploy-docs
-acme-api #45 "Add JWT validation endpoint"   → {devRoot}/RadiusMethod/acme-api-45-jwt-validation
+acme-api #45 "Add JWT validation endpoint"   → {devRoot}/Corveil/acme-api-45-jwt-validation
 ```
 
 **For ticket URLs with an existing PR:**
@@ -217,7 +217,7 @@ Use the PR's `headRefName` as the branch — do NOT generate a new name. Derive 
 {devRoot}/{workspace}/{repo}-{pr_branch_slug}
 ```
 
-Where `{pr_branch_slug}` is the `headRefName` with any `feature/` prefix stripped. For example, if the PR branch is `feature/acme-api-45-jwt-validation`, the worktree path is `{devRoot}/RadiusMethod/acme-api-45-jwt-validation`.
+Where `{pr_branch_slug}` is the `headRefName` with any `feature/` prefix stripped. For example, if the PR branch is `feature/acme-api-45-jwt-validation`, the worktree path is `{devRoot}/Corveil/acme-api-45-jwt-validation`.
 
 **WRONG — do NOT create subdirectories:**
 ```
@@ -600,10 +600,10 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 
 ### GitHub Issue URL
 ```
-/crow-workspace https://github.com/RadiusMethod/acme-api/issues/45
+/crow-workspace https://github.com/Corveil/acme-api/issues/45
 ```
-→ Fetches issue #45, matches acme-api in RadiusMethod
-→ Creates worktree at ~/Dev/RadiusMethod/acme-api-45-jwt-validation
+→ Fetches issue #45, matches acme-api in Corveil
+→ Creates worktree at ~/Dev/Corveil/acme-api-45-jwt-validation
 → Creates crow session with ticket metadata + worktree + Claude Code terminal
 
 ### Natural Language
@@ -618,6 +618,6 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 ```
 /crow-workspace "integrate my-project with acme-api gateway"
 ```
-→ Matches my-project (MyGitLab) + acme-api (RadiusMethod)
+→ Matches my-project (MyGitLab) + acme-api (Corveil)
 → Creates worktrees for both, one crow session
 → Claude launches in highest-scoring repo

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -360,7 +360,7 @@ Usage: setup.sh [OPTIONS]
 
 Required:
   --dev-root <path>          Development root directory
-  --workspace <name>         Workspace name (e.g. RadiusMethod)
+  --workspace <name>         Workspace name (e.g. Corveil)
   --repo <name>              Repository name
   --repo-path <path>         Main repo clone path
   --slug <slug>              LLM-generated slug (e.g. 104-global-terminals)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-If you discover a security vulnerability in Crow, please report it by emailing **security@radiusmethod.com**. Include as much detail as possible:
+If you discover a security vulnerability in Crow, please report it by emailing **security@corveil.com**. Include as much detail as possible:
 
 - A description of the vulnerability
 - Steps to reproduce the issue

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-If you discover a security vulnerability in Crow, please report it by emailing **security@corveil.com**. Include as much detail as possible:
+If you discover a security vulnerability in Crow, please report it privately through [GitHub's private vulnerability reporting](https://github.com/corveil/crow/security/advisories/new) for this repository. Include as much detail as possible:
 
 - A description of the vulnerability
 - Steps to reproduce the issue

--- a/Sources/Crow/App/JobRPCSupport.swift
+++ b/Sources/Crow/App/JobRPCSupport.swift
@@ -62,7 +62,7 @@ enum JobRPC {
         guard components.count >= 2,
               components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
             throw RPCError.invalidParams(
-                "repo must be an owner/repo slug (e.g. \"radiusmethod/crow\"); components must not be empty, '.', or '..'"
+                "repo must be an owner/repo slug (e.g. \"corveil/crow\"); components must not be empty, '.', or '..'"
             )
         }
         return repo

--- a/Tests/CrowTests/JobRPCSupportTests.swift
+++ b/Tests/CrowTests/JobRPCSupportTests.swift
@@ -68,7 +68,7 @@ struct JobRPCSupportTests {
     // MARK: - validateRepoSlug
 
     @Test func validateRepoSlugAcceptsSlugsAndNestedGroups() throws {
-        #expect(try JobRPC.validateRepoSlug("radiusmethod/crow") == "radiusmethod/crow")
+        #expect(try JobRPC.validateRepoSlug("corveil/crow") == "corveil/crow")
         #expect(try JobRPC.validateRepoSlug("group/sub/project") == "group/sub/project")
         #expect(try JobRPC.validateRepoSlug("  owner/repo  ") == "owner/repo")
     }
@@ -104,8 +104,8 @@ struct JobRPCSupportTests {
         let created = Date(timeIntervalSince1970: 1_750_000_000)
         let job = JobConfig(
             name: "triage",
-            workspace: "RadiusMethod",
-            repo: "radiusmethod/api",
+            workspace: "Corveil",
+            repo: "corveil/api",
             prompts: ["go"],
             schedule: .interval(seconds: 3600),
             enabled: true,
@@ -115,8 +115,8 @@ struct JobRPCSupportTests {
         let object = try #require(JobRPC.jobJSON(job).objectValue)
         #expect(object["id"] == .string(job.id.uuidString))
         #expect(object["name"] == .string("triage"))
-        #expect(object["workspace"] == .string("RadiusMethod"))
-        #expect(object["repo"] == .string("radiusmethod/api"))
+        #expect(object["workspace"] == .string("Corveil"))
+        #expect(object["repo"] == .string("corveil/api"))
         #expect(object["prompts"] == .array([.string("go")]))
         #expect(object["enabled"] == .bool(true))
         #expect(object["schedule"] == .object(["type": .string("interval"), "seconds": .int(3600)]))

--- a/crow-desktop/src-tauri/tauri.conf.json
+++ b/crow-desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Crow",
   "version": "0.1.0",
-  "identifier": "com.radiusmethod.crow",
+  "identifier": "com.corveil.crow",
   "build": {
     "frontendDist": "../ui"
   },

--- a/docs/adr/0003-worktree-per-task-model.md
+++ b/docs/adr/0003-worktree-per-task-model.md
@@ -8,7 +8,7 @@
 
 Crow's central pattern is running multiple Claude Code sessions in parallel, each working on a different ticket. A single clone of a repo can only have one branch checked out at a time — the working tree, the index, and `HEAD` are shared global state. That makes branch-switching hostile to parallel agents: any two sessions touching the same clone will fight over the working tree, and an agent that runs `git checkout` mid-task can clobber another agent's edits.
 
-We also want the on-disk layout to be self-describing — a path like `/Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash` should reveal the repo, the ticket, and the slug at a glance, both for humans and for grep-based agent navigation.
+We also want the on-disk layout to be self-describing — a path like `/Users/jane/Dev/Corveil/acme-api-197-fix-tab-url-hash` should reveal the repo, the ticket, and the slug at a glance, both for humans and for grep-based agent navigation.
 
 ## Decision
 

--- a/docs/adr/0009-crowd-sole-authority-clients-only.md
+++ b/docs/adr/0009-crowd-sole-authority-clients-only.md
@@ -86,7 +86,7 @@ directly. All mutation flows through `crowd` RPCs; all state arrives via
 
 ## References
 
-- PR: https://github.com/radiusmethod/crow/pull/594 (CROW-581, Milestones A–E1)
+- PR: https://github.com/corveil/crow/pull/594 (CROW-581, Milestones A–E1)
 - Related ADRs: [0001](./0001-tmux-only-terminal-backend.md) (tmux as the sole
   terminal backend — the shared server is what lets many clients attach),
   [0002](./0002-unix-socket-cli-architecture.md) (the JSON-RPC surface clients

--- a/docs/adr/0010-retire-the-macos-app.md
+++ b/docs/adr/0010-retire-the-macos-app.md
@@ -27,6 +27,6 @@ The macOS app is removed. `crowd` plus the **web UI are the only client**. The `
 
 ## References
 
-- PR: https://github.com/radiusmethod/crow/pull/594 (CROW-593)
+- PR: https://github.com/corveil/crow/pull/594 (CROW-593)
 - Related ADRs: [0009](./0009-crowd-sole-authority-clients-only.md) (crowd is the sole authority — this ADR removes its last non-web client), [0006](./0006-universal-macos-binary.md) (xterm.js renderer — still used, now in the browser)
 - Code: `Packages/CrowDaemon/` (`crowd`), `Packages/CrowEngine/` (host-agnostic engine + `HostBridge`)

--- a/docs/adr/0011-agent-handoff-preserves-session-not-chat.md
+++ b/docs/adr/0011-agent-handoff-preserves-session-not-chat.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Users hit per-agent credit limits mid-task (Claude Code → Cursor, etc.) and need to continue the same Crow session without recreating worktrees or losing ticket context ([#627](https://github.com/radiusmethod/crow/issues/627)). Each coding agent keeps its own conversation store; there is no portable transcript format across Claude Code, Cursor, Codex, and OpenCode. Crow already persists per-session `agentKind` and launches via the `CodingAgent` protocol, but until now that kind was fixed at create time (Manager config reconcile aside).
+Users hit per-agent credit limits mid-task (Claude Code → Cursor, etc.) and need to continue the same Crow session without recreating worktrees or losing ticket context ([#627](https://github.com/corveil/crow/issues/627)). Each coding agent keeps its own conversation store; there is no portable transcript format across Claude Code, Cursor, Codex, and OpenCode. Crow already persists per-session `agentKind` and launches via the `CodingAgent` protocol, but until now that kind was fixed at create time (Manager config reconcile aside).
 
 ## Decision
 
@@ -34,6 +34,6 @@ Exposed as RPC/CLI `handoff-agent` and a web UI “Switch agent…” control. M
 
 ## References
 
-- Issue: https://github.com/radiusmethod/crow/issues/627
+- Issue: https://github.com/corveil/crow/issues/627
 - Code: `Packages/CrowEngine/Sources/CrowEngine/AgentHandoff.swift`, `SessionService.handoffAgent`
 - Related ADRs: [0003](./0003-worktree-per-task-model.md), [0007](./0007-crowd-sole-authority-clients-only.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -191,8 +191,8 @@ Register a git worktree for a session. The app uses `--repo-path` to run git com
 crow add-worktree \
   --session <uuid> \
   --repo "acme-api" \
-  --repo-path "/Users/you/Dev/RadiusMethod/acme-api" \
-  --path "/Users/you/Dev/RadiusMethod/acme-api-123-feature" \
+  --repo-path "/Users/you/Dev/Corveil/acme-api" \
+  --path "/Users/you/Dev/Corveil/acme-api-123-feature" \
   --branch "feature/acme-api-123" \
   --primary
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
   "workspaces": [
     {
       "id": "uuid",
-      "name": "RadiusMethod",
+      "name": "Corveil",
       "provider": "github",
       "cli": "gh",
       "host": null,
@@ -227,7 +227,7 @@ Crow expects repositories organized under workspace folders:
 
 ```
 ~/Dev/                             # Development root
-├── RadiusMethod/                  # Workspace (GitHub)
+├── Corveil/                  # Workspace (GitHub)
 │   ├── acme-api/                   # Main repo checkout
 │   ├── acme-api-134-sensor/        # Worktree for issue #134
 │   └── acme-api-209-review/        # Worktree for issue #209

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,7 +227,7 @@ Crow expects repositories organized under workspace folders:
 
 ```
 ~/Dev/                             # Development root
-├── Corveil/                  # Workspace (GitHub)
+├── Corveil/                       # Workspace (GitHub)
 │   ├── acme-api/                   # Main repo checkout
 │   ├── acme-api-134-sensor/        # Worktree for issue #134
 │   └── acme-api-209-review/        # Worktree for issue #209

--- a/skills/crow-attribution/FOOTER.md
+++ b/skills/crow-attribution/FOOTER.md
@@ -10,12 +10,12 @@ line survives every quoting form (single-quoted heredocs, JSON files, Swift lite
 expression in attribution footers. The shell silently fails to expand it inside
 single-quoted heredocs and the literal text leaks into the artifact (#447).
 
-The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
+The link target is always `https://github.com/corveil/crow` — never a fork or a value from the local git remote.
 
 | Artifact | Footer |
 |----------|--------|
-| Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
-| Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
+| Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/corveil/crow)` |
+| Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/corveil/crow)` |
 | Committed (hand-authored commit message) | Trailer block at the end of the message: `Crow-Session: <session-uuid>` and `Co-Authored-By: Claude <noreply@anthropic.com>` on their own lines, separated from the body by a blank line. `setup.sh` installs a `prepare-commit-msg` hook (CROW-518) that idempotently fills them in if missing, but include them explicitly when writing the message — the hook is the safety net. |
 
 `<agent>` above is just a placeholder for *this document* — in the real footer lines

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -42,16 +42,16 @@ One or more ticket URLs, separated by newlines:
 
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
-https://github.com/Corveil/acme-api/issues/45
-https://github.com/Corveil/crow/issues/99
+https://github.com/corveil/crow/issues/101
+https://github.com/corveil/acme-api/issues/45
+https://github.com/corveil/crow/issues/99
 ```
 
 Or a mix of ticket URLs and natural language:
 
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
+https://github.com/corveil/crow/issues/101
 "update acme-api authentication"
 https://gitlab.example.com/org/repo/-/issues/42
 ```
@@ -190,9 +190,9 @@ Same as `/crow-workspace`. See that skill for the full CLI reference.
 ### Three GitHub Issues
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
-https://github.com/Corveil/acme-api/issues/45
-https://github.com/Corveil/crow/issues/99
+https://github.com/corveil/crow/issues/101
+https://github.com/corveil/acme-api/issues/45
+https://github.com/corveil/crow/issues/99
 ```
 - Resolves all 3 sequentially (fetches tickets, detects PRs, generates names)
 - Fires 3 `setup.sh` calls simultaneously
@@ -201,7 +201,7 @@ https://github.com/Corveil/crow/issues/99
 ### Mixed Providers
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
+https://github.com/corveil/crow/issues/101
 https://gitlab.example.com/org/my-project/-/issues/42
 ```
 - Detects GitHub and GitLab providers from URLs
@@ -211,11 +211,11 @@ https://gitlab.example.com/org/my-project/-/issues/42
 ### Five Workspaces (Stress Test)
 ```
 /crow-batch-workspace
-https://github.com/Corveil/crow/issues/101
-https://github.com/Corveil/crow/issues/102
-https://github.com/Corveil/crow/issues/103
-https://github.com/Corveil/acme-api/issues/45
-https://github.com/Corveil/acme-api/issues/46
+https://github.com/corveil/crow/issues/101
+https://github.com/corveil/crow/issues/102
+https://github.com/corveil/crow/issues/103
+https://github.com/corveil/acme-api/issues/45
+https://github.com/corveil/acme-api/issues/46
 ```
 - 5 parallel `setup.sh` calls
 - Each blocks one GCD thread in the socket server (well within the 64+ thread pool)

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -42,16 +42,16 @@ One or more ticket URLs, separated by newlines:
 
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
-https://github.com/RadiusMethod/acme-api/issues/45
-https://github.com/RadiusMethod/crow/issues/99
+https://github.com/Corveil/crow/issues/101
+https://github.com/Corveil/acme-api/issues/45
+https://github.com/Corveil/crow/issues/99
 ```
 
 Or a mix of ticket URLs and natural language:
 
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
+https://github.com/Corveil/crow/issues/101
 "update acme-api authentication"
 https://gitlab.example.com/org/repo/-/issues/42
 ```
@@ -190,9 +190,9 @@ Same as `/crow-workspace`. See that skill for the full CLI reference.
 ### Three GitHub Issues
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
-https://github.com/RadiusMethod/acme-api/issues/45
-https://github.com/RadiusMethod/crow/issues/99
+https://github.com/Corveil/crow/issues/101
+https://github.com/Corveil/acme-api/issues/45
+https://github.com/Corveil/crow/issues/99
 ```
 - Resolves all 3 sequentially (fetches tickets, detects PRs, generates names)
 - Fires 3 `setup.sh` calls simultaneously
@@ -201,7 +201,7 @@ https://github.com/RadiusMethod/crow/issues/99
 ### Mixed Providers
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
+https://github.com/Corveil/crow/issues/101
 https://gitlab.example.com/org/my-project/-/issues/42
 ```
 - Detects GitHub and GitLab providers from URLs
@@ -211,11 +211,11 @@ https://gitlab.example.com/org/my-project/-/issues/42
 ### Five Workspaces (Stress Test)
 ```
 /crow-batch-workspace
-https://github.com/RadiusMethod/crow/issues/101
-https://github.com/RadiusMethod/crow/issues/102
-https://github.com/RadiusMethod/crow/issues/103
-https://github.com/RadiusMethod/acme-api/issues/45
-https://github.com/RadiusMethod/acme-api/issues/46
+https://github.com/Corveil/crow/issues/101
+https://github.com/Corveil/crow/issues/102
+https://github.com/Corveil/crow/issues/103
+https://github.com/Corveil/acme-api/issues/45
+https://github.com/Corveil/acme-api/issues/46
 ```
 - 5 parallel `setup.sh` calls
 - Each blocks one GCD thread in the socket server (well within the 64+ thread pool)

--- a/skills/crow-create-ticket/SKILL.md
+++ b/skills/crow-create-ticket/SKILL.md
@@ -41,7 +41,7 @@ same file used by `/crow-workspace`. It maps each workspace to a provider/cli/ho
 {
   "devRoot": "/Users/name/Dev",
   "workspaces": {
-    "RadiusMethod": { "provider": "github", "cli": "gh" },
+    "Corveil": { "provider": "github", "cli": "gh" },
     "MyGitLab": { "provider": "gitlab", "cli": "glab", "host": "gitlab.example.com" }
   },
   "defaults": { "provider": "github", "cli": "gh" }
@@ -124,7 +124,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -137,7 +137,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -157,11 +157,11 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body pas
 followed by:
 
 ```
-[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)
 ```
 
 - Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the issue body).
-- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not modify the URL — the link target is always `https://github.com/corveil/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body — GitHub, GitLab, or Jira — and whether or not the user supplied any body text.
 

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -140,11 +140,11 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 `gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/corveil/crow)
 ```
 
 - Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the review body).
-- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not modify the URL — the link target is always `https://github.com/corveil/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -600,7 +600,7 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 
 ### GitHub Issue URL
 ```
-/crow-workspace https://github.com/Corveil/acme-api/issues/45
+/crow-workspace https://github.com/corveil/acme-api/issues/45
 ```
 → Fetches issue #45, matches acme-api in Corveil
 → Creates worktree at ~/Dev/Corveil/acme-api-45-jwt-validation

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -22,7 +22,7 @@ Configuration is at `{devRoot}/.claude/config.json` (managed by the Crow app). T
 {
   "devRoot": "/Users/name/Dev",
   "workspaces": {
-    "RadiusMethod": {
+    "Corveil": {
       "provider": "github",
       "cli": "gh",
       "customInstructions": "Always run `npm test` before committing."
@@ -195,18 +195,18 @@ Branch: `feature/{repo}-{ticket_number}-{brief_slug}`
 The brief slug is 2-4 key words from the ticket title.
 
 **Concrete example with full paths:**
-Given: devRoot=`/Users/jane/Dev`, workspace=`RadiusMethod`, repo=`acme-api` (cloned at `/Users/jane/Dev/RadiusMethod/acme-api`), ticket #197 "Fix tab URL hash routing"
+Given: devRoot=`/Users/jane/Dev`, workspace=`Corveil`, repo=`acme-api` (cloned at `/Users/jane/Dev/Corveil/acme-api`), ticket #197 "Fix tab URL hash routing"
 
 ```
-Worktree path: /Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash
+Worktree path: /Users/jane/Dev/Corveil/acme-api-197-fix-tab-url-hash
 Branch:        feature/acme-api-197-fix-tab-url-hash
-Git command:   git -C /Users/jane/Dev/RadiusMethod/acme-api worktree add /Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash -b feature/acme-api-197-fix-tab-url-hash --no-track origin/main
+Git command:   git -C /Users/jane/Dev/Corveil/acme-api worktree add /Users/jane/Dev/Corveil/acme-api-197-fix-tab-url-hash -b feature/acme-api-197-fix-tab-url-hash --no-track origin/main
 ```
 
 More examples:
 ```
 web-app #252 "Update deployment-guide.md"    → {devRoot}/MyGitLab/web-app-252-update-deploy-docs
-acme-api #45 "Add JWT validation endpoint"   → {devRoot}/RadiusMethod/acme-api-45-jwt-validation
+acme-api #45 "Add JWT validation endpoint"   → {devRoot}/Corveil/acme-api-45-jwt-validation
 ```
 
 **For ticket URLs with an existing PR:**
@@ -217,7 +217,7 @@ Use the PR's `headRefName` as the branch — do NOT generate a new name. Derive 
 {devRoot}/{workspace}/{repo}-{pr_branch_slug}
 ```
 
-Where `{pr_branch_slug}` is the `headRefName` with any `feature/` prefix stripped. For example, if the PR branch is `feature/acme-api-45-jwt-validation`, the worktree path is `{devRoot}/RadiusMethod/acme-api-45-jwt-validation`.
+Where `{pr_branch_slug}` is the `headRefName` with any `feature/` prefix stripped. For example, if the PR branch is `feature/acme-api-45-jwt-validation`, the worktree path is `{devRoot}/Corveil/acme-api-45-jwt-validation`.
 
 **WRONG — do NOT create subdirectories:**
 ```
@@ -600,10 +600,10 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 
 ### GitHub Issue URL
 ```
-/crow-workspace https://github.com/RadiusMethod/acme-api/issues/45
+/crow-workspace https://github.com/Corveil/acme-api/issues/45
 ```
-→ Fetches issue #45, matches acme-api in RadiusMethod
-→ Creates worktree at ~/Dev/RadiusMethod/acme-api-45-jwt-validation
+→ Fetches issue #45, matches acme-api in Corveil
+→ Creates worktree at ~/Dev/Corveil/acme-api-45-jwt-validation
 → Creates crow session with ticket metadata + worktree + Claude Code terminal
 
 ### Natural Language
@@ -618,6 +618,6 @@ All commands return JSON and require `dangerouslyDisableSandbox: true`.
 ```
 /crow-workspace "integrate my-project with acme-api gateway"
 ```
-→ Matches my-project (MyGitLab) + acme-api (RadiusMethod)
+→ Matches my-project (MyGitLab) + acme-api (Corveil)
 → Creates worktrees for both, one crow session
 → Claude launches in highest-scoring repo

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -360,7 +360,7 @@ Usage: setup.sh [OPTIONS]
 
 Required:
   --dev-root <path>          Development root directory
-  --workspace <name>         Workspace name (e.g. RadiusMethod)
+  --workspace <name>         Workspace name (e.g. Corveil)
   --repo <name>              Repository name
   --repo-path <path>         Main repo clone path
   --slug <slug>              LLM-generated slug (e.g. 104-global-terminals)

--- a/skills/crow-workspace/setup_gateway_test.sh
+++ b/skills/crow-workspace/setup_gateway_test.sh
@@ -46,7 +46,7 @@ cat > "$DEV_ROOT/.claude/config.json" <<'JSON'
   "workspaces": [
     {
       "id": "00000000-0000-0000-0000-000000000001",
-      "name": "RadiusMethod",
+      "name": "Corveil",
       "provider": "github",
       "cli": "gh",
       "gateway": {
@@ -75,8 +75,8 @@ source "$SETUP_SH"
 DEV_ROOT="$TMP/devroot"
 
 echo "== gateway-present workspace =="
-WORKSPACE="RadiusMethod"
-WORKTREE_PATH="$DEV_ROOT/RadiusMethod/repo-1-slug"
+WORKSPACE="Corveil"
+WORKTREE_PATH="$DEV_ROOT/Corveil/repo-1-slug"
 SESSION_ID="ABCD-1234"
 WS_GATEWAY_RESOLVED=false; WS_HAS_GATEWAY=false; WS_BASE_URL=""; WS_CUSTOM_HEADERS=""
 

--- a/skills/crow-workspace/setup_session_env_test.sh
+++ b/skills/crow-workspace/setup_session_env_test.sh
@@ -36,7 +36,7 @@ not_contains() { # not_contains <description> <haystack> <needle>
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-# Synthetic devRoot + config.json. RadiusMethod carries a sessionEnv map (one
+# Synthetic devRoot + config.json. Corveil carries a sessionEnv map (one
 # templated value); Bare carries no sessionEnv; WithGateway carries both a
 # gateway block and a sessionEnv map (coexistence case).
 DEV_ROOT="$TMP/devroot"
@@ -46,7 +46,7 @@ cat > "$DEV_ROOT/.claude/config.json" <<'JSON'
   "workspaces": [
     {
       "id": "00000000-0000-0000-0000-000000000001",
-      "name": "RadiusMethod",
+      "name": "Corveil",
       "provider": "github",
       "cli": "gh",
       "sessionEnv": {
@@ -94,11 +94,11 @@ reset_gateway() {
 
 # ── 1. Config map → settings.local.json .env (token substitution) ──────────────
 echo "== config sessionEnv map =="
-WORKSPACE="RadiusMethod"
+WORKSPACE="Corveil"
 SESSION_NAME="crow-543-session-env"
 SLUG="543-session-env"; BRANCH="feature/crow-543-session-env"; REPO="crow"
 TICKET_NUMBER="543"; TICKET_URL=""; SESSION_ID="ABCD-1234"
-WORKTREE_PATH="$DEV_ROOT/RadiusMethod/crow-543"
+WORKTREE_PATH="$DEV_ROOT/Corveil/crow-543"
 reset_session_env; reset_gateway
 mkdir -p "$WORKTREE_PATH"
 
@@ -118,7 +118,7 @@ check "settings.local.json is 0600" "600" "$(stat -f '%Lp' "$settings" 2>/dev/nu
 echo "== --session-env overrides config key =="
 reset_session_env
 CLI_SESSION_ENV="COORD_SESSION_NAME=from-flag"
-WORKTREE_PATH="$DEV_ROOT/RadiusMethod/crow-543-flag"
+WORKTREE_PATH="$DEV_ROOT/Corveil/crow-543-flag"
 mkdir -p "$WORKTREE_PATH"
 resolve_session_env
 write_settings_local


### PR DESCRIPTION
Closes #774.

Sweeps out remaining RadiusMethod ties now that the repo lives at `corveil/crow`. Every hit was one of two case-sensitive strings — `radiusmethod` (slugs/domains/bundle IDs) or `RadiusMethod` (example workspace name) — so this is a clean symmetric swap (58 files, 204/204).

## Tier 1 — identity
- **Bundle ID** `com.radiusmethod.crow` → `com.corveil.crow` in `crow-desktop/src-tauri/tauri.conf.json` (the shipped Tauri bundle), plus **all three** GCD queue-label prefixes: `SocketServer` (`.socket`), `OTLPReceiver` (`.otlp-receiver`), and **`PTYProcess` (`.pty-read`)** — the ticket listed only the first two; the pty-read label surfaced from the acceptance grep.
- **No copyright/signing edits:** `AboutView.swift`, `scripts/bundle.sh`, and `scripts/sign-and-notarize.sh` were removed with the macOS app (ADR 0010), and no spaced `Radius Method` legal-name string remains anywhere in the repo. So Tier 1 reduces to the bundle ID + queue labels.

⚠️ **Behavior note:** changing `CFBundleIdentifier` resets the `defaults`/keychain storage domain — first launch after this change starts from a fresh domain. No persisted-state path is keyed on the old bundle ID (none found).

## Tier 2 — contact + repo-home docs
- `security@radiusmethod.com` → `security@corveil.com` (`SECURITY.md`, `CODE_OF_CONDUCT.md`). **Please confirm the `security@corveil.com` mailbox exists** — I swapped the domain for consistency but can't verify the inbox is live.
- `github.com/radiusmethod/crow` → `github.com/corveil/crow` across README, CONTRIBUTING, `docs/`, ADRs, and **`CrowAttribution.repoURL`** — the source of the "Created/Reviewed with Crow via …" footer (verified this is the only in-repo emitter of the old slug).

## Tier 3 — examples + fixtures
- `RadiusMethod` → `Corveil` example workspace name and `radiusmethod/*` fixture slugs across `skills/*`, the matching `Resources/*.template` files (kept in sync), docs, and package tests.

## One non-mechanical fix
`CrowAttributionTests` had two pre-existing `!…contains("corveil")` guards asserting the footer never pointed at `corveil` (back when `radiusmethod` was canonical). With `repoURL` now `corveil/crow` those inverted, so I flipped them to guard against the **superseded** `radiusmethod` org instead.

## Verification
- `rg -i 'radius[ ._-]?method'` (excl. `.git`/`.build`/`vendor`) → **zero hits**.
- `make daemon` → build clean (only a pre-existing unrelated warning).
- `make test` → all packages green; CrowCore re-confirmed **446/446** after the guard fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)