### PR TITLE
Restore sidebar row PR status icons + crow:merge indicator (CROW-773)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/PRStatus.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRStatus.swift
@@ -26,6 +26,12 @@ public struct PRStatus: Codable, Sendable, Equatable {
     /// the stateless rule to know whether the author has substantively
     /// responded since the latest CHANGES_REQUESTED review.
     public var lastSubstantiveCommitAt: Date?
+    /// Whether the PR currently carries the `crow:merge` auto-merge label
+    /// (`IssueTracker.autoMergeLabel`). Distinct from
+    /// `Session.autoMergeEnabledAt`, which records that Crow has already
+    /// *enabled* GitHub auto-merge: the label is the request, the timestamp is
+    /// the action. The UI shows them as separate indicators (CROW-773).
+    public var hasMergeLabel: Bool
 
     public init(
         checksPass: CheckStatus = .unknown,
@@ -35,7 +41,8 @@ public struct PRStatus: Codable, Sendable, Equatable {
         headSha: String? = nil,
         isOpen: Bool = true,
         lastChangesRequestedAt: Date? = nil,
-        lastSubstantiveCommitAt: Date? = nil
+        lastSubstantiveCommitAt: Date? = nil,
+        hasMergeLabel: Bool = false
     ) {
         self.checksPass = checksPass
         self.reviewStatus = reviewStatus
@@ -45,6 +52,7 @@ public struct PRStatus: Codable, Sendable, Equatable {
         self.isOpen = isOpen
         self.lastChangesRequestedAt = lastChangesRequestedAt
         self.lastSubstantiveCommitAt = lastSubstantiveCommitAt
+        self.hasMergeLabel = hasMergeLabel
     }
 
     public init(from decoder: Decoder) throws {
@@ -57,11 +65,12 @@ public struct PRStatus: Codable, Sendable, Equatable {
         isOpen = try c.decodeIfPresent(Bool.self, forKey: .isOpen) ?? true
         lastChangesRequestedAt = try c.decodeIfPresent(Date.self, forKey: .lastChangesRequestedAt)
         lastSubstantiveCommitAt = try c.decodeIfPresent(Date.self, forKey: .lastSubstantiveCommitAt)
+        hasMergeLabel = try c.decodeIfPresent(Bool.self, forKey: .hasMergeLabel) ?? false
     }
 
     private enum CodingKeys: String, CodingKey {
         case checksPass, reviewStatus, mergeable, failedCheckNames, headSha, isOpen
-        case lastChangesRequestedAt, lastSubstantiveCommitAt
+        case lastChangesRequestedAt, lastSubstantiveCommitAt, hasMergeLabel
     }
 
     public enum CheckStatus: String, Codable, Sendable {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -83,6 +83,10 @@ private func prStatusJSON(_ pr: PRStatus) -> [String: JSONValue] {
         "ready_to_merge": .bool(pr.isReadyToMerge),
         "has_blockers": .bool(pr.hasBlockers),
         "failed_checks": .array(pr.failedCheckNames.map { .string($0) }),
+        // `crow:merge` label presence — the *request* for auto-merge, distinct
+        // from `session.auto_merge` (Crow already enabled it). The web row
+        // renders them as two indicators (CROW-773).
+        "has_merge_label": .bool(pr.hasMergeLabel),
     ]
 }
 
@@ -169,8 +173,8 @@ func makeCommandRouter(
 
         // Expanded for the web UI: enough per session to render the sidebar
         // rows and the detail header (status/kind/agent/ticket + primary
-        // worktree). PR status, labels, and hook-activity state need RPC the
-        // daemon doesn't expose yet and are omitted.
+        // worktree), plus ticket labels and hook-activity state. Live PR status
+        // is not here — it comes from `list-sessions-live`.
         "list-sessions": { _ in
             let items: [JSONValue] = await MainActor.run {
                 appState.sessions.map { session in
@@ -214,6 +218,18 @@ func makeCommandRouter(
                                 "label": .string(link.label),
                                 "url": .string(link.url),
                                 "type": .string(link.linkType.rawValue),
+                            ])
+                        })
+                    }
+                    // Ticket/review labels for the sidebar row's label pills —
+                    // restores native `SessionRow`'s LabelPillsView, which read
+                    // the same `labels(forSession:)` source (CROW-773).
+                    let labels = appState.labels(forSession: session)
+                    if !labels.isEmpty {
+                        object["labels"] = .array(labels.map { label in
+                            .object([
+                                "name": .string(label.name),
+                                "color": label.color.map { .string($0) } ?? .null,
                             ])
                         })
                     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -193,9 +193,13 @@ html, body {
 }
 .row-badges { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 6px; }
 .pr-badge {
-  display: inline-block; padding: 2px 8px; border-radius: 10px;
+  display: inline-flex; align-items: center; gap: 3px; padding: 2px 8px; border-radius: 10px;
   font-size: 10px; font-weight: 600; border: 1px solid; background: var(--bg-surface);
 }
+/* Per-status glyphs inside the pill (checks / review / conflict / crow:merge).
+   Each carries its own color, so they must not inherit the pill's — hence the
+   inline style on the span; this rule only handles sizing (CROW-773). */
+.pr-badge .pr-ico { font-size: 9px; line-height: 1; }
 .activity-badge { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; }
 /* Org-goal tag (#723): the sidebar glyph reuses .badge sizing (non-clickable);
    the detail-header .meta-goal row shows the full text and turns gold on hover
@@ -526,6 +530,14 @@ html, body {
   font-size: 10px; padding: 1px 7px; border-radius: 9px;
   border: 1px solid var(--border-subtle); color: var(--text-secondary);
 }
+/* Sidebar rows reuse the board's label pills at a tighter scale, and clamp long
+   label names so a verbose label can't push the row wide (CROW-773). */
+.session-row .label-row { gap: 4px; margin-top: 4px; }
+.session-row .label-pill {
+  font-size: 9px; padding: 0 5px;
+  max-width: 90px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.session-row .label-more { color: var(--text-muted); }
 .card-foot { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
 .card-foot .badge { text-transform: capitalize; }
 .card-foot .action-btn { margin-left: auto; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1156,6 +1156,9 @@ function sessionRow(s) {
   if (!uiConfig.hideSessionDetails) {
     if (s.ticket_title) content.appendChild(el('div', 'subtle', s.ticket_title));
     if (s.repo) content.appendChild(el('div', 'meta', s.repo + (s.branch ? ' · ' + s.branch : '')));
+    // Ticket/review label pills — native `SessionRow` showed these below the
+    // repo line, capped at 2, behind the same hideSessionDetails gate (CROW-773).
+    if (s.labels && s.labels.length) content.appendChild(labelPills(s.labels, 2));
   }
 
   const badges = el('div', 'row-badges');
@@ -1168,13 +1171,27 @@ function sessionRow(s) {
     badges.appendChild(g);
   }
   // PR badge — shown whenever a PR link exists (stored, or live from the app
-  // when it's only in memory); colored by live status when available.
+  // when it's only in memory); colored AND glyphed by live status when
+  // available. The glyphs mirror the retired native `PRBadge` (CROW-773): a
+  // color-only pill can't distinguish failing checks from changes-requested.
   const prLink = (s.links || []).find((l) => l.type === 'pr') || liveFor(s.id).pr_link;
   if (prLink) {
-    const color = prBadgeColor(liveFor(s.id).pr);
+    const pr = liveFor(s.id).pr;
+    const color = prBadgeColor(pr);
     const prb = el('span', 'pr-badge', prLink.label || 'PR');
     prb.style.color = color;
     prb.style.borderColor = color;
+    const parts = prBadgeParts(pr);
+    for (const part of parts) {
+      const ico = el('span', 'pr-ico', part.glyph);
+      ico.style.color = part.color;
+      prb.appendChild(ico);
+    }
+    // Glyph + color must not be the only channel — mirrors native PRBadge's
+    // `accessibilityDescription` ("#123, Checks pass, Approved").
+    const desc = [prLink.label || 'PR', ...parts.map((p) => p.label)].join(', ');
+    prb.title = desc;
+    prb.setAttribute('aria-label', desc);
     badges.appendChild(prb);
   }
   // Activity badge (Working/Waiting/Done/…) is redundant on managers — they
@@ -1211,6 +1228,52 @@ function prBadgeColor(pr) {
   if (pr.has_blockers) return 'var(--red)';
   if (pr.ready_to_merge) return 'var(--green)';
   return 'var(--gold)';
+}
+
+// ---------------------------------------------------------------------------
+// PR status glyphs — ONE vocabulary shared by the sidebar row pill
+// (`sessionRow`) and the detail header (`prStatusInline`), so the two can never
+// disagree about the same PR (CROW-773).
+// ---------------------------------------------------------------------------
+const PR_CHECKS_GLYPH = {
+  passing: { glyph: '✔', color: 'var(--green)', label: 'Checks pass' },
+  failing: { glyph: '✕', color: 'var(--red)', label: 'Checks failing' },
+  pending: { glyph: '◷', color: 'var(--orange)', label: 'Checks running' },
+  unknown: { glyph: '?', color: 'var(--text-muted)', label: 'No checks' },
+};
+const PR_REVIEW_GLYPH = {
+  approved: { glyph: '✔', color: 'var(--green)', label: 'Approved' },
+  changesRequested: { glyph: '✕', color: 'var(--red)', label: 'Changes requested' },
+  reviewRequired: { glyph: '◷', color: 'var(--orange)', label: 'Needs review' },
+  unknown: { glyph: '○', color: 'var(--text-muted)', label: 'No reviews' },
+};
+const PR_MERGED_GLYPH = { glyph: '✔', color: 'var(--purple)', label: 'Merged' };
+const PR_CONFLICT_GLYPH = { glyph: '⚠', color: 'var(--red)', label: 'Conflicts' };
+const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge label' };
+
+function prChecksGlyph(pr) {
+  const base = PR_CHECKS_GLYPH[pr.checks] || PR_CHECKS_GLYPH.unknown;
+  // Failing checks carry their count when the daemon sent the names.
+  if (pr.checks === 'failing' && pr.failed_checks && pr.failed_checks.length) {
+    return { ...base, label: pr.failed_checks.length + ' failing' };
+  }
+  return base;
+}
+
+function prReviewGlyph(pr) {
+  return PR_REVIEW_GLYPH[pr.review] || PR_REVIEW_GLYPH.unknown;
+}
+
+// The ordered glyphs for a session-row PR pill, mirroring native `PRBadge`:
+// merged collapses to a single check, otherwise checks + review, plus the
+// conflict and crow:merge-label markers the native pill folded into its tint.
+function prBadgeParts(pr) {
+  if (!pr || !pr.has_pr) return [];
+  if (pr.is_merged) return [PR_MERGED_GLYPH];
+  const parts = [prChecksGlyph(pr), prReviewGlyph(pr)];
+  if (pr.merge === 'conflicting') parts.push(PR_CONFLICT_GLYPH);
+  if (pr.has_merge_label) parts.push(PR_MERGE_LABEL_GLYPH);
+  return parts;
 }
 
 // ---------------------------------------------------------------------------
@@ -1703,25 +1766,24 @@ function renderSessionAnalyticsStrip(s, root) {
   root.appendChild(strip);
 }
 
-// Inline PR status, mirroring the desktop PRStatusDetail.
+// Inline PR status, mirroring the desktop PRStatusDetail. Same glyph/color
+// vocabulary as the sidebar row pill (`prBadgeParts`) — spelled out with labels
+// here, glyph-only there (CROW-773).
 function prStatusInline(pr) {
   const wrap = el('div', 'pr-status-inline');
-  if (pr.is_merged) { wrap.appendChild(prStatusPart('✔ Merged', 'var(--purple)')); return wrap; }
-  const checks = {
-    passing: ['✔ Checks pass', 'var(--green)'],
-    failing: [(pr.failed_checks && pr.failed_checks.length ? '✕ ' + pr.failed_checks.length + ' failing' : '✕ Checks failing'), 'var(--red)'],
-    pending: ['◷ Checks running', 'var(--orange)'],
-    unknown: ['? No checks', 'var(--text-muted)'],
-  }[pr.checks] || ['? No checks', 'var(--text-muted)'];
-  wrap.appendChild(prStatusPart(checks[0], checks[1]));
-  const review = {
-    approved: ['✔ Approved', 'var(--green)'],
-    changesRequested: ['✕ Changes requested', 'var(--red)'],
-    reviewRequired: ['◷ Needs review', 'var(--orange)'],
-    unknown: ['○ No reviews', 'var(--text-muted)'],
-  }[pr.review] || ['○ No reviews', 'var(--text-muted)'];
-  wrap.appendChild(prStatusPart(review[0], review[1]));
-  if (pr.merge === 'conflicting') wrap.appendChild(prStatusPart('⚠ Conflicts', 'var(--red)'));
+  if (pr.is_merged) {
+    wrap.appendChild(prStatusPart(PR_MERGED_GLYPH.glyph + ' ' + PR_MERGED_GLYPH.label, PR_MERGED_GLYPH.color));
+    return wrap;
+  }
+  for (const part of [prChecksGlyph(pr), prReviewGlyph(pr)]) {
+    wrap.appendChild(prStatusPart(part.glyph + ' ' + part.label, part.color));
+  }
+  if (pr.merge === 'conflicting') {
+    wrap.appendChild(prStatusPart(PR_CONFLICT_GLYPH.glyph + ' ' + PR_CONFLICT_GLYPH.label, PR_CONFLICT_GLYPH.color));
+  }
+  if (pr.has_merge_label) {
+    wrap.appendChild(prStatusPart(PR_MERGE_LABEL_GLYPH.glyph + ' ' + PR_MERGE_LABEL_GLYPH.label, PR_MERGE_LABEL_GLYPH.color));
+  }
   return wrap;
 }
 
@@ -2403,12 +2465,22 @@ function linkChip(text, url, type) {
   return a;
 }
 
-function labelPills(labels) {
+// `maxVisible` caps how many pills render, with a trailing `+N` for the rest —
+// the sidebar row is narrow and passes 2 (native LabelPillsView's cap). Board
+// cards omit it and render every label, as before (CROW-773).
+function labelPills(labels, maxVisible) {
   const wrap = el('div', 'label-row');
-  for (const l of (labels || [])) {
+  const all = labels || [];
+  const shown = maxVisible != null ? all.slice(0, maxVisible) : all;
+  for (const l of shown) {
     const pill = el('span', 'label-pill', l.name);
     if (l.color) { pill.style.borderColor = '#' + l.color; pill.style.color = '#' + l.color; }
     wrap.appendChild(pill);
+  }
+  if (all.length > shown.length) {
+    const more = el('span', 'label-pill label-more', '+' + (all.length - shown.length));
+    more.title = all.slice(shown.length).map((l) => l.name).join(', ');
+    wrap.appendChild(more);
   }
   return wrap;
 }

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -23,6 +23,15 @@ accumulation, the alternate-screen branch (SGR wheel reports when the TUI has
 mouse tracking on, cursor keys otherwise, capped per event), multi-touch
 pass-through, and degenerate cell metrics.
 
+## `row.test.js` — sidebar session rows (CROW-773)
+
+Drives `sessionRow`. Coverage: the PR pill's status glyphs for every
+checks/review state, merged collapsing to a single purple check, the conflict
+`⚠`, the `crow:merge` label `🏷` as a signal independent of the `⛙`
+auto-merge-enabled glyph, the composed `aria-label`, graceful degradation when
+the live `pr` entry is missing or `has_pr: false`, and the ticket-label pills
+(2-pill cap + `+N` overflow, hidden under `hideSessionDetails`).
+
 ## Run
 
 ```sh

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "crow-web-board-tests",
+  "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board rendering; terminal touch-scroll). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch-scroll; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "node board.test.js && node touch-scroll.test.js"
+    "test": "node board.test.js && node touch-scroll.test.js && node row.test.js"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/row.test.js
+++ b/Packages/CrowDaemon/web-tests/row.test.js
@@ -1,0 +1,145 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// Sidebar session-row regression tests (CROW-773) — PR-pill status glyphs,
+// the crow:merge indicator, and ticket-label pills. Same loader shape as
+// board.test.js: run the REAL app.js in a jsdom VM and drive `sessionRow`
+// directly, with an epilogue exposing the module-scope state it reads.
+const epilogue = `
+;globalThis.__t = {
+  sessionRow(s){ return sessionRow(s); },
+  set live(v){ liveById = v; },
+  set hideDetails(v){ uiConfig.hideSessionDetails = v; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body>
+     <div id="sidebar"></div><div id="board"></div><div id="header"></div>
+   </body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+const SESSION = {
+  id: 'sess-1', name: 'crow-773', status: 'active', kind: 'work',
+  agent_kind: 'claude-code', activity: 'idle', repo: 'corveil/crow', branch: 'feature/x',
+  links: [{ label: '#800', url: 'https://github.com/corveil/crow/pull/800', type: 'pr' }],
+};
+
+// Render a row with the given live `pr` entry, returning { row, glyphs }.
+function render(pr, overrides) {
+  T.live = pr === undefined ? {} : { 'sess-1': { pr } };
+  const row = T.sessionRow({ ...SESSION, ...(overrides || {}) });
+  return { row, glyphs: [...row.querySelectorAll('.pr-badge .pr-ico')].map((n) => n.textContent) };
+}
+const badge = (row) => row.querySelector('.pr-badge');
+
+console.log('Failing checks + changes requested:');
+let r = render({ has_pr: true, checks: 'failing', review: 'changesRequested', merge: 'MERGEABLE',
+  is_merged: false, has_blockers: true, ready_to_merge: false, failed_checks: ['build', 'lint'] });
+check('two glyphs rendered', r.glyphs.length === 2);
+check('both are ✕', r.glyphs.join('') === '✕✕');
+check('glyphs are red', [...r.row.querySelectorAll('.pr-ico')].every((n) => n.style.color === 'var(--red)'));
+check('pill itself is red', badge(r.row).style.color === 'var(--red)');
+check('aria-label names the failing count and review', (() => {
+  const a = badge(r.row).getAttribute('aria-label');
+  return /#800/.test(a) && /2 failing/.test(a) && /Changes requested/.test(a);
+})());
+
+console.log('\nPassing checks + approved:');
+r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergeable',
+  is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [] });
+check('two ✔ glyphs', r.glyphs.join('') === '✔✔');
+check('glyphs green', [...r.row.querySelectorAll('.pr-ico')].every((n) => n.style.color === 'var(--green)'));
+check('pill green', badge(r.row).style.color === 'var(--green)');
+
+console.log('\nPending checks + review required:');
+r = render({ has_pr: true, checks: 'pending', review: 'reviewRequired', merge: 'unknown',
+  is_merged: false, has_blockers: false, ready_to_merge: false, failed_checks: [] });
+check('two ◷ glyphs', r.glyphs.join('') === '◷◷');
+check('glyphs orange', [...r.row.querySelectorAll('.pr-ico')].every((n) => n.style.color === 'var(--orange)'));
+
+console.log('\nMerged PR collapses to a single purple check:');
+r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'merged',
+  is_merged: true, has_blockers: false, ready_to_merge: false, failed_checks: [] });
+check('exactly one glyph', r.glyphs.length === 1);
+check('glyph is ✔', r.glyphs[0] === '✔');
+check('glyph purple', r.row.querySelector('.pr-ico').style.color === 'var(--purple)');
+
+console.log('\nConflicting PR adds a ⚠:');
+r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'conflicting',
+  is_merged: false, has_blockers: true, ready_to_merge: false, failed_checks: [] });
+check('three glyphs (checks, review, conflict)', r.glyphs.length === 3);
+check('third glyph is ⚠', r.glyphs[2] === '⚠');
+
+console.log('\ncrow:merge label vs auto-merge enabled (two independent signals):');
+r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergeable',
+  is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [], has_merge_label: true });
+check('🏷 present when has_merge_label', r.glyphs.includes('🏷'));
+check('no ⛙ when auto_merge is false', !r.row.querySelector('.automerge'));
+r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergeable',
+  is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [] });
+check('no 🏷 when has_merge_label absent', !r.glyphs.includes('🏷'));
+r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergeable',
+  is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [], has_merge_label: true },
+  { auto_merge: true });
+check('🏷 and ⛙ can both show', r.glyphs.includes('🏷') && !!r.row.querySelector('.automerge'));
+
+console.log('\nGraceful degradation (older daemon payload / no PR status):');
+r = render(undefined);
+check('pill still rendered from the link', !!badge(r.row) && /#800/.test(badge(r.row).textContent));
+check('no glyphs without live PR state', r.glyphs.length === 0);
+r = render({ has_pr: false });
+check('has_pr:false renders no glyphs', r.glyphs.length === 0);
+check('has_pr:false pill is gold', badge(r.row).style.color === 'var(--gold)');
+r = render({ has_pr: true, is_merged: false, has_blockers: false, ready_to_merge: false });
+check('missing checks/review fall back to ? and ○', r.glyphs.join('') === '?○');
+
+console.log('\nSession label pills:');
+const LABELS = [{ name: 'bug', color: 'd73a4a' }, { name: 'web' }, { name: 'p1' }, { name: 'infra' }];
+T.hideDetails = false;
+r = render({ has_pr: false }, { labels: LABELS });
+let pills = [...r.row.querySelectorAll('.label-pill')];
+check('capped at 2 + a "+N" pill', pills.length === 3);
+check('first two label names shown', pills[0].textContent === 'bug' && pills[1].textContent === 'web');
+check('overflow pill reads +2', pills[2].textContent === '+2');
+check('overflow pill lists the rest in its title', pills[2].getAttribute('title') === 'p1, infra');
+// jsdom normalizes a hex color to rgb(); the second pill has no color and
+// keeps the stylesheet default, so an empty inline color proves it wasn't set.
+check('color applied when provided', pills[0].style.color === 'rgb(215, 58, 74)');
+check('no inline color when the label has none', pills[1].style.color === '');
+r = render({ has_pr: false }, { labels: [{ name: 'bug' }] });
+check('no "+N" when nothing is hidden', r.row.querySelectorAll('.label-pill').length === 1);
+r = render({ has_pr: false }, {});
+check('no label row when the session has no labels', !r.row.querySelector('.label-row'));
+
+T.hideDetails = true;
+r = render({ has_pr: false }, { labels: LABELS });
+check('hidden under hideSessionDetails', !r.row.querySelector('.label-row'));
+check('PR pill still shown under hideSessionDetails', !!badge(r.row));
+T.hideDetails = false;
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -231,6 +231,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         "ready_to_merge": .bool(pr.isReadyToMerge),
                         "has_blockers": .bool(pr.hasBlockers),
                         "failed_checks": .array(pr.failedCheckNames.map { .string($0) }),
+                        "has_merge_label": .bool(pr.hasMergeLabel),
                     ]
                 }
             },
