### PR TITLE
fix(web): restore the mouse-mode swallow in the app terminal (#776)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2941,6 +2941,32 @@ function ensureTerminal() {
   term.loadAddon(imageAddon);
   term.loadAddon(searchAddon);
   term.loadAddon(webLinksAddon);
+
+  // Mouse-mode swallow — same handler as web/terminal.html (CROW-581). The
+  // agent TUIs (Claude Code, Cursor) turn the xterm mouse protocol on
+  // themselves, and crow-tmux.conf's `mouse off` means tmux forwards those
+  // DECSETs straight through to this client. Left alone, xterm.js enters
+  // mouse-reporting mode and every mouse MOVE emits an SGR report to the PTY →
+  // the TUI repaints → the viewport is yanked to the bottom while the user is
+  // scrolled up; drag-select and the browser context menu are eaten too.
+  // Dropping the mode toggles at the parser keeps selection, the context menu,
+  // and wheel-scroll client-side. Inner apps that genuinely want the mouse
+  // (vim/htop) lose it here — the same acceptable trade terminal.html makes.
+  // #776: this surface was built without the swallow, so it regressed against
+  // the standalone renderer. Must be registered before open()/first write.
+  const MOUSE_MODES = new Set([1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016]);
+  function swallowMouseMode(params) {
+    const arr = params && params.params ? params.params : params;
+    const len = arr ? arr.length : 0;
+    for (let i = 0; i < len; i++) {
+      const v = arr[i];
+      if (MOUSE_MODES.has(Array.isArray(v) ? v[0] : v)) return true; // handled → drop it
+    }
+    return false; // not a mouse mode → let xterm apply it normally
+  }
+  term.parser.registerCsiHandler({ prefix: '?', final: 'h' }, swallowMouseMode);
+  term.parser.registerCsiHandler({ prefix: '?', final: 'l' }, swallowMouseMode);
+
   // #677: seed the skeleton before first open() so it covers the initial xterm
   // layout / first-fit reflow flash; connectTerminalWs() re-arms it below.
   showTerminalSkeleton();
@@ -3020,14 +3046,22 @@ function enableTouchScroll(node) {
 
 // Let xterm.js own wheel scrolling in the browser: scroll the local 50k-line
 // scrollback instead of forwarding the wheel to tmux (whose server-global
-// `mouse on` would otherwise drop into copy-mode — janky in a browser). A
-// fullscreen/alternate-screen app (vim, htop) still gets the wheel.
+// `mouse on` would otherwise drop into copy-mode — janky in a browser).
+//
+// #776: this used to bail on the alternate-screen buffer to "let TUIs handle
+// the wheel", but the mouse-mode swallow in ensureTerminal means no inner app
+// can receive mouse events here — so bailing just handed the wheel to xterm's
+// alternate-scroll fallback, which emits ARROW KEYS. Claude Code reads those as
+// input-history navigation: exactly the bug crow-tmux.conf documents under
+// `alternate-screen off`. Keep owning the event in both buffers; an alternate
+// buffer has no scrollback, so there we swallow the wheel rather than scroll.
+// (crow-tmux.conf also strips the client's smcup/rmcup, so in practice the
+// terminal stays in the main buffer and the scrollback path is the live one.)
 function enableWheelScroll(node) {
   node.addEventListener('wheel', (e) => {
     if (!term) return;
     const buf = term.buffer && term.buffer.active;
-    if (buf && buf.type === 'alternate') return; // let TUIs handle the wheel
-    term.scrollLines(e.deltaY > 0 ? 3 : -3);
+    if (!buf || buf.type !== 'alternate') term.scrollLines(e.deltaY > 0 ? 3 : -3);
     e.preventDefault();
     e.stopPropagation();
   }, { capture: true, passive: false });

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -33,6 +33,24 @@ import Testing
         return try String(contentsOf: url, encoding: .utf8)
     }
 
+    /// The single line declaring the swallowed-mode set. Anchoring the per-mode
+    /// assertions to it keeps them meaningful: a bare `contains("1000")` over
+    /// all of `app.js` would match any unrelated timeout literal (review).
+    private static func mouseModesLine(_ source: String) throws -> Substring {
+        try #require(
+            source.split(separator: "\n").first { $0.contains("const MOUSE_MODES") },
+            "no `const MOUSE_MODES` declaration")
+    }
+
+    /// The body of a top-level `function <name>(` … `\n}` block, for asserting on
+    /// one handler rather than the whole file.
+    private static func functionBody(_ name: String, in source: String) throws -> Substring {
+        let start = try #require(source.range(of: "function \(name)("), "no \(name)")
+        let rest = source[start.upperBound...]
+        let end = try #require(rest.range(of: "\n}\n"), "unterminated \(name)")
+        return rest[..<end.lowerBound]
+    }
+
     /// Both surfaces must drop the mouse-tracking DECSET/DECRST toggles
     /// (`?1000/1001/1002/1003/1005/1006/1015/1016`) at the parser, for `h` (set)
     /// and `l` (reset) alike — a swallow that covers only one of the two leaves
@@ -43,10 +61,11 @@ import Testing
         #expect(
             source.contains("MOUSE_MODES"),
             "\(asset) must keep the mouse-mode swallow (#776)")
