### PR TITLE
crow CLI: add edit-link; document remove-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 
 ### Tooling & Misc
 
+- #805 — `crow edit-link` updates a session link's label, URL, or type in place (`--id`/`--url` selects, `--new-url` sets the new URL, only provided fields change) so a mislabeled link can be corrected without a remove-then-add round trip. Also documents the pre-existing `crow remove-link`, which detaches a link by `--id` or `--url` — it was implemented but missing from the CLI reference, skill, and CLAUDE.md.
 - #769 — `crowd` can start at login again (the gap ADR-0010 left when the macOS app was retired). `crow autostart install | uninstall | status` registers a launchd LaunchAgent — idempotent, re-points itself after an upgrade, and never bootstraps a duplicate over a running daemon. Same toggle at Settings → General → Autostart from a local browser. macOS only for now; Linux waits on #645.
 - #152 — Replace dock icon with the Corveil Brandmark.
 - #155 — Docs refresh: README, `make build` promotion, GitHub project scope wording.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]
 crow set-goal --session <uuid> --goal "..." | --clear                  → tag the session's org goal/KPI (feeds alignment weight; exactly one of --goal/--clear)
 crow add-link --session <uuid> --label "Issue" --url "..." --type ticket|pr|repo|custom
 crow list-links --session <uuid>