@@ -410,6 +411,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                                 "ready_to_merge": .bool(pr.isReadyToMerge),
                                 "has_blockers": .bool(pr.hasBlockers),
                                 "failed_checks": .array(pr.failedCheckNames.map { .string($0) }),
+                                "has_merge_label": .bool(pr.hasMergeLabel),
                             ])
                         } else {
                             entry["pr"] = .object(["has_pr": .bool(false)])

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -1703,7 +1703,7 @@ public final class IssueTracker {
             guard let pr = byURL[prLink.url] else { continue }
             livePRURLs.insert(prLink.url)
 
-            let newStatus = buildPRStatus(from: pr)
+            let newStatus = Self.buildPRStatus(from: pr)
             let oldStatus = previousPRStatus[session.id]
 
             // Checks-failing edge: fire only when transitioning from
@@ -2644,7 +2644,10 @@ public final class IssueTracker {
         }
     }
 
-    private func buildPRStatus(from pr: ViewerPR) -> PRStatus {
+    /// Pure projection of a provider PR record onto the UI-facing `PRStatus`.
+    /// `nonisolated static` (like `shouldAttemptAutoMerge`) because it touches
+    /// no tracker state — which also makes it directly unit-testable.
+    nonisolated static func buildPRStatus(from pr: ViewerPR) -> PRStatus {
         // Checks
         let checksPass: PRStatus.CheckStatus
         var failedChecks: [String] = []
@@ -2698,7 +2701,13 @@ public final class IssueTracker {
             headSha: pr.headRefOid.isEmpty ? nil : pr.headRefOid,
             isOpen: pr.state == "OPEN",
             lastChangesRequestedAt: pr.lastChangesRequestedAt,
-            lastSubstantiveCommitAt: pr.lastSubstantiveCommitAt
+            lastSubstantiveCommitAt: pr.lastSubstantiveCommitAt,
+            // Same case-insensitive match `shouldAttemptAutoMerge` gates on —
+            // surfaced for the UI so the sidebar can show "labeled for merge"
+            // separately from "auto-merge already enabled" (CROW-773).
+            hasMergeLabel: pr.labels.contains {
+                $0.name.caseInsensitiveCompare(Self.autoMergeLabel) == .orderedSame
+            }
         )
     }
 

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
@@ -51,6 +51,25 @@ struct IssueTrackerAutoMergeTests {
         )
     }
 
+    // MARK: - buildPRStatus surfaces the label to the UI (CROW-773)
+
+    @Test func buildPRStatusFlagsCrowMergeLabel() {
+        #expect(IssueTracker.buildPRStatus(from: makePR()).hasMergeLabel)
+    }
+
+    @Test func buildPRStatusClearsFlagWithoutTheLabel() {
+        #expect(!IssueTracker.buildPRStatus(from: makePR(labels: [Self.otherLabel])).hasMergeLabel)
+        #expect(!IssueTracker.buildPRStatus(from: makePR(labels: [])).hasMergeLabel)
+    }
+
+    @Test func buildPRStatusMatchesLabelCaseInsensitively() {
+        // Same case-insensitive rule `shouldAttemptAutoMerge` gates on — the
+        // indicator must never disagree with the watcher about the same PR.
+        let pr = makePR(labels: [LabelInfo(name: "Crow:Merge", color: nil)])
+        #expect(IssueTracker.buildPRStatus(from: pr).hasMergeLabel)
+        #expect(IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
     // MARK: - shouldAttemptAutoMerge guards
 
     @Test func acceptsHealthyLabeledPR() {


### PR DESCRIPTION
Closes #773

The native→web move (ADR-0010, CROW-593) dropped the status glyphs from the sidebar session row's PR pill. Native `PRBadge` drew the PR label plus a checks glyph and a review glyph (or a single merged glyph), each colored; the web pill was color-only, so failing checks, changes-requested and conflicts all read as just "red".

## What changed

**PR-pill glyphs restored.** Extracted the glyph/color tables that lived inline in `prStatusInline` (the detail header) into shared helpers — `prChecksGlyph` / `prReviewGlyph` / `prBadgeParts` — now consumed by **both** the header and the sidebar pill. The two views can no longer disagree about the same PR. Header text is byte-identical to before.

Merged collapses to a single purple ✔; otherwise checks + review glyphs, plus ⚠ on conflict. The pill also carries a composed `title`/`aria-label` (`"#800, 2 failing, Changes requested"`), mirroring native's `accessibilityDescription`, so color and glyph are not the only channel.

**crow:merge indicator (new data).** The ⛙ glyph reflects auto-merge *enablement* (`Session.autoMergeEnabledAt`), never whether the PR carries the `crow:merge` label — the ticket's open question. The label was already being fetched for the auto-merge gate and dropped on the floor, so `PRStatus.hasMergeLabel` now carries it (the same case-insensitive comparison `shouldAttemptAutoMerge` gates on), out through `prStatusJSON` as `has_merge_label`, rendered as a distinct 🏷. Both indicators can show at once: 🏷 = requested, ⛙ = Crow acted.

`buildPRStatus` was `private` and pure; it becomes `nonisolated static` like `shouldAttemptAutoMerge`, which also makes it directly testable.

**Row audit — one more gap found and fixed.** Native `SessionRow` had a "Row 3.5" rendering up to 2 ticket-label pills from `labels(forSession:)`; the web row omitted them entirely. `list-sessions` now sends `labels` and the row renders them through the existing `labelPills()`, which gained an optional cap with a `+N` overflow. Board call sites pass no cap and are unchanged. Everything else (lock 🔒, remote-control, ⛙, activity dot, left accent, row tint) was already present with conditions matching native.

## Compatibility

`PRStatus` has a hand-written per-field-lenient decoder, so `hasMergeLabel` decodes as `false` from existing persisted payloads. The web degrades to a label-only pill when the live `pr` entry is absent or `has_pr: false`, as it does today.

## Tests

New `Packages/CrowDaemon/web-tests/row.test.js` (34 assertions) reusing `board.test.js`'s jsdom loader against the real `app.js`: every checks/review state, merged collapsing to one glyph, the conflict ⚠, 🏷 independent of ⛙, the composed aria-label, graceful degradation of an older payload, and the label pills (cap, `+N`, `hideSessionDetails` gate). Plus 3 `IssueTracker` cases asserting label extraction agrees with the auto-merge gate, including a case-differing label name.

`npm test` in `web-tests` runs both files. `make test` — all 14 packages, 1391 tests, pass. `make build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8B6NzYZaYzEDUNYKvwXVh