### PR TITLE
fix(web): terminal touch-scroll on iOS — own the gesture, scroll real history (#777)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -351,8 +351,12 @@ html, body {
 .tab.add { color: var(--gold); font-size: 16px; font-weight: 700; }
 .tab-close { color: var(--text-muted); font-size: 14px; }
 .tab-close:hover { color: var(--red); }
-#terminal-wrap { flex: 1; min-height: 0; background: #1e1e1e; position: relative; }
-#terminal { width: 100%; height: 100%; }
+#terminal-wrap { flex: 1; min-height: 0; background: #1e1e1e; position: relative; overscroll-behavior: contain; }
+/* #777: `touch-action: none` hands the one-finger gesture to enableTouchScroll
+   instead of iOS Safari's overscroll — without it Safari rubber-bands the fixed
+   xterm canvas and the swipe never reaches the buffer. Costs pinch-zoom over the
+   terminal (change the font size instead); long-press selection is unaffected. */
+#terminal { width: 100%; height: 100%; touch-action: none; }
 
 /* ---- Terminal skeleton loading overlay (#677) ----
    Masks the xterm attach/reload window (blank/garbled grid, reflow flash,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2955,9 +2955,7 @@ function ensureTerminal() {
     webglAddon.onContextLoss(() => webglAddon.dispose());
     term.loadAddon(webglAddon);
   } catch (_) { /* WebGL unavailable → canvas/DOM renderer */ }
-  term.onData((data) => {
-    if (termWs && termWs.readyState === WebSocket.OPEN) termWs.send(new TextEncoder().encode(data));
-  });
+  term.onData(sendToPTY);
   // Cmd/Ctrl+C copies the selection (falling through to SIGINT when nothing is
   // selected so Ctrl+C still interrupts); Cmd+V pastes. Lets the browser own
   // copy/paste instead of tmux's copy-mode.
@@ -3001,21 +2999,81 @@ function ensureTerminal() {
   connectTerminalWs();
 }
 
+// The one guarded writer to the PTY socket, shared by term.onData and the touch
+// scroll shim below (mirrors terminal.html's sendToPTY of the same name).
+function sendToPTY(text) {
+  if (!text) return;
+  if (termWs && termWs.readyState === WebSocket.OPEN) termWs.send(new TextEncoder().encode(text));
+}
+
+// One rendered row in CSS pixels. `.xterm-screen` is exactly rows × cellHeight
+// under both the WebGL and DOM renderers, so it's a truer metric than the
+// container's clientHeight (which carries padding and, on mobile, the keyboard
+// inset / dPR mis-fit that made the old `clientHeight / rows` yield delta 0).
+function terminalCellHeight(node) {
+  const rows = (term && term.rows) || 0;
+  if (rows > 0) {
+    const screen = term.element && term.element.querySelector('.xterm-screen');
+    const h = screen ? screen.clientHeight / rows : 0;
+    if (isFinite(h) && h >= 4) return h;
+    const fallback = (node ? node.clientHeight : 0) / rows;
+    if (isFinite(fallback) && fallback >= 4) return fallback;
+  }
+  return 18;
+}
+
+// Translate N lines of scroll into what a wheel tick would send, for the case
+// where the local buffer can't scroll: the alternate screen has no scrollback,
+// so term.scrollLines is a silent no-op there (#777 — on mobile that read as
+// "the same frame forever"). Matches enableWheelScroll's policy of letting a
+// fullscreen TUI own the wheel. Negative = up/back.
+const MAX_PTY_SCROLL_LINES = 24; // a fling must not flood the PTY
+function sendScrollToPTY(lines) {
+  const n = Math.min(Math.abs(lines), MAX_PTY_SCROLL_LINES);
+  if (n === 0) return;
+  const up = lines < 0;
+  const modes = (term && term.modes) || {};
+  // Mouse-reporting apps (and tmux, whose `mouse on` relays to them) want SGR
+  // wheel buttons 64/65; everything else takes the cursor-key fallback xterm
+  // itself uses for an alt-buffer wheel.
+  let seq;
+  if (modes.mouseTrackingMode && modes.mouseTrackingMode !== 'none') {
+    seq = up ? '\x1b[<64;1;1M' : '\x1b[<65;1;1M';
+  } else {
+    const ss3 = modes.applicationCursorKeysMode;
+    seq = up ? (ss3 ? '\x1bOA' : '\x1b[A') : (ss3 ? '\x1bOB' : '\x1b[B');
+  }
+  sendToPTY(seq.repeat(n));
+}
+
 // xterm.js doesn't scroll its scrollback on touch drags — map a one-finger
