### PR TITLE
Fix agent-surface wheel scroll speed (1 notch/notch + deltaMode normalization)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -28,6 +28,10 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// unless the user opts in (#586).
     public var coderViewAutoPermissionMode: Bool
     public var telemetry: TelemetryConfig
+    /// Terminal wheel-scroll tuning (CROW-835). Separate knobs for the two
+    /// per-surface scroll paths (ADR-0013): local scrollback lines-per-notch on
+    /// plain shells, and forwarded notches-per-notch on agent surfaces.
+    public var terminal: TerminalSettings
     public var autoRespond: AutoRespondSettings
     /// When true, `setup.sh` writes a per-worktree `.claude/settings.local.json`
     /// that overrides Claude Code's `attribution.commit` to include the crow
@@ -104,6 +108,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         reviewAutoPermissionMode: Bool = true,
         coderViewAutoPermissionMode: Bool = false,
         telemetry: TelemetryConfig = TelemetryConfig(),
+        terminal: TerminalSettings = TerminalSettings(),
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         attributionTrailers: Bool = true,
         autoMergeWatcherEnabled: Bool = false,
@@ -126,6 +131,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.reviewAutoPermissionMode = reviewAutoPermissionMode
         self.coderViewAutoPermissionMode = coderViewAutoPermissionMode
         self.telemetry = telemetry
+        self.terminal = terminal
         self.autoRespond = autoRespond
         self.attributionTrailers = attributionTrailers
         self.autoMergeWatcherEnabled = autoMergeWatcherEnabled
@@ -151,6 +157,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         reviewAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .reviewAutoPermissionMode) ?? true
         coderViewAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .coderViewAutoPermissionMode) ?? false
         telemetry = try container.decodeIfPresent(TelemetryConfig.self, forKey: .telemetry) ?? TelemetryConfig()
+        terminal = try container.decodeIfPresent(TerminalSettings.self, forKey: .terminal) ?? TerminalSettings()
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
         autoMergeWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoMergeWatcherEnabled) ?? false
@@ -208,7 +215,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
     }
 
     /// Resolve the agent that should drive a newly-created session of the
@@ -678,6 +685,35 @@ public struct TelemetryConfig: Codable, Sendable, Equatable {
         self.port = port
         self.retentionDays = retentionDays
     }
+}
+
+/// Terminal wheel-scroll tuning (CROW-835). The web terminal routes the wheel by
+/// surface under ADR-0013's per-surface hybrid model, and the two paths have
+/// different natural units, so each gets its own knob. Device normalization
+/// (`deltaMode` + sub-notch accumulation) is a fixed client-side concern and is
+/// deliberately not configurable — these only scale the resulting notch count.
+public struct TerminalSettings: Codable, Sendable, Equatable {
+    /// Plain-shell surfaces: local xterm scrollback **lines per physical wheel
+    /// notch** (default 3 — the historical hardcoded value).
+    public var wheelScrollLines: Int
+    /// Agent-TUI surfaces (Claude Code / Cursor / Manager): number of wheel
+    /// reports **forwarded to the app per physical notch** (default 1 — one notch
+    /// in, one notch out; the app owns its own lines-per-notch). Raise it if agent
+    /// scrolling feels too slow.
+    public var agentWheelNotches: Int
+
+    public init(wheelScrollLines: Int = 3, agentWheelNotches: Int = 1) {
+        self.wheelScrollLines = wheelScrollLines
+        self.agentWheelNotches = agentWheelNotches
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        wheelScrollLines = try c.decodeIfPresent(Int.self, forKey: .wheelScrollLines) ?? 3
+        agentWheelNotches = try c.decodeIfPresent(Int.self, forKey: .agentWheelNotches) ?? 1
+    }
+
+    enum CodingKeys: String, CodingKey { case wheelScrollLines, agentWheelNotches }
 }
 
 /// Auto-cleanup settings for completed and archived sessions.

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -178,6 +178,35 @@ import Testing
     #expect(config.cleanup.retentionHours == 24)
 }
 
