### PR TITLE
feat(autostart): start crowd at login (launchd login item)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 
 ### Tooling & Misc
 
+- #769 — `crowd` can start at login again (the gap ADR-0010 left when the macOS app was retired). `crow autostart install | uninstall | status` registers a launchd LaunchAgent — idempotent, re-points itself after an upgrade, and never bootstraps a duplicate over a running daemon. Same toggle at Settings → General → Autostart from a local browser. macOS only for now; Linux waits on #645.
 - #152 — Replace dock icon with the Corveil Brandmark.
 - #155 — Docs refresh: README, `make build` promotion, GitHub project scope wording.
 - #162 — Silence noisy console logs from Ghostty and IssueTracker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,17 @@ crow handoff-agent --session <uuid> --agent cursor [--note "..."] → {"session_
 crow delete-session --session <uuid>            → {"deleted":true}
 ```
 
+### Daemon Autostart
+
+Runs locally, not over the socket — these work with `crowd` down (CROW-769). macOS only for now.
+
+```
+crow autostart install [--binary PATH] [--host H] [--port N] [--dev-root PATH] [--socket PATH]
+                                                → registers a launchd LaunchAgent so crowd starts at login (idempotent; re-points after an upgrade)
+crow autostart uninstall                        → removes the login item
+crow autostart status [--json]                  → {enabled, running, loaded, stale, plistPath, logPath, ...}
+```
+
 ### Metadata Commands
 ```
 crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]

--- a/Packages/CrowAutostart/Package.swift
+++ b/Packages/CrowAutostart/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CrowAutostart",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "CrowAutostart", targets: ["CrowAutostart"]),
+    ],
+    targets: [
+        .target(name: "CrowAutostart"),
+        .testTarget(name: "CrowAutostartTests", dependencies: ["CrowAutostart"]),
+    ]
+)

--- a/Packages/CrowAutostart/Sources/CrowAutostart/AutostartService.swift
+++ b/Packages/CrowAutostart/Sources/CrowAutostart/AutostartService.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+/// Registering `crowd` to start at login (CROW-769).
+///
+/// ADR-0010 retired the macOS app, which used to launch at login and bring its
+/// daemon with it. `crowd` had no equivalent, so after a reboot Crow simply
+/// wasn't running until the user started it by hand. This package closes that
+/// gap behind a platform-neutral protocol: macOS gets a launchd LaunchAgent
+/// today, and the Linux daemon effort (#645) can add a `systemctl --user` unit
+/// without reshaping the API or the `crow autostart` CLI surface.
+public protocol AutostartService: Sendable {
+    /// Register (or re-point) the login item and report the resulting state.
+    /// Idempotent: installing twice leaves exactly one registration.
+    func install(_ spec: AutostartSpec) throws -> AutostartStatus
+
+    /// Remove the login item. A missing registration is success, not an error.
+    func uninstall() throws -> AutostartStatus
+
+    /// Report the current state without changing anything.
+    ///
+    /// - Parameter expected: the `crowd` this machine *should* be launching, if
+    ///   known. Supplying it enables stale detection (a plist left pointing at
+    ///   a binary that moved). `nil` when the caller can't resolve one.
+    func status(expected: AutostartSpec?) throws -> AutostartStatus
+}
+
+// MARK: - Spec
+
+/// What to launch at login: the `crowd` binary plus the flags it should carry.
+///
+/// The flags mirror `DaemonOptions` so the login-item daemon comes up
+/// configured exactly like the one the user is already running.
+public struct AutostartSpec: Sendable, Equatable {
+    public var binaryPath: String
+    public var host: String?
+    public var httpPort: Int?
+    public var devRoot: String?
+    public var socketPath: String?
+
+    public init(
+        binaryPath: String,
+        host: String? = nil,
+        httpPort: Int? = nil,
+        devRoot: String? = nil,
+        socketPath: String? = nil
+    ) {
+        self.binaryPath = binaryPath
+        self.host = host
+        self.httpPort = httpPort
+        self.devRoot = devRoot
+        self.socketPath = socketPath
+    }
+
+    /// The full argv the login item runs — `ProgramArguments` on macOS.
+    public var programArguments: [String] {
+        var args = [binaryPath]
+        if let host { args += ["--host", host] }
+        if let httpPort { args += ["--http-port", String(httpPort)] }
+        if let devRoot { args += ["--dev-root", devRoot] }
+        if let socketPath { args += ["--socket", socketPath] }
+        return args
+    }
+}
+
+// MARK: - Status
+
+/// A snapshot of the login item, shaped for both `crow autostart status --json`
+/// and the Settings → General toggle. `Codable` so both render the same fields.
+public struct AutostartStatus: Codable, Sendable, Equatable {
+    /// `"macos"` / `"linux"` — which backend answered.
+    public var platform: String
+    /// False when the platform has no backend yet (see `UnsupportedAutostart`).
+    public var supported: Bool
+    /// Service identifier (launchd label / systemd unit name).
+    public var label: String
+    /// Where the registration lives on disk, when the backend uses a file.
+    public var plistPath: String?
+    /// Where the daemon's stdout/stderr are captured.
+    public var logPath: String?
+    /// A registration exists — "start Crow at login" is on.
+    public var enabled: Bool
+    /// The init system currently knows about the service (loaded this session).
+    public var loaded: Bool
+    /// A `crowd` is answering on the socket right now.
+    public var running: Bool
+    /// The binary the registration actually points at.
+    public var installedPath: String?
+    /// The binary it *should* point at, when the caller could resolve one.
+    public var expectedPath: String?
+    /// The registration points somewhere other than `expectedPath` — a stale
+    /// plist left behind by a move or reinstall. Reinstall to re-point.
+    public var stale: Bool
+    /// Human-readable summary; the CLI prints it, the web UI shows it inline.
+    public var message: String
+
+    public init(
+        platform: String,
+        supported: Bool,
+        label: String,
+        plistPath: String? = nil,
+        logPath: String? = nil,
+        enabled: Bool = false,
+        loaded: Bool = false,
+        running: Bool = false,
+        installedPath: String? = nil,
+        expectedPath: String? = nil,
+        stale: Bool = false,
+        message: String = ""
+    ) {
+        self.platform = platform
+        self.supported = supported
+        self.label = label
+        self.plistPath = plistPath
+        self.logPath = logPath
+        self.enabled = enabled
+        self.loaded = loaded
+        self.running = running
+        self.installedPath = installedPath
+        self.expectedPath = expectedPath
+        self.stale = stale
+        self.message = message
+    }
+}
+
+// MARK: - Errors
+
+public enum AutostartError: Error, LocalizedError, Equatable {
+    case unsupportedPlatform(String)
+    case binaryNotFound(String)
+    case commandFailed(command: String, status: Int32, output: String)
+    case writeFailed(path: String, reason: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedPlatform(let detail):
+            return detail
+        case .binaryNotFound(let detail):
+            return detail
+        case .commandFailed(let command, let status, let output):
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return "`\(command)` failed (exit \(status))\(trimmed.isEmpty ? "" : ": \(trimmed)")"
+        case .writeFailed(let path, let reason):
+            return "Failed to write \(path): \(reason)"
+        }
+    }
+}
+
+// MARK: - Command runner
+
+/// Result of a shelled-out command: exit status plus combined output.
+public struct CommandResult: Sendable, Equatable {
+    public var status: Int32
+    public var output: String
+
+    public init(status: Int32, output: String) {
+        self.status = status
+        self.output = output
+    }
+
+    public var succeeded: Bool { status == 0 }
+}
+
+/// Runs an external command. Injected so tests exercise the install/uninstall
+/// logic without ever spawning `launchctl`.
+public typealias CommandRunner = @Sendable (_ executable: String, _ arguments: [String]) -> CommandResult
+
+/// The real runner: spawns the executable and captures its combined output.
+public let systemCommandRunner: CommandRunner = { executable, arguments in
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    do {
+        try process.run()
+    } catch {
+        return CommandResult(status: -1, output: "\(error)")
+    }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return CommandResult(status: process.terminationStatus, output: String(data: data, encoding: .utf8) ?? "")
+}
+
+// MARK: - Factory
+
+public enum Autostart {
+    /// The backend for the host platform. macOS → launchd LaunchAgent; anything
+    /// else → an `UnsupportedAutostart` that reports cleanly instead of failing
+    /// obscurely, until #645 adds the systemd `--user` backend.
+    public static func service() -> AutostartService {
+        #if os(macOS)
+        return LaunchdAutostart()
+        #else
+        return UnsupportedAutostart()
+        #endif
+    }
+}
+
+/// Placeholder backend for platforms with no installer yet. Every call reports
+/// `supported: false` rather than pretending to have registered something.
+public struct UnsupportedAutostart: AutostartService {
+    private let platform: String
+
+    public init(platform: String = UnsupportedAutostart.hostPlatform) {
+        self.platform = platform
+    }
+
+    public static var hostPlatform: String {
+        #if os(Linux)
+        return "linux"
+        #elseif os(macOS)
+        return "macos"
+        #else
+        return "unknown"
+        #endif
+    }
+
+    private var explanation: String {
+        "Autostart is not supported on \(platform) yet — start crowd yourself (a terminal, tmux, "
+            + "or your own systemd --user unit). Tracking: https://github.com/corveil/crow/issues/645"
+    }
+
+    public func install(_ spec: AutostartSpec) throws -> AutostartStatus {
+        throw AutostartError.unsupportedPlatform(explanation)
+    }
+
+    public func uninstall() throws -> AutostartStatus {
+        throw AutostartError.unsupportedPlatform(explanation)
+    }
+
+    public func status(expected: AutostartSpec?) throws -> AutostartStatus {
+        AutostartStatus(
+            platform: platform,
+            supported: false,
+            label: LaunchdAutostart.label,
+            expectedPath: expected?.binaryPath,
+            message: explanation
+        )
+    }
+}

