### PR TITLE
Per-surface hybrid terminal scroll model (ADR-0013)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
@@ -90,3 +90,29 @@ public struct SessionTerminal: Identifiable, Codable, Sendable {
         tmuxBinding = try container.decodeIfPresent(TmuxBinding.self, forKey: .tmuxBinding)
     }
 }
+
+extension SessionTerminal {
+    /// Whether this terminal hosts a repainting agent TUI, and so takes the
+    /// alt-buffer scroll model instead of the unified scrollback (ADR-0013).
+    /// Single source of truth for that classification — the daemon uses it to
+    /// set `alternate-screen on` at window creation/adopt, and `list-terminals`
+    /// uses it for the `agent_surface` fallback, so the two can't disagree.
+    ///
+    /// TWO shapes qualify, and both are load-bearing:
+    ///   * a managed work terminal (`isManaged`), and
+    ///   * a Manager session's terminal, which always launches an agent but is
+    ///     built WITHOUT `isManaged` — `createManagerTerminal` relies on the
+    ///     memberwise default of `false`. Keying on `isManaged` alone silently
+    ///     excludes the Manager, which is itself one of the repainting agent
+    ///     windows #822 was reported against.
+    ///
+    /// Deliberately NOT `agentKind` (it always resolves to a configured
+    /// default, so it never discriminates) and NOT `trackReadiness` (false for
+    /// Manager sessions precisely because they launch the agent via `command`).
+    ///
+    /// `session` is this terminal's session; `nil` (not yet hydrated) falls
+    /// back to `isManaged` alone.
+    public func isAgentSurface(session: Session?) -> Bool {
+        isManaged || (session?.isManager ?? false)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Terminal.swift
@@ -100,19 +100,36 @@ extension SessionTerminal {
     ///
     /// TWO shapes qualify, and both are load-bearing:
     ///   * a managed work terminal (`isManaged`), and
-    ///   * a Manager session's terminal, which always launches an agent but is
-    ///     built WITHOUT `isManaged` — `createManagerTerminal` relies on the
-    ///     memberwise default of `false`. Keying on `isManaged` alone silently
-    ///     excludes the Manager, which is itself one of the repainting agent
-    ///     windows #822 was reported against.
+    ///   * a Manager session's **agent** terminal, which launches an agent via
+    ///     `command` but is built WITHOUT `isManaged` — `createManagerTerminal`
+    ///     relies on the memberwise default of `false`. Keying on `isManaged`
+    ///     alone silently excludes the Manager, itself one of the repainting
+    ///     agent windows #822 was reported against.
+    ///
+    /// The `command != nil` half of the Manager test is what keeps this from
+    /// over-classifying. A Manager session can hold ADDITIONAL plain shells —
+    /// `new-terminal` with just a `session_id` (the `+` button, or
+    /// `crow new-terminal --session <manager-uuid>`) yields `isManaged: false`
+    /// with no command. Those are line-streaming surfaces and must keep the
+    /// unified 50k scrollback; only the terminal that actually launches the
+    /// agent gets the alt-buffer model. `createManagerTerminal` always passes a
+    /// non-nil `managerCommand(for:)`, so the two are cleanly separable.
     ///
     /// Deliberately NOT `agentKind` (it always resolves to a configured
     /// default, so it never discriminates) and NOT `trackReadiness` (false for
     /// Manager sessions precisely because they launch the agent via `command`).
     ///
+    /// Known boundary: an extra Manager-session terminal created with an
+    /// explicit `--command` is treated as an agent surface. That is a deliberate
+    /// trade — the alternative is persisting a new per-terminal field — and the
+    /// cost is only that a hand-launched full-screen program there gets the
+    /// naked-terminal scroll model instead of the unified one.
+    ///
     /// `session` is this terminal's session; `nil` (not yet hydrated) falls
     /// back to `isManaged` alone.
     public func isAgentSurface(session: Session?) -> Bool {
-        isManaged || (session?.isManager ?? false)
+        if isManaged { return true }
+        guard session?.isManager == true else { return false }
+        return command != nil
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentSurfaceClassificationTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentSurfaceClassificationTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// Which terminals take the alt-buffer scroll model (ADR-0013, #824).
+///
+/// The classification lives in one place because the daemon uses it twice — to
+/// set `alternate-screen on` at window creation/adopt, and as the
+/// `list-terminals` `agent_surface` fallback before a window exists. If those
+/// two ever disagree, the client routes the wheel one way while tmux is
+/// configured the other.
+@Suite("Agent-surface classification")
+struct AgentSurfaceClassificationTests {
+
+    private func terminal(isManaged: Bool, sessionID: UUID = UUID()) -> SessionTerminal {
+        SessionTerminal(sessionID: sessionID, name: "t", cwd: "/tmp", isManaged: isManaged)
+    }
+
+    @Test func managedWorkTerminalIsAnAgentSurface() {
+        let session = Session(name: "work", status: .active, kind: .work)
+        #expect(terminal(isManaged: true).isAgentSurface(session: session))
+    }
+
+    @Test func plainShellIsNotAnAgentSurface() {
+        // The unified 50k scrollback is the right model for line-streaming
+        // output; this is the case that must NOT regress.
+        let session = Session(name: "work", status: .active, kind: .work)
+        #expect(!terminal(isManaged: false).isAgentSurface(session: session))
+    }
+
+    /// The regression this suite exists for. `createManagerTerminal` builds its
+    /// row via `SessionTerminal(sessionID:name:cwd:command:)`, so `isManaged`
+    /// takes the memberwise default of `false` — yet the Manager runs a
+    /// full-frame repainting agent and was one of the windows #822 was reported
+    /// against. Keying the scroll model on `isManaged` alone silently left the
+    /// Manager on the sediment path.
+    @Test func managerTerminalIsAnAgentSurfaceDespiteNotBeingManaged() {
+        let session = Session(name: "Manager", status: .active, kind: .manager)
+        let managerTerminal = SessionTerminal(
+            sessionID: session.id, name: session.name, cwd: "/dev/root", command: "claude --rc")
+        #expect(!managerTerminal.isManaged, "precondition: the Manager row carries no isManaged flag")
+        #expect(managerTerminal.isAgentSurface(session: session))
+    }
+
+    @Test func unhydratedSessionFallsBackToIsManaged() {
+        // Before the session is known we can only trust the flag we have.
+        #expect(terminal(isManaged: true).isAgentSurface(session: nil))
+        #expect(!terminal(isManaged: false).isAgentSurface(session: nil))
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentSurfaceClassificationTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentSurfaceClassificationTests.swift
@@ -42,9 +42,31 @@ struct AgentSurfaceClassificationTests {
         #expect(managerTerminal.isAgentSurface(session: session))
     }
 
+    /// The counterweight to the test above. A Manager session can hold extra
+    /// plain shells — `new-terminal` with only a `session_id` (the `+` button,
+    /// or `crow new-terminal --session <manager-uuid>`) produces
+    /// `isManaged: false` with no command. Classifying by session kind ALONE
+    /// swept those into the alt-buffer model, taking away the unified 50k
+    /// scrollback from an ordinary line-streaming shell. Only the terminal that
+    /// actually launches the agent qualifies.
+    @Test func plainShellInAManagerSessionIsNotAnAgentSurface() {
+        let session = Session(name: "Manager", status: .active, kind: .manager)
+        let shell = SessionTerminal(sessionID: session.id, name: "Shell", cwd: "/dev/root")
+        #expect(shell.command == nil, "precondition: an added shell carries no launch command")
+        #expect(!shell.isAgentSurface(session: session))
+    }
+
     @Test func unhydratedSessionFallsBackToIsManaged() {
         // Before the session is known we can only trust the flag we have.
         #expect(terminal(isManaged: true).isAgentSurface(session: nil))
         #expect(!terminal(isManaged: false).isAgentSurface(session: nil))
+    }
+
+    @Test func managerSessionKindDoesNotLeakAcrossSessions() {
+        // A work session's plain shell stays unified even if a Manager exists.
+        let work = Session(name: "work", status: .active, kind: .work)
+        let shell = SessionTerminal(sessionID: work.id, name: "Shell", cwd: "/repo", command: "vim")
+        #expect(!shell.isAgentSurface(session: work),
+                "a command alone must not promote a work-session shell")
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -769,6 +769,12 @@ html, body {
 .ctx-item.ctx-danger { color: var(--red); }
 .ctx-item.ctx-danger:hover { background: rgba(255, 69, 58, 0.14); }
 .ctx-sep { height: 1px; background: var(--border-subtle); margin: 4px 6px; }
+/* Non-interactive footnote in the terminal context menu — tells the user how to
+   select text on an agent surface, where the app owns the mouse (ADR-0013). */
+.ctx-hint {
+  padding: 6px 10px 2px; font-size: 11px; color: var(--text-secondary);
+  border-top: 1px solid var(--border-subtle); margin-top: 4px; cursor: default;
+}
 
 /* ---- Detail header: gold PR chip + inline PR status ---- */
 .link-chip.link-pr { color: var(--gold); border-color: var(--border-strong); }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -3302,6 +3302,71 @@ function setTerminalReconnecting(on) {
 // Terminal font stack: Nerd Fonts → system monospace.
 const DEFAULT_TERM_FONT = '"MesloLGS NF", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", "FiraCode Nerd Font", Menlo, Monaco, monospace';
 
+// --- Per-surface hybrid scroll model (ADR-0013) -----------------------------
+//
+// Crow runs two scroll models side by side, chosen per tmux window:
+//
+//   * PLAIN SHELL / REVIEW surfaces keep the unified model — output flows into
+//     xterm's 50k scrollback, the daemon replays tmux history on reconnect
+//     (CROW-606), and the wheel scrolls that local buffer.
+//   * AGENT-TUI surfaces (Claude Code, Cursor, Manager) own their own viewport
+//     like a naked terminal. crowd sets `alternate-screen on` for those windows
+//     so the agent's constant full-frame repaints stay in the alt buffer, which
+//     has no scrollback. Without that, every repaint deposited its predecessor
+//     into the shared history and scrolling up walked hundreds of stacked
+//     copies of the TUI (#822).
+//
+// `agent_surface` comes from `list-terminals`, sourced from the tmux window
+// option crowd actually set — NOT from `term.buffer.active.type`. The client
+// can't use the buffer type here: crow-tmux.conf strips the client's
+// smcup/rmcup, and `terminal-overrides` is keyed on the client's TERM while a
+// single tmux client serves every tab, so there is no per-window client buffer
+// state to read. The buffer/mouse-mode checks below are kept as an additional
+// signal for surfaces that do legitimately enter the alt buffer.
+function activeSurfaceIsAgent() {
+  return !!(activeTerminal && activeTerminal.agent_surface);
+}
+
+// Mouse-mode swallow — same handler as web/terminal.html (CROW-581). The agent
+// TUIs turn the xterm mouse protocol on themselves, and crow-tmux.conf's
+// `mouse off` means tmux forwards those DECSETs straight through to this
+// client.
+//
+// On a PLAIN SHELL we drop them: left alone, xterm.js enters mouse-reporting
+// mode and every mouse MOVE emits an SGR report to the PTY → the TUI repaints →
+// the viewport is yanked to the bottom while the user is scrolled up;
+// drag-select and the browser context menu are eaten too (#776).
+//
+// On an AGENT SURFACE we let them THROUGH, so the agent claims the wheel and
+// owns its own scroll exactly like a naked terminal (ADR-0013). The cost is the
+// one the swallow was avoiding: native drag-select and the right-click menu are
+// eaten inside agent windows. Hold ⌥ (Alt) to force selection anyway — that's
+// why `macOptionClickForcesSelection` is enabled in the Terminal config, since
+// xterm.js gates the Mac force-selection path on it and it defaults to false.
+const MOUSE_MODES = new Set([1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016]);
+function swallowMouseMode(params) {
+  if (activeSurfaceIsAgent()) return false; // agent surface → let it own the mouse
+  const arr = params && params.params ? params.params : params;
+  const len = arr ? arr.length : 0;
+  for (let i = 0; i < len; i++) {
+    const v = arr[i];
+    if (MOUSE_MODES.has(Array.isArray(v) ? v[0] : v)) return true; // handled → drop it
+  }
+  return false; // not a mouse mode → let xterm apply it normally
+}
+
+// True when the app on the other end should receive the scroll instead of us
+// scrolling xterm's local buffer: an agent surface, an actual alternate buffer,
+// or an app that has mouse tracking on. Shared by the wheel and touch shims so
+// both agree on who owns the surface.
+function appOwnsScroll() {
+  if (activeSurfaceIsAgent()) return true;
+  const buf = term && term.buffer && term.buffer.active;
+  if (buf && buf.type === 'alternate') return true;
+  const modes = (term && term.modes) || {};
+  return !!(modes.mouseTrackingMode && modes.mouseTrackingMode !== 'none');
+}
+
 function ensureTerminal() {
   if (term) return;
   fitAddon = new FitAddon.FitAddon();
@@ -3316,34 +3381,20 @@ function ensureTerminal() {
     theme: { background: '#1e1e1e', foreground: '#d4d4d4' },
     scrollback: 50000,
     allowTransparency: true,
+    // Escape hatch for agent surfaces, where we stop swallowing mouse modes so
+    // the agent owns the wheel (ADR-0013) — which also means xterm reports
+    // drags to the app instead of selecting text. xterm.js's Mac force-select
+    // path is `altKey && macOptionClickForcesSelection`, and this option
+    // DEFAULTS TO FALSE, so without it ⌥-drag would silently do nothing and
+    // there'd be no way to select text inside an agent window at all.
+    macOptionClickForcesSelection: true,
   });
   term.loadAddon(fitAddon);
   term.loadAddon(imageAddon);
   term.loadAddon(searchAddon);
   term.loadAddon(webLinksAddon);
 
-  // Mouse-mode swallow — same handler as web/terminal.html (CROW-581). The
-  // agent TUIs (Claude Code, Cursor) turn the xterm mouse protocol on
-  // themselves, and crow-tmux.conf's `mouse off` means tmux forwards those
-  // DECSETs straight through to this client. Left alone, xterm.js enters
-  // mouse-reporting mode and every mouse MOVE emits an SGR report to the PTY →
-  // the TUI repaints → the viewport is yanked to the bottom while the user is
-  // scrolled up; drag-select and the browser context menu are eaten too.
-  // Dropping the mode toggles at the parser keeps selection, the context menu,
-  // and wheel-scroll client-side. Inner apps that genuinely want the mouse
-  // (vim/htop) lose it here — the same acceptable trade terminal.html makes.
-  // #776: this surface was built without the swallow, so it regressed against
-  // the standalone renderer. Must be registered before open()/first write.
-  const MOUSE_MODES = new Set([1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016]);
-  function swallowMouseMode(params) {
-    const arr = params && params.params ? params.params : params;
-    const len = arr ? arr.length : 0;
-    for (let i = 0; i < len; i++) {
-      const v = arr[i];
-      if (MOUSE_MODES.has(Array.isArray(v) ? v[0] : v)) return true; // handled → drop it
-    }
-    return false; // not a mouse mode → let xterm apply it normally
-  }
+  // Registered before open()/first write so no mode toggle slips past.
   term.parser.registerCsiHandler({ prefix: '?', final: 'h' }, swallowMouseMode);
   term.parser.registerCsiHandler({ prefix: '?', final: 'l' }, swallowMouseMode);
 
@@ -3474,32 +3525,35 @@ function enableTouchScroll(node) {
     const delta = Math.trunc(accum);
     if (delta === 0) return;
     accum -= delta;
-    const buf = term.buffer && term.buffer.active;
-    if (buf && buf.type === 'alternate') sendScrollToPTY(delta);
+    // Same ownership test as the wheel (ADR-0013) so touch and wheel never
+    // disagree about who owns the surface.
+    if (appOwnsScroll()) sendScrollToPTY(delta);
     else term.scrollLines(delta);
   }, { passive: false });
   node.addEventListener('touchend', () => { lastY = null; accum = 0; }, { passive: true });
   node.addEventListener('touchcancel', () => { lastY = null; accum = 0; }, { passive: true });
 }
 
-// Let xterm.js own wheel scrolling in the browser: scroll the local 50k-line
-// scrollback instead of forwarding the wheel to tmux (whose server-global
-// `mouse on` would otherwise drop into copy-mode — janky in a browser).
+// Route the wheel by surface (ADR-0013) — the mirror of what enableTouchScroll
+// does for touch:
 //
-// #776: this used to bail on the alternate-screen buffer to "let TUIs handle
-// the wheel", but the mouse-mode swallow in ensureTerminal means no inner app
-// can receive mouse events here — so bailing just handed the wheel to xterm's
-// alternate-scroll fallback, which emits ARROW KEYS. Claude Code reads those as
-// input-history navigation: exactly the bug crow-tmux.conf documents under
-// `alternate-screen off`. Keep owning the event in both buffers; an alternate
-// buffer has no scrollback, so there we swallow the wheel rather than scroll.
-// (crow-tmux.conf also strips the client's smcup/rmcup, so in practice the
-// terminal stays in the main buffer and the scrollback path is the live one.)
+//   * PLAIN SHELL → scroll xterm's local 50k scrollback. Forwarding to tmux
+//     instead would drop into copy-mode, which is janky in a browser.
+//   * AGENT SURFACE → forward the tick to the app so it scrolls its own
+//     transcript, like a naked terminal.
+//
+// This handler always CONSUMES the event (capture + preventDefault +
+// stopPropagation) so xterm's own alternate-scroll fallback never runs. That
+// fallback emits ARROW KEYS, which Claude Code reads as input-history
+// navigation — the #776 bug. Forwarding goes through sendScrollToPTY, which
+// picks SGR wheel buttons when the app is mouse-tracking and cursor keys
+// otherwise, and caps a fling so it can't flood the PTY.
 function enableWheelScroll(node) {
   node.addEventListener('wheel', (e) => {
     if (!term) return;
-    const buf = term.buffer && term.buffer.active;
-    if (!buf || buf.type !== 'alternate') term.scrollLines(e.deltaY > 0 ? 3 : -3);
+    const delta = e.deltaY > 0 ? 3 : -3;
+    if (appOwnsScroll()) sendScrollToPTY(delta);
+    else term.scrollLines(delta);
     e.preventDefault();
     e.stopPropagation();
   }, { capture: true, passive: false });
@@ -3599,6 +3653,13 @@ function showTerminalMenu(e) {
     const item = el('div', 'ctx-item', it.label);
     item.onclick = (ev) => { ev.stopPropagation(); closeContextMenu(); it.action(); };
     menu.appendChild(item);
+  }
+  // On an agent surface the app receives the mouse (ADR-0013), so a plain drag
+  // scrolls the agent instead of selecting. Surface the escape hatch rather
+  // than leaving the user to discover it.
+  if (activeSurfaceIsAgent() && !sel) {
+    const hint = el('div', 'ctx-hint', 'Hold ⌥ to select text');
+    menu.appendChild(hint);
   }
   document.body.appendChild(menu);
   const x = Math.min(e.clientX, window.innerWidth - menu.offsetWidth - 8);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2032,9 +2032,15 @@ async function refreshTerminals() {
   } catch (_) {
     terminals = [];
   }
-  if (!activeTerminal || !terminals.find((t) => t.id === activeTerminal.id)) {
-    activeTerminal = terminals[0] || null;
-  }
+  // Rebind to the FRESH row, don't just check the old one is still present.
+  // `activeTerminal` is not merely a selection marker: `agent_surface` drives
+  // the wheel/mouse routing (ADR-0013) and `window` drives attachWindow, and
+  // both can change under a stable id — `agent_surface` starts as the
+  // pre-binding fallback and becomes authoritative once the tmux window exists
+  // or an adopt re-applies the option. Keeping the stale object left routing on
+  // the old value until the user happened to switch tabs.
+  activeTerminal = terminals.find((t) => t.id === (activeTerminal && activeTerminal.id))
+    || terminals[0] || null;
   renderTabs();
   // #673: session switches funnel through here too (selectSession → refreshTerminals),
   // changing which window this shared socket shows — same corruption as a terminal-tab

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -3371,11 +3371,29 @@ function forceSelectModifierLabel() {
 }
 
 // True when the app on the other end should receive the scroll instead of us
-// scrolling xterm's local buffer: an agent surface, an actual alternate buffer,
-// or an app that has mouse tracking on. Shared by the wheel and touch shims so
-// both agree on who owns the surface.
+// scrolling xterm's local buffer. Shared by the wheel and touch shims so both
+// agree on who owns the surface.
+//
+// The daemon-supplied `agent_surface` is AUTHORITATIVE whenever we have it: an
+// agent surface forwards, and a known plain shell scrolls its unified 50k
+// scrollback — full stop. The alt-buffer / mouse-tracking checks are consulted
+// ONLY when we have no surface metadata at all (before the first
+// `list-terminals` lands).
+//
+// That gating is load-bearing, not defensive coding. There is ONE shared xterm
+// instance across every tab, and agent surfaces now let DECSET 1000–1016
+// through, so `term.modes.mouseTrackingMode` can outlive the tab that set it:
+// `attachWindow` only clears it via `reloadTerminal()`/`term.reset()` when the
+// socket is already OPEN, and skips that during a reconnect. Ungated, a shell
+// tab visited right after an agent tab would inherit its modes and forward the
+// wheel to the PTY as arrow keys — regressing the exact shell path this model
+// exists to preserve. Nothing is lost by gating: under the smcup strip plus the
+// conditional swallow, a real shell surface can never legitimately be in the
+// alternate buffer or be mouse-tracking.
 function appOwnsScroll() {
-  if (activeSurfaceIsAgent()) return true;
+  if (activeTerminal && typeof activeTerminal.agent_surface === 'boolean') {
+    return activeTerminal.agent_surface;
+  }
   const buf = term && term.buffer && term.buffer.active;
   if (buf && buf.type === 'alternate') return true;
   const modes = (term && term.modes) || {};

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -3355,6 +3355,15 @@ function swallowMouseMode(params) {
   return false; // not a mouse mode → let xterm apply it normally
 }
 
+// The modifier that forces a text selection when the app owns the mouse.
+// Mirrors xterm.js's own `shouldForceSelection`: Alt on macOS (which is why
+// `macOptionClickForcesSelection` must be enabled), Shift on every other
+// platform. Best-effort UA sniff — only ever used for a label.
+function forceSelectModifierLabel() {
+  const ua = (navigator.userAgent || '') + ' ' + (navigator.platform || '');
+  return /Mac|iPhone|iPad|iPod/.test(ua) ? '⌥' : 'Shift';
+}
+
 // True when the app on the other end should receive the scroll instead of us
 // scrolling xterm's local buffer: an agent surface, an actual alternate buffer,
 // or an app that has mouse tracking on. Shared by the wheel and touch shims so
@@ -3656,9 +3665,12 @@ function showTerminalMenu(e) {
   }
   // On an agent surface the app receives the mouse (ADR-0013), so a plain drag
   // scrolls the agent instead of selecting. Surface the escape hatch rather
-  // than leaving the user to discover it.
+  // than leaving the user to discover it. xterm.js's force-select modifier is
+  // platform-dependent — ⌥ on macOS (gated on macOptionClickForcesSelection,
+  // set in ensureTerminal), Shift everywhere else — and this UI is reachable
+  // from any browser, so name the right key for the client we're running on.
   if (activeSurfaceIsAgent() && !sel) {
-    const hint = el('div', 'ctx-hint', 'Hold ⌥ to select text');
+    const hint = el('div', 'ctx-hint', `Hold ${forceSelectModifierLabel()} to select text`);
     menu.appendChild(hint);
   }
   document.body.appendChild(menu);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -77,6 +77,15 @@
       // never reports the mouse: native selection, our context menu, and
       // wheel-scroll all work client-side instead (CROW-581). Inner apps that
       // want the mouse (vim/htop) lose it in the browser — an acceptable trade.
+      //
+      // DELIBERATELY UNCONDITIONAL here, unlike app.js (#824). app.js makes the
+      // swallow depend on surface kind so agent TUIs own their own wheel
+      // (ADR-0013), which needs the `agent_surface` flag from `list-terminals`
+      // and an `activeTerminal` to hang it on — neither exists on this
+      // single-terminal debug page. The #822 frame sediment is fixed SERVER-side
+      // (per-window `alternate-screen on`), so this page benefits from that fix
+      // regardless; what it gives up is only the wheel forwarding. So the two
+      // files are expected to differ now — do NOT "resync" this with app.js.
       const MOUSE_MODES = new Set([1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016]);
       function swallowMouseMode(params) {
         const arr = params && params.params ? params.params : params;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -46,7 +46,9 @@ struct TerminalCockpit: Sendable {
     private func logDegradedScrollbackWindows() {
         guard let windows = try? controller.listWindowScrollback() else { return }
         for w in windows where TmuxBackend.isScrollbackDegraded(
-            historyLimit: w.historyLimit, alternateOn: w.alternateOn) {
+            historyLimit: w.historyLimit,
+            alternateOn: w.alternateOn,
+            alternateScreenEnabled: w.alternateScreenEnabled) {
             NSLog("[CrowTelemetry tmux:scrollback_degraded index=\(w.index) history_limit=\(w.historyLimit) alternate_on=\(w.alternateOn ? 1 : 0)]")
         }
     }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -74,21 +74,26 @@ import Testing
         }
     }
 
-    /// The wheel handler owns the event in BOTH buffers. Any early return on the
-    /// alternate buffer hands the wheel to xterm's alternate-scroll fallback,
-    /// which emits arrow keys the agent TUI reads as input-history navigation
-    /// (crow-tmux.conf's `alternate-screen off` rationale, #776).
+    /// The wheel handler always CONSUMES the event, and ROUTES it by surface
+    /// rather than dropping it (ADR-0013).
     ///
-    /// Asserted as the positive ownership shape rather than the absence of one
-    /// comment string, so reintroducing the bail with different wording still
-    /// fails (review): the alternate check may only gate `scrollLines`, the
-    /// event is always consumed, and the sole `return` is the no-terminal guard.
-    @Test func wheelHandlerOwnsTheEventInBothBuffers() throws {
+    /// Consuming is the #776 invariant: any early return hands the wheel to
+    /// xterm's alternate-scroll fallback, which emits arrow keys that the agent
+    /// TUI reads as input-history navigation. Routing is the #824 invariant: a
+    /// plain shell scrolls the local 50k scrollback, while an agent surface
+    /// forwards the tick to the app so it scrolls its own transcript.
+    ///
+    /// Asserted as the positive shape rather than the absence of a string, so
+    /// reintroducing a bail with different wording still fails (review).
+    @Test func wheelHandlerOwnsTheEventAndRoutesBySurface() throws {
         let body = try Self.functionBody("enableWheelScroll", in: Self.webAsset("app.js"))
         #expect(
-            body.contains("buf.type !== 'alternate'"),
-            "the alternate-buffer check must gate scrolling, not handling")
+            body.contains("appOwnsScroll()"),
+            "the wheel must route by surface ownership, not unconditionally")
         #expect(body.contains("term.scrollLines("), "must scroll the local scrollback")
+        #expect(
+            body.contains("sendScrollToPTY("),
+            "must forward the wheel to the app on an agent surface")
         for consume in ["e.preventDefault();", "e.stopPropagation();"] {
             #expect(body.contains(consume), "must always consume the wheel event: \(consume)")
         }
@@ -96,5 +101,44 @@ import Testing
         // preventDefault/stopPropagation pair below it.
         let returns = body.components(separatedBy: "return").count - 1
         #expect(returns == 1, "only the `if (!term)` guard may return early, found \(returns)")
+    }
+
+    /// The surface-ownership predicate the wheel and touch shims share. Agent
+    /// surfaces are identified by the daemon-supplied `agent_surface` flag, NOT
+    /// by `buffer.active.type`: crow-tmux.conf strips the client's smcup/rmcup
+    /// and one tmux client serves every tab, so the client never actually enters
+    /// the alternate buffer per-window and a buffer-type-only check would be
+    /// permanently false (the trap the #822 prototype fell into).
+    @Test func scrollOwnershipConsultsTheDaemonSuppliedSurfaceKind() throws {
+        let source = try Self.webAsset("app.js")
+        let body = try Self.functionBody("appOwnsScroll", in: source)
+        #expect(body.contains("activeSurfaceIsAgent()"), "must consult the surface kind")
+        #expect(
+            body.contains("'alternate'") && body.contains("mouseTrackingMode"),
+            "must keep the alt-buffer / mouse-tracking signals as well")
+        #expect(
+            try Self.functionBody("activeSurfaceIsAgent", in: source).contains("agent_surface"),
+            "the surface kind comes from the list-terminals payload")
+        // Touch must not diverge from the wheel — #777's shim and #824's wheel
+        // routing have to agree about who owns the surface.
+        #expect(
+            try Self.functionBody("enableTouchScroll", in: source).contains("appOwnsScroll()"),
+            "touch must share the wheel's ownership test")
+    }
+
+    /// The swallow is conditional on surface kind (ADR-0013): plain shells keep
+    /// it (so drag-select and the context menu survive), agent surfaces let the
+    /// mode toggles through so the app claims the wheel. Because that hands
+    /// drags to the app, `macOptionClickForcesSelection` is the only way left to
+    /// select text in an agent window — and xterm.js defaults it to false, so it
+    /// must be set explicitly or the ⌥-drag escape hatch silently does nothing.
+    @Test func mouseSwallowIsConditionalWithASelectionEscapeHatch() throws {
+        let source = try Self.webAsset("app.js")
+        #expect(
+            try Self.functionBody("swallowMouseMode", in: source).contains("activeSurfaceIsAgent()"),
+            "the swallow must be conditional on the surface kind")
+        #expect(
+            source.contains("macOptionClickForcesSelection: true"),
+            "⌥-drag selection must be enabled explicitly (xterm.js defaults it to false)")
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -126,6 +126,28 @@ import Testing
             "touch must share the wheel's ownership test")
     }
 
