### PR TITLE
In Progress status via crow:in-progress label fallback when an issue has no Project (#790)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -100,6 +100,25 @@ public enum TicketStatus: String, Codable, Sendable, CaseIterable {
     /// a board, and the label is ignored there.
     public static let inReviewFallbackLabel = "crow:in-review"
 
+    /// Sibling of `inReviewFallbackLabel` for In Progress (#790). Applied on
+    /// session start when the issue has no board; mutually exclusive with the
+    /// in-review label (In Review wins if both are somehow present).
+    public static let inProgressFallbackLabel = "crow:in-progress"
+
+    /// The no-project fallback status labels, in pipeline order.
+    public static let fallbackStatusLabels = [inProgressFallbackLabel, inReviewFallbackLabel]
+
+    /// The fallback label that encodes `self`, or nil for statuses that carry
+    /// no label (Done is signaled by closing the issue; Backlog/Ready have no
+    /// off-board representation).
+    public var fallbackStatusLabel: String? {
+        switch self {
+        case .inProgress: return TicketStatus.inProgressFallbackLabel
+        case .inReview:   return TicketStatus.inReviewFallbackLabel
+        default:          return nil
+        }
+    }
+
     /// Initialize from a GitHub/GitLab project board status name (case-insensitive).
     public init(projectBoardName name: String) {
         switch name.lowercased().trimmingCharacters(in: .whitespaces) {

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -3435,12 +3435,17 @@ public final class IssueTracker {
             appState.assignedIssues[idx].projectStatus = .done
         }
 
-        // Cosmetic cleanup (#706): a closed issue reads as Done regardless, so
-        // drop a lingering no-project `crow:in-review` fallback label. Gated on
-        // the in-memory labels to avoid a gratuitous API call; best-effort.
-        if let issue = appState.assignedIssues.first(where: { $0.url == ticketURL }),
-           issue.labels.contains(where: { $0.name == TicketStatus.inReviewFallbackLabel }) {
-            try? await backend.setLabels(url: ticketURL, add: [], remove: [TicketStatus.inReviewFallbackLabel])
+        // Cosmetic cleanup (#706, #790): a closed issue reads as Done
+        // regardless, so drop any lingering no-project fallback status label.
+        // Only the labels the issue actually carries are removed — gated on the
+        // in-memory labels to avoid a gratuitous API call (and a "not found"
+        // failure); best-effort.
+        if let issue = appState.assignedIssues.first(where: { $0.url == ticketURL }) {
+            let names = Set(issue.labels.map(\.name))
+            let stale = TicketStatus.fallbackStatusLabels.filter { names.contains($0) }
+            if !stale.isEmpty {
+                try? await backend.setLabels(url: ticketURL, add: [], remove: stale)
+            }
         }
 
         print("[IssueTracker] Marked issue done: \(ticketURL)")

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -158,12 +158,13 @@ public struct GitHubTaskBackend: TaskBackend {
         guard let resolved = Self.resolveProjectFieldOption(queryOut, target: status) else {
             if !Self.hasProjectItems(queryOut) {
                 // No project board attached to the issue: represent pipeline
-                // status with the `crow:in-review` fallback label instead
-                // (#706). The label only encodes In Review — any other target
-                // status just clears it (Done is signaled by closing the
-                // issue; In Progress by the active session).
-                try await setInReviewFallbackLabel(
-                    url: url, repo: "\(parsed.org)/\(parsed.repo)", applied: status == .inReview
+                // status with a `crow:in-progress` / `crow:in-review` fallback
+                // label instead (#706, #790). The two are mutually exclusive —
+                // the target status' label is applied and the other cleared.
+                // Statuses with no label (notably Done, signaled by closing the
+                // issue) just clear both.
+                try await setFallbackStatusLabel(
+                    url: url, repo: "\(parsed.org)/\(parsed.repo)", status: status
                 )
                 return
             }
@@ -287,33 +288,41 @@ public struct GitHubTaskBackend: TaskBackend {
         return .commandFailed(stderr)
     }
 
-    /// Apply or clear the `crow:in-review` fallback label on an issue that has
-    /// no project board (#706).
-    private func setInReviewFallbackLabel(url: String, repo: String, applied: Bool) async throws {
-        let label = TicketStatus.inReviewFallbackLabel
-        if applied {
-            try await ensureInReviewLabel(repo: repo)
-            try await setLabels(url: url, add: [label], remove: [])
-        } else {
+    /// Apply the fallback status label for `status` — and clear the other one —
+    /// on an issue that has no project board (#706, #790).
+    ///
+    /// The add and each removal go out as separate `gh issue edit` calls on
+    /// purpose: `--remove-label` fails the whole invocation when the label
+    /// doesn't exist in the repo, which would take the add down with it.
+    private func setFallbackStatusLabel(url: String, repo: String, status: TicketStatus) async throws {
+        let target = status.fallbackStatusLabel
+        if let target {
+            try await ensureFallbackLabel(target, repo: repo)
+            try await setLabels(url: url, add: [target], remove: [])
+        }
+        for stale in TicketStatus.fallbackStatusLabels where stale != target {
             do {
-                try await setLabels(url: url, add: [], remove: [label])
+                try await setLabels(url: url, add: [], remove: [stale])
             } catch ShellRunnerError.nonZeroExit(_, let output)
                 where output.localizedCaseInsensitiveContains("not found") {
-                // Label doesn't exist in the repo (never entered review here);
-                // removal is best-effort.
+                // Label doesn't exist in the repo (never reached that status
+                // here); removal is best-effort.
             }
         }
     }
 
-    /// Ensure the `crow:in-review` fallback label exists in `repo`, mirroring
+    /// Ensure a `crow:` fallback status label exists in `repo`, mirroring
     /// `GitHubCodeBackend.ensureMergeLabel`.
-    private func ensureInReviewLabel(repo: String) async throws {
+    private func ensureFallbackLabel(_ label: String, repo: String) async throws {
+        let isInReview = label == TicketStatus.inReviewFallbackLabel
         do {
             _ = try await shellRunner.run(
-                "gh", "label", "create", TicketStatus.inReviewFallbackLabel,
+                "gh", "label", "create", label,
                 "--repo", repo,
-                "--color", "FBCA04",
-                "--description", "Crow: in review (no-project status fallback)"
+                "--color", isInReview ? "FBCA04" : "1D76DB",
+                "--description", isInReview
+                    ? "Crow: in review (no-project status fallback)"
+                    : "Crow: in progress (no-project status fallback)"
             )
         } catch ShellRunnerError.nonZeroExit(_, let output) where output.localizedCaseInsensitiveContains("already exists") {
             return
@@ -602,12 +611,18 @@ public struct GitHubTaskBackend: TaskBackend {
                     }
                 }
             }
-            // Label fallback (#706): when the board yields no status (issue
-            // not on any project), the `crow:in-review` label carries the
-            // In Review state. A board status, when present, wins above.
-            if projectStatusOverride == nil, projectStatus == .unknown,
-               labels.contains(where: { $0.name == TicketStatus.inReviewFallbackLabel }) {
-                projectStatus = .inReview
+            // Label fallback (#706, #790): when the board yields no status
+            // (issue not on any project), the `crow:in-review` /
+            // `crow:in-progress` labels carry the state. A board status, when
+            // present, wins above. In Review wins if both labels are somehow
+            // present, matching pipeline order.
+            if projectStatusOverride == nil, projectStatus == .unknown {
+                let names = Set(labels.map(\.name))
+                if names.contains(TicketStatus.inReviewFallbackLabel) {
+                    projectStatus = .inReview
+                } else if names.contains(TicketStatus.inProgressFallbackLabel) {
+                    projectStatus = .inProgress
+                }
             }
             return AssignedIssue(
                 id: "github:\(repoName)#\(number)",

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -164,6 +164,40 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(listing.closed[0].projectStatus, .done)
     }
 
+    func testGitHubTaskBackendParsesInProgressLabelFallback() async throws {
+        let fake = FakeShellRunner()
+        // #1 no project item + `crow:in-progress` → .inProgress; #2 is on a
+        // board, which wins over the label; #3 carries both fallback labels →
+        // In Review wins (pipeline order).
+        let json = """
+        {"data":{
+          "openIssues":{"nodes":[
+            {"number":1,"title":"Working","url":"https://github.com/a/b/issues/1","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"crow:in-progress","color":"1D76DB"}]},
+             "projectItems":{"nodes":[]}},
+            {"number":2,"title":"On board","url":"https://github.com/a/b/issues/2","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"crow:in-progress","color":"1D76DB"}]},
+             "projectItems":{"nodes":[{"fieldValueByName":{"name":"Backlog"}}]}},
+            {"number":3,"title":"Both","url":"https://github.com/a/b/issues/3","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"crow:in-progress","color":"1D76DB"},
+                                {"name":"crow:in-review","color":"FBCA04"}]},
+             "projectItems":{"nodes":[]}}
+          ]},
+          "closedIssues":{"nodes":[]}
+        }}
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.open.count, 3)
+        XCTAssertEqual(listing.open[0].projectStatus, .inProgress)
+        XCTAssertEqual(listing.open[1].projectStatus, .backlog)
+        XCTAssertEqual(listing.open[2].projectStatus, .inReview)
+    }
+
     func testGitHubTaskBackendClosedTotalFallsBackToNodeCount() async throws {
         let fake = FakeShellRunner()
         // No issueCount in the response — closedTotalCount falls back to the
@@ -364,17 +398,18 @@ final class BackendsTests: XCTestCase {
         XCTAssertTrue(fake.calls[1].args.contains("optionId=OPT_REVIEW"))
     }
 
-    // No project board at all → the `crow:in-review` label carries the status
-    // instead of a Projects-v2 field (#706).
+    // No project board at all → the `crow:in-review` / `crow:in-progress`
+    // labels carry the status instead of a Projects-v2 field (#706, #790).
     private static let noProjectLookup = #"{"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}"#
 
     func testGitHubTaskBackendSetTaskStatusFallsBackToLabelWhenNoProject() async throws {
         let fake = FakeShellRunner()
-        // Lookup (no project items) → label create → issue edit.
-        fake.responses = [.success(Self.noProjectLookup), .success(""), .success("")]
+        // Lookup (no project items) → label create → add edit → clear the
+        // sibling in-progress label.
+        fake.responses = [.success(Self.noProjectLookup), .success(""), .success(""), .success("")]
         let backend = GitHubTaskBackend(shellRunner: fake)
         try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
-        XCTAssertEqual(fake.calls.count, 3)
+        XCTAssertEqual(fake.calls.count, 4)
         let createArgs = fake.calls[1].args
         XCTAssertEqual(Array(createArgs.prefix(4)), ["gh", "label", "create", "crow:in-review"])
         XCTAssertTrue(createArgs.contains("a/b"))
@@ -382,6 +417,29 @@ final class BackendsTests: XCTestCase {
         XCTAssertTrue(editArgs.contains("--add-label"))
         XCTAssertTrue(editArgs.contains("crow:in-review"))
         XCTAssertFalse(editArgs.contains("--remove-label"))
+        // The two fallback labels are mutually exclusive.
+        let clearArgs = fake.calls[3].args
+        XCTAssertTrue(clearArgs.contains("--remove-label"))
+        XCTAssertTrue(clearArgs.contains("crow:in-progress"))
+    }
+
+    func testGitHubTaskBackendSetTaskStatusFallsBackToInProgressLabelWhenNoProject() async throws {
+        let fake = FakeShellRunner()
+        // Lookup → label create → add edit → clear the sibling in-review label.
+        fake.responses = [.success(Self.noProjectLookup), .success(""), .success(""), .success("")]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inProgress)
+        XCTAssertEqual(fake.calls.count, 4)
+        let createArgs = fake.calls[1].args
+        XCTAssertEqual(Array(createArgs.prefix(4)), ["gh", "label", "create", "crow:in-progress"])
+        XCTAssertTrue(createArgs.contains("a/b"))
+        let editArgs = fake.calls[2].args
+        XCTAssertTrue(editArgs.contains("--add-label"))
+        XCTAssertTrue(editArgs.contains("crow:in-progress"))
+        XCTAssertFalse(editArgs.contains("--remove-label"))
+        let clearArgs = fake.calls[3].args
+        XCTAssertTrue(clearArgs.contains("--remove-label"))
+        XCTAssertTrue(clearArgs.contains("crow:in-review"))
     }
 
     func testGitHubTaskBackendSetTaskStatusFallbackToleratesExistingLabel() async throws {
@@ -389,38 +447,41 @@ final class BackendsTests: XCTestCase {
         fake.responses = [
             .success(Self.noProjectLookup),
             .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "label 'crow:in-review' already exists")),
+            .success(""),
             .success("")
         ]
         let backend = GitHubTaskBackend(shellRunner: fake)
         try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
-        XCTAssertEqual(fake.calls.count, 3)
+        XCTAssertEqual(fake.calls.count, 4)
         XCTAssertTrue(fake.calls[2].args.contains("--add-label"))
         XCTAssertTrue(fake.calls[2].args.contains("crow:in-review"))
     }
 
-    func testGitHubTaskBackendSetTaskStatusFallbackRemovesLabelWhenLeavingReview() async throws {
+    func testGitHubTaskBackendSetTaskStatusFallbackClearsBothLabelsWhenNoTarget() async throws {
         let fake = FakeShellRunner()
-        fake.responses = [.success(Self.noProjectLookup), .success("")]
+        // Done carries no fallback label (the issue gets closed): no create, no
+        // add — just a removal edit per label.
+        fake.responses = [.success(Self.noProjectLookup), .success(""), .success("")]
         let backend = GitHubTaskBackend(shellRunner: fake)
-        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inProgress)
-        // No label create on the way out — just the removal edit.
-        XCTAssertEqual(fake.calls.count, 2)
-        let editArgs = fake.calls[1].args
-        XCTAssertTrue(editArgs.contains("--remove-label"))
-        XCTAssertTrue(editArgs.contains("crow:in-review"))
-        XCTAssertFalse(editArgs.contains("--add-label"))
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .done)
+        XCTAssertEqual(fake.calls.count, 3)
+        let removed = fake.calls.dropFirst().flatMap(\.args)
+        XCTAssertFalse(removed.contains("--add-label"))
+        XCTAssertTrue(removed.contains("crow:in-progress"))
+        XCTAssertTrue(removed.contains("crow:in-review"))
     }
 
     func testGitHubTaskBackendSetTaskStatusFallbackSwallowsMissingLabelOnRemove() async throws {
         let fake = FakeShellRunner()
         fake.responses = [
             .success(Self.noProjectLookup),
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "'crow:in-progress' not found")),
             .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "'crow:in-review' not found"))
         ]
         let backend = GitHubTaskBackend(shellRunner: fake)
         // Removal is best-effort: a repo that never entered review has no label.
         try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .done)
-        XCTAssertEqual(fake.calls.count, 2)
+        XCTAssertEqual(fake.calls.count, 3)
     }
 
     func testGitHubTaskBackendAssignInvokesGhIssueEdit() async throws {

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -1187,7 +1187,16 @@ GRAPHQL
   project_id=$(echo "$item_result" | grep -o '"id":"[^"]*"' | tail -1 | cut -d'"' -f4)
 
   if [[ -z "$item_id" || -z "$project_id" || "$item_id" == "$project_id" ]]; then
-    log "Issue not on any project, skipping status update"
+    # CROW-790: no board to mutate — delegate to the app, which represents
+    # In Progress with the `crow:in-progress` fallback label instead of
+    # dropping the transition on the floor. Best-effort, never fatal.
+    if [[ -n "$CROW_BIN" && -n "$SESSION_ID" ]]; then
+      log "Issue not on any project, using the crow:in-progress label fallback"
+      "$CROW_BIN" transition-ticket --session "$SESSION_ID" --to inProgress >/dev/null 2>&1 \
+        || log "Warning: in-progress label fallback failed (non-fatal)"
+    else
+      log "Issue not on any project, skipping status update"
+    fi
     return 0
   fi
 


### PR DESCRIPTION
Closes #790

Mirrors the In Review fallback from #706 for In Progress. Issues that aren't on a GitHub Project board had nowhere to record status, so opening a session left them visibly untouched — `setup.sh`'s project mutation logged "Issue not on any project, skipping status update" and dropped the transition.

## Changes

- **`Enums.swift`** — `TicketStatus.inProgressFallbackLabel` (`crow:in-progress`), plus `fallbackStatusLabels` and a `fallbackStatusLabel` per-status mapping.
- **`GitHubTaskBackend` write path** — the no-project branch is now status-driven (`setFallbackStatusLabel`): applies the target status' label (creating it on demand, `1D76DB` / "Crow: in progress (no-project status fallback)") and clears the other, so the two labels are mutually exclusive. Done clears both. The add and each removal stay separate `gh issue edit` calls on purpose — `--remove-label` fails the whole invocation when the repo lacks the label, which would take the add down with it.
- **Read path** — `crow:in-progress` parses back to `.inProgress`. A board status still wins whenever present; In Review wins if both labels are somehow present (pipeline order).
- **`IssueTracker.markIssueDone`** — clears whichever fallback labels the issue actually carries.
- **`setup.sh`** — the "not on any project" branch delegates to `crow transition-ticket --to inProgress` instead of silently skipping, so the fallback actually fires on session start.

## Tests

Table-driven backend tests mirroring the in-review coverage: `.inProgress` with no project creates + adds `crow:in-progress` and clears `crow:in-review`; `.inReview` does the inverse; `.done` clears both and tolerates "not found"; listing parses `crow:in-progress` → `.inProgress`, board wins over label, both labels → In Review. Issues on a project are unchanged (still a Projects-v2 mutation, no `gh label` call).

`make test` is green except a pre-existing `TmuxBackendTests.retryReadinessEmitsTimedOutWhenSentinelMissing` failure that also fails on a clean checkout of this base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PiNhbudSfRSjBNzbfzf5t