--- a/Packages/CrowAutostart/Sources/CrowAutostart/CrowdBinaryResolver.swift
+++ b/Packages/CrowAutostart/Sources/CrowAutostart/CrowdBinaryResolver.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Works out which `crowd` the login item should launch.
+///
+/// Order: an explicit override → a `crowd` sitting next to the calling
+/// executable (`make install` symlinks `crow` and `crowd` into the same
+/// `~/.local/bin`) → `PATH`.
+///
+/// Symlinks are deliberately **not** resolved. `make install` points
+/// `~/.local/bin/crowd` at `.build/<config>/crowd`, so the symlink is the
+/// stable path — it keeps working across rebuilds and debug/release switches,
+/// while the resolved target would pin the plist to one build directory. Pass
+/// an explicit path when you want the real binary registered instead.
+public enum CrowdBinaryResolver {
+    /// - Parameters:
+    ///   - override: an explicit path (the CLI's `--binary`), used verbatim.
+    ///   - siblingOf: an executable whose directory to search — normally the
+    ///     running `crow`/`crowd` (`Bundle.main.executableURL`).
+    /// - Throws: `AutostartError.binaryNotFound` when nothing usable turns up.
+    public static func resolve(
+        override: String? = nil,
+        siblingOf executable: URL? = Bundle.main.executableURL,
+        fileManager: FileManager = .default,
+        pathEnvironment: String? = ProcessInfo.processInfo.environment["PATH"]
+    ) throws -> String {
+        if let override {
+            let expanded = (override as NSString).expandingTildeInPath
+            guard isExecutableFile(expanded, fileManager: fileManager) else {
+                throw AutostartError.binaryNotFound(
+                    "No executable crowd at \(expanded). Pass --binary with the path to your crowd.")
+            }
+            return absolute(expanded)
+        }
+
+        if let executable {
+            let sibling = executable.deletingLastPathComponent().appendingPathComponent("crowd").path
+            if isExecutableFile(sibling, fileManager: fileManager) {
+                return sibling
+            }
+        }
+
+        for directory in (pathEnvironment ?? "").split(separator: ":", omittingEmptySubsequences: true) {
+            let candidate = (String(directory) as NSString).appendingPathComponent("crowd")
+            if isExecutableFile(candidate, fileManager: fileManager) {
+                return absolute(candidate)
+            }
+        }
+
+        throw AutostartError.binaryNotFound(
+            "Could not find a crowd binary next to this executable or on PATH. "
+                + "Build and install it with `make daemon && make install`, or pass --binary.")
+    }
+
+    /// Executable *file* — a directory named `crowd` is reported executable by
+    /// `isExecutableFile` (that's the search bit), so check the type too.
+    static func isExecutableFile(_ path: String, fileManager: FileManager = .default) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            return false
+        }
+        return fileManager.isExecutableFile(atPath: path)
+    }
+
+    private static func absolute(_ path: String) -> String {
+        path.hasPrefix("/") ? path : URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+}

--- a/Packages/CrowAutostart/Sources/CrowAutostart/DaemonProbe.swift
+++ b/Packages/CrowAutostart/Sources/CrowAutostart/DaemonProbe.swift
@@ -1,0 +1,67 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// "Is a `crowd` answering right now?" — a bare `connect()` to the Unix socket.
+///
+/// Deliberately not an RPC round trip: install/status need this on the cold
+/// path (daemon possibly down, possibly mid-start), and a connect probe costs
+/// nothing and needs no method to exist. It backs two things:
+///   - `AutostartStatus.running`, so status can report enabled-vs-running
+///     separately, and
+///   - the install-time decision to *not* touch launchd while a daemon is
+///     already up (`LaunchdAutostart.install`) — bootstrapping a second one
+///     would trip `crowd`'s single-instance / store-writer locks.
+public enum DaemonProbe {
+    /// The well-known socket, matching `SocketServer.defaultSocketPath()` and
+    /// the `CROW_SOCKET` override the CLI and hooks honor. Duplicated rather
+    /// than imported so this package stays dependency-free (and so the probe
+    /// never has the side effect of *creating* the socket directory).
+    public static func defaultSocketPath() -> String {
+        if let override = ProcessInfo.processInfo.environment["CROW_SOCKET"] {
+            return override
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/crow/crow.sock").path
+    }
+
+    /// True when something accepts a connection on `socketPath`.
+    ///
+    /// A stale socket file left by a killed daemon fails to connect
+    /// (`ECONNREFUSED`), so this reports liveness, not file existence.
+    public static func isRunning(socketPath: String? = nil) -> Bool {
+        let path = socketPath ?? defaultSocketPath()
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+
+        #if canImport(Darwin)
+        let streamType = SOCK_STREAM
+        #else
+        let streamType = Int32(SOCK_STREAM.rawValue)
+        #endif
+        let fd = socket(AF_UNIX, streamType, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        guard path.utf8.count < capacity else { return false }
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                pathPtr.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+                    _ = strlcpy(destination, source, capacity)
+                }
+            }
+        }
+
+        let connected = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        return connected == 0
+    }
+}

--- a/Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift
+++ b/Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift
@@ -1,0 +1,269 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// macOS backend: a per-user launchd LaunchAgent at
+/// `~/Library/LaunchAgents/com.corveil.crowd.plist`.
+///
+/// A LaunchAgent (not a system-wide daemon) is the right shape — `crowd` runs
+/// as the logged-in user, reads that user's `~/.claude` config and store, and
+/// drives that user's tmux. launchd loads every plist in `~/Library/LaunchAgents`
+/// at login, so writing the file is what makes "start Crow at login" true; the
+/// `launchctl` calls only affect the *current* session.
+///
+/// Two hazards shape the install logic:
+///   - `crowd` refuses to start when another one holds the socket or store
+///     lock and `exit(1)`s (`CrowDaemon.run`). So install never bootstraps over
+///     a daemon that's already running — it writes the plist and lets the next
+///     login pick it up.
+///   - For the same reason `KeepAlive` is `{Crashed: true}` rather than
+///     `{SuccessfulExit: false}`: a deliberate duplicate-instance `exit(1)` is
+///     a *clean* exit, and `SuccessfulExit: false` would respawn it forever.
+///     `Crashed` restarts on an actual crash and leaves clean exits alone.
+public struct LaunchdAutostart: AutostartService {
+    public static let label = "com.corveil.crowd"
+
+    let launchAgentsDirectory: URL
+    let logDirectory: URL
+    let uid: uid_t
+    let runner: CommandRunner
+    let isDaemonRunning: @Sendable () -> Bool
+    let launchctl: String
+
+    /// `FileManager` is not `Sendable`, so it is reached through the shared
+    /// instance rather than stored. Tests isolate themselves with temp
+    /// directories (`launchAgentsDirectory` / `logDirectory`), not a fake FS.
+    var fileManager: FileManager { .default }
+
+    public init(
+        launchAgentsDirectory: URL? = nil,
+        logDirectory: URL? = nil,
+        uid: uid_t = getuid(),
+        runner: @escaping CommandRunner = systemCommandRunner,
+        isDaemonRunning: @escaping @Sendable () -> Bool = { DaemonProbe.isRunning() },
+        launchctl: String = "/bin/launchctl"
+    ) {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        self.launchAgentsDirectory = launchAgentsDirectory ?? home.appendingPathComponent("Library/LaunchAgents")
+        self.logDirectory = logDirectory ?? home.appendingPathComponent("Library/Logs/crow")
+        self.uid = uid
+        self.runner = runner
+        self.isDaemonRunning = isDaemonRunning
+        self.launchctl = launchctl
+    }
+
+    public var plistURL: URL {
+        launchAgentsDirectory.appendingPathComponent("\(Self.label).plist")
+    }
+
+    public var logURL: URL {
+        logDirectory.appendingPathComponent("crowd.log")
+    }
+
+    private var domainTarget: String { "gui/\(uid)" }
+    private var serviceTarget: String { "gui/\(uid)/\(Self.label)" }
+
+    // MARK: - Install
+
+    public func install(_ spec: AutostartSpec) throws -> AutostartStatus {
+        guard CrowdBinaryResolver.isExecutableFile(spec.binaryPath, fileManager: fileManager) else {
+            throw AutostartError.binaryNotFound(
+                "No executable crowd at \(spec.binaryPath). Build and install it with "
+                    + "`make daemon && make install`, or pass --binary.")
+        }
+
+        // Probe BEFORE touching launchd: booting out would stop a daemon that's
+        // currently serving, and bootstrapping alongside a hand-started one
+        // would spawn a duplicate that immediately refuses to run.
+        let alreadyRunning = isDaemonRunning()
+
+        try createDirectory(launchAgentsDirectory)
+        try createDirectory(logDirectory)
+        try writePlist(for: spec)
+
+        var notes: [String] = []
+        if alreadyRunning {
+            // The plist is on disk, so login is covered. Reloading now would
+            // either kill the running daemon (if launchd owns it) or spawn a
+            // doomed duplicate (if the user started it by hand) — neither is
+            // worth doing to a working daemon.
+            notes.append("a crowd is already running, so launchd was left alone — the login item takes effect at next login")
+        } else {
+            // Clear any previous registration first so an upgraded path takes
+            // effect in this session too. "not loaded" is the normal case.
+            _ = runner(launchctl, ["bootout", serviceTarget])
+
+            let bootstrap = runner(launchctl, ["bootstrap", domainTarget, plistURL.path])
+            if !bootstrap.succeeded, !isLoaded() {
+                throw AutostartError.commandFailed(
+                    command: "launchctl bootstrap \(domainTarget) \(plistURL.path)",
+                    status: bootstrap.status,
+                    output: bootstrap.output)
+            }
+            // `RunAtLoad` usually starts it on bootstrap; kickstart makes that
+            // deterministic (and covers a re-bootstrap of an already-loaded job).
+            let kickstart = runner(launchctl, ["kickstart", "-k", serviceTarget])
+            if kickstart.succeeded {
+                notes.append("crowd started")
+            } else {
+                notes.append("registered, but launchd could not start crowd now (\(shortOutput(kickstart))) — check \(logURL.path)")
+            }
+        }
+
+        var result = try status(expected: spec)
+        result.message = (["Autostart enabled (\(Self.label))"] + notes).joined(separator: "; ") + "."
+        return result
+    }
+
+    // MARK: - Uninstall
+
+    public func uninstall() throws -> AutostartStatus {
+        // Best effort: an unloaded service is exactly what we want, so a
+        // non-zero bootout ("no such process") is not a failure.
+        _ = runner(launchctl, ["bootout", serviceTarget])
+
+        let path = plistURL.path
+        let existed = fileManager.fileExists(atPath: path)
+        if existed {
+            do {
+                try fileManager.removeItem(at: plistURL)
+            } catch {
+                throw AutostartError.writeFailed(path: path, reason: error.localizedDescription)
+            }
+        }
+
+        var result = try status(expected: nil)
+        result.message = existed
+            ? "Autostart disabled; removed \(path)."
+            : "Autostart was not enabled — nothing to remove."
+        return result
+    }
+
+    // MARK: - Status
+
+    public func status(expected: AutostartSpec? = nil) throws -> AutostartStatus {
+        let installedPath = installedProgramPath()
+        let expectedPath = expected?.binaryPath
+        let enabled = installedPath != nil || fileManager.fileExists(atPath: plistURL.path)
+        let stale = {
+            guard enabled, let installedPath, let expectedPath else { return false }
+            return installedPath != expectedPath
+        }()
+        let loaded = isLoaded()
+        let running = isDaemonRunning()
+
+        var result = AutostartStatus(
+            platform: "macos",
+            supported: true,
+            label: Self.label,
+            plistPath: plistURL.path,
+            logPath: logURL.path,
+            enabled: enabled,
+            loaded: loaded,
+            running: running,
+            installedPath: installedPath,
+            expectedPath: expectedPath,
+            stale: stale
+        )
+        result.message = describe(result)
+        return result
+    }
+
+    private func describe(_ status: AutostartStatus) -> String {
+        guard status.enabled else {
+            return status.running
+                ? "Autostart is off; a crowd is running but will not come back after a reboot."
+                : "Autostart is off and no crowd is running. Enable it with `crow autostart install`."
+        }
+        if status.stale {
+            return "Autostart points at \(status.installedPath ?? "an unknown path"), but crowd is at "
+                + "\(status.expectedPath ?? "another path"). Re-run `crow autostart install` to re-point it."
+        }
+        if status.running {
+            return "Autostart is on and crowd is running."
+        }
+        return status.loaded
+            ? "Autostart is on and registered with launchd, but crowd is not answering — check \(status.logPath ?? logURL.path)."
+            : "Autostart is on; it takes effect at next login (not loaded in this session)."
+    }
+
+    // MARK: - launchd / plist plumbing
+
+    /// The plist's `ProgramArguments[0]`, or nil when there's no readable plist.
+    func installedProgramPath() -> String? {
+        guard let data = fileManager.contents(atPath: plistURL.path),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let dict = plist as? [String: Any],
+              let arguments = dict["ProgramArguments"] as? [String]
+        else { return nil }
+        return arguments.first
+    }
+
+    private func isLoaded() -> Bool {
+        runner(launchctl, ["print", serviceTarget]).succeeded
+    }
+
+    /// XML plist (not binary) so the file stays greppable and diffable — you
+    /// can see what Crow registered without `plutil`.
+    func plistData(for spec: AutostartSpec) throws -> Data {
+        let dict: [String: Any] = [
+            "Label": Self.label,
+            "ProgramArguments": spec.programArguments,
+            "RunAtLoad": true,
+            // See the type doc: restart on a crash, never on a clean exit —
+            // crowd's duplicate-instance refusal is a clean exit(1).
+            "KeepAlive": ["Crashed": true],
+            "ThrottleInterval": 10,
+            "ProcessType": "Background",
+            "EnvironmentVariables": ["PATH": loginPath()],
+            "StandardOutPath": logURL.path,
+            "StandardErrorPath": logURL.path,
+        ]
+        do {
+            return try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+        } catch {
+            throw AutostartError.writeFailed(path: plistURL.path, reason: error.localizedDescription)
+        }
+    }
+
+    private func writePlist(for spec: AutostartSpec) throws {
+        do {
+            try plistData(for: spec).write(to: plistURL, options: .atomic)
+        } catch let error as AutostartError {
+            throw error
+        } catch {
+            throw AutostartError.writeFailed(path: plistURL.path, reason: error.localizedDescription)
+        }
+    }
+
+    /// launchd hands agents a bare `PATH`, but `crowd` shells out to `git`,
+    /// `gh`, `tmux`, and the agent CLIs. Carry the installing shell's `PATH`
+    /// through, with the usual Homebrew/user prefixes appended as a floor.
+    private func loginPath() -> String {
+        let current = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        let defaults = [
+            fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin").path,
+            "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
+        ]
+        var seen = Set<String>()
+        let entries = (current.split(separator: ":").map(String.init) + defaults)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+        return entries.joined(separator: ":")
+    }
+
+    private func createDirectory(_ url: URL) throws {
+        do {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        } catch {
+            throw AutostartError.writeFailed(path: url.path, reason: error.localizedDescription)
+        }
+    }
+
+    private func shortOutput(_ result: CommandResult) -> String {
+        let trimmed = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "exit \(result.status)" : trimmed
+    }
+}