+crow remove-link --session <uuid> --id <link-uuid> | --url "..."       → detach a link by id (from list-links) or url; returns {"removed":N}
+crow edit-link --session <uuid> --id <link-uuid> | --url "..." [--label "..."] [--new-url "..."] [--type ...]   → update a link in place (only provided fields change; --url selects, --new-url sets); returns {"updated":N}
 crow transition-ticket --session <uuid> --to inProgress|inReview|done   → moves the linked ticket to a pipeline status (Jira honors jiraStatusMap)
 crow resync-jira                                                        → re-sync every Jira ticket's status from its Crow session state
 ```

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/MetadataCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/MetadataCommands.swift
@@ -204,6 +204,15 @@ public struct EditLink: ParsableCommand {
         guard label != nil || newUrl != nil || type != nil else {
             throw ValidationError("At least one of --label, --new-url, or --type is required")
         }
+        // Reject blank writes: an empty label/URL would break URL-keyed
+        // consumers (PR badge, review-session lookup). Mirrors add-link's
+        // non-empty guard.
+        if let label, label.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--label must not be blank")
+        }
+        if let newUrl, newUrl.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--new-url must not be blank")
+        }
         if let type { try validateLinkType(type) }
     }
 

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/MetadataCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/MetadataCommands.swift
@@ -178,3 +178,43 @@ public struct RemoveLink: ParsableCommand {
         printJSON(result)
     }
 }
+
+/// Edit a session link's label, URL, or type in place, identified by its link ID
+/// (from `list-links`) or its current URL. Only the fields provided change; the
+/// URL selector and the new URL value are distinct flags (`--url` selects,
+/// `--new-url` sets) so a link can be relabeled or re-pointed without a
+/// remove-then-add round trip (#805).
+public struct EditLink: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "edit-link", abstract: "Edit a link's label, URL, or type in place")
+    @Option(name: .long, help: "Session UUID") var session: String
+    @Option(name: .long, help: "Link ID (from list-links)") var id: String?
+    @Option(name: .long, help: "Current link URL to match (alternative to --id)") var url: String?
+    @Option(name: .long, help: "New label") var label: String?
+    @Option(name: .long, help: "New URL") var newUrl: String?
+    @Option(name: .long, help: "New link type: ticket, pr, repo, custom") var type: String?
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(session, label: "session UUID")
+        if let id { try validateUUID(id, label: "link ID") }
+        guard id != nil || url != nil else {
+            throw ValidationError("Provide --id or --url to identify the link to edit")
+        }
+        guard label != nil || newUrl != nil || type != nil else {
+            throw ValidationError("At least one of --label, --new-url, or --type is required")
+        }
+        if let type { try validateLinkType(type) }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["session_id": .string(session)]
+        if let id { params["link_id"] = .string(id) }
+        if let url { params["url"] = .string(url) }
+        if let label { params["label"] = .string(label) }
+        if let newUrl { params["new_url"] = .string(newUrl) }
+        if let type { params["type"] = .string(type) }
+        let result = try rpc("edit-link", params: params)
+        printJSON(result)
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -35,6 +35,7 @@ public struct CrowCommand: ParsableCommand {
             AddLink.self,
             ListLinks.self,
             RemoveLink.self,
+            EditLink.self,
             TransitionTicket.self,
             ResyncJira.self,
             HookEventCmd.self,

--- a/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
@@ -99,6 +99,59 @@ private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     #expect(cmd.type == "custom")
 }
 
+@Test func editLinkParsesAllArgs() throws {
+    let cmd = try EditLink.parse([
+        "--session", validUUID,
+        "--id", validUUID,
+        "--label", "PR #42",
+        "--new-url", "https://example.com/pr/42",
+        "--type", "pr",
+    ])
+    #expect(cmd.session == validUUID)
+    #expect(cmd.id == validUUID)
+    #expect(cmd.label == "PR #42")
+    #expect(cmd.newUrl == "https://example.com/pr/42")
+    #expect(cmd.type == "pr")
+    try cmd.validate()
+}
+
+@Test func editLinkSelectsByUrl() throws {
+    let cmd = try EditLink.parse(["--session", validUUID, "--url", "https://old.com", "--label", "Renamed"])
+    #expect(cmd.url == "https://old.com")
+    #expect(cmd.label == "Renamed")
+    try cmd.validate()
+}
+
+@Test func editLinkRequiresSelector() {
+    // Neither --id nor --url provided: cannot identify the link.
+    #expect(throws: (any Error).self) {
+        let cmd = try EditLink.parse(["--session", validUUID, "--label", "x"])
+        try cmd.validate()
+    }
+}
+
+@Test func editLinkRequiresMutation() {
+    // A selector but no field to change is a no-op the CLI rejects.
+    #expect(throws: (any Error).self) {
+        let cmd = try EditLink.parse(["--session", validUUID, "--id", validUUID])
+        try cmd.validate()
+    }
+}
+
+@Test func editLinkRejectsInvalidType() {
+    #expect(throws: (any Error).self) {
+        let cmd = try EditLink.parse(["--session", validUUID, "--id", validUUID, "--type", "bogus"])
+        try cmd.validate()
+    }
+}
+
+@Test func editLinkRejectsInvalidUUID() {
+    #expect(throws: (any Error).self) {
+        let cmd = try EditLink.parse(["--session", validUUID, "--id", "not-a-uuid", "--label", "x"])
+        try cmd.validate()
+    }
+}
+
 // MARK: - set-ticket --priority + set-goal (#696)
 
 @Test func setTicketParsesPriority() throws {

--- a/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
@@ -138,6 +138,22 @@ private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
 }
 
+@Test func editLinkRejectsBlankLabel() {
+    // An empty/whitespace label would wipe the display text.
+    #expect(throws: (any Error).self) {
+        let cmd = try EditLink.parse(["--session", validUUID, "--id", validUUID, "--label", "  "])
+        try cmd.validate()
+    }
+}
+
+@Test func editLinkRejectsBlankNewUrl() {
+    // An empty --new-url would break URL-keyed consumers, so reject it.
+    #expect(throws: (any Error).self) {
+        let cmd = try EditLink.parse(["--session", validUUID, "--id", validUUID, "--new-url", ""])
+        try cmd.validate()
+    }
+}
+
 @Test func editLinkRejectsInvalidType() {
     #expect(throws: (any Error).self) {
         let cmd = try EditLink.parse(["--session", validUUID, "--id", validUUID, "--type", "bogus"])

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -1046,6 +1046,46 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                     return ["removed": .int(removed)]
                 }
             },
+            "edit-link": { @Sendable params in
+                guard let idStr = params["session_id"]?.stringValue, let sessionID = UUID(uuidString: idStr) else {
+                    throw RPCError.invalidParams("session_id required")
+                }
+                let linkID = params["link_id"]?.stringValue.flatMap { UUID(uuidString: $0) }
+                let selectorURL = params["url"]?.stringValue
+                guard linkID != nil || selectorURL != nil else {
+                    throw RPCError.invalidParams("link_id or url required to identify the link")
+                }
+                let newLabel = params["label"]?.stringValue
+                let newURL = params["new_url"]?.stringValue
+                let newType = params["type"]?.stringValue.flatMap { LinkType(rawValue: $0) }
+                guard newLabel != nil || newURL != nil || newType != nil else {
+                    throw RPCError.invalidParams("at least one of label, new_url, type required")
+                }
+                func matches(_ l: SessionLink) -> Bool {
+                    (linkID != nil && l.id == linkID) || (selectorURL != nil && l.url == selectorURL)
+                }
+                func apply(_ l: inout SessionLink) {
+                    if let newLabel { l.label = newLabel }
+                    if let newURL { l.url = newURL }
+                    if let newType { l.linkType = newType }
+                }
+                return await MainActor.run {
+                    var updated = 0
+                    if var existing = capturedAppState.links[sessionID] {
+                        for i in existing.indices where matches(existing[i]) {
+                            apply(&existing[i])
+                            updated += 1
+                        }
+                        capturedAppState.links[sessionID] = existing
+                    }
+                    capturedStore.mutate { data in
+                        for i in data.links.indices where data.links[i].sessionID == sessionID && matches(data.links[i]) {
+                            apply(&data.links[i])
+                        }
+                    }
+                    return ["updated": .int(updated)]
+                }
+            },
             "hook-event": { @Sendable params in
                 guard let eventName = params["event_name"]?.stringValue else {
                     throw RPCError.invalidParams("event_name required")

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -1057,7 +1057,21 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }
                 let newLabel = params["label"]?.stringValue
                 let newURL = params["new_url"]?.stringValue
-                let newType = params["type"]?.stringValue.flatMap { LinkType(rawValue: $0) }
+                // Blank label/URL would break URL-keyed consumers; reject them
+                // like add-link does rather than silently wiping a field.
+                if let newLabel, newLabel.trimmingCharacters(in: .whitespaces).isEmpty {
+                    throw RPCError.invalidParams("label must not be empty")
+                }
+                if let newURL, newURL.trimmingCharacters(in: .whitespaces).isEmpty {
+                    throw RPCError.invalidParams("new_url must not be empty")
+                }
+                var newType: LinkType?
+                if let typeStr = params["type"]?.stringValue {
+                    guard let parsed = LinkType(rawValue: typeStr) else {
+                        throw RPCError.invalidParams("invalid type '\(typeStr)' (expected ticket, pr, repo, or custom)")
+                    }
+                    newType = parsed
+                }
                 guard newLabel != nil || newURL != nil || newType != nil else {
                     throw RPCError.invalidParams("at least one of label, new_url, type required")
                 }

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -24,6 +24,8 @@ crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]
 crow set-goal --session <uuid> --goal "..." | --clear
 crow add-link --session <uuid> --label "Issue" --url "..." --type ticket|pr|repo|custom
 crow list-links --session <uuid>
+crow remove-link --session <uuid> --id <link-uuid> | --url "..."
+crow edit-link --session <uuid> --id <link-uuid> | --url "..." [--label "..."] [--new-url "..."] [--type ticket|pr|repo|custom]
 ```
 
 ### Worktree Commands

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -592,6 +592,8 @@ crow list-terminals --session <uuid>
 crow send --session <uuid> --terminal <uuid> "text"
 crow add-link --session <uuid> --label "..." --url "..." --type ticket|pr|repo|custom
 crow list-links --session <uuid>