+    /// `refreshTerminals` must REBIND `activeTerminal` to the freshly-fetched
+    /// row, not merely check the old one is still present.
+    ///
+    /// `activeTerminal` stopped being a selection marker once `agent_surface`
+    /// began driving the wheel/mouse routing (ADR-0013) — and that field can
+    /// change under a stable terminal id, because `list-terminals` answers with
+    /// the pre-binding fallback until the tmux window exists and with the
+    /// authoritative option read afterwards. Holding the stale object left the
+    /// client routing on an outdated flag until the user switched tabs.
+    ///
+    /// Asserted on source shape because driving `refreshTerminals` needs a live
+    /// RPC socket; the jsdom suite covers the routing this feeds.
+    @Test func refreshTerminalsRebindsTheActiveTerminalToTheFreshRow() throws {
+        let body = try Self.functionBody("refreshTerminals", in: Self.webAsset("app.js"))
+        #expect(
+            body.contains("activeTerminal = terminals.find("),
+            "must re-resolve activeTerminal from the fresh list, not keep the old object")
+        #expect(
+            body.contains("|| terminals[0] || null"),
+            "must still fall back to the first terminal, then null")
+    }
+
     /// The swallow is conditional on surface kind (ADR-0013): plain shells keep
     /// it (so drag-select and the context menu survive), agent surfaces let the
     /// mode toggles through so the app claims the wheel. Because that hands

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -112,10 +112,20 @@ import Testing
     @Test func scrollOwnershipConsultsTheDaemonSuppliedSurfaceKind() throws {
         let source = try Self.webAsset("app.js")
         let body = try Self.functionBody("appOwnsScroll", in: source)
-        #expect(body.contains("activeSurfaceIsAgent()"), "must consult the surface kind")
+        // The daemon flag must be consulted FIRST and must be able to answer
+        // `false`. There is one shared xterm across tabs, and agent surfaces now
+        // let the mouse-mode DECSETs through, so `mouseTrackingMode` can outlive
+        // the tab that set it — an ungated legacy branch would let a known plain
+        // shell inherit it and forward the wheel to the PTY.
+        #expect(
+            body.contains("typeof activeTerminal.agent_surface === 'boolean'"),
+            "must treat a known surface kind as authoritative in BOTH directions")
+        #expect(
+            body.contains("return activeTerminal.agent_surface;"),
+            "a known plain shell must scroll locally, not fall through to the legacy signals")
         #expect(
             body.contains("'alternate'") && body.contains("mouseTrackingMode"),