--- a/Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift
+++ b/Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift
@@ -30,7 +30,11 @@ public struct LaunchdAutostart: AutostartService {
     let logDirectory: URL
     let uid: uid_t
     let runner: CommandRunner
-    let isDaemonRunning: @Sendable () -> Bool
+    /// Liveness probe, keyed by the socket the daemon would be listening on.
+    /// The socket comes from the spec's `--socket` (the login item registers
+    /// one there), so a daemon on a custom socket is detected instead of being
+    /// missed and needlessly restarted. `nil` → the well-known default.
+    let isDaemonRunning: @Sendable (_ socketPath: String?) -> Bool
     let launchctl: String
 
     /// `FileManager` is not `Sendable`, so it is reached through the shared
@@ -43,7 +47,7 @@ public struct LaunchdAutostart: AutostartService {
         logDirectory: URL? = nil,
         uid: uid_t = getuid(),
         runner: @escaping CommandRunner = systemCommandRunner,
-        isDaemonRunning: @escaping @Sendable () -> Bool = { DaemonProbe.isRunning() },
+        isDaemonRunning: @escaping @Sendable (_ socketPath: String?) -> Bool = { DaemonProbe.isRunning(socketPath: $0) },
         launchctl: String = "/bin/launchctl"
     ) {
         let home = FileManager.default.homeDirectoryForCurrentUser
@@ -77,8 +81,10 @@ public struct LaunchdAutostart: AutostartService {
 
         // Probe BEFORE touching launchd: booting out would stop a daemon that's
         // currently serving, and bootstrapping alongside a hand-started one
-        // would spawn a duplicate that immediately refuses to run.
-        let alreadyRunning = isDaemonRunning()
+        // would spawn a duplicate that immediately refuses to run. Probe the
+        // socket THIS login item targets, so a daemon on a custom `--socket`
+        // isn't missed and needlessly restarted.
+        let alreadyRunning = isDaemonRunning(spec.socketPath)
 
         try createDirectory(launchAgentsDirectory)
         try createDirectory(logDirectory)
@@ -146,14 +152,19 @@ public struct LaunchdAutostart: AutostartService {
 
     public func status(expected: AutostartSpec? = nil) throws -> AutostartStatus {
         let installedPath = installedProgramPath()
-        let expectedPath = expected?.binaryPath
+        // An empty binaryPath (a socket-only status probe) is "no expectation",
+        // not a comparison target — otherwise it would read as stale.
+        let expectedPath = expected?.binaryPath.isEmpty == true ? nil : expected?.binaryPath
         let enabled = installedPath != nil || fileManager.fileExists(atPath: plistURL.path)
         let stale = {
             guard enabled, let installedPath, let expectedPath else { return false }
             return installedPath != expectedPath
         }()
         let loaded = isLoaded()
-        let running = isDaemonRunning()
+        // Probe the socket the login item actually targets (from the installed
+        // plist), so a launchd-started daemon on a custom `--socket` is seen;
+        // fall back to the caller's expected socket, then the well-known one.
+        let running = isDaemonRunning(installedSocketPath() ?? expected?.socketPath)
 
         var result = AutostartStatus(
             platform: "macos",
@@ -192,14 +203,30 @@ public struct LaunchdAutostart: AutostartService {
 
     // MARK: - launchd / plist plumbing
 
-    /// The plist's `ProgramArguments[0]`, or nil when there's no readable plist.
-    func installedProgramPath() -> String? {
+    /// The registered `ProgramArguments`, or nil when there's no readable plist.
+    private func installedProgramArguments() -> [String]? {
         guard let data = fileManager.contents(atPath: plistURL.path),
               let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
-              let dict = plist as? [String: Any],
-              let arguments = dict["ProgramArguments"] as? [String]
+              let dict = plist as? [String: Any]
         else { return nil }
-        return arguments.first
+        return dict["ProgramArguments"] as? [String]
+    }
+
+    /// The plist's `ProgramArguments[0]`, or nil when there's no readable plist.
+    func installedProgramPath() -> String? {
+        installedProgramArguments()?.first
+    }
+
+    /// The `--socket` (or `--socket-path`) the login item registered, so status
+    /// probes the right socket. Nil when unset — the daemon uses the default.
+    func installedSocketPath() -> String? {
+        guard let arguments = installedProgramArguments() else { return nil }
+        for flag in ["--socket", "--socket-path"] {
+            if let index = arguments.firstIndex(of: flag), index + 1 < arguments.count {
+                return arguments[index + 1]
+            }
+        }
+        return nil
     }
 
     private func isLoaded() -> Bool {

--- a/Packages/CrowAutostart/Tests/CrowAutostartTests/CrowdBinaryResolverTests.swift
+++ b/Packages/CrowAutostart/Tests/CrowAutostartTests/CrowdBinaryResolverTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Foundation
+@testable import CrowAutostart
+
+private func makeTempRoot() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("crow-resolver-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+@discardableResult
+private func makeExecutable(_ url: URL) throws -> String {
+    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data("#!/bin/sh\n".utf8).write(to: url)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    return url.path
+}
+
+@Test func resolverPrefersAnExplicitOverride() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let override = try makeExecutable(root.appendingPathComponent("custom/crowd"))
+    let sibling = root.appendingPathComponent("bin/crow")
+    try makeExecutable(sibling)
+    try makeExecutable(root.appendingPathComponent("bin/crowd"))
+
+    let resolved = try CrowdBinaryResolver.resolve(override: override, siblingOf: sibling, pathEnvironment: nil)
+
+    #expect(resolved == override)
+}
+
+/// `make install` symlinks `crow` and `crowd` into the same directory, so the
+/// sibling of the running CLI is the right default.
+@Test func resolverFindsCrowdNextToTheCallingExecutable() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let sibling = root.appendingPathComponent("bin/crow")
+    try makeExecutable(sibling)
+    let crowd = try makeExecutable(root.appendingPathComponent("bin/crowd"))
+
+    let resolved = try CrowdBinaryResolver.resolve(siblingOf: sibling, pathEnvironment: nil)
+
+    #expect(resolved == crowd)
+}
+
+@Test func resolverFallsBackToPATH() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let crowd = try makeExecutable(root.appendingPathComponent("path-dir/crowd"))
+
+    let resolved = try CrowdBinaryResolver.resolve(
+        siblingOf: root.appendingPathComponent("elsewhere/crow"),
+        pathEnvironment: root.appendingPathComponent("path-dir").path)
+
+    #expect(resolved == crowd)
+}
+
+/// The plist must point at the symlink `make install` created, not its target —
+/// the symlink survives rebuilds and debug/release switches.
+@Test func resolverDoesNotResolveSymlinks() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let real = try makeExecutable(root.appendingPathComponent("build/crowd"))
+    let binDir = root.appendingPathComponent("bin")
+    try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+    let link = binDir.appendingPathComponent("crowd")
+    try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: real)
+
+    let resolved = try CrowdBinaryResolver.resolve(siblingOf: binDir.appendingPathComponent("crow"),
+                                                  pathEnvironment: nil)
+
+    #expect(resolved == link.path)
+}
+
+@Test func resolverRejectsANonExecutableOverride() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let plain = root.appendingPathComponent("crowd")
+    try Data("not executable".utf8).write(to: plain)
+
+    #expect(throws: AutostartError.self) {
+        _ = try CrowdBinaryResolver.resolve(override: plain.path, siblingOf: nil, pathEnvironment: nil)
+    }
+}
+
+/// A *directory* named `crowd` reports as "executable" (that's the search bit),
+/// so the resolver has to check the file type too.
+@Test func resolverIgnoresADirectoryNamedCrowd() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: root.appendingPathComponent("bin/crowd"),
+                                            withIntermediateDirectories: true)
+
+    #expect(throws: AutostartError.self) {
+        _ = try CrowdBinaryResolver.resolve(siblingOf: root.appendingPathComponent("bin/crow"),
+                                            pathEnvironment: nil)
+    }
+}
+
+@Test func resolverErrorPointsAtMakeInstall() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    do {
+        _ = try CrowdBinaryResolver.resolve(siblingOf: root.appendingPathComponent("bin/crow"),
+                                            pathEnvironment: "")
+        Issue.record("expected the resolver to throw")
+    } catch let error as AutostartError {
+        #expect(error.errorDescription?.contains("make install") == true)
+    }
+}
+
+@Test func unsupportedPlatformReportsCleanlyInsteadOfFailing() throws {
+    let service = UnsupportedAutostart(platform: "linux")
+
+    let status = try service.status(expected: AutostartSpec(binaryPath: "/usr/bin/crowd"))
+
+    #expect(!status.supported)
+    #expect(!status.enabled)
+    #expect(status.platform == "linux")
+    #expect(status.message.contains("645"))
+    #expect(throws: AutostartError.self) {
+        _ = try service.install(AutostartSpec(binaryPath: "/usr/bin/crowd"))
+    }
+}

