### PR TITLE
fix(crowd): wire terminal-independent automations regardless of tmux, add durable automation log

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
@@ -83,7 +83,9 @@ public enum CrowLog {
         let dir = resolvedDirectoryLocked()
         let url = dir.appendingPathComponent("crowd-automation.log")
         let fm = FileManager.default
-        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? fm.createDirectory(
+            at: dir, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
 
         rotateIfNeededLocked(url: url)
 
@@ -93,9 +95,16 @@ public enum CrowLog {
             _ = try? handle.seekToEnd()
             try? handle.write(contentsOf: data)
         } else {
-            // First write (or the file was removed under us) — create it.
+            // First write, or the file was rotated/removed under us — create it.
             try? data.write(to: url, options: .atomic)
         }
+        // The log carries session UUIDs, PR URLs and raw `gh` error text, so it
+        // gets the same owner-only treatment as Crow's other durable local state
+        // (JSONStore / ConfigStore, 0o700 dirs + 0o600 files). Re-applied after
+        // every write: an atomic write replaces the inode, so permissions set on
+        // a previous generation don't carry over (review #787).
+        try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
     }
 
     private static func rotateIfNeededLocked(url: URL) {
@@ -105,6 +114,10 @@ public enum CrowLog {
         let rotated = url.appendingPathExtension("1")
         try? fm.removeItem(at: rotated)
         try? fm.moveItem(at: url, to: rotated)
+        // The rotated generation holds the same data as the active file, so it
+        // keeps the same owner-only permissions (a move preserves them, but the
+        // active file may predate this hardening).
+        try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: rotated.path)
     }
 
     /// Mirrors `JSONStore.isRunningUnderTests()` — see ADR 0012 for why each

--- a/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Durable, greppable log file for background-automation decisions (CROW-782).
+///
+/// The daemon's own `log()` writes to stderr, and `IssueTracker` `NSLog`s only
+/// when it *acts* — so when auto-merge silently skipped every PR there was
+/// nothing left to read afterwards. This sink gives each poll's automation
+/// decisions (including the skips and their reasons) a stable file that
+/// survives daemon restarts and stderr redirection:
+///
+///     ~/Library/Logs/crow/crowd-automation.log
+///
+/// Lines are `<ISO8601> [automation] <message>` and are also mirrored to
+/// `NSLog`, so existing Console-based debugging keeps working unchanged.
+///
+/// Writes are serialized with an `NSLock` (same approach as `JSONStore`) and
+/// the file is size-capped: past `maxBytes` it rotates to `…log.1`, keeping
+/// exactly one previous generation, so a long-lived daemon can't fill the disk.
+///
+/// Per ADR 0012, a test process never writes to the live log directory — the
+/// default directory resolves to a per-process temp dir under a test runner.
+public enum CrowLog {
+    /// Rotate once the active file exceeds this size (bytes).
+    static let maxBytes: Int = 5 * 1024 * 1024
+
+    private static let lock = NSLock()
+    /// `nonisolated(unsafe)`: only ever touched while holding `lock`.
+    private nonisolated(unsafe) static var overrideDirectory: URL?
+
+    /// `nonisolated(unsafe)`: only ever used while holding `lock`.
+    private nonisolated(unsafe) static let timestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Point the sink at a different directory. Tests use this to write into a
+    /// temp dir; production leaves it alone.
+    public static func configure(directory: URL?) {
+        lock.lock()
+        overrideDirectory = directory
+        lock.unlock()
+    }
+
+    /// Directory holding the automation log. `~/Library/Logs/crow` in
+    /// production; a temp directory under a test runner (ADR 0012).
+    public static var directory: URL {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolvedDirectoryLocked()
+    }
+
+    /// Full path of the active automation log file.
+    public static var fileURL: URL { directory.appendingPathComponent("crowd-automation.log") }
+
+    /// Append one automation line, and mirror it to `NSLog`.
+    public static func automation(_ message: String) {
+        NSLog("[Crow][automation] %@", message as NSString)
+        let now = Date()
+        lock.lock()
+        defer { lock.unlock() }
+        appendLocked("\(timestampFormatter.string(from: now)) [automation] \(message)\n")
+    }
+
+    // MARK: - Internals (all callers hold `lock`)
+
+    private static func resolvedDirectoryLocked() -> URL {
+        if let overrideDirectory { return overrideDirectory }
+        if isRunningUnderTests() {
+            // Never write into the developer's real log directory from a test
+            // process (ADR 0012). Appending is not destructive the way a
+            // full-store `mutate` is, but test noise in a diagnostic log is
+            // exactly what makes the log untrustworthy later.
+            return URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("crow-test-logs-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+        }
+        return FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/crow", isDirectory: true)
+    }
+
+    private static func appendLocked(_ line: String) {
+        let dir = resolvedDirectoryLocked()
+        let url = dir.appendingPathComponent("crowd-automation.log")
+        let fm = FileManager.default
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        rotateIfNeededLocked(url: url)
+
+        guard let data = line.data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: url) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+        } else {
+            // First write (or the file was removed under us) — create it.
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    private static func rotateIfNeededLocked(url: URL) {
+        let fm = FileManager.default
+        guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? Int, size > maxBytes else { return }
+        let rotated = url.appendingPathExtension("1")
+        try? fm.removeItem(at: rotated)
+        try? fm.moveItem(at: url, to: rotated)
+    }
+
+    /// Mirrors `JSONStore.isRunningUnderTests()` — see ADR 0012 for why each
+    /// signal is checked. Duplicated rather than shared because `CrowCore` sits
+    /// below `CrowPersistence` in the package graph.
+    private static func isRunningUnderTests() -> Bool {
+        if NSClassFromString("XCTestCase") != nil { return true }
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestConfigurationFilePath"] != nil || env["XCTestBundlePath"] != nil { return true }
+        let arg0 = CommandLine.arguments.first
+        let runnerNames: Set<String> = ["swiftpm-testing-helper", "xctest"]
+        if let base = (arg0 as NSString?)?.lastPathComponent, runnerNames.contains(base) { return true }
+        if runnerNames.contains(ProcessInfo.processInfo.processName) { return true }
+        if arg0?.contains(".xctest") == true { return true }
+        return false
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
@@ -61,6 +61,47 @@ struct CrowLogTests {
         }
     }
 
+    @Test func logFileAndDirectoryAreOwnerOnly() throws {
+        // The log carries session UUIDs, PR URLs and raw `gh` error text — same
+        // 0o700 dir / 0o600 file treatment as JSONStore/ConfigStore (review #787).
+        try withTempLogDirectory { dir in
+            CrowLog.automation("first line creates the file")
+            let fm = FileManager.default
+            let filePerms = try #require(
+                (try fm.attributesOfItem(atPath: CrowLog.fileURL.path))[.posixPermissions] as? NSNumber)
+            let dirPerms = try #require(
+                (try fm.attributesOfItem(atPath: dir.path))[.posixPermissions] as? NSNumber)
+            #expect(filePerms.int16Value == 0o600)
+            #expect(dirPerms.int16Value == 0o700)
+
+            // Still owner-only after an append to the existing file...
+            CrowLog.automation("second line appends")
+            let afterAppend = try #require(
+                (try fm.attributesOfItem(atPath: CrowLog.fileURL.path))[.posixPermissions] as? NSNumber)
+            #expect(afterAppend.int16Value == 0o600)
+        }
+    }
+
+    @Test func permissionsSurviveRotation() throws {
+        try withTempLogDirectory { _ in
+            let url = CrowLog.fileURL
+            CrowLog.automation("seed")
+            let filler = String(repeating: "x", count: CrowLog.maxBytes + 1)
+            try filler.write(to: url, atomically: true, encoding: .utf8)
+
+            CrowLog.automation("triggers rotation")
+
+            let fm = FileManager.default
+            // Both the fresh active file and the rotated generation stay 0o600 —
+            // the atomic write above replaced the inode, dropping any prior mode.
+            for path in [url.path, url.appendingPathExtension("1").path] {
+                let perms = try #require(
+                    (try fm.attributesOfItem(atPath: path))[.posixPermissions] as? NSNumber)
+                #expect(perms.int16Value == 0o600, "\(path) should be owner-only")
+            }
+        }
+    }
+
     @Test func defaultDirectoryUnderTestsIsNotTheLiveLogDirectory() {
         // No `configure` override: the ADR 0012 test-process fallback must keep
         // the suite out of ~/Library/Logs/crow.

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// `CrowLog` is the durable automation log added for CROW-782. Every test here
+/// points the sink at a fresh temp directory (ADR 0012 — tests never write to
+/// the live `~/Library/Logs/crow`) and restores the default afterwards.
+@Suite(.serialized)
+struct CrowLogTests {
+    private func withTempLogDirectory(_ body: (URL) throws -> Void) rethrows {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-test-crowlog-\(UUID().uuidString)", isDirectory: true)
+        CrowLog.configure(directory: dir)
+        defer {
+            CrowLog.configure(directory: nil)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        try body(dir)
+    }
+
+    @Test func automationAppendsTimestampedLines() throws {
+        try withTempLogDirectory { dir in
+            CrowLog.automation("auto-merge: enabled=1 skipped=0")
+            CrowLog.automation("auto-rebase: candidates=0")
+
+            let contents = try String(contentsOf: CrowLog.fileURL, encoding: .utf8)
+            let lines = contents.split(separator: "\n").map(String.init)
+            #expect(lines.count == 2)
+            #expect(lines[0].hasSuffix("[automation] auto-merge: enabled=1 skipped=0"))
+            #expect(lines[1].hasSuffix("[automation] auto-rebase: candidates=0"))
+            // Leading ISO8601 timestamp, so lines sort chronologically.
+            #expect(lines[0].hasPrefix("2"))
+            #expect(CrowLog.fileURL.deletingLastPathComponent() == dir)
+        }
+    }
+
+    @Test func fileURLLivesUnderTheConfiguredDirectory() throws {
+        try withTempLogDirectory { dir in
+            #expect(CrowLog.fileURL == dir.appendingPathComponent("crowd-automation.log"))
+        }
+    }
+
+    @Test func oversizedLogRotatesToASingleGeneration() throws {
+        try withTempLogDirectory { _ in
+            let url = CrowLog.fileURL
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            // Seed a file past the cap so the next append rotates it.
+            let filler = String(repeating: "x", count: CrowLog.maxBytes + 1)
+            try filler.write(to: url, atomically: true, encoding: .utf8)
+
+            CrowLog.automation("after rotation")
+
+            let rotated = url.appendingPathExtension("1")
+            #expect(FileManager.default.fileExists(atPath: rotated.path))
+            let active = try String(contentsOf: url, encoding: .utf8)
+            #expect(active.hasSuffix("[automation] after rotation\n"))
+            // The active file starts fresh — the old bulk moved aside.
+            #expect(active.count < CrowLog.maxBytes)
+            #expect(try String(contentsOf: rotated, encoding: .utf8).hasPrefix("xxx"))
+        }
+    }
+
+    @Test func defaultDirectoryUnderTestsIsNotTheLiveLogDirectory() {
+        // No `configure` override: the ADR 0012 test-process fallback must keep
+        // the suite out of ~/Library/Logs/crow.
+        CrowLog.configure(directory: nil)
+        let live = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/crow", isDirectory: true)
+        #expect(CrowLog.directory != live)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -283,21 +283,49 @@ public enum CrowDaemon {
             tracker: tracker, eventHub: eventHub, sessionService: sessionService,
             appState: appState, devRoot: options.devRoot)
 
-        // Wire the IssueTracker background automations — crow:auto, auto-respond,
-        // auto-merge, auto-rebase, auto-cleanup, review auto-kickoff. Needs a live
-        // cockpit (terminals to dispatch into) (CROW-581).
+        // Wire the IssueTracker's config-flag providers and its notification-only
+        // outcome hooks. Terminal-INDEPENDENT, so this runs whenever `crowd` runs —
+        // enabling GitHub native auto-merge is a pure gh/GraphQL call and
+        // auto-rebase is pure git; neither needs tmux, and a broadcast needs only
+        // the event hub. Bundling these behind the cockpit is what silently killed
+        // every automation on a daemon started without tmux (CROW-782): the
+        // providers stayed at their `{ false }` defaults and `applyAutoMerge`
+        // bailed on its first guard, every poll, with no log line. The retired
+        // AppDelegate wired them unconditionally; this restores that.
+        await MainActor.run {
+            wireTrackerAutomations(
+                tracker: tracker, appState: appState, devRoot: options.devRoot,
+                autoRespond: autoRespond, eventHub: eventHub)
+        }
+
+        // Wire the automations that DO need a terminal / SessionService to act:
+        // crow:auto workspace spawns, auto-respond + conflict hand-off dispatch,
+        // session completion/in-review, auto-cleanup teardown, review auto-kickoff
+        // (CROW-581). Without a cockpit these stay nil and the corresponding paths
+        // are inert no-ops — but auto-merge above keeps working.
         // Serializes review kickoffs (auto-review + the start-review RPC share
         // the internal createReviewSession dedupe; a dedicated serializer keeps a
         // burst of pending review requests from racing duplicate clones).
         let reviewSerializer = ReviewKickoffSerializer()
         if let sessionService {
             await MainActor.run {
-                wireTrackerAutomations(
+                wireTerminalAutomations(
                     tracker: tracker, appState: appState, sessionService: sessionService,
                     autoRespond: autoRespond, devRoot: options.devRoot,
                     reviewSerializer: reviewSerializer, eventHub: eventHub)
             }
         }
+
+        // One durable startup line so "were automations even armed?" is
+        // answerable from the log alone, without a rebuild (CROW-782).
+        let cfg = ConfigStore.loadConfig(devRoot: options.devRoot)
+        CrowLog.automation(
+            "startup: tmux=\(cockpit == nil ? "missing" : "present") "
+            + "terminalAutomations=\(sessionService == nil ? "off" : "on") "
+            + "autoMergeWatcherEnabled=\(cfg?.autoMergeWatcherEnabled ?? false) "
+            + "autoCreateWatcherEnabled=\(cfg?.autoCreateWatcherEnabled ?? false) "
+            + "respondToChangesRequested=\(cfg?.autoRespond.respondToChangesRequested ?? false) "
+            + "autoRebaseAndResolveConflicts=\(cfg?.autoRespond.autoRebaseAndResolveConflicts ?? false)")
 
         // Scheduled jobs (CROW-317) — run them headless too. `JobScheduler.start()`
         // uses a `RunLoop.main` Timer the daemon lacks, so build it here and drive
@@ -524,26 +552,35 @@ public enum CrowDaemon {
         #endif
     }
 
-    /// Wire the IssueTracker's background automation hooks: spawns go to the
-    /// daemon's Manager terminal / SessionService, and the user-facing
-    /// notifications are pushed to connected web clients over `eventHub`
-    /// (CROW-768 — restoring what the retired native NotificationManager did).
-    /// Config-gated behaviors read `{devRoot}/.claude/config.json` fresh each
-    /// poll so Settings edits take effect (CROW-581).
+    /// Wire the terminal-independent half of the automation wiring: the
+    /// config-flag providers, plus the outcome hooks that only need `eventHub` to
+    /// push a user-facing notification to connected web clients (CROW-768 —
+    /// restoring what the retired native NotificationManager did). Each provider
+    /// reads `{devRoot}/.claude/config.json` fresh on every poll so Settings edits
+    /// take effect without a restart (CROW-581).
+    ///
+    /// MUST be called unconditionally, not from inside a `if let sessionService`
+    /// (i.e. tmux-present) branch: a provider left at its `{ false }` default
+    /// disables the whole watcher — `applyAutoMerge`'s first guard — even though
+    /// enabling auto-merge and rebasing a branch need no terminal at all
+    /// (CROW-782). `internal` (not `private`) so `CrowDaemonTests` can assert the
+    /// providers come up armed.
+    ///
+    /// `autoRespond` is optional here precisely because it's nil without tmux: the
+    /// conflict hand-off is then skipped, but the notification still fires.
     @MainActor
-    private static func wireTrackerAutomations(
+    static func wireTrackerAutomations(
         tracker: IssueTracker,
         appState: AppState,
-        sessionService: SessionService,
-        autoRespond: AutoRespondCoordinator?,
         devRoot: String,
-        reviewSerializer: ReviewKickoffSerializer,
-        eventHub: EventHub
+        autoRespond: AutoRespondCoordinator? = nil,
+        eventHub: EventHub? = nil
     ) {
         func config() -> AppConfig? { ConfigStore.loadConfig(devRoot: devRoot) }
         // The tracker's hooks are synchronous; the hub is an actor. Hop off in a
         // detached-from-the-caller Task so a broadcast never blocks a watcher.
         func notify(_ event: NotificationEvent, key: String, title: String, body: String) {
+            guard let eventHub else { return }
             Task { await eventHub.broadcastNotification(event: event, key: key, title: title, body: body) }
         }
         // Name a session for a notification title, as the native manager did.
@@ -551,31 +588,15 @@ public enum CrowDaemon {
             appState.sessions.first(where: { $0.id == id })?.name ?? "session"
         }
 
-        // crow:auto — run /crow-workspace on the Manager for a newly-labeled
-        // assigned issue (the tracker strips the label after, so once-only).
+        // crow:auto — gate only; the dispatch lives in wireTerminalAutomations.
+        // The tracker refuses to strip the label when no handler is wired, so an
+        // armed provider with no Manager terminal can't burn the trigger (#787).
         tracker.autoCreateWatcherEnabledProvider = { (config()?.autoCreateWatcherEnabled ?? false) }
-        tracker.onAutoCreateRequest = { issue in
-            guard let managerTerminal = appState.terminals[AppState.managerSessionID]?.first else {
-                log("crow:auto: Manager terminal not ready; dropped \(issue.url)")
-                return
-            }
-            TerminalRouter.send(managerTerminal, text: "/crow-workspace \(issue.url)\n")
-            // No session exists yet — key the notification on the issue URL.
-            notify(.autoWorkspaceCreated, key: issue.url,
-                   title: "Auto-creating workspace — \(issue.repo)",
-                   body: "#\(issue.number): \(issue.title)")
-        }
 
-        // Auto-respond to PR transitions (changes-requested / checks-failing) and
-        // auto-rebase conflict hand-off — both go through the coordinator, which
-        // pastes the prompt into the session's managed terminal.
-        if let autoRespond {
-            tracker.onPRStatusTransitions = { transitions in
-                autoRespond.handle(transitions)
-            }
-            tracker.respondToChangesRequestedProvider = { (config()?.autoRespond.respondToChangesRequested ?? false) }
-            tracker.autoRebaseAndResolveConflictsProvider = { (config()?.autoRespond.autoRebaseAndResolveConflicts ?? false) }
-        }
+        // Auto-respond / auto-rebase gates. The rebase + force-push itself runs in
+        // the tracker (pure git); only the conflict hand-off needs a terminal.
+        tracker.respondToChangesRequestedProvider = { (config()?.autoRespond.respondToChangesRequested ?? false) }
+        tracker.autoRebaseAndResolveConflictsProvider = { (config()?.autoRespond.autoRebaseAndResolveConflicts ?? false) }
 
         // Auto-rebase outcomes. The conflict hand-off dispatches to the session's
         // agent when a coordinator exists, but the notification fires either way —
@@ -600,14 +621,69 @@ public enum CrowDaemon {
         }
 
         // Auto-merge (enable GitHub native auto-merge on eligible Crow PRs). The
-        // audit line is NSLog'd at the tracker's call site regardless of whether
-        // any client is connected to receive the notification.
+        // audit line goes to the automation log at the tracker's call site
+        // regardless of whether any client is connected to receive the notification.
         tracker.autoMergeWatcherEnabledProvider = { (config()?.autoMergeWatcherEnabled ?? false) }
         tracker.onAutoMergeEnabled = { sessionID, _, number in
             notify(.autoMergeEnabled, key: sessionID.uuidString,
                    title: "Auto-merge enabled — \(sessionName(sessionID))",
                    body: "PR #\(number) will merge once required reviews and checks pass.")
         }
+    }
+
+    /// Wire the automation hooks that need somewhere to act: the daemon's Manager
+    /// terminal, the session's managed terminal, or `SessionService`. Only called
+    /// when the tmux cockpit came up (CROW-581). Notifications for these paths go
+    /// to connected web clients over `eventHub` (CROW-768).
+    @MainActor
+    private static func wireTerminalAutomations(
+        tracker: IssueTracker,
+        appState: AppState,
+        sessionService: SessionService,
+        autoRespond: AutoRespondCoordinator?,
+        devRoot: String,
+        reviewSerializer: ReviewKickoffSerializer,
+        eventHub: EventHub
+    ) {
+        func config() -> AppConfig? { ConfigStore.loadConfig(devRoot: devRoot) }
+        // The tracker's hooks are synchronous; the hub is an actor. Hop off in a
+        // detached-from-the-caller Task so a broadcast never blocks a watcher.
+        func notify(_ event: NotificationEvent, key: String, title: String, body: String) {
+            Task { await eventHub.broadcastNotification(event: event, key: key, title: title, body: body) }
+        }
+        // Name a session for a notification title, as the native manager did.
+        func sessionName(_ id: UUID) -> String {
+            appState.sessions.first(where: { $0.id == id })?.name ?? "session"
+        }
+
+        // crow:auto — run /crow-workspace on the Manager for a newly-labeled
+        // assigned issue (the tracker strips the label after, so once-only).
+        tracker.onAutoCreateRequest = { issue in
+            guard let managerTerminal = appState.terminals[AppState.managerSessionID]?.first else {
+                log("crow:auto: Manager terminal not ready; dropped \(issue.url)")
+                return
+            }
+            TerminalRouter.send(managerTerminal, text: "/crow-workspace \(issue.url)\n")
+            // No session exists yet — key the notification on the issue URL.
+            notify(.autoWorkspaceCreated, key: issue.url,
+                   title: "Auto-creating workspace — \(issue.repo)",
+                   body: "#\(issue.number): \(issue.title)")
+        }
+
+        // Auto-respond to PR transitions (changes-requested / checks-failing) and
+        // auto-rebase conflict hand-off — both go through the coordinator, which
+        // pastes the prompt into the session's managed terminal.
+        if let autoRespond {
+            tracker.onPRStatusTransitions = { transitions in
+                autoRespond.handle(transitions)
+            }
+        }
+        // Note: the auto-rebase/auto-merge OUTCOME hooks (onAutoRebasePushed,
+        // onAutoRebaseConflicts, onAutoMergeEnabled) and the config-flag providers
+        // are wired in `wireTrackerAutomations` instead — they need only `eventHub`
+        // (and, for the conflict hand-off, an optional coordinator), so gating them
+        // on tmux would silence notifications for automations that still run
+        // (CROW-768 + CROW-782).
 
         // Auto-complete on merge/close, and auto-move-to-inReview when a
         // session's PR opens, run INSIDE the tracker's own refresh via these

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/TrackerAutomationWiringTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/TrackerAutomationWiringTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowEngine
+import CrowPersistence
+import CrowProvider
+@testable import CrowDaemon
+
+/// CROW-782 — the terminal-independent automation providers must come up armed
+/// whenever `crowd` runs. They used to be wired inside the daemon's
+/// `if let sessionService` (tmux-present) branch, so a daemon started without
+/// tmux on its PATH left every provider at its `{ false }` default and silently
+/// disabled auto-merge, auto-respond, auto-rebase and crow:auto at once.
+@Suite("Daemon tracker automation wiring (tmux-independent)")
+struct TrackerAutomationWiringTests {
+
+    /// A temp devRoot with `.claude/config.json` written from `config`.
+    private func makeDevRoot(_ config: AppConfig) throws -> String {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-test-devroot-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try ConfigStore.saveConfig(config, devRoot: root.path)
+        return root.path
+    }
+
+    @MainActor
+    private func makeTracker(appState: AppState) -> IssueTracker {
+        IssueTracker(appState: appState, providerManager: ProviderManager(), store: .temporary())
+    }
+
+    @Test @MainActor func providersReflectEnabledConfigWithoutASessionService() throws {
+        var config = AppConfig()
+        config.autoMergeWatcherEnabled = true
+        config.autoCreateWatcherEnabled = true
+        config.autoRespond.respondToChangesRequested = true
+        config.autoRespond.autoRebaseAndResolveConflicts = true
+        let devRoot = try makeDevRoot(config)
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let appState = AppState()
+        let tracker = makeTracker(appState: appState)
+        // No SessionService, no cockpit — exactly the no-tmux daemon.
+        CrowDaemon.wireTrackerAutomations(tracker: tracker, appState: appState, devRoot: devRoot)
+
+        #expect(tracker.autoMergeWatcherEnabledProvider())
+        #expect(tracker.autoCreateWatcherEnabledProvider())
+        #expect(tracker.respondToChangesRequestedProvider())
+        #expect(tracker.autoRebaseAndResolveConflictsProvider())
+    }
+
+    @Test @MainActor func providersReflectDisabledConfig() throws {
+        var config = AppConfig()
+        config.autoMergeWatcherEnabled = false
+        config.autoCreateWatcherEnabled = false
+        // `respondToChangesRequested` ships on by default, so opt out explicitly.
+        config.autoRespond.respondToChangesRequested = false
+        config.autoRespond.autoRebaseAndResolveConflicts = false
+        let devRoot = try makeDevRoot(config)
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let appState = AppState()
+        let tracker = makeTracker(appState: appState)
+        CrowDaemon.wireTrackerAutomations(tracker: tracker, appState: appState, devRoot: devRoot)
+
+        #expect(!tracker.autoMergeWatcherEnabledProvider())
+        #expect(!tracker.autoCreateWatcherEnabledProvider())
+        #expect(!tracker.respondToChangesRequestedProvider())
+        #expect(!tracker.autoRebaseAndResolveConflictsProvider())
+    }
+
+    @Test @MainActor func providersRereadConfigOnEveryCall() throws {
+        var config = AppConfig()
+        config.autoMergeWatcherEnabled = false
+        let devRoot = try makeDevRoot(config)
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let appState = AppState()
+        let tracker = makeTracker(appState: appState)
+        CrowDaemon.wireTrackerAutomations(tracker: tracker, appState: appState, devRoot: devRoot)
+        #expect(!tracker.autoMergeWatcherEnabledProvider())
+
+        // Toggling the setting takes effect on the next poll — no daemon restart.
+        config.autoMergeWatcherEnabled = true
+        try ConfigStore.saveConfig(config, devRoot: devRoot)
+        #expect(tracker.autoMergeWatcherEnabledProvider())
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -148,6 +148,11 @@ public final class IssueTracker {
     /// persisted, which the gating guard checks first.
     private var autoMergeInFlight: Set<String> = []
 
+    /// Last time we logged "auto-merge watcher disabled" to the automation log.
+    /// Rate-limits that line to hourly so a deliberately-off watcher doesn't
+    /// bury the interesting entries at one line per 60s poll (CROW-782).
+    private var lastAutoMergeDisabledLogAt: Date?
+
     /// Per-head-commit guard for `gh pr update-branch`. Keyed
     /// `"<url>\n<headRefOid>"` so a PR that is `BEHIND` its base gets exactly
     /// one update attempt per head state — a successful update adds a merge
@@ -1749,12 +1754,11 @@ public final class IssueTracker {
                     failedCheckNames: [],
                     isCooldownReFire: isCooldownReFire
                 ))
-                NSLog("[IssueTracker] needs-refine fired — session=%@, sha=%@, lastCR=%@, lastCommit=%@, reFire=%@",
-                      session.id.uuidString as NSString,
-                      (newStatus.headSha ?? "") as NSString,
-                      Self.iso(newStatus.lastChangesRequestedAt) as NSString,
-                      Self.iso(newStatus.lastSubstantiveCommitAt) as NSString,
-                      (isCooldownReFire ? "yes" : "no") as NSString)
+                CrowLog.automation(
+                    "auto-respond: needs-refine fired — session=\(session.id.uuidString), "
+                    + "sha=\(newStatus.headSha ?? ""), lastCR=\(Self.iso(newStatus.lastChangesRequestedAt)), "
+                    + "lastCommit=\(Self.iso(newStatus.lastSubstantiveCommitAt)), "
+                    + "reFire=\(isCooldownReFire ? "yes" : "no")")
             }
             seenPRs.insert(prLink.url)
 
@@ -1846,13 +1850,36 @@ public final class IssueTracker {
     /// - the `crow:merge` label is absent
     /// - the PR is in CONFLICTING or CHANGES_REQUESTED state
     nonisolated static func shouldAttemptAutoMerge(pr: ViewerPR, session: Session) -> Bool {
-        guard session.autoMergeEnabledAt == nil else { return false }
-        guard pr.state == "OPEN" else { return false }
-        guard !pr.isDraft else { return false }
-        guard pr.labels.contains(where: { $0.name.caseInsensitiveCompare(autoMergeLabel) == .orderedSame }) else { return false }
-        guard pr.mergeable != "CONFLICTING" else { return false }
-        guard pr.reviewDecision != "CHANGES_REQUESTED" else { return false }
-        return true
+        autoMergeSkipReason(pr: pr, session: session) == nil
+    }
+
+    /// Why `pr` is not an auto-merge candidate, or `nil` when it is one.
+    ///
+    /// The reason exists so a skip leaves a trace: `shouldAttemptAutoMerge`
+    /// used to collapse six distinct guards into a bare `false`, which is why
+    /// "why wasn't this PR merged?" was unanswerable after the fact (CROW-782).
+    /// `applyAutoMerge` logs the reason per PR each poll; the boolean helper
+    /// above is derived from this one so the two can never disagree.
+    ///
+    /// Raw values are the strings that land in the automation log — keep them
+    /// stable enough to grep for.
+    enum AutoMergeSkipReason: String {
+        case alreadyEnabled = "already-enabled"
+        case notOpen = "not-open"
+        case draft = "draft"
+        case noMergeLabel = "no-crow-merge-label"
+        case conflicting = "conflicting"
+        case changesRequested = "changes-requested"
+    }
+
+    nonisolated static func autoMergeSkipReason(pr: ViewerPR, session: Session) -> AutoMergeSkipReason? {
+        guard session.autoMergeEnabledAt == nil else { return .alreadyEnabled }
+        guard pr.state == "OPEN" else { return .notOpen }
+        guard !pr.isDraft else { return .draft }
+        guard pr.labels.contains(where: { $0.name.caseInsensitiveCompare(autoMergeLabel) == .orderedSame }) else { return .noMergeLabel }
+        guard pr.mergeable != "CONFLICTING" else { return .conflicting }
+        guard pr.reviewDecision != "CHANGES_REQUESTED" else { return .changesRequested }
+        return nil
     }
 
     /// True when `gh pr merge --auto` failed for a permanent repo/policy
@@ -2346,15 +2373,40 @@ public final class IssueTracker {
     /// kicks off the async enable flow once each. No-op when the global
     /// `autoMergeWatcherEnabled` setting is off.
     private func applyAutoMerge(viewerPRs: [ViewerPR]) {
-        guard autoMergeWatcherEnabledProvider() else { return }
-        guard !viewerPRs.isEmpty else { return }
+        guard autoMergeWatcherEnabledProvider() else {
+            // Durable, not silent: this exact early return is how the tmux-gated
+            // wiring regression went dark for weeks (CROW-782). Rate-limited to
+            // once per hour so an intentionally-disabled watcher doesn't spam.
+            logAutoMergeDisabledIfDue()
+            return
+        }
+        guard !viewerPRs.isEmpty else {
+            CrowLog.automation("auto-merge: no viewer PRs in this poll's fetch — nothing to evaluate")
+            return
+        }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
+
+        var enabledCount = 0
+        var updateBranchCount = 0
+        var skips: [String] = []
 
         for session in appState.sessions where !session.isManager {
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
-            guard !autoMergeInFlight.contains(prLink.url) else { continue }
-            guard let pr = byURL[prLink.url] else { continue }
-            guard Self.shouldAttemptAutoMerge(pr: pr, session: session) else { continue }
+            guard !autoMergeInFlight.contains(prLink.url) else {
+                skips.append("\(prLink.url):in-flight")
+                continue
+            }
+            guard let pr = byURL[prLink.url] else {
+                // The PR is linked to a live session but absent from the
+                // viewer-PR fetch — a fetch/scope problem, not an eligibility
+                // one, and invisible before CROW-782.
+                skips.append("\(prLink.url):not-in-viewer-prs")
+                continue
+            }
+            if let reason = Self.autoMergeSkipReason(pr: pr, session: session) {
+                skips.append("#\(pr.number):\(reason.rawValue)")
+                continue
+            }
 
             let capturedSession = session
             if Self.shouldUpdateBranchBeforeMerge(pr: pr, session: session) {
@@ -2362,15 +2414,39 @@ public final class IssueTracker {
                 // of merging. One attempt per head commit (loop safety); the
                 // next poll re-evaluates once GitHub recomputes mergeability.
                 let key = "\(prLink.url)\n\(pr.headRefOid)"
-                guard !autoUpdateBranchAttempted.contains(key) else { continue }
+                guard !autoUpdateBranchAttempted.contains(key) else {
+                    skips.append("#\(pr.number):update-branch-already-attempted-for-head")
+                    continue
+                }
                 autoUpdateBranchAttempted.insert(key)
                 autoMergeInFlight.insert(prLink.url)
+                updateBranchCount += 1
                 Task { await self.attemptUpdateBranch(session: capturedSession, pr: pr) }
             } else {
                 autoMergeInFlight.insert(prLink.url)
+                enabledCount += 1
                 Task { await self.attemptEnableAutoMerge(session: capturedSession, pr: pr) }
             }
         }
+
+        // One line per poll, always — an empty candidate set is itself the
+        // answer to "why didn't my PR merge?" (CROW-782).
+        let skipDetail = skips.isEmpty ? "" : " [\(skips.joined(separator: ", "))]"
+        CrowLog.automation(
+            "auto-merge: dispatched=\(enabledCount) updateBranch=\(updateBranchCount) "
+            + "skipped=\(skips.count)\(skipDetail)")
+    }
+
+    /// Emit the "watcher disabled" line at most once an hour. `nil` until the
+    /// first emission, so a daemon that starts with the watcher off says so
+    /// immediately.
+    private func logAutoMergeDisabledIfDue() {
+        let now = Date()
+        if let last = lastAutoMergeDisabledLogAt, now.timeIntervalSince(last) < 3600 { return }
+        lastAutoMergeDisabledLogAt = now
+        CrowLog.automation(
+            "auto-merge: skipped entirely — autoMergeWatcherEnabledProvider() is false "
+            + "(config `autoMergeWatcherEnabled` off, or the provider was never wired)")
     }
 
     /// Resolve the `CodeBackend` for a session's PR/merge actions, following the
@@ -2393,8 +2469,7 @@ public final class IssueTracker {
             return
         }
         guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
-            NSLog("[Crow] crow:merge ignored on %@ — no Crow-Session trailer matching a known session",
-                  pr.url as NSString)
+            CrowLog.automation("auto-merge: #\(pr.number) ignored — no Crow-Session trailer matching a known session")
             return
         }
 
@@ -2403,6 +2478,7 @@ public final class IssueTracker {
         guard backend.capabilities.contains(.autoMerge) else {
             // Capability gate: don't even try if the backend can't enable auto-merge.
             autoMergeInFlight.remove(pr.url)
+            CrowLog.automation("auto-merge: #\(pr.number) skipped — backend lacks the autoMerge capability")
             return
         }
         do {
@@ -2421,19 +2497,20 @@ public final class IssueTracker {
                     data.sessions[idx].updatedAt = now
                 }
             }
-            NSLog("[Crow] Auto-merge enabled on %@ (session %@, squash)",
-                  pr.url as NSString, session.id.uuidString as NSString)
+            CrowLog.automation("auto-merge: ENABLED on \(pr.url) (session \(session.id.uuidString), squash)")
             onAutoMergeEnabled?(session.id, pr.url, pr.number)
         } catch {
             if Self.isPermanentAutoMergeFailure(error) {
                 // Leave `autoMergeInFlight` set so subsequent polls skip this
                 // PR instead of re-logging a permanent repo policy failure.
-                NSLog("[Crow] enableAutoMerge skipped for %@ (auto-merge not allowed on repo): %@",
-                      pr.url as NSString, error.localizedDescription as NSString)
+                CrowLog.automation(
+                    "auto-merge: #\(pr.number) permanently skipped (auto-merge not allowed on repo): "
+                    + error.localizedDescription)
             } else {
                 autoMergeInFlight.remove(pr.url)
-                NSLog("[Crow] enableAutoMerge failed for %@: %@",
-                      pr.url as NSString, error.localizedDescription as NSString)
+                CrowLog.automation(
+                    "auto-merge: #\(pr.number) enableAutoMerge failed (will retry next poll): "
+                    + error.localizedDescription)
             }
         }
     }
@@ -2534,6 +2611,7 @@ public final class IssueTracker {
         guard !viewerPRs.isEmpty else { return }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
+        var dispatched = 0
         for session in appState.sessions where Self.sessionEligibleForAutoRebase(session) {
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
             guard !autoRebaseInFlight.contains(prLink.url) else { continue }
@@ -2554,8 +2632,13 @@ public final class IssueTracker {
             guard !autoRebaseAttempted.contains(key) else { continue }
             autoRebaseAttempted.insert(key)
             autoRebaseInFlight.insert(prLink.url)
+            dispatched += 1
+            CrowLog.automation("auto-rebase: dispatched #\(pr.number) (\(pr.mergeStateStatus), mergeable=\(pr.mergeable))")
             let capturedSession = session
             Task { await self.attemptRebase(session: capturedSession, pr: pr) }
+        }
+        if dispatched == 0 {
+            CrowLog.automation("auto-rebase: enabled, no candidates this poll")
         }
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -153,6 +153,21 @@ public final class IssueTracker {
     /// bury the interesting entries at one line per 60s poll (CROW-782).
     private var lastAutoMergeDisabledLogAt: Date?
 
+    /// Same hourly rate-limit for the two other steady-state "nothing happened"
+    /// lines — an idle auto-rebase watcher and `crow:auto` issues with no
+    /// handler to dispatch them. At one line per 60s poll they'd rotate the
+    /// interesting entries out of the log (review #787).
+    private var lastAutoRebaseIdleLogAt: Date?
+    private var lastAutoCreateUndispatchableLogAt: Date?
+
+    /// Why we permanently stopped trying to auto-merge a PR, keyed by PR URL.
+    /// `autoMergeInFlight` is deliberately left set for permanent outcomes (repo
+    /// disallows auto-merge, no Crow-Session trailer) so the failure isn't
+    /// re-logged every poll — but then the per-poll summary would report a bare
+    /// `in-flight` forever instead of the real reason. Recording it here keeps
+    /// the summary honest (review #787).
+    private var autoMergePermanentSkips: [String: String] = [:]
+
     /// Per-head-commit guard for `gh pr update-branch`. Keyed
     /// `"<url>\n<headRefOid>"` so a PR that is `BEHIND` its base gets exactly
     /// one update attempt per head state — a successful update adds a merge
@@ -638,8 +653,19 @@ public final class IssueTracker {
     /// No-op when the global `autoCreateWatcherEnabled` setting is off
     /// (CROW-312). The label is intentionally left in place while disabled
     /// so a later opt-in still picks up the issue on the next poll.
+    ///
+    /// Also a no-op when no `onAutoCreateRequest` handler is wired: since
+    /// CROW-782 the *provider* is armed even on a daemon with no tmux (and so no
+    /// Manager terminal to spawn into), and dispatching into a nil callback here
+    /// would strip `crow:auto` anyway — permanently burning the one-shot trigger
+    /// for a workspace that was never created (review #787). Same contract as
+    /// the disabled case: leave the label, pick it up once a host can act.
     private func detectAutoCreateCandidates(issues: [AssignedIssue]) {
-        guard autoCreateWatcherEnabledProvider() else { return }
+        guard Self.canRunAutoCreate(enabled: autoCreateWatcherEnabledProvider(),
+                                    hasHandler: onAutoCreateRequest != nil) else {
+            if autoCreateWatcherEnabledProvider() { logAutoCreateUndispatchableIfDue(issues: issues) }
+            return
+        }
         // Purge in-flight URLs that now have an active session — the dispatch
         // succeeded and the set can shrink.
         if !autoCreateInFlight.isEmpty {
@@ -662,6 +688,33 @@ public final class IssueTracker {
             onAutoCreateRequest?(issue)
             Task { [weak self] in await self?.removeAutoCreateLabel(from: issue) }
         }
+    }
+
+    /// Whether the auto-create sweep may run — i.e. whether stripping `crow:auto`
+    /// (which the sweep always does after dispatch) is justified. Requires BOTH
+    /// the config opt-in AND a wired handler: dispatching into a nil callback
+    /// still burns the one-shot label without creating anything (review #787).
+    /// Pure so the rule is unit-testable without an `IssueTracker`.
+    nonisolated static func canRunAutoCreate(enabled: Bool, hasHandler: Bool) -> Bool {
+        enabled && hasHandler
+    }
+
+    /// Say (hourly at most) that `crow:auto` issues are waiting but nothing can
+    /// act on them — the enabled-but-undispatchable state a no-tmux daemon is in.
+    /// Silent when there's nothing labeled, so a normal headless daemon with no
+    /// pending auto-create work doesn't log at all.
+    private func logAutoCreateUndispatchableIfDue(issues: [AssignedIssue]) {
+        let waiting = issues.filter { issue in
+            issue.state == "open"
+                && issue.labels.contains { $0.name.caseInsensitiveCompare(Self.autoCreateLabel) == .orderedSame }
+        }
+        guard !waiting.isEmpty else { return }
+        let now = Date()
+        if let last = lastAutoCreateUndispatchableLogAt, now.timeIntervalSince(last) < 3600 { return }
+        lastAutoCreateUndispatchableLogAt = now
+        CrowLog.automation(
+            "crow:auto: \(waiting.count) labeled issue(s) waiting but no onAutoCreateRequest handler is "
+            + "wired (no Manager terminal — is tmux available?); leaving the label in place")
     }
 
     /// Best-effort removal of the auto-create label. Failure is logged and
@@ -2393,7 +2446,9 @@ public final class IssueTracker {
         for session in appState.sessions where !session.isManager {
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
             guard !autoMergeInFlight.contains(prLink.url) else {
-                skips.append("\(prLink.url):in-flight")
+                // A permanent outcome keeps its marker set on purpose — report
+                // the reason it stopped, not the bare marker (review #787).
+                skips.append("\(prLink.url):\(autoMergePermanentSkips[prLink.url] ?? "in-flight")")
                 continue
             }
             guard let pr = byURL[prLink.url] else {
@@ -2469,6 +2524,9 @@ public final class IssueTracker {
             return
         }
         guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
+            // Leaves `autoMergeInFlight` set (one log line, not one per poll);
+            // record why so the summary doesn't just say "in-flight" forever.
+            autoMergePermanentSkips[pr.url] = "no-crow-session-trailer"
             CrowLog.automation("auto-merge: #\(pr.number) ignored — no Crow-Session trailer matching a known session")
             return
         }
@@ -2476,8 +2534,12 @@ public final class IssueTracker {
         await ensureMergeLabel(repo: pr.repoNameWithOwner, backend: backend)
 
         guard backend.capabilities.contains(.autoMerge) else {
-            // Capability gate: don't even try if the backend can't enable auto-merge.
-            autoMergeInFlight.remove(pr.url)
+            // Capability gate: don't even try if the backend can't enable
+            // auto-merge. A backend's capability set is static, so this is
+            // permanent — keep the in-flight marker (with its reason) rather
+            // than clearing it and re-running the authorship commit fetch, and
+            // re-logging, on every 60s poll (review #787).
+            autoMergePermanentSkips[pr.url] = "backend-lacks-auto-merge-capability"
             CrowLog.automation("auto-merge: #\(pr.number) skipped — backend lacks the autoMerge capability")
             return
         }
@@ -2503,11 +2565,13 @@ public final class IssueTracker {
             if Self.isPermanentAutoMergeFailure(error) {
                 // Leave `autoMergeInFlight` set so subsequent polls skip this
                 // PR instead of re-logging a permanent repo policy failure.
+                autoMergePermanentSkips[pr.url] = "repo-disallows-auto-merge"
                 CrowLog.automation(
                     "auto-merge: #\(pr.number) permanently skipped (auto-merge not allowed on repo): "
                     + error.localizedDescription)
             } else {
                 autoMergeInFlight.remove(pr.url)
+                autoMergePermanentSkips[pr.url] = nil
                 CrowLog.automation(
                     "auto-merge: #\(pr.number) enableAutoMerge failed (will retry next poll): "
                     + error.localizedDescription)
@@ -2527,20 +2591,22 @@ public final class IssueTracker {
     private func attemptUpdateBranch(session: Session, pr: ViewerPR) async {
         guard let backend = codeBackend(for: session) else { return }
         guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
-            NSLog("[Crow] crow:merge update-branch skipped on %@ — no Crow-Session trailer matching a known session",
-                  pr.url as NSString)
+            CrowLog.automation(
+                "auto-merge: #\(pr.number) update-branch skipped — no Crow-Session trailer matching a known session")
             return
         }
 
         defer { autoMergeInFlight.remove(pr.url) }
-        guard backend.capabilities.contains(.updateBranch) else { return }
+        guard backend.capabilities.contains(.updateBranch) else {
+            CrowLog.automation("auto-merge: #\(pr.number) update-branch skipped — backend lacks the updateBranch capability")
+            return
+        }
         do {
             try await backend.updateBranch(prURL: pr.url)
-            NSLog("[Crow] Updated branch for %@ (session %@, was BEHIND base)",
-                  pr.url as NSString, session.id.uuidString as NSString)
+            CrowLog.automation(
+                "auto-merge: #\(pr.number) branch updated from base (session \(session.id.uuidString), was BEHIND)")
         } catch {
-            NSLog("[Crow] updateBranch failed for %@: %@",
-                  pr.url as NSString, error.localizedDescription as NSString)
+            CrowLog.automation("auto-merge: #\(pr.number) updateBranch failed: \(error.localizedDescription)")
         }
     }
 
@@ -2638,7 +2704,17 @@ public final class IssueTracker {
             Task { await self.attemptRebase(session: capturedSession, pr: pr) }
         }
         if dispatched == 0 {
-            CrowLog.automation("auto-rebase: enabled, no candidates this poll")
+            // Hourly, not per-poll: an idle-but-enabled watcher is the steady
+            // state, and one line per 60s would rotate the interesting entries
+            // out of the log (review #787).
+            let now = Date()
+            if lastAutoRebaseIdleLogAt.map({ now.timeIntervalSince($0) >= 3600 }) ?? true {
+                lastAutoRebaseIdleLogAt = now
+                CrowLog.automation("auto-rebase: enabled, no candidates this poll")
+            }
+        } else {
+            // A live dispatch means the next idle stretch is worth reporting.
+            lastAutoRebaseIdleLogAt = nil
         }
     }
 

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
@@ -161,6 +161,18 @@ struct IssueTrackerAutoMergeTests {
         #expect(IssueTracker.AutoMergeSkipReason.changesRequested.rawValue == "changes-requested")
     }
 
+    // MARK: - canRunAutoCreate (review #787 — never burn crow:auto with no handler)
+
+    @Test func autoCreateRunsOnlyWhenEnabledAndDispatchable() {
+        #expect(IssueTracker.canRunAutoCreate(enabled: true, hasHandler: true))
+        // Enabled but no handler: the sweep would strip `crow:auto` after
+        // dispatching into nil, permanently burning the one-shot trigger on a
+        // daemon that never created a workspace. The label must survive.
+        #expect(!IssueTracker.canRunAutoCreate(enabled: true, hasHandler: false))
+        #expect(!IssueTracker.canRunAutoCreate(enabled: false, hasHandler: true))
+        #expect(!IssueTracker.canRunAutoCreate(enabled: false, hasHandler: false))
+    }
+
     // MARK: - shouldUpdateBranchBeforeMerge (BEHIND base)
 
     @Test func updatesBranchWhenBehindBase() {

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
@@ -110,6 +110,57 @@ struct IssueTrackerAutoMergeTests {
         #expect(IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
     }
 
+    // MARK: - autoMergeSkipReason (CROW-782 — skips must name themselves)
+
+    @Test func skipReasonIsNilForAnEligiblePR() {
+        #expect(IssueTracker.autoMergeSkipReason(pr: makePR(), session: makeSession()) == nil)
+    }
+
+    @Test func skipReasonNamesEachGuard() {
+        let cases: [(IssueTracker.ViewerPR, Session, IssueTracker.AutoMergeSkipReason)] = [
+            (makePR(), makeSession(autoMergeEnabledAt: Date()), .alreadyEnabled),
+            (makePR(state: "CLOSED"), makeSession(), .notOpen),
+            (makePR(isDraft: true), makeSession(), .draft),
+            (makePR(labels: [Self.otherLabel]), makeSession(), .noMergeLabel),
+            (makePR(mergeable: "CONFLICTING"), makeSession(), .conflicting),
+            (makePR(reviewDecision: "CHANGES_REQUESTED"), makeSession(), .changesRequested),
+        ]
+        for (pr, session, expected) in cases {
+            #expect(IssueTracker.autoMergeSkipReason(pr: pr, session: session) == expected)
+        }
+    }
+
+    @Test func skipReasonAgreesWithShouldAttemptAutoMerge() {
+        // The boolean helper is derived from the reason, so every fixture must
+        // agree — otherwise the log would name a reason for a PR we still merge.
+        let fixtures: [(IssueTracker.ViewerPR, Session)] = [
+            (makePR(), makeSession()),
+            (makePR(), makeSession(autoMergeEnabledAt: Date())),
+            (makePR(state: "MERGED"), makeSession()),
+            (makePR(isDraft: true), makeSession()),
+            (makePR(labels: []), makeSession()),
+            (makePR(mergeable: "CONFLICTING"), makeSession()),
+            (makePR(reviewDecision: "CHANGES_REQUESTED"), makeSession()),
+            (makePR(reviewDecision: ""), makeSession()),
+            (makePR(mergeStateStatus: "BEHIND"), makeSession()),
+        ]
+        for (pr, session) in fixtures {
+            #expect(IssueTracker.shouldAttemptAutoMerge(pr: pr, session: session)
+                    == (IssueTracker.autoMergeSkipReason(pr: pr, session: session) == nil))
+        }
+    }
+
+    @Test func skipReasonRawValuesAreStableForGrepping() {
+        // These strings land in ~/Library/Logs/crow/crowd-automation.log and are
+        // what a future investigation greps for — pin them.
+        #expect(IssueTracker.AutoMergeSkipReason.alreadyEnabled.rawValue == "already-enabled")
+        #expect(IssueTracker.AutoMergeSkipReason.notOpen.rawValue == "not-open")
+        #expect(IssueTracker.AutoMergeSkipReason.draft.rawValue == "draft")
+        #expect(IssueTracker.AutoMergeSkipReason.noMergeLabel.rawValue == "no-crow-merge-label")
+        #expect(IssueTracker.AutoMergeSkipReason.conflicting.rawValue == "conflicting")
+        #expect(IssueTracker.AutoMergeSkipReason.changesRequested.rawValue == "changes-requested")
+    }
+
     // MARK: - shouldUpdateBranchBeforeMerge (BEHIND base)
 
     @Test func updatesBranchWhenBehindBase() {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,7 @@
 | Sidebar status dot stuck gray                            | Terminal never initialized — click the session tab to trigger `createSurface()` |
 | Sidebar status dot stuck yellow                          | Shell is spawning but the probe file never appeared. Check `[TerminalManager]` logs for shell-startup errors |
 | Auto-respond didn't fire on a failed CI run              | Toggle is at **Settings → Automation → Auto-respond**, off by default. The session must have an active Claude Code terminal that `TerminalRouter.canSend` accepts; a torn-down terminal won't receive the prompt. See [automation.md](automation.md) for full coverage. |
+| Auto-merge never enables on a `crow:merge` PR            | Check `~/Library/Logs/crow/crowd-automation.log` — every poll writes an `auto-merge:` line naming each candidate and its skip reason (`no-crow-merge-label`, `changes-requested`, `not-in-viewer-prs`, …). A `skipped entirely — autoMergeWatcherEnabledProvider() is false` line means the watcher is off in Settings. Before #782, a `crowd` started without tmux on its PATH disabled every automation silently; the `startup:` line in that log now records whether tmux was found. |
 | Sidebar shows "working" forever after a `※ recap:` line  | The Claude Code session recap (`awaySummaryEnabled`, on by default in v2.1.108+) fires hook events after a turn's `Stop`. Crow now ignores those — if you're on an older build, disable the recap by setting `"awaySummaryEnabled": false` in `~/.claude/settings.json`, toggling "Session recap" off via `/config` inside Claude Code, or exporting `CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0`. |
 
 ## Debugging
@@ -50,6 +51,21 @@ Filter for scope / auth errors while you're iterating on `gh` permissions:
 ```bash
 .build/debug/crowd 2>&1 | grep '\[IssueTracker\]'
 ```
+
+### Automation log
+
+Background-automation decisions (auto-merge, auto-rebase, auto-respond) are also
+written to a durable, rotating file so a skip is diagnosable after the fact —
+stderr is not retained across daemon restarts (#782):
+
+```bash
+tail -f ~/Library/Logs/crow/crowd-automation.log
+grep 'auto-merge' ~/Library/Logs/crow/crowd-automation.log | tail -20
+```
+
+Each poll emits one `auto-merge:` summary (`dispatched=… updateBranch=… skipped=…`
+with a per-PR reason list), plus a `startup:` line recording whether tmux was found
+and which automation flags were armed. The file rotates to `…log.1` past 5 MB.
 
 ## Unsigned Builds
 


### PR DESCRIPTION
Closes #782

## The regression

`wireTrackerAutomations(...)` wires **every** `IssueTracker` automation, but it was only called from
inside `if let sessionService {` (`CrowDaemon.swift:171`), and `sessionService` is `nil` whenever the
tmux cockpit fails to build (`guard let cockpit else { return (nil, nil) }`, `:138` — cockpit is nil when
tmux ≥3.3 isn't on the daemon's PATH).

So a `crowd` started without tmux left every provider at its `{ false }` default
(`IssueTracker.swift:66, 73, 86, 94`), and `applyAutoMerge` bailed on its first line —
`guard autoMergeWatcherEnabledProvider() else { return }` — on every 60s poll. Auto-merge, auto-respond,
auto-rebase and `crow:auto` all went dark together, with no log line. That matches the report: PR #775
passed every static eligibility gate yet `autoMergeRequest` stayed `null`.

Enabling GitHub native auto-merge is a pure `gh`/GraphQL call and auto-rebase is pure git — neither has a
terminal dependency. The retired `AppDelegate` wired them unconditionally; the daemon-side
reimplementation bundled them behind the tmux gate.

## The fix

Split the wiring in two:

- **`wireTrackerAutomations(tracker:devRoot:)`** — the config-flag providers only
  (`autoMergeWatcherEnabled`, `autoCreateWatcherEnabled`, `respondToChangesRequested`,
  `autoRebaseAndResolveConflicts`). Called **unconditionally**, whenever `crowd` runs.
- **`wireTerminalAutomations(...)`** — the callbacks that need a terminal or `SessionService`
  (`crow:auto` dispatch, auto-respond + conflict hand-off, `onCompleteSession`/`onSetSessionInReview`,
  auto-cleanup teardown, review auto-kickoff). Still gated on the cockpit.

With a provider armed but no dispatch target, those paths are inert no-ops — strictly better than today's
"all automations off".

## Observability (the other half of the ticket)

Debugging this was blocked by the daemon not durably logging its automation decisions.

- New **`CrowLog`** (CrowCore): `NSLock`-serialized, size-capped (5 MB, one rotation) appender at
  `~/Library/Logs/crow/crowd-automation.log`, mirrored to `NSLog`. Per ADR 0012 it resolves to a temp
  directory under a test process, so the suite never writes to the real log.
- **`IssueTracker.autoMergeSkipReason`** turns each of the six previously-silent `shouldAttemptAutoMerge`
  guards into a named reason (`already-enabled`, `not-open`, `draft`, `no-crow-merge-label`,
  `conflicting`, `changes-requested`). `shouldAttemptAutoMerge` is now derived from it, so the boolean and
  the logged reason can never disagree.
- **`applyAutoMerge` logs one line per poll**:
  `auto-merge: dispatched=1 updateBranch=0 skipped=2 [#775:changes-requested, https://…/pull/9:not-in-viewer-prs]`
  — including the loop-level skips the pure helper can't see. `not-in-viewer-prs` is exactly the
  "under-populated `ViewerPR`" alternative cause the ticket asked to rule out. The disabled-watcher early
  return now logs (hourly rate-limited) instead of returning silently.
- Auto-rebase, needs-refine, and the auto-merge enable/permanent-failure/transient-failure paths log there too.
- The daemon writes a `startup:` line recording tmux presence, whether terminal automations were wired, and
  each automation flag's value — so "were automations even armed?" is answerable from the log alone.

## Tests

- `IssueTrackerAutoMergeTests`: a case per skip reason, an agreement check between `shouldAttemptAutoMerge`
  and `autoMergeSkipReason` across nine fixtures, and pinned raw values (they're what you grep for).
- `CrowLogTests` (new): append + timestamp format, `fileURL` under the configured directory, rotation to a
  single `.1` generation, and the ADR 0012 test-directory fallback.
- `TrackerAutomationWiringTests` (new, CrowDaemon): the providers come up armed from config **with no
  `SessionService`** — the no-tmux daemon — and re-read config on every call.

`make test` is green except a pre-existing `TmuxBackend integration` failure
(`retryReadinessEmitsTimedOutWhenSentinelMissing`), which fails identically on a stashed clean tree.

## Verifying on a live daemon

Not done here (this branch is tests + build only). After merge:

```bash
swift build --product crowd
# restart your crowd, then:
tail -f ~/Library/Logs/crow/crowd-automation.log
gh pr view 775 --json autoMergeRequest
```

The `startup:` line should show the flags armed, and each poll an `auto-merge:` summary naming #775 and
either dispatching it or saying exactly why not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MveHKNbDCnuuFrnsiKhrAg