-            "must keep the alt-buffer / mouse-tracking signals as well")
+            "must keep the alt-buffer / mouse-tracking signals as the unclassified fallback")
         #expect(
             try Self.functionBody("activeSurfaceIsAgent", in: source).contains("agent_surface"),
             "the surface kind comes from the list-terminals payload")

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -23,6 +23,20 @@ accumulation, the alternate-screen branch (SGR wheel reports when the TUI has
 mouse tracking on, cursor keys otherwise, capped per event), multi-touch
 pass-through, and degenerate cell metrics.
 
+## `wheel-scroll.test.js` — per-surface hybrid scroll (#824, ADR-0013)
+
+Drives `enableWheelScroll` and `swallowMouseMode` against a fake xterm + PTY
+socket. Coverage: the #776 invariant that the handler always consumes the wheel
+(capture-phase, non-passive, `preventDefault`) on every surface; routing by
+surface — a plain shell scrolls the local 50k scrollback and writes nothing to
+the PTY, while an agent surface forwards SGR wheel reports (or cursor keys when
+the app isn't mouse-tracking) and never scrolls locally; the legacy alt-buffer
+and mouse-tracking signals still routing to the app; the conditional mouse-mode
+swallow (swallowed on a shell, passed through on an agent surface, never
+swallowing a non-mouse mode like `?25`), including xterm's params-object and
+sub-parameter shapes; and graceful degradation when `activeTerminal` is null or
+an older daemon omits `agent_surface`.
+
 ## `row.test.js` — sidebar session rows (CROW-773)
 
 Drives `sessionRow`. Coverage: the PR pill's status glyphs for every

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,9 +2,9 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch-scroll; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "node board.test.js && node touch-scroll.test.js && node row.test.js"
+    "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node row.test.js"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
@@ -1,0 +1,197 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// #824 / ADR-0013: the per-surface hybrid scroll model. Drives the real
+// enableWheelScroll + swallowMouseMode from Resources/web/app.js against a fake
+// xterm + PTY socket. Same harness shape as touch-scroll.test.js — an epilogue
+// evaluated in app.js's own top-level lexical scope exposes the module-scope
+// bindings we need (which is why swallowMouseMode lives at module scope rather
+// than nested inside ensureTerminal).
+const epilogue = `
+;globalThis.__t = {
+  enableWheelScroll(node){ return enableWheelScroll(node); },
+  swallowMouseMode(params){ return swallowMouseMode(params); },
+  appOwnsScroll(){ return appOwnsScroll(); },
+  set term(v){ term = v; },
+  set termWs(v){ termWs = v; },
+  set activeTerminal(v){ activeTerminal = v; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body><div id="terminal"></div></body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.WebSocket.OPEN = 1;
+window.TextEncoder = TextEncoder; // jsdom omits it; real browsers have it
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+// ---- Fakes -----------------------------------------------------------------
+
+// A fresh #terminal node with the wheel listener attached, plus recorders for
+// what the handler did. `agentSurface` models the daemon-supplied
+// `agent_surface` flag from the list-terminals payload.
+function setup({ agentSurface = false, altScreen = false,
+                 mouseTrackingMode = 'none', applicationCursorKeysMode = false } = {}) {
+  const node = window.document.createElement('div');
+  window.document.body.appendChild(node);
+
+  const scrolled = [];
+  const sent = [];
+  T.term = {
+    rows: 24,
+    buffer: { active: { type: altScreen ? 'alternate' : 'normal' } },
+    modes: { mouseTrackingMode, applicationCursorKeysMode },
+    scrollLines: (n) => scrolled.push(n),
+  };
+  T.termWs = {
+    readyState: 1,
+    send: (bytes) => sent.push(new TextDecoder().decode(bytes)),
+  };
+  T.activeTerminal = { id: 't1', window: 1, agent_surface: agentSurface };
+
+  const opts = {};
+  const realAdd = node.addEventListener.bind(node);
+  node.addEventListener = (type, fn, o) => { opts[type] = o; realAdd(type, fn, o); };
+  T.enableWheelScroll(node);
+
+  let defaultPrevented = 0;
+  const wheel = (deltaY) => {
+    const e = new window.Event('wheel', { bubbles: true, cancelable: true });
+    e.deltaY = deltaY;
+    node.dispatchEvent(e);
+    if (e.defaultPrevented) defaultPrevented++;
+  };
+  return {
+    node, opts, scrolled, sent,
+    up: () => wheel(-120),
+    down: () => wheel(120),
+    prevented: () => defaultPrevented,
+  };
+}
+
+// ---- Event ownership (#776 invariant) --------------------------------------
+
+console.log('The wheel handler owns the event on every surface (#776):');
+{
+  const t = setup();
+  check('wheel registered non-passive', t.opts.wheel && t.opts.wheel.passive === false);
+  check('wheel registered in the capture phase', t.opts.wheel && t.opts.wheel.capture === true);
+  t.up();
+  check('preventDefault called on a plain shell', t.prevented() === 1);
+}
+{
+  const t = setup({ agentSurface: true });
+  t.up();
+  check('preventDefault called on an agent surface too', t.prevented() === 1);
+}
+
+// ---- Routing (#824 / ADR-0013) ---------------------------------------------
+
+console.log('\nPlain shell scrolls the unified local scrollback:');
+{
+  const t = setup();
+  t.up();
+  check('scrollLines(-3) on wheel-up', t.scrolled.join() === '-3');
+  t.down();
+  check('scrollLines(+3) on wheel-down', t.scrolled.join() === '-3,3');
+  check('nothing written to the PTY', t.sent.length === 0);
+}
+
+console.log('\nAgent surface forwards the wheel to the app:');
+{
+  // The agent turned mouse tracking on and — because the swallow is now
+  // conditional — xterm actually recorded it, so we speak SGR wheel buttons.
+  const t = setup({ agentSurface: true, mouseTrackingMode: 'any' });
+  t.up();
+  check('SGR wheel-up report sent', t.sent.join() === '\x1b[<64;1;1M'.repeat(3));
+  t.down();
+  check('SGR wheel-down report on the way back', t.sent[1] === '\x1b[<65;1;1M'.repeat(3));
+  check('no local scrollLines on an agent surface', t.scrolled.length === 0);
+}
+{
+  // An agent surface whose app has NOT enabled mouse tracking still must not
+  // scroll the (empty) local buffer — that was the "same frame forever" bug.
+  const t = setup({ agentSurface: true, mouseTrackingMode: 'none' });
+  t.up();
+  check('no mouse tracking → cursor keys, still not scrollLines', t.sent.join() === '\x1b[A'.repeat(3));
+  check('still nothing scrolled locally', t.scrolled.length === 0);
+}
+
+console.log('\nThe legacy signals still route to the app (back-compat):');
+{
+  const t = setup({ agentSurface: false, altScreen: true, mouseTrackingMode: 'vt200' });
+  t.up();
+  check('a real alternate buffer forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
+}
+{
+  const t = setup({ agentSurface: false, altScreen: false, mouseTrackingMode: 'any' });
+  t.up();
+  check('active mouse tracking forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
+}
+
+// ---- Conditional mouse-mode swallow ----------------------------------------
+
+console.log('\nThe mouse-mode swallow is conditional on the surface:');
+{
+  setup({ agentSurface: false });
+  const swallowed = [1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016]
+    .every((m) => T.swallowMouseMode([m]) === true);
+  check('plain shell swallows every tracking mode (#776)', swallowed);
+  check('plain shell lets a non-mouse mode through (?25 cursor)', T.swallowMouseMode([25]) === false);
+}
+{
+  setup({ agentSurface: true });
+  const passed = [1000, 1002, 1003, 1006, 1016]
+    .every((m) => T.swallowMouseMode([m]) === false);
+  check('agent surface lets the tracking modes through', passed);
+  check('agent surface still lets a non-mouse mode through', T.swallowMouseMode([25]) === false);
+}
+{
+  // xterm passes a params object, not a bare array — the shim handles both.
+  setup({ agentSurface: false });
+  check('unwraps the xterm params object', T.swallowMouseMode({ params: [1006] }) === true);
+  check('handles sub-parameter arrays', T.swallowMouseMode([[1006, 0]]) === true);
+  check('empty params are not swallowed', T.swallowMouseMode([]) === false);
+}
+
+// ---- Degenerate state ------------------------------------------------------
+
+console.log('\nMissing surface metadata degrades to the shell path:');
+{
+  const t = setup({ agentSurface: false });
+  T.activeTerminal = null; // no list-terminals payload yet
+  t.up();
+  check('no activeTerminal → scrolls locally, does not throw', t.scrolled.join() === '-3');
+  check('...and swallows mouse modes as before', T.swallowMouseMode([1006]) === true);
+}
+{
+  const t = setup({ agentSurface: false });
+  T.activeTerminal = { id: 't1', window: 1 }; // older daemon: field absent
+  t.up();
+  check('absent agent_surface field → shell path', t.scrolled.join() === '-3');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
@@ -140,16 +140,38 @@ console.log('\nAgent surface forwards the wheel to the app:');
   check('still nothing scrolled locally', t.scrolled.length === 0);
 }
 
-console.log('\nThe legacy signals still route to the app (back-compat):');
+// There is ONE shared xterm across every tab, and agent surfaces now let the
+// mouse-mode DECSETs through, so `modes.mouseTrackingMode` can outlive the tab
+// that set it (attachWindow only resets when the socket is already OPEN). A
+// KNOWN shell must never inherit that and start forwarding the wheel.
+console.log('\nA known plain shell ignores stale state from a previous agent tab:');
 {
-  const t = setup({ agentSurface: false, altScreen: true, mouseTrackingMode: 'vt200' });
+  const t = setup({ agentSurface: false, mouseTrackingMode: 'any' });
   t.up();
-  check('a real alternate buffer forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
+  check('sticky mouseTrackingMode does not hijack the shell', t.scrolled.join() === '-3');
+  check('nothing forwarded to the PTY', t.sent.length === 0);
 }
 {
-  const t = setup({ agentSurface: false, altScreen: false, mouseTrackingMode: 'any' });
+  const t = setup({ agentSurface: false, altScreen: true });
   t.up();
-  check('active mouse tracking forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
+  check('a stale alternate buffer does not hijack the shell either', t.scrolled.join() === '-3');
+  check('still nothing forwarded to the PTY', t.sent.length === 0);
+}
+
+// Those same signals remain the fallback when the daemon hasn't told us the
+// surface kind yet — pre-#824 behavior for an unclassified surface.
+console.log('\nWith no surface metadata, the legacy signals still apply:');
+{
+  const t = setup({ agentSurface: false, altScreen: true, mouseTrackingMode: 'vt200' });
+  T.activeTerminal = null;
+  t.up();
+  check('unclassified + alternate buffer forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
+}
+{
+  const t = setup({ agentSurface: false, mouseTrackingMode: 'any' });
+  T.activeTerminal = { id: 't1', window: 1 }; // no agent_surface field
+  t.up();
+  check('unclassified + mouse tracking forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
 }
 
 // ---- Conditional mouse-mode swallow ----------------------------------------

--- a/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
@@ -13,6 +13,7 @@ const epilogue = `
   enableWheelScroll(node){ return enableWheelScroll(node); },
   swallowMouseMode(params){ return swallowMouseMode(params); },
   appOwnsScroll(){ return appOwnsScroll(); },
+  showTerminalMenu(e){ return showTerminalMenu(e); },
   set term(v){ term = v; },
   set termWs(v){ termWs = v; },
   set activeTerminal(v){ activeTerminal = v; },
@@ -191,6 +192,43 @@ console.log('\nMissing surface metadata degrades to the shell path:');
   T.activeTerminal = { id: 't1', window: 1 }; // older daemon: field absent
   t.up();
   check('absent agent_surface field → shell path', t.scrolled.join() === '-3');
+}
+
+// ---- Selection escape-hatch discoverability --------------------------------
+
+// Letting mouse modes through costs native drag-select on agent surfaces, so
+// the ⌥/Shift-drag hint is the only in-product teaching of the way back. It
+// lives in the right-click menu, which stays reachable under live mouse
+// tracking: xterm.js's only `contextmenu` listener is `rightClickHandler`,
+// which calls neither preventDefault() nor stopPropagation(), and our listener
+// sits on the #terminal-wrap ANCESTOR of xterm's element, so the event bubbles
+// up regardless of what the app is reporting.
+console.log('\nThe selection hint is discoverable on agent surfaces:');
+function openMenu({ agentSurface, selection = '' }) {
+  document.querySelectorAll('.ctx-menu').forEach((n) => n.remove());
+  T.term = { getSelection: () => selection, selectAll() {}, clear() {} };
+  T.activeTerminal = { id: 't1', window: 1, agent_surface: agentSurface };
+  const e = new window.Event('contextmenu', { bubbles: true, cancelable: true });
+  T.showTerminalMenu(e);
+  return document.querySelector('.ctx-menu');
+}
+const { document } = window;
+{
+  const menu = openMenu({ agentSurface: true });
+  const hint = menu && menu.querySelector('.ctx-hint');
+  check('agent surface shows the selection hint', !!hint);
+  check('hint names a modifier key', !!hint && /⌥|Shift/.test(hint.textContent));
+  check('hint is not a clickable menu item', !!hint && !hint.classList.contains('ctx-item'));
+}
+{
+  const menu = openMenu({ agentSurface: false });
+  check('plain shell shows no hint (drag-select just works)', menu && !menu.querySelector('.ctx-hint'));
+}
+{
+  const menu = openMenu({ agentSurface: true, selection: 'already selected' });
+  check('no hint once the user has a selection', menu && !menu.querySelector('.ctx-hint'));
+  check('...and Copy is offered instead',
+    menu && [...menu.querySelectorAll('.ctx-item')].some((n) => n.textContent === 'Copy'));
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -894,12 +894,14 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // old 5000-line history-limit can't show full scroll-up history
                 // and can only be healed by recreation (CROW-804). Read the live
                 // set once so the web UI can badge the affected tabs.
-                let degraded = await MainActor.run { TmuxBackend.shared.degradedWindowIndices() }
-                // Which windows run the agent-TUI scroll model (ADR-0013). Read
-                // from tmux (`alternate-screen` per window) rather than inferred
-                // client-side, so `app.js` routes the wheel on the SAME ground
-                // truth the daemon actually applied.
-                let agentSurfaces = await MainActor.run { TmuxBackend.shared.agentSurfaceWindowIndices() }
+                // Paired with which windows run the agent-TUI scroll model
+                // (ADR-0013) — read from tmux (`alternate-screen` per window)
+                // rather than inferred client-side, so `app.js` routes the wheel
+                // on the SAME ground truth the daemon actually applied. One
+                // combined read so this RPC forks a single `tmux` subprocess.
+                let (degraded, agentSurfaces) = await MainActor.run {
+                    TmuxBackend.shared.windowScrollbackClassification()
+                }
                 // Only for the pre-binding fallback below — the tmux read above
                 // is authoritative once a window exists.
                 let session = await MainActor.run {

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -850,7 +850,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                                 // plain shells keep the unified scrollback
                                 // (ADR-0013). `agentKind` can't discriminate —
                                 // it always resolves to a default.
-                                agentSurface: isManaged,
+                                agentSurface: terminal.isAgentSurface(session: session),
                                 newWindowTimeout: 3.0
                             )
                         }