--- a/Packages/CrowAutostart/Tests/CrowAutostartTests/LaunchdAutostartTests.swift
+++ b/Packages/CrowAutostart/Tests/CrowAutostartTests/LaunchdAutostartTests.swift
@@ -1,0 +1,343 @@
+import Testing
+import Foundation
+@testable import CrowAutostart
+
+// MARK: - Harness
+
+/// Records every `launchctl` invocation and replays canned results, so the
+/// install/uninstall/status logic is exercised without touching the real
+/// `~/Library/LaunchAgents` or spawning launchd.
+final class FakeLaunchctl: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [[String]] = []
+    /// Exit status per subcommand (`bootout`, `bootstrap`, `kickstart`, `print`).
+    var statuses: [String: Int32] = ["bootout": 0, "bootstrap": 0, "kickstart": 0, "print": 0]
+
+    var calls: [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls
+    }
+
+    var subcommands: [String] { calls.compactMap(\.first) }
+
+    func runner() -> CommandRunner {
+        { [self] _, arguments in
+            lock.lock()
+            _calls.append(arguments)
+            lock.unlock()
+            let status = statuses[arguments.first ?? ""] ?? 0
+            return CommandResult(status: status, output: status == 0 ? "" : "no such process")
+        }
+    }
+}
+
+/// A LaunchdAutostart rooted in a temp directory.
+private func makeService(
+    root: URL,
+    launchctl: FakeLaunchctl,
+    running: Bool = false
+) -> LaunchdAutostart {
+    LaunchdAutostart(
+        launchAgentsDirectory: root.appendingPathComponent("LaunchAgents"),
+        logDirectory: root.appendingPathComponent("Logs/crow"),
+        uid: 501,
+        runner: launchctl.runner(),
+        isDaemonRunning: { running }
+    )
+}
+
+/// A file that passes the "executable file" check, standing in for `crowd`.
+private func makeFakeBinary(in directory: URL, named name: String = "crowd") throws -> String {
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let url = directory.appendingPathComponent(name)
+    try Data("#!/bin/sh\n".utf8).write(to: url)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    return url.path
+}
+
+private func makeTempRoot() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("crow-autostart-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func readPlist(_ service: LaunchdAutostart) throws -> [String: Any] {
+    let data = try #require(FileManager.default.contents(atPath: service.plistURL.path))
+    let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+    return try #require(plist as? [String: Any])
+}
+
+// MARK: - Spec
+
+@Test func specBuildsProgramArgumentsFromDaemonFlags() {
+    let spec = AutostartSpec(
+        binaryPath: "/usr/local/bin/crowd",
+        host: "127.0.0.1",
+        httpPort: 8787,
+        devRoot: "/Users/jane/Dev",
+        socketPath: "/tmp/crow.sock")
+    #expect(spec.programArguments == [
+        "/usr/local/bin/crowd",
+        "--host", "127.0.0.1",
+        "--http-port", "8787",
+        "--dev-root", "/Users/jane/Dev",
+        "--socket", "/tmp/crow.sock",
+    ])
+}
+
+@Test func specOmitsUnsetFlags() {
+    let spec = AutostartSpec(binaryPath: "/usr/local/bin/crowd")
+    #expect(spec.programArguments == ["/usr/local/bin/crowd"])
+}
+
+// MARK: - Plist contents
+
+@Test func installWritesPlistWithExpectedKeys() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    let service = makeService(root: root, launchctl: launchctl)
+
+    _ = try service.install(AutostartSpec(binaryPath: binary, host: "127.0.0.1", httpPort: 8787))
+
+    let plist = try readPlist(service)
+    #expect(plist["Label"] as? String == "com.corveil.crowd")
+    #expect(plist["ProgramArguments"] as? [String] == [binary, "--host", "127.0.0.1", "--http-port", "8787"])
+    #expect(plist["RunAtLoad"] as? Bool == true)
+    #expect(plist["ProcessType"] as? String == "Background")
+    #expect(plist["StandardOutPath"] as? String == service.logURL.path)
+    #expect(plist["StandardErrorPath"] as? String == service.logURL.path)
+    // The PATH launchd hands an agent is too bare for git/gh/tmux.
+    let path = try #require((plist["EnvironmentVariables"] as? [String: String])?["PATH"])
+    #expect(path.contains("/usr/bin"))
+}
+
+/// crowd exits(1) — a *clean* exit — when another instance holds the socket or
+/// store lock. `SuccessfulExit: false` would respawn it forever; `Crashed`
+/// restarts only on an actual crash.
+@Test func keepAliveRestartsOnCrashOnly() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+
+    _ = try service.install(AutostartSpec(binaryPath: binary))
+
+    let keepAlive = try #require(try readPlist(service)["KeepAlive"] as? [String: Bool])
+    #expect(keepAlive == ["Crashed": true])
+}
+
+@Test func installWritesXMLPlistSoItStaysReadable() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+
+    _ = try service.install(AutostartSpec(binaryPath: binary))
+
+    let data = try #require(FileManager.default.contents(atPath: service.plistURL.path))
+    let text = try #require(String(data: data, encoding: .utf8))
+    #expect(text.hasPrefix("<?xml"))
+    #expect(text.contains("com.corveil.crowd"))
+}
+
+// MARK: - Install behavior
+
+@Test func installBootstrapsAndStartsWhenNoDaemonIsRunning() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    let service = makeService(root: root, launchctl: launchctl, running: false)
+
+    let status = try service.install(AutostartSpec(binaryPath: binary))
+
+    #expect(launchctl.subcommands.contains("bootout"))
+    #expect(launchctl.subcommands.contains("bootstrap"))
+    #expect(launchctl.subcommands.contains("kickstart"))
+    #expect(status.enabled)
+    #expect(status.message.contains("crowd started"))
+}
+
+/// Bootstrapping alongside a running daemon would spawn a duplicate that
+/// immediately refuses to start (single-instance + store-writer locks), and
+/// booting out would kill a daemon that's currently serving. Write the plist
+/// and let the next login pick it up.
+@Test func installLeavesLaunchdAloneWhenDaemonIsAlreadyRunning() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    let service = makeService(root: root, launchctl: launchctl, running: true)
+
+    let status = try service.install(AutostartSpec(binaryPath: binary))
+
+    #expect(!launchctl.subcommands.contains("bootstrap"))
+    #expect(!launchctl.subcommands.contains("bootout"))
+    #expect(!launchctl.subcommands.contains("kickstart"))
+    #expect(status.enabled)
+    #expect(status.message.contains("next login"))
+}
+
+@Test func installIsIdempotent() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    let service = makeService(root: root, launchctl: launchctl)
+    let spec = AutostartSpec(binaryPath: binary)
+
+    _ = try service.install(spec)
+    let first = try readPlist(service)
+    let status = try service.install(spec)
+    let second = try readPlist(service)
+
+    #expect(first["ProgramArguments"] as? [String] == second["ProgramArguments"] as? [String])
+    #expect(status.enabled)
+    #expect(!status.stale)
+}
+
+/// A previous registration that fails to boot out ("not loaded") is the normal
+/// first-install case — it must not abort the install.
+@Test func installToleratesBootoutFailure() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    launchctl.statuses["bootout"] = 3
+    let service = makeService(root: root, launchctl: launchctl)
+
+    let status = try service.install(AutostartSpec(binaryPath: binary))
+
+    #expect(status.enabled)
+}
+
+@Test func installThrowsWhenBootstrapFailsAndServiceIsNotLoaded() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    launchctl.statuses["bootstrap"] = 5
+    launchctl.statuses["print"] = 113
+    let service = makeService(root: root, launchctl: launchctl)
+
+    #expect(throws: AutostartError.self) {
+        _ = try service.install(AutostartSpec(binaryPath: binary))
+    }
+}
+
+@Test func installRejectsAMissingBinary() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+
+    #expect(throws: AutostartError.self) {
+        _ = try service.install(AutostartSpec(binaryPath: root.appendingPathComponent("nope").path))
+    }
+}
+
+/// An upgrade must re-point the plist rather than leave it aimed at the old
+/// binary — the "no stale plist" acceptance criterion.
+@Test func reinstallRepointsAtTheNewBinary() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let oldBinary = try makeFakeBinary(in: root.appendingPathComponent("old"))
+    let newBinary = try makeFakeBinary(in: root.appendingPathComponent("new"))
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+
+    _ = try service.install(AutostartSpec(binaryPath: oldBinary))
+    let status = try service.install(AutostartSpec(binaryPath: newBinary))
+
+    #expect(status.installedPath == newBinary)
+    #expect(!status.stale)
+}
+
+// MARK: - Status
+
+@Test func statusReportsDisabledWithNoPlist() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+
+    let status = try service.status(expected: nil)
+
+    #expect(!status.enabled)
+    #expect(!status.stale)
+    #expect(status.supported)
+    #expect(status.platform == "macos")
+    #expect(status.installedPath == nil)
+}
+
+@Test func statusFlagsAPlistPointingAtAnotherBinary() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let oldBinary = try makeFakeBinary(in: root.appendingPathComponent("old"))
+    let newBinary = try makeFakeBinary(in: root.appendingPathComponent("new"))
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+    _ = try service.install(AutostartSpec(binaryPath: oldBinary))
+
+    let status = try service.status(expected: AutostartSpec(binaryPath: newBinary))
+
+    #expect(status.enabled)
+    #expect(status.stale)
+    #expect(status.installedPath == oldBinary)
+    #expect(status.message.contains("Re-run"))
+}
+
+@Test func statusReportsRunningIndependentlyOfEnabled() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let service = makeService(root: root, launchctl: FakeLaunchctl(), running: true)
+
+    let status = try service.status(expected: nil)
+
+    #expect(status.running)
+    #expect(!status.enabled)
+    #expect(status.message.contains("reboot"))
+}
+
+@Test func statusEncodesToJSONForTheCLIAndWebUI() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+
+    let data = try JSONEncoder().encode(try service.status(expected: nil))
+    let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    #expect(json["enabled"] as? Bool == false)
+    #expect(json["label"] as? String == "com.corveil.crowd")
+    #expect(json["supported"] as? Bool == true)
+}
+
+// MARK: - Uninstall
+
+@Test func uninstallRemovesThePlistAndBootsOut() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    let service = makeService(root: root, launchctl: launchctl)
+    _ = try service.install(AutostartSpec(binaryPath: binary))
+
+    let status = try service.uninstall()
+
+    #expect(!FileManager.default.fileExists(atPath: service.plistURL.path))
+    #expect(launchctl.subcommands.contains("bootout"))
+    #expect(!status.enabled)
+    #expect(status.message.contains("removed"))
+}
+
+@Test func uninstallIsANoOpWhenNotInstalled() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let launchctl = FakeLaunchctl()
+    launchctl.statuses["bootout"] = 3
+    let service = makeService(root: root, launchctl: launchctl)
+
+    let status = try service.uninstall()
+
+    #expect(!status.enabled)
+    #expect(status.message.contains("nothing to remove"))
+}

