### PR TITLE
fix(web): split sidebar nav pills into two deterministic rows

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -719,7 +719,10 @@ html, body {
 .tk-dot { width: 7px; height: 7px; border-radius: 50%; }
 .tk-n { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-.nav-pills { display: flex; gap: 6px; margin: 0 2px 8px; }
+/* Two deterministic rows: Reviews/Allowlist/Scorecard, then Manager + "+".
+   Each .nav-pills-row is its own non-wrapping flex line so groups never reflow. */
+.nav-pills { display: flex; flex-direction: column; gap: 6px; margin: 0 2px 8px; }
+.nav-pills-row { display: flex; gap: 6px; }
 .nav-pill {
   flex: 1 1 auto; min-width: 0; display: flex; align-items: center; justify-content: center; gap: 5px;
   padding: 6px 8px; border-radius: 6px; cursor: pointer;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -975,17 +975,20 @@ function sidebarToolsStack() {
 
 // Reviews / Allowlist / Manager pills + "+" (new manager).
 function navPillRow() {
-  const row = el('div', 'nav-pills');
+  const wrap = el('div', 'nav-pills');
 
+  // Row 1: Reviews · Allowlist · Scorecard (kept together, no mid-group wrap).
+  const row1 = el('div', 'nav-pills-row');
   const rev = navPill('Reviews', selectedBoard === 'reviews', () => selectBoard('reviews'));
   const unseen = (boardData.reviews && boardData.reviews.unseen) || 0;
   if (unseen) rev.appendChild(el('span', 'pill-badge', String(unseen)));
-  row.appendChild(rev);
+  row1.appendChild(rev);
+  row1.appendChild(navPill('Allowlist', selectedBoard === 'allowlist', () => selectBoard('allowlist')));
+  row1.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
+  wrap.appendChild(row1);
 
-  row.appendChild(navPill('Allowlist', selectedBoard === 'allowlist', () => selectBoard('allowlist')));
-
-  row.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
-
+  // Row 2: Manager pill (when a primary manager session exists) + the "+" new-manager button.
+  const row2 = el('div', 'nav-pills-row');
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
     const mgr = navPill('Manager', selectedId === primaryManager.id, () => selectSession(primaryManager.id));
@@ -994,14 +997,15 @@ function navPillRow() {
     dot.style.background = ind.color;
     mgr.insertBefore(dot, mgr.firstChild);
     if (liveFor(primaryManager.id).remote_control_active) mgr.appendChild(rcGlyph());
-    row.appendChild(mgr);
+    row2.appendChild(mgr);
   }
-
   const plus = el('button', 'nav-plus', '+');
   plus.title = 'New Manager session';
   plus.onclick = () => openNewManagerMenu(plus);
-  row.appendChild(plus);
-  return row;
+  row2.appendChild(plus);
+  wrap.appendChild(row2);
+
+  return wrap;
 }
 
 function navPill(label, active, onClick) {


### PR DESCRIPTION
Closes #799. Groups Reviews/Allowlist/Scorecard on row 1 and Manager + '+' on row 2 via explicit `.nav-pills-row` containers inside a column `.nav-pills` wrapper, removing width-dependent reflow. Preserves the Reviews unseen badge, the Manager pill's activity dot / remote-control glyph, and the new-manager menu; row 2 still holds '+' when no manager session exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)