### PR TITLE
Restore web notifications for automation events (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 ### Web UI
 
 - #613 — Left pane paints chrome + skeleton (or cached last-known) session rows on first load before `list-sessions` returns, then swaps in real rows without a blank flash.
+- #768 — Notifications for automation events are back after the native→web move: auto-workspace created, auto-merge enabled, auto-rebase pushed, auto-rebase conflicts, and config reloaded. The daemon pushes each over the existing `/rpc` socket at the moment the watcher acts; the web UI chimes and posts a browser notification, with per-event Enabled / sound / system toggles under Settings → Notifications. Conflict events use a distinct, harsher tone and are never suppressed by the "you're looking at it" focus rule.
 
 ### Automation
 

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ test:
 			swift test --package-path "$$pkg"; \
 		fi; \
 	done
+	@echo "==> Checking notification-event catalogs (CROW-768)..."
+	@./scripts/check-notification-events.sh
 
 clean:
 	rm -rf .build

--- a/Packages/CrowCore/Sources/CrowCore/Models/NotificationEvent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/NotificationEvent.swift
@@ -1,16 +1,28 @@
 import Foundation
 
-/// User-facing notification event categories, mapped from raw Claude Code hook events.
+/// User-facing notification event categories.
 ///
-/// Only events that require human attention trigger notifications. Most hook events
-/// (e.g., tool execution, streaming responses) are intentionally unmapped — they fire
-/// too frequently and don't need the user's immediate attention.
+/// Two families:
+///  - **Agent/PR events** mapped from raw Claude Code hook events + PR status polling.
+///    Only events that require human attention trigger notifications. Most hook events
+///    (e.g., tool execution, streaming responses) are intentionally unmapped — they fire
+///    too frequently and don't need the user's immediate attention.
+///  - **Automation events** — the moments Crow acts on your behalf (auto-workspace,
+///    auto-merge, auto-rebase, config reload). These never arrive as hook events; the
+///    daemon pushes them to clients at the point the watcher acts (CROW-768).
 public enum NotificationEvent: String, Codable, Sendable, CaseIterable, Identifiable {
     case taskComplete
     case agentWaiting
     case reviewRequested
     case changesRequested
     case checksFailing
+    // Automation events (CROW-768). Restored from the retired native
+    // NotificationManager (ADR-0010); emitted by the daemon's watchers.
+    case autoWorkspaceCreated
+    case autoMergeEnabled
+    case autoRebasePushed
+    case autoRebaseConflicts
+    case configReloaded
 
     public var id: String { rawValue }
 
@@ -21,6 +33,11 @@ public enum NotificationEvent: String, Codable, Sendable, CaseIterable, Identifi
         case .reviewRequested: "Review Requested"
         case .changesRequested: "Changes Requested"
         case .checksFailing: "CI Failing"
+        case .autoWorkspaceCreated: "Auto-Workspace Created"
+        case .autoMergeEnabled: "Auto-Merge Enabled"
+        case .autoRebasePushed: "Branch Rebased"
+        case .autoRebaseConflicts: "Rebase Conflicts"
+        case .configReloaded: "Config Reloaded"
         }
     }
 
@@ -31,6 +48,11 @@ public enum NotificationEvent: String, Codable, Sendable, CaseIterable, Identifi
         case .reviewRequested: "Someone requested your review on a PR"
         case .changesRequested: "A reviewer requested changes on your PR"
         case .checksFailing: "CI checks started failing on your PR"
+        case .autoWorkspaceCreated: "Crow auto-created a workspace for an assigned issue"
+        case .autoMergeEnabled: "Crow enabled auto-merge on a PR"
+        case .autoRebasePushed: "Crow rebased a PR branch onto its base and pushed"
+        case .autoRebaseConflicts: "An auto-rebase hit conflicts that need attention"
+        case .configReloaded: "Crow reloaded its configuration"
         }
     }
 
@@ -41,6 +63,26 @@ public enum NotificationEvent: String, Codable, Sendable, CaseIterable, Identifi
         case .reviewRequested: "Glass"
         case .changesRequested: "Funk"
         case .checksFailing: "Sosumi"
+        case .autoWorkspaceCreated: "Hero"
+        case .autoMergeEnabled: "Glass"
+        case .autoRebasePushed: "Bottle"
+        // Deliberately harsh, so a conflict is audibly distinct from the
+        // success events it sits next to (CROW-768).
+        case .autoRebaseConflicts: "Basso"
+        case .configReloaded: "Tink"
+        }
+    }
+
+    /// Whether this event is one Crow's own automation emits (as opposed to an
+    /// agent hook / PR-status transition). Automation events are pushed by the
+    /// daemon and always carry their own notification body.
+    public var isAutomationEvent: Bool {
+        switch self {
+        case .autoWorkspaceCreated, .autoMergeEnabled, .autoRebasePushed,
+             .autoRebaseConflicts, .configReloaded:
+            true
+        case .taskComplete, .agentWaiting, .reviewRequested, .changesRequested, .checksFailing:
+            false
         }
     }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/NotificationEventTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/NotificationEventTests.swift