--- a/Packages/CrowAutostart/Tests/CrowAutostartTests/LaunchdAutostartTests.swift
+++ b/Packages/CrowAutostart/Tests/CrowAutostartTests/LaunchdAutostartTests.swift
@@ -42,8 +42,33 @@ private func makeService(
         logDirectory: root.appendingPathComponent("Logs/crow"),
         uid: 501,
         runner: launchctl.runner(),
-        isDaemonRunning: { running }
+        isDaemonRunning: { _ in running }
     )
+}
+
+/// A service whose probe reports "running" only for one specific socket path,
+/// and records the paths it was asked about.
+private final class SocketProbeSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _asked: [String?] = []
+    let liveSocket: String?
+
+    init(liveSocket: String?) { self.liveSocket = liveSocket }
+
+    var asked: [String?] { lock.lock(); defer { lock.unlock() }; return _asked }
+
+    func service(root: URL, launchctl: FakeLaunchctl) -> LaunchdAutostart {
+        LaunchdAutostart(
+            launchAgentsDirectory: root.appendingPathComponent("LaunchAgents"),
+            logDirectory: root.appendingPathComponent("Logs/crow"),
+            uid: 501,
+            runner: launchctl.runner(),
+            isDaemonRunning: { [self] socket in
+                lock.lock(); _asked.append(socket); lock.unlock()
+                return socket == liveSocket
+            }
+        )
+    }
 }
 
 /// A file that passes the "executable file" check, standing in for `crowd`.
@@ -252,6 +277,57 @@ private func readPlist(_ service: LaunchdAutostart) throws -> [String: Any] {
 
     #expect(status.installedPath == newBinary)
     #expect(!status.stale)
+}
+
+/// The install-time probe must check the socket the login item targets, not
+/// the well-known default — otherwise a daemon on a custom `--socket` is missed
+/// and needlessly bootstrapped/restarted (review Yellow #1).
+@Test func installProbesTheSpecSocketNotTheDefault() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let launchctl = FakeLaunchctl()
+    let spy = SocketProbeSpy(liveSocket: "/tmp/custom.sock")
+    let service = spy.service(root: root, launchctl: launchctl)
+
+    let status = try service.install(AutostartSpec(binaryPath: binary, socketPath: "/tmp/custom.sock"))
+
+    // Probed the custom socket, saw the daemon, and left launchd alone.
+    #expect(spy.asked.contains("/tmp/custom.sock"))
+    #expect(!launchctl.subcommands.contains("bootstrap"))
+    #expect(status.message.contains("next login"))
+}
+
+/// Status must probe the socket the installed plist registered, so a
+/// launchd-started daemon on a custom socket reads as running.
+@Test func statusProbesTheInstalledSocket() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let spy = SocketProbeSpy(liveSocket: "/tmp/custom.sock")
+    let service = spy.service(root: root, launchctl: FakeLaunchctl())
+    _ = try service.install(AutostartSpec(binaryPath: binary, socketPath: "/tmp/custom.sock"))
+
+    let status = try service.status(expected: nil)
+
+    #expect(status.running)
+    #expect(spy.asked.contains("/tmp/custom.sock"))
+    #expect(service.installedSocketPath() == "/tmp/custom.sock")
+}
+
+/// A socket-only status probe (empty binaryPath) is "no expectation" — it must
+/// not read as a stale plist just because the path differs from "".
+@Test func socketOnlyStatusIsNotStale() throws {
+    let root = try makeTempRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let binary = try makeFakeBinary(in: root.appendingPathComponent("bin"))
+    let service = makeService(root: root, launchctl: FakeLaunchctl())
+    _ = try service.install(AutostartSpec(binaryPath: binary))
+
+    let status = try service.status(expected: AutostartSpec(binaryPath: "", socketPath: "/tmp/x.sock"))
+
+    #expect(!status.stale)
+    #expect(status.expectedPath == nil)
 }
 
 // MARK: - Status

