### PR TITLE
Document coding-agent adapter architecture + harness capability matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ This is the development root managed by Crow. The Manager tab runs Claude Code h
 
 Architectural decisions live in [`docs/adr/`](docs/adr/). Read [`docs/adr/README.md`](docs/adr/README.md) for the index, and copy [`docs/adr/template.md`](docs/adr/template.md) to start a new one. When superseding a decision, update the old ADR's `Status` field to `Superseded by NNNN` — don't delete it. The history is the point.
 
+**Coding-agent harnesses:** Crow drives Claude Code, Cursor, Codex, and OpenCode through the `CodingAgent` adapter. What each harness can (and can't) do — and why — lives in [`docs/agent-harness-matrix.md`](docs/agent-harness-matrix.md); the architecture is [ADR 0014](docs/adr/0014-pluggable-coding-agent-adapter.md) and the capability gaps are [ADR 0015](docs/adr/0015-harness-capability-tiers.md).
+
 ## crow CLI Reference
 
 The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. **All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true`** and return JSON.

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -18,8 +18,8 @@ public protocol CodingAgent: Sendable {
 
     /// Whether this agent supports Crow's "remote control" feature (the
     /// `--rc --name` flags Claude Code uses to register a session in
-    /// claude.ai's Remote Control panel). Drives whether the
-    /// `RemoteControlBadge` is shown for this agent's sessions.
+    /// claude.ai's Remote Control panel). Drives whether the remote-control
+    /// badge is shown for this agent's sessions.
     var supportsRemoteControl: Bool { get }
 
     /// The shell token that identifies a command as launching this agent.

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -71,7 +71,8 @@ public struct CursorAgent: CodingAgent {
             // GUI-stored creds are inherited otherwise), no `--continue`
             // (MVP doesn't auto-resume), no remote-control flag (remote
             // control is `crow send` typing into the TUI — agent-agnostic,
-            // handled by `SessionService.send`, not a per-launch flag).
+            // handled by the `send` RPC → `TerminalRouter.send`, not a
+            // per-launch flag).
             return "\(agentPath)\n"
         case .job, .review:
             // Jobs and reviews share the same dispatch shape: a pre-written

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
@@ -76,8 +76,9 @@ public struct OpenCodeAgent: CodingAgent {
             // TUI. No env prefix (OpenCode reads provider creds from its own
             // config / env), no `--continue` (MVP doesn't auto-resume), no
             // remote-control flag (remote control is `crow send` typing into
-            // the TUI — agent-agnostic, handled by `SessionService.send`).
-            // OpenCode has no `--rc`/`--name` analog anyway.
+            // the TUI — agent-agnostic, handled by the `send` RPC →
+            // `TerminalRouter.send`). OpenCode has no `--rc`/`--name` analog
+            // anyway.
             return "\(opencodePath)\n"
         case .job, .review:
             // First launch: headless `run` consumes the prompt file, then

--- a/docs/adr/0005-task-and-code-backend-protocols.md
+++ b/docs/adr/0005-task-and-code-backend-protocols.md
@@ -129,6 +129,7 @@ After #454, `rg '"gh"|"glab"|gh api|glab api' Sources/Crow/App/IssueTracker.swif
 
 - Tickets: [#410](https://github.com/corveil/crow/issues/410) (foundation, closed via #411), [#454](https://github.com/corveil/crow/issues/454) (migration), [#495](https://github.com/corveil/crow/issues/495) (real Corveil backend)
 - PRs: #411 (foundation), the PR closing #454 (migration)
+- Related ADRs: [0014](./0014-pluggable-coding-agent-adapter.md) — the `CodingAgent` harness adapter is the **orthogonal** axis (which agent edits the code) to this ADR's task/code-provider axis (where the ticket and PR live). They compose at `CodingAgent.generatePrompt`, which routes a Jira-task + GitHub-code session's ticket fetch and PR step to different CLIs.
 - Code:
   - `Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift`
   - `Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift`

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -93,12 +93,14 @@ abstract a Claude-specific concept:
    inherits the slash-command form — the sharpest edge of these residual identity
    checks, and the reason this switch (not just the prep branch) is a candidate
    for a capability member.
-2. **Claude-only prep**, gated by `if …kind == .claudeCode`, for three
-   capabilities no other harness has: **trust seeding**
-   (`ClaudeTrustSeeder.seedTrust`, at `launchAgent`, `handoffAgent`, and the two
-   Manager paths — four sites), **AI-gateway env**
-   (`ClaudeHookConfigWriter.writeGatewayEnv` + `gatewayEnvPrefix`), and **OTEL
-   telemetry env** (`AgentLaunch.prepareAgentLaunchText`).
+2. **Claude-only prep**, gated by `if …kind == .claudeCode`, for capabilities no
+   other harness has: **trust seeding** (`ClaudeTrustSeeder.seedTrust`, gated at
+   all four call sites — `launchAgent`, `handoffAgent`, and the two Manager
+   paths), **AI-gateway env** (`ClaudeHookConfigWriter.writeGatewayEnv` +
+   `gatewayEnvPrefix`, gated at `launchAgent` / `handoffAgent`; the
+   Manager-terminal write in `createManagerTerminal` is **unconditional** —
+   harmless, since a non-Claude agent ignores `settings.local.json`), and **OTEL
+   telemetry env** (`AgentLaunch.prepareAgentLaunchText`, gated).
 
 These are the accepted exceptions — the candidates for a future
 `capabilities`-style member if a second harness ever grows an analogue (see

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -98,7 +98,8 @@ abstract a Claude-specific concept:
    all four call sites — `launchAgent`, `handoffAgent`, and the two Manager
    paths), **AI-gateway env** (`ClaudeHookConfigWriter.writeGatewayEnv` gated at
    `launchAgent` / `handoffAgent`, plus the launch-line `gatewayEnvPrefix` at
-   `launchAgent` only; the **two** Manager gateway writes —
+   `launchAgent` (and `managerCommand`'s no-registered-agent fallback); the
+   **two** Manager gateway writes —
    `createManagerTerminal` and the hydrate path's `writeManagerGatewayEnv` — are
    unconditional, harmless since a non-Claude agent ignores
    `settings.local.json`), and **OTEL telemetry env**

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -68,12 +68,26 @@ the default.** At daemon boot, `CrowDaemon.registerAgents` registers
 `findBinary()` resolves**. So Claude Code is always present and always the
 default; any other harness whose binary is off `PATH` is simply not in the map.
 
-The engine never switches on harness identity. `SessionService.launchAgent`,
-`handoffAgent`, and `buildReviewPrompt` look the agent up by kind and call
-protocol members. The one accepted exception is a small **Claude-only prep
-branch** (`if agent.kind == .claudeCode`) for trust seeding and AI-gateway env —
-capabilities the protocol does not (yet) abstract because no other harness has an
-analogue (see [ADR 0015](./0015-harness-capability-tiers.md)).
+The engine has **no central per-harness switch**: `SessionService.launchAgent`
+and `handoffAgent` resolve the agent by kind and drive it through protocol
+members (`autoLaunchCommand`, `hookConfigWriter`, `stateSignalSource`, …). A
+handful of **residual identity checks** remain where the protocol does not (yet)
+abstract a Claude-specific concept:
+
+1. **Review-prompt form.** `SessionService.buildReviewPrompt` is a literal
+   `switch agentKind` selecting the terse `/crow-review-pr <URL>` slash-command
+   (Claude) versus the inlined skill body (Cursor / OpenCode), with Codex
+   returning `nil` upstream.
+2. **Claude-only prep**, gated by `if …kind == .claudeCode`, for three
+   capabilities no other harness has: **trust seeding**
+   (`ClaudeTrustSeeder.seedTrust`, at `launchAgent`, `handoffAgent`, and the two
+   Manager paths — four sites), **AI-gateway env**
+   (`ClaudeHookConfigWriter.writeGatewayEnv` + `gatewayEnvPrefix`), and **OTEL
+   telemetry env** (`AgentLaunch.prepareAgentLaunchText`).
+
+These are the accepted exceptions — the candidates for a future
+`capabilities`-style member if a second harness ever grows an analogue (see
+[ADR 0015](./0015-harness-capability-tiers.md)).
 
 ## Consequences
 
@@ -93,13 +107,18 @@ analogue (see [ADR 0015](./0015-harness-capability-tiers.md)).
   picker and in `handoff-agent` (which fails `agentBinaryMissing`). This is
   intentional (no half-registered harness), but "why isn't Cursor in the list?"
   is answered by `findBinary()`, not an error message.
-- The `Claude-only` prep branch is a real switch-on-identity the abstraction
-  hasn't dissolved. It is documented and localized to two call sites, and is the
-  candidate for a future `capabilities`-style member if a second harness grows a
-  gateway/trust concept.
+- The residual identity checks above are real switches-on-identity the
+  abstraction hasn't dissolved — the review-prompt `switch` plus Claude-only prep
+  (trust seeding across four sites, gateway env, OTEL telemetry). They are the
+  candidates for a future `capabilities`-style member if a second harness grows a
+  gateway/trust/telemetry concept.
 - `AgentKind` being an open struct means a typo'd raw value (`"claude_code"` vs
-  `"claude-code"`) resolves to an unregistered kind rather than a compile error —
-  the CLI validates the four known tokens to blunt this.
+  `"claude-code"`) resolves to an unregistered kind rather than a compile error.
+  The CLI's `validate()` only rejects an empty `--agent` (the four tokens appear
+  in its help/error text, not a membership check), so the typo is caught
+  **server-side** by the registry lookup — `handoffAgent` throws
+  `AgentHandoffError.agentNotRegistered`. Behavior is safe; the guard just lives
+  in the daemon, not the client.
 
 ## Alternatives considered
 
@@ -131,5 +150,8 @@ analogue (see [ADR 0015](./0015-harness-capability-tiers.md)).
   - `Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift`
   - `Packages/CrowCore/Sources/CrowCore/Agent/{HookConfigWriter,StateSignalSource,BinaryOverrides}.swift`
   - `Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift` (`registerAgents`)
