### PR TITLE
fix(web): green PR status checkmarks (#802)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -764,7 +764,8 @@ html, body {
 /* ---- Detail header: gold PR chip + inline PR status ---- */
 .link-chip.link-pr { color: var(--gold); border-color: var(--border-strong); }
 .pr-status-inline { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-left: 4px; }
-.pr-stat { font-size: 11px; font-weight: 600; }
+.pr-stat { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; }
+.pr-stat-glyph { line-height: 1; }
 
 /* Artifacts — per-session generated images (CROW-593). Hidden until the
    session has any; a compact horizontal strip under the detail header. */

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1200,7 +1200,7 @@ function sessionRow(s) {
     prb.style.borderColor = color;
     const parts = prBadgeParts(pr);
     for (const part of parts) {
-      const ico = el('span', 'pr-ico', part.glyph);
+      const ico = part.icon ? icon(part.icon, 10) : el('span', 'pr-ico', part.glyph);
       ico.style.color = part.color;
       prb.appendChild(ico);
     }
@@ -1252,20 +1252,24 @@ function prBadgeColor(pr) {
 // (`sessionRow`) and the detail header (`prStatusInline`), so the two can never
 // disagree about the same PR (CROW-773).
 // ---------------------------------------------------------------------------
+// `icon` names an entry in ICONS: those glyphs render as monochrome SVGs that
+// inherit `currentColor`, so the checkmarks tint with their label instead of
+// staying black (Apple emoji ✔/✕/⚠ ignore CSS `color` — CROW-802). Geometric
+// glyphs (◷/○/?) and the 🏷 tag are already color-faithful, so they stay text.
 const PR_CHECKS_GLYPH = {
-  passing: { glyph: '✔', color: 'var(--green)', label: 'Checks pass' },
-  failing: { glyph: '✕', color: 'var(--red)', label: 'Checks failing' },
+  passing: { glyph: '✔', icon: 'check', color: 'var(--green)', label: 'Checks pass' },
+  failing: { glyph: '✕', icon: 'close', color: 'var(--red)', label: 'Checks failing' },
   pending: { glyph: '◷', color: 'var(--orange)', label: 'Checks running' },
   unknown: { glyph: '?', color: 'var(--text-muted)', label: 'No checks' },
 };
 const PR_REVIEW_GLYPH = {
-  approved: { glyph: '✔', color: 'var(--green)', label: 'Approved' },
-  changesRequested: { glyph: '✕', color: 'var(--red)', label: 'Changes requested' },
+  approved: { glyph: '✔', icon: 'check', color: 'var(--green)', label: 'Approved' },
+  changesRequested: { glyph: '✕', icon: 'close', color: 'var(--red)', label: 'Changes requested' },
   reviewRequired: { glyph: '◷', color: 'var(--orange)', label: 'Needs review' },
   unknown: { glyph: '○', color: 'var(--text-muted)', label: 'No reviews' },
 };
-const PR_MERGED_GLYPH = { glyph: '✔', color: 'var(--purple)', label: 'Merged' };
-const PR_CONFLICT_GLYPH = { glyph: '⚠', color: 'var(--red)', label: 'Conflicts' };
+const PR_MERGED_GLYPH = { glyph: '✔', icon: 'check', color: 'var(--purple)', label: 'Merged' };
+const PR_CONFLICT_GLYPH = { glyph: '⚠', icon: 'warning', color: 'var(--red)', label: 'Conflicts' };
 const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge label' };
 
 function prChecksGlyph(pr) {
@@ -1789,25 +1793,30 @@ function renderSessionAnalyticsStrip(s, root) {
 function prStatusInline(pr) {
   const wrap = el('div', 'pr-status-inline');
   if (pr.is_merged) {
-    wrap.appendChild(prStatusPart(PR_MERGED_GLYPH.glyph + ' ' + PR_MERGED_GLYPH.label, PR_MERGED_GLYPH.color));
+    wrap.appendChild(prStatusPart(PR_MERGED_GLYPH));
     return wrap;
   }
   for (const part of [prChecksGlyph(pr), prReviewGlyph(pr)]) {
-    wrap.appendChild(prStatusPart(part.glyph + ' ' + part.label, part.color));
+    wrap.appendChild(prStatusPart(part));
   }
   if (pr.merge === 'conflicting') {
-    wrap.appendChild(prStatusPart(PR_CONFLICT_GLYPH.glyph + ' ' + PR_CONFLICT_GLYPH.label, PR_CONFLICT_GLYPH.color));
+    wrap.appendChild(prStatusPart(PR_CONFLICT_GLYPH));
   }
   if (pr.has_merge_label) {
-    wrap.appendChild(prStatusPart(PR_MERGE_LABEL_GLYPH.glyph + ' ' + PR_MERGE_LABEL_GLYPH.label, PR_MERGE_LABEL_GLYPH.color));
+    wrap.appendChild(prStatusPart(PR_MERGE_LABEL_GLYPH));
   }
   return wrap;
 }
 
-function prStatusPart(text, color) {
-  const part = el('span', 'pr-stat', text);
-  part.style.color = color;
-  return part;
+// One status chip: a monochrome SVG glyph (or geometric char) + its label, both
+// tinted `part.color` — the SVG inherits it via currentColor so the checkmark
+// matches the text instead of rendering as a black emoji (CROW-802).
+function prStatusPart(part) {
+  const chip = el('span', 'pr-stat');
+  chip.style.color = part.color;
+  chip.appendChild(part.icon ? icon(part.icon, 12) : el('span', 'pr-stat-glyph', part.glyph));
+  chip.appendChild(el('span', 'pr-stat-label', part.label));
+  return chip;
 }
 
 function qaButton(label, action, id, variant, iconName, opts) {


### PR DESCRIPTION
Closes #802

## Problem

When a PR is approved and checks pass, the status **text** rendered green but the **checkmark icons** stayed black — in both the sidebar session-row PR pill and the session-detail PR status row.

## Cause

The glyphs `✔` / `✕` / `⚠` are Unicode dingbats that macOS renders as **Apple color emoji**, which ignore CSS `color`. Only the adjacent label text picked up the green/red tint.

## Fix

Give the emoji glyph entries an `icon` name into the existing monochrome `ICONS` set (`check` / `close` / `warning`) and render them through `icon()`, which emits an SVG with `stroke="currentColor"`. The checkmark now inherits the same color as its label.

This is the exact path the sidebar ticket counts already use for the green **Done** mark (#732) — reused, not reinvented. The geometric glyphs (`◷` / `○` / `?`) and the intentional `🏷` `crow:merge` tag stay as text, since they already respect `color`.

- `sessionRow` PR pill (`pr-ico`) → SVG when the part has an `icon`
- `prStatusInline` / `prStatusPart` → refactored to take the glyph object and emit `icon() + label`, both tinted `part.color`
- `.pr-stat` becomes an inline-flex chip so the icon and label align

Labels, `title`, and `aria-label` are unchanged (still driven by `part.label`), so the accessibility description is unaffected.

## Test plan

- Open a session whose PR is **approved + checks passing** → detail PR status row shows a **green** ✔ next to "Checks pass" / "Approved" (not black); sidebar row pill checkmarks are green.
- Failing checks / changes requested → **red** ✕. Conflicts → **red** ⚠. Merged → **purple** ✔.
- Pending (`◷`), no-checks (`?`), no-reviews (`○`), and the `🏷` merge-label marker render unchanged.

🐦‍⬛ Generated with Crow