--- a/Packages/CrowCLI/Package.swift
+++ b/Packages/CrowCLI/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     dependencies: [
         .package(path: "../CrowIPC"),
         .package(path: "../CrowCodex"),
+        .package(path: "../CrowAutostart"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     ],
     targets: [
@@ -18,6 +19,7 @@ let package = Package(
             dependencies: [
                 "CrowIPC",
                 "CrowCodex",
+                "CrowAutostart",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/AutostartCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/AutostartCommands.swift
@@ -1,0 +1,132 @@
+import ArgumentParser
+import CrowAutostart
+import Foundation
+
+// MARK: - Autostart Commands
+
+/// `crow autostart install | uninstall | status` — register `crowd` to start at
+/// login (CROW-769).
+///
+/// Unlike every other subcommand, these run **locally** instead of over the
+/// Unix socket. The whole point is to fix "the daemon isn't running", so they
+/// have to work with `crowd` down — an RPC would be exactly the wrong
+/// dependency. The daemon exposes the same operations over local-only HTTP for
+/// the Settings toggle (`AutostartRoutes`), sharing this package's logic.
+public struct AutostartCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "autostart",
+        abstract: "Start crowd at login (install/uninstall/status)",
+        subcommands: [Install.self, Uninstall.self, Status.self],
+        defaultSubcommand: Status.self
+    )
+
+    public init() {}
+}
+
+extension AutostartCommand {
+    /// Flags baked into the login item so the login-launched `crowd` comes up
+    /// configured the same way you run it by hand. Omitted flags leave the
+    /// daemon on its own defaults (`127.0.0.1:8787`, the well-known socket).
+    struct DaemonFlags: ParsableArguments {
+        @Option(name: .long, help: "Path to the crowd binary (default: next to this crow, then PATH)")
+        var binary: String?
+        @Option(name: .long, help: "Bind host to pass to crowd (default: crowd's own default)")
+        var host: String?
+        @Option(name: .long, help: "HTTP port to pass to crowd")
+        var port: Int?
+        @Option(name: .long, help: "Development root to pass to crowd")
+        var devRoot: String?
+        @Option(name: .long, help: "Unix socket path to pass to crowd")
+        var socket: String?
+
+        func spec() throws -> AutostartSpec {
+            AutostartSpec(
+                binaryPath: try CrowdBinaryResolver.resolve(override: binary),
+                host: host,
+                httpPort: port,
+                devRoot: devRoot.map { ($0 as NSString).expandingTildeInPath },
+                socketPath: socket.map { ($0 as NSString).expandingTildeInPath }
+            )
+        }
+    }
+
+    public struct Install: ParsableCommand {
+        public static let configuration = CommandConfiguration(
+            commandName: "install",
+            abstract: "Register crowd to start at login (idempotent; re-points after an upgrade)")
+
+        @OptionGroup var daemon: DaemonFlags
+        @Flag(name: .long, help: "Print the status as JSON") var json: Bool = false
+
+        public init() {}
+
+        public func run() throws {
+            let spec = try daemon.spec()
+            let status = try AutostartCommand.service().install(spec)
+            emit(status, json: json)
+        }
+    }
+
+    public struct Uninstall: ParsableCommand {
+        public static let configuration = CommandConfiguration(
+            commandName: "uninstall",
+            abstract: "Remove the login item (leaves a running crowd alone)")
+
+        @Flag(name: .long, help: "Print the status as JSON") var json: Bool = false
+
+        public init() {}
+
+        public func run() throws {
+            emit(try AutostartCommand.service().uninstall(), json: json)
+        }
+    }
+
+    public struct Status: ParsableCommand {
+        public static let configuration = CommandConfiguration(
+            commandName: "status",
+            abstract: "Report whether crowd is set to start at login, and whether it's running")
+
+        @Option(name: .long, help: "Path to the crowd binary to compare against (stale-plist detection)")
+        var binary: String?
+        @Flag(name: .long, help: "Print the status as JSON") var json: Bool = false
+
+        public init() {}
+
+        public func run() throws {
+            // Status must answer even when no crowd can be found — an
+            // unresolvable binary just means no stale comparison.
+            let expected = (try? CrowdBinaryResolver.resolve(override: binary)).map { AutostartSpec(binaryPath: $0) }
+            emit(try AutostartCommand.service().status(expected: expected), json: json)
+        }
+    }
+
+    static func service() -> AutostartService { CrowAutostart.Autostart.service() }
+}
+
+// MARK: - Output
+
+/// Human-readable by default, `--json` for scripts and the `AutostartStatus`
+/// shape the web UI consumes.
+private func emit(_ status: AutostartStatus, json: Bool) {
+    if json {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let data = try? encoder.encode(status), let text = String(data: data, encoding: .utf8) {
+            print(text)
+        }
+        return
+    }
+
+    print(status.message)
+    print("  at login: \(status.enabled ? "enabled" : "disabled")")
+    print("  running:  \(status.running ? "yes" : "no")")
+    if let installedPath = status.installedPath {
+        print("  crowd:    \(installedPath)\(status.stale ? "  (stale — reinstall to re-point)" : "")")
+    }
+    if let plistPath = status.plistPath, status.enabled {
+        print("  plist:    \(plistPath)")
+    }
+    if let logPath = status.logPath, status.enabled {
+        print("  log:      \(logPath)")
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/AutostartCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/AutostartCommands.swift
@@ -28,7 +28,7 @@ extension AutostartCommand {
     /// configured the same way you run it by hand. Omitted flags leave the
     /// daemon on its own defaults (`127.0.0.1:8787`, the well-known socket).
     struct DaemonFlags: ParsableArguments {
-        @Option(name: .long, help: "Path to the crowd binary (default: next to this crow, then PATH)")
+        @Option(name: .long, help: "Path to the crowd binary, launched at login as-is (default: next to this crow, then PATH)")
         var binary: String?
         @Option(name: .long, help: "Bind host to pass to crowd (default: crowd's own default)")
         var host: String?
@@ -88,14 +88,22 @@ extension AutostartCommand {
 
         @Option(name: .long, help: "Path to the crowd binary to compare against (stale-plist detection)")
         var binary: String?
+        @Option(name: .long, help: "Unix socket to probe for a running crowd (default: the login item's, else the well-known socket)")
+        var socket: String?
         @Flag(name: .long, help: "Print the status as JSON") var json: Bool = false
 
         public init() {}
 
         public func run() throws {
             // Status must answer even when no crowd can be found — an
-            // unresolvable binary just means no stale comparison.
-            let expected = (try? CrowdBinaryResolver.resolve(override: binary)).map { AutostartSpec(binaryPath: $0) }
+            // unresolvable binary just means no stale comparison. When the
+            // binary can't be resolved but a `--socket` was given, still carry
+            // the socket so the liveness probe targets it.
+            let resolved = try? CrowdBinaryResolver.resolve(override: binary)
+            let expected: AutostartSpec? = (resolved != nil || socket != nil)
+                ? AutostartSpec(binaryPath: resolved ?? "",
+                                socketPath: socket.map { ($0 as NSString).expandingTildeInPath })
+                : nil
             emit(try AutostartCommand.service().status(expected: expected), json: json)
         }
     }

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -11,6 +11,7 @@ public struct CrowCommand: ParsableCommand {
         version: CLIVersion.version,
         subcommands: [
             Setup.self,
+            AutostartCommand.self,
             NewSession.self,
             RenameSession.self,
             SelectSession.self,

--- a/Packages/CrowCLI/Tests/CrowCLITests/AutostartCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/AutostartCommandParsingTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+import ArgumentParser
+@testable import CrowCLILib
+
+// MARK: - `crow autostart` Parsing (CROW-769)
+
+@Test func autostartInstallParsesDaemonFlags() throws {
+    let cmd = try AutostartCommand.Install.parse([
+        "--binary", "/usr/local/bin/crowd",
+        "--host", "0.0.0.0",
+        "--port", "9000",
+        "--dev-root", "/Users/jane/Dev",
+        "--socket", "/tmp/crow.sock",
+    ])
+    #expect(cmd.daemon.binary == "/usr/local/bin/crowd")
+    #expect(cmd.daemon.host == "0.0.0.0")
+    #expect(cmd.daemon.port == 9000)
+    #expect(cmd.daemon.devRoot == "/Users/jane/Dev")
+    #expect(cmd.daemon.socket == "/tmp/crow.sock")
+    #expect(!cmd.json)
+}
+
+@Test func autostartInstallDefaultsEveryDaemonFlagToUnset() throws {
+    let cmd = try AutostartCommand.Install.parse([])
+    #expect(cmd.daemon.binary == nil)
+    #expect(cmd.daemon.host == nil)
+    #expect(cmd.daemon.port == nil)
+    #expect(cmd.daemon.devRoot == nil)
+    #expect(cmd.daemon.socket == nil)
+}
+
+@Test func autostartSubcommandsAcceptJSON() throws {
+    #expect(try AutostartCommand.Install.parse(["--json"]).json)
+    #expect(try AutostartCommand.Uninstall.parse(["--json"]).json)
+    #expect(try AutostartCommand.Status.parse(["--json"]).json)
+}
+
+@Test func autostartStatusTakesABinaryToCompareAgainst() throws {
+    let cmd = try AutostartCommand.Status.parse(["--binary", "/opt/crowd"])
+    #expect(cmd.binary == "/opt/crowd")
+}
+
+/// Bare `crow autostart` should report, not mutate anything.
+@Test func autostartDefaultsToStatus() throws {
+    let parsed = try AutostartCommand.parseAsRoot([])
+    #expect(parsed is AutostartCommand.Status)
+}
+
+@Test func autostartRejectsAnUnknownSubcommand() {
+    #expect(throws: (any Error).self) {
+        _ = try AutostartCommand.parseAsRoot(["enable"])
+    }
+}
+
+/// Tilde-relative paths are expanded before they land in the plist — launchd
+/// does no shell expansion, so `~/Dev` would be handed to crowd verbatim.
+@Test func autostartInstallExpandsTildePaths() throws {
+    let cmd = try AutostartCommand.Install.parse(["--dev-root", "~/Dev", "--socket", "~/sock", "--binary", "/bin/sh"])
+    let spec = try cmd.daemon.spec()
+    #expect(spec.devRoot?.hasPrefix("/") == true)
+    #expect(spec.socketPath?.hasPrefix("/") == true)
+    #expect(spec.devRoot?.hasSuffix("/Dev") == true)
+}

--- a/Packages/CrowDaemon/Package.swift
+++ b/Packages/CrowDaemon/Package.swift
@@ -12,6 +12,8 @@ let package = Package(
         .package(path: "../CrowPersistence"),
         .package(path: "../CrowGit"),
         .package(path: "../CrowIPC"),
+        // Login-item installer shared with the crow CLI (CROW-769).
+        .package(path: "../CrowAutostart"),
         .package(path: "../CrowTerminal"),
         // The headless engine (IssueTracker / AllowListService) + its provider
         // layer, so the daemon owns the board reads with the app down (CROW-581).
@@ -37,6 +39,7 @@ let package = Package(
                 .product(name: "CrowPersistence", package: "CrowPersistence"),
                 .product(name: "CrowGit", package: "CrowGit"),
                 .product(name: "CrowIPC", package: "CrowIPC"),
+                .product(name: "CrowAutostart", package: "CrowAutostart"),
                 .product(name: "CrowTerminal", package: "CrowTerminal"),
                 .product(name: "CrowEngine", package: "CrowEngine"),
                 .product(name: "CrowProvider", package: "CrowProvider"),
@@ -57,6 +60,7 @@ let package = Package(
             dependencies: [
                 "CrowDaemon",
                 .product(name: "CrowCore", package: "CrowCore"),
+                .product(name: "CrowAutostart", package: "CrowAutostart"),
                 .product(name: "CrowClaude", package: "CrowClaude"),
                 .product(name: "CrowEngine", package: "CrowEngine"),
                 .product(name: "CrowProvider", package: "CrowProvider"),

--- a/Packages/CrowDaemon/Package.swift
+++ b/Packages/CrowDaemon/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
                 "CrowDaemon",
                 .product(name: "CrowCore", package: "CrowCore"),
                 .product(name: "CrowAutostart", package: "CrowAutostart"),
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
                 .product(name: "CrowClaude", package: "CrowClaude"),
                 .product(name: "CrowEngine", package: "CrowEngine"),
                 .product(name: "CrowProvider", package: "CrowProvider"),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/AutostartRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/AutostartRoutes.swift
@@ -1,0 +1,102 @@
+import CrowAutostart
+import Foundation
+import HTTPTypes
+import Hummingbird
+import NIOCore
+
+/// Local-only "start Crow at login" control for Settings → General (CROW-769).
+///
+/// Same shape and gating as ``SecretRoutes``: dedicated HTTP endpoints rather
+/// than JSON-RPC methods, because the handler needs the peer address +
+/// `X-Forwarded-For` to tell a local browser from a logged-in remote one, and
+/// registering a login item mutates the *host machine*. A remote session must
+/// not be able to install (or silently remove) a launch agent on someone else's
+/// Mac, so writes require a local-direct, same-origin request.
+///
+/// The `crowd` written into the login item is **this** daemon's own executable
+/// with **this** daemon's flags — no path guessing, and the login-launched
+/// daemon comes up configured exactly like the one you're talking to. The
+/// `crow autostart` CLI covers the case this can't: the daemon being down.
+enum AutostartRoutes {
+    static func mount(
+        on router: Router<CrowHTTPContext>,
+        boundHost: String,
+        options: DaemonOptions,
+        service: AutostartService = Autostart.service()
+    ) {
+        // Read-only: safe from any authenticated session, so a remote user can
+        // at least see whether the host is set up to come back after a reboot.
+        router.get("/autostart") { _, _ -> Response in
+            json(encode(try service.status(expected: currentSpec(options))))
+        }
+
+        // Enable / disable. Local-only (see type doc).
+        router.post("/autostart") { request, context -> Response in
+            guard SecretRoutes.gateOK(request, context, boundHost: boundHost) else {
+                return json(["error": "local-only"], status: .forbidden)
+            }
+            struct Body: Decodable { let enabled: Bool }
+            guard let body = await decode(Body.self, request) else {
+                return json(["error": "expected {\"enabled\": true|false}"], status: .badRequest)
+            }
+            do {
+                let status = body.enabled
+                    ? try service.install(try currentSpec(options))
+                    : try service.uninstall()
+                logLine("autostart \(body.enabled ? "enabled" : "disabled"): \(status.message)")
+                return json(encode(status))
+            } catch {
+                let message = (error as? AutostartError)?.errorDescription ?? error.localizedDescription
+                logLine("autostart \(body.enabled ? "install" : "uninstall") failed: \(message)")
+                return json(["error": message], status: .internalServerError)
+            }
+        }
+    }
+
+    /// What this daemon would register: its own binary plus its live flags.
+    ///
+    /// `Bundle.main.executableURL` is the running `crowd` itself, so there is no
+    /// resolution step and no way to register the wrong binary — and reinstalling
+    /// after an upgrade re-points the plist at wherever the new `crowd` lives.
+    static func currentSpec(_ options: DaemonOptions) throws -> AutostartSpec {
+        guard let executable = Bundle.main.executableURL?.path else {
+            throw AutostartError.binaryNotFound("Could not determine this crowd's own path.")
+        }
+        return AutostartSpec(
+            binaryPath: executable,
+            host: options.host,
+            httpPort: options.httpPort,
+            devRoot: options.devRoot,
+            socketPath: options.socketPath)
+    }
+
+    // MARK: - HTTP helpers
+
+    /// Same `[crowd]`-prefixed stderr line the daemon's own logging uses, so an
+    /// install/uninstall (and any failure) shows up in the daemon log.
+    private static func logLine(_ message: String) {
+        FileHandle.standardError.write(Data("[crowd] \(message)\n".utf8))
+    }
+
+    /// `AutostartStatus` → a JSON object, so the web UI reads the same field
+    /// names as `crow autostart status --json`.
+    private static func encode(_ status: AutostartStatus) -> [String: Any] {
+        guard let data = try? JSONEncoder().encode(status),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return dict
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, _ request: Request) async -> T? {
+        guard let buffer = try? await request.body.collect(upTo: 64 * 1024) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: Data(buffer.readableBytesView))
+    }
+
+    private static func json(_ dict: [String: Any], status: HTTPResponse.Status = .ok) -> Response {
+        let data = (try? JSONSerialization.data(withJSONObject: dict)) ?? Data("{}".utf8)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json; charset=utf-8"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data)))
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -276,6 +276,9 @@ public enum CrowDaemon {
         // Local-only secret management (web password + AI gateways) as
         // Origin-checked HTTP POSTs, gated to a local-direct peer (CROW-593).
         SecretRoutes.mount(on: httpRouter, boundHost: options.host, devRoot: options.devRoot)
+        // "Start Crow at login" for Settings → General — same local-only gating,
+        // since it registers a launch agent on the host machine (CROW-769).
+        AutostartRoutes.mount(on: httpRouter, boundHost: options.host, options: options)
         StaticAssets.mount(on: httpRouter, webDir: options.webDir)
         // Per-session generated images (diagrams/screenshots an agent dropped
         // in the scratch dir), served read-only + sandboxed (CROW-593).

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -23,6 +23,10 @@
   // browser (loopback, no proxy), false for a proxied/remote session — which
   // sees those settings read-only (CROW-593).
   let isLocal = false;
+  // Login-item state from GET /autostart (CROW-769). Not part of config.json —
+  // it's a host-machine registration, so the toggle acts immediately instead of
+  // riding the Save button. null when the read failed.
+  let autostart = null;
 
   const TABS = [
     ['general', 'General'],
@@ -116,6 +120,10 @@
     // gateways) — editable locally, read-only when proxied/remote (CROW-593).
     try { const cr = await fetch('/auth/context'); isLocal = cr.ok ? !!(await cr.json()).local : false; }
     catch (_) { isLocal = false; }
+    // Is crowd registered to start at login? Read-only for everyone; only a
+    // local browser may change it (CROW-769).
+    try { const ar2 = await fetch('/autostart'); autostart = ar2.ok ? await ar2.json() : null; }
+    catch (_) { autostart = null; }
     dirty = false;
     subForm = null;
     activeTab = 'general';
@@ -443,6 +451,8 @@
     body.appendChild(textField('Path', { path: devRoot }, 'path',
       { readonly: true, help: 'The dev root is fixed for this daemon and managed in the desktop app.' }));
 
+    renderAutostart(body);
+
     body.appendChild(group('Agent'));
     if (agents.length >= 2) {
       // Choose the default agent, like the desktop Settings picker. The options
@@ -490,6 +500,58 @@
     body.appendChild(selectField('Retention', cfg.cleanup, 'retentionHours', [
       [1, '1 hour'], [4, '4 hours'], [8, '8 hours'], [24, '1 day'], [72, '3 days'], [168, '7 days'], [720, '30 days'],
     ], { number: true }));
+  }
+
+  // "Start Crow at login" (CROW-769). Unlike the rest of General this is not a
+  // config field: it registers a launch agent on the machine running crowd, so
+  // the toggle POSTs immediately (no Save) and — like the web password and the
+  // AI gateways — only a local browser may change it.
+  function renderAutostart(body) {
+    body.appendChild(group('Autostart'));
+    if (!autostart) {
+      body.appendChild(readonlyNote('Could not read the autostart status from crowd.'));
+      return;
+    }
+    if (!autostart.supported || !isLocal) {
+      body.appendChild(readonlyNote(autostart.supported
+        ? autostart.message + ' Autostart is changed only from a local browser (on the machine running crowd).'
+        : autostart.message));
+      return;
+    }
+
+    const row = el('label', 'st-switch-row');
+    const input = el('input', 'st-switch');
+    input.type = 'checkbox';
+    input.checked = !!autostart.enabled;
+    input.onchange = async () => {
+      input.disabled = true;
+      try {
+        autostart = await postConfig('/autostart', { enabled: input.checked });
+      } catch (err) {
+        alertModal('Could not change autostart: ' + (err.message || err));
+        input.checked = !input.checked;
+      }
+      input.disabled = false;
+      render();
+    };
+    row.appendChild(input);
+    row.appendChild(el('span', 'st-switch-label', 'Start Crow at login'));
+    const f = el('div', 'st-field');
+    f.appendChild(row);
+    f.appendChild(el('div', 'st-help', autostart.message));
+    body.appendChild(f);
+
+    // A plist left pointing at a crowd that has since moved — one click re-points it.
+    if (autostart.stale) {
+      const fix = el('button', 'action-primary', 'Re-point to this crowd');
+      fix.onclick = async () => {
+        fix.disabled = true;
+        try { autostart = await postConfig('/autostart', { enabled: true }); }
+        catch (err) { alertModal('Could not re-point autostart: ' + (err.message || err)); }
+        render();
+      };
+      body.appendChild(field(null, fix));
+    }
   }
 
   // ---- Automation ---------------------------------------------------------

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/AutostartRouteGatingTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/AutostartRouteGatingTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import CrowAutostart
+@testable import CrowDaemon
+
+// MARK: - `POST /autostart` is local-only (CROW-769)
+
+/// Records whether `install`/`uninstall` were reached, so a route test can
+/// prove the gate ran BEFORE the mutation — not just that a status came back.
+private final class RecordingAutostart: AutostartService, @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var installCalls = 0
+    private(set) var uninstallCalls = 0
+
+    func install(_ spec: AutostartSpec) throws -> AutostartStatus {
+        lock.lock(); installCalls += 1; lock.unlock()
+        return makeStatus(enabled: true)
+    }
+
+    func uninstall() throws -> AutostartStatus {
+        lock.lock(); uninstallCalls += 1; lock.unlock()
+        return makeStatus(enabled: false)
+    }
+
+    func status(expected: AutostartSpec?) throws -> AutostartStatus {
+        makeStatus(enabled: false)
+    }
+
+    private func makeStatus(enabled: Bool) -> AutostartStatus {
+        AutostartStatus(platform: "macos", supported: true, label: "com.corveil.crowd", enabled: enabled)
+    }
+}
+
+/// Same gating as the other local-only writes (`SecretRoutes`): registering a
+/// LaunchAgent mutates the host machine, so a proxied/remote session — even a
+/// logged-in one — must be refused. Driven end to end through the mounted route
+/// over a real loopback server, so a refactor that drops `gateOK` fails here.
+@Suite struct AutostartRouteGatingTests {
+    private func makeApp(_ service: AutostartService) -> some ApplicationProtocol {
+        let router = Router(context: CrowHTTPContext.self)
+        AutostartRoutes.mount(
+            on: router, boundHost: "127.0.0.1",
+            options: DaemonOptions.parse(["crowd"]), service: service)
+        return Application(
+            router: router,
+            configuration: .init(address: .hostname("127.0.0.1", port: 0), serverName: "crowd-test"))
+    }
+
+    private let jsonHeaders: HTTPFields = [.contentType: "application/json"]
+    private let xff = HTTPField.Name("x-forwarded-for")!
+
+    @Test func localDirectPeerMayInstall() async throws {
+        let fake = RecordingAutostart()
+        try await makeApp(fake).test(.live) { client in
+            try await client.execute(
+                uri: "/autostart", method: .post, headers: jsonHeaders,
+                body: ByteBuffer(string: #"{"enabled":true}"#)
+            ) { response in
+                #expect(response.status == .ok)
+            }
+        }
+        #expect(fake.installCalls == 1)
+    }
+
+    /// A loopback peer WITH an X-Forwarded-For is a local reverse proxy carrying
+    /// a remote user — not local-direct. Must be refused before any mutation.
+    @Test func proxiedPeerIsForbidden() async throws {
+        let fake = RecordingAutostart()
+        let headers: HTTPFields = [.contentType: "application/json", xff: "203.0.113.9"]
+        try await makeApp(fake).test(.live) { client in
+            try await client.execute(
+                uri: "/autostart", method: .post, headers: headers,
+                body: ByteBuffer(string: #"{"enabled":false}"#)
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(fake.installCalls == 0)
+        #expect(fake.uninstallCalls == 0)
+    }
+
+    /// A cross-site Origin fails the CSRF check even from a local peer.
+    @Test func crossSiteOriginIsForbidden() async throws {
+        let fake = RecordingAutostart()
+        let headers: HTTPFields = [.contentType: "application/json", .origin: "https://evil.com"]
+        try await makeApp(fake).test(.live) { client in
+            try await client.execute(
+                uri: "/autostart", method: .post, headers: headers,
+                body: ByteBuffer(string: #"{"enabled":true}"#)
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(fake.installCalls == 0)
+    }
+
+    /// Reading status is safe from any authenticated session — a remote user may
+    /// at least see whether the host comes back after a reboot.
+    @Test func statusReadIsAllowedEvenWhenProxied() async throws {
+        let fake = RecordingAutostart()
+        let headers: HTTPFields = [xff: "203.0.113.9"]
+        try await makeApp(fake).test(.live) { client in
+            try await client.execute(uri: "/autostart", method: .get, headers: headers) { response in
+                #expect(response.status == .ok)
+            }
+        }
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/AutostartRoutesTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/AutostartRoutesTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+import CrowAutostart
+@testable import CrowDaemon
+
+// MARK: - Autostart Routes (CROW-769)
+
+/// The login item must carry the flags this daemon is actually running with,
+/// so the login-launched crowd binds the same host/port/socket and reads the
+/// same dev root — not the defaults.
+@Suite struct AutostartSpecTests {
+    @Test func specCarriesTheRunningDaemonsFlags() throws {
+        let options = DaemonOptions.parse([
+            "crowd", "--http-port", "9191", "--host", "127.0.0.1",
+            "--dev-root", "/Users/jane/Dev", "--socket", "/tmp/crow-test.sock",
+        ])
+
+        let spec = try AutostartRoutes.currentSpec(options)
+
+        #expect(spec.host == "127.0.0.1")
+        #expect(spec.httpPort == 9191)
+        #expect(spec.devRoot == "/Users/jane/Dev")
+        #expect(spec.socketPath == "/tmp/crow-test.sock")
+        // The binary is this daemon's own executable — never a resolved guess.
+        #expect(spec.binaryPath == Bundle.main.executableURL?.path)
+        #expect(spec.programArguments.first == spec.binaryPath)
+        #expect(spec.programArguments.contains("--http-port"))
+        #expect(spec.programArguments.contains("9191"))
+    }
+
+    @Test func specDefaultsMatchTheDaemonsOwnDefaults() throws {
+        let options = DaemonOptions.parse(["crowd"])
+
+        let spec = try AutostartRoutes.currentSpec(options)
+
+        #expect(spec.httpPort == options.httpPort)
+        #expect(spec.host == options.host)
+        #expect(spec.socketPath == options.socketPath)
+    }
+}

--- a/docs/adr/0010-retire-the-macos-app.md
+++ b/docs/adr/0010-retire-the-macos-app.md
@@ -30,3 +30,4 @@ The macOS app is removed. `crowd` plus the **web UI are the only client**. The `
 - PR: https://github.com/radiusmethod/crow/pull/594 (CROW-593)
 - Related ADRs: [0009](./0009-crowd-sole-authority-clients-only.md) (crowd is the sole authority — this ADR removes its last non-web client), [0006](./0006-universal-macos-binary.md) (xterm.js renderer — still used, now in the browser)
 - Code: `Packages/CrowDaemon/` (`crowd`), `Packages/CrowEngine/` (host-agnostic engine + `HostBridge`)
+- Follow-up: the "no autostart yet" consequence above is closed by [#769](https://github.com/corveil/crow/issues/769) — `crow autostart install` (and Settings → General → Autostart) registers a launchd LaunchAgent; see `Packages/CrowAutostart/`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ crow/
 │   │                                #   web-access auth, terminal WebSocket
 │   ├── CrowCLI/                     # CLI command definitions (CrowCommand + subcommands)
 │   ├── CrowIPC/                     # Unix socket JSON-RPC protocol (SocketServer/SocketClient)
+│   ├── CrowAutostart/               # Login-item installer (launchd LaunchAgent) for crowd
 │   ├── CrowTerminal/                # tmux backend + terminal cockpit
 │   ├── CrowGit/                     # Git operations
 │   ├── CrowProvider/                # GitHub/GitLab/Jira/Corveil provider abstraction
@@ -88,6 +89,7 @@ There are two `CrowCLI` directories:
 | **EventHub**               | `Packages/CrowDaemon/`                                 | Fan-out hub that pushes `changed` nudges to every connected `/rpc` client so UIs re-fetch reactively              |
 | **TmuxBackend / cockpit**  | `Packages/CrowTerminal/`                               | Owns the tmux server and the shared cockpit; each session terminal is a tmux window. `crowd` opens a private grouped view per browser connection |
 | **SocketServer**           | `Packages/CrowIPC/`                                    | Unix socket server at `~/.local/share/crow/crow.sock` — receives JSON-RPC from the `crow` CLI                     |
+| **AutostartService**       | `Packages/CrowAutostart/`                              | Registers `crowd` to start at login (launchd LaunchAgent on macOS). Shared by `crow autostart` and the daemon's local-only `/autostart` routes; the protocol leaves room for a systemd `--user` backend |
 | **HostBridge**             | `Packages/CrowEngine/.../HostBridge.swift`             | Seam for host affordances (clipboard, open-in-editor, notifications). `crowd` uses a no-op default; the browser provides these itself where it can |
 | **JSONStore**              | `Packages/CrowPersistence/`                            | NSLock-serialized JSON persistence for sessions, worktrees, links, terminals                                      |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # `crow` CLI Reference
 
-The `crow` CLI communicates over a Unix socket at `~/.local/share/crow/crow.sock` (override with `CROW_SOCKET`). A server must be listening on it for RPC commands to succeed — the `crowd` daemon owns this socket. `crow setup` is the only subcommand that works with nothing listening.
+The `crow` CLI communicates over a Unix socket at `~/.local/share/crow/crow.sock` (override with `CROW_SOCKET`). A server must be listening on it for RPC commands to succeed — the `crowd` daemon owns this socket. `crow setup` and `crow autostart` are the only subcommands that work with nothing listening.
 
 All commands print JSON to stdout on success. Session and terminal identifiers are full UUIDs (e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`) — short names are not accepted.
 
@@ -23,7 +23,35 @@ crow setup --dev-root ~/Dev
 | ------------ | -------- | ------------------------------------------- |
 | `--dev-root` | no       | Skip the interactive dev-root prompt        |
 
-This is the only subcommand that does not require a running app.
+This is one of two subcommands that do not require a running daemon (see `crow autostart`).
+
+---
+
+## Autostart
+
+### `crow autostart install | uninstall | status`
+
+Registers `crowd` to start at login — a launchd LaunchAgent at `~/Library/LaunchAgents/com.corveil.crowd.plist`, logging to `~/Library/Logs/crow/crowd.log`. Runs locally instead of over the socket, so it works with the daemon down (which is the point). macOS only for now; on other platforms it reports `supported: false` rather than pretending to register anything. The same control lives at Settings → General → Autostart for a local browser.
+
+```bash
+crow autostart install
+crow autostart install --host 0.0.0.0 --port 8080 --dev-root ~/Dev
+crow autostart status --json
+crow autostart uninstall
+```
+
+Bare `crow autostart` is `status`. `install` is idempotent and re-points the login item at the current `crowd` on every run, so an upgrade never leaves a stale plist. When a `crowd` is already running, `install` writes the login item and leaves launchd alone — it takes effect at next login rather than spawning a duplicate the single-instance guard would refuse.
+
+| Flag         | Applies to        | Description                                                              |
+| ------------ | ----------------- | ------------------------------------------------------------------------ |
+| `--binary`   | install, status   | Path to `crowd` (default: next to this `crow`, then `PATH`)              |
+| `--host`     | install           | Bind host passed to `crowd`                                              |
+| `--port`     | install           | HTTP port passed to `crowd`                                              |
+| `--dev-root` | install           | Development root passed to `crowd`                                       |
+| `--socket`   | install           | Unix socket path passed to `crowd`                                       |
+| `--json`     | all               | Print the status object instead of the human summary                     |
+
+The status object reports `enabled` (registered at login), `running` (a `crowd` is answering right now), `loaded` (launchd knows it in this session), and `stale` (the registration points at a different binary than `--binary` / the resolved one).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,7 +180,19 @@ make uninstall
 
 ### Running crowd as a background service
 
-Crow does not yet ship a launchd/login-item installer, so start `crowd` yourself (a terminal, `tmux`, or your own `launchd` plist). It binds `127.0.0.1:8787` by default; see [Remote access](../README.md#remote-access) to reach it from another device.
+Register `crowd` to start at login, so Crow is up after a reboot with no manual command:
+
+```bash
+crow autostart install     # writes ~/Library/LaunchAgents/com.corveil.crowd.plist
+crow autostart status      # enabled? running? add --json for scripts
+crow autostart uninstall   # remove the login item
+```
+
+Install is idempotent, and re-running it after a rebuild re-points the login item at the current `crowd` — so an upgrade never leaves a stale plist behind. If a `crowd` is already running, install writes the login item and leaves the running daemon alone (it takes effect at next login) rather than starting a second one. The login-item daemon logs to `~/Library/Logs/crow/crowd.log`. The same toggle lives at Settings → General → Autostart, from a browser on the machine running `crowd`.
+
+Pass the daemon's flags through if you don't run it on the defaults — `crow autostart install --host 0.0.0.0 --port 8080 --dev-root ~/Dev`.
+
+macOS only for now (launchd); on Linux, start `crowd` yourself or write a `systemd --user` unit until [#645](https://github.com/corveil/crow/issues/645) lands. `crowd` binds `127.0.0.1:8787` by default; see [Remote access](../README.md#remote-access) to reach it from another device.
 
 ## Next Steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -190,7 +190,7 @@ crow autostart uninstall   # remove the login item
 
 Install is idempotent, and re-running it after a rebuild re-points the login item at the current `crowd` — so an upgrade never leaves a stale plist behind. If a `crowd` is already running, install writes the login item and leaves the running daemon alone (it takes effect at next login) rather than starting a second one. The login-item daemon logs to `~/Library/Logs/crow/crowd.log`. The same toggle lives at Settings → General → Autostart, from a browser on the machine running `crowd`.
 
-Pass the daemon's flags through if you don't run it on the defaults — `crow autostart install --host 0.0.0.0 --port 8080 --dev-root ~/Dev`.
+Pass the daemon's flags through if you don't run it on the defaults — `crow autostart install --host 0.0.0.0 --port 8080 --dev-root ~/Dev`. Those flags are baked into the login item, so a non-loopback `--host` re-binds beyond loopback on every login; `crowd` still logs its usual unauthenticated-bind warning, so only do this on a trusted network.
 
 macOS only for now (launchd); on Linux, start `crowd` yourself or write a `systemd --user` unit until [#645](https://github.com/corveil/crow/issues/645) lands. `crowd` binds `127.0.0.1:8787` by default; see [Remote access](../README.md#remote-access) to reach it from another device.
 


### PR DESCRIPTION
Closes #769

## What

ADR-0010 retired the macOS app, which used to launch at login and bring its daemon with it. `crowd` had no equivalent, so after a reboot Crow simply wasn't running until you started it by hand — the gap the ADR calls out at `docs/adr/0010-retire-the-macos-app.md:21`.

New **`Packages/CrowAutostart`**: an `AutostartService` protocol with a macOS **launchd LaunchAgent** backend (`~/Library/LaunchAgents/com.corveil.crowd.plist`, logging to `~/Library/Logs/crow/crowd.log`). Other platforms resolve to `UnsupportedAutostart`, which reports `supported: false` cleanly instead of failing obscurely — the seam for a `systemd --user` backend when #645 lands.

Two control surfaces share it:

- **CLI** — `crow autostart install | uninstall | status [--json]`. Runs **locally**, not over the socket: it has to work with `crowd` down, which is the whole point. `install` takes `--binary/--host/--port/--dev-root/--socket`; bare `crow autostart` is `status`.
- **Settings → General → Autostart** — a toggle backed by `GET /autostart` (read-only, any session) and `POST /autostart` (local-only, gated exactly like `SecretRoutes`: registering a launch agent mutates the *host machine*, so a remote session may not). The daemon registers its own `Bundle.main.executableURL` with its live `DaemonOptions`, so the login-launched daemon comes up configured like the one you're talking to.

## Two details that fall out of crowd's guards

`crowd` `exit(1)`s when another instance holds the socket or store-writer lock, which shapes the install logic:

- **Install never bootstraps over a running daemon.** It writes the plist and reports "takes effect at next login" — rather than booting out a daemon that's currently serving, or spawning one that immediately refuses to start.
- **`KeepAlive` is `{Crashed: true}`, not `{SuccessfulExit: false}`.** A duplicate-instance refusal is a *clean* `exit(1)`; `SuccessfulExit: false` would respawn it forever. `Crashed` restarts on an actual crash and leaves clean exits alone.

Install is idempotent and rewrites the plist every run, so an upgrade re-points it — no stale path (`stale` is reported in status, and the web UI offers a one-click "Re-point to this crowd").

## Testing

`swift test` — CrowAutostart 26, CrowCLI 103, CrowDaemon 118, all passing. Unit tests inject a fake `launchctl` runner and temp directories, so they never touch the real `~/Library/LaunchAgents`.

Verified live on macOS 15 (machine left as found — no login item installed):

- `crow autostart status` correctly reported off-but-running.
- `install` wrote the plist (`plutil -p` confirms label / `ProgramArguments` / `RunAtLoad` / `KeepAlive`), re-install was idempotent, `--binary /bin/echo` flagged `stale`.
- Forced the cold path (probe seeing no daemon): launchd bootstrapped and started it, it hit the single-instance guard, logged `Another crowd is already running…`, exited 1, and **nothing respawned** — `last exit code = 1`, `state = not running`. That's the `KeepAlive` choice working.
- `uninstall` removed the plist; `launchctl print` then reports "could not find service".
- Routes exercised against an isolated `crowd`: `GET /autostart`, `POST {"enabled":true|false}` (both directions, with the daemon log lines), a proxied request rejected, and a malformed body → 400.

Not verified in a browser: running this build's web UI needs a second `crowd`, which the store-writer lock rightly refuses alongside the daemon on this machine. The settings JS is syntax-checked and follows the existing `isLocal` + `postConfig` pattern.

## Docs

`docs/getting-started.md` (replaces the "does not yet ship a launchd/login-item installer" note), `docs/cli-reference.md` (new Autostart section), `docs/architecture.md` (package tree + component table), CLAUDE.md CLI reference, CHANGELOG, and a References follow-up line on ADR-0010 — the decision text itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPmLvdQGtEu3jvcdFvNCTk