+  - `Packages/CrowEngine/Sources/CrowEngine/SessionService.swift` (`launchAgent`, `handoffAgent`, `buildReviewPrompt`, Manager trust-seed sites)
+  - `Packages/CrowEngine/Sources/CrowEngine/AgentLaunch.swift` (`prepareAgentLaunchText`, OTEL gate)
+  - `Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift` (`HandoffAgent.validate`)
   - `Packages/Crow{Claude,Cursor,Codex,OpenCode}/`
 - Reference: [Coding-agent harness capability matrix](../agent-harness-matrix.md)

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -1,0 +1,135 @@
+# 0014 — Pluggable `CodingAgent` adapter
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+- **Deciders:** @dgershman
+
+## Context
+
+Crow launches a coding agent into each session's terminal and observes it via
+hook events. Phase A shipped exactly one agent — Claude Code — with its launch
+flags, hook-config writer, and state machine hardwired into `SessionService`.
+Adding Cursor, OpenAI Codex, and OpenCode ([#627](https://github.com/corveil/crow/issues/627)
+and the harness follow-ups) meant those hardwired assumptions had to become an
+abstraction, or every new harness would be another `switch agentKind { … }`
+sprinkled across the engine.
+
+The harnesses differ on nearly every axis — binary name, remote-control support,
+hook transport, resume semantics, auto-permission, review support (see the
+[capability matrix](../agent-harness-matrix.md)). We needed a contract that (a)
+lets a harness declare its own capabilities as data the engine can branch on, (b)
+lets a *downstream package* register a new harness without editing `CrowCore`,
+and (c) makes a harness whose binary isn't installed simply absent rather than a
+runtime error.
+
+**Relationship to [ADR 0005](./0005-task-and-code-backend-protocols.md).**
+0005 governs the **task/code provider** axis — `TaskBackend` / `CodeBackend` for
+GitHub, GitLab, Jira, Corveil (*where the ticket and the PR live*). This ADR
+governs the orthogonal **coding-agent** axis — `CodingAgent` for Claude Code,
+Cursor, Codex, OpenCode (*which harness edits the code*). A session pairs one
+harness with one or two providers; the two abstractions compose but do not
+overlap. The 0005 file itself is `Accepted` (foundation #411, migration #454) —
+its earlier `Proposed` status in the index was stale and is corrected alongside
+this ADR. This ADR does **not** supersede 0005; they are parallel decisions on
+different axes. `CodingAgent.generatePrompt` is the one seam where they meet: it
+takes both `provider` and `codeProvider` so a Jira-task + GitHub-code session
+routes the ticket fetch and the PR step to different CLIs (the 0005 cross-backend
+case).
+
+## Decision
+
+Crow's harness contract is the
+[`CodingAgent`](../../Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift)
+protocol. Capabilities are **members of the protocol**, not a central switch:
+
+- **Static capability members:** `supportsRemoteControl`, `launchCommandToken`,
+  `displayName`, `iconSystemName`, `fallbackCandidates`.
+- **Delegated collaborators:** `hookConfigWriter: any HookConfigWriter` and
+  `stateSignalSource: any StateSignalSource` — each harness supplies its own hook
+  transport and its own pure event→state machine.
+- **Command builders:** `autoLaunchCommand`, `launchCommand`,
+  `managerLaunchCommand`, `generatePrompt`, `sessionRenameSlashCommand` — each
+  gets `autoPermissionMode` / `remoteControlEnabled` inputs it may honor or
+  ignore.
+- **Binary discovery:** `findBinary()` with a default three-tier impl
+  (explicit `defaults.binaries.<kind>` override → `PATH` walk →
+  hardcoded `fallbackCandidates`; CROW-484).
+
+Harnesses are keyed by
+[`AgentKind`](../../Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift),
+a `RawRepresentable` **struct** (not an enum) so a downstream package
+(`CrowCursor`, `CrowCodex`, `CrowOpenCode`) can define a new kind without
+modifying `CrowCore`.
+
+[`AgentRegistry`](../../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)
+is the process-wide map from kind → agent. **The first kind registered becomes
+the default.** At daemon boot, `CrowDaemon.registerAgents` registers
+`ClaudeCodeAgent` unconditionally first, then Codex / Cursor / OpenCode **only if
+`findBinary()` resolves**. So Claude Code is always present and always the
+default; any other harness whose binary is off `PATH` is simply not in the map.
+
+The engine never switches on harness identity. `SessionService.launchAgent`,
+`handoffAgent`, and `buildReviewPrompt` look the agent up by kind and call
+protocol members. The one accepted exception is a small **Claude-only prep
+branch** (`if agent.kind == .claudeCode`) for trust seeding and AI-gateway env —
+capabilities the protocol does not (yet) abstract because no other harness has an
+analogue (see [ADR 0015](./0015-harness-capability-tiers.md)).
+
+## Consequences
+
+**Easier:**
+
+- Adding a harness is a new package that conforms to `CodingAgent` plus one
+  registration line in `CrowDaemon.registerAgents` — no engine surgery.
+- Capabilities are declarative and testable per harness; the
+  [matrix](../agent-harness-matrix.md) is generated from real property values,
+  not aspirational.
+- Handoff ([ADR 0011](./0011-agent-handoff-preserves-session-not-chat.md)) is a
+  registry lookup + protocol calls; it inherited multi-harness support for free.
+
+**Harder / accepted:**
+
+- **A harness whose binary isn't on `PATH` is silently unavailable** in the
+  picker and in `handoff-agent` (which fails `agentBinaryMissing`). This is
+  intentional (no half-registered harness), but "why isn't Cursor in the list?"
+  is answered by `findBinary()`, not an error message.
+- The `Claude-only` prep branch is a real switch-on-identity the abstraction
+  hasn't dissolved. It is documented and localized to two call sites, and is the
+  candidate for a future `capabilities`-style member if a second harness grows a
+  gateway/trust concept.
+- `AgentKind` being an open struct means a typo'd raw value (`"claude_code"` vs
+  `"claude-code"`) resolves to an unregistered kind rather than a compile error —
+  the CLI validates the four known tokens to blunt this.
+
+## Alternatives considered
+
+- **Central `switch agentKind` in `SessionService`.** Rejected — reproduces the
+  provider-switch anti-pattern 0005 dissolved on the task/code axis, and forces
+  every harness's quirks into the engine.
+- **`AgentKind` as an enum.** Rejected — a closed enum in `CrowCore` would force
+  every new harness to modify the core module, breaking the "register from a
+  downstream package" goal.
+- **Supersede ADR 0005 with this one** (as the originating ticket floated).
+  Rejected — 0005 is a different, still-valid decision on the provider axis; the
+  two compose. The ticket's premise (that 0005 "predates and describes the
+  CodingAgent design") conflated the two abstractions. The correct fix was to
+  correct 0005's stale index status and record this as a parallel ADR.
+- **Fail loudly when a harness binary is missing.** Rejected — a user who never
+  installed Cursor should see a shorter picker, not an error; absence is the
+  right signal.
+
+## References
+
+- Issue: [#827](https://github.com/corveil/crow/issues/827) (this doc);
+  [#627](https://github.com/corveil/crow/issues/627) (handoff, first multi-harness driver)
+- Related ADRs: [0005](./0005-task-and-code-backend-protocols.md) (orthogonal
+  provider axis), [0011](./0011-agent-handoff-preserves-session-not-chat.md)
+  (handoff), [0015](./0015-harness-capability-tiers.md) (capability tiers)
+- Code:
+  - `Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift`
+  - `Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift`
+  - `Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift`
+  - `Packages/CrowCore/Sources/CrowCore/Agent/{HookConfigWriter,StateSignalSource,BinaryOverrides}.swift`
+  - `Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift` (`registerAgents`)
+  - `Packages/Crow{Claude,Cursor,Codex,OpenCode}/`
+- Reference: [Coding-agent harness capability matrix](../agent-harness-matrix.md)

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -96,11 +96,13 @@ abstract a Claude-specific concept:
 2. **Claude-only prep**, gated by `if …kind == .claudeCode`, for capabilities no
    other harness has: **trust seeding** (`ClaudeTrustSeeder.seedTrust`, gated at
    all four call sites — `launchAgent`, `handoffAgent`, and the two Manager
-   paths), **AI-gateway env** (`ClaudeHookConfigWriter.writeGatewayEnv` +
-   `gatewayEnvPrefix`, gated at `launchAgent` / `handoffAgent`; the
-   Manager-terminal write in `createManagerTerminal` is **unconditional** —
-   harmless, since a non-Claude agent ignores `settings.local.json`), and **OTEL
-   telemetry env** (`AgentLaunch.prepareAgentLaunchText`, gated).
+   paths), **AI-gateway env** (`ClaudeHookConfigWriter.writeGatewayEnv` gated at
+   `launchAgent` / `handoffAgent`, plus the launch-line `gatewayEnvPrefix` at
+   `launchAgent` only; the **two** Manager gateway writes —
+   `createManagerTerminal` and the hydrate path's `writeManagerGatewayEnv` — are
+   unconditional, harmless since a non-Claude agent ignores
+   `settings.local.json`), and **OTEL telemetry env**
+   (`AgentLaunch.prepareAgentLaunchText`, gated).
 
 These are the accepted exceptions — the candidates for a future
 `capabilities`-style member if a second harness ever grows an analogue (see

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -75,9 +75,13 @@ handful of **residual identity checks** remain where the protocol does not (yet)
 abstract a Claude-specific concept:
 
 1. **Review-prompt form.** `SessionService.buildReviewPrompt` is a literal
-   `switch agentKind` selecting the terse `/crow-review-pr <URL>` slash-command
-   (Claude) versus the inlined skill body (Cursor / OpenCode), with Codex
-   returning `nil` upstream.
+   `switch agentKind`: `.cursor` / `.openCode` get the inlined skill body, Codex
+   returns `nil` upstream, and **Claude is the `default:` arm** (the terse
+   `/crow-review-pr <URL>` slash-command). Because Claude is the default, a
+   *future* harness registered without touching `buildReviewPrompt` silently
+   inherits the slash-command form — the sharpest edge of these residual identity
+   checks, and the reason this switch (not just the prep branch) is a candidate
+   for a capability member.
 2. **Claude-only prep**, gated by `if …kind == .claudeCode`, for three
    capabilities no other harness has: **trust seeding**
    (`ClaudeTrustSeeder.seedTrust`, at `launchAgent`, `handoffAgent`, and the two

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -100,8 +100,9 @@ These are the accepted exceptions — the candidates for a future
 - Adding a harness is a new package that conforms to `CodingAgent` plus one
   registration line in `CrowDaemon.registerAgents` — no engine surgery.
 - Capabilities are declarative and testable per harness; the
-  [matrix](../agent-harness-matrix.md) is generated from real property values,
-  not aspirational.
+  [matrix](../agent-harness-matrix.md) is hand-maintained but **verified against**
+  real property values, not aspirational — the doc's own contract is to update it
+  in the same PR that changes a capability.
 - Handoff ([ADR 0011](./0011-agent-handoff-preserves-session-not-chat.md)) is a
   registry lookup + protocol calls; it inherited multi-harness support for free.
 

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -63,10 +63,21 @@ modifying `CrowCore`.
 
 [`AgentRegistry`](../../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)
 is the process-wide map from kind → agent. **The first kind registered becomes
-the default.** At daemon boot, `CrowDaemon.registerAgents` registers
-`ClaudeCodeAgent` unconditionally first, then Codex / Cursor / OpenCode **only if
-`findBinary()` resolves**. So Claude Code is always present and always the
-default; any other harness whose binary is off `PATH` is simply not in the map.
+the registry's *fallback* default.** At daemon boot, `CrowDaemon.registerAgents`
+registers `ClaudeCodeAgent` unconditionally first, then Codex / Cursor / OpenCode
+**only if `findBinary()` resolves**. So Claude Code is always present, and is the
+registry fallback; any other harness whose binary is off `PATH` is simply not in
+the map.
+
+The harness a **new session** actually launches with is a separate, config-driven
+choice: `AppState.agentKind(for:) = agentsByKind[sessionKind] ?? defaultAgentKind`
+(`AppConfig`, CROW-421 / CROW-433), both user-settable in Settings → "Default
+agent" and per-session-kind overrides. Every creation site reads that; the
+registry's `defaultAgent` is only a last-resort fallback (e.g. `managerCommand`
+when the session's kind isn't registered) and the `"default": true` flag on the
+web agent menu. A user who sets Default agent = Cursor gets Cursor on every new
+session — `defaultAgentKind` defaults to `.claudeCode`, which is why Claude is the
+*out-of-the-box* default, not a hardwired one.
 
 The engine has **no central per-harness switch**: `SessionService.launchAgent`
 and `handoffAgent` resolve the agent by kind and drive it through protocol
@@ -109,9 +120,13 @@ These are the accepted exceptions — the candidates for a future
 **Harder / accepted:**
 
 - **A harness whose binary isn't on `PATH` is silently unavailable** in the
-  picker and in `handoff-agent` (which fails `agentBinaryMissing`). This is
-  intentional (no half-registered harness), but "why isn't Cursor in the list?"
-  is answered by `findBinary()`, not an error message.
+  picker and in `handoff-agent`. Because `registerAgents` gates registration on
+  `findBinary()` at boot, such a harness is *unregistered*, so a handoff to it
+  throws `agentNotRegistered` (the registry lookup precedes the binary check in
+  `handoffAgent`). `agentBinaryMissing` is the narrower post-boot case — the
+  harness *was* registered at boot but its binary later disappeared or its
+  `defaults.binaries.<kind>` override was repointed. Either way, "why isn't Cursor
+  in the list?" is answered by `findBinary()`, not an error message.
 - The residual identity checks above are real switches-on-identity the
   abstraction hasn't dissolved — the review-prompt `switch` plus Claude-only prep
   (trust seeding across four sites, gateway env, OTEL telemetry). They are the

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -75,8 +75,13 @@ records the rationale for each gap here (verbatim reasons preserved from source)
    *creation* (`EngineRouter` new-session) takes `requestedAgentKind ??
    agentKind(for: .work)` with **no** registry check, so a session can be created
    with an unregistered kind and `launchAgent` then silently no-ops on the
-   registry lookup. The Manager path does validate against the registry. Closing
-   that asymmetry is a code follow-up, not a doc change.
+   registry lookup. The two Manager-creation surfaces also differ: the **web**
+   `create-manager` (`EngineRouter`) validates against the registry (CROW-593
+   security gate, falling back to the configured default), but the **daemon's**
+   `create-manager` (`RPCHandlers`) passes the requested kind straight through —
+   and there the launch degrades differently again, `managerCommand` falling back
+   to `AgentRegistry.defaultAgent` rather than no-op'ing. Closing these
+   asymmetries is a code follow-up, not a doc change.
 
 These gaps are **phased parity, not permanent tiers.** Comments mark the phase
 that will close them (Cursor/Codex/OpenCode launchers are written but
@@ -90,18 +95,16 @@ that will close them (Cursor/Codex/OpenCode launchers are written but
   hook scope) remain Claude-first. The [matrix](../agent-harness-matrix.md) is
   the single place that says which is which.
 - **Version-pinned reasons are re-check targets, not settled facts.** Each pin
-  below must be re-verified when the harness ships a new release; a stale pin is
-  a bug in this ADR. This table is the explicit **seed for a follow-up capability
-  audit** — the audit walks each row and confirms (or retires) the reason.
-
-  | Gap | Pin | Source of truth |
-  |---|---|---|
-  | Codex hooks sync-only | Codex **v0.139.0** | `CodexHookConfigWriter.asyncEvents` |
-  | Codex `config.toml` key `codex_hooks` → `hooks` | Codex **v0.139.0+** | `CodexHookConfigWriter.installGlobalTomlConfig` |
-  | Codex reuses `ClaudeHooksEngine` (schemas byte-compatible) | **codex 0.123.0** | `CodexSignalSource` |
-  | Claude recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` |
-  | Cursor `PostToolUse`/`Notification` async timing | empirical (unpinned) | `CursorSignalSource` |
-  | OpenCode `session.idle` "done" semantics | CROW-545 (empirical) | `OpenCodeHookConfigWriter` |
+  must be re-verified when the harness ships a new release; a stale pin is a bug.
+  These pins are the explicit **seed for a follow-up capability audit** — the
+  audit walks each row and confirms (or retires) the reason. The canonical
+  row-set lives in the matrix's
+  [Version-pinned reasons — re-check targets](../agent-harness-matrix.md#version-pinned-reasons--re-check-targets)
+  table (kept in one place so the two docs can't go stale asymmetrically);
+  today it covers Codex sync-only (**v0.139.0**), the `codex_hooks`→`hooks`
+  rename (**v0.139.0+**), the `ClaudeHooksEngine` reuse (**codex 0.123.0**),
+  Claude's recap subagent (**≥ 2.1.108**), and the two unpinned empirical
+  timings (Cursor async, OpenCode `session.idle` / CROW-545).
 
 - The gating rule (8) means a partially-installed environment produces a smaller,
   correct picker rather than broken entries — but "why can't I hand off to X?"

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -70,7 +70,13 @@ records the rationale for each gap here (verbatim reasons preserved from source)
 8. **Capability availability is gated on binary registration.** A harness whose
    `findBinary()` misses is never registered ([ADR 0014](./0014-pluggable-coding-agent-adapter.md)),
    so *all* of its capabilities are unavailable — the picker and `handoff-agent`
-   act as if it doesn't exist. Claude is always registered.
+   act as if it doesn't exist (a handoff to it throws `agentNotRegistered`).
+   Claude is always registered. Gating is uneven across surfaces, though: session
+   *creation* (`EngineRouter` new-session) takes `requestedAgentKind ??
+   agentKind(for: .work)` with **no** registry check, so a session can be created
+   with an unregistered kind and `launchAgent` then silently no-ops on the
+   registry lookup. The Manager path does validate against the registry. Closing
+   that asymmetry is a code follow-up, not a doc change.
 
 These gaps are **phased parity, not permanent tiers.** Comments mark the phase
 that will close them (Cursor/Codex/OpenCode launchers are written but

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -82,7 +82,8 @@ records the rationale for each gap here (verbatim reasons preserved from source)
    `create-manager` (`RPCHandlers.swift`) passes the requested kind straight through —
    and there the launch degrades differently again, `managerCommand` falling back
    to `AgentRegistry.defaultAgent` rather than no-op'ing. Closing these
-   asymmetries is a code follow-up, not a doc change.
+   asymmetries is a code follow-up ([#834](https://github.com/corveil/crow/issues/834)),
+   not a doc change.
 
 These gaps are **phased parity, not permanent tiers.** Comments mark the phase
 that will close them (Cursor/Codex/OpenCode launchers are written but

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -48,10 +48,11 @@ records the rationale for each gap here (verbatim reasons preserved from source)
    session-state detection."*
 
 5. **Auto-permission is Claude + OpenCode only.** Claude emits
-   `--permission-mode auto`; OpenCode runtime-probes `opencode --help` for
-   `--auto` (falling back to `--dangerously-skip-permissions`) and applies it to
-   `.job` sessions with auto-permission only. Cursor and Codex accept and ignore
-   the `autoPermissionMode` argument.
+   `--permission-mode auto`; OpenCode runtime-probes `opencode --help` for the
+   TUI `--auto` flag (no fallback) and `opencode run --help` for the headless
+   auto-approve flag (`--auto`, else `--dangerously-skip-permissions`), applying
+   them to `.job` sessions with auto-permission only. Cursor and Codex accept and
+   ignore the `autoPermissionMode` argument.
 
 6. **MCP is Claude-only.** Claude's prompt fetches Jira via the `jira` MCP
    server (`jira_get_issue`); its MCP config lives in `~/.claude.json`. The other

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -1,0 +1,129 @@
+# 0015 — Harness capability tiers & phased parity
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+- **Deciders:** @dgershman
+
+## Context
+
+[ADR 0014](./0014-pluggable-coding-agent-adapter.md) established the
+`CodingAgent` adapter and registered four harnesses: Claude Code, Cursor, OpenAI
+Codex, OpenCode. They are **not at parity** — Claude Code is the reference
+implementation with every capability wired; the other three ship with
+deliberate, documented gaps (full grid in the
+[capability matrix](../agent-harness-matrix.md)).
+
+Until now, the *why* behind each gap lived only in scattered code comments —
+several of them **pinned to a specific upstream version** ("sync-only as of
+v0.139.0"). That makes the reasons easy to lose and, worse, easy to leave stale:
+a comment saying "Codex can't do async hooks as of v0.139.0" is a claim with an
+expiry date, and nobody re-checks a code comment on a release cadence. This ADR
+records the gaps and their rationale as a durable decision, and names the
+version-pinned reasons as standing re-check targets.
+
+## Decision
+
+Crow ships non-Claude harnesses at a **lower capability tier on purpose**, and
+records the rationale for each gap here (verbatim reasons preserved from source):
+
+1. **Codex review is unsupported.** `OpenAICodexAgent.autoLaunchCommand(.review)`
+   returns `nil`: *"Review-on-Codex isn't supported in Phase C — the
+   `/crow-review-pr` skill is Claude-only."* Cursor and OpenCode instead get the
+   skill body inlined into the prompt (they have no slash-command engine);
+   Claude uses the terse `/crow-review-pr <URL>` form.
+
+2. **Cursor & Codex have no resume.** Both `.job` branches note *"no `--continue`
+   equivalent in MVP"* — a restart re-enters a bare TUI rather than replaying the
+   prompt. OpenCode's `--continue` re-enters the TUI but carries no history.
+
+3. **Remote control is Claude-native; others are faked or absent.** Codex sets
+   `supportsRemoteControl = false` ("Codex doesn't do remote control", no `--rc`
+   flag). Cursor and OpenCode set it `true` but have **no RC flag** — remote
+   driving is `crow send` typing into the interactive TUI
+   (`SessionService.send`), agent-agnostic, not a per-launch flag.
+
+4. **Codex hooks are sync-only.** `CodexHookConfigWriter.asyncEvents` is empty:
+   *"Codex's hook runtime is sync-only as of v0.139.0 — declaring `async = true`
+   causes the entry to be silently skipped on startup, which breaks Crow's
+   session-state detection."*
+
+5. **Auto-permission is Claude + OpenCode only.** Claude emits
+   `--permission-mode auto`; OpenCode runtime-probes `opencode --help` for
+   `--auto` (falling back to `--dangerously-skip-permissions`) and applies it to
+   `.job` sessions with auto-permission only. Cursor and Codex accept and ignore
+   the `autoPermissionMode` argument.
+
+6. **MCP is Claude-only.** Claude's prompt fetches Jira via the `jira` MCP
+   server (`jira_get_issue`); its MCP config lives in `~/.claude.json`. Cursor
+   falls back to `acli jira workitem view`; Codex and OpenCode have no MCP wiring.
+
+7. **Non-Claude hooks are global-scope, session resolved by `cwd`.** Only Claude
+   writes a per-worktree config keyed by `--session <UUID>`. Cursor
+   (`~/.cursor/hooks.json`), Codex (`~/.codex/hooks.json` + `config.toml`
+   `notify`), and OpenCode (global JS plugin `crow-hooks.js`) all omit
+   `--session` and let the server resolve the session by matching `cwd` against
+   registered worktree paths.
+
+8. **Capability availability is gated on binary registration.** A harness whose
+   `findBinary()` misses is never registered ([ADR 0014](./0014-pluggable-coding-agent-adapter.md)),
+   so *all* of its capabilities are unavailable — the picker and `handoff-agent`
+   act as if it doesn't exist. Claude is always registered.
+
+These gaps are **phased parity, not permanent tiers.** Comments mark the phase
+that will close them (Cursor/Codex/OpenCode launchers are written but
+"not wired into the auto-launch path yet"; Phase D adds harness-flavored
+`crow-workspace` skills). Nothing here is a decision to *never* reach parity.
+
+## Consequences
+
+- Users get a **consistent core loop on every harness** (launch → observe state
+  → handoff) while advanced affordances (review, MCP, native RC, per-session
+  hook scope) remain Claude-first. The [matrix](../agent-harness-matrix.md) is
+  the single place that says which is which.
+- **Version-pinned reasons are re-check targets, not settled facts.** Each pin
+  below must be re-verified when the harness ships a new release; a stale pin is
+  a bug in this ADR. This table is the explicit **seed for a follow-up capability
+  audit** — the audit walks each row and confirms (or retires) the reason.
+
+  | Gap | Pin | Source of truth |
+  |---|---|---|
+  | Codex hooks sync-only | Codex **v0.139.0** | `CodexHookConfigWriter.asyncEvents` |
+  | Codex `config.toml` key `codex_hooks` → `hooks` | Codex **v0.139.0+** | `CodexHookConfigWriter.installGlobalTomlConfig` |
+  | Codex reuses `ClaudeHooksEngine` (schemas byte-compatible) | **codex 0.123.0** | `CodexSignalSource` |
+  | Claude recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` |
+  | Cursor `PostToolUse`/`Notification` async timing | empirical (unpinned) | `CursorSignalSource` |
+  | OpenCode `session.idle` "done" semantics | CROW-545 (empirical) | `OpenCodeHookConfigWriter` |
+
+- The gating rule (8) means a partially-installed environment produces a smaller,
+  correct picker rather than broken entries — but "why can't I hand off to X?"
+  is answered by binary presence, which is easy to miss.
+
+## Alternatives considered
+
+- **Block non-Claude harnesses until they reach parity.** Rejected — the core
+  loop works on all four today; withholding them helps no one and the gaps are
+  clearly labeled.
+- **Leave the rationale in code comments only** (status quo before this ADR).
+  Rejected — version-pinned claims rot silently and there was no single index of
+  what's missing or why.
+- **Fake the missing capabilities** (e.g. emit `--auto` for Codex regardless).
+  Rejected — a flag the harness silently drops (or that breaks state detection,
+  as async Codex hooks do) is worse than an honest gap.
+- **A `Set<Capability>` per agent** (mirroring 0005's `TaskCapability`).
+  Considered — the current design encodes capabilities as typed protocol members
+  instead, which the compiler checks. A capability set may still be worth adding
+  if the number of "is X supported?" branches grows; deferred.
+
+## References
+
+- Issue: [#827](https://github.com/corveil/crow/issues/827)
+- Related ADRs: [0014](./0014-pluggable-coding-agent-adapter.md) (the adapter),
+  [0004](./0004-manager-auto-permission-mode.md) (`--permission-mode auto`),
+  [0011](./0011-agent-handoff-preserves-session-not-chat.md) (handoff)
+- Code:
+  - `Packages/CrowCodex/Sources/CrowCodex/{OpenAICodexAgent,CodexHookConfigWriter,CodexSignalSource,CodexNotifyPayload}.swift`
+  - `Packages/CrowCursor/Sources/CrowCursor/{CursorAgent,CursorHookConfigWriter,CursorSignalSource}.swift`
+  - `Packages/CrowOpenCode/Sources/CrowOpenCode/{OpenCodeAgent,OpenCodeLaunchArgs,OpenCodeHookConfigWriter}.swift`
+  - `Packages/CrowClaude/Sources/CrowClaude/{ClaudeLauncher,ClaudeHookConfigWriter,ClaudeHookSignalSource}.swift`
+  - `Packages/CrowEngine/Sources/CrowEngine/SessionService.swift` (`buildReviewPrompt`, `launchAgent`)
+- Reference: [Coding-agent harness capability matrix](../agent-harness-matrix.md)

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -54,8 +54,10 @@ records the rationale for each gap here (verbatim reasons preserved from source)
    the `autoPermissionMode` argument.
 
 6. **MCP is Claude-only.** Claude's prompt fetches Jira via the `jira` MCP
-   server (`jira_get_issue`); its MCP config lives in `~/.claude.json`. Cursor
-   falls back to `acli jira workitem view`; Codex and OpenCode have no MCP wiring.
+   server (`jira_get_issue`); its MCP config lives in `~/.claude.json`. The other
+   three have no MCP wiring — Cursor, Codex, and OpenCode all emit the same
+   `acli jira workitem view <key>` fallback line. The gap is MCP, not Jira
+   ticket-fetch: every harness can still fetch the ticket via `acli`.
 
 7. **Non-Claude hooks are global-scope, session resolved by `cwd`.** Only Claude
    writes a per-worktree config keyed by `--session <UUID>`. Cursor

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -40,7 +40,7 @@ records the rationale for each gap here (verbatim reasons preserved from source)
    `supportsRemoteControl = false` ("Codex doesn't do remote control", no `--rc`
    flag). Cursor and OpenCode set it `true` but have **no RC flag** — remote
    driving is `crow send` typing into the interactive TUI (the `send` RPC handler
-   in `EngineRouter` → `TerminalRouter.send`), agent-agnostic, not a per-launch
+   in `EngineRouter.swift` → `TerminalRouter.send`), agent-agnostic, not a per-launch
    flag.
 
 4. **Codex hooks are sync-only.** `CodexHookConfigWriter.asyncEvents` is empty:
@@ -73,13 +73,13 @@ records the rationale for each gap here (verbatim reasons preserved from source)
    so *all* of its capabilities are unavailable — the picker and `handoff-agent`
    act as if it doesn't exist (a handoff to it throws `agentNotRegistered`).
    Claude is always registered. Gating is uneven across surfaces, though: session
-   *creation* (`EngineRouter` new-session) takes `requestedAgentKind ??
+   *creation* (`EngineRouter.swift` new-session) takes `requestedAgentKind ??
    agentKind(for: .work)` with **no** registry check, so a session can be created
    with an unregistered kind and `launchAgent` then silently no-ops on the
    registry lookup. The two Manager-creation surfaces also differ: the **web**
-   `create-manager` (`EngineRouter`) validates against the registry (CROW-593
+   `create-manager` (`EngineRouter.swift`) validates against the registry (CROW-593
    security gate, falling back to the configured default), but the **daemon's**
-   `create-manager` (`RPCHandlers`) passes the requested kind straight through —
+   `create-manager` (`RPCHandlers.swift`) passes the requested kind straight through —
    and there the launch degrades differently again, `managerCommand` falling back
    to `AgentRegistry.defaultAgent` rather than no-op'ing. Closing these
    asymmetries is a code follow-up, not a doc change.

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -39,8 +39,9 @@ records the rationale for each gap here (verbatim reasons preserved from source)
 3. **Remote control is Claude-native; others are faked or absent.** Codex sets
    `supportsRemoteControl = false` ("Codex doesn't do remote control", no `--rc`
    flag). Cursor and OpenCode set it `true` but have **no RC flag** — remote
-   driving is `crow send` typing into the interactive TUI
-   (`SessionService.send`), agent-agnostic, not a per-launch flag.
+   driving is `crow send` typing into the interactive TUI (the `send` RPC handler
+   in `EngineRouter` → `TerminalRouter.send`), agent-agnostic, not a per-launch
+   flag.
 
 4. **Codex hooks are sync-only.** `CodexHookConfigWriter.asyncEvents` is empty:
    *"Codex's hook runtime is sync-only as of v0.139.0 — declaring `async = true`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,7 +41,7 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0002 | [Unix-socket CLI ↔ app architecture](./0002-unix-socket-cli-architecture.md) | Accepted | 2026-05-25 |
 | 0003 | [Worktree-per-task model](./0003-worktree-per-task-model.md) | Accepted | 2026-05-25 |
 | 0004 | [Manager session launches in auto-permission mode by default](./0004-manager-auto-permission-mode.md) | Accepted | 2026-05-25 |
-| 0005 | [TaskBackend and CodeBackend protocols](./0005-task-and-code-backend-protocols.md) | Proposed | 2026-06-03 |
+| 0005 | [TaskBackend and CodeBackend protocols](./0005-task-and-code-backend-protocols.md) | Accepted | 2026-06-07 |
 | 0006 | [xterm.js terminal renderer (Intel support)](./0006-universal-macos-binary.md) | Accepted | 2026-07-01 |
 | 0007 | [Swift CI runs on Linux, not macOS](./0007-linux-ci-swift.md) | Accepted | 2026-07-10 |
 | 0008 | [AI-usage efficiency scorecard](./0008-ai-usage-efficiency-scorecard.md) | Accepted | 2026-07-10 |
@@ -50,3 +50,5 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0011 | [Mid-session agent handoff preserves Crow identity, not chat history](./0011-agent-handoff-preserves-session-not-chat.md) | Accepted | 2026-07-09 |
 | 0012 | [Tests must never touch live application data](./0012-tests-never-touch-live-data.md) | Accepted | 2026-07-19 |
 | 0013 | [Terminal scroll model: per-surface hybrid](./0013-terminal-scroll-model.md) | Accepted | 2026-07-23 |
+| 0014 | [Pluggable `CodingAgent` adapter](./0014-pluggable-coding-agent-adapter.md) | Accepted | 2026-07-23 |
+| 0015 | [Harness capability tiers & phased parity](./0015-harness-capability-tiers.md) | Accepted | 2026-07-23 |

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -99,7 +99,7 @@ harness's sessions
   Remote Control panel.
 - **Cursor & OpenCode:** `true`, but there is **no RC flag** — remote driving is
   `crow send` typing into the interactive TUI (the agent-agnostic stdin path: the
-  `send` RPC handler in `EngineRouter` → `TerminalRouter.send`). The badge
+  `send` RPC handler in `EngineRouter.swift` → `TerminalRouter.send`). The badge
   reflects that Crow *can* drive them, not that the agent has a native RC
   protocol.
 - **Codex:** `false` — Codex has no remote-control surface at all
@@ -134,7 +134,7 @@ All harnesses report lifecycle events by shelling out to `crow hook-event`, but
   plus a `config.toml` `notify = ["<crow>", "codex-notify"]` line and
   `features.hooks = true`. `cwd`-resolved like Cursor. The `notify` bridge is a
   Tier-2 fallback: `crow codex-notify` translates Codex's post-turn JSON payload
-  into a hook event (`CodexNotifyPayload`, `CodexNotifyCommand`).
+  into a hook event (`CodexNotifyPayload`, `CodexNotify`).
 - **OpenCode** — no command-hook file at all; Crow installs a global **JS
   plugin** `crow-hooks.js` under `~/.config/opencode/plugins/` that subscribes to
   OpenCode's event bus + `tool.execute.*` / `permission.ask` hooks and pipes a

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -1,0 +1,240 @@
+# Coding-agent harness capability matrix
+
+Crow can drive four coding agents ("harnesses") through one adapter protocol,
+[`CodingAgent`](../Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift):
+**Claude Code**, **Cursor**, **OpenAI Codex**, and **OpenCode** (sst/opencode).
+Claude Code is the reference implementation and the default; the other three
+ship with deliberate gaps.
+
+This page is the living reference for **what each harness can do and why the
+gaps exist**. The *architecture* of the adapter is
+[ADR 0014](adr/0014-pluggable-coding-agent-adapter.md); the *rationale for the
+gaps* (capability tiers + phased parity) is
+[ADR 0015](adr/0015-harness-capability-tiers.md). When you change a harness's
+capabilities, update this table in the same PR.
+
+> **Scope.** "Harness" here means a *coding agent* (`CodingAgent` /
+> `AgentKind`). Do not confuse it with the *task/code provider* abstraction
+> (`TaskBackend` / `CodeBackend` for GitHub / GitLab / Jira / Corveil), which is
+> a separate axis governed by [ADR 0005](adr/0005-task-and-code-backend-protocols.md).
+> A session pairs one harness with one (or two) providers.
+
+## The matrix
+
+| Dimension | Claude Code | Cursor | Codex | OpenCode |
+|---|---|---|---|---|
+| Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` |
+| Registered at boot | **always** (also the default) | only if binary found | only if binary found | only if binary found |
+| Resume / continue | ✅ `--continue` | ❌ no MVP resume | ❌ no MVP resume | ⚠️ `--continue` re-enters TUI, no history |
+| Remote control | ✅ native `--rc --name` | ⚠️ faked via `crow send` stdin | ❌ `supportsRemoteControl=false` | ⚠️ faked via `crow send` stdin |
+| Auto-permission | ✅ `--permission-mode auto` | ❌ ignored | ❌ ignored | ⚠️ runtime-probed `--auto`, `.job` only |
+| Hooks transport | per-worktree `.claude/settings.local.json` | global `~/.cursor/hooks.json` | global `~/.codex/hooks.json` + `config.toml` `notify` bridge | global JS plugin `~/.config/opencode/plugins/crow-hooks.js` |
+| Hook → session scope | ✅ per-session UUID | ❌ `cwd` match | ❌ `cwd` match | ❌ `cwd` match |
+| Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.139.0) | ⚠️ names verified, timing unverified |
+| MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ❌ falls back to `acli` | ❌ | ❌ |
+| Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ❌ returns `nil` (Phase C) | ✅ inlined skill body |
+| Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `agent "$(cat …)"` (launcher not auto-wired) | job only (review → `nil`) | ✅ run-then-`--continue` |
+| Gateway env / trust seed | ✅ Claude special-case | ❌ | ❌ | ❌ |
+| Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ |
+
+Legend: ✅ full · ⚠️ partial / faked / unverified · ❌ not supported.
+
+## Notes per dimension
+
+Each note cites the source of truth. Line numbers drift; the symbol names are
+stable anchors.
+
+### Binary token & registration
+
+Each harness declares a `launchCommandToken` — the binary name Crow resolves on
+`PATH` and the token the `send` RPC watches for to decide whether a
+managed-terminal command needs hook/env prep.
+
+- Tokens: `claude`, `agent`, `codex`, `opencode`
+  (`ClaudeCodeAgent`, `CursorAgent`, `OpenAICodexAgent`, `OpenCodeAgent`).
+- **Cursor's token is `agent`, a generic name.** CI runners (Azure DevOps,
+  TeamCity) also ship a binary called `agent`; Crow accepts the false-positive
+  risk and lets users pin the real path via `defaults.binaries.cursor`
+  (`CursorAgent.swift` launch-token comment, CROW-484).
+- **Registration order = default.** `AgentRegistry.register` sets the default to
+  the *first* kind registered
+  ([`AgentRegistry.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)).
+  `CrowDaemon.registerAgents` registers **Claude unconditionally first**, then
+  Codex / Cursor / OpenCode **only if `findBinary()` resolves**
+  ([`CrowDaemon.swift`](../Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift),
+  `registerAgents`). So a harness whose binary is off `PATH` is silently absent
+  from the picker and from `handoff-agent` — see
+  [ADR 0015](adr/0015-harness-capability-tiers.md).
+- `findBinary()` resolves in three tiers: explicit `defaults.binaries.<kind>`
+  override → `PATH` walk → hardcoded `fallbackCandidates`
+  (`CodingAgent` default impl; `BinaryOverrides`, CROW-484).
+
+### Resume / continue
+
+- **Claude:** work sessions relaunch with `--continue`; review/job sessions read
+  their prompt file on first launch, then fall through to `--continue` on
+  restart (`ClaudeCodeAgent.autoLaunchCommand`, CROW-224 / CROW-317).
+- **Cursor & Codex:** no `--continue` equivalent in the MVP — a restart drops
+  the user back into a bare TUI rather than re-running the prompt
+  (`CursorAgent` / `OpenAICodexAgent` `.job` branches).
+- **OpenCode:** `--continue` re-enters the TUI (`resumeTUICommand`,
+  `OpenCodeLaunchArgs`) but does not replay conversation history; `.work`
+  launches bare ("MVP doesn't auto-resume").
+
+### Remote control
+
+`supportsRemoteControl` drives the `RemoteControlBadge`
+([`CodingAgent.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift)).
+
+- **Claude:** `true`, backed by real `--rc --name` flags
+  (`ClaudeLaunchArgs.argsSuffix`). `--name` labels the session in claude.ai's
+  Remote Control panel.
+- **Cursor & OpenCode:** `true`, but there is **no RC flag** — remote driving is
+  `crow send` typing into the interactive TUI (the agent-agnostic stdin path in
+  `SessionService.send`). The badge reflects that Crow *can* drive them, not that
+  the agent has a native RC protocol.
+- **Codex:** `false` — Codex has no remote-control surface at all
+  (`OpenAICodexAgent`, "Codex doesn't do remote control").
+
+### Auto-permission
+
+- **Claude:** `--permission-mode auto` (`ClaudeLaunchArgs`), the same knob the
+  Manager uses ([ADR 0004](adr/0004-manager-auto-permission-mode.md)).
+- **Cursor & Codex:** the `autoPermissionMode` argument is accepted and ignored —
+  no flag is emitted.
+- **OpenCode:** `autoPermissionMode` is honored for `.job` sessions only, via a
+  **runtime-probed** `--auto` (falling back to
+  `--dangerously-skip-permissions`). `OpenCodeLaunchArgs` shells `opencode
+  --help` once, caches whether `--auto` is advertised, and omits the flag if
+  not (#547). Reviews never auto-approve.
+
+### Hooks transport & session scope
+
+All harnesses report lifecycle events by shelling out to `crow hook-event`, but
+**where the hook config lives** and **how the session is resolved** differ.
+
+- **Claude** — per-worktree `.claude/settings.local.json`, written per session
+  with `hook-event --session <UUID>`, so the session is resolved by **UUID**
+  ([`ClaudeHookConfigWriter`](../Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift)).
+- **Cursor** — global `~/.cursor/hooks.json` (override `CURSOR_CONFIG_DIR`).
+  Commands carry `--agent cursor` with **no `--session`**; the server resolves
+  the session by matching `cwd` in the payload against registered worktrees
+  (`CursorHookConfigWriter`). Per-project `.cursor/hooks.json` is deferred.
+- **Codex** — global `$CODEX_HOME/hooks.json` (default `~/.codex/hooks.json`),
+  plus a `config.toml` `notify = ["<crow>", "codex-notify"]` line and
+  `features.hooks = true`. `cwd`-resolved like Cursor. The `notify` bridge is a
+  Tier-2 fallback: `crow codex-notify` translates Codex's post-turn JSON payload
+  into a hook event (`CodexNotifyPayload`, `CodexNotifyCommand`).
+- **OpenCode** — no command-hook file at all; Crow installs a global **JS
+  plugin** `crow-hooks.js` under `~/.config/opencode/plugins/` that subscribes to
+  OpenCode's event bus + `tool.execute.*` / `permission.ask` hooks and pipes a
+  `{cwd, …}` JSON payload to `crow hook-event --agent opencode`. `cwd`-resolved
+  (`OpenCodeHookConfigWriter`).
+
+Only Claude gets **per-session UUID scope**; the other three share the host's
+global config and are disambiguated by `cwd`. See
+[ADR 0015](adr/0015-harness-capability-tiers.md).
+
+### Hook async delivery
+
+- **Claude:** `PostToolUse` / `PostToolUseFailure` fire async; `PreToolUse` is
+  intentionally *not* async so it arrives before `PermissionRequest` and keeps
+  state-machine ordering reliable (`ClaudeHookConfigWriter.asyncEvents`).
+- **Codex:** **sync-only as of v0.139.0** — declaring `async = true` makes Codex
+  silently skip the entry on startup, breaking Crow's state detection;
+  `asyncEvents` is deliberately empty (`CodexHookConfigWriter`). *(version-pinned
+  re-check target — see below.)*
+- **Cursor:** declares `PostToolUse` / `Notification` async, but the timing is
+  "one of the three things to confirm empirically" (`CursorSignalSource`).
+- **OpenCode:** event *names* are verified; the *timing/semantics* (esp. whether
+  `session.idle` is the right "done" signal for interactive TUI sessions) are an
+  open empirical question (CROW-545, `OpenCodeHookConfigWriter`).
+
+### MCP (Jira and beyond)
+
+- **Claude:** the initial prompt tells the agent to fetch Jira work items via the
+  **`jira` MCP server** (`jira_get_issue`, `jira_*` tools), not `acli`
+  (`ClaudeLauncher`, CROW-522). MCP server config lives in Claude Code's own
+  `~/.claude.json` (which `ClaudeTrustSeeder` merges into for trust). This is the
+  cross-backend prompt-routing case from
+  [ADR 0005](adr/0005-task-and-code-backend-protocols.md) (Jira task + GitHub
+  code): the ticket is fetched via MCP while the PR is still opened with `gh`.
+- **Cursor:** its Jira prompt uses `acli jira workitem view` — no MCP
+  (`CursorLauncher`).
+- **Codex / OpenCode:** no MCP wiring.
+
+### Review (`/crow-review-pr`)
+
+`SessionService.buildReviewPrompt` branches on `agentKind`:
+
+- **Claude** gets the terse slash-command form `/crow-review-pr <URL>`; the
+  bundled `.claude/skills/crow-review-pr/SKILL.md` supplies the instructions.
+- **Cursor & OpenCode** have no slash-command engine, so Crow **inlines the whole
+  skill body** into the prompt file (`cursorReviewPrompt`, #431).
+- **Codex** returns `nil` from `autoLaunchCommand(.review)`:
+  *"Review-on-Codex isn't supported in Phase C — the `/crow-review-pr` skill is
+  Claude-only."* Crow logs the skip and pastes a `⚠️` echo
+  (`OpenAICodexAgent`).
+
+### Initial-prompt injection
+
+Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
+`.crow-job-prompt.md`) inlined via shell substitution on first launch.
+
+- **Claude:** `$(cat …-prompt.md)`, dispatched through the deferred `#408`
+  paste path (stash in `pendingLaunchCommands`, paste on `.shellReady`). A
+  preflight refuses to dispatch if the file is missing (CROW-439).
+- **Cursor:** `agent "$(cat …)"`. `CursorLauncher` (the workspace-skill prompt
+  generator) is written but **not yet auto-wired** — Phase-C MVP launches
+  `agent` bare for `.work`.
+- **Codex:** job only; review returns `nil`.
+- **OpenCode:** **run-then-`--continue`** — headless `opencode run "$(cat …)"`
+  consumes the prompt reliably, then `; opencode --continue` opens the TUI with a
+  fresh stdin so `crow send` keeps working (#547).
+
+### Gateway env / trust seed
+
+`SessionService.launchAgent` and `handoffAgent` run a **Claude-only** prep branch
+(`if agent.kind == .claudeCode`):
+
+- `ClaudeTrustSeeder.seedTrust` pre-trusts the worktree in `~/.claude.json` so
+  the "Do you trust the files in this folder?" dialog never blocks an
+  auto-launched session (CROW-600).
+- `ClaudeHookConfigWriter.writeGatewayEnv` + `ClaudeLaunchArgs.gatewayEnvPrefix`
+  apply (or clear) the workspace's `ANTHROPIC_BASE_URL` /
+  `ANTHROPIC_CUSTOM_HEADERS` AI-gateway env (CROW-402).
+
+These vars are Claude-specific; no other harness has an analogue.
+
+### Rename passthrough
+
+All four override `sessionRenameSlashCommand` to return `"/rename <name>\n"`,
+sent after a Crow rename so the agent's own session title stays in sync
+(CROW-629). The protocol default is `nil` so a *future* harness can't inherit a
+spurious `/rename` paste.
+
+## Handoff between harnesses
+
+`crow handoff-agent --session <UUID> --agent <claude-code|cursor|codex|opencode>
+[--note "…"]` switches a running session to a different harness. It preserves the
+Crow session identity, worktree, branch, ticket, and links; it does **not**
+transfer chat history ([ADR 0011](adr/0011-agent-handoff-preserves-session-not-chat.md)).
+A handoff to an unregistered harness (binary missing) fails with
+`AgentHandoffError.agentBinaryMissing` — the binary-gating from
+[ADR 0015](adr/0015-harness-capability-tiers.md) surfaces here too.
+
+## Version-pinned reasons — re-check targets
+
+Several gaps are pinned to a specific upstream version. Each is a standing
+**re-check target**: when the harness ships a new release, confirm the reason
+still holds and update this page + [ADR 0015](adr/0015-harness-capability-tiers.md).
+This list is the seed for a follow-up capability audit.
+
+| Reason | Pin | Source |
+|---|---|---|
+| Codex hooks are sync-only (async → silent skip → broken state detection) | Codex **v0.139.0** | `CodexHookConfigWriter.asyncEvents` |
+| Codex `config.toml` hook key renamed `codex_hooks` → `hooks` | Codex **v0.139.0+** | `CodexHookConfigWriter.installGlobalTomlConfig` |
+| Codex reuses Claude's hook engine (`ClaudeHooksEngine`, byte-compatible schemas) | verified against **codex 0.123.0** | `CodexSignalSource` |
+| Claude background-recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` |
+| Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` |
+| OpenCode `session.idle` "done" semantics unconfirmed for TUI | — (CROW-545) | `OpenCodeHookConfigWriter` |

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -90,16 +90,18 @@ managed-terminal command needs hook/env prep.
 
 ### Remote control
 
-`supportsRemoteControl` drives the `RemoteControlBadge`
+`supportsRemoteControl` drives whether the remote-control badge is shown for a
+harness's sessions
 ([`CodingAgent.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift)).
 
 - **Claude:** `true`, backed by real `--rc --name` flags
   (`ClaudeLaunchArgs.argsSuffix`). `--name` labels the session in claude.ai's
   Remote Control panel.
 - **Cursor & OpenCode:** `true`, but there is **no RC flag** — remote driving is
-  `crow send` typing into the interactive TUI (the agent-agnostic stdin path in
-  `SessionService.send`). The badge reflects that Crow *can* drive them, not that
-  the agent has a native RC protocol.
+  `crow send` typing into the interactive TUI (the agent-agnostic stdin path: the
+  `send` RPC handler in `EngineRouter` → `TerminalRouter.send`). The badge
+  reflects that Crow *can* drive them, not that the agent has a native RC
+  protocol.
 - **Codex:** `false` — Codex has no remote-control surface at all
   (`OpenAICodexAgent`, "Codex doesn't do remote control").
 
@@ -189,11 +191,12 @@ global config and are disambiguated by `cwd`. See
 ### Initial-prompt injection
 
 Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
-`.crow-job-prompt.md`) inlined via shell substitution on first launch.
+`.crow-job-prompt.md`) inlined via shell substitution on first launch. A preflight
+in `launchAgent` refuses to dispatch if that file is missing, for **every**
+harness (CROW-439) — it's gated on the prompt-file convention, not on agent kind.
 
 - **Claude:** `$(cat …-prompt.md)`, dispatched through the deferred `#408`
-  paste path (stash in `pendingLaunchCommands`, paste on `.shellReady`). A
-  preflight refuses to dispatch if the file is missing (CROW-439).
+  paste path (stash in `pendingLaunchCommands`, paste on `.shellReady`).
 - **Cursor:** `agent "$(cat …)"`. `CursorLauncher` (the workspace-skill prompt
   generator) is written but **not yet auto-wired** — Phase-C MVP launches
   `agent` bare for `.work`.
@@ -216,7 +219,8 @@ identity (`if …kind == .claudeCode`), because no other harness has an analogue
   `ANTHROPIC_CUSTOM_HEADERS` (CROW-402): `ClaudeHookConfigWriter.writeGatewayEnv`
   writes the env block into `settings.local.json` (Claude-gated at `launchAgent`
   and `handoffAgent`), and `ClaudeLaunchArgs.gatewayEnvPrefix` adds the
-  launch-line `export …` prefix (at `launchAgent` only). The **two** Manager
+  launch-line `export …` prefix (at `launchAgent`, plus `managerCommand`'s
+  no-registered-agent fallback). The **two** Manager
   gateway writes — `createManagerTerminal` and the hydrate path's
   `writeManagerGatewayEnv` — are **unconditional** (harmless: a non-Claude agent
   ignores `settings.local.json`).

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -33,7 +33,7 @@ capabilities, update this table in the same PR.
 | Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.139.0) | ⚠️ names verified, timing unverified |
 | MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ❌ falls back to `acli` | ❌ falls back to `acli` | ❌ falls back to `acli` |
 | Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ❌ returns `nil` (Phase C) | ✅ inlined skill body |
-| Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `agent "$(cat …)"` (launcher not auto-wired) | job only (review → `nil`) | ✅ run-then-`--continue` |
+| Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ⚠️ job/review only, `.work` launcher not auto-wired | job only (review → `nil`) | ✅ run-then-`--continue` |
 | Gateway env / trust seed / telemetry | ✅ Claude special-case | ❌ | ❌ | ❌ |
 | Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ |
 
@@ -71,8 +71,8 @@ managed-terminal command needs hook/env prep.
 - **Registration order ≠ new-session default.** First-registered only sets the
   *registry's* fallback (`AgentRegistry.defaultAgent`). The harness a new session
   launches with is config-driven: `AppState.agentKind(for:) =
-  agentsByKind[sessionKind] ?? defaultAgentKind`, both user-settable in Settings →
-  "Default agent" + per-session-kind overrides (CROW-421 / CROW-433).
+  agentsByKind[sessionKind.rawValue] ?? defaultAgentKind`, both user-settable in
+  Settings → "Default agent" + per-session-kind overrides (CROW-421 / CROW-433).
   `defaultAgentKind` ships as `.claudeCode`, so Claude is the *out-of-the-box*
   default; set it to Cursor and every new session uses Cursor.
 
@@ -258,11 +258,11 @@ Several gaps are pinned to a specific upstream version. Each is a standing
 still holds and update this page + [ADR 0015](adr/0015-harness-capability-tiers.md).
 This list is the seed for a follow-up capability audit.
 
-| Reason | Pin | Source |
-|---|---|---|
-| Codex hooks are sync-only (async → silent skip → broken state detection) | Codex **v0.139.0** | `CodexHookConfigWriter.asyncEvents` |
-| Codex `config.toml` hook key renamed `codex_hooks` → `hooks` | Codex **v0.139.0+** | `CodexHookConfigWriter.installGlobalTomlConfig` |
-| Codex reuses Claude's hook engine (`ClaudeHooksEngine`, byte-compatible schemas) | verified against **codex 0.123.0** | `CodexSignalSource` |
-| Claude background-recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` |
-| Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` |
-| OpenCode `session.idle` "done" semantics unconfirmed for TUI | — (CROW-545) | `OpenCodeHookConfigWriter` |
+| Reason | Pin | Source | Last verified |
+|---|---|---|---|
+| Codex hooks are sync-only (async → silent skip → broken state detection) | Codex **v0.139.0** | `CodexHookConfigWriter.asyncEvents` | 2026-07-24 |
+| Codex `config.toml` hook key renamed `codex_hooks` → `hooks` | Codex **v0.139.0+** | `CodexHookConfigWriter.installGlobalTomlConfig` | 2026-07-24 |
+| Codex reuses Claude's hook engine (`ClaudeHooksEngine`, byte-compatible schemas) | verified against **codex 0.123.0** | `CodexSignalSource` | 2026-07-24 |
+| Claude background-recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` | 2026-07-24 |
+| Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` | 2026-07-24 |
+| OpenCode `session.idle` "done" semantics unconfirmed for TUI | — (CROW-545) | `OpenCodeHookConfigWriter` | 2026-07-24 |

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -102,11 +102,12 @@ managed-terminal command needs hook/env prep.
   Manager uses ([ADR 0004](adr/0004-manager-auto-permission-mode.md)).
 - **Cursor & Codex:** the `autoPermissionMode` argument is accepted and ignored —
   no flag is emitted.
-- **OpenCode:** `autoPermissionMode` is honored for `.job` sessions only, via a
-  **runtime-probed** `--auto` (falling back to
-  `--dangerously-skip-permissions`). `OpenCodeLaunchArgs` shells `opencode
-  --help` once, caches whether `--auto` is advertised, and omits the flag if
-  not (#547). Reviews never auto-approve.
+- **OpenCode:** `autoPermissionMode` is honored for `.job` sessions only, via
+  **runtime-probed** flags. `OpenCodeLaunchArgs` runs two independently-cached
+  probes: the interactive TUI's `--auto` (probed with `opencode --help`, **no**
+  fallback) and the headless-`run` auto-approve (probed with `opencode run
+  --help`: `--auto`, else `--dangerously-skip-permissions`). Each flag is omitted
+  when its probe doesn't advertise it (#547). Reviews never auto-approve.
 
 ### Hooks transport & session scope
 

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -204,8 +204,9 @@ Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
 
 ### Gateway env / trust seed / telemetry
 
-Three capabilities the protocol doesn't abstract are gated on Claude identity
-(`if …kind == .claudeCode`), because no other harness has an analogue:
+Three Claude-specific capabilities the protocol doesn't abstract key on Claude
+identity (`if …kind == .claudeCode`), because no other harness has an analogue
+(gating is exhaustive except the one Manager gateway write noted below):
 
 - **Trust seeding** — `ClaudeTrustSeeder.seedTrust` pre-trusts the worktree in
   `~/.claude.json` so the "Do you trust the files in this folder?" dialog never
@@ -213,7 +214,10 @@ Three capabilities the protocol doesn't abstract are gated on Claude identity
   `SessionService.launchAgent`, `handoffAgent`, and the two Manager paths.
 - **AI-gateway env** — `ClaudeHookConfigWriter.writeGatewayEnv` +
   `ClaudeLaunchArgs.gatewayEnvPrefix` apply (or clear) the workspace's
-  `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` env (CROW-402).
+  `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` env (CROW-402). Gated on
+  Claude at `launchAgent` / `handoffAgent`; the Manager-terminal write in
+  `createManagerTerminal` is **unconditional** (harmless — a non-Claude agent
+  ignores `settings.local.json`).
 - **OTEL telemetry env** — `AgentLaunch.prepareAgentLaunchText` prepends the
   `OTEL_*` exporter vars, gated on `agent.kind == .claudeCode` (Codex has no OTLP
   equivalent).

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -31,7 +31,7 @@ capabilities, update this table in the same PR.
 | Hooks transport | per-worktree `.claude/settings.local.json` | global `~/.cursor/hooks.json` | global `~/.codex/hooks.json` + `config.toml` `notify` bridge | global JS plugin `~/.config/opencode/plugins/crow-hooks.js` |
 | Hook → session scope | ✅ per-session UUID | ❌ `cwd` match | ❌ `cwd` match | ❌ `cwd` match |
 | Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.139.0) | ⚠️ names verified, timing unverified |
-| MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ❌ falls back to `acli` | ❌ | ❌ |
+| MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ❌ falls back to `acli` | ❌ falls back to `acli` | ❌ falls back to `acli` |
 | Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ❌ returns `nil` (Phase C) | ✅ inlined skill body |
 | Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `agent "$(cat …)"` (launcher not auto-wired) | job only (review → `nil`) | ✅ run-then-`--continue` |
 | Gateway env / trust seed | ✅ Claude special-case | ❌ | ❌ | ❌ |
@@ -159,9 +159,11 @@ global config and are disambiguated by `cwd`. See
   cross-backend prompt-routing case from
   [ADR 0005](adr/0005-task-and-code-backend-protocols.md) (Jira task + GitHub
   code): the ticket is fetched via MCP while the PR is still opened with `gh`.
-- **Cursor:** its Jira prompt uses `acli jira workitem view` — no MCP
-  (`CursorLauncher`).
-- **Codex / OpenCode:** no MCP wiring.
+- **Cursor, Codex, OpenCode:** none have MCP wiring — all three fall back to the
+  same `acli jira workitem view <key> --fields …` prompt line
+  (`CursorLauncher`, `CodexLauncher`, `OpenCodeLauncher`). The gap is **MCP**,
+  not Jira ticket-fetch: every harness can fetch the ticket, just via `acli`
+  rather than the `jira` MCP server.
 
 ### Review (`/crow-review-pr`)
 

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -24,7 +24,7 @@ capabilities, update this table in the same PR.
 | Dimension | Claude Code | Cursor | Codex | OpenCode |
 |---|---|---|---|---|
 | Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` |
-| Registered at boot | **always** (also the default) | only if binary found | only if binary found | only if binary found |
+| Registered at boot | **always** (default out of the box) | only if binary found | only if binary found | only if binary found |
 | Resume / continue | ✅ `--continue` | ❌ no MVP resume | ❌ no MVP resume | ⚠️ `--continue` re-enters TUI, no history |
 | Remote control | ✅ native `--rc --name` | ⚠️ faked via `crow send` stdin | ❌ `supportsRemoteControl=false` | ⚠️ faked via `crow send` stdin |
 | Auto-permission | ✅ `--permission-mode auto` | ❌ ignored | ❌ ignored | ⚠️ runtime-probed `--auto`, `.job` only |
@@ -34,7 +34,7 @@ capabilities, update this table in the same PR.
 | MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ❌ falls back to `acli` | ❌ falls back to `acli` | ❌ falls back to `acli` |
 | Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ❌ returns `nil` (Phase C) | ✅ inlined skill body |
 | Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `agent "$(cat …)"` (launcher not auto-wired) | job only (review → `nil`) | ✅ run-then-`--continue` |
-| Gateway env / trust seed | ✅ Claude special-case | ❌ | ❌ | ❌ |
+| Gateway env / trust seed / telemetry | ✅ Claude special-case | ❌ | ❌ | ❌ |
 | Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ |
 
 Legend: ✅ full · ⚠️ partial / faked / unverified · ❌ not supported.
@@ -68,6 +68,13 @@ managed-terminal command needs hook/env prep.
 - `findBinary()` resolves in three tiers: explicit `defaults.binaries.<kind>`
   override → `PATH` walk → hardcoded `fallbackCandidates`
   (`CodingAgent` default impl; `BinaryOverrides`, CROW-484).
+- **Registration order ≠ new-session default.** First-registered only sets the
+  *registry's* fallback (`AgentRegistry.defaultAgent`). The harness a new session
+  launches with is config-driven: `AppState.agentKind(for:) =
+  agentsByKind[sessionKind] ?? defaultAgentKind`, both user-settable in Settings →
+  "Default agent" + per-session-kind overrides (CROW-421 / CROW-433).
+  `defaultAgentKind` ships as `.claudeCode`, so Claude is the *out-of-the-box*
+  default; set it to Cursor and every new session uses Cursor.
 
 ### Resume / continue
 
@@ -195,19 +202,24 @@ Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
   consumes the prompt reliably, then `; opencode --continue` opens the TUI with a
   fresh stdin so `crow send` keeps working (#547).
 
-### Gateway env / trust seed
+### Gateway env / trust seed / telemetry
 
-`SessionService.launchAgent` and `handoffAgent` run a **Claude-only** prep branch
-(`if agent.kind == .claudeCode`):
+Three capabilities the protocol doesn't abstract are gated on Claude identity
+(`if …kind == .claudeCode`), because no other harness has an analogue:
 
-- `ClaudeTrustSeeder.seedTrust` pre-trusts the worktree in `~/.claude.json` so
-  the "Do you trust the files in this folder?" dialog never blocks an
-  auto-launched session (CROW-600).
-- `ClaudeHookConfigWriter.writeGatewayEnv` + `ClaudeLaunchArgs.gatewayEnvPrefix`
-  apply (or clear) the workspace's `ANTHROPIC_BASE_URL` /
-  `ANTHROPIC_CUSTOM_HEADERS` AI-gateway env (CROW-402).
+- **Trust seeding** — `ClaudeTrustSeeder.seedTrust` pre-trusts the worktree in
+  `~/.claude.json` so the "Do you trust the files in this folder?" dialog never
+  blocks an auto-launched session (CROW-600). Runs at **four** call sites:
+  `SessionService.launchAgent`, `handoffAgent`, and the two Manager paths.
+- **AI-gateway env** — `ClaudeHookConfigWriter.writeGatewayEnv` +
+  `ClaudeLaunchArgs.gatewayEnvPrefix` apply (or clear) the workspace's
+  `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` env (CROW-402).
+- **OTEL telemetry env** — `AgentLaunch.prepareAgentLaunchText` prepends the
+  `OTEL_*` exporter vars, gated on `agent.kind == .claudeCode` (Codex has no OTLP
+  equivalent).
 
-These vars are Claude-specific; no other harness has an analogue.
+These are the residual Claude-identity switches called out in
+[ADR 0014](adr/0014-pluggable-coding-agent-adapter.md).
 
 ### Rename passthrough
 
@@ -222,9 +234,12 @@ spurious `/rename` paste.
 [--note "…"]` switches a running session to a different harness. It preserves the
 Crow session identity, worktree, branch, ticket, and links; it does **not**
 transfer chat history ([ADR 0011](adr/0011-agent-handoff-preserves-session-not-chat.md)).
-A handoff to an unregistered harness (binary missing) fails with
-`AgentHandoffError.agentBinaryMissing` — the binary-gating from
-[ADR 0015](adr/0015-harness-capability-tiers.md) surfaces here too.
+A handoff to a harness whose binary isn't on `PATH` throws
+`AgentHandoffError.agentNotRegistered` — such a harness was never registered at
+boot (`registerAgents` gates on `findBinary()`), and `handoffAgent`'s registry
+lookup precedes its binary check. `agentBinaryMissing` is the narrower case where
+the harness *was* registered but its binary later vanished. Either way, the
+binary-gating from [ADR 0015](adr/0015-harness-capability-tiers.md) surfaces here.
 
 ## Version-pinned reasons — re-check targets
 

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -206,17 +206,19 @@ Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
 
 Three Claude-specific capabilities the protocol doesn't abstract key on Claude
 identity (`if …kind == .claudeCode`), because no other harness has an analogue
-(gating is exhaustive except the one Manager gateway write noted below):
+(gating is exhaustive except the two Manager gateway writes noted below):
 
 - **Trust seeding** — `ClaudeTrustSeeder.seedTrust` pre-trusts the worktree in
   `~/.claude.json` so the "Do you trust the files in this folder?" dialog never
   blocks an auto-launched session (CROW-600). Runs at **four** call sites:
   `SessionService.launchAgent`, `handoffAgent`, and the two Manager paths.
-- **AI-gateway env** — `ClaudeHookConfigWriter.writeGatewayEnv` +
-  `ClaudeLaunchArgs.gatewayEnvPrefix` apply (or clear) the workspace's
-  `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` env (CROW-402). Gated on
-  Claude at `launchAgent` / `handoffAgent`; the Manager-terminal write in
-  `createManagerTerminal` is **unconditional** (harmless — a non-Claude agent
+- **AI-gateway env** — two mechanisms for the workspace's `ANTHROPIC_BASE_URL` /
+  `ANTHROPIC_CUSTOM_HEADERS` (CROW-402): `ClaudeHookConfigWriter.writeGatewayEnv`
+  writes the env block into `settings.local.json` (Claude-gated at `launchAgent`
+  and `handoffAgent`), and `ClaudeLaunchArgs.gatewayEnvPrefix` adds the
+  launch-line `export …` prefix (at `launchAgent` only). The **two** Manager
+  gateway writes — `createManagerTerminal` and the hydrate path's
+  `writeManagerGatewayEnv` — are **unconditional** (harmless: a non-Claude agent
   ignores `settings.local.json`).
 - **OTEL telemetry env** — `AgentLaunch.prepareAgentLaunchText` prepends the
   `OTEL_*` exporter vars, gated on `agent.kind == .claudeCode` (Codex has no OTLP

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Crow coordinates AI-assisted development sessions. Each session is a git worktree + a Claude Code terminal + ticket metadata, tracked in a persistent store. The `crowd` daemon is the **sole authority**: it owns the store, spawns workspaces (worktree + tmux window + agent), runs the background automations, and serves the web UI + a JSON-RPC surface. Every interface — the browser UI and the `crow` CLI — is a **pure client** that sends RPCs and renders pushed state. See [ADR 0009](adr/0009-crowd-sole-authority-clients-only.md) (crowd is the sole authority) and [ADR 0010](adr/0010-retire-the-macos-app.md) (the macOS app was retired).
+Crow coordinates AI-assisted development sessions. Each session is a git worktree + a coding-agent terminal (Claude Code by default; Cursor, OpenAI Codex, or OpenCode when installed) + ticket metadata, tracked in a persistent store. The `crowd` daemon is the **sole authority**: it owns the store, spawns workspaces (worktree + tmux window + agent), runs the background automations, and serves the web UI + a JSON-RPC surface. Every interface — the browser UI and the `crow` CLI — is a **pure client** that sends RPCs and renders pushed state. See [ADR 0009](adr/0009-crowd-sole-authority-clients-only.md) (crowd is the sole authority) and [ADR 0010](adr/0010-retire-the-macos-app.md) (the macOS app was retired).
 
 ## System diagram
 
@@ -92,6 +92,30 @@ There are two `CrowCLI` directories:
 | **AutostartService**       | `Packages/CrowAutostart/`                              | Registers `crowd` to start at login (launchd LaunchAgent on macOS). Shared by `crow autostart` and the daemon's local-only `/autostart` routes; the protocol leaves room for a systemd `--user` backend |
 | **HostBridge**             | `Packages/CrowEngine/.../HostBridge.swift`             | Seam for host affordances (clipboard, open-in-editor, notifications). `crowd` uses a no-op default; the browser provides these itself where it can |
 | **JSONStore**              | `Packages/CrowPersistence/`                            | NSLock-serialized JSON persistence for sessions, worktrees, links, terminals                                      |
+
+## Coding-agent harnesses
+
+Crow drives four coding agents ("harnesses") through one adapter protocol,
+`CodingAgent`: **Claude Code**, **Cursor**, **OpenAI Codex**, and **OpenCode**.
+Each harness declares its own capabilities (remote control, hook transport,
+resume, review support, …) as protocol members; the engine branches on those,
+never on a central `switch`. Harnesses register at daemon boot into
+`AgentRegistry` — Claude Code always (and as the default), the others only when
+their binary resolves on `PATH`.
+
+The harnesses are **not at parity**: Claude Code is the reference implementation
+and the others ship with deliberate, documented gaps. Two references cover this:
+
+- **[Coding-agent harness capability matrix](agent-harness-matrix.md)** — the
+  living harness × capability grid, with a why/notes column citing code and ADRs.
+- **[ADR 0014](adr/0014-pluggable-coding-agent-adapter.md)** — the pluggable
+  `CodingAgent` adapter architecture (and how it relates to the orthogonal
+  task/code-provider axis in [ADR 0005](adr/0005-task-and-code-backend-protocols.md)).
+- **[ADR 0015](adr/0015-harness-capability-tiers.md)** — why the non-Claude
+  harnesses ship with capability gaps, and the version-pinned reasons to re-check.
+
+Mid-session, a session can switch harnesses via `crow handoff-agent`
+([ADR 0011](adr/0011-agent-handoff-preserves-session-not-chat.md)).
 
 ## Data Flow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,10 +104,10 @@ never on a central `switch`. Harnesses register at daemon boot into
 their binary resolves on `PATH`.
 
 The harnesses are **not at parity**: Claude Code is the reference implementation
-and the others ship with deliberate, documented gaps. Two references cover this:
+and the others ship with deliberate, documented gaps. Three references cover this:
 
 - **[Coding-agent harness capability matrix](agent-harness-matrix.md)** — the
-  living harness × capability grid, with a why/notes column citing code and ADRs.
+  living harness × capability grid, with a per-dimension why/notes section citing code and ADRs.
 - **[ADR 0014](adr/0014-pluggable-coding-agent-adapter.md)** — the pluggable
   `CodingAgent` adapter architecture (and how it relates to the orthogonal
   task/code-provider axis in [ADR 0005](adr/0005-task-and-code-backend-protocols.md)).


### PR DESCRIPTION
Closes #827

## What

Documents Crow's coding-agent harness architecture — undocumented outside scattered code comments until now. Three deliverables, all docs-only:

### 1. `docs/agent-harness-matrix.md` (living reference)
A harness × capability grid for Claude Code / Cursor / Codex / OpenCode with a per-dimension **why/notes** section citing verified code paths and the ADRs below. Every cell was verified against source (not copied from the ticket's baseline). Includes a **version-pinned "re-check targets"** table — the seed for the follow-up capability audit.

### 2. ADR 0014 — Pluggable `CodingAgent` adapter (Accepted)
Records the shipped design: capabilities as protocol members, extensible `AgentKind` (struct, so downstream packages register kinds without touching `CrowCore`), and `AgentRegistry` where the first-registered kind is the default and non-Claude kinds register only if `findBinary()` resolves.

### 3. ADR 0015 — Harness capability tiers & phased parity (Accepted)
Records *why* the non-Claude harnesses ship with gaps, with the version-pinned reasons verbatim from source (e.g. Codex hooks sync-only *"as of v0.139.0"*, Codex review → `nil` *"Phase C … Claude-only"*).

## ADR 0005 reconciliation — note for the reviewer

The ticket asked to reconcile ADR 0005 on the premise that it "predates and describes the CodingAgent design." On inspection that premise conflates two **orthogonal** abstractions:

- **0005** = `TaskBackend`/`CodeBackend` — the *provider* axis (GitHub/GitLab/Jira/Corveil: where the ticket & PR live).
- **0014** (new) = `CodingAgent` — the *harness* axis (which agent edits the code).

0005's **file body was already `Accepted`** (foundation #411, migration #454) — only the index still said `Proposed`. So rather than superseding a valid, active decision, I:
- corrected the stale index status (`Proposed` → `Accepted`), and
- cross-referenced 0005 ↔ 0014 as parallel axes that compose at `CodingAgent.generatePrompt` (the Jira-task + GitHub-code case).

This is called out in 0014's *Alternatives considered*.

## Links added
- `docs/agent-harness-matrix.md` linked from `docs/architecture.md` (new "Coding-agent harnesses" section) and `CLAUDE.md`.
- ADR index updated: 0005 resolved, 0014 + 0015 added.

## Acceptance criteria
- [x] `docs/agent-harness-matrix.md` exists, linked from `architecture.md` + `CLAUDE.md`, cites code + ADRs.
- [x] ADR index updated; 0005 status resolved; new ADRs `Accepted` with Context/Decision/Consequences/Alternatives considered.
- [x] No runtime code behavior change (docs only).

## Verification
- All code paths cited in the docs confirmed to exist.
- All relative doc/ADR links confirmed to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Scope note (updated):** now 10 files — the 7 docs plus 3 **comment-only** Swift edits (phantom-anchor fixes in `CursorAgent`/`OpenCodeAgent`/`CodingAgent`). `git diff origin/main...HEAD -- "*.swift"` filtered to non-comment lines is empty; `swift build` passes. The "no runtime code behavior change" acceptance criterion holds.