+crow remove-link --session <uuid> --id <link-uuid> | --url "..."
+crow edit-link --session <uuid> --id <link-uuid> | --url "..." [--label "..."] [--new-url "..."] [--type ticket|pr|repo|custom]
 ```
 
 All commands return JSON and require `dangerouslyDisableSandbox: true`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -207,6 +207,45 @@ crow add-link --session <uuid> --label "Issue #123" --url "https://..." --type t
 crow list-links --session <uuid>
 ```
 
+Returns each link's `id`, `label`, `url`, and `type` — the `id` is what `edit-link` / `remove-link` take.
+
+### `crow remove-link`
+
+Detach a link from a session, identified by its link ID (from `list-links`) or its URL.
+
+```bash
+crow remove-link --session <uuid> --id <link-uuid>
+crow remove-link --session <uuid> --url "https://..."
+```
+
+| Flag        | Required | Description                                  |
+| ----------- | -------- | -------------------------------------------- |
+| `--session` | yes      | Session UUID                                 |
+| `--id`      | one of   | Link UUID (from `list-links`)                |
+| `--url`     | one of   | Link URL (alternative to `--id`)             |
+
+Provide at least one of `--id` / `--url`. Returns `{"removed": N}`.
+
+### `crow edit-link`
+
+Update a link's label, URL, or type in place. The link is selected by `--id` or its current `--url`; only the fields you pass change. Because `--url` selects the link, the *new* URL is set via `--new-url`.
+
+```bash
+crow edit-link --session <uuid> --id <link-uuid> --label "PR #42" --type pr
+crow edit-link --session <uuid> --url "https://old..." --new-url "https://new..."
+```
+
+| Flag        | Required | Description                                        |
+| ----------- | -------- | -------------------------------------------------- |
+| `--session` | yes      | Session UUID                                        |
+| `--id`      | one of   | Link UUID to edit (from `list-links`)              |
+| `--url`     | one of   | Current link URL to match (alternative to `--id`)  |
+| `--label`   | no       | New display label                                  |
+| `--new-url` | no       | New target URL                                     |
+| `--type`    | no       | New type: `ticket`, `pr`, `repo`, or `custom`      |
+
+Provide at least one selector (`--id` / `--url`) and at least one field to change (`--label` / `--new-url` / `--type`). Returns `{"updated": N}`.
+
 ---
 
 ## Worktree Commands

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -592,6 +592,8 @@ crow list-terminals --session <uuid>
 crow send --session <uuid> --terminal <uuid> "text"
 crow add-link --session <uuid> --label "..." --url "..." --type ticket|pr|repo|custom
 crow list-links --session <uuid>