@@ -900,6 +900,11 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // client-side, so `app.js` routes the wheel on the SAME ground
                 // truth the daemon actually applied.
                 let agentSurfaces = await MainActor.run { TmuxBackend.shared.agentSurfaceWindowIndices() }
+                // Only for the pre-binding fallback below — the tmux read above
+                // is authoritative once a window exists.
+                let session = await MainActor.run {
+                    capturedAppState.sessions.first(where: { $0.id == id })
+                }
                 let items: [JSONValue] = terms.map { t in
                     // `readiness` lets CLI callers (setup.sh) verify the agent
                     // actually started rather than assuming a launch succeeded
@@ -922,11 +927,14 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // True when this terminal is an agent-TUI surface that
                         // owns its own viewport + scrollback (ADR-0013). The web
                         // client routes the wheel and the mouse-mode swallow on
-                        // this. Falls back to `isManaged` before the window
-                        // exists (or when tmux is unreachable), which is the
-                        // same predicate the daemon registers the window with.
+                        // this. Before the window exists (or when tmux is
+                        // unreachable) it falls back to the SAME predicate the
+                        // daemon registers the window with, so the two agree —
+                        // including for the Manager, whose terminal carries no
+                        // `isManaged` flag.
                         "agent_surface": .bool(
-                            t.tmuxBinding.map { agentSurfaces.contains($0.windowIndex) } ?? t.isManaged),
+                            t.tmuxBinding.map { agentSurfaces.contains($0.windowIndex) }
+                                ?? t.isAgentSurface(session: session)),
                     ])
                 }
                 return ["terminals": .array(items)]

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -846,6 +846,11 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                                 command: registerCommand,
                                 trackReadiness: trackReadiness,
                                 agentKind: agentKind,
+                                // Agent TUIs get the alt-buffer scroll model;
+                                // plain shells keep the unified scrollback
+                                // (ADR-0013). `agentKind` can't discriminate —
+                                // it always resolves to a default.
+                                agentSurface: isManaged,
                                 newWindowTimeout: 3.0
                             )
                         }
@@ -890,6 +895,11 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // and can only be healed by recreation (CROW-804). Read the live
                 // set once so the web UI can badge the affected tabs.
                 let degraded = await MainActor.run { TmuxBackend.shared.degradedWindowIndices() }
+                // Which windows run the agent-TUI scroll model (ADR-0013). Read
+                // from tmux (`alternate-screen` per window) rather than inferred
+                // client-side, so `app.js` routes the wheel on the SAME ground
+                // truth the daemon actually applied.
+                let agentSurfaces = await MainActor.run { TmuxBackend.shared.agentSurfaceWindowIndices() }
                 let items: [JSONValue] = terms.map { t in
                     // `readiness` lets CLI callers (setup.sh) verify the agent
                     // actually started rather than assuming a launch succeeded
@@ -909,6 +919,14 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // and needs a recreate (CROW-804). Never degraded when
                         // there's no window binding yet.
                         "scrollback_degraded": .bool(t.tmuxBinding.map { degraded.contains($0.windowIndex) } ?? false),
+                        // True when this terminal is an agent-TUI surface that
+                        // owns its own viewport + scrollback (ADR-0013). The web
+                        // client routes the wheel and the mouse-mode swallow on
+                        // this. Falls back to `isManaged` before the window
+                        // exists (or when tmux is unreachable), which is the
+                        // same predicate the daemon registers the window with.
+                        "agent_surface": .bool(
+                            t.tmuxBinding.map { agentSurfaces.contains($0.windowIndex) } ?? t.isManaged),
                     ])
                 }
                 return ["terminals": .array(items)]

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -899,11 +899,14 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // rather than inferred client-side, so `app.js` routes the wheel
                 // on the SAME ground truth the daemon actually applied. One
                 // combined read so this RPC forks a single `tmux` subprocess.