@@ -3,7 +3,8 @@ import Testing
 @testable import CrowCore
 
 @Test func notificationEventAllCasesCount() {
-    #expect(NotificationEvent.allCases.count == 5)
+    // 5 agent/PR events + 5 automation events (CROW-768).
+    #expect(NotificationEvent.allCases.count == 10)
 }
 
 @Test func notificationEventDefaultSoundsNonEmpty() {
@@ -73,4 +74,36 @@ import Testing
 @Test func prTransitionEventsHaveDistinctDefaultSounds() {
     // Different default sounds so the two events are audibly distinct.
     #expect(NotificationEvent.changesRequested.defaultSound != NotificationEvent.checksFailing.defaultSound)
+}
+
+// MARK: - Automation events (CROW-768)
+
+@Test func automationEventsArePresentAndClassified() {
+    let automation: [NotificationEvent] = [
+        .autoWorkspaceCreated, .autoMergeEnabled, .autoRebasePushed,
+        .autoRebaseConflicts, .configReloaded,
+    ]
+    for event in automation {
+        #expect(NotificationEvent.allCases.contains(event))
+        #expect(event.isAutomationEvent)
+    }
+    // Everything else is derived from hooks / PR polling, not pushed.
+    for event in NotificationEvent.allCases where !automation.contains(event) {
+        #expect(!event.isAutomationEvent)
+    }
+}
+
+@Test func automationEventsNeverArriveAsHookEvents() {
+    // `from` maps raw Claude Code hook names; automation events are pushed by the
+    // daemon's watchers and must not be reachable through that mapper.
+    for event in NotificationEvent.allCases where event.isAutomationEvent {
+        #expect(NotificationEvent.from(eventName: event.rawValue) == nil)
+    }
+}
+
+@Test func rebaseConflictsSoundsDistinctFromRebaseSuccess() {
+    // Acceptance criterion: an attention event must be audibly distinguishable
+    // from the success event beside it.
+    #expect(NotificationEvent.autoRebaseConflicts.defaultSound
+            != NotificationEvent.autoRebasePushed.defaultSound)
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/NotificationSettingsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/NotificationSettingsTests.swift
@@ -77,3 +77,24 @@ import Testing
                 "Default sound '\(event.defaultSound)' for \(event) not in builtInSounds")
     }
 }
+
+// MARK: - Forward compatibility (CROW-768)
+
+@Test func legacyConfigWithoutAutomationEventsFallsBackToDefaults() throws {
+    // A config written before the automation events existed carries only the
+    // original five entries. `config(for:)` must still hand back a sensible
+    // enabled-by-default config rather than dropping the notification.
+    var legacy = NotificationSettings(eventSettings: [:])
+    legacy.eventSettings[.taskComplete] = EventNotificationConfig(soundName: "Glass")
+    let data = try JSONEncoder().encode(legacy)
+    let decoded = try JSONDecoder().decode(NotificationSettings.self, from: data)
+
+    for event in NotificationEvent.allCases where event.isAutomationEvent {
+        #expect(decoded.eventSettings[event] == nil)
+        let config = decoded.config(for: event)
+        #expect(config.enabled == true)
+        #expect(config.soundEnabled == true)
+        #expect(config.systemNotificationEnabled == true)
+        #expect(config.soundName == event.defaultSound)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -109,7 +109,8 @@ public enum CrowDaemon {
 
         // Live-reload the store so the web UI reflects the desktop app's writes
         // (new sessions/status/terminals/links) without a daemon restart.
-        startStoreReloadPoll(store: store, appState: appState, eventHub: eventHub)
+        startStoreReloadPoll(
+            store: store, appState: appState, eventHub: eventHub, devRoot: options.devRoot)
 
         // Terminal cockpit (tmux). Optional — RPC still works without tmux, but
         // the terminal handlers (new-terminal/close-terminal) and `/terminal`
@@ -173,7 +174,7 @@ public enum CrowDaemon {
                 wireTrackerAutomations(
                     tracker: tracker, appState: appState, sessionService: sessionService,
                     autoRespond: autoRespond, devRoot: options.devRoot,
-                    reviewSerializer: reviewSerializer)
+                    reviewSerializer: reviewSerializer, eventHub: eventHub)
             }
         }
 
@@ -397,8 +398,10 @@ public enum CrowDaemon {
     }
 
     /// Wire the IssueTracker's background automation hooks: spawns go to the