+crow remove-link --session <uuid> --id <link-uuid> | --url "..."
+crow edit-link --session <uuid> --id <link-uuid> | --url "..." [--label "..."] [--new-url "..."] [--type ticket|pr|repo|custom]
 ```
 
 All commands return JSON and require `dangerouslyDisableSandbox: true`.


### PR DESCRIPTION
Closes #805

## What

Session links were add-only from the CLI's perspective — a mislabeled link could only be fixed in the app UI, so Manager-driven automation had no way to correct its own mistakes.

Tracing the code surfaced that a **`remove-link` verb already exists** and removes a link by `--id` or `--url` — it was simply undocumented (absent from the CLI reference, the crow-workspace skill, and the CLAUDE.md files), which is why the ticket believed links were add-only.

## Changes

- **New `crow edit-link`** — update a link's label, URL, or type in place. The link is selected by `--id` or its current `--url`; the *new* URL is set via `--new-url` (since `--url` is the selector). Only the fields provided change. Returns `{"updated":N}`.
  - CLI verb `EditLink` in `MetadataCommands.swift` + registration in `CrowCommand.swift`.
  - `"edit-link"` handler in `EngineRouter.swift`, mirroring the existing `remove-link` handler — dual-writes the in-memory `AppState.links` mirror and the persisted `JSONStore` array inside a single `MainActor.run`. No daemon `RPCHandlers.swift` change (the engine router is its fallback).
- **Documented the pre-existing `crow remove-link`** across `docs/cli-reference.md`, the crow-workspace `SKILL.md` + template, `CLAUDE.md` + template, and `CHANGELOG.md`.

Per discussion, `delete-link` was **not** added — `remove-link` already covers "remove a link by id", so it's documented rather than duplicated.

## Tests

Added `edit-link` parsing/validation tests to `CommandParsingTests.swift` mirroring the `add-link` tests (all-args parse, url selector, missing-selector rejection, missing-mutation rejection, invalid type, invalid UUID). Full CrowCLI suite passes (109 tests); `swift build` clean.

## Verify

```bash
crow add-link --session <uuid> --label "x" --url "https://old..." --type custom   # capture link_id
crow edit-link --session <uuid> --id <link_id> --label "PR #42" --type pr          # => {"updated":1}
crow list-links --session <uuid>                                                  # reflects the change
crow remove-link --session <uuid> --id <link_id>                                  # => {"removed":1}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DQKWo5zCmhRkmLoPFTt7q