-                let (degraded, agentSurfaces) = await MainActor.run {
+                // `nil` means the read FAILED (tmux down / timed out), which is
+                // not the same as "no such windows" — see the agent_surface
+                // fallback below.
+                let classification = await MainActor.run {
                     TmuxBackend.shared.windowScrollbackClassification()
                 }
-                // Only for the pre-binding fallback below — the tmux read above
-                // is authoritative once a window exists.
+                let degraded = classification?.degraded ?? []
+                // For the fallback below, when tmux couldn't answer.
                 let session = await MainActor.run {
                     capturedAppState.sessions.first(where: { $0.id == id })
                 }
@@ -929,14 +932,21 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // True when this terminal is an agent-TUI surface that
                         // owns its own viewport + scrollback (ADR-0013). The web
                         // client routes the wheel and the mouse-mode swallow on
-                        // this. Before the window exists (or when tmux is
-                        // unreachable) it falls back to the SAME predicate the
-                        // daemon registers the window with, so the two agree —
-                        // including for the Manager, whose terminal carries no
-                        // `isManaged` flag.
+                        // this.
+                        //
+                        // tmux is authoritative when it ANSWERED and this
+                        // terminal has a window. Otherwise — no binding yet, or
+                        // the read failed — fall back to the SAME predicate the
+                        // daemon registers the window with, so the two agree
+                        // (including for the Manager, whose terminal carries no
+                        // `isManaged` flag). Failing to `false` instead would
+                        // tell the client to swallow mouse modes and scroll
+                        // locally while tmux has that window in the alt buffer,
+                        // where there is no scrollback to scroll.
                         "agent_surface": .bool(
-                            t.tmuxBinding.map { agentSurfaces.contains($0.windowIndex) }
-                                ?? t.isAgentSurface(session: session)),
+                            classification.flatMap { c in
+                                t.tmuxBinding.map { c.agentSurfaces.contains($0.windowIndex) }
+                            } ?? t.isAgentSurface(session: session)),
                     ])
                 }
                 return ["terminals": .array(items)]

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -582,6 +582,18 @@ public final class SessionService {
                 // would drive launchClaude and paste a *second* `claude
                 // --continue` into a pane where Claude is already running.
                 try TmuxBackend.shared.adoptTerminal(id: terminal.id, binding: binding, trackReadiness: false)
+                // Adopted windows were born under whatever conf was live at the
+                // time, and `alternate-screen` is a per-WINDOW option that a
+                // `source-file` reload does NOT retrofit. Re-apply the agent
+                // scroll model here so a window predating ADR-0013 stops
+                // accumulating duplicate-frame sediment once its agent next
+                // enters the alt screen. Idempotent and best-effort — no live
+                // agent is interrupted, so an already-running agent keeps its
+                // current buffer until it restarts (the ⚠ Recreate affordance
+                // remains the immediate manual path).
+                if terminal.isManaged {
+                    TmuxBackend.shared.enableAlternateScreen(index: binding.windowIndex)
+                }
                 // The window survived the prior quit → Claude is already up.
                 // Belt-and-suspenders against any other readiness path: drop
                 // the terminal from autoLaunchTerminals (also stops the
@@ -648,6 +660,9 @@ public final class SessionService {
                 command: terminal.command,
                 trackReadiness: trackReadiness,
                 agentKind: agentKind,
+                // isManaged, not trackReadiness: the latter is false for
+                // Manager sessions, which are agent TUIs too (ADR-0013).
+                agentSurface: terminal.isManaged,
                 extraEnv: Self.artifactsEnv(sessionID: terminal.sessionID)
             )
             var updated = terminal
@@ -3148,6 +3163,7 @@ public final class SessionService {
                 command: t.command,
                 trackReadiness: trackReadiness,
                 agentKind: agentKind,
+                agentSurface: t.isManaged,
                 extraEnv: Self.artifactsEnv(sessionID: t.sessionID)
             )
             t.tmuxBinding = binding

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -591,7 +591,8 @@ public final class SessionService {
                 // agent is interrupted, so an already-running agent keeps its
                 // current buffer until it restarts (the ⚠ Recreate affordance
                 // remains the immediate manual path).
-                if terminal.isManaged {
+                let session = appState.sessions.first(where: { $0.id == terminal.sessionID })
+                if terminal.isAgentSurface(session: session) {
                     TmuxBackend.shared.enableAlternateScreen(index: binding.windowIndex)
                 }
                 // The window survived the prior quit → Claude is already up.
@@ -652,17 +653,15 @@ public final class SessionService {
         // window was closed, or a legacy per-PID socketPath that no longer
         // matches the stable socket). Create a fresh window as before.
         do {
-            let agentKind = appState.sessions.first(where: { $0.id == terminal.sessionID })?.agentKind
+            let session = appState.sessions.first(where: { $0.id == terminal.sessionID })
             let binding = try TmuxBackend.shared.registerTerminal(
                 id: terminal.id,
                 name: terminal.name,
                 cwd: terminal.cwd,
                 command: terminal.command,
                 trackReadiness: trackReadiness,
-                agentKind: agentKind,
-                // isManaged, not trackReadiness: the latter is false for
-                // Manager sessions, which are agent TUIs too (ADR-0013).
-                agentSurface: terminal.isManaged,
+                agentKind: session?.agentKind,
+                agentSurface: terminal.isAgentSurface(session: session),
                 extraEnv: Self.artifactsEnv(sessionID: terminal.sessionID)
             )
             var updated = terminal
@@ -3154,7 +3153,7 @@ public final class SessionService {
             NSLog("[SessionService] tmux not configured; terminal \(t.id) will not render")
             return t
         }
-        let agentKind = appState.sessions.first(where: { $0.id == t.sessionID })?.agentKind
+        let session = appState.sessions.first(where: { $0.id == t.sessionID })
         do {
             let binding = try TmuxBackend.shared.registerTerminal(
                 id: t.id,
@@ -3162,8 +3161,10 @@ public final class SessionService {
                 cwd: t.cwd,
                 command: t.command,
                 trackReadiness: trackReadiness,
-                agentKind: agentKind,
-                agentSurface: t.isManaged,
+                agentKind: session?.agentKind,
+                // Covers the Manager, whose terminal is built without
+                // `isManaged` but still runs a repainting agent (ADR-0013).
+                agentSurface: t.isAgentSurface(session: session),
                 extraEnv: Self.artifactsEnv(sessionID: t.sessionID)
             )
             t.tmuxBinding = binding

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -67,8 +67,9 @@ set -gs mouse off
 #
 # So crowd sets `alternate-screen on` PER WINDOW for agent-TUI surfaces at
 # creation (TmuxBackend.registerTerminal → enableAlternateScreen), keyed on
-# SessionTerminal.isAgentSurface(session:) — a managed work terminal OR a
-# Manager's terminal, which runs an agent but carries no `isManaged` flag:
+# SessionTerminal.isAgentSurface(session:) — a managed work terminal OR the
+# Manager's AGENT terminal, which runs an agent but carries no `isManaged`
+# flag. Extra plain shells added to a Manager session keep the default:
 #     tmux set-window-option -t <agent-window> alternate-screen on
 # Per-window `on` coexists with this global `off` in one server. Do NOT flip
 # this default to `on` to "fix" the agent case — that is spike Option A, which

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -53,6 +53,32 @@ set -gs mouse off
 # window default) — the scope-correct idiom for "apply to every new window."
 # (`-gs` happened to work in tmux 3.6a via option-table leniency, but `-gw` is
 # the documented scope and keeps the #804 `alternate_on` detection meaningful.)
+#
+# PER-SURFACE HYBRID (ADR-0013, #824): this is the DEFAULT, not the whole
+# story. It is the right model for LINE-STREAMING output (shells, git log,
+# build logs, review diffs) — text flows down and never repaints, so it lands
+# in scrollback and the wheel scrolls it.
+#
+# It is the WRONG model for a continuously repainting full-frame TUI. Denied a
+# fixed viewport, an agent's repaints land in a main buffer that is itself
+# scrolling, so every clear-and-redraw deposits the prior frame into the 50k
+# history as sediment — scrolling up walked 42 stacked copies of the Claude
+# Code TUI (#822, measured: history_size 1641 vs 0 with the alt screen on).
+#
+# So crowd sets `alternate-screen on` PER WINDOW for agent-TUI surfaces at
+# creation (TmuxBackend.registerTerminal → enableAlternateScreen), keyed on the
+# terminal's `isManaged`:
+#     tmux set-window-option -t <agent-window> alternate-screen on
+# Per-window `on` coexists with this global `off` in one server. Do NOT flip
+# this default to `on` to "fix" the agent case — that is spike Option A, which
+# deletes the unified scrollback for EVERY surface (a plain shell's history
+# would go to 0 and CROW-606 replay would have nothing to restore).
+#
+# Two consequences worth knowing: an agent window in its alt buffer is NOT a
+# CROW-804 degraded window (TmuxBackend.isScrollbackDegraded takes
+# `alternateScreenEnabled` so healthy agent tabs aren't badged ⚠), and the
+# option is frozen per window at creation, so pre-existing windows are
+# re-applied on adopt rather than retrofitted by a source-file reload.
 set -gw alternate-screen off
 
 # Cancel the CLIENT terminal's alternate-screen capability (smcup/rmcup). On
@@ -67,6 +93,22 @@ set -gw alternate-screen off
 # browser client (xterm*) plus the default-terminal family (screen*) for good
 # measure. Takes effect on the NEXT attach — reconnect the terminal after
 # reloading this conf.
+#
+# THIS STAYS GLOBAL — it cannot be scoped per surface (#824). `terminal-
+# overrides` is a SERVER option matched on the CLIENT's TERM, and one tmux
+# client serves every tab (each web surface opens ONE grouped `crowd-web-*`
+# session; switching tabs is `select-window` within that single attach). smcup
+# is therefore emitted once for the whole attachment, and there is no
+# per-window client buffer state to scope. Dropping it would put xterm.js in
+# its alternate buffer for ALL tabs, killing the unified scrollback everywhere.
+#
+# That is why `app.js` must NOT route the hybrid scroll model on
+# `term.buffer.active.type === 'alternate'`: with this strip in place the web
+# client is permanently in its main buffer, so that test is always false. The
+# window kind is signalled out of band instead — crowd emits `agent_surface`
+# per terminal on `list-terminals`, read from the `alternate-screen` window
+# option it actually set, and app.js routes the wheel and the mouse-mode
+# swallow on that. See ADR-0013.
 set -gas terminal-overrides ',xterm*:smcup@:rmcup@,screen*:smcup@:rmcup@'
 
 # Crow owns the keyboard namespace: the prefix table must end up empty so

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -66,8 +66,9 @@ set -gs mouse off
 # Code TUI (#822, measured: history_size 1641 vs 0 with the alt screen on).
 #
 # So crowd sets `alternate-screen on` PER WINDOW for agent-TUI surfaces at
-# creation (TmuxBackend.registerTerminal → enableAlternateScreen), keyed on the
-# terminal's `isManaged`:
+# creation (TmuxBackend.registerTerminal → enableAlternateScreen), keyed on
+# SessionTerminal.isAgentSurface(session:) — a managed work terminal OR a
+# Manager's terminal, which runs an agent but carries no `isManaged` flag:
 #     tmux set-window-option -t <agent-window> alternate-screen on
 # Per-window `on` coexists with this global `off` in one server. Do NOT flip
 # this default to `on` to "fix" the agent case — that is spike Option A, which

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -236,6 +236,13 @@ public final class TmuxBackend {
     /// Create a new tmux window for `id`. If the cockpit session doesn't
     /// exist yet, starts it. Returns the binding so callers can persist
     /// it on the `SessionTerminal` row.
+    ///
+    /// `agentSurface` selects this window's scroll model (ADR-0013). Pass the
+    /// terminal's `isManaged`: managed terminals run a repainting agent TUI and
+    /// get `alternate-screen on`; plain shells keep the global `off` and the
+    /// unified 50k scrollback. Note this is deliberately NOT keyed on
+    /// `agentKind` (always non-nil — it falls back to the AppState default) nor
+    /// on `trackReadiness` (false for Manager sessions, which ARE agent TUIs).
     @discardableResult
     public func registerTerminal(
         id: UUID,
@@ -244,6 +251,7 @@ public final class TmuxBackend {
         command: String?,
         trackReadiness: Bool,
         agentKind: AgentKind? = nil,
+        agentSurface: Bool = false,
         extraEnv: [String: String] = [:],
         newWindowTimeout: TimeInterval = TmuxController.defaultTimeout
     ) throws -> TmuxBinding {
@@ -309,6 +317,13 @@ public final class TmuxBackend {
             timeout: newWindowTimeout
         )
         bindings[id] = windowIndex
+
+        // Hand agent-TUI windows their own viewport BEFORE the launch command
+        // below is pasted, so the agent enters the alt buffer on its very first
+        // repaint and never deposits a frame into the shared history (#822).
+        if agentSurface {
+            enableAlternateScreen(index: windowIndex)
+        }
 
         if trackReadiness {
             startReadinessWatch(id: id, sentinelPath: sentinelPath)
@@ -714,10 +729,30 @@ public final class TmuxBackend {
     /// birth and can't resize/undo either in place (see `crow-tmux.conf`
     /// history-limit caveat), so a degraded window's only remedy is recreation.
     /// `nonisolated static` so the policy is unit-testable without tmux.
+    ///
+    /// `alternateScreenEnabled` makes the alt-buffer half of that test
+    /// KIND-AWARE (ADR-0013). Under the per-surface hybrid scroll model an
+    /// agent-TUI window deliberately runs with `alternate-screen on`, so
+    /// `alternateOn == true` there is the design working, not a stuck window —
+    /// flagging it would badge every agent tab with the ⚠ "Recreate" affordance.
+    /// The `history_limit` floor still applies to those windows, and it is what
+    /// keeps the CROW-804/#821 detection meaningful: the real pre-config
+    /// casualties measured `history_limit=5000` alongside `alternate_on=1`, so
+    /// they stay caught by the floor.
+    ///
+    /// Known blind spot: an agent window genuinely wedged in the alt buffer at
+    /// the full 50000 limit is now indistinguishable from the normal state.
+    /// That is the accepted cost of the hybrid model — the alternative is a
+    /// false ⚠ on every healthy agent surface.
     nonisolated public static func isScrollbackDegraded(
-        historyLimit: Int, alternateOn: Bool, floor: Int = TmuxBackend.scrollbackHistoryLimit
+        historyLimit: Int,
+        alternateOn: Bool,
+        alternateScreenEnabled: Bool = false,
+        floor: Int = TmuxBackend.scrollbackHistoryLimit
     ) -> Bool {
-        alternateOn || historyLimit < floor
+        if historyLimit < floor { return true }
+        // An agent surface is SUPPOSED to be in the alt buffer.
+        return alternateScreenEnabled ? false : alternateOn
     }
 
     /// Window indices whose scrollback is degraded per `isScrollbackDegraded`.
@@ -729,11 +764,53 @@ public final class TmuxBackend {
         do {
             let windows = try ctrl.listWindowScrollback()
             return Set(windows
-                .filter { Self.isScrollbackDegraded(historyLimit: $0.historyLimit, alternateOn: $0.alternateOn, floor: floor) }
+                .filter { Self.isScrollbackDegraded(
+                    historyLimit: $0.historyLimit,
+                    alternateOn: $0.alternateOn,
+                    alternateScreenEnabled: $0.alternateScreenEnabled,
+                    floor: floor) }
                 .map(\.index))
         } catch {
             reportIfTimeout(error)
             return []
+        }
+    }
+
+    /// Window indices configured as agent-TUI surfaces (`alternate-screen on`),
+    /// i.e. the windows that own their own viewport + scrollback under the
+    /// hybrid scroll model (ADR-0013). Read from tmux rather than inferred from
+    /// window names so the daemon and the web client route on the SAME ground
+    /// truth the daemon actually applied. Best-effort — `[]` when tmux is
+    /// unavailable, mirroring `degradedWindowIndices`.
+    public func agentSurfaceWindowIndices() -> Set<Int> {
+        guard let ctrl = controller else { return [] }
+        do {
+            return Set(try ctrl.listWindowScrollback()
+                .filter(\.alternateScreenEnabled)
+                .map(\.index))
+        } catch {
+            reportIfTimeout(error)
+            return []
+        }
+    }
+
+    /// Give one window the agent-TUI scroll model: `alternate-screen on`, so a
+    /// repainting agent keeps its frames in the alt buffer (which has no
+    /// scrollback) instead of depositing every repaint into the shared 50k
+    /// history as duplicate-frame sediment (#822, ADR-0013).
+    ///
+    /// Best-effort by design: the window is already usable without it, so a
+    /// failure here must never fail terminal creation. Returns whether it stuck.
+    @discardableResult
+    public func enableAlternateScreen(index: Int) -> Bool {
+        guard let ctrl = controller else { return false }
+        do {
+            try ctrl.setWindowOption(index: index, name: "alternate-screen", value: "on")
+            return true
+        } catch {
+            reportIfTimeout(error)
+            NSLog("[Crow] could not set alternate-screen on window \(index): \(error)")
+            return false
         }
     }
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -761,12 +761,20 @@ public final class TmuxBackend {
     ///
     /// They ship together on every `list-terminals` RPC, and each is derived
     /// from the same three fields, so reading twice would fork a second `tmux`
-    /// subprocess per call for nothing. Best-effort — empty sets when tmux is
-    /// unavailable or the read fails, mirroring `listCockpitWindows`.
+    /// subprocess per call for nothing.
+    ///
+    /// Returns `nil` when tmux is unavailable or the read fails — deliberately
+    /// NOT a pair of empty sets. Empty is a perfectly valid SUCCESS (a server
+    /// of nothing but plain shells), so emptiness cannot double as a failure
+    /// signal. Callers that need to fall back to a different source of truth on
+    /// failure — `list-terminals` re-deriving `agent_surface` from
+    /// `SessionTerminal.isAgentSurface` — can only do that if failure is
+    /// distinguishable. Callers that are happy to fail open collapse it with
+    /// `?? []`.
     public func windowScrollbackClassification(
         floor: Int = TmuxBackend.scrollbackHistoryLimit
-    ) -> (degraded: Set<Int>, agentSurfaces: Set<Int>) {
-        guard let ctrl = controller else { return ([], []) }
+    ) -> (degraded: Set<Int>, agentSurfaces: Set<Int>)? {
+        guard let ctrl = controller else { return nil }
         do {
             let windows = try ctrl.listWindowScrollback()
             let degraded = windows.filter {
@@ -780,15 +788,17 @@ public final class TmuxBackend {
             return (Set(degraded.map(\.index)), Set(agents.map(\.index)))
         } catch {
             reportIfTimeout(error)
-            return ([], [])
+            return nil
         }
     }
 
     /// Window indices whose scrollback is degraded per `isScrollbackDegraded`.
-    /// Callers needing BOTH this and the agent-surface set should use
-    /// `windowScrollbackClassification` so tmux is only read once.
+    /// Fails open (`[]`) — not badging a window on a failed read is the safe
+    /// direction, and matches `listCockpitWindows`. Callers needing BOTH this
+    /// and the agent-surface set should use `windowScrollbackClassification`
+    /// so tmux is only read once.
     public func degradedWindowIndices(floor: Int = TmuxBackend.scrollbackHistoryLimit) -> Set<Int> {
-        windowScrollbackClassification(floor: floor).degraded
+        windowScrollbackClassification(floor: floor)?.degraded ?? []
     }
 
     /// Window indices configured as agent-TUI surfaces (`alternate-screen on`),
@@ -797,7 +807,7 @@ public final class TmuxBackend {
     /// window names so the daemon and the web client route on the SAME ground
     /// truth the daemon actually applied.
     public func agentSurfaceWindowIndices() -> Set<Int> {
-        windowScrollbackClassification().agentSurfaces
+        windowScrollbackClassification()?.agentSurfaces ?? []
     }
 
     /// Give one window the agent-TUI scroll model: `alternate-screen on`, so a

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -237,12 +237,12 @@ public final class TmuxBackend {
     /// exist yet, starts it. Returns the binding so callers can persist
     /// it on the `SessionTerminal` row.
     ///
-    /// `agentSurface` selects this window's scroll model (ADR-0013). Pass the
-    /// terminal's `isManaged`: managed terminals run a repainting agent TUI and
-    /// get `alternate-screen on`; plain shells keep the global `off` and the
-    /// unified 50k scrollback. Note this is deliberately NOT keyed on
-    /// `agentKind` (always non-nil — it falls back to the AppState default) nor
-    /// on `trackReadiness` (false for Manager sessions, which ARE agent TUIs).
+    /// `agentSurface` selects this window's scroll model (ADR-0013): a
+    /// repainting agent TUI gets `alternate-screen on`, while a plain shell
+    /// keeps the global `off` and the unified 50k scrollback. Callers should
+    /// pass `SessionTerminal.isAgentSurface(session:)` rather than a hand-rolled
+    /// test — in particular `isManaged` ALONE is wrong, because the Manager's
+    /// terminal is built without that flag yet still runs an agent.
     @discardableResult
     public func registerTerminal(
         id: UUID,

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -755,43 +755,49 @@ public final class TmuxBackend {
         return alternateScreenEnabled ? false : alternateOn
     }
 
-    /// Window indices whose scrollback is degraded per `isScrollbackDegraded`.
-    /// Best-effort — `[]` when tmux is unavailable or the read fails, mirroring
-    /// `listCockpitWindows`. Callers use it to badge terminals in the web UI and
-    /// to log the degraded set on daemon start (CROW-804).
-    public func degradedWindowIndices(floor: Int = TmuxBackend.scrollbackHistoryLimit) -> Set<Int> {
-        guard let ctrl = controller else { return [] }
+    /// Both per-window classifications the web UI needs, from ONE `list-windows`
+    /// read: which windows are scrollback-degraded (CROW-804 ⚠ Recreate) and
+    /// which run the agent-TUI scroll model (ADR-0013 wheel/mouse routing).
+    ///
+    /// They ship together on every `list-terminals` RPC, and each is derived
+    /// from the same three fields, so reading twice would fork a second `tmux`
+    /// subprocess per call for nothing. Best-effort — empty sets when tmux is
+    /// unavailable or the read fails, mirroring `listCockpitWindows`.
+    public func windowScrollbackClassification(
+        floor: Int = TmuxBackend.scrollbackHistoryLimit
+    ) -> (degraded: Set<Int>, agentSurfaces: Set<Int>) {
+        guard let ctrl = controller else { return ([], []) }
         do {
             let windows = try ctrl.listWindowScrollback()
-            return Set(windows
-                .filter { Self.isScrollbackDegraded(
+            let degraded = windows.filter {
+                Self.isScrollbackDegraded(
                     historyLimit: $0.historyLimit,
                     alternateOn: $0.alternateOn,
                     alternateScreenEnabled: $0.alternateScreenEnabled,
-                    floor: floor) }
-                .map(\.index))
+                    floor: floor)
+            }
+            let agents = windows.filter(\.alternateScreenEnabled)
+            return (Set(degraded.map(\.index)), Set(agents.map(\.index)))
         } catch {
             reportIfTimeout(error)
-            return []
+            return ([], [])
         }
+    }
+
+    /// Window indices whose scrollback is degraded per `isScrollbackDegraded`.
+    /// Callers needing BOTH this and the agent-surface set should use
+    /// `windowScrollbackClassification` so tmux is only read once.
+    public func degradedWindowIndices(floor: Int = TmuxBackend.scrollbackHistoryLimit) -> Set<Int> {
+        windowScrollbackClassification(floor: floor).degraded
     }
 
     /// Window indices configured as agent-TUI surfaces (`alternate-screen on`),
     /// i.e. the windows that own their own viewport + scrollback under the
     /// hybrid scroll model (ADR-0013). Read from tmux rather than inferred from
     /// window names so the daemon and the web client route on the SAME ground
-    /// truth the daemon actually applied. Best-effort — `[]` when tmux is
-    /// unavailable, mirroring `degradedWindowIndices`.
+    /// truth the daemon actually applied.
     public func agentSurfaceWindowIndices() -> Set<Int> {
-        guard let ctrl = controller else { return [] }
-        do {
-            return Set(try ctrl.listWindowScrollback()
-                .filter(\.alternateScreenEnabled)
-                .map(\.index))
-        } catch {
-            reportIfTimeout(error)
-            return []
-        }
+        windowScrollbackClassification().agentSurfaces
     }
 
     /// Give one window the agent-TUI scroll model: `alternate-screen on`, so a

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -163,29 +163,40 @@ public struct TmuxController: Sendable {
         }
     }
 
-    /// Per-window scrollback health: each window's index plus the two pane
-    /// facts that determine whether scroll-up can show the full transcript —
-    /// `#{history_limit}` (the frozen-at-birth scrollback cap) and
-    /// `#{alternate_on}` (whether the active pane is in the alternate buffer,
-    /// which has NO scrollback). Windows created before the current
-    /// `crow-tmux.conf` are stuck at `history_limit=5000 alternate_on=1` and
-    /// tmux cannot resize/undo either in place, so this is how Crow detects the
-    /// degraded windows that need a recreate (CROW-804). `history_limit`/
-    /// `alternate_on` resolve against each window's active pane under
-    /// `list-windows -F`.
-    public func listWindowScrollback() throws -> [(index: Int, historyLimit: Int, alternateOn: Bool)] {
+    /// Per-window scrollback health: each window's index plus the three facts
+    /// that determine whether scroll-up can show the full transcript —
+    /// `#{history_limit}` (the frozen-at-birth scrollback cap), `#{alternate_on}`
+    /// (whether the active pane is CURRENTLY in the alternate buffer, which has
+    /// NO scrollback), and `#{alternate-screen}` (whether this window is
+    /// CONFIGURED to honor the alternate screen at all).
+    ///
+    /// Windows created before the current `crow-tmux.conf` are stuck at
+    /// `history_limit=5000 alternate_on=1` and tmux cannot resize/undo either in
+    /// place, so this is how Crow detects the degraded windows that need a
+    /// recreate (CROW-804).
+    ///
+    /// The `alternate-screen` OPTION is what separates "degraded" from "working
+    /// as designed" under the hybrid scroll model (ADR-0013): agent-TUI windows
+    /// deliberately run with it `on`, so `alternate_on=1` there is expected
+    /// rather than broken. It is a window OPTION, not a pane variable, but tmux
+    /// resolves options in format strings, so one `list-windows` read serves
+    /// both the health check and the agent-surface classification. (Verified on
+    /// tmux 3.6a: a real option renders `0`/`1`, an unknown one renders empty.)
+    public func listWindowScrollback() throws
+        -> [(index: Int, historyLimit: Int, alternateOn: Bool, alternateScreenEnabled: Bool)] {
         let out = try run(["list-windows", "-t", sessionName,
-                           "-F", "#{window_index}\t#{history_limit}\t#{alternate_on}"])
+                           "-F", "#{window_index}\t#{history_limit}\t#{alternate_on}\t#{alternate-screen}"])
         return out.split(separator: "\n").compactMap { line in
-            let parts = line.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false)
-            guard parts.count == 3,
+            let parts = line.split(separator: "\t", maxSplits: 3, omittingEmptySubsequences: false)
+            guard parts.count == 4,
                   let idx = Int(parts[0].trimmingCharacters(in: .whitespaces)),
                   let limit = Int(parts[1].trimmingCharacters(in: .whitespaces)) else {
                 return nil
             }
-            // tmux renders boolean flags as "1"/"0".
+            // tmux renders boolean flags AND boolean options as "1"/"0".
             let alt = parts[2].trimmingCharacters(in: .whitespaces) == "1"
-            return (idx, limit, alt)
+            let altOption = parts[3].trimmingCharacters(in: .whitespaces) == "1"
+            return (idx, limit, alt, altOption)
         }
     }
 
@@ -222,6 +233,19 @@ public struct TmuxController: Sendable {
             )
         }
         return idx
+    }
+
+    /// Set a tmux WINDOW option on a single window, overriding the global
+    /// default from `crow-tmux.conf` for that window only.
+    ///
+    /// Crow's terminal settings are otherwise all server-global (set once at
+    /// startup via `tmux -f crow-tmux.conf`); this is the one place a window
+    /// deviates. It exists for the per-surface hybrid scroll model (ADR-0013):
+    /// agent-TUI windows get `alternate-screen on` so their full-frame repaints
+    /// stay in the alt buffer instead of silting up the shared scrollback, while
+    /// plain shell windows keep the global `off` and the unified 50k history.
+    public func setWindowOption(index: Int, name: String, value: String) throws {
+        try run(["set-window-option", "-t", "\(sessionName):\(index)", name, value])
     }
 
     public func selectWindow(index: Int) throws {

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -54,7 +54,14 @@ struct BundledResourcesTests {
         let body = try String(contentsOf: url, encoding: .utf8)
         #expect(body.contains("set -gs mouse off"))
         #expect(!body.contains("set -gs mouse on"))
-        #expect(body.contains("set -gs alternate-screen off"))
+        // `alternate-screen` is a WINDOW option, so the scope-correct idiom is
+        // `-gw` (global window default), not `-gs`. This assertion pinned `-gs`
+        // and so silently failed from #821 (which corrected the conf) until
+        // #824. Pin the real scope, and pin that the DEFAULT is `off` — agent
+        // windows override it per window at runtime (ADR-0013), they must not
+        // flip this global.
+        #expect(body.contains("set -gw alternate-screen off"))
+        #expect(!body.contains("set -gw alternate-screen on"))
         // Cancel the client's smcup/rmcup so tmux renders into the outer
         // terminal's main buffer (scrollback), not its alternate buffer — the
         // load-bearing half of the native-wheel-scroll fix.

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/ScrollbackHealthTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/ScrollbackHealthTests.swift
@@ -15,8 +15,37 @@ struct ScrollbackHealthTests {
 
     @Test func alternateBufferIsDegraded() {
         // A pane stuck in the alternate-screen buffer has NO scrollback, even at
-        // the full history-limit.
+        // the full history-limit. This is the #804/#821 case and must STAY
+        // detected — a window that never opted into the alt screen has no
+        // business being in it.
         #expect(TmuxBackend.isScrollbackDegraded(historyLimit: 50000, alternateOn: true))
+        #expect(TmuxBackend.isScrollbackDegraded(
+            historyLimit: 50000, alternateOn: true, alternateScreenEnabled: false))
+    }
+
+    // MARK: - Kind-awareness (ADR-0013)
+
+    @Test func agentSurfaceInAlternateBufferIsHealthy() {
+        // An agent-TUI window is CONFIGURED for the alt screen so its repaints
+        // don't silt up the scrollback (#822). Being in that buffer is the
+        // design working — flagging it would badge every agent tab with the ⚠
+        // "Recreate" affordance.
+        #expect(!TmuxBackend.isScrollbackDegraded(
+            historyLimit: 50000, alternateOn: true, alternateScreenEnabled: true))
+        // Also healthy before the agent has actually entered the alt screen.
+        #expect(!TmuxBackend.isScrollbackDegraded(
+            historyLimit: 50000, alternateOn: false, alternateScreenEnabled: true))
+    }
+
+    @Test func agentSurfaceStillFailsTheHistoryFloor() {
+        // Kind-awareness only relaxes the alt-buffer term. A pre-config window
+        // is caught by the floor whether or not it's an agent surface — which
+        // is what keeps the CROW-804 detection meaningful, since the real
+        // casualties measured history_limit=5000 alongside alternate_on=1.
+        #expect(TmuxBackend.isScrollbackDegraded(
+            historyLimit: 5000, alternateOn: true, alternateScreenEnabled: true))
+        #expect(TmuxBackend.isScrollbackDegraded(
+            historyLimit: 5000, alternateOn: false, alternateScreenEnabled: true))
     }
 
     @Test func fullLimitMainBufferIsHealthy() {

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/ScrollbackHealthTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/ScrollbackHealthTests.swift
@@ -37,6 +37,26 @@ struct ScrollbackHealthTests {
             historyLimit: 50000, alternateOn: false, alternateScreenEnabled: true))
     }
 
+    /// A failed tmux read must be distinguishable from a successful read that
+    /// found nothing. `list-terminals` re-derives `agent_surface` from
+    /// `SessionTerminal.isAgentSurface` when tmux can't answer; if failure were
+    /// reported as an empty set, every bound agent tab would instead be told
+    /// `agent_surface: false` — so the client would swallow mouse modes and
+    /// scroll xterm locally while tmux has that window in the alternate buffer,
+    /// which has no scrollback to scroll.
+    @Test @MainActor func classificationReportsFailureDistinctlyFromAnEmptyResult() {
+        // A fresh, unconfigured backend has no controller, so the read cannot
+        // run — the same shape as tmux being unavailable at runtime. Uses its
+        // own instance rather than `.shared` so the result doesn't depend on
+        // whether this host happens to have a live tmux server.
+        let backend = TmuxBackend()
+        #expect(backend.windowScrollbackClassification() == nil,
+                "a read that could not run must be nil, not ([], [])")
+        // The fail-open convenience accessors still collapse it to empty.
+        #expect(backend.degradedWindowIndices().isEmpty)
+        #expect(backend.agentSurfaceWindowIndices().isEmpty)
+    }
+
     @Test func agentSurfaceStillFailsTheHistoryFloor() {
         // Kind-awareness only relaxes the alt-buffer term. A pre-config window
         // is caught by the floor whether or not it's an agent surface — which

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxControllerTests.swift
@@ -189,6 +189,12 @@ struct TmuxControllerTests {
     /// stays in the MAIN buffer (`alternate_on == 0`). Without the setting this
     /// pane reads `alternate_on == 1` (verified: bare conf → 1), so this genuinely
     /// locks the config behavior, not a tautology.
+    ///
+    /// Scope (ADR-0013): this pins the GLOBAL DEFAULT, i.e. the plain shell /
+    /// review surface. Agent-TUI windows deliberately override it per window —
+    /// see `agentWindowOptsIntoAlternateScreenWithoutAffectingSiblings`. The
+    /// assertion below therefore also checks the window did NOT opt in, so this
+    /// test keeps failing for the right reason if the default ever flips.
     @Test func bundledConfKeepsInnerAppsOutOfAlternateBuffer() throws {
         let confURL = try #require(BundledResources.tmuxConfURL)
         let ctrl = makeController()
@@ -206,14 +212,66 @@ struct TmuxControllerTests {
             configPath: confURL.path,
             command: #"/bin/sh -c 'while true; do printf "\033[?1049h"; sleep 0.05; done'"#)
         var reads: [Bool] = []
+        var optedIn: [Bool] = []
         let deadline = Date().addingTimeInterval(1.0)
         repeat {
             Thread.sleep(forTimeInterval: 0.1)
             if let anchor = (try? ctrl.listWindowScrollback())?.first(where: { $0.index == 0 }) {
                 reads.append(anchor.alternateOn)
+                optedIn.append(anchor.alternateScreenEnabled)
             }
         } while Date() < deadline
         #expect(!reads.isEmpty)
         #expect(reads.allSatisfy { $0 == false })
+        // The window never opted in, so `alternate_on == 0` above is the global
+        // default doing its job — not an agent surface that happens to be idle.
+        #expect(optedIn.allSatisfy { $0 == false })
+    }
+
+    /// ADR-0013 (per-surface hybrid): the daemon flips `alternate-screen on` for
+    /// AGENT windows only, and that must coexist with the global `off` in the
+    /// same server — the spike measured exactly this pairing (agent window
+    /// `alternate_on=1 history_size=0`, shell window `alternate_on=0` with a
+    /// growing history). Drives a real tmux server: one window opts in, a
+    /// sibling does not, and both continuously request the alternate screen.
+    @Test func agentWindowOptsIntoAlternateScreenWithoutAffectingSiblings() throws {
+        let confURL = try #require(BundledResources.tmuxConfURL)
+        let ctrl = makeController()
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: ctrl.socketPath)
+        }
+        let smcupLoop = #"/bin/sh -c 'while true; do printf "\033[?1049h"; sleep 0.05; done'"#
+        // Window 0 = the plain-shell control; it stays on the global default.
+        try ctrl.newSessionDetached(configPath: confURL.path, command: smcupLoop)
+        let agentIdx = try ctrl.newWindow(name: "Claude Code", command: smcupLoop)
+        try ctrl.setWindowOption(index: agentIdx, name: "alternate-screen", value: "on")
+
+        // Poll until the agent window enters the alt buffer, so the assertions
+        // below aren't racing the shell's first emit.
+        var agent: (index: Int, historyLimit: Int, alternateOn: Bool, alternateScreenEnabled: Bool)?
+        let deadline = Date().addingTimeInterval(2.0)
+        repeat {
+            Thread.sleep(forTimeInterval: 0.1)
+            agent = (try? ctrl.listWindowScrollback())?.first(where: { $0.index == agentIdx })
+        } while !(agent?.alternateOn ?? false) && Date() < deadline
+
+        let agentWindow = try #require(agent)
+        #expect(agentWindow.alternateScreenEnabled, "the per-window option must stick")
+        #expect(agentWindow.alternateOn, "the agent window should be IN the alt buffer")
+        // Still born with the full history-limit, so the floor check is intact.
+        #expect(agentWindow.historyLimit == TmuxBackend.scrollbackHistoryLimit)
+        // The regression guard that #824 must not break: an agent surface in the
+        // alt buffer is healthy, NOT a CROW-804 degraded window.
+        #expect(!TmuxBackend.isScrollbackDegraded(
+            historyLimit: agentWindow.historyLimit,
+            alternateOn: agentWindow.alternateOn,
+            alternateScreenEnabled: agentWindow.alternateScreenEnabled))
+
+        // The sibling is untouched: still on the global default, still in the
+        // main buffer, and therefore still keeping the unified scrollback.
+        let shell = try #require((try ctrl.listWindowScrollback()).first(where: { $0.index == 0 }))
+        #expect(!shell.alternateScreenEnabled, "per-window `on` must not leak to siblings")
+        #expect(!shell.alternateOn)
     }
 }

--- a/docs/adr/0013-terminal-scroll-model.md
+++ b/docs/adr/0013-terminal-scroll-model.md
@@ -47,7 +47,13 @@ So `term.buffer.active.type` is **permanently `'normal'`** on the web client, an
 
 **Chosen: (b), carried on the existing `list-terminals` RPC payload.** `crowd` emits a per-terminal `agent_surface` flag beside the existing `scrollback_degraded`, and `app.js` routes on it. The flag's source of truth is the `alternate-screen` **window option the daemon actually set**, read back via `#{alternate-screen}` in the same `list-windows` call that feeds degraded-detection — so daemon and client agree by construction, with no window-name matching. The `/terminal` socket was deliberately not used: its server→client direction is binary-only through a single writer task, so adding text frames would mean widening the stream type and racing that writer.
 
-Classification is the terminal's `isManaged` — **not** `agentKind` (always non-nil; it falls back to a default) and **not** `trackReadiness` (false for Manager sessions, which are agent TUIs too).
+Classification is `SessionTerminal.isAgentSurface(session:)` — a managed work terminal **or** a Manager session's terminal. Both halves are load-bearing, and the alternatives all fail:
+
+- `agentKind` never discriminates: it always resolves to a configured default, so every terminal has one.
+- `trackReadiness` is `false` for Manager sessions, precisely because they launch the agent via `command`.
+- `isManaged` **alone** silently excludes the Manager: `createManagerTerminal` builds its row without that flag, so it takes the memberwise default of `false` — yet the Manager runs a full-frame repainting agent and is one of the windows #822 was reported against.
+
+The predicate lives in `CrowCore` because the daemon needs it twice — to set the window option at creation/adopt, and as the `list-terminals` fallback before a window exists — and those two must not drift apart.
 
 ## Consequences
 

--- a/docs/adr/0013-terminal-scroll-model.md
+++ b/docs/adr/0013-terminal-scroll-model.md
@@ -1,6 +1,6 @@
 # 0013 — Terminal scroll model: per-surface hybrid (unified scrollback for shells, native alt-screen for agent TUIs)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-23
 - **Deciders:** @dhilgaertner
 
@@ -30,13 +30,24 @@ Prior work healed a *related* degradation (stale alt-screen / 5000-line windows,
 Crow adopts a **per-surface hybrid** terminal scroll model:
 
 - **Plain shell / review surfaces** keep the unified xterm.js scrollback (the current behavior): `alternate-screen off`, output flows into the 50k history, CROW-606 replay restores it, the browser wheel scrolls xterm.
-- **Agent-TUI surfaces** (Claude Code, Cursor) own their own viewport and scrollback like a naked terminal: the daemon sets `alternate-screen on` **per agent window**, the client stops swallowing that window's mouse modes, and the wheel is forwarded to the app. No frame sediment because repaints stay in the alt buffer, which has no scrollback.
+- **Agent-TUI surfaces** (Claude Code, Cursor, and the Manager, which runs one too) own their own viewport and scrollback like a naked terminal: the daemon sets `alternate-screen on` **per agent window**, the client stops swallowing that window's mouse modes, and the wheel is forwarded to the app. No frame sediment because repaints stay in the alt buffer, which has no scrollback.
 
-`swallowMouseMode` and `enableWheelScroll` become **conditional on pane state** (`buffer.active.type === 'alternate'` OR active mouse tracking → the app owns the wheel; else xterm scrolls its scrollback) rather than global. This mirrors what `enableTouchScroll`/`sendScrollToPTY` already do for touch on the alt buffer.
+`swallowMouseMode` and `enableWheelScroll` become **conditional on surface kind** rather than global, sharing one predicate (`appOwnsScroll`): an agent surface, a real alternate buffer, or an app with active mouse tracking → the app owns the wheel; else xterm scrolls its scrollback. `enableTouchScroll` routes on the same predicate so touch and wheel can't disagree. How "agent surface" is determined is the crux, resolved below — it is *not* `buffer.active.type`.
 
 This is the **Option B** of the spike. It is chosen over Option A (honor the alt screen everywhere) because A throws away the unified scrollback for *every* surface — regressing the exact behavior CROW-606, #776, and #777 were built to deliver — to fix a problem that only the repainting agent surfaces have.
 
-Status is **Proposed**: the spike delivers the decision + this record; implementation lands under a follow-up ticket, at which point this ADR moves to Accepted.
+### Resolved: how the client learns a surface is an agent TUI
+
+The spike left this open, offering (a) scope the `smcup@/rmcup@` strip to non-agent surfaces, or (b) signal window-kind to `app.js`. **Option (a) turned out to be unimplementable**, verified against a live server during #824:
+
+- `terminal-overrides` is a **server** option matched on the **client's `TERM`**, not on a window.
+- `tmux list-clients` shows **one client serving every tab** — each web surface opens a single grouped `crowd-web-*` session and switches tabs with `select-window`. smcup is emitted once for the whole attachment, so there is no per-window client buffer state to scope.
+
+So `term.buffer.active.type` is **permanently `'normal'`** on the web client, and routing on it cannot work. (The spike's Option B prototype did exactly that and was therefore inert: its `swallowMouseMode` early-return never fired, and its `mouseTrackingMode` fallback was suppressed by the very swallow it was meant to gate — a circular dependency that latched into the plain-shell path.)
+
+**Chosen: (b), carried on the existing `list-terminals` RPC payload.** `crowd` emits a per-terminal `agent_surface` flag beside the existing `scrollback_degraded`, and `app.js` routes on it. The flag's source of truth is the `alternate-screen` **window option the daemon actually set**, read back via `#{alternate-screen}` in the same `list-windows` call that feeds degraded-detection — so daemon and client agree by construction, with no window-name matching. The `/terminal` socket was deliberately not used: its server→client direction is binary-only through a single writer task, so adding text frames would mean widening the stream type and racing that writer.
+
+Classification is the terminal's `isManaged` — **not** `agentKind` (always non-nil; it falls back to a default) and **not** `trackReadiness` (false for Manager sessions, which are agent TUIs too).
 
 ## Consequences
 
@@ -48,8 +59,13 @@ Status is **Proposed**: the spike delivers the decision + this record; implement
 **Harder / to live with**
 - **Two code paths.** The wheel/mouse handling is now conditional; both branches must be kept correct and tested. The `swallowMouseMode` and `enableWheelScroll` conditionals are the crux.
 - **Agent-window classification.** The daemon must know which windows are agent TUIs to set `alternate-screen on` at creation (it already names them, e.g. "Claude Code", and launches a known command — a reliable signal).
-- **Client alt-buffer detection is the load-bearing open question.** For `app.js` to route by `buffer.active.type === 'alternate'`, the **client** (xterm.js) must also enter the alt buffer for an agent window — which the global `smcup@/rmcup@` strip (layer 2) currently prevents. The follow-up must either (a) scope that strip to non-agent surfaces so agent windows re-gain client smcup, or (b) have crowd signal window-kind to `app.js` over the existing control channel and route on that instead of buffer type. The spike validated the tmux side (per-window `alternate-screen on` coexists with `off` in one server) but flagged this wiring as the real implementation work.
-- **Agent-window scrollback boundary.** Inside an agent window, "scroll behind the app" into pre-launch shell history is no longer available (the alt buffer has no scrollback) — same trade a naked terminal makes. CROW-606 replay for an agent window restores only its current frame; the jump-to-bottom pill and copy/paste semantics need a pass for the alt-buffer case.
+- **The client cannot detect the alt buffer itself** — resolved above by signalling `agent_surface` out of band. The cost is that the two layers must stay in sync: if the daemon ever stops setting the window option, the client silently falls back to the shell path.
+- **Agent-window scrollback boundary.** Inside an agent window, "scroll behind the app" into pre-launch shell history is no longer available (the alt buffer has no scrollback) — same trade a naked terminal makes. Settled during #824:
+  - **CROW-606 replay** is correct by construction. `capture-pane -pe -S -50000` on an alt-buffer pane returns just the current frame, and `replayFrame` prepends `ESC[H ESC[2J ESC[3J`, so reconnects rebuild rather than stack. No change needed.
+  - **Jump-to-bottom pill** keys off `viewportY >= baseY`. On an agent surface tmux repaints in place, the client's scrollback never grows, both stay 0, and the pill correctly stays hidden — there is nothing to jump back to. No change needed.
+  - **Copy/paste** is the one real regression: native drag-select and the right-click menu are eaten inside agent windows, because they worked *because* of the mouse-mode swallow. Mitigated by enabling `macOptionClickForcesSelection` so ⌥-drag forces selection (xterm.js defaults that option to `false`, so it must be set explicitly), surfaced as a hint in the terminal context menu. Plain shells are unaffected.
+- **A degraded-window blind spot.** `isScrollbackDegraded` now takes `alternateScreenEnabled`, so an agent surface in the alt buffer is healthy rather than badged ⚠ Recreate. The consequence is that an agent window *genuinely* wedged in the alt buffer at the full 50000 limit is no longer distinguishable from the normal state. The `history_limit` floor still catches the real #804/#821 casualties, which measured `history_limit=5000`.
+- **The window option is frozen at creation.** tmux applies `alternate-screen` per window, and a `source-file` reload does not retrofit it. Windows adopted from a previous crowd are re-applied on adopt, but a *live* agent keeps its current buffer until it restarts; the ⚠ Recreate affordance remains the immediate manual path.
 
 ## Alternatives considered
 
@@ -62,4 +78,6 @@ Status is **Proposed**: the spike delivers the decision + this record; implement
 - Prototype branches (not merged): `spike/822-option-a`, `spike/822-option-b`.
 - Related ADRs: [0001 — tmux as the sole terminal backend](./0001-tmux-only-terminal-backend.md) (this ADR carves the scroll model out of ADR-0001's terminal-backend scope; ADR-0001 is otherwise unchanged).
 - Prior art: CROW-606 (replay, #609/#612), #776/#789 (mouse-mode swallow), #777/#786 (iOS touch-scroll ownership), #804/#821 (scrollback heal), epic #783 (replay reflow fidelity).
-- Code: `Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf` (alt-screen, smcup/rmcup, mouse, history-limit); `Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js` (`swallowMouseMode`, `enableWheelScroll`, `enableTouchScroll`, `sendScrollToPTY`); `Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift` / `TerminalWebSocket.swift` (CROW-606 replay).
+- Implementation: [#824](https://github.com/corveil/crow/issues/824).
+- Code: `crow-tmux.conf` (alt-screen default, smcup/rmcup, mouse, history-limit); `TmuxController.setWindowOption` / `listWindowScrollback` (per-window option + the `#{alternate-screen}` read-back); `TmuxBackend.registerTerminal(agentSurface:)`, `enableAlternateScreen`, `isScrollbackDegraded(alternateScreenEnabled:)`, `agentSurfaceWindowIndices`; `EngineRouter` `list-terminals` (`agent_surface`); `web/app.js` (`activeSurfaceIsAgent`, `appOwnsScroll`, `swallowMouseMode`, `enableWheelScroll`, `enableTouchScroll`, `sendScrollToPTY`); `TerminalCockpit.swift` / `TerminalWebSocket.swift` (CROW-606 replay).
+- Tests: `ScrollbackHealthTests` (kind-aware policy truth table), `TmuxControllerTests.agentWindowOptsIntoAlternateScreenWithoutAffectingSiblings` (real-tmux per-window coexistence), `WebTerminalAssetTests` (client routing shape), `web-tests/wheel-scroll.test.js` (jsdom wheel + conditional swallow).

--- a/docs/adr/0013-terminal-scroll-model.md
+++ b/docs/adr/0013-terminal-scroll-model.md
@@ -47,11 +47,14 @@ So `term.buffer.active.type` is **permanently `'normal'`** on the web client, an
 
 **Chosen: (b), carried on the existing `list-terminals` RPC payload.** `crowd` emits a per-terminal `agent_surface` flag beside the existing `scrollback_degraded`, and `app.js` routes on it. The flag's source of truth is the `alternate-screen` **window option the daemon actually set**, read back via `#{alternate-screen}` in the same `list-windows` call that feeds degraded-detection — so daemon and client agree by construction, with no window-name matching. The `/terminal` socket was deliberately not used: its server→client direction is binary-only through a single writer task, so adding text frames would mean widening the stream type and racing that writer.
 
-Classification is `SessionTerminal.isAgentSurface(session:)` — a managed work terminal **or** a Manager session's terminal. Both halves are load-bearing, and the alternatives all fail:
+Classification is `SessionTerminal.isAgentSurface(session:)` — a managed work terminal, **or** a Manager session's terminal that carries a launch `command`. Every part is load-bearing, and the simpler alternatives all fail:
 
 - `agentKind` never discriminates: it always resolves to a configured default, so every terminal has one.
 - `trackReadiness` is `false` for Manager sessions, precisely because they launch the agent via `command`.
-- `isManaged` **alone** silently excludes the Manager: `createManagerTerminal` builds its row without that flag, so it takes the memberwise default of `false` — yet the Manager runs a full-frame repainting agent and is one of the windows #822 was reported against.
+- `isManaged` **alone** under-classifies: `createManagerTerminal` builds its row without that flag, so it takes the memberwise default of `false` — yet the Manager runs a full-frame repainting agent and is one of the windows #822 was reported against.
+- Session kind **alone** over-classifies in the other direction: a Manager session can hold additional plain shells (`new-terminal` with just a `session_id`), and those are line-streaming surfaces that must keep the unified scrollback. The `command != nil` test separates the Manager's agent terminal from them.
+
+Boundary accepted: an extra Manager-session terminal created with an explicit `--command` is treated as an agent surface. The alternative is persisting a new per-terminal field; the cost here is only that a hand-launched full-screen program in that one spot gets the naked-terminal scroll model.
 
 The predicate lives in `CrowCore` because the daemon needs it twice — to set the window option at creation/adopt, and as the `list-terminals` fallback before a window exists — and those two must not drift apart.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,4 +49,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0010 | [Retire the macOS app; the web UI is the only client](./0010-retire-the-macos-app.md) | Accepted | 2026-07-07 |
 | 0011 | [Mid-session agent handoff preserves Crow identity, not chat history](./0011-agent-handoff-preserves-session-not-chat.md) | Accepted | 2026-07-09 |
 | 0012 | [Tests must never touch live application data](./0012-tests-never-touch-live-data.md) | Accepted | 2026-07-19 |
-| 0013 | [Terminal scroll model: per-surface hybrid](./0013-terminal-scroll-model.md) | Proposed | 2026-07-23 |
+| 0013 | [Terminal scroll model: per-surface hybrid](./0013-terminal-scroll-model.md) | Accepted | 2026-07-23 |


### PR DESCRIPTION
Closes #824

Implements the ADR-0013 decision from spike #822: agent-TUI surfaces own their own viewport and scrollback like a naked terminal, while plain shell / review surfaces keep the unified xterm.js 50k scrollback and CROW-606 replay.

## The bug

Scrolling up in an agent tab showed stacked duplicate copies of the Claude Code TUI. Denied a fixed viewport, an agent's full-frame repaints landed in a main buffer that was itself scrolling, so every clear-and-redraw deposited its predecessor into the 50k history as sediment.

## Measured result

Two windows side by side on one isolated server under the **bundled** conf, driven by a repainting TUI mimic:

| window | `alternate-screen` | `alternate_on` | `history_size` | stacked footer copies |
|---|:---:|:---:|:---:|:---:|
| win 0 — plain shell (global default) | 0 | 0 | **2183** | **60** |
| win 1 — agent surface | 1 | 1 | **0** | **1** |

Sediment gone on the agent surface; the shell keeps its full unified scrollback.

## The crux, resolved

ADR-0013 left one open question: how does `app.js` know a surface is an agent TUI? It offered **(a)** scope the `smcup@/rmcup@` strip to non-agent surfaces, or **(b)** signal window-kind.

**(a) is unimplementable**, verified against a live server:
- `terminal-overrides` is a **server** option matched on the **client's `TERM`**, not on a window.
- `tmux list-clients` shows **one client serving every tab** — each web surface opens a single grouped `crowd-web-*` session, and switching tabs is `select-window` within that one attach. smcup is emitted once for the whole attachment, so there is no per-window client buffer state to scope.

So `term.buffer.active.type` is **permanently `'normal'`** on the web client. This is the trap the spike's Option B prototype fell into: its `swallowMouseMode` early-return never fired, and its `mouseTrackingMode` fallback was suppressed by the very swallow it was meant to gate — a circular dependency that latched into the plain-shell path. Productionizing it as written would have shipped a no-op.

**Chosen: (b), on the existing `list-terminals` payload.** `crowd` emits a per-terminal `agent_surface` flag beside `scrollback_degraded`, sourced from the `alternate-screen` window option it actually set (read back via `#{alternate-screen}` in the same `list-windows` call), so daemon and client agree by construction with no name-matching. The `/terminal` socket was avoided deliberately: its server→client direction is binary-only through a single writer task.

## Changes

**Daemon**
- `TmuxController.setWindowOption` + `#{alternate-screen}` in `listWindowScrollback`.
- `registerTerminal(agentSurface:)` sets `alternate-screen on` per agent window *before* the launch command is pasted. Keyed on `isManaged` — **not** `agentKind` (always non-nil, falls back to a default) and **not** `trackReadiness` (false for Manager sessions, which are agent TUIs too). Re-applied on adopt so windows predating this heal when their agent restarts, without interrupting a live agent.
- `list-terminals` emits `agent_surface`.

**Client**
- `swallowMouseMode` hoisted to module scope and made conditional — agent surfaces let DECSET 1000–1016 through so the app claims the wheel.
- `enableWheelScroll` routes through a shared `appOwnsScroll()` predicate instead of swallowing; `enableTouchScroll` shares it so touch and wheel can't disagree. Forwarding reuses the existing `sendScrollToPTY`.
- `macOptionClickForcesSelection: true` — letting mouse modes through costs drag-select, and xterm.js gates the Mac force-selection path on this option, which **defaults to `false`**. Without it the ⌥-drag escape hatch silently does nothing. Surfaced as a context-menu hint.

## Regression guard (#804/#821)

`isScrollbackDegraded` treated `alternateOn` as degraded outright, so every agent window would have been badged ⚠ Recreate. It now takes `alternateScreenEnabled` — an agent surface in the alt buffer is the design working. The `history_limit` floor still catches the real casualties, which measured `5000`. Documented blind spot: an agent window genuinely wedged in the alt buffer at 50000 is no longer distinguishable from normal.

## Alt-buffer pass

- **CROW-606 replay** — correct by construction, no change. `capture-pane` on an alt pane returns the current frame, and `replayFrame` prepends `ESC[H ESC[2J ESC[3J` so reconnects rebuild rather than stack.
- **Jump-to-bottom pill** — correctly stays hidden (`viewportY == baseY == 0`); there is nothing to jump back to.
- **Copy/paste** — the one real regression, mitigated by ⌥-drag above. Plain shells unaffected.

## Drive-by

`BundledResourcesTests` asserted `set -gs alternate-screen off`, but #821 corrected the conf to `set -gw` — **that assertion has been failing on `main`** since. Fixed while editing the same line.

## Tests

- `ScrollbackHealthTests` — kind-aware truth table, including that a **non-agent** window in the alt buffer is still degraded.
- `TmuxControllerTests.agentWindowOptsIntoAlternateScreenWithoutAffectingSiblings` — real tmux: per-window `on` sticks, coexists with a sibling on the global `off`, and is not flagged degraded.
- `WebTerminalAssetTests` — client routing shape, the conditional swallow, and the selection escape hatch.
- New `web-tests/wheel-scroll.test.js` — 24 jsdom assertions over the wheel and the conditional swallow, incl. graceful degradation when `agent_surface` is absent.

`swift test` on CrowDaemon (149) and CrowEngine (325) fully green; CrowTerminal green except `retryReadinessEmitsTimedOutWhenSentinelMissing`, **confirmed failing on the clean base** with all changes stashed (the pre-existing flake #821 documented). Full JS suite green apart from a pre-existing `row.test.js` failure, likewise confirmed against an untouched `app.js`.

ADR-0013 flipped Proposed → Accepted, recording the crux resolution and why (a) was rejected.

## Out of scope

Replay reflow fidelity (epic #783).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEV3MkQnjbLKqr3qNzf1wZ