### PR TITLE
Restore the Scorecard's ungraded Manager-usage section on the web (#767)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/ScorecardDTO.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/ScorecardDTO.swift
@@ -31,6 +31,20 @@ public struct ScorecardDTO: Codable, Sendable, Equatable {
     public let baseline: BaselineDTO
     /// Current week's per-session drill-down rows, newest first.
     public let sessions: [SessionRowDTO]
+    /// Ungraded Manager-session weekly usage, newest first (#745, #767).
+    /// Deliberately NOT derived from `ScorecardModel` — the Manager session
+    /// never reaches a terminal status, so it has no snapshot to grade. These
+    /// rows are a straight projection of the persisted `managerUsageWeekly`
+    /// mirror, which is what keeps them structurally out of the grade, the
+    /// shipped count, the combined score, and the baseline.
+    public let managerWeeks: [ManagerUsageWeekDTO]
+
+    // Live telemetry capture health (#745), for the header status line and the
+    // empty state's "why is this empty" copy. `telemetryCapturing == false`
+    // means telemetry is off or hasn't started.
+    public let telemetryCapturing: Bool
+    public let telemetrySessionCount: Int
+    public let telemetryLastReceivedAtMillis: Double?
 
     // Tuning constants the web needs for its "baseline building" / "insufficient
     // data" copy, so those thresholds live in Core, not duplicated in JS.
@@ -41,10 +55,18 @@ public struct ScorecardDTO: Codable, Sendable, Equatable {
     public init(
         _ model: ScorecardModel,
         telemetryEnabled: Bool,
-        snapshotCount: Int
+        snapshotCount: Int,
+        managerUsage: [ManagerWeeklyUsage] = [],
+        captureStatus: TelemetryCaptureStatus? = nil
     ) {
         self.telemetryEnabled = telemetryEnabled
         self.snapshotCount = snapshotCount
+        self.managerWeeks = managerUsage
+            .sorted { $0.weekStart > $1.weekStart }
+            .map(ManagerUsageWeekDTO.init)
+        self.telemetryCapturing = captureStatus != nil
+        self.telemetrySessionCount = captureStatus?.sessionCount ?? 0
+        self.telemetryLastReceivedAtMillis = captureStatus?.lastReceivedAt?.millis
         self.currentWeek = WeeklyDTO(model.currentWeek)
         self.priorWeeks = model.priorWeeks.map(WeeklyDTO.init)
         self.baseline = BaselineDTO(model.baseline)
@@ -233,6 +255,23 @@ public struct SessionRowDTO: Codable, Sendable, Equatable {
         self.totalCost = row.analytics.totalCost
         self.activeTimeSeconds = row.analytics.activeTimeSeconds
         self.wallClockDurationSeconds = row.wallClockDurationSeconds
+    }
+}
+
+/// One ungraded Manager-usage week (#745, #767) — the three figures the
+/// desktop `ScorecardView`'s Manager row rendered, plus its week key. No
+/// grade, by design: the always-on Manager session is visibility only.
+public struct ManagerUsageWeekDTO: Codable, Sendable, Equatable {
+    public let weekStartMillis: Double
+    public let promptCount: Int
+    public let totalTokens: Int
+    public let totalCost: Double
+
+    init(_ week: ManagerWeeklyUsage) {
+        self.weekStartMillis = week.weekStart.millis
+        self.promptCount = week.analytics.promptCount
+        self.totalTokens = week.analytics.totalTokens
+        self.totalCost = week.analytics.totalCost
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/ScorecardDTOTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ScorecardDTOTests.swift
@@ -152,4 +152,102 @@ private func snapshot(
     #expect(!off.telemetryEnabled)
     #expect(off.sessions.isEmpty)
     #expect(off.priorWeeks.isEmpty)
+    #expect(off.managerWeeks.isEmpty)
+    #expect(!off.telemetryCapturing)
+}
+
+// MARK: - Manager usage (ungraded bucket; #745, #767)
+
+private func managerWeek(
+    _ weekStart: Date, prompts: Int = 12, cost: Double = 3, inputTokens: Int = 900
+) -> ManagerWeeklyUsage {
+    ManagerWeeklyUsage(
+        weekStart: weekStart,
+        analytics: SessionAnalytics(
+            totalCost: cost,
+            inputTokens: inputTokens,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            activeTimeSeconds: 1800,
+            linesAdded: 0,
+            linesRemoved: 0,
+            commitCount: 0,
+            promptCount: prompts,
+            apiRequestCount: 0,
+            apiErrorCount: 0
+        ))
+}
+
+@Test func dtoProjectsManagerWeeksNewestFirst() {
+    let model = ScorecardModel.build(snapshots: [], now: now, calendar: utc)
+    // Deliberately supplied oldest-first — the DTO owns the ordering, because
+    // it comes off an unordered dictionary on `AppState`.
+    let usage = [
+        managerWeek(date(2026, 6, 29), prompts: 4, cost: 1),
+        managerWeek(date(2026, 7, 13), prompts: 12, cost: 3),
+        managerWeek(date(2026, 7, 6), prompts: 8, cost: 2),
+    ]
+    let dto = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: 0, managerUsage: usage)
+
+    #expect(dto.managerWeeks.map(\.promptCount) == [12, 8, 4])
+    #expect(dto.managerWeeks.map(\.totalCost) == [3, 2, 1])
+    #expect(dto.managerWeeks[0].weekStartMillis == date(2026, 7, 13).timeIntervalSince1970 * 1000)
+    // totalTokens is SessionAnalytics' derived sum, not a stored field.
+    #expect(dto.managerWeeks[0].totalTokens == usage[1].analytics.totalTokens)
+}
+
+@Test func managerUsageNeverTouchesTheGradedMath() {
+    // AC for #767: the Manager bucket is visibility only. Same snapshots, with
+    // and without Manager usage — every graded surface must be identical.
+    let snapshots = [
+        snapshot(endedAt: date(2026, 7, 13), compactions: 3, prompts: 10, cost: 4),
+        snapshot(endedAt: date(2026, 7, 14), compactions: 0, prompts: 8, cost: 6),
+    ]
+    let model = ScorecardModel.build(snapshots: snapshots, now: now, calendar: utc)
+    let without = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: snapshots.count)
+    let with = ScorecardDTO(
+        model, telemetryEnabled: true, snapshotCount: snapshots.count,
+        // An implausibly expensive Manager week: if it leaked into the math at
+        // all, cost-per-shipped and the combined score would move.
+        managerUsage: [managerWeek(date(2026, 7, 13), prompts: 5000, cost: 999)])
+
+    #expect(with.currentWeek == without.currentWeek)
+    #expect(with.priorWeeks == without.priorWeeks)
+    #expect(with.baseline == without.baseline)
+    #expect(with.sessions == without.sessions)
+    #expect(with.managerWeeks.count == 1)
+}
+
+@Test func dtoCarriesManagerWeeksWithZeroSnapshots() {
+    // The web's empty-state gate is `!snapshotCount && !managerWeeks.length`,
+    // so captured Manager usage must survive a scorecard with nothing graded.
+    let model = ScorecardModel.build(snapshots: [], now: now, calendar: utc)
+    let dto = ScorecardDTO(
+        model, telemetryEnabled: true, snapshotCount: 0,
+        managerUsage: [managerWeek(date(2026, 7, 13))])
+
+    #expect(dto.snapshotCount == 0)
+    #expect(dto.managerWeeks.count == 1)
+}
+
+@Test func dtoCarriesCaptureStatus() throws {
+    let model = ScorecardModel.build(snapshots: [], now: now, calendar: utc)
+    let receivedAt = date(2026, 7, 15, 9)
+    let dto = ScorecardDTO(
+        model, telemetryEnabled: true, snapshotCount: 0,
+        managerUsage: [managerWeek(date(2026, 7, 13))],
+        captureStatus: TelemetryCaptureStatus(sessionCount: 3, lastReceivedAt: receivedAt))
+
+    #expect(dto.telemetryCapturing)
+    #expect(dto.telemetrySessionCount == 3)
+    #expect(dto.telemetryLastReceivedAtMillis == receivedAt.timeIntervalSince1970 * 1000)
+
+    // Manager rows + capture status survive the wire (the web reads only JSON).
+    let decoded = try JSONDecoder().decode(ScorecardDTO.self, from: JSONEncoder().encode(dto))
+    #expect(decoded == dto)
+
+    // A nil status is "not capturing", never a fake zero-count capture.
+    let dark = ScorecardDTO(model, telemetryEnabled: true, snapshotCount: 0)
+    #expect(!dark.telemetryCapturing)
+    #expect(dark.telemetryLastReceivedAtMillis == nil)
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -250,18 +250,39 @@ public enum CrowDaemon {
             return (service, coordinator)
         }
 
+        // One rebuild entry point (#767), shared by the launch startup below, the
+        // hourly poll, and the `rebuild-scorecard` RPC: backfill snapshots for
+        // sessions recorded before snapshotting existed, recompute the ungraded
+        // Manager weekly rollups, and refresh the capture-status line. In-flight
+        // guard via `isRebuildingScorecard` so the three callers can't interleave
+        // and clear the flag out from under each other. Nil when telemetry is off.
+        let rebuildScorecard: (@MainActor @Sendable () async -> Void)?
+        if let telemetry, let sessionService {
+            rebuildScorecard = {
+                guard !appState.isRebuildingScorecard else { return }
+                appState.isRebuildingScorecard = true
+                defer { appState.isRebuildingScorecard = false }
+                await sessionService.backfillAnalyticsSnapshots()
+                await sessionService.refreshManagerUsage()
+                appState.telemetryCaptureStatus = await telemetry.captureStatus()
+            }
+        } else {
+            rebuildScorecard = nil
+        }
+
         // The rest of the telemetry startup, deferred until SessionService exists to
         // drive it. Order mirrors the app's: backfill BEFORE pruning, so sessions
-        // whose rows are about to age out still produce a snapshot (#745).
-        if let telemetry {
+        // whose rows are about to age out still produce a snapshot (#745). The
+        // hourly poll keeps the current week's Manager rollup and the capture line
+        // moving — the app refreshed only at launch, fine for a process restarted
+        // daily but not for a daemon that runs for weeks (#767).
+        if let telemetry, let rebuildScorecard {
             let retentionDays = telemetryConfig.retentionDays
             Task {
-                await sessionService?.backfillAnalyticsSnapshots()
-                await sessionService?.refreshManagerUsage()
-                let status = await telemetry.captureStatus()
-                await MainActor.run { appState.telemetryCaptureStatus = status }
+                await rebuildScorecard()
                 await telemetry.pruneOldData(retentionDays: retentionDays)
             }
+            startScorecardPoll(rebuild: rebuildScorecard)
         }
 
         // Write-actions that mutate session state run locally on the daemon's
@@ -344,7 +365,7 @@ public enum CrowDaemon {
             appState: appState, store: store, git: git, devRoot: options.devRoot,
             cockpit: cockpit, tracker: tracker, allowList: allowList,
             sessionService: sessionService, autoRespond: autoRespond, jobScheduler: jobScheduler,
-            fallback: engineFallback)
+            rebuildScorecard: rebuildScorecard, fallback: engineFallback)
 
         // Unix socket — lets the existing `crow` CLI talk to the daemon. By
         // default this IS the app's well-known `crow.sock` (the daemon owns it in
@@ -700,6 +721,21 @@ public enum CrowDaemon {
         }
     }
 
+    /// Keep the ungraded Manager rollups and the capture-status line moving
+    /// while the daemon runs (#767). The desktop app refreshed these only at
+    /// launch and on the manual Rebuild — fine for a process restarted daily,
+    /// but `crowd` runs for weeks, so without this the current week's Manager
+    /// usage would freeze at whatever it was when the daemon started. Hourly:
+    /// these are week-grain numbers and the backfill touches the DB.
+    private static func startScorecardPoll(rebuild: @escaping @MainActor @Sendable () async -> Void) {
+        Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 3600 * 1_000_000_000)
+                await rebuild()
+            }
+        }
+    }
+
     @MainActor
     private static func seedAppState(from store: JSONStore) -> AppState {
         let appState = AppState()
@@ -773,6 +809,13 @@ public enum CrowDaemon {
         // and never runs here, so without this the snapshot fallback is dead for
         // any session that completed before this daemon process started (#736 review).
         appState.analyticsSnapshots = data.analyticsSnapshots ?? [:]
+        // Same reasoning for the ungraded Manager rollups (#767): `get-scorecard`
+        // reads `appState.managerUsageWeekly`, `hydrateState` never runs here, and
+        // the detached launch rebuild may not have finished (or never runs when
+        // telemetry is off). Without this mirror, persisted Manager weeks in
+        // store.json stay invisible on the cold / telemetry-off path — the very
+        // #745 empty-state invisibility this restores.
+        appState.managerUsageWeekly = data.managerUsageWeekly ?? [:]
     }
 
     /// Mirror the config-derived `AppState` fields the desktop app syncs in

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -254,19 +254,23 @@ public enum CrowDaemon {
         // One rebuild entry point (#767), shared by the launch startup below, the
         // hourly poll, and the `rebuild-scorecard` RPC: backfill snapshots for
         // sessions recorded before snapshotting existed, recompute the ungraded
-        // Manager weekly rollups, and refresh the capture-status line. In-flight
-        // guard via `isRebuildingScorecard` so the three callers can't interleave
-        // and clear the flag out from under each other. Nil when telemetry is off.
+        // Manager weekly rollups, and refresh the capture-status line. Wrapped in
+        // a single-flight `ScorecardRebuilder` so overlapping callers await one
+        // rebuild instead of racing (the RPC never reports success for skipped
+        // work, and `isRebuildingScorecard` can't clear mid-run — #781). Nil when
+        // telemetry is off.
         let rebuildScorecard: (@MainActor @Sendable () async -> Void)?
         if let telemetry, let sessionService {
-            rebuildScorecard = {
-                guard !appState.isRebuildingScorecard else { return }
-                appState.isRebuildingScorecard = true
-                defer { appState.isRebuildingScorecard = false }
-                await sessionService.backfillAnalyticsSnapshots()
-                await sessionService.refreshManagerUsage()
-                appState.telemetryCaptureStatus = await telemetry.captureStatus()
+            let rebuilder = await MainActor.run {
+                ScorecardRebuilder {
+                    appState.isRebuildingScorecard = true
+                    defer { appState.isRebuildingScorecard = false }
+                    await sessionService.backfillAnalyticsSnapshots()
+                    await sessionService.refreshManagerUsage()
+                    appState.telemetryCaptureStatus = await telemetry.captureStatus()
+                }
             }
+            rebuildScorecard = { await rebuilder.rebuild() }
         } else {
             rebuildScorecard = nil
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -123,6 +123,10 @@ func makeCommandRouter(
     sessionService: SessionService? = nil,
     autoRespond: AutoRespondCoordinator? = nil,
     jobScheduler: JobScheduler? = nil,
+    // Backs `rebuild-scorecard` (#767). Defined by the daemon where both the
+    // SessionService and the telemetry receiver are in scope; nil when telemetry
+    // is off (there'd be no DB to rebuild from).
+    rebuildScorecard: (@MainActor @Sendable () async -> Void)? = nil,
     fallback: CommandRouter? = nil
 ) -> CommandRouter {
     // Serializes review kickoffs (see start-review) — one per router instance.
@@ -844,7 +848,11 @@ func makeCommandRouter(
                 return ScorecardDTO(
                     model,
                     telemetryEnabled: telemetryEnabled,
-                    snapshotCount: appState.analyticsSnapshots.count
+                    snapshotCount: appState.analyticsSnapshots.count,
+                    // Ungraded Manager rollups ride alongside the model rather
+                    // than through it (#767) — see `ScorecardDTO.managerWeeks`.
+                    managerUsage: Array(appState.managerUsageWeekly.values),
+                    captureStatus: appState.telemetryCaptureStatus
                 )
             }
             do {
@@ -857,6 +865,21 @@ func makeCommandRouter(
             } catch {
                 throw DaemonRPCError.applicationError("Failed to encode scorecard: \(error)")
             }
+        },
+
+        // Manual scorecard rebuild (#745, #767) — backs the web Rebuild button,
+        // the port of the desktop's `AppDelegate.rebuildScorecard()`. Backfills
+        // snapshots for sessions recorded before snapshotting existed (without
+        // re-running them), recomputes the ungraded Manager weekly rollups, and
+        // refreshes the capture-status line. Idempotent, local-only, and a
+        // no-op error when telemetry is off (there'd be no DB to read).
+        "rebuild-scorecard": { _ in
+            guard let rebuildScorecard else {
+                throw DaemonRPCError.applicationError(
+                    "Rebuilding the scorecard requires telemetry — enable it in Settings and restart crowd")
+            }
+            await rebuildScorecard()
+            return ["rebuilt": .bool(true)]
         },
 
         // App config (the web Settings modal). Forward to the app when it's

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -1215,6 +1215,26 @@ html, body {
 .score-prior-combined { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 30px; text-align: right; }
 .score-prior-cost { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 56px; text-align: right; }
 
+/* Manager usage (#767) — the ungraded bucket. Same row rhythm as .score-prior
+   so it belongs to the card system, but muted throughout and badge-free: it
+   must never read as a graded surface. */
+.score-manager { display: flex; flex-direction: column; gap: 6px; }
+.score-manager-row { display: flex; align-items: center; gap: 10px; font-size: 12px; }
+.score-manager-week { color: var(--text-secondary); }
+.score-manager-prompts { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--text-secondary); }
+.score-manager-stat { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 72px; text-align: right; }
+.score-ungraded {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.score-capture { color: var(--text-muted); font-size: 11px; margin: -8px 0 12px; }
+
 .score-sessions { display: flex; flex-direction: column; gap: 8px; }
 .score-session { display: flex; flex-direction: column; gap: 3px; padding: 2px 0; }
 .score-session-line { display: flex; align-items: center; gap: 8px; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2065,6 +2065,22 @@ function renderScorecard(root) {
   const refresh = el('button', 'action-btn', 'Refresh');
   refresh.onclick = () => refreshBoard('scorecard');
   head.appendChild(refresh);
+  // Rebuild backfills snapshots from telemetry.db and recomputes the ungraded
+  // Manager rollups (#745) — only offered when telemetry is actually capturing,
+  // since with it off there is no database to rebuild from.
+  if (data && data.telemetryCapturing) {
+    const rebuild = el('button', 'action-btn', 'Rebuild');
+    rebuild.title = 'Rebuild scorecard data from the local telemetry database';
+    rebuild.onclick = async () => {
+      rebuild.disabled = true;
+      rebuild.textContent = 'Rebuilding…';
+      try { await rpc('rebuild-scorecard'); } catch (_) { /* surfaced by the unchanged board */ }
+      rebuild.disabled = false;
+      rebuild.textContent = 'Rebuild';
+      refreshBoard('scorecard');
+    };
+    head.appendChild(rebuild);
+  }
   root.appendChild(head);
 
   const banner = el('div', 'score-banner',
@@ -2076,7 +2092,13 @@ function renderScorecard(root) {
     root.appendChild(el('div', 'score-empty', 'Loading…'));
     return;
   }
-  if (!data.snapshotCount) {
+  root.appendChild(el('div', 'score-capture', captureStatusText(data)));
+  const manager = managerWeeks(data);
+  // Manager-only data still shows the content pane: the grade card renders
+  // "insufficient data" gracefully with zero snapshots, and hiding captured
+  // Manager usage behind the empty state would repeat the invisibility this
+  // gate is meant to fix (#745) — same condition the desktop view used.
+  if (!data.snapshotCount && !manager.length) {
     root.appendChild(scorecardEmpty(data));
     return;
   }
@@ -2090,17 +2112,32 @@ function renderScorecard(root) {
   wrap.appendChild(combinedCardEl(data.currentWeek));
   wrap.appendChild(baselineCardEl(data));
   wrap.appendChild(displayedStatsEl(data.currentWeek));
+  if (manager.length) wrap.appendChild(managerUsageEl(manager));
   if (data.priorWeeks.length) wrap.appendChild(priorWeeksEl(data.priorWeeks));
   if (data.sessions.length) wrap.appendChild(sessionsEl(data.sessions));
   root.appendChild(wrap);
 }
 
+// A daemon that isn't capturing is the usual reason a section is empty, so say
+// so instead of leaving the user to guess (#745).
+function captureStatusText(data) {
+  if (!data.telemetryCapturing) {
+    return 'Telemetry not capturing — enable it in Settings, then restart crowd';
+  }
+  return 'Telemetry capturing — ' + data.telemetrySessionCount +
+    ' session' + (data.telemetrySessionCount === 1 ? '' : 's') + ' recorded';
+}
+
+// Tolerates a daemon predating #767, whose `get-scorecard` has no such field.
+function managerWeeks(data) { return data.managerWeeks || []; }
+
 function scorecardEmpty(data) {
   const box = el('div', 'score-empty');
   box.appendChild(el('div', 'score-empty-title', 'No Session Data Yet'));
-  const msg = el('div', 'score-empty-msg', data.telemetryEnabled
+  const msg = el('div', 'score-empty-msg', (data.telemetryEnabled
     ? 'The scorecard is computed from analytics snapshots written when sessions complete or archive. Telemetry is on — finish a session and it will appear here.'
-    : 'The scorecard is computed from analytics snapshots written when sessions complete or archive. Snapshots require Claude Code telemetry, which is off by default.');
+    : 'The scorecard is computed from analytics snapshots written when sessions complete or archive. Snapshots require Claude Code telemetry, which is off by default.') +
+    ' The Manager session is never graded — its usage appears in its own ungraded section once captured.');
   box.appendChild(msg);
   if (!data.telemetryEnabled) {
     const btn = el('button', 'action-btn action-primary', 'Open Settings');
@@ -2246,6 +2283,34 @@ function statChipEl(label, value) {
   chip.appendChild(el('span', 'score-chip-label', label));
   chip.appendChild(el('span', 'score-chip-value', value));
   return chip;
+}
+
+// Manager usage — the ungraded bucket (#745, #767). The always-on Manager
+// session never reaches a terminal status, so it produces no snapshot and no
+// grade; these rows come straight off the persisted weekly rollups and are
+// deliberately absent from the grade, the shipped count, the combined score,
+// and the baseline. Visually a sibling of "Previous Weeks", minus every graded
+// affordance — no badge, no score, muted throughout.
+function managerUsageEl(weeks) {
+  const label = el('div', 'score-card-label');
+  label.appendChild(el('span', null, 'Manager Usage'));
+  label.appendChild(el('span', 'score-ungraded', 'ungraded'));
+  const body = [label];
+  const list = el('div', 'score-manager');
+  for (const w of weeks) {
+    const row = el('div', 'score-manager-row');
+    row.appendChild(el('span', 'score-manager-week', scoreWeekLabel(w.weekStartMillis)));
+    row.appendChild(el('span', 'score-manager-prompts',
+      w.promptCount + ' prompt' + (w.promptCount === 1 ? '' : 's')));
+    row.appendChild(el('span', 'score-manager-stat', fmtCount(w.totalTokens) + ' tokens'));
+    row.appendChild(el('span', 'score-manager-stat', fmtCost(w.totalCost)));
+    list.appendChild(row);
+  }
+  body.push(list);
+  body.push(el('div', 'score-muted',
+    'The always-on Manager session never completes, so its usage is tracked here directly from ' +
+    'telemetry — visibility only, never graded.'));
+  return scoreCard(body);
 }
 
 function priorWeeksEl(weeks) {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2074,7 +2074,13 @@ function renderScorecard(root) {
     rebuild.onclick = async () => {
       rebuild.disabled = true;
       rebuild.textContent = 'Rebuilding…';
-      try { await rpc('rebuild-scorecard'); } catch (_) { /* surfaced by the unchanged board */ }
+      try {
+        await rpc('rebuild-scorecard');
+      } catch (e) {
+        // Match the other board actions' failure affordance (alertModal) rather
+        // than swallow — a failed rebuild otherwise re-enables silently.
+        alertModal('Rebuild scorecard failed: ' + (e.message || e));
+      }
       rebuild.disabled = false;
       rebuild.textContent = 'Rebuild';
       refreshBoard('scorecard');

--- a/Packages/CrowDaemon/Sources/CrowDaemon/ScorecardRebuilder.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/ScorecardRebuilder.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Single-flight coalescer for the scorecard rebuild (#767, #781).
+///
+/// Launch, the hourly poll, and the `rebuild-scorecard` RPC all funnel through
+/// `rebuild()`. A caller that arrives while a rebuild is running awaits *that*
+/// rebuild instead of starting a second one — so the RPC never reports success
+/// for work it skipped, and two runs can't race the same telemetry.db or clear
+/// `isRebuildingScorecard` out from under each other. Every caller returns only
+/// once a full rebuild has completed.
+///
+/// Main-isolated, so the `inFlight` check-and-set is atomic without a lock.
+@MainActor
+final class ScorecardRebuilder {
+    private let work: @MainActor @Sendable () async -> Void
+    private var inFlight: Task<Void, Never>?
+
+    init(work: @escaping @MainActor @Sendable () async -> Void) {
+        self.work = work
+    }
+
+    /// Run `work`, or await the in-flight run if one is already going. Returns
+    /// only after a full rebuild has finished.
+    func rebuild() async {
+        if let inFlight {
+            return await inFlight.value
+        }
+        // `defer` clears `inFlight` on the main actor as the task's last act, so
+        // there is no window where it points at an already-finished task (which
+        // would make the next caller coalesce into a completed no-op).
+        let task = Task { @MainActor [work] in
+            defer { self.inFlight = nil }
+            await work()
+        }
+        inFlight = task
+        await task.value
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
@@ -360,6 +360,35 @@ import CrowPersistence
         #expect(num(a?["totalCost"]) == 9.75)
     }
 
+    @Test @MainActor func reseedSurfacesPersistedManagerWeeksOnScorecard() async {
+        // #767: the ungraded Manager rollups persist in store.json, but a fresh
+        // crowd appState is empty until reseed mirrors them — `hydrateState`
+        // (the app's fuller restore) never runs here, and the detached launch
+        // rebuild may not have run (or never runs when telemetry is off). Without
+        // the reseed mirror, `get-scorecard` reads an empty `managerUsageWeekly`
+        // and the persisted weeks stay invisible — the #745 empty-state bug.
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        let weekStart = Date(timeIntervalSince1970: 1_752_364_800) // Mon 2026-07-13 UTC
+        let rollup = ManagerWeeklyUsage(
+            weekStart: weekStart,
+            analytics: SessionAnalytics(totalCost: 4.25, inputTokens: 900, promptCount: 7))
+        let store = JSONStore.temporary()
+        store.mutate { $0.managerUsageWeekly = ["2026-07-13": rollup] }
+
+        let appState = AppState()
+        CrowDaemon.reseed(appState, from: store)
+        #expect(appState.managerUsageWeekly["2026-07-13"] == rollup)
+
+        // …and it reaches the wire the web reads.
+        let resp = await router(appState: appState, store: store)
+            .handle(request: JSONRPCRequest(id: 1, method: "get-scorecard"))
+        let weeks = resp.result?["managerWeeks"]?.arrayValue
+        #expect(weeks?.count == 1)
+        let week = weeks?.first?.objectValue
+        #expect(week?["promptCount"]?.intValue == 7)
+        #expect(num(week?["totalCost"]) == 4.25)
+    }
+
     @Test @MainActor func omitsAnalyticsWhenNoLiveOrSnapshot() async {
         AgentRegistry.shared.register(ClaudeCodeAgent())
         let session = Session(name: "s", kind: .work, agentKind: .claudeCode)

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/RebuildScorecardTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/RebuildScorecardTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowIPC
+import CrowPersistence
+import CrowGit
+@testable import CrowDaemon
+
+/// #767/#781: the `rebuild-scorecard` RPC and its single-flight coalescer. The
+/// DTO/reseed paths are covered elsewhere (`ScorecardDTOTests`,
+/// `reseedSurfacesPersistedManagerWeeksOnScorecard`); these pin the handler's
+/// telemetry-off error and that success is only ever reported for real work.
+@Suite struct RebuildScorecardHandlerTests {
+    @MainActor
+    private func router(rebuildScorecard: (@MainActor @Sendable () async -> Void)?) -> CommandRouter {
+        makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: NSTemporaryDirectory(), cockpit: nil,
+            rebuildScorecard: rebuildScorecard)
+    }
+
+    @Test @MainActor func errorsWhenTelemetryUnavailable() async {
+        // nil closure == telemetry off / receiver never came up: there is no DB
+        // to rebuild from, so the RPC must error rather than invent success.
+        let resp = await router(rebuildScorecard: nil)
+            .handle(request: JSONRPCRequest(id: 1, method: "rebuild-scorecard"))
+        #expect(resp.error?.code == RPCErrorCode.applicationError)
+        #expect(resp.result == nil)
+    }
+
+    @Test @MainActor func invokesRebuildAndReportsSuccess() async {
+        let ran = Counter()
+        let resp = await router(rebuildScorecard: { ran.bump() })
+            .handle(request: JSONRPCRequest(id: 1, method: "rebuild-scorecard"))
+        #expect(resp.error == nil)
+        #expect(resp.result?["rebuilt"]?.boolValue == true)
+        #expect(ran.value == 1) // the handler actually drove a rebuild
+    }
+}
+
+@Suite struct ScorecardRebuilderTests {
+    /// A caller arriving while a rebuild is in flight coalesces into it — the
+    /// whole point: the RPC must not report success for a rebuild it skipped, and
+    /// two runs must not race the same telemetry.db.
+    @Test @MainActor func coalescesOverlappingCallers() async {
+        let runs = Counter()
+        let gate = Gate()
+        let rebuilder = ScorecardRebuilder {
+            runs.bump()
+            await gate.wait() // hold this rebuild open while a second caller arrives
+        }
+        // Start the first rebuild and deterministically wait until its work has
+        // actually begun (and is now blocked on the gate) before the second call —
+        // so the second is guaranteed to observe an in-flight rebuild, not a race.
+        let first = Task { await rebuilder.rebuild() }
+        while runs.value == 0 { await Task.yield() }
+        let second = Task { await rebuilder.rebuild() }
+        await Task.yield() // let `second` reach its `await inFlight.value`
+
+        gate.open()
+        await first.value
+        await second.value
+        #expect(runs.value == 1) // second coalesced, did not start its own run
+
+        // Once settled, `inFlight` is cleared, so a fresh call runs again.
+        await rebuilder.rebuild()
+        #expect(runs.value == 2)
+    }
+}
+
+/// Main-isolated mutable counters/gates for the async assertions above — plain
+/// `var` capture isn't allowed in the `@Sendable` rebuild closures.
+@MainActor private final class Counter {
+    private(set) var value = 0
+    func bump() { value += 1 }
+}
+
+@MainActor private final class Gate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var opened = false
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { continuations.append($0) }
+    }
+    func open() {
+        opened = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+}


### PR DESCRIPTION
Closes #767

## What

The native `ScorecardView` rendered an ungraded **Manager Usage** card (#745, ADR 0008 addendum): the always-on Manager session never reaches a terminal status, so it produces no `SessionAnalyticsSnapshot` and can't be graded — its usage is rolled up per ISO week straight from `telemetry.db` and shown for visibility only. The web scorecard never got that section, because `ScorecardDTO` is a projection of `ScorecardModel`, which is pure over completion snapshots. There was nothing on the wire to render.

Behind that sat a larger gap, which this PR also closes: **`crowd` didn't link `CrowTelemetry` at all.** Its `SessionService` was built with no `telemetryPort` and none of the analytics providers — all of which lived in the `AppDelegate` retired by ADR 0010. Headless that meant no OTLP receiver, no `OTEL_*` env vars on spawned Claude commands, no snapshots, no backfill, no Manager rollups, no capture status: the whole scorecard was frozen at whatever an old desktop build happened to leave in `store.json`.

## How

**Daemon telemetry (`DaemonTelemetry.swift`, `CrowDaemon.swift`)** — owns the receiver and the one `rebuild()` entry point (backfill → Manager rollups → capture status) that both the launch path and the new `rebuild-scorecard` RPC call. Launch order is start → rebuild → prune, so rows about to age out still become snapshots. `delete-session` now drops the session's telemetry rows first, mirroring the app's `onDeleteSession`.

An **hourly poll** keeps the current week moving. The app refreshed only at launch and on the manual Rebuild — fine for a process restarted daily, not for a daemon that runs for weeks.

**Wire (`ScorecardDTO`)** — gains `managerWeeks` (newest-first) and the capture-status trio. The Manager rows are projected off the persisted `managerUsageWeekly` mirror, *never* through `ScorecardModel`. That's what keeps them structurally out of the grade, the shipped count, the combined score, and the baseline, rather than merely tested out.

**Web (`app.js`, `app.css`)** — the card renders between "This Week" and "Previous Weeks", muted and badge-free with an `ungraded` pill and the native footnote. The empty-state gate now matches the desktop's `snapshots.isEmpty && managerUsage.isEmpty`, so captured Manager usage isn't hidden behind the empty state — the exact invisibility #745 set out to fix. Also adds the capture-status line and the Rebuild button the native header had.

## Row fields

Exact native parity: prompts / tokens / cost per week.

## Testing

- `ScorecardDTOTests` — ordering, projection, the zero-snapshot case, capture-status round-trip, and **every graded surface identical with and without Manager usage supplied** (the AC).
- `DaemonTelemetryTests` — the exporter-port mapping, i.e. the silent `nil` that caused this gap.
- 450 CrowCore / 121 CrowDaemon / 311 CrowEngine tests pass. One pre-existing `CrowTerminal` tmux-readiness failure is unrelated (reproduces on a clean tree).
- The render path was exercised by driving the real `renderScorecard` against a synthetic DTO with a DOM stub — 19 assertions covering the card, formatting, the gate in all three states, and tolerance of a pre-#767 daemon that sends no `managerWeeks` field. Not yet run against a live daemon in a browser: that needs `telemetry.enabled` and a `crowd` restart, which would have disrupted the running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4RMMKTjt7nFjqLpw5Dg1Q