+        let modes = try Self.mouseModesLine(source)
         for mode in ["1000", "1001", "1002", "1003", "1005", "1006", "1015", "1016"] {
             #expect(
-                source.contains(mode),
-                "\(asset) must swallow mouse mode ?\(mode)")
+                modes.contains(mode),
+                "\(asset)'s MOUSE_MODES must include ?\(mode)")
         }
         for final in ["'h'", "'l'"] {
             #expect(
@@ -55,12 +74,27 @@ import Testing
         }
     }
 
-    /// The wheel handler owns the event in BOTH buffers. Returning early on the
-    /// alternate buffer would hand the wheel to xterm's alternate-scroll
-    /// fallback, which emits arrow keys the agent TUI reads as input-history
-    /// navigation (crow-tmux.conf's `alternate-screen off` rationale, #776).
-    @Test func wheelHandlerNeverFallsThroughOnAlternateBuffer() throws {
-        let source = try Self.webAsset("app.js")
-        #expect(!source.contains("return; // let TUIs handle the wheel"))
+    /// The wheel handler owns the event in BOTH buffers. Any early return on the
+    /// alternate buffer hands the wheel to xterm's alternate-scroll fallback,
+    /// which emits arrow keys the agent TUI reads as input-history navigation
+    /// (crow-tmux.conf's `alternate-screen off` rationale, #776).
+    ///
+    /// Asserted as the positive ownership shape rather than the absence of one
+    /// comment string, so reintroducing the bail with different wording still
+    /// fails (review): the alternate check may only gate `scrollLines`, the
+    /// event is always consumed, and the sole `return` is the no-terminal guard.
+    @Test func wheelHandlerOwnsTheEventInBothBuffers() throws {
+        let body = try Self.functionBody("enableWheelScroll", in: Self.webAsset("app.js"))
+        #expect(
+            body.contains("buf.type !== 'alternate'"),
+            "the alternate-buffer check must gate scrolling, not handling")
+        #expect(body.contains("term.scrollLines("), "must scroll the local scrollback")
+        for consume in ["e.preventDefault();", "e.stopPropagation();"] {
+            #expect(body.contains(consume), "must always consume the wheel event: \(consume)")
+        }
+        // `if (!term) return;` — nothing else may short-circuit before the
+        // preventDefault/stopPropagation pair below it.
+        let returns = body.components(separatedBy: "return").count - 1
+        #expect(returns == 1, "only the `if (!term)` guard may return early, found \(returns)")
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import CrowDaemon
+
+/// Drift guard for the terminal surfaces served out of `Resources/web`.
+///
+/// There are two xterm.js setups in that directory — the app's inline terminal
+/// (`app.js` → `ensureTerminal`) and the standalone single-terminal page
+/// (`terminal.html`). #776: the inline one shipped WITHOUT the mouse-mode
+/// swallow that `terminal.html` has carried since CROW-581, so the agent TUI's
+/// mouse tracking stayed live in the app and every mouse move yanked a
+/// scrolled-up viewport back to the bottom. These tests pin the swallow into
+/// both files so the two can't silently diverge again while they remain
+/// separate implementations.
+@Suite struct WebTerminalAssetTests {
+    /// Walk up from this source file to the repo's `Resources/web` directory —
+    /// same lookup style as `CrowAttributionTests`' footer drift guard. The
+    /// assets are `.copy`d resources, so asserting on the repo copy (rather than
+    /// a bundle) keeps the test about what a reviewer actually edits.
+    private static func webAsset(_ name: String) throws -> String {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        var found: URL?
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent(
+                "Sources/CrowDaemon/Resources/web/\(name)")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                found = candidate
+                break
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        let url = try #require(found, "could not locate Resources/web/\(name)")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Both surfaces must drop the mouse-tracking DECSET/DECRST toggles
+    /// (`?1000/1001/1002/1003/1005/1006/1015/1016`) at the parser, for `h` (set)
+    /// and `l` (reset) alike — a swallow that covers only one of the two leaves
+    /// the mode reachable.
+    @Test(arguments: ["app.js", "terminal.html"])
+    func swallowsMouseTrackingModes(asset: String) throws {
+        let source = try Self.webAsset(asset)
+        #expect(
+            source.contains("MOUSE_MODES"),
+            "\(asset) must keep the mouse-mode swallow (#776)")
+        for mode in ["1000", "1001", "1002", "1003", "1005", "1006", "1015", "1016"] {
+            #expect(
+                source.contains(mode),
+                "\(asset) must swallow mouse mode ?\(mode)")
+        }
+        for final in ["'h'", "'l'"] {
+            #expect(
+                source.contains("registerCsiHandler({ prefix: '?', final: \(final) }, swallowMouseMode)"),
+                "\(asset) must register the swallow for CSI ? … \(final)")
+        }
+    }
+
+    /// The wheel handler owns the event in BOTH buffers. Returning early on the
+    /// alternate buffer would hand the wheel to xterm's alternate-scroll
+    /// fallback, which emits arrow keys the agent TUI reads as input-history
+    /// navigation (crow-tmux.conf's `alternate-screen off` rationale, #776).
+    @Test func wheelHandlerNeverFallsThroughOnAlternateBuffer() throws {
+        let source = try Self.webAsset("app.js")
+        #expect(!source.contains("return; // let TUIs handle the wheel"))
+    }
+}