+@Test func appConfigTerminalRoundTrip() throws {
+    // CROW-835: the two per-surface wheel-scroll knobs survive encode→decode.
+    var config = AppConfig()
+    config.terminal.wheelScrollLines = 5
+    config.terminal.agentWheelNotches = 2
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.terminal.wheelScrollLines == 5)
+    #expect(decoded.terminal.agentWheelNotches == 2)
+}
+
+@Test func appConfigTerminalDefaultsWhenKeyMissing() throws {
+    // Forward-compat: a pre-CROW-835 config (no `terminal` block) decodes to the
+    // historical 3 lines/notch on shells and 1 forwarded notch/notch on agents.
+    let json = #"{"workspaces":[]}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.terminal.wheelScrollLines == 3)
+    #expect(config.terminal.agentWheelNotches == 1)
+}
+
+@Test func appConfigTerminalPartialKeyKeepsOtherDefault() throws {
+    // Only one knob present → the other stays at its default.
+    let json = #"{"terminal": {"agentWheelNotches": 4}}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.terminal.wheelScrollLines == 3)
+    #expect(config.terminal.agentWheelNotches == 4)
+}
+
 @Test func appConfigRemoteControlRoundTrip() throws {
     var config = AppConfig()
     config.remoteControlEnabled = true

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -112,12 +112,22 @@ function onServerChanged() {
 // `changed`, so we load this on boot and re-load it when the Settings modal
 // saves (via `window.reloadUIConfig`). Mirrors the desktop's
 // `appState.hideSessionDetails`.
-const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false, vsCodeAvailable: false, isLocal: false };
+const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false, vsCodeAvailable: false, isLocal: false,
+  // Terminal wheel-scroll sensitivity (CROW-835), consumed by enableWheelScroll.
+  // Defaults mirror AppConfig.TerminalSettings: 3 local lines/notch on plain
+  // shells, 1 forwarded notch/notch on agent surfaces.
+  wheelScrollLines: 3, agentWheelNotches: 1 };
 async function loadUIConfig() {
   try {
     const res = await rpc('get-config');
     const cfg = JSON.parse((res && res.config) || '{}');
     uiConfig.hideSessionDetails = !!(cfg.sidebar && cfg.sidebar.hideSessionDetails);
+    // Wheel-scroll sensitivity (CROW-835). Fall back to the defaults for a config
+    // that predates the `terminal` block or omits a knob; clamp to a sane floor of
+    // 1 so a stray 0 can't wedge the wheel (Math.trunc would never emit a notch).
+    const t = cfg.terminal || {};
+    uiConfig.wheelScrollLines = Math.max(1, Number(t.wheelScrollLines) || 3);
+    uiConfig.agentWheelNotches = Math.max(1, Number(t.agentWheelNotches) || 1);
     uiConfig.notifications = parseNotificationSettings(cfg.notifications);
     // Presence of the (secret-stripped) webAuth block means a web password is set.
     uiConfig.webPasswordSet = !!cfg.webAuth;
@@ -3567,6 +3577,23 @@ function enableTouchScroll(node) {
   node.addEventListener('touchcancel', () => { lastY = null; accum = 0; }, { passive: true });
 }
 
+// Device normalization for the wheel (CROW-835). Translate ONE `wheel` event
+// into fractional PHYSICAL notches so a notched mouse, a trackpad, and a
+// free-spinning wheel all land at ~1 notch per detent — instead of the old fixed
+// ±3, which (forwarded to an agent that already scrolls several lines per notch)
+// flew multiple pages. `e.deltaMode` disambiguates the unit; the pixel branch
+// magnitude-snaps a discrete detent to exactly one notch regardless of whether
+// the device reports 100/120/240 px, while sub-detent trackpad deltas fall
+// through to the accumulator in enableWheelScroll.
+const WHEEL_NOTCH_MIN_PX = 40; // a single pixel-mode delta at least this big is one detent
+function wheelNotches(e) {
+  const mode = e.deltaMode || 0;
+  if (mode === 1) return e.deltaY / 3; // line mode (Firefox mouse): OS 3 lines/notch
+  if (mode === 2) return e.deltaY;      // page mode (rare): one page ≈ one notch
+  const px = e.deltaY;                  // pixel mode (Chrome/Safari mouse + all trackpads)
+  return Math.abs(px) >= WHEEL_NOTCH_MIN_PX ? Math.sign(px) : px / WHEEL_NOTCH_MIN_PX;
+}
+
 // Route the wheel by surface (ADR-0013) — the mirror of what enableTouchScroll
 // does for touch:
 //
@@ -3581,14 +3608,27 @@ function enableTouchScroll(node) {
 // navigation — the #776 bug. Forwarding goes through sendScrollToPTY, which
 // picks SGR wheel buttons when the app is mouse-tracking and cursor keys
 // otherwise, and caps a fling so it can't flood the PTY.
+//
+// Magnitude is device-normalized to whole notches (wheelNotches) with a
+// sub-notch accumulator (mirroring enableTouchScroll's `accum`), then scaled by
+// the user's per-path sensitivity (CROW-835): agent surfaces forward
+// `agentWheelNotches` reports per notch (default 1 — one detent in, one out),
+// plain shells scroll `wheelScrollLines` local lines per notch (default 3 — the
+// historical feel). The `if (!term)` guard is the only early exit; a partial
+// notch simply consumes the event and waits for more.
 function enableWheelScroll(node) {
+  let accum = 0; // sub-notch remainder, so slow trackpad dust isn't truncated away
   node.addEventListener('wheel', (e) => {
     if (!term) return;
-    const delta = e.deltaY > 0 ? 3 : -3;
-    if (appOwnsScroll()) sendScrollToPTY(delta);
-    else term.scrollLines(delta);
     e.preventDefault();
     e.stopPropagation();
+    accum += wheelNotches(e);
+    const notches = Math.trunc(accum);
+    if (notches !== 0) {
+      accum -= notches;
+      if (appOwnsScroll()) sendScrollToPTY(notches * (uiConfig.agentWheelNotches || 1));
+      else term.scrollLines(notches * (uiConfig.wheelScrollLines || 3));
+    }
   }, { capture: true, passive: false });
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -470,6 +470,7 @@
     cfg.sidebar = cfg.sidebar || {};
     cfg.telemetry = cfg.telemetry || {};
     cfg.cleanup = cfg.cleanup || {};
+    cfg.terminal = cfg.terminal || {};
 
     body.appendChild(group('Development Root'));
     body.appendChild(textField('Path', { path: devRoot }, 'path',
@@ -509,6 +510,14 @@
     body.appendChild(group('Sidebar'));
     body.appendChild(toggleField('Hide session details', cfg.sidebar, 'hideSessionDetails',
       'Hides ticket title and repo/branch lines in sidebar rows.'));
+
+    body.appendChild(group('Terminal Scroll'));
+    body.appendChild(selectField('Wheel speed — plain shell', cfg.terminal, 'wheelScrollLines', [
+      [1, '1 line / notch'], [2, '2 lines / notch'], [3, '3 lines / notch (default)'], [5, '5 lines / notch'], [8, '8 lines / notch'],
+    ], { number: true, help: 'Local scrollback lines scrolled per wheel notch on shell/review surfaces.' }));
+    body.appendChild(selectField('Wheel speed — agent surfaces', cfg.terminal, 'agentWheelNotches', [
+      [1, '1 notch / notch (default)'], [2, '2 notches / notch'], [3, '3 notches / notch'],
+    ], { number: true, help: 'Wheel reports forwarded to Claude Code / Cursor per physical notch. Raise if agent scrolling feels too slow.' }));
 
     body.appendChild(group('Telemetry'));
     body.appendChild(toggleField('Enable session analytics', cfg.telemetry, 'enabled',

--- a/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
@@ -14,9 +14,11 @@ const epilogue = `
   swallowMouseMode(params){ return swallowMouseMode(params); },
   appOwnsScroll(){ return appOwnsScroll(); },
   showTerminalMenu(e){ return showTerminalMenu(e); },
+  wheelNotches(e){ return wheelNotches(e); },
   set term(v){ term = v; },
   set termWs(v){ termWs = v; },
   set activeTerminal(v){ activeTerminal = v; },
+  get uiConfig(){ return uiConfig; },
 };
 `;
 const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
@@ -78,14 +80,16 @@ function setup({ agentSurface = false, altScreen = false,
   T.enableWheelScroll(node);
 
   let defaultPrevented = 0;
-  const wheel = (deltaY) => {
+  const wheel = (deltaY, deltaMode) => {
     const e = new window.Event('wheel', { bubbles: true, cancelable: true });
     e.deltaY = deltaY;
+    if (deltaMode !== undefined) e.deltaMode = deltaMode;
     node.dispatchEvent(e);
     if (e.defaultPrevented) defaultPrevented++;
   };
   return {
     node, opts, scrolled, sent,
+    wheel, // (deltaY, deltaMode?) — deltaMode defaults to 0 (pixel)
     up: () => wheel(-120),
     down: () => wheel(120),
     prevented: () => defaultPrevented,
@@ -124,11 +128,13 @@ console.log('\nAgent surface forwards the wheel to the app:');
 {
   // The agent turned mouse tracking on and — because the swallow is now
   // conditional — xterm actually recorded it, so we speak SGR wheel buttons.
+  // CROW-835: one physical notch (deltaY ±120, pixel mode) forwards exactly ONE
+  // SGR wheel report — not the old ±3 that flew pages in Claude Code.
   const t = setup({ agentSurface: true, mouseTrackingMode: 'any' });
   t.up();
-  check('SGR wheel-up report sent', t.sent.join() === '\x1b[<64;1;1M'.repeat(3));
+  check('one SGR wheel-up report per notch', t.sent.join() === '\x1b[<64;1;1M');
   t.down();
-  check('SGR wheel-down report on the way back', t.sent[1] === '\x1b[<65;1;1M'.repeat(3));
+  check('one SGR wheel-down report on the way back', t.sent[1] === '\x1b[<65;1;1M');
   check('no local scrollLines on an agent surface', t.scrolled.length === 0);
 }
 {
@@ -136,7 +142,7 @@ console.log('\nAgent surface forwards the wheel to the app:');
   // scroll the (empty) local buffer — that was the "same frame forever" bug.
   const t = setup({ agentSurface: true, mouseTrackingMode: 'none' });
   t.up();
-  check('no mouse tracking → cursor keys, still not scrollLines', t.sent.join() === '\x1b[A'.repeat(3));
+  check('no mouse tracking → cursor keys, still not scrollLines', t.sent.join() === '\x1b[A');
   check('still nothing scrolled locally', t.scrolled.length === 0);
 }
 
@@ -172,6 +178,69 @@ console.log('\nWith no surface metadata, the legacy signals still apply:');
   T.activeTerminal = { id: 't1', window: 1 }; // no agent_surface field
   t.up();
   check('unclassified + mouse tracking forwards to the PTY', t.sent.length > 0 && t.scrolled.length === 0);
+}
+
+// ---- Device normalization (CROW-835) ---------------------------------------
+
+// wheelNotches maps ONE event to fractional physical notches by deltaMode, so a
+// mouse, a trackpad, and a free-spin wheel all land near 1 notch per detent.
+console.log('\nwheelNotches normalizes by deltaMode:');
+{
+  const n = (deltaY, deltaMode) => T.wheelNotches({ deltaY, deltaMode });
+  // Pixel mode (0): a discrete detent (|delta| >= 40) snaps to exactly ±1,
+  // regardless of whether the device reports 100, 120, or 240 px.
+  check('pixel 120 → +1 notch', n(120, 0) === 1);
+  check('pixel -100 → -1 notch', n(-100, 0) === -1);
+  check('pixel 240 → still +1 notch (no burst)', n(240, 0) === 1);
+  check('pixel 1000 → still +1 notch (no page-fly)', n(1000, 0) === 1);
+  // Sub-detent pixel deltas (trackpad dust) stay fractional so they accumulate.
+  check('pixel 10 → 0.25 notch (accumulates)', Math.abs(n(10, 0) - 0.25) < 1e-9);
+  check('absent deltaMode is treated as pixel', n(120) === 1 && n(120, undefined) === 1);
+  // Line mode (1, Firefox mouse): 3 lines is one OS notch.
+  check('line 3 → +1 notch', n(3, 1) === 1);
+  check('line 1 → 1/3 notch (accumulates)', Math.abs(n(1, 1) - 1 / 3) < 1e-9);
+  // Page mode (2, rare): one page per notch.
+  check('page 1 → +1 notch', n(1, 2) === 1);
+}
+
+console.log('\nSub-detent trackpad deltas accumulate into whole notches:');
+{
+  // Plain shell, pixel mode: four 10px deltas (40px total) = one notch = 3 lines.
+  const t = setup({ agentSurface: false });
+  t.wheel(10, 0); t.wheel(10, 0); t.wheel(10, 0);
+  check('three 10px deltas (<40) emit nothing yet', t.scrolled.length === 0);
+  t.wheel(10, 0);
+  check('the fourth crosses 40px → one notch = 3 lines', t.scrolled.join() === '3');
+  check('every dust event is still consumed (#776)', t.prevented() === 4);
+}
+{
+  // Agent surface, pixel mode: two 30px deltas (60px total, each < 40) accumulate
+  // into one forwarded notch — a free-spin wheel doesn't burst. (30/40 = 0.75 is
+  // exact in IEEE754, so the accumulator crosses 1.0 cleanly on the second event.)
+  const t = setup({ agentSurface: true, mouseTrackingMode: 'any' });
+  t.wheel(30, 0);
+  check('one 30px delta (<40) forwards nothing yet', t.sent.length === 0);
+  t.wheel(30, 0);
+  check('the second completes a notch → one SGR report', t.sent.join() === '\x1b[<65;1;1M');
+}
+
+// ---- Configurable sensitivity (CROW-835) -----------------------------------
+
+console.log('\nWheel sensitivity scales by uiConfig (config round-trip):');
+{
+  const saved = { l: T.uiConfig.wheelScrollLines, a: T.uiConfig.agentWheelNotches };
+  // Agent surface: agentWheelNotches multiplies the forwarded report count.
+  T.uiConfig.agentWheelNotches = 2;
+  const a = setup({ agentSurface: true, mouseTrackingMode: 'any' });
+  a.down();
+  check('agentWheelNotches=2 → two SGR reports per notch', a.sent.join() === '\x1b[<65;1;1M'.repeat(2));
+  // Plain shell: wheelScrollLines multiplies the local scroll.
+  T.uiConfig.wheelScrollLines = 8;
+  const s = setup({ agentSurface: false });
+  s.down();
+  check('wheelScrollLines=8 → scrollLines(8) per notch', s.scrolled.join() === '8');
+  T.uiConfig.wheelScrollLines = saved.l;
+  T.uiConfig.agentWheelNotches = saved.a;
 }
 
 // ---- Conditional mouse-mode swallow ----------------------------------------


### PR DESCRIPTION
Closes #835

## Problem

After ADR-0013's per-surface hybrid scroll model (#824), the mouse wheel on **agent surfaces** (Claude Code / Cursor / Manager) scrolled far too fast — one physical notch flew up multiple pages. `enableWheelScroll` sent a fixed **±3 per `wheel` event**, which `sendScrollToPTY` forwarded as `.repeat(3)` SGR reports → **3 notches to the app per physical notch**, on top of the app already scrolling several lines per notch. It also referenced `e.deltaMode` **zero times**, so trackpads / free-spin wheels that fire many high-frequency events burst-scrolled.

## Fix

All in `web/app.js` `enableWheelScroll` — the ADR-0013 per-surface routing (`sendScrollToPTY`, `appOwnsScroll`, `enableTouchScroll`) is untouched.

- **1 notch per physical notch on the forward-to-app path.** Feed a device-normalized integer notch count into the existing routing: agent surface → `sendScrollToPTY(±1)` (was ±3); plain shell → `scrollLines(±3)` **unchanged**.
- **Device normalization + sub-notch accumulation** (`wheelNotches`). Honor `e.deltaMode` (line / page / pixel) and accumulate a fractional remainder, mirroring `enableTouchScroll`. Pixel mode **magnitude-snaps** a discrete detent to exactly ±1 regardless of the device's px/notch (100/120/240…), while trackpad dust accumulates to ~1 notch per 40px — no dead first notch, no burst. The single `return` guard is preserved, keeping the #776 always-consume invariant (and `WebTerminalAssetTests`) green.
- **Configurable sensitivity.** New `AppConfig.TerminalSettings` — `wheelScrollLines` (default 3, local lines/notch on shells) and `agentWheelNotches` (default 1, forwarded notches/notch on agents) — round-tripped via `get-config`/`set-config`, surfaced in the web Settings **Terminal Scroll** section, consumed as per-path multipliers.

> **Note on the ticket's CLI-parity requirement:** the "#807 parity test" and "#814 config CLI verb" the ticket says a new setting must satisfy **do not exist on this branch** — there is no config/settings CLI subcommand and no parity test. Config round-trips automatically through the daemon's `get-config`/`set-config` RPC (which decode/re-encode the whole `AppConfig`) the moment a field lands on the model, so no CLI/parity work is possible or required here. If that machinery lands later, wiring these two keys into it is a trivial follow-up.

## Acceptance

- ✅ One physical notch → one SGR report in Claude Code (was 3× → pages).
- ✅ Trackpad / free-spin wheel accumulates to ~1 notch per 40px — no burst.
- ✅ Plain-shell local scrollback unchanged (discrete notch → `scrollLines(3)`); touch path untouched.
- ✅ Setting round-trips config, is reachable from web Settings; CLI/parity N/A on this branch.

## Tests

- `web-tests/wheel-scroll.test.js`: single sequence per notch; `deltaMode` normalization; sub-notch accumulation; no-burst (deltaY 1000 → 1 notch); config-multiplier round-trip. **50 passed.**
- `CrowCoreTests/AppConfigTests.swift`: `terminal` round-trip + forward-compat (missing key → 3/1, partial key). **Green.**
- `CrowDaemonTests/WebTerminalAssetTests` (routing shape / single-return / consume invariant) and `touch-scroll.test.js` unchanged and green.

_(Pre-existing unrelated failure in `row.test.js` — PR-row glyphs — is present on `main` too and untouched here.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxvQ4PhGy2fBe1sTYVC4gA