### PR TITLE
Run the OTLP telemetry receiver in the daemon (restores the per-session analytics strip)

### DIFF
--- a/Packages/CrowDaemon/Package.swift
+++ b/Packages/CrowDaemon/Package.swift
@@ -23,6 +23,11 @@ let package = Package(
         .package(path: "../CrowCodex"),
         .package(path: "../CrowCursor"),
         .package(path: "../CrowOpenCode"),
+        // OTLP receiver + telemetry.db, so the daemon produces the per-session
+        // analytics the web strip and the scorecard read (#772). Darwin-only
+        // (Network.framework) — CrowDaemon already is, via CrowTerminal, and
+        // ci.yml's Linux allow-list excludes both.
+        .package(path: "../CrowTelemetry"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
         // Already resolved transitively (via NIO/Hummingbird); declared directly
@@ -44,6 +49,7 @@ let package = Package(
                 .product(name: "CrowCodex", package: "CrowCodex"),
                 .product(name: "CrowCursor", package: "CrowCursor"),
                 .product(name: "CrowOpenCode", package: "CrowOpenCode"),
+                .product(name: "CrowTelemetry", package: "CrowTelemetry"),
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
                 .product(name: "Crypto", package: "swift-crypto"),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -15,10 +15,21 @@ import CrowGit
 import CrowTerminal
 import CrowIPC
 import CrowPersistence
+import CrowTelemetry
 import Foundation
 import Hummingbird
 import HummingbirdWebSocket
 import NIOCore
+
+/// One-slot box for the `TelemetryService`, so the receiver's `onDataReceived`
+/// callback and `SessionService`'s analytics providers — all built before (or
+/// alongside) the service itself — can reach it once it exists. MainActor-isolated
+/// because that is where every reader already runs, which also makes it `Sendable`
+/// without a lock (#772).
+@MainActor
+final class TelemetryHolder {
+    var service: TelemetryService?
+}
 
 /// The headless `crowd` daemon: serves Crow's JSON-RPC domain logic and the
 /// browser terminal over HTTP + WebSocket, reusing `CrowCore`/`CrowIPC`/
@@ -119,6 +130,52 @@ public enum CrowDaemon {
             log("WARNING: tmux not found; /terminal + terminal RPC disabled (set CROW_TMUX to override)")
         }
 
+        // Telemetry (#772). The OTLP receiver that used to run inside the retired
+        // macOS app never moved to the daemon, so `hookState.analytics` was always
+        // empty and the web's per-session analytics strip — which treats absence as
+        // its empty state — never rendered. Built BEFORE SessionService because the
+        // service captures `telemetryPort` (the `OTEL_*` env prefix Claude Code
+        // needs to emit anything at all) and the analytics providers at init.
+        // Enable/port are read once here: changing them needs a daemon restart,
+        // exactly as it did natively.
+        let telemetryConfig = ConfigStore.loadConfig(devRoot: options.devRoot)?.telemetry
+            ?? TelemetryConfig()
+        // The `onDataReceived` callback has to reach the service it is being passed
+        // to, so it resolves through a holder the init fills in afterwards (the app
+        // used `self.telemetryService` for the same reason).
+        let telemetryHolder = TelemetryHolder()
+        let telemetry: TelemetryService?
+        if telemetryConfig.enabled {
+            do {
+                telemetry = try TelemetryService(
+                    port: telemetryConfig.port,
+                    onDataReceived: { sessionID in
+                        // Already @MainActor — the analytics write is serialized
+                        // with every other AppState mutation.
+                        Task { @MainActor in
+                            guard let service = telemetryHolder.service else { return }
+                            let analytics = await service.analytics(for: sessionID)
+                            appState.hookState(for: sessionID).analytics = analytics
+                            // Keep the capture-status line live without re-querying
+                            // the DB; the exact session count refreshes at startup.
+                            appState.telemetryCaptureStatus = TelemetryCaptureStatus(
+                                sessionCount: max(appState.telemetryCaptureStatus?.sessionCount ?? 0, 1),
+                                lastReceivedAt: Date())
+                        }
+                    })
+            } catch {
+                log("WARNING: failed to create the telemetry receiver on port \(telemetryConfig.port) "
+                    + "(\(error)) — per-session analytics will be unavailable")
+                telemetry = nil
+            }
+        } else {
+            telemetry = nil
+        }
+        await MainActor.run { telemetryHolder.service = telemetry }
+        // nil when telemetry is off OR the receiver failed to bind: without a live
+        // receiver the `OTEL_*` exporter vars would point at a closed port.
+        let telemetryPort: UInt16? = telemetry.map(\.port)
+
         // Host the real SessionService so the daemon can spawn Manager (and
         // later review/job) workspaces headlessly with the app down (ADR 0007;
         // CROW-581, M-E2). It drives tmux through the process-global
@@ -140,9 +197,28 @@ public enum CrowDaemon {
                 tmuxBinary: cockpit.controller.tmuxBinary,
                 socketPath: cockpit.controller.socketPath,
                 crowBinDir: (options.devRoot as NSString).appendingPathComponent(".claude/bin"))
+            // The four telemetry closures resolve through the holder rather than
+            // capturing `telemetry` directly, so they stay correct (and nil-safe)
+            // whether or not the receiver was created (#772).
             let service = SessionService(
                 store: store, appState: appState,
-                providerManager: providerManager, hostBridge: NoopHostBridge())
+                telemetryPort: telemetryPort,
+                providerManager: providerManager,
+                analyticsProvider: { id in
+                    await MainActor.run { telemetryHolder.service }?.analytics(for: id)
+                },
+                telemetrySessionIDsProvider: {
+                    await MainActor.run { telemetryHolder.service }?.sessionIDs() ?? []
+                },
+                managerUsageProvider: { start, end in
+                    await MainActor.run { telemetryHolder.service }?
+                        .analytics(for: AppState.managerSessionID, receivedBetween: start, end: end)
+                        ?? SessionAnalytics()
+                },
+                telemetryDeleteProvider: { id in
+                    await MainActor.run { telemetryHolder.service }?.deleteSessionData(for: id)
+                },
+                hostBridge: NoopHostBridge())
             service.wireTerminalReadiness()
             let coordinator = AutoRespondCoordinator(
                 appState: appState, providerManager: providerManager,
@@ -150,6 +226,27 @@ public enum CrowDaemon {
                     ConfigStore.loadConfig(devRoot: options.devRoot)?.autoRespond ?? AutoRespondSettings()
                 })
             return (service, coordinator)
+        }
+
+        // Start the OTLP receiver now that SessionService exists to drive the
+        // scorecard rebuild. Order mirrors the app's: start → backfill → prune, so
+        // sessions whose rows are about to age out still produce a snapshot (#745).
+        if let telemetry {
+            let retentionDays = telemetryConfig.retentionDays
+            Task {
+                do {
+                    try await telemetry.start()
+                } catch {
+                    log("WARNING: telemetry receiver failed to start on port \(telemetry.port) "
+                        + "(\(error)) — per-session analytics will be unavailable")
+                    return
+                }
+                await sessionService?.backfillAnalyticsSnapshots()
+                await sessionService?.refreshManagerUsage()
+                let status = await telemetry.captureStatus()
+                await MainActor.run { appState.telemetryCaptureStatus = status }
+                await telemetry.pruneOldData(retentionDays: retentionDays)
+            }
         }
 
         // Write-actions that mutate session state run locally on the daemon's
@@ -214,7 +311,7 @@ public enum CrowDaemon {
             guard let sessionService else { return nil }
             let ctx = EngineContext(
                 appState: appState, store: store, sessionService: sessionService,
-                issueTracker: tracker, telemetryPort: nil, devRoot: engineDevRoot,
+                issueTracker: tracker, telemetryPort: telemetryPort, devRoot: engineDevRoot,
                 hostBridge: NoopHostBridge(),
                 loadConfig: {
                     let dr = ConfigStore.loadDevRoot() ?? engineDevRoot
@@ -293,6 +390,9 @@ public enum CrowDaemon {
 
         log("HTTP/WS listening on http://\(options.host):\(options.httpPort) (terminal at /)")
         try await app.runService()
+        // Close the OTLP listener and the SQLite handle before we exit or re-exec —
+        // the re-exec'd image binds the same port and opens the same db file (#772).
+        if let telemetry { await telemetry.stop() }
         // First-run setup (`run-setup`) asks us to re-exec so the freshly-written
         // devroot pointer is adopted by every subsystem that captured it at
         // startup (CROW-605). Hummingbird's runService() returns cleanly on

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -144,10 +144,17 @@ public enum CrowDaemon {
         // to, so it resolves through a holder the init fills in afterwards (the app
         // used `self.telemetryService` for the same reason).
         let telemetryHolder = TelemetryHolder()
-        let telemetry: TelemetryService?
+        // Create AND start before deriving `telemetryPort`: `start()` is where the
+        // database opens and the listener comes up, so a service that merely
+        // constructed is not yet usable. Starting later would leave a window where
+        // the port is already baked into every agent launch (exporting at a dead
+        // endpoint) and the holder already answers queries (against an unopened DB)
+        // (review). `start()` needs nothing from SessionService — only the backfill
+        // below does — so it belongs here.
+        var startedTelemetry: TelemetryService?
         if telemetryConfig.enabled {
             do {
-                telemetry = try TelemetryService(
+                let service = try TelemetryService(
                     port: telemetryConfig.port,
                     onDataReceived: { sessionID in
                         // Already @MainActor — the analytics write is serialized
@@ -163,16 +170,19 @@ public enum CrowDaemon {
                                 lastReceivedAt: Date())
                         }
                     })
+                // Publish before `start()` so the first datapoint can't arrive to an
+                // empty holder; cleared again below if the start throws.
+                await MainActor.run { telemetryHolder.service = service }
+                try await service.start()
+                startedTelemetry = service
             } catch {
-                log("WARNING: failed to create the telemetry receiver on port \(telemetryConfig.port) "
-                    + "(\(error)) — per-session analytics will be unavailable")
-                telemetry = nil
+                log("WARNING: telemetry receiver unavailable on port \(telemetryConfig.port) "
+                    + "(\(error)) — per-session analytics will not be collected")
+                await MainActor.run { telemetryHolder.service = nil }
             }
-        } else {
-            telemetry = nil
         }
-        await MainActor.run { telemetryHolder.service = telemetry }
-        // nil when telemetry is off OR the receiver failed to bind: without a live
+        let telemetry = startedTelemetry
+        // nil when telemetry is off OR the receiver never came up: without a live
         // receiver the `OTEL_*` exporter vars would point at a closed port.
         let telemetryPort: UInt16? = telemetry.map(\.port)
 
@@ -228,19 +238,12 @@ public enum CrowDaemon {
             return (service, coordinator)
         }
 
-        // Start the OTLP receiver now that SessionService exists to drive the
-        // scorecard rebuild. Order mirrors the app's: start → backfill → prune, so
-        // sessions whose rows are about to age out still produce a snapshot (#745).
+        // The rest of the telemetry startup, deferred until SessionService exists to
+        // drive it. Order mirrors the app's: backfill BEFORE pruning, so sessions
+        // whose rows are about to age out still produce a snapshot (#745).
         if let telemetry {
             let retentionDays = telemetryConfig.retentionDays
             Task {
-                do {
-                    try await telemetry.start()
-                } catch {
-                    log("WARNING: telemetry receiver failed to start on port \(telemetry.port) "
-                        + "(\(error)) — per-session analytics will be unavailable")
-                    return
-                }
                 await sessionService?.backfillAnalyticsSnapshots()
                 await sessionService?.refreshManagerUsage()
                 let status = await telemetry.captureStatus()

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LocalLiveActionTests.swift
@@ -322,6 +322,44 @@ import CrowPersistence
         #expect(num(a?["wallClockDurationSeconds"]) == 7200)
     }
 
+    /// The branch #772 made reachable: until the daemon ran the OTLP receiver,
+    /// nothing ever wrote `hookState.analytics`, so an OPEN session could never
+    /// render the strip no matter how much telemetry it produced.
+    @Test @MainActor func liveHookAggregateRendersForAnOpenSession() async {
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        let session = Session(name: "__TEST__SessionAnalyticsStripLive", kind: .work, agentKind: .claudeCode)
+        let appState = AppState()
+        appState.sessions = [session]
+        appState.hookState(for: session.id).analytics = SessionAnalytics(
+            totalCost: 1.25, inputTokens: 10, outputTokens: 20, toolCallCount: 4, apiErrorCount: 2)
+
+        let resp = await router(appState: appState, store: JSONStore.temporary())
+            .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
+        let a = resp.result?["sessions"]?.objectValue?[session.id.uuidString]?.objectValue?["analytics"]?.objectValue
+        #expect(a?["source"]?.stringValue == "live")
+        #expect(num(a?["totalCost"]) == 1.25)
+        #expect(num(a?["totalTokens"]) == 30) // 10 + 20
+        #expect(num(a?["toolCallCount"]) == 4)
+        #expect(num(a?["apiErrorCount"]) == 2)
+    }
+
+    /// A live aggregate wins over a stale snapshot — a completed session that was
+    /// reopened keeps updating instead of freezing at its end-of-session numbers.
+    @Test @MainActor func liveAggregateWinsOverSnapshot() async {
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        let session = Session(name: "__TEST__SessionAnalyticsStripBoth", kind: .work, agentKind: .claudeCode)
+        let appState = AppState()
+        appState.sessions = [session]
+        appState.analyticsSnapshots[session.id.uuidString] = snapshot(for: session.id, cost: 2.5)
+        appState.hookState(for: session.id).analytics = SessionAnalytics(totalCost: 9.75)
+
+        let resp = await router(appState: appState, store: JSONStore.temporary())
+            .handle(request: JSONRPCRequest(id: 1, method: "list-sessions-live"))
+        let a = resp.result?["sessions"]?.objectValue?[session.id.uuidString]?.objectValue?["analytics"]?.objectValue
+        #expect(a?["source"]?.stringValue == "live")
+        #expect(num(a?["totalCost"]) == 9.75)
+    }
+
     @Test @MainActor func omitsAnalyticsWhenNoLiveOrSnapshot() async {
         AgentRegistry.shared.register(ClaudeCodeAgent())
         let session = Session(name: "s", kind: .work, agentKind: .claudeCode)

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -26,6 +26,12 @@ public final class SessionService {
     /// Windowed Manager-session aggregate from telemetry.db for the ungraded
     /// weekly usage bucket (#745). Optional for the same reason.
     private let managerUsageProvider: (@Sendable (Date, Date) async -> SessionAnalytics)?
+    /// Drops a session's rows from telemetry.db as part of `deleteSession`
+    /// (#772). Injected here rather than at each call site so all three delete
+    /// paths — the daemon's `delete-session` handler, the engine-router
+    /// fallback, and the auto-cleanup reaper — clean up through one choke
+    /// point. Optional: telemetry-off hosts and unit tests pass nil.
+    private let telemetryDeleteProvider: (@Sendable (UUID) async -> Void)?
     /// Host-only affordances (clipboard, editor/terminal launching, hook
     /// notifications). Defaults to a headless no-op so tests and the daemon
     /// need not supply one; the macOS app injects a real `AppHostBridge`.
@@ -39,6 +45,7 @@ public final class SessionService {
         analyticsProvider: (@Sendable (UUID) async -> SessionAnalytics?)? = nil,
         telemetrySessionIDsProvider: (@Sendable () async -> [UUID])? = nil,
         managerUsageProvider: (@Sendable (Date, Date) async -> SessionAnalytics)? = nil,
+        telemetryDeleteProvider: (@Sendable (UUID) async -> Void)? = nil,
         hostBridge: HostBridge = NoopHostBridge()
     ) {
         self.store = store
@@ -48,6 +55,7 @@ public final class SessionService {
         self.analyticsProvider = analyticsProvider
         self.telemetrySessionIDsProvider = telemetrySessionIDsProvider
         self.managerUsageProvider = managerUsageProvider
+        self.telemetryDeleteProvider = telemetryDeleteProvider
         self.hostBridge = hostBridge
     }
 
@@ -1536,6 +1544,15 @@ public final class SessionService {
             data.hookStates?[id.uuidString] = nil
         }
 
+        // Drop the session's raw telemetry rows now that the session itself is
+        // gone (#772). Only after the cleanup succeeded — a retryable failure
+        // returns above with the session intact, and its metrics with it. Any
+        // `SessionAnalyticsSnapshot` is deliberately left alone: the scorecard
+        // aggregates historical work whose sessions have since been deleted.
+        if let telemetryDeleteProvider {
+            await telemetryDeleteProvider(id)
+        }
+
         if appState.selectedSessionID == id {
             appState.selectedSessionID = appState.sessions.first?.id
         }
@@ -2798,7 +2815,7 @@ public final class SessionService {
     /// empty-analytics guard in `writeAnalyticsSnapshot` still applies.
     /// Returns the number of snapshots written.
     @discardableResult
-    func backfillAnalyticsSnapshots() async -> Int {
+    public func backfillAnalyticsSnapshots() async -> Int {
         guard let telemetrySessionIDsProvider else { return 0 }
         var written = 0
         for id in await telemetrySessionIDsProvider() {
@@ -2836,7 +2853,7 @@ public final class SessionService {
     /// pruning. Known bounded edge: the oldest still-covered week can be
     /// partially pruned mid-week, briefly dipping its recomputed total; it
     /// self-corrects once the week ages out entirely.
-    func refreshManagerUsage(now: Date = Date()) async {
+    public func refreshManagerUsage(now: Date = Date()) async {
         guard let managerUsageProvider else { return }
         // ISO-8601 weeks in the current timezone — the same bucketing
         // ScorecardModel.build uses, so the Manager card's weeks line up

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceTelemetryDeleteTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceTelemetryDeleteTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+@testable import CrowEngine
+
+/// `deleteSession` is the single choke point for dropping a session's raw
+/// telemetry rows (#772) — the daemon's `delete-session` handler, the
+/// engine-router fallback, and the auto-cleanup reaper all funnel through it, so
+/// injecting the cleanup here is what keeps telemetry.db from accumulating rows
+/// for sessions that no longer exist.
+@Suite("SessionService telemetry cleanup on delete")
+struct SessionServiceTelemetryDeleteTests {
+
+    /// Collects the ids the provider was called with. A class (not an actor) so
+    /// the MainActor-isolated assertions read it without hopping; the provider
+    /// closure only ever runs from `deleteSession`, itself `@MainActor`.
+    @MainActor
+    private final class DeleteRecorder {
+        var ids: [UUID] = []
+    }
+
+    private static func tempStore() -> JSONStore {
+        JSONStore(directory: URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-tel-del-\(UUID().uuidString)"))
+    }
+
+    @MainActor
+    private func service(appState: AppState, recorder: DeleteRecorder) -> SessionService {
+        SessionService(
+            store: Self.tempStore(), appState: appState,
+            telemetryDeleteProvider: { id in
+                await MainActor.run { recorder.ids.append(id) }
+            })
+    }
+
+    @Test @MainActor
+    func deletingASessionDropsItsTelemetryRows() async {
+        // No worktrees → `performDiskCleanup` has nothing to do and succeeds, so
+        // the delete reaches its teardown tail.
+        let session = Session(name: "__TEST__TelemetryDelete", kind: .work)
+        let appState = AppState()
+        appState.sessions = [session]
+        let recorder = DeleteRecorder()
+
+        await service(appState: appState, recorder: recorder).deleteSession(id: session.id)
+
+        #expect(appState.sessions.isEmpty)
+        #expect(recorder.ids == [session.id])
+    }
+
+    /// The primary Manager can't be deleted, so nothing may be purged for it —
+    /// its telemetry backs the scorecard's weekly usage rollups.
+    @Test @MainActor
+    func managerSessionIsNeverPurged() async {
+        let appState = AppState()
+        appState.sessions = [Session(id: AppState.managerSessionID, name: "Manager", kind: .manager)]
+        let recorder = DeleteRecorder()
+
+        await service(appState: appState, recorder: recorder)
+            .deleteSession(id: AppState.managerSessionID)
+
+        #expect(appState.sessions.count == 1)
+        #expect(recorder.ids.isEmpty)
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceTelemetryDeleteTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceTelemetryDeleteTests.swift
@@ -49,6 +49,41 @@ struct SessionServiceTelemetryDeleteTests {
         #expect(recorder.ids == [session.id])
     }
 
+    /// The purge must sit AFTER the disk-cleanup guard: a retryable failure leaves
+    /// the session (and the user's ability to retry) intact, so its metrics have to
+    /// survive too. Forces the failure by making the clone's parent read-only, so
+    /// `removeItem` fails with EACCES.
+    @Test @MainActor
+    func failedDiskCleanupKeepsTelemetryRows() async {
+        let fm = FileManager.default
+        let parent = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-tel-del-locked-\(UUID().uuidString)")
+        let clone = parent.appendingPathComponent("clone")
+        try? fm.createDirectory(at: clone, withIntermediateDirectories: true)
+        try? fm.setAttributes([.posixPermissions: 0o555], ofItemAtPath: parent.path)
+        defer {
+            try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: parent.path)
+            try? fm.removeItem(at: parent)
+        }
+
+        // A review session: repoPath == worktreePath == the clone, which is the
+        // branch that reports a fatal error when the directory can't be removed.
+        let session = Session(name: "__TEST__TelemetryDeleteFailed", kind: .review)
+        let appState = AppState()
+        appState.sessions = [session]
+        appState.worktrees[session.id] = [SessionWorktree(
+            sessionID: session.id, repoName: "repo", repoPath: clone.path,
+            worktreePath: clone.path, branch: "feature/pr")]
+        let recorder = DeleteRecorder()
+
+        await service(appState: appState, recorder: recorder).deleteSession(id: session.id)
+
+        // Cleanup failed → session preserved for retry, telemetry preserved with it.
+        #expect(appState.sessions.count == 1)
+        #expect(appState.sessionDeletionError[session.id] != nil)
+        #expect(recorder.ids.isEmpty)
+    }
+
     /// The primary Manager can't be deleted, so nothing may be purged for it —
     /// its telemetry backs the scorecard's weekly usage rollups.
     @Test @MainActor


### PR DESCRIPTION
Closes #772

## Root cause

Not a missing UI. The web render (`renderSessionAnalyticsStrip`), the `list-sessions-live` `analytics` field, and `writeAnalyticsSnapshot` all survived the native→web move intact. What never migrated was the **producer**: `rg TelemetryService --type swift` matched exactly one file — its own definition — and `CrowTelemetry` was not even a dependency of `CrowDaemon`.

Two things were dead at once:

1. No OTLP receiver was bound, so `hookState.analytics` was never populated.
2. `SessionService` and `EngineContext` were built with `telemetryPort: nil`, so `AgentLaunch` / `ClaudeCodeAgent.autoLaunchCommand` never exported the `CLAUDE_CODE_ENABLE_TELEMETRY` / `OTEL_*` prefix — Claude Code was not emitting anything to receive in the first place.

The strip treats absent analytics as its empty state (by design), so it silently rendered nothing. Confirmed live: nothing was listening on port 4318 despite `telemetry.enabled: true`.

## Changes

- **`CrowDaemon.swift`** — start `TelemetryService` when `config.telemetry.enabled`; its `onDataReceived` (already `@MainActor`) writes `appState.hookState(id).analytics` and refreshes `telemetryCaptureStatus`. Thread the real port into both `SessionService` and `EngineContext`. Restore the lifecycle the native AppDelegate owned: start → scorecard backfill + Manager rollups → retention prune (that order, so rows about to age out still snapshot), and `stop()` before exit/re-exec.
- **`SessionService.swift`** — `backfillAnalyticsSnapshots` / `refreshManagerUsage` made `public` for the daemon; new injected `telemetryDeleteProvider` awaited in `deleteSession`, so all three delete paths (RPC handler, engine-router fallback, auto-cleanup reaper) purge telemetry rows through one choke point. `SessionAnalyticsSnapshot`s are deliberately kept — the scorecard aggregates history.
- **`Packages/CrowDaemon/Package.swift`** — add `CrowTelemetry`. Darwin-only (Network.framework), which `CrowDaemon` already was via `CrowTerminal`; `ci.yml`'s Linux allow-list excludes both.

No web change — the render code was already correct.

## Tests

- `LocalLiveActionTests` — two new cases in `SessionAnalyticsStripLiveTests` pinning the branch this fix makes reachable: an open session with a live hook aggregate renders `source: "live"`, and a live aggregate wins over a stale snapshot. The suite previously covered only the snapshot and omission branches.
- `SessionServiceTelemetryDeleteTests` (new) — deleting a session invokes the provider once with its id; the Manager session is never purged.

## Verification

- `swift build --product crowd` ✅
- `swift test --package-path Packages/CrowDaemon` — 118 tests ✅
- `swift test --package-path Packages/CrowEngine` — 313 tests ✅
- `swift test --package-path Packages/CrowTelemetry` — 25 tests ✅

Not yet exercised against a live daemon (would require restarting the running `crowd`): with telemetry enabled, expect the `[OTLPReceiver] Listening on localhost:4318` log, the `export CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_… &&` prefix on spawned Claude sessions, and the strip filling in within one 4s `refreshLive` tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Si2urYjhSLHt2Y1S276wMg