### PR TITLE
Spike #822: terminal scroll model — decision + ADR

### DIFF
--- a/docs/adr/0013-terminal-scroll-model.md
+++ b/docs/adr/0013-terminal-scroll-model.md
@@ -1,0 +1,65 @@
+# 0013 — Terminal scroll model: per-surface hybrid (unified scrollback for shells, native alt-screen for agent TUIs)
+
+- **Status:** Proposed
+- **Date:** 2026-07-23
+- **Deciders:** @dhilgaertner
+
+## Context
+
+Crow's web terminal delivers a **single unified xterm.js scrollback**: the browser wheel scrolls a 50k-line buffer and, on (re)connect, the daemon replays the pane's full tmux history back into it (`capture-pane -pe -S -50000`, CROW-606). To get there, Crow deliberately strips a full-screen app's scroll ownership at three layers:
+
+1. `crow-tmux.conf` — `set -gw alternate-screen off` keeps inner apps in the pane's **main** buffer (no alt buffer).
+2. `crow-tmux.conf` — `terminal-overrides ',xterm*:smcup@:rmcup@,screen*:smcup@:rmcup@'` cancels the **client's** alt-screen capability too.
+3. `web/app.js` — `swallowMouseMode` drops the DECSET 1000–1016 mouse-tracking sequences an agent emits to claim the wheel; `enableWheelScroll` owns the wheel and scrolls xterm's buffer.
+
+This model is a good fit for **line-streaming** output (shells, `git log`, build logs, review diffs — text flows down and never repaints). It is a **bad fit for a continuously repainting full-frame TUI** like Claude Code or Cursor. Issue #822 reported the symptom: scrolling up in the web terminal shows **stacked duplicate copies of the agent's TUI** instead of a clean transcript.
+
+**Root cause, confirmed by spike #822.** Denied a fixed viewport, an agent's full-frame repaints (streaming tokens, spinner, every keystroke) land in a main buffer that is itself scrolling. Each screen-clear-and-redraw deposits the prior frame into the 50k scrollback as sediment. Scrolling up walks the fossil record of past frames.
+
+The spike measured this directly. Against the **live** tmux server, a Claude Code pane sat in the main buffer (`alternate_on=0`) with history accumulating while idle, and `capture-pane` showed the same footer stacked 3× in one pane's scrollback. An isolated-tmux A/B harness (a repainting TUI mimic) made it deterministic:
+
+| Config | `alternate_on` | `history_size` | Stacked footer copies in scrollback |
+|--------|:---:|:---:|:---:|
+| `alternate-screen off` (current) | 0 | 1641 | **42** |
+| `alternate-screen on` | 1 | **0** | **1** (the live frame only) |
+
+Prior work healed a *related* degradation (stale alt-screen / 5000-line windows, #804/#821) but did not address this: the duplicate-frame artifact is a property of the core scroll model, not of degraded windows. The rationale for that model is today scattered across `crow-tmux.conf` comments and ADR-0001 (which is about tmux-as-backend, not scrolling); this ADR gives the scroll model its own record.
+
+## Decision
+
+Crow adopts a **per-surface hybrid** terminal scroll model:
+
+- **Plain shell / review surfaces** keep the unified xterm.js scrollback (the current behavior): `alternate-screen off`, output flows into the 50k history, CROW-606 replay restores it, the browser wheel scrolls xterm.
+- **Agent-TUI surfaces** (Claude Code, Cursor) own their own viewport and scrollback like a naked terminal: the daemon sets `alternate-screen on` **per agent window**, the client stops swallowing that window's mouse modes, and the wheel is forwarded to the app. No frame sediment because repaints stay in the alt buffer, which has no scrollback.
+
+`swallowMouseMode` and `enableWheelScroll` become **conditional on pane state** (`buffer.active.type === 'alternate'` OR active mouse tracking → the app owns the wheel; else xterm scrolls its scrollback) rather than global. This mirrors what `enableTouchScroll`/`sendScrollToPTY` already do for touch on the alt buffer.
+
+This is the **Option B** of the spike. It is chosen over Option A (honor the alt screen everywhere) because A throws away the unified scrollback for *every* surface — regressing the exact behavior CROW-606, #776, and #777 were built to deliver — to fix a problem that only the repainting agent surfaces have.
+
+Status is **Proposed**: the spike delivers the decision + this record; implementation lands under a follow-up ticket, at which point this ADR moves to Accepted.
+
+## Consequences
+
+**Easier / better**
+- Agent TUIs behave like a naked terminal: the input box stays pinned, the wheel scrolls the agent's own transcript, and the duplicate-frame sediment is gone.
+- Shells, review diffs, and build logs keep the unified 50k scrollback and CROW-606 replay unchanged.
+- The scroll model now has a single documented home (this ADR + a scroll-model comment block), instead of being reverse-engineered from three interacting settings.
+
+**Harder / to live with**
+- **Two code paths.** The wheel/mouse handling is now conditional; both branches must be kept correct and tested. The `swallowMouseMode` and `enableWheelScroll` conditionals are the crux.
+- **Agent-window classification.** The daemon must know which windows are agent TUIs to set `alternate-screen on` at creation (it already names them, e.g. "Claude Code", and launches a known command — a reliable signal).
+- **Client alt-buffer detection is the load-bearing open question.** For `app.js` to route by `buffer.active.type === 'alternate'`, the **client** (xterm.js) must also enter the alt buffer for an agent window — which the global `smcup@/rmcup@` strip (layer 2) currently prevents. The follow-up must either (a) scope that strip to non-agent surfaces so agent windows re-gain client smcup, or (b) have crowd signal window-kind to `app.js` over the existing control channel and route on that instead of buffer type. The spike validated the tmux side (per-window `alternate-screen on` coexists with `off` in one server) but flagged this wiring as the real implementation work.
+- **Agent-window scrollback boundary.** Inside an agent window, "scroll behind the app" into pre-launch shell history is no longer available (the alt buffer has no scrollback) — same trade a naked terminal makes. CROW-606 replay for an agent window restores only its current frame; the jump-to-bottom pill and copy/paste semantics need a pass for the alt-buffer case.
+
+## Alternatives considered
+
+- **Option A — honor the alt screen everywhere** (`alternate-screen on` globally, drop the smcup strip, stop swallowing mouse modes, forward the wheel to the app). Simplest and fully fixes the sediment (spike-proven: `history_size` 1641→0, 42 copies→1). Rejected because it deletes the unified scrollback for *all* surfaces — plain shells lose native wheel scrollback and CROW-606 replay has nothing to restore (`history_size=0`) — regressing CROW-606/#776/#777 to fix a problem only agent TUIs have. Kept on throwaway branch `spike/822-option-a`.
+- **Option C — dedupe repaints in the unified buffer.** Rejected up front: there is no reliable way to recognize and collapse full-frame TUI repaints in a linear text buffer.
+
+## References
+
+- Spike: [#822](https://github.com/corveil/crow/issues/822); findings + prototype details in [`docs/spikes/822-terminal-scroll.md`](../spikes/822-terminal-scroll.md).
+- Prototype branches (not merged): `spike/822-option-a`, `spike/822-option-b`.
+- Related ADRs: [0001 — tmux as the sole terminal backend](./0001-tmux-only-terminal-backend.md) (this ADR carves the scroll model out of ADR-0001's terminal-backend scope; ADR-0001 is otherwise unchanged).
+- Prior art: CROW-606 (replay, #609/#612), #776/#789 (mouse-mode swallow), #777/#786 (iOS touch-scroll ownership), #804/#821 (scrollback heal), epic #783 (replay reflow fidelity).
+- Code: `Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf` (alt-screen, smcup/rmcup, mouse, history-limit); `Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js` (`swallowMouseMode`, `enableWheelScroll`, `enableTouchScroll`, `sendScrollToPTY`); `Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift` / `TerminalWebSocket.swift` (CROW-606 replay).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0010 | [Retire the macOS app; the web UI is the only client](./0010-retire-the-macos-app.md) | Accepted | 2026-07-07 |
 | 0011 | [Mid-session agent handoff preserves Crow identity, not chat history](./0011-agent-handoff-preserves-session-not-chat.md) | Accepted | 2026-07-09 |
 | 0012 | [Tests must never touch live application data](./0012-tests-never-touch-live-data.md) | Accepted | 2026-07-19 |
+| 0013 | [Terminal scroll model: per-surface hybrid](./0013-terminal-scroll-model.md) | Proposed | 2026-07-23 |

--- a/docs/spikes/822-terminal-scroll.md
+++ b/docs/spikes/822-terminal-scroll.md
@@ -1,0 +1,89 @@
+# Spike #822 — Web terminal duplicate Claude Code TUI frames on scroll-up
+
+**Issue:** [#822](https://github.com/corveil/crow/issues/822) · **Date:** 2026-07-23 · **Author:** @dhilgaertner
+**Decision:** Option B (per-surface hybrid) — see [ADR-0013](../adr/0013-terminal-scroll-model.md).
+**Prototype branches (not merged):** `spike/822-option-a`, `spike/822-option-b`.
+
+This spike characterizes why scrolling up in the web terminal shows stacked duplicate copies of the Claude Code TUI, prototypes two fixes, and picks one. Per the ticket's "Out of scope", it does **not** implement the fix — that's a follow-up ticket.
+
+## 1. Root cause — frame sediment
+
+Claude Code is a **full-frame repainting TUI**: in a capable terminal it keeps itself in a fixed viewport (alternate screen + its own mouse-wheel reporting) and manages its own scrollback. Crow deliberately strips that ownership at three layers so it can deliver one unified xterm.js scrollback (browser wheel scrolls a 50k buffer; `capture-pane` replays history on reconnect, CROW-606):
+
+1. `crow-tmux.conf` — `set -gw alternate-screen off` (inner apps stay in the pane's **main** buffer).
+2. `crow-tmux.conf` — `terminal-overrides ',xterm*:smcup@:rmcup@,screen*:smcup@:rmcup@'` (cancels the **client's** alt-screen too).
+3. `web/app.js` — `swallowMouseMode` drops DECSET 1000–1016; `enableWheelScroll` owns the wheel and scrolls xterm's buffer.
+
+**Mechanism:** denied a fixed viewport, the agent's constant full-frame repaints land in a main buffer that is itself scrolling. Each clear-and-redraw deposits the prior frame into the 50k scrollback as sediment. Scrolling up walks hundreds of past frames — "Claude Code multiple times."
+
+## 2. Live reproduction (read-only)
+
+Against the running shared tmux server (`$TMPDIR/crow-tmux.sock`, grouped session `crowd-web-*`):
+
+- Claude Code panes sit in the **main buffer** (`alternate_on=0`) with history growing while idle (`hist=181`, `239` lines).
+- `capture-pane -p` of one pane showed the same footer (`⏵⏵ auto mode on … PR #1785`) stacked **3×** at scrollback lines 120 / 239 / 307 — ~119 lines apart, i.e. one full-frame repaint per copy.
+- Global options confirmed: `mouse off`, `alternate-screen off`, `history-limit 50000`.
+- Nuance: `mouse_any=1`/`mouse_all=1` on those panes — tmux *does* register the agent's mouse tracking; the swallow is purely client-side. Some stale panes still showed `alternate_on=1` + `hist=…/5000` (the #804/#821 heal case), so alt-screen suppression is not absolute.
+
+## 3. Deterministic A/B measurement (isolated tmux)
+
+To avoid disturbing the live instance, all prototype validation ran on a **throwaway** tmux server (`tmux -S $TMPDIR/spike822*.sock -f <conf>`) with a repaint harness that mimics a full-frame TUI (enter alt screen → clear+redraw a full frame with a per-frame marker + a fixed "input box" footer → repeat → leave alt screen). No crowd rebuild; live instance untouched.
+
+**Option A vs baseline** (pane 100×40, sampled mid-run while repainting):
+
+| Config | `alternate_on` | `history_size` | Footer copies | Input-box copies |
+|--------|:---:|:---:|:---:|:---:|
+| Baseline (`alternate-screen off`, current) | 0 | **1641** | **42** | **43** |
+| Option A (`alternate-screen on`) | 1 | **0** | **1** | **1** |
+
+The baseline scrollback dump showed the input box + footer repeated once per frame, every 40 lines (= pane height) — the same pattern as the live capture:
+
+```
+38:╭ INPUT BOX top (frame 1)
+40:╰ auto mode on · FOOTER MARKER
+78:╭ INPUT BOX top (frame 2)
+80:╰ auto mode on · FOOTER MARKER
+118:╭ INPUT BOX top (frame 3)
+120:╰ auto mode on · FOOTER MARKER
+… (one copy per repaint)
+```
+
+**Takeaways:** the sediment is real and mechanical, and moving the app into the alt buffer eliminates it completely (`history_size` 1641 → 0; 42 stacked copies → 1 live frame). It also shows Option A's cost concretely: `history_size=0` means CROW-606 replay has nothing to restore for that window.
+
+## 4. Prototype Option A — `spike/822-option-a`
+
+Honor the alt screen everywhere. Changes:
+- `crow-tmux.conf`: `alternate-screen on`; drop the `smcup@/rmcup@` override.
+- `app.js`: stop swallowing mouse modes; `enableWheelScroll` forwards the wheel to the app unconditionally (via `sendScrollToPTY`).
+
+**Result:** input box stays pinned, duplicates vanish (alt buffer owns the viewport). **What breaks:**
+- **Unified browser scrollback** dies for *every* surface — the alt buffer has no history, so `capture-pane -pe -S -50000` replays only the current frame (`history_size=0` measured).
+- **Plain shells** lose native wheel scrollback too (everything routes to the PTY).
+- **Mobile touch, copy/paste across history, jump-to-bottom pill** all assume a scrollable local buffer that no longer exists on agent surfaces.
+
+Fully fixes the reported bug, but by deleting the behavior CROW-606/#776/#777 were built to deliver, for all surfaces.
+
+## 5. Prototype Option B — `spike/822-option-b`
+
+Per-surface hybrid. Changes:
+- `crow-tmux.conf`: global default stays `alternate-screen off` (plain shells keep unified scrollback); document that the daemon sets `alternate-screen on` **per agent window** at creation.
+- `app.js`: `swallowMouseMode` and `enableWheelScroll` become **conditional** — alt buffer / active mouse tracking → forward the wheel to the app; else scroll xterm's 50k scrollback (mirrors what `enableTouchScroll`/`sendScrollToPTY` already do for touch).
+
+**Validation** — two windows in one isolated server, sampled mid-run:
+
+| Window | `alternate-screen` | `alternate_on` | `history_size` | Footer copies | Shell-log lines |
+|--------|:---:|:---:|:---:|:---:|:---:|
+| agent (repaint TUI) | on | 1 | **0** | 1 | 0 |
+| shell (streaming) | off (default) | 0 | **761** | 0 | **800** |
+
+Per-window `alternate-screen on` coexists with the global `off` in the same server: the agent window owns the alt buffer (no sediment) while the plain shell keeps its growing unified scrollback.
+
+**Open question surfaced (the real implementation work):** for `app.js` to route by `buffer.active.type === 'alternate'`, the **client** (xterm.js) must also enter the alt buffer for an agent window — which the global `smcup@/rmcup@` strip currently prevents. The follow-up must either (a) scope that strip to non-agent surfaces, or (b) have crowd signal window-kind to `app.js` and route on that instead of buffer type. The spike proved the tmux side; this wiring is the follow-up's crux.
+
+## 6. Decision: Option B
+
+Option A is simpler and fully fixes the sediment, but it regresses unified scrollback for every surface to fix a problem only the repainting agent TUIs have. Option B keeps the unified model where it fits (line-streaming shells, review diffs) and gives agent TUIs native ownership where they need it. Chosen. Recorded in [ADR-0013](../adr/0013-terminal-scroll-model.md). Cost: two code paths + the client alt-buffer-detection wiring above.
+
+## 7. Follow-up
+
+Implementation is tracked in a separate ticket (filed from this spike): per-agent-window `alternate-screen on` + agent-window classification in the daemon, conditional `swallowMouseMode`/`enableWheelScroll` in `app.js`, the client alt-buffer-detection wiring (scope the smcup strip or signal window-kind), and an alt-buffer pass over CROW-606 replay / jump-to-bottom / copy-paste. Prototype branches `spike/822-option-a` and `spike/822-option-b` are reference only — not for merge.

--- a/docs/spikes/822-terminal-scroll.md
+++ b/docs/spikes/822-terminal-scroll.md
@@ -86,4 +86,4 @@ Option A is simpler and fully fixes the sediment, but it regresses unified scrol
 
 ## 7. Follow-up
 
-Implementation is tracked in a separate ticket (filed from this spike): per-agent-window `alternate-screen on` + agent-window classification in the daemon, conditional `swallowMouseMode`/`enableWheelScroll` in `app.js`, the client alt-buffer-detection wiring (scope the smcup strip or signal window-kind), and an alt-buffer pass over CROW-606 replay / jump-to-bottom / copy-paste. Prototype branches `spike/822-option-a` and `spike/822-option-b` are reference only — not for merge.
+Implementation is tracked in [#824](https://github.com/corveil/crow/issues/824) (filed from this spike): per-agent-window `alternate-screen on` + agent-window classification in the daemon, conditional `swallowMouseMode`/`enableWheelScroll` in `app.js`, the client alt-buffer-detection wiring (scope the smcup strip or signal window-kind), and an alt-buffer pass over CROW-606 replay / jump-to-bottom / copy-paste. Prototype branches `spike/822-option-a` and `spike/822-option-b` are reference only — not for merge.


### PR DESCRIPTION
Closes #822.

Spike outcome: the web terminal's duplicate-Claude-Code-frames-on-scroll-up is **frame sediment** — a repainting full-frame TUI denied a fixed viewport deposits every repaint into the main-buffer scrollback. Confirmed live and reproduced deterministically in an isolated tmux server.

## Decision
**Option B — per-surface hybrid** (recorded in **ADR-0013**): agent-TUI windows get `alternate-screen on` + own their wheel (native scroll, no sediment); plain shell / review windows keep the unified xterm.js 50k scrollback + CROW-606 replay. Chosen over Option A (honor the alt screen everywhere), which fixes the bug but deletes unified scrollback for every surface.

Status is **Proposed** — this PR ships the decision + record; implementation is tracked separately in **#824** and flips the ADR to Accepted when it lands.

## What's in this PR (docs only)
- `docs/adr/0013-terminal-scroll-model.md` + index row — gives the scroll model its own record (was scattered across `crow-tmux.conf` comments + ADR-0001).
- `docs/spikes/822-terminal-scroll.md` — root cause, live repro, deterministic A/B measurements, both prototypes, decision.

## Evidence (isolated-tmux A/B, sampled mid-run)
| Config | `alternate_on` | `history_size` | Stacked frame copies |
|--------|:---:|:---:|:---:|
| `alternate-screen off` (current) | 0 | 1641 | 42 |
| `alternate-screen on` | 1 | 0 | 1 |

## Prototypes (reference only — NOT merged)
- `spike/822-option-a` — honor the alt screen everywhere.
- `spike/822-option-b` — per-surface hybrid (the chosen direction).

No production code changes here; the live instance was never touched (all prototype validation ran on a throwaway tmux socket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7kfrUnGCfrieiTGC4bQiR