### PR TITLE
fix(web): default Tickets pipeline tab to Backlog, not All

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -564,7 +564,7 @@ function persistSidebarCache() {
     sidebarCacheHit = true;
   } catch (_) { /* quota / private mode */ }
 }
-let ticketFilter = 'All'; // pipeline segment ('All' or a status rawValue); default to All so the board isn't misread as empty when work moves to Done
+let ticketFilter = 'Backlog'; // pipeline segment ('All' or a status rawValue); default to Backlog so the Tickets view opens on the intake queue (CROW-795). 'All' stays a selectable tab.
 let allowlistHideGlobal = false;
 let allowlistFilter = ''; // #701: case-insensitive substring filter on entry pattern
 let ticketSearch = ''; // #714: case-insensitive substring on ticket text, composed with ticketFilter


### PR DESCRIPTION
Closes #795. Sets the Tickets view's initial selected pipeline tab to Backlog; PIPELINE array unchanged and All remains selectable. Preserves any persisted last-selected tab — only the cold-start default changes (`ticketFilter` is session-only in-memory state, so nothing is persisted).

## Verify
- Fresh load → **Backlog** tab pre-selected, showing its filtered list.
- Clicking **All** and the other pipeline tabs still filters correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)