### PR TITLE
fix(web): spin an inner glyph in the Tickets refresh button, not the whole button

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -641,21 +641,15 @@ html, body {
 .tickets-title { color: var(--gold); font-weight: 700; font-size: 13px; }
 .tickets-refresh {
   position: absolute; right: 0; top: 50%; transform: translateY(-50%);
+  display: inline-flex; align-items: center; justify-content: center;
   width: 22px; height: 22px; border-radius: 6px; cursor: pointer; line-height: 1;
   border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--text-secondary); font-size: 12px;
 }
 .tickets-refresh:hover { color: var(--text-primary); border-color: var(--border-strong); }
-/* In-flight ticket refresh (CROW-771). Can't reuse `wizard-spin`: the button is
-   absolutely positioned with `translateY(-50%)`, which a bare rotate keyframe
-   would clobber — so the keyframe composes both transforms. */
-.tickets-refresh.spinning {
-  opacity: 0.6; cursor: default;
-  animation: tickets-refresh-spin 0.7s linear infinite;
-}
-@keyframes tickets-refresh-spin {
-  from { transform: translateY(-50%) rotate(0deg); }
-  to   { transform: translateY(-50%) rotate(360deg); }
-}
+/* In-flight ticket refresh (CROW-771): the button chrome stays put while the
+   `.action-spinner` glyph swapped in for the `↻` turns inside it (CROW-797) —
+   matching the detail-header action-button spinner (CROW-749). */
+.tickets-refresh.spinning { opacity: 0.6; cursor: default; }
 .tickets-row { display: flex; align-items: stretch; gap: 6px; margin: 2px 2px 8px; }
 .tickets-row .tickets-card { flex: 1 1 auto; margin: 0; }
 .sidebar-tools { display: flex; flex-direction: column; justify-content: center; gap: 4px; flex: 0 0 auto; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -642,7 +642,7 @@ html, body {
 .tickets-refresh {
   position: absolute; right: 0; top: 50%; transform: translateY(-50%);
   display: inline-flex; align-items: center; justify-content: center;
-  width: 22px; height: 22px; border-radius: 6px; cursor: pointer; line-height: 1;
+  width: 22px; height: 22px; padding: 0; border-radius: 6px; cursor: pointer; line-height: 1;
   border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--text-secondary); font-size: 12px;
 }
 .tickets-refresh:hover { color: var(--text-primary); border-color: var(--border-strong); }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -830,7 +830,10 @@ function ticketsCard() {
   const head = el('div', 'tickets-head');
   head.appendChild(el('span', 'tickets-title', 'Tickets'));
   const busy = ticketsRefreshing();
-  const refresh = el('button', 'tickets-refresh' + (busy ? ' spinning' : ''), '↻');
+  // While refreshing, swap the ↻ glyph for the shared `.action-spinner` ring so
+  // the spinner turns inside a stationary button, not the button itself (CROW-797).
+  const refresh = el('button', 'tickets-refresh' + (busy ? ' spinning' : ''), busy ? '' : '↻');
+  if (busy) refresh.appendChild(el('span', 'action-spinner'));
   refresh.title = busy ? 'Refreshing tickets…' : 'Refresh tickets';
   refresh.disabled = busy;
   refresh.onclick = (e) => { e.stopPropagation(); refreshTickets(); };

--- a/Packages/CrowDaemon/web-tests/board.test.js
+++ b/Packages/CrowDaemon/web-tests/board.test.js
@@ -165,14 +165,18 @@ check('spinner shown without the daemon flag', q('.board-title .action-spinner')
 check('Refresh button disabled', [...q('.action-btn')].find((b) => b.textContent === 'Refresh').disabled === true);
 
 console.log('\nRefresh spinner — sidebar Tickets card ↻:');
-check('↻ spins + disabled while refreshing', (() => {
+check('↻ swaps for inner .action-spinner + disabled while refreshing', (() => {
   const b = T.ticketsCard().querySelector('.tickets-refresh');
-  return b.className.includes('spinning') && b.disabled === true && /Refreshing/.test(b.title);
+  return b.className.includes('spinning') && b.disabled === true && /Refreshing/.test(b.title)
+    // The spinner turns on an inner node, not the button itself (CROW-797): the ↻
+    // glyph is gone and the shared `.action-spinner` ring is present.
+    && b.querySelector('.action-spinner') !== null && b.textContent === '';
 })());
 T.ticketRefreshPending = false;
-check('↻ idle when not refreshing', (() => {
+check('↻ glyph restored, no spinner node when idle', (() => {
   const b = T.ticketsCard().querySelector('.tickets-refresh');
-  return !b.className.includes('spinning') && b.disabled === false && b.title === 'Refresh tickets';
+  return !b.className.includes('spinning') && b.disabled === false && b.title === 'Refresh tickets'
+    && b.querySelector('.action-spinner') === null && b.textContent === '↻';
 })());
 
 console.log('\nRefresh spinner — Reviews board:');


### PR DESCRIPTION
Closes #797. Moves the in-flight rotation off `.tickets-refresh` onto an inner spinner node: while refreshing, the `↻` glyph is swapped for the shared `.action-spinner` ring (matching the board-title / CROW-749 spinners), keeping 0.7s linear infinite timing via the existing `wizard-spin` keyframe. The bespoke `tickets-refresh-spin` keyframe is deleted. The button is now flex-centered and fixed-size, so its chrome stays put with no layout shift.

## Verify
Click refresh on the Tickets card → the button stays fixed in place; a spinner turns inside it; when the fetch completes the spinner stops and the `↻` returns. No layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)