-    /// daemon's Manager terminal / SessionService, notifications are dropped (no
-    /// UI). Config-gated behaviors read `{devRoot}/.claude/config.json` fresh each
+    /// daemon's Manager terminal / SessionService, and the user-facing
+    /// notifications are pushed to connected web clients over `eventHub`
+    /// (CROW-768 — restoring what the retired native NotificationManager did).
+    /// Config-gated behaviors read `{devRoot}/.claude/config.json` fresh each
     /// poll so Settings edits take effect (CROW-581).
     @MainActor
     private static func wireTrackerAutomations(
@@ -407,9 +410,20 @@ public enum CrowDaemon {
         sessionService: SessionService,
         autoRespond: AutoRespondCoordinator?,
         devRoot: String,
-        reviewSerializer: ReviewKickoffSerializer
+        reviewSerializer: ReviewKickoffSerializer,
+        eventHub: EventHub
     ) {
         func config() -> AppConfig? { ConfigStore.loadConfig(devRoot: devRoot) }
+        // The tracker's hooks are synchronous; the hub is an actor. Hop off in a
+        // detached-from-the-caller Task so a broadcast never blocks a watcher.
+        func notify(_ event: NotificationEvent, key: String, title: String, body: String) {
+            Task { await eventHub.broadcastNotification(event: event, key: key, title: title, body: body) }
+        }
+        // Name a session for a notification title, as the native manager did.
+        func sessionName(_ id: UUID) -> String {
+            appState.sessions.first(where: { $0.id == id })?.name ?? "session"
+        }
+
         // crow:auto — run /crow-workspace on the Manager for a newly-labeled
         // assigned issue (the tracker strips the label after, so once-only).
         tracker.autoCreateWatcherEnabledProvider = { (config()?.autoCreateWatcherEnabled ?? false) }
@@ -419,6 +433,10 @@ public enum CrowDaemon {
                 return
             }
             TerminalRouter.send(managerTerminal, text: "/crow-workspace \(issue.url)\n")
+            // No session exists yet — key the notification on the issue URL.
+            notify(.autoWorkspaceCreated, key: issue.url,
+                   title: "Auto-creating workspace — \(issue.repo)",
+                   body: "#\(issue.number): \(issue.title)")
         }
 
         // Auto-respond to PR transitions (changes-requested / checks-failing) and
@@ -428,17 +446,34 @@ public enum CrowDaemon {
             tracker.onPRStatusTransitions = { transitions in
                 autoRespond.handle(transitions)
             }
-            tracker.onAutoRebaseConflicts = { sessionID, _, _ in
-                autoRespond.dispatchManual(action: .fixConflicts, sessionID: sessionID)
-            }
             tracker.respondToChangesRequestedProvider = { (config()?.autoRespond.respondToChangesRequested ?? false) }
             tracker.autoRebaseAndResolveConflictsProvider = { (config()?.autoRespond.autoRebaseAndResolveConflicts ?? false) }
         }
 
+        // Auto-rebase outcomes. The conflict hand-off dispatches to the session's
+        // agent when a coordinator exists, but the notification fires either way —
+        // conflicts need a human's attention even with no terminal to paste into.
+        tracker.onAutoRebasePushed = { sessionID, _, number in
+            notify(.autoRebasePushed, key: sessionID.uuidString,
+                   title: "Branch rebased — \(sessionName(sessionID))",
+                   body: "PR #\(number) was rebased onto its base and force-pushed.")
+        }
+        tracker.onAutoRebaseConflicts = { sessionID, _, number in
+            autoRespond?.dispatchManual(action: .fixConflicts, sessionID: sessionID)
+            notify(.autoRebaseConflicts, key: sessionID.uuidString,
+                   title: "Rebase conflicts — \(sessionName(sessionID))",
+                   body: "PR #\(number) has conflicts. Crow asked the agent to resolve them.")
+        }
+
         // Auto-merge (enable GitHub native auto-merge on eligible Crow PRs). The
-        // user-facing notification is dropped headless; the audit line is NSLog'd
-        // at the tracker's call site regardless.
+        // audit line is NSLog'd at the tracker's call site regardless of whether
+        // any client is connected to receive the notification.
         tracker.autoMergeWatcherEnabledProvider = { (config()?.autoMergeWatcherEnabled ?? false) }
+        tracker.onAutoMergeEnabled = { sessionID, _, number in
+            notify(.autoMergeEnabled, key: sessionID.uuidString,
+                   title: "Auto-merge enabled — \(sessionName(sessionID))",
+                   body: "PR #\(number) will merge once required reviews and checks pass.")
+        }
 
         // Auto-complete on merge/close, and auto-move-to-inReview when a
         // session's PR opens, run INSIDE the tracker's own refresh via these
@@ -696,9 +731,25 @@ public enum CrowDaemon {
     /// that break fd-based watching. Broadcasts a `changed` nudge on the hub so
     /// connected clients re-fetch immediately instead of waiting for their own
     /// interval poll (CROW-581, M-D).
-    private static func startStoreReloadPoll(store: JSONStore, appState: AppState, eventHub: EventHub) {
+    ///
+    /// The same tick stats `{devRoot}/.claude/config.json` and pushes a
+    /// `configReloaded` notification when it moves — the daemon re-reads config
+    /// lazily rather than holding a snapshot, so an mtime change *is* the reload.
+    /// One event per real change, covering Settings saves, CLI writes and hand
+    /// edits alike (CROW-768).
+    private static func startStoreReloadPoll(
+        store: JSONStore, appState: AppState, eventHub: EventHub, devRoot: String
+    ) {
+        let configPath = URL(fileURLWithPath: devRoot)
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("config.json").path
+        func configModified() -> Date? {
+            (try? FileManager.default.attributesOfItem(atPath: configPath)[.modificationDate]) as? Date
+        }
         Task {
             var lastModified = store.storeModificationDate
+            // Seeded before the loop so startup never fires a spurious reload.
+            var lastConfigModified = configModified()
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
                 let now = store.storeModificationDate
@@ -707,6 +758,14 @@ public enum CrowDaemon {
                     store.reload()
                     await reseed(appState, from: store)
                     await eventHub.broadcast()
+                }
+                let configNow = configModified()
+                if configNow != lastConfigModified {
+                    lastConfigModified = configNow
+                    await eventHub.broadcastNotification(
+                        event: .configReloaded, key: "config",
+                        title: "Config reloaded",
+                        body: "Settings were reloaded from config.json.")
                 }
             }
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -459,10 +459,17 @@ public enum CrowDaemon {
                    body: "PR #\(number) was rebased onto its base and force-pushed.")
         }
         tracker.onAutoRebaseConflicts = { sessionID, _, number in
-            autoRespond?.dispatchManual(action: .fixConflicts, sessionID: sessionID)
+            // Only claim the agent was asked to resolve when the prompt actually
+            // reached a managed terminal — with no coordinator, no terminal, or a
+            // refused review session the body would otherwise mislead (review).
+            let handedOff = autoRespond?.dispatchManual(
+                action: .fixConflicts, sessionID: sessionID).isSent ?? false
+            let body = handedOff
+                ? "PR #\(number) has conflicts. Crow asked the agent to resolve them."
+                : "PR #\(number) has conflicts that need attention."
             notify(.autoRebaseConflicts, key: sessionID.uuidString,
                    title: "Rebase conflicts — \(sessionName(sessionID))",
-                   body: "PR #\(number) has conflicts. Crow asked the agent to resolve them.")
+                   body: body)
         }
 
         // Auto-merge (enable GitHub native auto-merge on eligible Crow PRs). The

--- a/Packages/CrowDaemon/Sources/CrowDaemon/EventHub.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/EventHub.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CrowCore
 
 /// Fan-out hub for server-initiated `/rpc` WebSocket notifications. Each
 /// connected client registers its own per-connection outbound continuation;
@@ -40,6 +41,57 @@ actor EventHub {
         }
     }
 
+    /// Broadcast an automation notification. See `notifyFrame`.
+    func broadcastNotification(
+        event: NotificationEvent,
+        key: String,
+        title: String,
+        body: String
+    ) {
+        broadcast(Self.notifyFrame(event: event, key: key, title: title, body: body))
+    }
+
     /// Current subscriber count — for tests/diagnostics.
     var subscriberCount: Int { subscribers.count }
+
+    /// A pre-encoded JSON-RPC notification carrying one of Crow's own automation
+    /// events (CROW-768) — the moments a watcher acted on the user's behalf, which
+    /// no client can derive from polled state. Like `changedFrame` it carries no
+    /// `id`, so clients that don't know the method ignore it.
+    ///
+    /// `key` is the client-side dedup/navigation key: the session UUID where one
+    /// exists, otherwise the issue URL (auto-workspace) or a stable literal
+    /// (`"config"`). Encoded through `JSONEncoder` so a title/body containing
+    /// quotes or backslashes can't produce a malformed frame.
+    static func notifyFrame(
+        event: NotificationEvent,
+        key: String,
+        title: String,
+        body: String
+    ) -> String {
+        struct Params: Encodable {
+            let event: String
+            let key: String
+            let title: String
+            let body: String
+        }
+        struct Frame: Encodable {
+            let jsonrpc = "2.0"
+            let method = "notify"
+            let params: Params
+        }
+        let frame = Frame(params: Params(
+            event: event.rawValue, key: key, title: title, body: body))
+        let encoder = JSONEncoder()
+        // Deterministic key order — nothing parses these frames positionally, but
+        // a stable string keeps logs and tests comparable.
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(frame),
+              let text = String(data: data, encoding: .utf8) else {
+            // Encoding a fixed-shape struct of Strings can't realistically fail;
+            // fall back to the plain nudge so the client at least re-fetches.
+            return changedFrame
+        }
+        return text
+    }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -432,7 +432,12 @@ function onServerNotify(params) {
   if (!_soundArmed) return;
   if (!params || typeof params.event !== 'string') return;
   if (ALL_EVENTS.indexOf(params.event) === -1) return; // unknown/newer event — ignore
-  emitEvent(params.event, params.key || '', { title: params.title, body: params.body });
+  // Defensive: the daemon always sends strings, but never hand a non-string to
+  // the Notification API. A missing key just weakens dedup, so tolerate it.
+  const key = typeof params.key === 'string' ? params.key : '';
+  const title = typeof params.title === 'string' ? params.title : '';
+  const body = typeof params.body === 'string' ? params.body : '';
+  emitEvent(params.event, key, { title, body });
 }
 
 // Manual test hook, mirroring crowTestSound. crowTestNotify() shows one popup

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -37,6 +37,9 @@ function rpcConnect() {
       // daemon — re-fetch the live surfaces now instead of waiting for the
       // interval poll (CROW-581, M-D).
       if (msg.id == null && msg.method === 'changed') { onServerChanged(); return; }
+      // Automation event push (CROW-768): a moment Crow acted on the user's
+      // behalf, which no client can derive from polled state.
+      if (msg.id == null && msg.method === 'notify') { onServerNotify(msg.params); return; }
       const waiter = rpcState.pending.get(msg.id);
       if (!waiter) return;
       rpcState.pending.delete(msg.id);
@@ -150,6 +153,10 @@ window.reloadUIConfig = loadUIConfig;
 const DEFAULT_EVENT_SOUND = {
   taskComplete: 'Glass', agentWaiting: 'Funk', reviewRequested: 'Glass',
   changesRequested: 'Funk', checksFailing: 'Sosumi',
+  // Automation events (CROW-768) — Basso for conflicts so "needs attention" is
+  // audibly distinct from the success events beside it.
+  autoWorkspaceCreated: 'Hero', autoMergeEnabled: 'Glass',
+  autoRebasePushed: 'Bottle', autoRebaseConflicts: 'Basso', configReloaded: 'Tink',
 };
 
 // NotificationEvent.displayName / .description (CrowCore) — reused for the
@@ -158,6 +165,9 @@ const EVENT_LABEL = {
   taskComplete: 'Task Complete', agentWaiting: 'Agent Waiting',
   reviewRequested: 'Review Requested', changesRequested: 'Changes Requested',
   checksFailing: 'CI Failing',
+  autoWorkspaceCreated: 'Auto-Workspace Created', autoMergeEnabled: 'Auto-Merge Enabled',
+  autoRebasePushed: 'Branch Rebased', autoRebaseConflicts: 'Rebase Conflicts',
+  configReloaded: 'Config Reloaded',
 };
 const EVENT_DESC = {
   taskComplete: 'Claude finished responding',
@@ -165,7 +175,23 @@ const EVENT_DESC = {
   reviewRequested: 'Someone requested your review on a PR',
   changesRequested: 'A reviewer requested changes on your PR',
   checksFailing: 'CI checks started failing on your PR',
+  autoWorkspaceCreated: 'Crow auto-created a workspace for an assigned issue',
+  autoMergeEnabled: 'Crow enabled auto-merge on a PR',
+  autoRebasePushed: 'Crow rebased a PR branch onto its base and pushed',
+  autoRebaseConflicts: 'An auto-rebase hit conflicts that need attention',
+  configReloaded: 'Crow reloaded its configuration',
 };
+
+// NotificationEvent.isAutomationEvent (CrowCore) — the events the daemon pushes
+// rather than the client deriving them from polled state (CROW-768).
+const AUTOMATION_EVENTS = [
+  'autoWorkspaceCreated', 'autoMergeEnabled', 'autoRebasePushed',
+  'autoRebaseConflicts', 'configReloaded',
+];
+// Every event the notification layer knows about, in the Settings tab's order.
+const ALL_EVENTS = [
+  'taskComplete', 'agentWaiting', 'reviewRequested', 'changesRequested', 'checksFailing',
+].concat(AUTOMATION_EVENTS);
 
 // Crow brandmark (96px) as a data URL, so notifications are visibly ours
 // without adding a server asset route — Chrome won't render SVG notification
@@ -274,9 +300,7 @@ function playEventSound(event, key) {
 // crowTestSound('agentWaiting') plays one. Bypasses config/dedup so it's always
 // audible — useful to confirm audio works and hear each configured tone.
 window.crowTestSound = function (event) {
-  const evs = event
-    ? [event]
-    : ['taskComplete', 'agentWaiting', 'reviewRequested', 'changesRequested', 'checksFailing'];
+  const evs = event ? [event] : ALL_EVENTS;
   evs.forEach((ev, i) => setTimeout(() => {
     const cfg = (uiConfig.notifications && uiConfig.notifications.events[ev]) || {};
     const name = cfg.soundName || DEFAULT_EVENT_SOUND[ev] || 'Glass';
@@ -323,8 +347,11 @@ function sessionNameFor(id) {
   return (s && s.name) || 'Session';
 }
 
+// `detail` (optional) carries a server-supplied { title, body } for automation
+// events, whose text is specific (PR number, issue title) rather than derivable
+// from EVENT_DESC (CROW-768).
 const _lastNotifyAt = {};
-function showEventNotification(event, key) {
+function showEventNotification(event, key, detail) {
   const N = uiConfig.notifications;
   if (!N) return;                          // config not loaded — don't guess
   if (N.globalMute) return;
@@ -337,21 +364,29 @@ function showEventNotification(event, key) {
 
   const isSession = !!sessions.find((x) => x.id === key);
   // Focus-suppression, mirroring NotificationManager (!appFocused || !visible):
-  // don't ping about the session you're already looking at.
-  if (isSession && document.hasFocus() && selectedId === key) return;
+  // don't ping about the session you're already looking at. Automation events
+  // are exempt (as they were natively) — an action Crow took on your behalf is
+  // worth knowing about even while that session is on screen (CROW-768).
+  const isAutomation = AUTOMATION_EVENTS.indexOf(event) !== -1;
+  if (!isAutomation && isSession && document.hasFocus() && selectedId === key) return;
 
   const k = (key || '') + '|' + event;
   const now = Date.now();
   if (_lastNotifyAt[k] && now - _lastNotifyAt[k] < 2000) return;
   _lastNotifyAt[k] = now;
 
-  const label = EVENT_LABEL[event] || event;
-  let body = EVENT_DESC[event] || '';
-  if (isSession) {
-    body = `${sessionNameFor(key)} — ${body}`;
-  } else {
-    const r = ((boardData.reviews && boardData.reviews.reviews) || []).find((x) => x.id === key);
-    if (r && r.repo) body = `${r.repo} — ${body}`;
+  // A server-supplied title/body already names the PR / issue / session, so it's
+  // used verbatim; derived events get the label plus a subject prefix.
+  const label = (detail && detail.title) || EVENT_LABEL[event] || event;
+  let body = (detail && detail.body) || '';
+  if (!body) {
+    body = EVENT_DESC[event] || '';
+    if (isSession) {
+      body = `${sessionNameFor(key)} — ${body}`;
+    } else {
+      const r = ((boardData.reviews && boardData.reviews.reviews) || []).find((x) => x.id === key);
+      if (r && r.repo) body = `${r.repo} — ${body}`;
+    }
   }
   try {
     // In the desktop app, WKWebView lacks the Web Notification API — post via the
@@ -364,12 +399,14 @@ function showEventNotification(event, key) {
     });
     // Clicking focuses the window and returns to where it originated: the
     // session for session events, or the review's session / reviews board.
+    // Automation events keyed on something other than a session (an issue URL,
+    // `config`) have nowhere better to land than the window itself.
     n.onclick = () => {
       window.focus();
       try {
         if (isSession) {
           selectSession(key);
-        } else {
+        } else if (!isAutomation) {
           const r = ((boardData.reviews && boardData.reviews.reviews) || []).find((x) => x.id === key);
           if (r && r.review_session_id) selectSession(r.review_session_id);
           else selectBoard('reviews');
@@ -381,9 +418,21 @@ function showEventNotification(event, key) {
 }
 
 // Both channels fire from one call in the detectors below; each self-gates.
-function emitEvent(event, key) {
+function emitEvent(event, key, detail) {
   playEventSound(event, key);
-  showEventNotification(event, key);
+  showEventNotification(event, key, detail);
+}
+
+// Server-pushed automation event (CROW-768). The daemon fires these at the point
+// a watcher acts — auto-workspace, auto-merge, auto-rebase, config reload — since
+// none of them are visible in the state the client polls. Gating (global mute,
+// per-event toggles, dedup) is the detectors' gating; the arm window applies too,
+// so a frame landing mid-boot can't chime over a page load.
+function onServerNotify(params) {
+  if (!_soundArmed) return;
+  if (!params || typeof params.event !== 'string') return;
+  if (ALL_EVENTS.indexOf(params.event) === -1) return; // unknown/newer event — ignore
+  emitEvent(params.event, params.key || '', { title: params.title, body: params.body });
 }
 
 // Manual test hook, mirroring crowTestSound. crowTestNotify() shows one popup
@@ -392,9 +441,7 @@ function emitEvent(event, key) {
 window.crowTestNotify = function (event) {
   if (!notificationsSupported()) { console.warn('[crowNotify] Notification API unavailable'); return; }
   const fire = () => {
-    const evs = event
-      ? [event]
-      : ['taskComplete', 'agentWaiting', 'reviewRequested', 'changesRequested', 'checksFailing'];
+    const evs = event ? [event] : ALL_EVENTS;
     evs.forEach((ev, i) => setTimeout(() => {
       try {
         const n = new Notification(`Crow — ${EVENT_LABEL[ev] || ev} (test)`, {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -38,14 +38,38 @@
     taskComplete: 'Task Complete', agentWaiting: 'Agent Waiting',
     reviewRequested: 'Review Requested', changesRequested: 'Changes Requested',
     checksFailing: 'CI Failing',
+    autoWorkspaceCreated: 'Auto-Workspace Created', autoMergeEnabled: 'Auto-Merge Enabled',
+    autoRebasePushed: 'Branch Rebased', autoRebaseConflicts: 'Rebase Conflicts',
+    configReloaded: 'Config Reloaded',
+  };
+  // One-line "what fires this" hint per event, so the automation entries aren't
+  // guesswork (CrowCore NotificationEvent.description).
+  const EVENT_HINTS = {
+    taskComplete: 'Claude finished responding.',
+    agentWaiting: 'Claude needs your input or permission.',
+    reviewRequested: 'Someone requested your review on a PR.',
+    changesRequested: 'A reviewer requested changes on your PR.',
+    checksFailing: 'CI checks started failing on your PR.',
+    autoWorkspaceCreated: 'Crow auto-created a workspace for a crow:auto-labeled issue.',
+    autoMergeEnabled: 'Crow enabled auto-merge on a crow:merge-labeled PR.',
+    autoRebasePushed: 'Crow rebased a PR branch onto its base and force-pushed.',
+    autoRebaseConflicts: 'An auto-rebase hit conflicts that need attention.',
+    configReloaded: 'Crow picked up a change to config.json.',
   };
   // Canonical NotificationEvent set + defaults (CrowCore NotificationEvent) —
-  // the config only stores events the user has touched, so we render all five
-  // and materialize any missing ones with their default sound (CROW-593).
-  const EVENT_ORDER = ['taskComplete', 'agentWaiting', 'reviewRequested', 'changesRequested', 'checksFailing'];
+  // the config only stores events the user has touched, so we render all of them
+  // and materialize any missing ones with their default sound (CROW-593). The
+  // trailing five are Crow's own automation events (CROW-768).
+  const EVENT_ORDER = [
+    'taskComplete', 'agentWaiting', 'reviewRequested', 'changesRequested', 'checksFailing',
+    'autoWorkspaceCreated', 'autoMergeEnabled', 'autoRebasePushed', 'autoRebaseConflicts',
+    'configReloaded',
+  ];
   const EVENT_DEFAULT_SOUND = {
     taskComplete: 'Glass', agentWaiting: 'Funk', reviewRequested: 'Glass',
     changesRequested: 'Funk', checksFailing: 'Sosumi',
+    autoWorkspaceCreated: 'Hero', autoMergeEnabled: 'Glass',
+    autoRebasePushed: 'Bottle', autoRebaseConflicts: 'Basso', configReloaded: 'Tink',
   };
   const BUILT_IN_SOUNDS = [
     'Basso', 'Blow', 'Bottle', 'Frog', 'Funk', 'Glass', 'Hero', 'Morse',
@@ -592,7 +616,7 @@
 
     for (const [raw, conf] of ensureAllEvents(n)) {
       body.appendChild(group(EVENT_LABELS[raw] || raw));
-      body.appendChild(toggleField('Enabled', conf, 'enabled'));
+      body.appendChild(toggleField('Enabled', conf, 'enabled', EVENT_HINTS[raw]));
       body.appendChild(toggleField('Play sound', conf, 'soundEnabled'));
       body.appendChild(toggleField('System notification', conf, 'systemNotificationEnabled'));
       body.appendChild(soundField(conf));

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/EventHubTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/EventHubTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import CrowCore
 @testable import CrowDaemon
 
 /// The fan-in broadcast hub behind `/rpc` server-push notifications (CROW-581,
@@ -39,5 +40,64 @@ import Testing
     @Test func defaultFrameIsAnIdlessChangedNotification() async {
         // Older clients ignore it (no `id` to correlate) — safe to broadcast.
         #expect(EventHub.changedFrame == #"{"jsonrpc":"2.0","method":"changed"}"#)
+    }
+
+    // MARK: - Automation notifications (CROW-768)
+
+    /// Decode a frame back into its parts so the assertions don't depend on key
+    /// ordering, which `JSONEncoder` doesn't guarantee.
+    private func decode(_ text: String) throws -> (method: String, params: [String: String]) {
+        let object = try JSONSerialization.jsonObject(
+            with: Data(text.utf8)) as? [String: Any]
+        let params = (object?["params"] as? [String: Any])?
+            .compactMapValues { $0 as? String } ?? [:]
+        return ((object?["method"] as? String) ?? "", params)
+    }
+
+    @Test func notifyFrameIsAnIdlessNotificationCarryingTheEvent() throws {
+        let text = EventHub.notifyFrame(
+            event: .autoMergeEnabled, key: "session-id",
+            title: "Auto-merge enabled — feature", body: "PR #12 will merge.")
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+        // No `id`: clients that don't know the method can't correlate it and drop it.
+        #expect(object?["id"] == nil)
+        #expect(object?["jsonrpc"] as? String == "2.0")
+
+        let (method, params) = try decode(text)
+        #expect(method == "notify")
+        #expect(params["event"] == "autoMergeEnabled")
+        #expect(params["key"] == "session-id")
+        #expect(params["title"] == "Auto-merge enabled — feature")
+        #expect(params["body"] == "PR #12 will merge.")
+    }
+
+    @Test func notifyFrameEscapesQuotesAndBackslashes() throws {
+        // Titles/bodies embed issue titles and session names — user-controlled
+        // text that must not be able to produce a malformed frame.
+        let nasty = #"a "quoted" \ back\slash"#
+        let text = EventHub.notifyFrame(
+            event: .autoWorkspaceCreated, key: "https://example.com/issues/1",
+            title: nasty, body: nasty)
+        let (method, params) = try decode(text)
+        #expect(method == "notify")
+        #expect(params["title"] == nasty)
+        #expect(params["body"] == nasty)
+    }
+
+    @Test func broadcastNotificationReachesSubscribers() async throws {
+        let hub = EventHub()
+        let (stream, cont) = AsyncStream.makeStream(of: String.self)
+        _ = await hub.subscribe(cont)
+        await hub.broadcastNotification(
+            event: .autoRebaseConflicts, key: "s1", title: "Rebase conflicts", body: "PR #3")
+
+        var it = stream.makeAsyncIterator()
+        let received = try #require(await it.next())
+        let (method, params) = try decode(received)
+        #expect(method == "notify")
+        #expect(params["event"] == "autoRebaseConflicts")
+        #expect(params["key"] == "s1")
+        #expect(params["title"] == "Rebase conflicts")
+        #expect(params["body"] == "PR #3")
     }
 }

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -97,6 +97,30 @@ PR #299 added a single toggle that lets Crow enable GitHub's native auto-merge o
 
 Backed by `AppConfig.autoMergeWatcherEnabled`. Hand-written PRs without the Crow trailer are ignored even when labeled. Crow lazily creates the `crow:merge` label in the repo on first observation so repo owners don't need to pre-seed it.
 
+## Automation notifications
+
+Every automation above acts without you asking, so each one announces itself. Alongside the
+five agent/PR events (Task Complete, Agent Waiting, Review Requested, Changes Requested, CI
+Failing), the daemon pushes five **automation** events to connected clients at the moment a
+watcher acts:
+
+| Event                    | Fires when                                                              |
+| ------------------------ | ----------------------------------------------------------------------- |
+| Auto-Workspace Created   | A `crow:auto`-labeled assigned issue triggered `/crow-workspace`         |
+| Auto-Merge Enabled       | Crow enabled auto-merge on a `crow:merge`-labeled PR                     |
+| Branch Rebased           | An auto-rebase succeeded and force-pushed                               |
+| Rebase Conflicts         | An auto-rebase hit conflicts (needs attention — deliberately harsher tone) |
+| Config Reloaded          | `{devRoot}/.claude/config.json` changed and was picked up               |
+
+Each has its own **Enabled / Play sound / System notification / Sound** row under
+**Settings → Notifications**, on top of the global mute and sound/system category toggles.
+Unlike the session events, these are not suppressed when you are already looking at the
+session they belong to — an action Crow took on your behalf is worth surfacing either way.
+
+Transport is the existing `/rpc` WebSocket: the daemon broadcasts an idless JSON-RPC
+`notify` frame (`EventHub.notifyFrame`), which the web client turns into a chime plus a
+browser/Tauri notification with the same 2s per-`(key, event)` dedup as everything else.
+
 ## Per-PR feature notes
 
 Short descriptions of each shipped automation, in roughly the order they fire during the lifecycle.
@@ -147,6 +171,9 @@ Claude Code's OpenTelemetry exporter is wired up so each session emits standard 
 | Auto-create / auto-respond loop  | `Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift` (60s polling cycle)                                         |
 | Review session auto-start        | `Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift` + per-workspace flag in `AppConfig`                         |
 | Auto-merge watcher (`crow:merge`)| `Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift` (`applyAutoMerge`, `extractCrowSessionUUIDs`, `crowAuthored`) |
+| Automation notification push     | `Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift` (`wireTrackerAutomations`) + `EventHub.notifyFrame`             |
+| Notification events + defaults   | `Packages/CrowCore/Sources/CrowCore/Models/NotificationEvent.swift`                                                       |
+| Chime / browser notification     | `Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js` (`onServerNotify`, `emitEvent`)                             |
 
 ## See also
 

--- a/scripts/check-notification-events.sh
+++ b/scripts/check-notification-events.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Guard against drift between the three places the notification-event catalog
+# lives (CROW-768): the canonical `NotificationEvent` Swift enum and the two web
+# mirrors that render/gate it. They are separate languages, so nothing enforces
+# agreement at build time — this does, cheaply, in CI and locally.
+#
+#   - Swift enum cases      → Packages/CrowCore/Sources/CrowCore/Models/NotificationEvent.swift
+#   - client dispatch list  → .../web/app.js         (ALL_EVENTS = base ++ AUTOMATION_EVENTS)
+#   - Settings tab list     → .../web/settings.js    (EVENT_ORDER)
+#
+# Exit non-zero (with a diff) if any of the three disagree on the set of events.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENUM="$ROOT/Packages/CrowCore/Sources/CrowCore/Models/NotificationEvent.swift"
+APP="$ROOT/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js"
+SETTINGS="$ROOT/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js"
+
+# Swift: `case fooBar` lines inside the enum (skip the computed `isAutomationEvent`
+# switch, whose `case` lines are indented deeper and list multiple names).
+swift_events() {
+  grep -oE '^    case [a-zA-Z]+$' "$ENUM" | awk '{print $2}' | sort
+}
+
+# app.js: the base literal array concatenated with AUTOMATION_EVENTS.
+app_events() {
+  node -e '
+    const fs = require("fs");
+    const s = fs.readFileSync(process.argv[1], "utf8");
+    const all = s.match(/const ALL_EVENTS = \[([\s\S]*?)\]\.concat\(AUTOMATION_EVENTS\)/);
+    const auto = s.match(/const AUTOMATION_EVENTS = \[([\s\S]*?)\];/);
+    const names = (x) => (x.match(/'"'"'([^'"'"']+)'"'"'/g) || []).map((v) => v.slice(1, -1));
+    console.log(names(all[1]).concat(names(auto[1])).sort().join("\n"));
+  ' "$APP"
+}
+
+# settings.js: the EVENT_ORDER array.
+settings_events() {
+  node -e '
+    const fs = require("fs");
+    const s = fs.readFileSync(process.argv[1], "utf8");
+    const order = s.match(/const EVENT_ORDER = \[([\s\S]*?)\];/);
+    const names = (order[1].match(/'"'"'([^'"'"']+)'"'"'/g) || []).map((v) => v.slice(1, -1));
+    console.log(names.sort().join("\n"));
+  ' "$SETTINGS"
+}
+
+status=0
+if ! diff <(swift_events) <(app_events) >/tmp/notif-app.diff 2>&1; then
+  echo "MISMATCH: NotificationEvent.swift vs app.js (< Swift, > app.js):" >&2
+  cat /tmp/notif-app.diff >&2
+  status=1
+fi
+if ! diff <(swift_events) <(settings_events) >/tmp/notif-settings.diff 2>&1; then
+  echo "MISMATCH: NotificationEvent.swift vs settings.js (< Swift, > settings.js):" >&2
+  cat /tmp/notif-settings.diff >&2
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "notification-event catalogs agree ($(swift_events | wc -l | tr -d ' ') events)"
+fi
+exit "$status"


### PR DESCRIPTION
Closes #768

## What

The native→web move (ADR-0010, #594) dropped `NotificationManager`'s handling of Crow's own **automation** events. The web UI only notifies on the five events it can derive client-side by diffing polled state, so the moments Crow acts on your behalf went silent — you learned an auto-action happened, or failed, only by going looking.

This restores all five over the existing `/rpc` push path:

| Event | Fires when |
| --- | --- |
| Auto-Workspace Created | A `crow:auto`-labeled assigned issue triggered `/crow-workspace` |
| Auto-Merge Enabled | Crow enabled auto-merge on a `crow:merge`-labeled PR |
| Branch Rebased | An auto-rebase succeeded and force-pushed |
| Rebase Conflicts | An auto-rebase hit conflicts (needs attention) |
| Config Reloaded | `{devRoot}/.claude/config.json` changed and was picked up |

## How

- **CrowCore** — five new `NotificationEvent` cases with display name, description and default sound, plus an `isAutomationEvent` classifier. No migration needed: `NotificationSettings.config(for:)` already falls back to a case's defaults for events a stored config omits.
- **EventHub** — a `notify` frame alongside `changed`, carrying the event, a dedup/navigation key and a server-composed title/body. Idless like `changed`, so older clients drop it. Encoded via `JSONEncoder`, so a user-supplied issue title can't produce a malformed frame.
- **CrowDaemon** — broadcasts from `wireTrackerAutomations` at each watcher's hook. `onAutoMergeEnabled` and `onAutoRebasePushed` were declared on `IssueTracker` but never wired on the daemon side; they are now. `configReloaded` comes from a config.json mtime check folded into the existing 2s store-reload tick — one event per real change, covering Settings saves, CLI writes and hand edits alike.
- **Web** — `app.js` handles the frame and routes it through the same chime + browser/Tauri notification path, with the same global mute, per-event gating, on-page arm window and 2s per-`(key, event)` dedup. Settings → Notifications renders an enabled / sound / system / sound-picker row for each.

## Notes on behavior

- Automation events **bypass** the "don't ping about the session you're looking at" focus rule, as they did natively — an action Crow took on your behalf is worth surfacing either way.
- Conflict events are distinguishable from success events by wording *and* by a deliberately harsher default tone (Basso vs Bottle), per the ticket's third acceptance criterion.
- The notification for auto-rebase conflicts fires even when no `AutoRespondCoordinator` exists, so conflicts are announced with no terminal to paste into.

## Verification

- `make test` green across all packages (new coverage in `NotificationEventTests`, `NotificationSettingsTests`, `EventHubTests`).
- End-to-end against a scratch daemon on an isolated socket + dev root: editing `config.json` pushes a well-formed frame over `/rpc` —
  `{"jsonrpc":"2.0","method":"notify","params":{"body":"Settings were reloaded from config.json.","event":"configReloaded","key":"config","title":"Config reloaded"}}`
- Scripted cross-check that the event lists in `app.js`, `settings.js` and the Swift enum agree.
- Not verified in a live browser: the Settings tab rendering and the popup itself — the Chrome extension could not load the local page in this environment. Both are data-driven by the same arrays the existing five events use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyydffSFdem21R1ZKwGaup