-// vertical swipe to term.scrollLines so the terminal is scrollable on mobile.
+// vertical swipe to the terminal so it's scrollable on mobile. Registered
+// non-passive and preventDefault'ed: a passive listener can't stop iOS Safari's
+// native overscroll, so the browser rubber-banded the canvas while this shim
+// tried to scroll the buffer, and the native gesture won (#777). `#terminal`
+// also carries `touch-action: none` so Safari never claims the gesture at all.
 function enableTouchScroll(node) {
   let lastY = null;
+  let accum = 0; // sub-cell remainder, so slow drags aren't truncated away
   node.addEventListener('touchstart', (e) => {
-    if (e.touches.length === 1) lastY = e.touches[0].clientY;
+    if (e.touches.length === 1) { lastY = e.touches[0].clientY; accum = 0; }
+    else lastY = null; // pinch/multi-touch is not ours
   }, { passive: true });
   node.addEventListener('touchmove', (e) => {
     if (lastY == null || e.touches.length !== 1 || !term) return;
+    e.preventDefault(); // own the gesture instead of racing Safari's overscroll
     const y = e.touches[0].clientY;
-    const cell = (node.clientHeight / (term.rows || 24)) || 18;
-    const delta = Math.trunc((lastY - y) / cell);
-    if (delta !== 0) { term.scrollLines(delta); lastY = y; }
-  }, { passive: true });
-  node.addEventListener('touchend', () => { lastY = null; }, { passive: true });
+    accum += (lastY - y) / terminalCellHeight(node);
+    lastY = y;
+    const delta = Math.trunc(accum);
+    if (delta === 0) return;
+    accum -= delta;
+    const buf = term.buffer && term.buffer.active;
+    if (buf && buf.type === 'alternate') sendScrollToPTY(delta);
+    else term.scrollLines(delta);
+  }, { passive: false });
+  node.addEventListener('touchend', () => { lastY = null; accum = 0; }, { passive: true });
+  node.addEventListener('touchcancel', () => { lastY = null; accum = 0; }, { passive: true });
 }
 
 // Let xterm.js own wheel scrolling in the browser: scroll the local 50k-line

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -1,16 +1,27 @@
-# Web Ticket Board tests
+# Web UI tests
 
 Headless [jsdom](https://github.com/jsdom/jsdom) regression tests for the web
-**Ticket Board** (CROW-751). They load the **real** `Resources/web/app.js` and
-drive `renderTicketBoard` / `ticketCard` against mock board payloads — no
-running daemon required — then assert the resulting DOM.
+UI. They load the **real** `Resources/web/app.js` and drive its functions
+against mocks — no running daemon required — then assert the result.
 
-Coverage: repo filter, every sort mode, status-pipeline + text-search
-composition, the label-name search fix, richer card detail (author / created /
-comments / description excerpt + expand toggle), Open Issue / Open PR buttons
-(hrefs + `target=_blank`), inline PR state + CI badges (incl. failing-check
-tooltip), and graceful degradation of an older payload with the new fields
-absent.
+## `board.test.js` — Ticket Board (CROW-751)
+
+Drives `renderTicketBoard` / `ticketCard` against mock board payloads and
+asserts the resulting DOM. Coverage: repo filter, every sort mode,
+status-pipeline + text-search composition, the label-name search fix, richer
+card detail (author / created / comments / description excerpt + expand
+toggle), Open Issue / Open PR buttons (hrefs + `target=_blank`), inline PR
+state + CI badges (incl. failing-check tooltip), and graceful degradation of an
+older payload with the new fields absent.
+
+## `touch-scroll.test.js` — mobile terminal scroll (#777)
+
+Drives `enableTouchScroll` against a fake xterm + PTY socket. Coverage: the
+non-passive `touchmove` + `preventDefault` that stops iOS Safari's overscroll
+from rubber-banding the same frame, local scrollback scrolling with sub-cell
+accumulation, the alternate-screen branch (SGR wheel reports when the TUI has
+mouse tracking on, cursor keys otherwise, capped per event), multi-touch
+pass-through, and degenerate cell metrics.
 
 ## Run
 

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,9 +2,9 @@
   "name": "crow-web-board-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web Ticket Board (renderTicketBoard / ticketCard). Drives the real app.js from Resources/web against mock board payloads.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board rendering; terminal touch-scroll). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "node board.test.js"
+    "test": "node board.test.js && node touch-scroll.test.js"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/touch-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/touch-scroll.test.js
@@ -1,0 +1,192 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// #777 regression: the mobile terminal touch-scroll shim. Drives the real
+// enableTouchScroll from Resources/web/app.js against a fake xterm + PTY socket.
+// Same harness shape as board.test.js — an epilogue evaluated in app.js's own
+// top-level lexical scope exposes the module-scope bindings we need.
+const epilogue = `
+;globalThis.__t = {
+  enableTouchScroll(node){ return enableTouchScroll(node); },
+  set term(v){ term = v; },
+  set termWs(v){ termWs = v; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body><div id="terminal"></div></body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.WebSocket.OPEN = 1;
+window.TextEncoder = TextEncoder; // jsdom omits it; real browsers have it
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+// ---- Fakes -----------------------------------------------------------------
+
+const CELL = 20; // px per row in the fakes below
+
+// A fresh #terminal node with the listeners attached, plus recorders for what
+// the shim did. Returns a small driver for synthesising a one-finger drag.
+function setup({ rows = 24, screenHeight = rows * CELL, altScreen = false,
+                 mouseTrackingMode = 'none', applicationCursorKeysMode = false } = {}) {
+  const node = window.document.createElement('div');
+  window.document.body.appendChild(node);
+  Object.defineProperty(node, 'clientHeight', { value: rows * CELL, configurable: true });
+
+  const element = window.document.createElement('div');
+  const screen = window.document.createElement('div');
+  screen.className = 'xterm-screen';
+  Object.defineProperty(screen, 'clientHeight', { value: screenHeight, configurable: true });
+  element.appendChild(screen);
+
+  const scrolled = [];
+  const sent = [];
+  T.term = {
+    rows, element,
+    buffer: { active: { type: altScreen ? 'alternate' : 'normal' } },
+    modes: { mouseTrackingMode, applicationCursorKeysMode },
+    scrollLines: (n) => scrolled.push(n),
+  };
+  T.termWs = {
+    readyState: 1,
+    send: (bytes) => sent.push(new TextDecoder().decode(bytes)),
+  };
+
+  // Record listener registration so we can assert passive-ness directly.
+  const opts = {};
+  const realAdd = node.addEventListener.bind(node);
+  node.addEventListener = (type, fn, o) => { opts[type] = o; realAdd(type, fn, o); };
+  T.enableTouchScroll(node);
+
+  let defaultPrevented = 0;
+  const touch = (type, ys) => {
+    const e = new window.Event(type, { bubbles: true, cancelable: true });
+    e.touches = ys.map((clientY) => ({ clientY }));
+    node.dispatchEvent(e);
+    if (e.defaultPrevented) defaultPrevented++;
+  };
+  return {
+    node, opts, scrolled, sent,
+    start: (y) => touch('touchstart', [y]),
+    move: (y) => touch('touchmove', [y]),
+    moveTwo: (y) => touch('touchmove', [y, y + 40]),
+    end: () => touch('touchend', []),
+    prevented: () => defaultPrevented,
+  };
+}
+
+// ---- The regression itself -------------------------------------------------
+
+console.log('Gesture ownership (#777 root cause):');
+{
+  const t = setup();
+  check('touchmove registered non-passive', t.opts.touchmove && t.opts.touchmove.passive === false);
+  check('touchstart stays passive', t.opts.touchstart && t.opts.touchstart.passive === true);
+  t.start(500);
+  t.move(400);
+  check('preventDefault called on a one-finger drag', t.prevented() === 1);
+}
+
+// Direction convention (unchanged from the pre-#777 shim, and the natural touch
+// one): the content follows the finger. Dragging the finger DOWN pulls older
+// content into view — negative deltas, i.e. back through history.
+console.log('\nNormal buffer scrolls the local scrollback:');
+{
+  const t = setup();
+  t.start(500);
+  t.move(500 + 5 * CELL); // drag down 5 rows → back through history
+  check('scrollLines(-5) — dragging down walks back through history', t.scrolled.join() === '-5');
+  t.move(500); // drag back up 5 rows
+  check('scrollLines(+5) on the way back to the bottom', t.scrolled.join() === '-5,5');
+  check('nothing written to the PTY', t.sent.length === 0);
+}
+
+console.log('\nSub-cell drags accumulate instead of being truncated away:');
+{
+  const t = setup();
+  t.start(500);
+  [7, 14, 20].forEach((d) => t.move(500 + d)); // three part-row moves summing to one row
+  check('three part-row moves produce exactly one line', t.scrolled.join() === '-1');
+  const t2 = setup();
+  t2.start(500);
+  t2.move(500 + 7);
+  check('a single sub-cell move scrolls nothing yet', t2.scrolled.length === 0);
+  check('...but is still preventDefault\'ed', t2.prevented() === 1);
+}
+
+console.log('\nAlternate screen (TUI) forwards to the PTY — scrollLines is a no-op there:');
+{
+  const t = setup({ altScreen: true, mouseTrackingMode: 'vt200' });
+  t.start(500);
+  t.move(500 + 3 * CELL); // back through history
+  check('no local scrollLines in the alt buffer', t.scrolled.length === 0);
+  check('3 SGR wheel-up reports sent', t.sent.join() === '\x1b[<64;1;1M'.repeat(3));
+  t.move(500 + 1 * CELL); // forward 2 rows
+  check('wheel-down reports on the way back', t.sent[1] === '\x1b[<65;1;1M'.repeat(2));
+}
+{
+  const t = setup({ altScreen: true, mouseTrackingMode: 'none' });
+  t.start(500);
+  t.move(500 + 2 * CELL);
+  check('no mouse tracking → normal cursor keys', t.sent.join() === '\x1b[A\x1b[A');
+}
+{
+  const t = setup({ altScreen: true, mouseTrackingMode: 'none', applicationCursorKeysMode: true });
+  t.start(500);
+  t.move(500 + 2 * CELL);
+  check('application cursor keys → SS3 form', t.sent.join() === '\x1bOA\x1bOA');
+}
+{
+  const t = setup({ altScreen: true, mouseTrackingMode: 'none' });
+  t.start(500);
+  t.move(500 + 100 * CELL); // a fling
+  check('a fling is capped at 24 lines', t.sent.join() === '\x1b[A'.repeat(24));
+}
+
+console.log('\nMulti-touch is left to the browser:');
+{
+  const t = setup();
+  t.start(500);
+  t.moveTwo(400);
+  check('two-finger move does not scroll', t.scrolled.length === 0);
+  check('two-finger move is not preventDefault\'ed', t.prevented() === 0);
+}
+
+console.log('\nDegenerate metrics do not throw or emit NaN:');
+{
+  const t = setup({ rows: 0, screenHeight: 0 });
+  t.start(500);
+  t.move(500 + 36); // 2 × the 18px fallback cell
+  check('rows: 0 falls back to an 18px cell', t.scrolled.join() === '-2');
+}
+{
+  const t = setup({ screenHeight: 0 }); // no rendered screen yet → container fallback
+  t.start(500);
+  t.move(500 + 2 * CELL);
+  check('zero-height screen falls back to the container metric', t.scrolled.join() === '-2');
+  check('no NaN scrolls', t.scrolled.every((n) => Number.isFinite(n)));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #777

## Problem

The touch-scroll shim that arrived with the web-UI-parity merge (`c03daee` #590 → `eb7a489` #594) registered `touchmove` as `{ passive: true }` and never called `preventDefault()`, so it could not stop iOS Safari's native overscroll. Safari rubber-banded the fixed xterm canvas while the shim tried to scroll the buffer, and the native gesture won.

With a TUI on the alternate screen there was no scrollback to scroll either, so `term.scrollLines` was a silent no-op and the bounce-back was the *only* motion — which is why it read as "the same paragraph, forever."

## Fix

**Own the gesture** — `#terminal` gets `touch-action: none` (and `#terminal-wrap` `overscroll-behavior: contain`) so Safari never claims the pan at all, and `touchmove` is now registered non-passive and `preventDefault()`ed. Pinch-zoom over the terminal is intentionally traded away (change the font size instead); long-press text selection is unaffected.

**Alternate screen forwards to the TUI** instead of no-oping, mirroring `enableWheelScroll`'s existing "a fullscreen TUI owns the wheel" policy. Per line of swipe it emits what a wheel tick would: SGR wheel reports (`\e[<64;1;1M` / `\e[<65;1;1M`) when the app has mouse tracking on — tmux's `mouse on` relays these to Claude Code — and cursor keys otherwise, honouring application-cursor-keys mode. Capped at 24 lines per event so a fling can't flood the PTY. No daemon or tmux changes.

**Fixed cell metrics** — line height now derives from `.xterm-screen` (exactly `rows × cellHeight` under both the WebGL and DOM renderers) with container and 18px fallbacks and NaN/zero guards, and sub-cell drags accumulate rather than being truncated to zero. The old `clientHeight / rows` could stall the scroll entirely on mobile.

Also extracted the one guarded PTY writer as `sendToPTY`, matching `terminal.html`'s helper of the same name.

## Tests

New `Packages/CrowDaemon/web-tests/touch-scroll.test.js` — 20 assertions driving the real `enableTouchScroll` from `app.js` in jsdom against a fake xterm + PTY socket (same harness shape as `board.test.js`): non-passive registration + `preventDefault` (the regression itself), local scrollback with sub-cell accumulation, all four alternate-screen encodings, the fling cap, multi-touch pass-through, and degenerate metrics.

- `npm test` in `web-tests` — 32 board + 20 touch-scroll assertions pass (the script now runs both suites)
- `swift build --package-path Packages/CrowDaemon` — clean
- `swift test --package-path Packages/CrowDaemon` — 116 tests, 32 suites, pass

## Verification checklist

Automated coverage above; the remaining items need a physical device:

- [ ] iOS Safari: swipe at a shell prompt walks through history and lands where released, no bounce-back repeat
- [ ] iOS Safari: swipe scrolls a live Claude Code TUI transcript
- [ ] Long-press selection still works; two-finger gestures don't scroll the buffer
- [ ] Desktop wheel scroll + drag-select unchanged

Android Chrome honours the same contract (`touch-action: none` + non-passive `preventDefault`), so it should behave identically.

## Follow-up

Unrelated to this fix but worth a ticket: `app.js` and `terminal.html` are two independent terminal implementations that have already drifted (`terminal.html` swallows the mouse-tracking DECSET modes, `app.js` does not). Worth unifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQpzbFaMPipA4EhevSnpe