### PR DESCRIPTION
Closes #776

## Problem

In the web UI / Tauri desktop shell, scrolling up in a Claude Code terminal and then **moving the mouse snaps the viewport back to the bottom**. This worked in the native macOS terminal before the web-UI-parity merge (`eb7a489`, #594).

## Root cause

`Resources/web/terminal.html:80-91` has swallowed the mouse-tracking DECSET/DECRST toggles (`?1000/1001/1002/1003/1005/1006/1015/1016`) at the xterm parser since CROW-581. The app's inline terminal (`app.js` → `ensureTerminal`), added by the CROW-593 parity workstream, **never got that swallow** (`git log -S MOUSE_MODES -- app.js` → never present).

Confirmed against the live tmux server:

```
$ tmux -S $TMPDIR/crow-tmux.sock list-panes -a -F '… mouse_any=#{mouse_any_flag} alt=#{alternate_on}'
4 Claude Code mouse_any=1 alt=1 …
5 Claude Code mouse_any=1 alt=0 …
…
```

Every Claude Code pane reports `mouse_any_flag=1` — the agent TUI really does enable mouse tracking — and `crow-tmux.conf`'s `mouse off` forwards those DECSETs straight through to the client. So xterm.js entered mouse-reporting mode and emitted an SGR report on every mouse **move** → the TUI repainted → the scrolled-up viewport followed the new output to the bottom. Drag-select and the browser context menu were eaten for the same reason.

Two corrections to the issue's write-up, worth recording:

1. The renderer carrying the swallow is the **daemon's** `Resources/web/terminal.html`, not `CrowTerminal/.../xterm/terminal.html` (the native one has no swallow).
2. The alternate-buffer early return in `enableWheelScroll` is **not** the main cause of the "wall": `alternate_on=0` for nearly every pane (`alternate-screen off` + `terminal-overrides ,xterm*:smcup@:rmcup@`), so the client's xterm is normally in the main buffer with its 50k scrollback intact. The wall is dominated by the snap-to-bottom.

## Changes

- **Port the `MOUSE_MODES` swallow into `ensureTerminal`**, registered before `open()`/the first write. Same handler as `terminal.html`.
- **Stop `enableWheelScroll` bailing on the alternate-screen buffer.** With the mouse swallowed no inner app can receive the wheel, so bailing just handed it to xterm's alternate-scroll fallback, which emits **arrow keys** that Claude Code reads as input-history navigation — the exact failure `crow-tmux.conf` documents under `alternate-screen off`. The handler now owns the event in both buffers; an alternate buffer has no scrollback, so there the wheel is swallowed rather than scrolled.
- **`WebTerminalAssetTests`** — a drift guard pinning the swallow (all eight modes, both the `h` and `l` CSI handlers) into `app.js` *and* `terminal.html`, plus a check that the wheel handler no longer falls through. This is the guard that would have caught the original divergence.

## Testing

- `swift test --package-path Packages/CrowDaemon` → 118 tests / 33 suites pass, including the new guard.
- `node --check` on `app.js` clean.
- Interactive browser check not run from this environment (Chrome here can't reach loopback — `ERR_CONNECTION_REFUSED` where `curl` gets 200). To verify by hand in a session terminal: `term._core.coreMouseService.areMouseEventsActive` → `false`, `term.buffer.active.type` → `normal`, then scroll up and move the mouse — the viewport must stay put, with no `\x1b[<…` reports on the `/terminal` WebSocket.

## Follow-up

Unifying the two xterm setups (`app.js` inline vs `web/terminal.html`) remains the issue's suggested follow-up; the drift guard is the interim protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqok8ShzCHzkBZERsUaVBj