### PR TITLE
Terminal scrollback: heal stale alt-screen / 5000-line windows

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/TerminalCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/TerminalCommands.swift
@@ -71,6 +71,31 @@ public struct CloseTerminal: ParsableCommand {
     }
 }
 
+/// Recreate a terminal whose tmux window has degraded scrollback (CROW-804).
+/// Kills the stale window and rebuilds a fresh, correctly-configured one,
+/// relaunching the agent (`claude --continue`). Destructive to the running
+/// agent — the web UI confirms first; from the CLI the caller owns that choice.
+public struct RecreateTerminal: ParsableCommand {
+    public static let configuration = CommandConfiguration(commandName: "recreate-terminal", abstract: "Recreate a terminal to restore full scrollback (CROW-804)")
+    @Option(name: .long, help: "Session UUID") var session: String
+    @Option(name: .long, help: "Terminal UUID") var terminal: String
+
+    public init() {}
+
+    public func validate() throws {
+        try validateUUID(session, label: "session UUID")
+        try validateUUID(terminal, label: "terminal UUID")
+    }
+
+    public func run() throws {
+        let result = try rpc("recreate-terminal", params: [
+            "session_id": .string(session),
+            "terminal_id": .string(terminal),
+        ])
+        printJSON(result)
+    }
+}
+
 /// Rename a terminal tab.
 public struct RenameTerminal: ParsableCommand {
     public static let configuration = CommandConfiguration(commandName: "rename-terminal", abstract: "Rename a terminal tab")

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -30,6 +30,7 @@ public struct CrowCommand: ParsableCommand {
             NewTerminal.self,
             ListTerminals.self,
             CloseTerminal.self,
+            RecreateTerminal.self,
             RenameTerminal.self,
             Send.self,
             AddLink.self,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -357,6 +357,9 @@ html, body {
 .tab.add { color: var(--gold); font-size: 16px; font-weight: 700; }
 .tab-close { color: var(--text-muted); font-size: 14px; }
 .tab-close:hover { color: var(--red); }
+/* CROW-804: degraded-scrollback warning badge on a terminal tab. */
+.tab-degraded { color: var(--gold); font-size: 12px; }
+.tab-degraded:hover { color: var(--text-primary); }
 #terminal-wrap { flex: 1; min-height: 0; background: #1e1e1e; position: relative; overscroll-behavior: contain; }
 /* #777: `touch-action: none` hands the one-finger gesture to enableTouchScroll
    instead of iOS Safari's overscroll — without it Safari rubber-bands the fixed

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -360,6 +360,12 @@ html, body {
 /* CROW-804: degraded-scrollback warning badge on a terminal tab. */
 .tab-degraded { color: var(--gold); font-size: 12px; }
 .tab-degraded:hover { color: var(--text-primary); }
+/* CROW-804: Manager surface has no tabs — a slim warning strip carries the
+   degraded-scrollback notice + Recreate action instead. */
+.degraded-strip { display: flex; align-items: center; gap: 8px; padding: 6px 12px; font-size: 12px; }
+.degraded-msg { color: var(--text-secondary); }
+.degraded-recreate { color: var(--gold); cursor: pointer; font-weight: 600; }
+.degraded-recreate:hover { color: var(--text-primary); text-decoration: underline; }
 #terminal-wrap { flex: 1; min-height: 0; background: #1e1e1e; position: relative; overscroll-behavior: contain; }
 /* #777: `touch-action: none` hands the one-finger gesture to enableTouchScroll
    instead of iOS Safari's overscroll — without it Safari rubber-bands the fixed

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2053,7 +2053,25 @@ function renderTabs() {
   // moots the stale-tab naming bug: a renamed manager session has no tab to go
   // stale, since tabs are labeled from the terminal name, not the session name.)
   const sel = sessions.find((x) => x.id === selectedId);
-  if (sel && sel.kind === 'manager') return;
+  if (sel && sel.kind === 'manager') {
+    // #680: managers have no tabs. But the Manager window is a common CROW-804
+    // "stuck alt-screen / 5000-line" case, and with no tab there'd be no ⚠ or
+    // Recreate. Surface a slim warning strip with a Recreate action when the
+    // Manager terminal is degraded; otherwise leave #tabbar empty so it stays
+    // collapsed. Recreate routes through restartManager (SessionService).
+    const degraded = terminals.find((t) => t.scrollback_degraded);
+    if (degraded) {
+      const strip = el('div', 'degraded-strip');
+      strip.appendChild(el('span', 'tab-degraded', '⚠'));
+      strip.appendChild(el('span', 'degraded-msg', 'Scrollback degraded — this Manager window can\'t show full history.'));
+      const btn = el('span', 'degraded-recreate', 'Recreate');
+      btn.title = 'Rebuild this Manager terminal to restore full scroll-up history (restarts the agent).';
+      btn.onclick = () => recreateTerminal(degraded);
+      strip.appendChild(btn);
+      bar.appendChild(strip);
+    }
+    return;
+  }
   for (const t of terminals) {
     const tab = el('div', 'tab' + (activeTerminal && t.id === activeTerminal.id ? ' active' : ''));
     const label = el('span', null, t.name);
@@ -2128,8 +2146,13 @@ async function recreateTerminal(t) {
     return;
   }
   await refreshTerminals();
-  // Re-attach so the fresh window streams into the surface immediately.
-  if (activeTerminal && activeTerminal.id === t.id) attachWindow(activeTerminal.window);
+  // Recreate keeps the terminal id but binds a NEW tmux window index, and
+  // refreshTerminals() only swaps activeTerminal when the id disappears — so the
+  // active tab would keep the old (killed) window object and attachWindow's
+  // `win === attachedWindow` guard would skip the reload. Re-point at the
+  // refreshed row and switch onto its new window so the fresh pane streams in.
+  const refreshed = terminals.find((x) => x.id === t.id);
+  if (refreshed) switchTerminal(refreshed);
 }
 
 // ---------------------------------------------------------------------------

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2059,6 +2059,15 @@ function renderTabs() {
     const label = el('span', null, t.name);
     label.onclick = () => switchTerminal(t);
     tab.appendChild(label);
+    // CROW-804: this terminal's tmux window is stuck with degraded scrollback
+    // (alternate-screen buffer and/or the old 5000-line history-limit) that
+    // tmux can't fix in place. Badge it and offer a one-click recreate.
+    if (t.scrollback_degraded) {
+      const warn = el('span', 'tab-degraded', '⚠');
+      warn.title = 'Scrollback degraded — this window can\'t show full history (created before the current config). Click to recreate it and restore scroll-up.';
+      warn.onclick = (e) => { e.stopPropagation(); recreateTerminal(t); };
+      tab.appendChild(warn);
+    }
     const close = el('span', 'tab-close', '×');
     close.onclick = (e) => { e.stopPropagation(); closeTerminal(t); };
     tab.appendChild(close);
@@ -2100,6 +2109,27 @@ async function closeTerminal(t) {
   try { await rpc('close-terminal', { session_id: selectedId, terminal_id: t.id }); } catch (_) {}
   if (activeTerminal && activeTerminal.id === t.id) activeTerminal = null;
   await refreshTerminals();
+}
+
+// CROW-804: heal a terminal whose tmux window has degraded scrollback. Recreate
+// kills the window and rebuilds it under the current config, relaunching the
+// agent (`claude --continue`) — so confirm first, since it interrupts whatever
+// is running in the pane.
+async function recreateTerminal(t) {
+  const ok = await confirmModal(
+    'This rebuilds “' + (t.name || 'terminal') + '” to restore full scroll-up history. '
+    + 'The agent running in it will be restarted (resumed via claude --continue).',
+    { title: 'Recreate terminal', okLabel: 'Recreate', danger: true });
+  if (!ok) return;
+  try {
+    await rpc('recreate-terminal', { session_id: selectedId, terminal_id: t.id });
+  } catch (e) {
+    if (term) term.write('\r\n\x1b[31m[crow] recreate-terminal failed: ' + (e.message || e) + '\x1b[0m\r\n');
+    return;
+  }
+  await refreshTerminals();
+  // Re-attach so the fresh window streams into the surface immediately.
+  if (activeTerminal && activeTerminal.id === t.id) attachWindow(activeTerminal.window);
 }
 
 // ---------------------------------------------------------------------------

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2143,6 +2143,10 @@ async function recreateTerminal(t) {
     await rpc('recreate-terminal', { session_id: selectedId, terminal_id: t.id });
   } catch (e) {
     if (term) term.write('\r\n\x1b[31m[crow] recreate-terminal failed: ' + (e.message || e) + '\x1b[0m\r\n');
+    // Register-then-kill means a failed heal leaves the old window live and
+    // still degraded — refresh so the ⚠ / Recreate affordance re-renders for a
+    // retry instead of vanishing on a half-applied state.
+    await refreshTerminals();
     return;
   }
   await refreshTerminals();

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2136,7 +2136,7 @@ async function closeTerminal(t) {
 async function recreateTerminal(t) {
   const ok = await confirmModal(
     'This rebuilds “' + (t.name || 'terminal') + '” to restore full scroll-up history. '
-    + 'The agent running in it will be restarted (resumed via claude --continue).',
+    + 'The agent running in it will be restarted (and resumed where the agent supports it).',
     { title: 'Recreate terminal', okLabel: 'Recreate', danger: true });
   if (!ok) return;
   try {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2146,12 +2146,16 @@ async function recreateTerminal(t) {
     return;
   }
   await refreshTerminals();
-  // Recreate keeps the terminal id but binds a NEW tmux window index, and
-  // refreshTerminals() only swaps activeTerminal when the id disappears — so the
-  // active tab would keep the old (killed) window object and attachWindow's
-  // `win === attachedWindow` guard would skip the reload. Re-point at the
-  // refreshed row and switch onto its new window so the fresh pane streams in.
-  const refreshed = terminals.find((x) => x.id === t.id);
+  // Recreate binds a FRESH tmux window, but `new-window` (no -a) reuses the
+  // index just freed by killWindow — so the new index usually EQUALS the old
+  // one. Even after re-pointing at the refreshed row, attachWindow's
+  // `win === attachedWindow` guard would then skip the reload and leave the
+  // surface on the dead pane (the stale-*index* case; the stale-*object* case
+  // was fixed earlier). Clear attachedWindow so the reattach can't short-circuit,
+  // then switch onto the refreshed row — for the primary Manager its id changes,
+  // so fall back to the activeTerminal refreshTerminals already swapped in.
+  const refreshed = terminals.find((x) => x.id === t.id) || activeTerminal;
+  attachedWindow = null;
   if (refreshed) switchTerminal(refreshed);
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -35,6 +35,20 @@ struct TerminalCockpit: Sendable {
         // Reap grouped sessions this or a prior crowd leaked (#667). Runs on
         // every startup, whether we adopted or created the cockpit.
         reapOrphanedViewSessions()
+        logDegradedScrollbackWindows()
+    }
+
+    /// Diagnostic: log every window whose scroll-up can't show the full
+    /// transcript — stuck in the alternate-screen buffer (`alternate_on=1`)
+    /// and/or capped below the current `history-limit` because it was created
+    /// before the config bump. tmux can't heal these in place; the web UI badges
+    /// them and offers a recreate (CROW-804). Best-effort; never throws.
+    private func logDegradedScrollbackWindows() {
+        guard let windows = try? controller.listWindowScrollback() else { return }
+        for w in windows where TmuxBackend.isScrollbackDegraded(
+            historyLimit: w.historyLimit, alternateOn: w.alternateOn) {
+            NSLog("[CrowTelemetry tmux:scrollback_degraded index=\(w.index) history_limit=\(w.historyLimit) alternate_on=\(w.alternateOn ? 1 : 0)]")
+        }
     }
 
     /// Kill `crowd-web-*` grouped sessions left detached by a prior crowd's

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -103,11 +103,13 @@ struct TerminalCockpit: Sendable {
         _ = try? controller.run(["select-window", "-t", "\(group):\(index)"])
     }
 
-    /// How many lines of pane history to replay on (re)connect. Matched to the
-    /// xterm.js client scrollback (`scrollback: 50000` in app.js) and the tmux
-    /// `history-limit` (crow-tmux.conf) so the full retained history survives a
-    /// crowd restart or browser reload (CROW-606).
-    static let replayLines = 50000
+    /// How many lines of pane history to replay on (re)connect. Wired to
+    /// `TmuxBackend.scrollbackHistoryLimit` — the same value baked into the tmux
+    /// `history-limit` (crow-tmux.conf) and the xterm.js client scrollback
+    /// (`scrollback: 50000` in app.js) — so the full retained history survives a
+    /// crowd restart or browser reload (CROW-606) and the daemon replay can't
+    /// drift from the policy floor (CROW-804 review).
+    static let replayLines = TmuxBackend.scrollbackHistoryLimit
 
     /// Capture window `index`'s pane scrollback (history + current screen) and
     /// package it as bytes ready to write into a reconnecting xterm.js buffer.

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -956,7 +956,10 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 return try await MainActor.run {
                     guard capturedService.recreateTerminalSurface(
                         sessionID: sessionID, terminalID: terminalID, devRoot: devRoot) else {
-                        throw RPCError.applicationError("Terminal not found")
+                        // False = terminal not found OR the fresh tmux window
+                        // failed to register (the old window was killed, so the
+                        // terminal is now unbound). Surface it either way (CROW-804).
+                        throw RPCError.applicationError("Could not recreate terminal (not found or tmux window failed to register)")
                     }
                     return ["recreated": .bool(true)]
                 }

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -885,6 +885,11 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }
                 let terms = await MainActor.run { capturedAppState.terminals(for: id) }
                 let readiness = await MainActor.run { capturedAppState.terminalReadiness }
+                // Windows stuck in the alternate-screen buffer or capped at the
+                // old 5000-line history-limit can't show full scroll-up history
+                // and can only be healed by recreation (CROW-804). Read the live
+                // set once so the web UI can badge the affected tabs.
+                let degraded = await MainActor.run { TmuxBackend.shared.degradedWindowIndices() }
                 let items: [JSONValue] = terms.map { t in
                     // `readiness` lets CLI callers (setup.sh) verify the agent
                     // actually started rather than assuming a launch succeeded
@@ -900,6 +905,10 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // to provide it — CROW-593 review regression).
                         "window": t.tmuxBinding.map { .int($0.windowIndex) } ?? .null,
                         "readiness": .string((readiness[t.id] ?? .uninitialized).rawValue),
+                        // True when this terminal's window has degraded scrollback
+                        // and needs a recreate (CROW-804). Never degraded when
+                        // there's no window binding yet.
+                        "scrollback_degraded": .bool(t.tmuxBinding.map { degraded.contains($0.windowIndex) } ?? false),
                     ])
                 }
                 return ["terminals": .array(items)]
@@ -929,6 +938,27 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                     }
                     capturedStore.mutate { data in data.terminals.removeAll { $0.id == terminalID } }
                     return ["deleted": .bool(true)]
+                }
+            },
+            // Heal a terminal whose tmux window has degraded scrollback — stuck
+            // in the alternate-screen buffer and/or capped at the old 5000-line
+            // history-limit, which tmux can't fix in place (CROW-804). Kills the
+            // window and rebuilds a fresh, correctly-configured one, relaunching
+            // the agent (`claude --continue`). Destructive to the running agent,
+            // so the web UI confirms before calling this.
+            "recreate-terminal": { @Sendable params in
+                guard let sessionIDStr = params["session_id"]?.stringValue,
+                      let sessionID = UUID(uuidString: sessionIDStr),
+                      let terminalIDStr = params["terminal_id"]?.stringValue,
+                      let terminalID = UUID(uuidString: terminalIDStr) else {
+                    throw RPCError.invalidParams("session_id and terminal_id required")
+                }
+                return try await MainActor.run {
+                    guard capturedService.recreateTerminalSurface(
+                        sessionID: sessionID, terminalID: terminalID, devRoot: devRoot) else {
+                        throw RPCError.applicationError("Terminal not found")
+                    }
+                    return ["recreated": .bool(true)]
                 }
             },
             "rename-terminal": { @Sendable params in

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -526,6 +526,14 @@ public final class SessionService {
         NSLog("[CrowTelemetry tmux:scrollback_recreate terminal=\(terminalID) session=\(sessionID)]")
         let updated = rehydrateTerminalSurface(seed, trackReadiness: trackReadiness)
         applyRehydrationResult(sessionID: sessionID, original: seed, updated: updated)
+        // We already killed the old window. If registration failed the terminal
+        // is now unbound (worse than the degraded-but-live prior state), so report
+        // failure rather than a false success — the RPC surfaces it to the web
+        // error path instead of the UI refreshing as if healed (review).
+        if updated.tmuxBinding == nil {
+            NSLog("[SessionService] recreateTerminalSurface: re-register failed for \(terminalID); terminal is now unbound")
+            return false
+        }
         return true
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -473,21 +473,29 @@ public final class SessionService {
     /// applied to a single terminal on user request. Returns whether a recreate
     /// was performed (false if the terminal wasn't found).
     ///
-    /// The Manager terminal has its own purpose-built recreate that preserves
-    /// `managerSessionID` and re-arms the exit monitor, so it delegates to
-    /// `restartManager`. Recreating interrupts whatever agent is running in the
+    /// The **primary** Manager terminal has its own purpose-built recreate that
+    /// preserves `managerSessionID` and re-arms the exit monitor, so it delegates
+    /// to `restartManager`. Secondary Manager sessions (also `kind == .manager`,
+    /// but NOT the well-known primary) fall through to the general rehydrate path
+    /// — `restartManager` hard-codes `AppState.managerSessionID`, so routing them
+    /// there would restart the *primary* Manager and leave the selected window
+    /// untouched (review). Their command-launches-agent terminal re-runs its
+    /// stored `managerCommand` via `registerTerminal` on rehydrate, healing the
+    /// correct window. Recreating interrupts whatever agent is running in the
     /// window — the caller is expected to have confirmed with the user first.
     @MainActor
     @discardableResult
     public func recreateTerminalSurface(sessionID: UUID, terminalID: UUID, devRoot: String) -> Bool {
-        guard let session = appState.sessions.first(where: { $0.id == sessionID }),
+        guard appState.sessions.contains(where: { $0.id == sessionID }),
               let terminal = appState.terminals(for: sessionID).first(where: { $0.id == terminalID }) else {
             NSLog("[SessionService] recreateTerminalSurface: terminal \(terminalID) not found in session \(sessionID)")
             return false
         }
 
-        // The Manager isn't a per-session tab; route to its dedicated recreate.
-        if session.isManager {
+        // Only the PRIMARY Manager routes to its dedicated recreate — that path
+        // is keyed on the well-known managerSessionID. Everything else (work,
+        // review, job, AND secondary Managers) heals via the rehydrate path.
+        if Self.shouldRestartPrimaryManagerOnRecreate(sessionID: sessionID) {
             restartManager(devRoot: devRoot)
             return true
         }
@@ -519,6 +527,16 @@ public final class SessionService {
         let updated = rehydrateTerminalSurface(seed, trackReadiness: trackReadiness)
         applyRehydrationResult(sessionID: sessionID, original: seed, updated: updated)
         return true
+    }
+
+    /// Pure policy (CROW-804): only the well-known **primary** Manager session
+    /// routes a recreate to `restartManager`, which hard-codes
+    /// `AppState.managerSessionID`. Secondary Manager sessions (created via
+    /// `createManagerSession`) are also `kind == .manager` but must NOT restart
+    /// the primary — they fall through to the rehydrate path. `nonisolated static`
+    /// so the branch is unit-testable without a live app.
+    nonisolated static func shouldRestartPrimaryManagerOnRecreate(sessionID: UUID) -> Bool {
+        sessionID == AppState.managerSessionID
     }
 
     /// Re-hydrate one persisted terminal's tmux window on app launch. Returns

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -503,12 +503,17 @@ public final class SessionService {
         wireTerminalReadiness()
 
         let trackReadiness = terminal.isManaged
-        // Drop the old (degraded) window so its agent doesn't linger in a
-        // duplicate pane; `rehydrateTerminalSurface` below then registers a
-        // fresh window under the current config.
-        if let oldIndex = terminal.tmuxBinding?.windowIndex {
-            TmuxBackend.shared.killWindow(index: oldIndex)
-        }
+        // Register-then-kill (review): register the fresh window FIRST and only
+        // drop the old (degraded) window once the replacement is bound. On a
+        // register failure the old window stays live, so the terminal remains
+        // degraded-but-live (still badged + recreatable) instead of unbound with
+        // a dead pane. A brief duplicate-agent overlap is the accepted cost.
+        let oldIndex = terminal.tmuxBinding?.windowIndex
+        // Snapshot the readiness state we're about to re-arm so a failed register
+        // can restore it — otherwise a managed terminal is left half-armed
+        // pointing at a window that never got created.
+        let priorReadiness = appState.terminalReadiness[terminalID]
+        let priorAutoLaunch = appState.autoLaunchTerminals.contains(terminalID)
 
         var seed = terminal
         seed.tmuxBinding = nil
@@ -525,15 +530,24 @@ public final class SessionService {
 
         NSLog("[CrowTelemetry tmux:scrollback_recreate terminal=\(terminalID) session=\(sessionID)]")
         let updated = rehydrateTerminalSurface(seed, trackReadiness: trackReadiness)
-        applyRehydrationResult(sessionID: sessionID, original: seed, updated: updated)
-        // We already killed the old window. If registration failed the terminal
-        // is now unbound (worse than the degraded-but-live prior state), so report
-        // failure rather than a false success — the RPC surfaces it to the web
-        // error path instead of the UI refreshing as if healed (review).
-        if updated.tmuxBinding == nil {
-            NSLog("[SessionService] recreateTerminalSurface: re-register failed for \(terminalID); terminal is now unbound")
+
+        guard updated.tmuxBinding != nil else {
+            // Register failed. Leave the terminal exactly as it was — the old
+            // window is untouched (still live/degraded), so restore the readiness
+            // we re-armed and report failure. The RPC surfaces it and the ⚠ /
+            // Recreate affordance persists for a retry (review).
+            NSLog("[SessionService] recreateTerminalSurface: re-register failed for \(terminalID); keeping the existing degraded window")
+            if trackReadiness {
+                appState.terminalReadiness[terminalID] = priorReadiness
+                if !priorAutoLaunch { appState.autoLaunchTerminals.remove(terminalID) }
+            }
             return false
         }
+
+        // Replacement bound — persist the new window index, then drop the old
+        // degraded window so its (now-duplicate) agent doesn't linger.
+        applyRehydrationResult(sessionID: sessionID, original: seed, updated: updated)
+        if let oldIndex { TmuxBackend.shared.killWindow(index: oldIndex) }
         return true
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -463,6 +463,64 @@ public final class SessionService {
         }
     }
 
+    /// Heal one terminal whose tmux window is stuck with degraded scrollback —
+    /// created before the current `crow-tmux.conf` so it's frozen in the
+    /// alternate-screen buffer and/or capped at the old 5000-line history-limit,
+    /// neither of which tmux can fix in place (CROW-804). Kills the degraded
+    /// window and rebuilds a fresh, correctly-configured one (50000-line main
+    /// buffer), relaunching the agent — the exact per-terminal work
+    /// `rebuildAllSurfaces(forceRegister:true)` does on a cold-start takeover,
+    /// applied to a single terminal on user request. Returns whether a recreate
+    /// was performed (false if the terminal wasn't found).
+    ///
+    /// The Manager terminal has its own purpose-built recreate that preserves
+    /// `managerSessionID` and re-arms the exit monitor, so it delegates to
+    /// `restartManager`. Recreating interrupts whatever agent is running in the
+    /// window — the caller is expected to have confirmed with the user first.
+    @MainActor
+    @discardableResult
+    public func recreateTerminalSurface(sessionID: UUID, terminalID: UUID, devRoot: String) -> Bool {
+        guard let session = appState.sessions.first(where: { $0.id == sessionID }),
+              let terminal = appState.terminals(for: sessionID).first(where: { $0.id == terminalID }) else {
+            NSLog("[SessionService] recreateTerminalSurface: terminal \(terminalID) not found in session \(sessionID)")
+            return false
+        }
+
+        // The Manager isn't a per-session tab; route to its dedicated recreate.
+        if session.isManager {
+            restartManager(devRoot: devRoot)
+            return true
+        }
+
+        wireTerminalReadiness()
+
+        let trackReadiness = terminal.isManaged
+        // Drop the old (degraded) window so its agent doesn't linger in a
+        // duplicate pane; `rehydrateTerminalSurface` below then registers a
+        // fresh window under the current config.
+        if let oldIndex = terminal.tmuxBinding?.windowIndex {
+            TmuxBackend.shared.killWindow(index: oldIndex)
+        }
+
+        var seed = terminal
+        seed.tmuxBinding = nil
+        // Re-arm managed work terminals so the fresh shell's `.shellReady` drives
+        // the agent relaunch via `claude --continue` (never the stored initial
+        // command) — same seeding as `rebuildAllSurfaces(forceRegister:true)`.
+        if trackReadiness {
+            appState.terminalReadiness[terminalID] = .uninitialized
+            appState.autoLaunchTerminals.insert(terminalID)
+            if let cmd = seed.command, cmd.contains("claude") {
+                seed.command = nil
+            }
+        }
+
+        NSLog("[CrowTelemetry tmux:scrollback_recreate terminal=\(terminalID) session=\(sessionID)]")
+        let updated = rehydrateTerminalSurface(seed, trackReadiness: trackReadiness)
+        applyRehydrationResult(sessionID: sessionID, original: seed, updated: updated)
+        return true
+    }
+
     /// Re-hydrate one persisted terminal's tmux window on app launch. Returns
     /// the (possibly-modified) row with `tmuxBinding.windowIndex` updated to
     /// the freshly-registered window. If tmux is unavailable or registration

--- a/Packages/CrowEngine/Tests/CrowEngineTests/RecreateTerminalTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/RecreateTerminalTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowIPC
+@testable import CrowEngine
+
+/// CROW-804 recreate-terminal wiring. `recreateTerminalSurface` drives real tmux
+/// for the happy path (kill + re-register + relaunch), which the smoke suites
+/// avoid — but its not-found guard and the RPC's param validation are testable
+/// headlessly with a `NoopHostBridge`.
+@Suite("recreate-terminal (CROW-804)")
+@MainActor
+struct RecreateTerminalTests {
+
+    private func makeService() -> (SessionService, AppState, JSONStore, String) {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-recreate-\(UUID().uuidString)")
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+        return (service, appState, store, tmp.path)
+    }
+
+    /// An unknown terminal is a no-op that returns false — never a crash or a
+    /// spurious recreate.
+    @Test func returnsFalseWhenTerminalNotFound() {
+        let (service, _, _, devRoot) = makeService()
+        #expect(!service.recreateTerminalSurface(
+            sessionID: UUID(), terminalID: UUID(), devRoot: devRoot))
+    }
+
+    /// The RPC rejects a call missing its ids rather than reaching the service.
+    @Test func rpcRequiresSessionAndTerminalIDs() async throws {
+        let (service, appState, store, devRoot) = makeService()
+        let ctx = EngineContext(
+            appState: appState, store: store, sessionService: service,
+            issueTracker: nil, telemetryPort: nil, devRoot: devRoot,
+            hostBridge: NoopHostBridge(), loadConfig: { nil }, applyConfig: { _ in nil })
+        let router = makeEngineRouter(ctx)
+
+        let response = await router.handle(
+            request: JSONRPCRequest(id: 1, method: "recreate-terminal"))
+        #expect(response.error != nil)
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/RecreateTerminalTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/RecreateTerminalTests.swift
@@ -30,6 +30,16 @@ struct RecreateTerminalTests {
             sessionID: UUID(), terminalID: UUID(), devRoot: devRoot))
     }
 
+    /// Only the well-known primary Manager routes a recreate to `restartManager`
+    /// (which hard-codes `AppState.managerSessionID`). A secondary Manager — also
+    /// `kind == .manager` — must NOT, or it would restart the primary and leave
+    /// the selected window untouched. Locks the review fix.
+    @Test func onlyPrimaryManagerRestartsManager() {
+        #expect(SessionService.shouldRestartPrimaryManagerOnRecreate(sessionID: AppState.managerSessionID))
+        // A secondary Manager (any other id) falls through to the rehydrate path.
+        #expect(!SessionService.shouldRestartPrimaryManagerOnRecreate(sessionID: UUID()))
+    }
+
     /// The RPC rejects a call missing its ids rather than reaching the service.
     @Test func rpcRequiresSessionAndTerminalIDs() async throws {
         let (service, appState, store, devRoot) = makeService()

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -41,7 +41,7 @@ set -gs mouse off
 # to the emulator's "alternate scroll": it sends arrow keys, which the agent
 # reads as input-history navigation instead of scrolling (the reported bug).
 # Keeping inner apps in the pane's MAIN buffer means output that scrolls off the
-# top lands in xterm.js's 10k-line scrollback, so the wheel scrolls the terminal
+# top lands in xterm.js's 50k-line scrollback, so the wheel scrolls the terminal
 # window natively — exactly what mouse-off is meant to deliver.
 #
 # Trade-off: classic full-screen apps (vim, htop, less) no longer restore the
@@ -57,7 +57,7 @@ set -gs alternate-screen off
 # governs only inner apps; every pane here is already `alternate_on=0`), and
 # it's why the browser wheel still fell into arrow-key "alternate scroll" that
 # navigates the agent's input history. Removing the capability with `@` makes
-# tmux render into the client's MAIN buffer instead, where xterm.js's 10k-line
+# tmux render into the client's MAIN buffer instead, where xterm.js's 50k-line
 # scrollback applies and the wheel scrolls the window natively. Matches the
 # browser client (xterm*) plus the default-terminal family (screen*) for good
 # measure. Takes effect on the NEXT attach — reconnect the terminal after

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -48,7 +48,12 @@ set -gs mouse off
 # pre-launch screen on exit — their final frame stays in scrollback. For a
 # session-runner whose main content is the agent transcript, unified scrollback
 # is the better default. Flip back to `on` to restore alternate-screen behavior.
-set -gs alternate-screen off
+#
+# Scope: `alternate-screen` is a WINDOW option, so it's set with `-gw` (global
+# window default) — the scope-correct idiom for "apply to every new window."
+# (`-gs` happened to work in tmux 3.6a via option-table leniency, but `-gw` is
+# the documented scope and keeps the #804 `alternate_on` detection meaningful.)
+set -gw alternate-screen off
 
 # Cancel the CLIENT terminal's alternate-screen capability (smcup/rmcup). On
 # attach, tmux switches its client — here xterm.js, which reports as

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
@@ -71,7 +71,11 @@
           // Nerd Font first for Claude/Cursor TUI icons; Menlo fallback if not installed.
           fontFamily: '"MesloLGS NF", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", "FiraCode Nerd Font", Menlo, Monaco, monospace',
           theme: { background: '#1e1e1e', foreground: '#d4d4d4' },
-          scrollback: 10000,
+          // Match the web UI (app.js), the tmux history-limit, and the daemon
+          // replay window so the full retained transcript survives a reconnect
+          // (CROW-804). Was 10000, which truncated scroll-up below the 50000
+          // tmux keeps.
+          scrollback: 50000,
           allowTransparency: true,
         });
         term.loadAddon(fitAddon);

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -737,14 +737,6 @@ public final class TmuxBackend {
         }
     }
 
-    /// Per-window scrollback facts (index, history_limit, alternate_on) for
-    /// diagnostics/logging. Best-effort; `[]` on any failure.
-    public func windowScrollbackHealth() -> [(index: Int, historyLimit: Int, alternateOn: Bool)] {
-        guard let ctrl = controller else { return [] }
-        do { return try ctrl.listWindowScrollback() }
-        catch { reportIfTimeout(error); return [] }
-    }
-
     /// Kill the cockpit window at `index`. Passthrough to the controller so
     /// callers outside `TmuxBackend` (e.g. the CROW-804 terminal recreate in
     /// `SessionService`) can drop a degraded window before re-registering a

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -33,6 +33,15 @@ protocol CockpitSessionStarter {
 public final class TmuxBackend {
     public static let shared = TmuxBackend()
 
+    /// Scrollback ceiling every managed window should be born with. Mirrors the
+    /// bundled `crow-tmux.conf` `set -gs history-limit 50000`, the daemon's
+    /// `TerminalCockpit.replayLines`, and the web UI's xterm.js `scrollback:
+    /// 50000` — the single number those four surfaces must agree on so a full
+    /// transcript survives a reconnect. A window whose `history_limit` is below
+    /// this (created under an older 2000/5000 default) is degraded and can only
+    /// be fixed by recreating it (CROW-804).
+    nonisolated public static let scrollbackHistoryLimit = 50000
+
     /// Fired when a tmux-backed terminal's readiness state changes.
     /// Callers wire this through to the `TerminalReadiness` state machine so
     /// downstream consumers (e.g. `ClaudeLauncher`) stay backend-agnostic.
@@ -695,6 +704,53 @@ public final class TmuxBackend {
         guard let ctrl = controller else { return [] }
         do { return try ctrl.listWindows() }
         catch { reportIfTimeout(error); return [] }
+    }
+
+    // MARK: - Scrollback health (CROW-804)
+
+    /// Pure policy: a window's scroll-up can't show the full transcript when its
+    /// pane is in the alternate buffer (no scrollback) OR its `history_limit` is
+    /// below the ceiling we bake into new windows. tmux freezes both at window
+    /// birth and can't resize/undo either in place (see `crow-tmux.conf`
+    /// history-limit caveat), so a degraded window's only remedy is recreation.
+    /// `nonisolated static` so the policy is unit-testable without tmux.
+    nonisolated public static func isScrollbackDegraded(
+        historyLimit: Int, alternateOn: Bool, floor: Int = TmuxBackend.scrollbackHistoryLimit
+    ) -> Bool {
+        alternateOn || historyLimit < floor
+    }
+
+    /// Window indices whose scrollback is degraded per `isScrollbackDegraded`.
+    /// Best-effort — `[]` when tmux is unavailable or the read fails, mirroring
+    /// `listCockpitWindows`. Callers use it to badge terminals in the web UI and
+    /// to log the degraded set on daemon start (CROW-804).
+    public func degradedWindowIndices(floor: Int = TmuxBackend.scrollbackHistoryLimit) -> Set<Int> {
+        guard let ctrl = controller else { return [] }
+        do {
+            let windows = try ctrl.listWindowScrollback()
+            return Set(windows
+                .filter { Self.isScrollbackDegraded(historyLimit: $0.historyLimit, alternateOn: $0.alternateOn, floor: floor) }
+                .map(\.index))
+        } catch {
+            reportIfTimeout(error)
+            return []
+        }
+    }
+
+    /// Per-window scrollback facts (index, history_limit, alternate_on) for
+    /// diagnostics/logging. Best-effort; `[]` on any failure.
+    public func windowScrollbackHealth() -> [(index: Int, historyLimit: Int, alternateOn: Bool)] {
+        guard let ctrl = controller else { return [] }
+        do { return try ctrl.listWindowScrollback() }
+        catch { reportIfTimeout(error); return [] }
+    }
+
+    /// Kill the cockpit window at `index`. Passthrough to the controller so
+    /// callers outside `TmuxBackend` (e.g. the CROW-804 terminal recreate in
+    /// `SessionService`) can drop a degraded window before re-registering a
+    /// fresh one. No-op when tmux is unavailable.
+    public func killWindow(index: Int) {
+        controller?.killWindow(index: index)
     }
 
     /// Reap orphaned cockpit windows per `shouldReapOrphanWindow` (targeted-auto).

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -163,6 +163,32 @@ public struct TmuxController: Sendable {
         }
     }
 
+    /// Per-window scrollback health: each window's index plus the two pane
+    /// facts that determine whether scroll-up can show the full transcript —
+    /// `#{history_limit}` (the frozen-at-birth scrollback cap) and
+    /// `#{alternate_on}` (whether the active pane is in the alternate buffer,
+    /// which has NO scrollback). Windows created before the current
+    /// `crow-tmux.conf` are stuck at `history_limit=5000 alternate_on=1` and
+    /// tmux cannot resize/undo either in place, so this is how Crow detects the
+    /// degraded windows that need a recreate (CROW-804). `history_limit`/
+    /// `alternate_on` resolve against each window's active pane under
+    /// `list-windows -F`.
+    public func listWindowScrollback() throws -> [(index: Int, historyLimit: Int, alternateOn: Bool)] {
+        let out = try run(["list-windows", "-t", sessionName,
+                           "-F", "#{window_index}\t#{history_limit}\t#{alternate_on}"])
+        return out.split(separator: "\n").compactMap { line in
+            let parts = line.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false)
+            guard parts.count == 3,
+                  let idx = Int(parts[0].trimmingCharacters(in: .whitespaces)),
+                  let limit = Int(parts[1].trimmingCharacters(in: .whitespaces)) else {
+                return nil
+            }
+            // tmux renders boolean flags as "1"/"0".
+            let alt = parts[2].trimmingCharacters(in: .whitespaces) == "1"
+            return (idx, limit, alt)
+        }
+    }
+
     // MARK: - Windows
 
     /// `timeout` defaults to the per-call default. Callers spawning a window

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/ScrollbackHealthTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/ScrollbackHealthTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import CrowTerminal
+
+/// Pure-policy tests for the CROW-804 scrollback-degradation check. No tmux
+/// required — `isScrollbackDegraded` is a `nonisolated static` predicate, so
+/// this suite always runs (unlike the tmux-gated integration suites).
+@Suite("Scrollback degradation policy")
+struct ScrollbackHealthTests {
+
+    @Test func oldHistoryLimitIsDegraded() {
+        // Windows born under the old 5000/2000 default keep that cap forever.
+        #expect(TmuxBackend.isScrollbackDegraded(historyLimit: 5000, alternateOn: false))
+        #expect(TmuxBackend.isScrollbackDegraded(historyLimit: 2000, alternateOn: false))
+    }
+
+    @Test func alternateBufferIsDegraded() {
+        // A pane stuck in the alternate-screen buffer has NO scrollback, even at
+        // the full history-limit.
+        #expect(TmuxBackend.isScrollbackDegraded(historyLimit: 50000, alternateOn: true))
+    }
+
+    @Test func fullLimitMainBufferIsHealthy() {
+        #expect(!TmuxBackend.isScrollbackDegraded(historyLimit: 50000, alternateOn: false))
+    }
+
+    @Test func floorIsInclusiveBoundary() {
+        // Exactly at the floor is healthy; one below is degraded.
+        let floor = TmuxBackend.scrollbackHistoryLimit
+        #expect(!TmuxBackend.isScrollbackDegraded(historyLimit: floor, alternateOn: false))
+        #expect(TmuxBackend.isScrollbackDegraded(historyLimit: floor - 1, alternateOn: false))
+    }
+
+    @Test func customFloorIsHonored() {
+        // A caller can tighten the floor; a window below the custom floor is degraded.
+        #expect(TmuxBackend.isScrollbackDegraded(historyLimit: 10000, alternateOn: false, floor: 20000))
+        #expect(!TmuxBackend.isScrollbackDegraded(historyLimit: 10000, alternateOn: false, floor: 5000))
+    }
+}

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -196,14 +196,24 @@ struct TmuxControllerTests {
             ctrl.killServer()
             try? FileManager.default.removeItem(atPath: ctrl.socketPath)
         }
-        // The anchor pane (window 0) requests the alternate screen, then stays
-        // alive so we can read its buffer state back.
+        // The anchor pane (window 0) *continuously* re-requests the alternate
+        // screen. A broken `alternate-screen off` (or wrong option scope) would
+        // flip `alternate_on` to 1 within a tick; poll across a window and assert
+        // it stays 0 the whole time. Polling (vs a single fixed sleep) avoids a
+        // flake if the first read lands before the shell's first emit, and the
+        // persistent emitter makes an all-0 result meaningful rather than a race.
         try ctrl.newSessionDetached(
             configPath: confURL.path,
-            command: #"/bin/sh -c 'printf "\033[?1049h"; sleep 60'"#)
-        Thread.sleep(forTimeInterval: 0.3)
-        let health = try ctrl.listWindowScrollback()
-        let anchor = try #require(health.first(where: { $0.index == 0 }))
-        #expect(anchor.alternateOn == false)
+            command: #"/bin/sh -c 'while true; do printf "\033[?1049h"; sleep 0.05; done'"#)
+        var reads: [Bool] = []
+        let deadline = Date().addingTimeInterval(1.0)
+        repeat {
+            Thread.sleep(forTimeInterval: 0.1)
+            if let anchor = (try? ctrl.listWindowScrollback())?.first(where: { $0.index == 0 }) {
+                reads.append(anchor.alternateOn)
+            }
+        } while Date() < deadline
+        #expect(!reads.isEmpty)
+        #expect(reads.allSatisfy { $0 == false })
     }
 }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -158,4 +158,27 @@ struct TmuxControllerTests {
         #expect(out.contains("LINE-0000-"))
         #expect(out.contains("LINE-1199-"))
     }
+
+    /// CROW-804 enforcement: a window created under the **bundled** `crow-tmux.conf`
+    /// is born with the 50000-line main-buffer scrollback, so it is NOT flagged
+    /// degraded. This is the regression guard that new managed windows always get
+    /// correct scrollback (the whole point of the config fix); a window stuck at
+    /// the old 5000 limit or in the alt buffer is what `isScrollbackDegraded`
+    /// catches for the recreate flow.
+    @Test func newWindowUnderBundledConfIsNotDegraded() throws {
+        let confURL = try #require(BundledResources.tmuxConfURL)
+        let ctrl = makeController()
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: ctrl.socketPath)
+        }
+        try ctrl.newSessionDetached(configPath: confURL.path, command: "/bin/sh -c 'sleep 60'")
+        let idx = try ctrl.newWindow(command: "/bin/sh -c 'sleep 60'")
+        let health = try ctrl.listWindowScrollback()
+        let window = try #require(health.first(where: { $0.index == idx }))
+        #expect(window.historyLimit == TmuxBackend.scrollbackHistoryLimit)
+        #expect(window.alternateOn == false)
+        #expect(!TmuxBackend.isScrollbackDegraded(
+            historyLimit: window.historyLimit, alternateOn: window.alternateOn))
+    }
 }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -181,4 +181,29 @@ struct TmuxControllerTests {
         #expect(!TmuxBackend.isScrollbackDegraded(
             historyLimit: window.historyLimit, alternateOn: window.alternateOn))
     }
+
+    /// CROW-804: assert `alternate-screen off` in the bundled conf actually
+    /// suppresses the alternate buffer — a `sleep`-only pane never requests it,
+    /// so it wouldn't catch a regression that broke the setting or its option
+    /// scope. Drive a process that issues smcup (DECSET 1049) and assert the pane
+    /// stays in the MAIN buffer (`alternate_on == 0`). Without the setting this
+    /// pane reads `alternate_on == 1` (verified: bare conf → 1), so this genuinely
+    /// locks the config behavior, not a tautology.
+    @Test func bundledConfKeepsInnerAppsOutOfAlternateBuffer() throws {
+        let confURL = try #require(BundledResources.tmuxConfURL)
+        let ctrl = makeController()
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: ctrl.socketPath)
+        }
+        // The anchor pane (window 0) requests the alternate screen, then stays
+        // alive so we can read its buffer state back.
+        try ctrl.newSessionDetached(
+            configPath: confURL.path,
+            command: #"/bin/sh -c 'printf "\033[?1049h"; sleep 60'"#)
+        Thread.sleep(forTimeInterval: 0.3)
+        let health = try ctrl.listWindowScrollback()
+        let anchor = try #require(health.first(where: { $0.index == 0 }))
+        #expect(anchor.alternateOn == false)
+    }
 }


### PR DESCRIPTION
Closes #804

## Problem

Scrolling up in the web xterm.js terminal doesn't reliably show the complete Claude Code session history. The dominant, reproducible cause (verified against a live tmux read): **windows created before the current `crow-tmux.conf` are permanently stuck in the alternate-screen buffer (`alternate_on=1`) with `history-limit=5000`.** A pane in the alt buffer has zero scrollback; the 5000 cap truncates the rest. tmux can't resize history or leave the alt buffer in place, and nothing detected, surfaced, or healed these after the config bump.

```
Manager     limit=5000   alt=1   ⚠ broken (pre-config)
Claude Code limit=5000   alt=1   ⚠ broken (pre-config)
Claude Code limit=50000  alt=0   ✓ (all windows born after the bump)
```

## Fix (checklist item A: detect + surface + one-click recreate)

- **Detect**: `TmuxController.listWindowScrollback()` reads per-window `history_limit` + `alternate_on`; `TmuxBackend.isScrollbackDegraded()` is the pure policy (alt buffer OR below the 50000 floor). `TmuxBackend.scrollbackHistoryLimit` is the single source of truth shared with the conf, the daemon replay window, and xterm.js.
- **Diagnostic**: the daemon logs every degraded window on start (`tmux:scrollback_degraded index=… history_limit=… alternate_on=…`).
- **Surface**: `list-terminals` now returns `scrollback_degraded`; the web UI badges the affected tab with a ⚠ and offers a confirm-gated **Recreate**.
- **Heal**: `recreate-terminal` RPC → `SessionService.recreateTerminalSurface` kills the degraded window and rebuilds a correctly-configured one (50000-line main buffer), relaunching the agent via `claude --continue` — reusing the CROW-747 rehydrate/relaunch machinery. Manager terminals route to `restartManager`. A `crow recreate-terminal` CLI command mirrors it.

Healing is **manual** (no auto-heal): recreating interrupts the live agent, so the user decides when.

## Consistency

- Desktop `xterm/terminal.html` scrollback `10000 → 50000` (matches the web UI / tmux / replay).
- Stale "10k-line scrollback" comments in `crow-tmux.conf` corrected.

## Tests

- `ScrollbackHealthTests` — pure policy truth table (old limit, alt buffer, floor boundary, custom floor).
- `TmuxControllerTests.newWindowUnderBundledConfIsNotDegraded` — real-tmux enforcement that a window created under the **bundled** conf is born `50000`/main-buffer and not flagged degraded.
- `RecreateTerminalTests` — recreate not-found returns false + RPC param validation, headless.

All build; new tests pass. (One pre-existing readiness-timing flake, `retryReadinessEmitsTimedOutWhenSentinelMissing`, is unrelated — confirmed failing on the clean base.)

## Out of scope (follow-up)

Checklist B (capture-pane/`ESC[3J` replay width/reflow fidelity) is left to epic #783 rather than re-specifying the VT-engine rework here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYMwoE9Wi8HMdteFE9NjHm