### PR TITLE
Crow worker-runner: runner mode + repo-less jobs + run-complete mapping (slice 1)

### DIFF
--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -84,9 +84,11 @@ public struct AntigravityAgent: CodingAgent {
             // no resume flag (a fresh work TUI launching bare is deliberate), no
             // RC flag (remote control is `crow send` into the TUI).
             return "\(agentPath)\(autoArgs)\n"
-        case .job:
+        case .job, .workerRun:
             // Unattended dispatch: feed the pre-written `.crow-job-prompt.md` as
-            // the initial prompt via `-p` on first launch. Crow runs `agy` inside
+            // the initial prompt via `-p` on first launch. A Corveil worker run
+            // (corveil/crow#801) reuses the same prompt-file convention in its
+            // scratch workdir, so it shares this branch. Crow runs `agy` inside
             // a tmux window — a real PTY — so the non-TTY `-p` stdout-drop
             // (headless *pipe* case, upstream FRs #119/#597) doesn't apply here;
             // no PTY shim is needed on this path.

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -187,7 +187,16 @@ struct ParityGateTests {
             agentsByKind: ["work": .claudeCode],
             managerGateway: gateway,
             jiraCredential: JiraCredential(username: "probe", tokenRef: "op://probe/token"),
-            webAuth: WebAuthConfig(hashB64: "aGFzaA==", saltB64: "c2FsdA==", iterations: 210_000)
+            webAuth: WebAuthConfig(hashB64: "aGFzaA==", saltB64: "c2FsdA==", iterations: 210_000),
+            runner: RunnerConfig(
+                enabled: true,
+                corveilURL: "https://corveil.example",
+                workerID: "crow-probe-1",
+                caps: ["ontology-write"],
+                kinds: ["tend-ontology"],
+                maxConcurrentRuns: 2,
+                pollIntervalSeconds: 30
+            )
         )
     }
 
@@ -253,7 +262,12 @@ struct ParityGateTests {
     /// `get-something` that mutates state is a write, full stop. This set only
     /// forces the disagreement to be *stated* rather than sitting unnoticed in a
     /// row nobody re-reads.
-    static let namingExceptions: Set<String> = []
+    static let namingExceptions: Set<String> = [
+        // Read-only runner snapshot whose name is neither `get-`/`list-` prefixed
+        // (it's a `-status` suffix). The `.read` classification is correct
+        // (corveil/crow#801).
+        "runner-status",
+    ]
 
     /// `isWrite` is hand-set per row, deliberately, because a `get-`/`list-`
     /// heuristic would wave through a future write named `get-something`. But

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
@@ -74,9 +74,12 @@ public struct ClaudeCodeAgent: CodingAgent {
         // "initial prompt dispatched" gate.
         let initialPromptFile: String?
         switch session.kind {
-        case .review:         initialPromptFile = ".crow-review-prompt.md"
-        case .job:            initialPromptFile = ".crow-job-prompt.md"
-        case .work, .manager: initialPromptFile = nil
+        case .review:            initialPromptFile = ".crow-review-prompt.md"
+        // A Corveil worker run reuses the job prompt-file convention: its wrapped
+        // prompt is written to `.crow-job-prompt.md` in the scratch workdir
+        // (corveil/crow#801).
+        case .job, .workerRun:   initialPromptFile = ".crow-job-prompt.md"
+        case .work, .manager:    initialPromptFile = nil
         }
         if let initialPromptFile, !session.reviewPromptDispatched {
             let promptPath = (worktreePath as NSString)

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -223,8 +223,7 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
                 [.posixPermissions: 0o600], ofItemAtPath: settingsPath)
             return true
         } catch {
-            NSLog("[ClaudeHookConfigWriter] Failed to write Corveil run env to %@: %@",
-                  settingsPath, error.localizedDescription)
+            CrowLog.error("[ClaudeHookConfigWriter] Failed to write Corveil run env to \(settingsPath): \(error.localizedDescription)")
             return false
         }
     }

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -101,6 +101,13 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
         // Write back
         let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: URL(fileURLWithPath: settingsPath))
+        // This same file also carries the `env` block, which can hold the
+        // AI-gateway bearer token and (for worker runs) the scoped
+        // CORVEIL_API_KEY. Rewriting it here would otherwise revert it to the
+        // process umask (e.g. 0644); re-apply 0600 so a hook-config rewrite never
+        // widens the secret file's permissions (corveil/crow#801 review).
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: settingsPath)
     }
 
     // MARK: - Gateway env

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -176,13 +176,20 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
     /// secret) and the scratch dir is wiped on finish — so the key never
     /// persists. Empty values are skipped so a blank var never shadows ambient
     /// state.
+    ///
+    /// Returns `true` only when the secret file was written and locked down to
+    /// 0600. The caller (`SessionService.runWorkerRun`) treats `false` as fatal —
+    /// launching an agent without the injected credentials would leave it unable
+    /// to write back (or reaching for ambient creds), so the run is failed
+    /// instead (corveil/crow#801 review).
+    @discardableResult
     public static func writeCorveilRunEnv(
         dirPath: String,
         corveilURL: String,
         apiKey: String,
         runID: String,
         workerID: String
-    ) {
+    ) -> Bool {
         let claudeDir = (dirPath as NSString).appendingPathComponent(".claude")
         let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.local.json")
 
@@ -205,11 +212,13 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
             try data.write(to: URL(fileURLWithPath: settingsPath))
             // The env block carries the scoped CORVEIL_API_KEY — restrict to
             // owner-only, matching writeGatewayEnv / ConfigStore's 0600.
-            try? FileManager.default.setAttributes(
+            try FileManager.default.setAttributes(
                 [.posixPermissions: 0o600], ofItemAtPath: settingsPath)
+            return true
         } catch {
             NSLog("[ClaudeHookConfigWriter] Failed to write Corveil run env to %@: %@",
                   settingsPath, error.localizedDescription)
+            return false
         }
     }
 

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -162,6 +162,57 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
         }
     }
 
+    // MARK: - Corveil worker-run env
+
+    /// Inject the Corveil runner credentials + run identity into a scratch
+    /// workdir's `.claude/settings.local.json` `env` block (corveil/crow#801).
+    ///
+    /// A repo-less worker run executes in a throwaway scratch dir with no
+    /// `corveil login` state, so the agent needs `CORVEIL_URL` + the scoped
+    /// `CORVEIL_API_KEY` to call `corveil worker-run mcp-call` / `corveil ask`.
+    /// It also needs the run id + worker id so its write-back calls target the
+    /// right run under the same bearer identity Crow claimed with. These land in
+    /// the same 0600 `env` block `writeGatewayEnv` uses (the file carries an org
+    /// secret) and the scratch dir is wiped on finish — so the key never
+    /// persists. Empty values are skipped so a blank var never shadows ambient
+    /// state.
+    public static func writeCorveilRunEnv(
+        dirPath: String,
+        corveilURL: String,
+        apiKey: String,
+        runID: String,
+        workerID: String
+    ) {
+        let claudeDir = (dirPath as NSString).appendingPathComponent(".claude")
+        let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.local.json")
+
+        var settings: [String: Any] = [:]
+        if let data = FileManager.default.contents(atPath: settingsPath),
+           let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            settings = parsed
+        }
+
+        var env = settings["env"] as? [String: Any] ?? [:]
+        if !corveilURL.isEmpty { env["CORVEIL_URL"] = corveilURL }
+        if !apiKey.isEmpty { env["CORVEIL_API_KEY"] = apiKey }
+        env["CROW_WORKER_RUN_ID"] = runID
+        env["CROW_WORKER_ID"] = workerID
+        settings["env"] = env
+
+        do {
+            try FileManager.default.createDirectory(atPath: claudeDir, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: settingsPath))
+            // The env block carries the scoped CORVEIL_API_KEY — restrict to
+            // owner-only, matching writeGatewayEnv / ConfigStore's 0600.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: settingsPath)
+        } catch {
+            NSLog("[ClaudeHookConfigWriter] Failed to write Corveil run env to %@: %@",
+                  settingsPath, error.localizedDescription)
+        }
+    }
+
     /// Remove our hook entries from a worktree's settings.local.json, preserving user settings.
     public func removeHookConfig(worktreePath: String) {
         let settingsPath = (worktreePath as NSString)

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
@@ -76,6 +76,31 @@ struct ClaudeHookConfigWriterTests {
         // Re-write still restricts the file (unrelated USER_VAR could be secret too).
         #expect(try posixPerms(at: dir) == 0o600)
     }
+
+    /// `writeHookConfig` rewrites the same `settings.local.json` that carries the
+    /// `env` block (gateway token + worker-run CORVEIL_API_KEY), so it must also
+    /// lock the file to 0600 — otherwise a hook-config write after the secret was
+    /// injected would revert it to the process umask (corveil/crow#801 review).
+    @Test func writeHookConfigLocksFileTo0600() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Pre-seed a secret-bearing env block, then write hooks on top.
+        let claudeDir = dir.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let seed: [String: Any] = ["env": ["CORVEIL_API_KEY": "sk-secret"]]
+        try JSONSerialization.data(withJSONObject: seed)
+            .write(to: claudeDir.appendingPathComponent("settings.local.json"))
+
+        try ClaudeHookConfigWriter().writeHookConfig(
+            worktreePath: dir.path, sessionID: UUID(), crowPath: "/usr/bin/true")
+
+        #expect(try posixPerms(at: dir) == 0o600)
+        // The secret survived the hook merge (and is now owner-only).
+        let env = try #require(try settings(at: dir)["env"] as? [String: Any])
+        #expect(env["CORVEIL_API_KEY"] as? String == "sk-secret")
+        #expect(try settings(at: dir)["hooks"] != nil)
+    }
 }
 
 /// #897: a hook command must never name a build product. An old dev build baked

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeWorkerRunEnvTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeWorkerRunEnvTests.swift
@@ -33,7 +33,7 @@ struct ClaudeWorkerRunEnvTests {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        ClaudeHookConfigWriter.writeCorveilRunEnv(
+        let ok = ClaudeHookConfigWriter.writeCorveilRunEnv(
             dirPath: dir.path,
             corveilURL: "https://corveil.acme.io",
             apiKey: "sk-secret",
@@ -41,6 +41,7 @@ struct ClaudeWorkerRunEnvTests {
             workerID: "crow-host-1"
         )
 
+        #expect(ok)  // success is reported so the caller can proceed
         #expect(try posixPerms(at: dir) == 0o600)  // carries the scoped API key
         let env = try env(at: dir)
         #expect(env["CORVEIL_URL"] as? String == "https://corveil.acme.io")
@@ -86,5 +87,20 @@ struct ClaudeWorkerRunEnvTests {
         #expect(env["CORVEIL_API_KEY"] == nil)
         #expect(env["CROW_WORKER_RUN_ID"] as? String == "r1")
         #expect(env["CROW_WORKER_ID"] as? String == "w1")
+    }
+
+    @Test func returnsFalseWhenTheFileCannotBeWritten() throws {
+        // Point `dirPath` at an existing *file*, so creating the `.claude`
+        // subdirectory under it fails — the writer must report failure so the
+        // caller fails the run rather than launching without credentials (review).
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("blocker-\(UUID().uuidString)")
+        FileManager.default.createFile(atPath: file.path, contents: Data("x".utf8))
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let ok = ClaudeHookConfigWriter.writeCorveilRunEnv(
+            dirPath: file.path, corveilURL: "u", apiKey: "k", runID: "r", workerID: "w"
+        )
+        #expect(!ok)
     }
 }

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeWorkerRunEnvTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeWorkerRunEnvTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import CrowClaude
+
+/// `writeCorveilRunEnv` injects the runner credentials + run identity into a
+/// worker run's scratch `.claude/settings.local.json` `env` block
+/// (corveil/crow#801). Like `writeGatewayEnv`, the file carries the scoped
+/// `CORVEIL_API_KEY`, so it must be owner-only (0600); the scratch dir is wiped
+/// on finish so the key never persists.
+@Suite("ClaudeHookConfigWriter.writeCorveilRunEnv")
+struct ClaudeWorkerRunEnvTests {
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-corveilenv-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func env(at dir: URL) throws -> [String: Any] {
+        let path = dir.appendingPathComponent(".claude/settings.local.json")
+        let data = try #require(FileManager.default.contents(atPath: path.path))
+        let settings = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return try #require(settings["env"] as? [String: Any])
+    }
+
+    private func posixPerms(at dir: URL) throws -> Int {
+        let path = dir.appendingPathComponent(".claude/settings.local.json").path
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        return try #require((attrs[.posixPermissions] as? NSNumber)?.intValue)
+    }
+
+    @Test func writesAllFourKeysOwnerOnly() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        ClaudeHookConfigWriter.writeCorveilRunEnv(
+            dirPath: dir.path,
+            corveilURL: "https://corveil.acme.io",
+            apiKey: "sk-secret",
+            runID: "run-42",
+            workerID: "crow-host-1"
+        )
+
+        #expect(try posixPerms(at: dir) == 0o600)  // carries the scoped API key
+        let env = try env(at: dir)
+        #expect(env["CORVEIL_URL"] as? String == "https://corveil.acme.io")
+        #expect(env["CORVEIL_API_KEY"] as? String == "sk-secret")
+        #expect(env["CROW_WORKER_RUN_ID"] as? String == "run-42")
+        #expect(env["CROW_WORKER_ID"] as? String == "crow-host-1")
+    }
+
+    @Test func mergesWithExistingSettingsAndEnv() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Pre-seed unrelated settings + an unrelated env var — both must survive.
+        let claudeDir = dir.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let seed: [String: Any] = ["hooks": ["X": "y"], "env": ["PATH_HINT": "/opt"]]
+        let data = try JSONSerialization.data(withJSONObject: seed)
+        try data.write(to: claudeDir.appendingPathComponent("settings.local.json"))
+
+        ClaudeHookConfigWriter.writeCorveilRunEnv(
+            dirPath: dir.path, corveilURL: "u", apiKey: "k", runID: "r", workerID: "w"
+        )
+
+        let env = try env(at: dir)
+        #expect(env["PATH_HINT"] as? String == "/opt")   // preserved
+        #expect(env["CORVEIL_API_KEY"] as? String == "k") // added
+
+        let path = dir.appendingPathComponent(".claude/settings.local.json")
+        let reread = try #require(FileManager.default.contents(atPath: path.path))
+        let settings = try #require(try JSONSerialization.jsonObject(with: reread) as? [String: Any])
+        #expect(settings["hooks"] != nil)  // unrelated top-level key preserved
+    }
+
+    @Test func omitsBlankURLAndKeyButAlwaysWritesRunIdentity() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        ClaudeHookConfigWriter.writeCorveilRunEnv(
+            dirPath: dir.path, corveilURL: "", apiKey: "", runID: "r1", workerID: "w1"
+        )
+        let env = try env(at: dir)
+        #expect(env["CORVEIL_URL"] == nil)      // blank ⇒ don't shadow ambient state
+        #expect(env["CORVEIL_API_KEY"] == nil)
+        #expect(env["CROW_WORKER_RUN_ID"] as? String == "r1")
+        #expect(env["CROW_WORKER_ID"] as? String == "w1")
+    }
+}

--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -72,7 +72,18 @@ public struct OpenAICodexAgent: CodingAgent {
             // No env prefix (Codex has no OTEL equivalent), no `--rc` (Codex
             // doesn't do remote control). Mirrors Claude's `--continue`.
             return "\(codexPath) resume --last\n"
-        case .job:
+        case .job, .workerRun:
+            // First launch: feed `.crow-job-prompt.md` as the positional
+            // initial message so Codex starts working unattended. A Corveil
+            // worker run (corveil/crow#801) reuses the same prompt-file
+            // convention in its scratch workdir, so it shares this branch.
+            // `SessionService.launchAgent` wrote the file before invoking us
+            // and flips `reviewPromptDispatched` (the generic "initial
+            // prompt dispatched" gate) after the command goes out.
+            // Subsequent restarts fall back to bare `codex` — Codex has no
+            // `--continue` equivalent in MVP, so the user just resumes the
+            // TUI rather than re-running the whole prompt (CROW-493).
+            // Mirrors `CursorAgent.autoLaunchCommand`'s `.job` branch.
             if !session.reviewPromptDispatched {
                 // First launch: feed `.crow-job-prompt.md` as the initial
                 // message so Codex starts working unattended. `SessionService`

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -279,6 +279,14 @@ public struct AppConfig: Codable, Sendable, Equatable {
 /// read from the `CORVEIL_API_KEY` env of the crowd process so it never lands at
 /// rest in `config.json`. Decoding is forward-compatible (missing keys fall back
 /// to defaults) like `JobConfig`.
+///
+/// Trust boundary (operational): an enabled runner hands the scoped
+/// `CORVEIL_API_KEY` to the coding agent under `jobsAutoPermissionMode`, so a
+/// worker whose `prompt_body` was maliciously enqueued could, in principle,
+/// exfiltrate the key via auto-approved tools. This is acceptable only for a
+/// **trusted intra-org fleet** (ADR-0014) where Corveil enforces the per-run
+/// `mcp-call` allow-list server-side; do not enable it against an untrusted
+/// worker queue. Distributed/public-pool hardening is a later phase.
 public struct RunnerConfig: Codable, Sendable, Equatable {
     /// Master switch. When false, the runner poll loop never starts.
     public var enabled: Bool

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -89,6 +89,15 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// the `set-web-password` RPC, never through `set-config`.
     public var webAuth: WebAuthConfig?
 
+    /// Optional Corveil worker-runner configuration (corveil/crow#801). When
+    /// `enabled`, `crowd` polls a Corveil queue for claimable worker runs,
+    /// executes each in a repo-less scratch workdir, and maps the agent's finish
+    /// to `corveil worker-run complete`. The org-scoped API key is **not** stored
+    /// here — it's sourced from the `CORVEIL_API_KEY` env of the crowd process so
+    /// no org secret lands at rest in `config.json`. When nil/`disabled`, nothing
+    /// changes (local `jobs` keep working; the Corveil source is additive).
+    public var runner: RunnerConfig?
+
     /// Effective review-exclude patterns: the global `defaults.excludeReviewRepos`
     /// unioned with every workspace's per-workspace `excludeReviewRepos`. A repo
     /// excluded by any workspace (or the global default) is hidden from the review
@@ -149,7 +158,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
         agentsByKind: [String: AgentKind] = [:],
         managerGateway: WorkspaceGateway? = nil,
         jiraCredential: JiraCredential? = nil,
-        webAuth: WebAuthConfig? = nil
+        webAuth: WebAuthConfig? = nil,
+        runner: RunnerConfig? = nil
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
@@ -173,6 +183,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.managerGateway = managerGateway
         self.jiraCredential = jiraCredential
         self.webAuth = webAuth
+        self.runner = runner
     }
 
     public init(from decoder: Decoder) throws {
@@ -222,6 +233,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
             }
         }
         webAuth = try container.decodeIfPresent(WebAuthConfig.self, forKey: .webAuth)
+        runner = try container.decodeIfPresent(RunnerConfig.self, forKey: .runner)
     }
 
     /// Pre-CROW-528 shape of the now-removed `atlassianMCP` config, decoded only
@@ -245,7 +257,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth, runner
     }
 
     /// Resolve the agent that should drive a newly-created session of the
@@ -253,6 +265,104 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// back to `defaultAgentKind` (CROW-421, CROW-433).
     public func agentKind(for sessionKind: SessionKind) -> AgentKind {
         return agentsByKind[sessionKind.rawValue] ?? defaultAgentKind
+    }
+}
+
+/// Corveil worker-runner settings (corveil/crow#801). Makes `crowd` a
+/// first-class runner for Corveil worker runs alongside its local `jobs`:
+/// register with a stable `worker_id`, poll/claim queued runs matching this
+/// runner's routing (`kinds` + `caps`), execute each in a repo-less scratch
+/// workdir, heartbeat to hold the lease, and complete via
+/// `corveil worker-run complete`.
+///
+/// The org-scoped API key is deliberately **absent** from this struct — it's
+/// read from the `CORVEIL_API_KEY` env of the crowd process so it never lands at
+/// rest in `config.json`. Decoding is forward-compatible (missing keys fall back
+/// to defaults) like `JobConfig`.
+public struct RunnerConfig: Codable, Sendable, Equatable {
+    /// Master switch. When false, the runner poll loop never starts.
+    public var enabled: Bool
+    /// Corveil base URL. Falls back to the crowd `CORVEIL_URL` env when blank.
+    public var corveilURL: String
+    /// Stable worker identity used across a run's claim → heartbeat → complete.
+    /// Blank ⇒ resolve `crow-<host>-1` at runtime via ``resolvedWorkerID()``.
+    public var workerID: String
+    /// Capabilities this runner advertises. A run's `required_caps` must be a
+    /// subset for it to be claimable here (hard routing filter).
+    public var caps: [String]
+    /// Worker slugs (`kind`) this runner will claim. Empty ⇒ any kind.
+    public var kinds: [String]
+    /// Backpressure: the most runs this host executes at once (corveil/crow#801
+    /// §5, paired with Corveil's staleness SLO corveil#1834). Clamped to ≥ 1.
+    public var maxConcurrentRuns: Int
+    /// How often the claim/heartbeat/finish loop ticks, in seconds. Clamped ≥ 5.
+    public var pollIntervalSeconds: Int
+
+    public init(
+        enabled: Bool = false,
+        corveilURL: String = "",
+        workerID: String = "",
+        caps: [String] = [],
+        kinds: [String] = [],
+        maxConcurrentRuns: Int = 1,
+        pollIntervalSeconds: Int = 30
+    ) {
+        self.enabled = enabled
+        self.corveilURL = corveilURL
+        self.workerID = workerID
+        self.caps = caps
+        self.kinds = kinds
+        self.maxConcurrentRuns = maxConcurrentRuns
+        self.pollIntervalSeconds = pollIntervalSeconds
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        corveilURL = try c.decodeIfPresent(String.self, forKey: .corveilURL) ?? ""
+        workerID = try c.decodeIfPresent(String.self, forKey: .workerID) ?? ""
+        caps = try c.decodeIfPresent([String].self, forKey: .caps) ?? []
+        kinds = try c.decodeIfPresent([String].self, forKey: .kinds) ?? []
+        maxConcurrentRuns = try c.decodeIfPresent(Int.self, forKey: .maxConcurrentRuns) ?? 1
+        pollIntervalSeconds = try c.decodeIfPresent(Int.self, forKey: .pollIntervalSeconds) ?? 30
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled, corveilURL, workerID, caps, kinds, maxConcurrentRuns, pollIntervalSeconds
+    }
+
+    /// Effective per-host concurrency cap (never below 1).
+    public var effectiveMaxConcurrentRuns: Int { max(1, maxConcurrentRuns) }
+
+    /// Effective poll interval in seconds (never below 5, to bound Corveil load).
+    public var effectivePollIntervalSeconds: Int { max(5, pollIntervalSeconds) }
+
+    /// The worker id to use: the configured value, or a `crow-<host>-1` default
+    /// derived from the machine hostname when blank.
+    public func resolvedWorkerID(hostName: String = ProcessInfo.processInfo.hostName) -> String {
+        let trimmed = workerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return "crow-\(Self.slugHost(hostName))-1"
+    }
+
+    /// Normalize a hostname into a worker-id-safe token: drop a trailing
+    /// `.local`, lowercase, and reduce runs of non-alphanumerics to single `-`.
+    static func slugHost(_ hostName: String) -> String {
+        var name = hostName
+        if name.hasSuffix(".local") { name = String(name.dropLast(6)) }
+        var slug = ""
+        var lastDash = false
+        for scalar in name.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                slug.unicodeScalars.append(scalar)
+                lastDash = false
+            } else if !lastDash {
+                slug.append("-")
+                lastDash = true
+            }
+        }
+        let cleaned = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return cleaned.isEmpty ? "host" : cleaned
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -13,6 +13,7 @@ public enum SessionKind: String, Codable, Sendable, CaseIterable {
     case review  // PR review session
     case job     // Session spun up by a scheduled job (CROW-317)
     case manager // Orchestration session running Claude Code in the devRoot
+    case workerRun // Session executing a claimed Corveil worker run in a repo-less scratch workdir (corveil/crow#801)
 }
 
 /// Status of a development session.

--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -73,6 +73,18 @@ public struct Session: Identifiable, Codable, Sendable {
     // field (CROW-593).
     public var reviewAuthor: String?
 
+    // Corveil worker-run linkage for a `.workerRun` session (corveil/crow#801).
+    // Persisted so a relaunched `crowd` can still map the agent's finish onto
+    // `corveil worker-run complete` for the right run, with the right worker id,
+    // and wipe the scratch dir (which holds the scoped `CORVEIL_API_KEY`). Nil
+    // for every other session kind.
+    /// The claimed Corveil worker-run id this session is executing.
+    public var workerRunID: String?
+    /// The stable `worker_id` used to claim/heartbeat/complete the run.
+    public var workerID: String?
+    /// The repo-less scratch workdir the run executes in (wiped on finish).
+    public var workerRunScratchDir: String?
+
     /// Whether this session is a Manager (orchestration) session. Managers run
     /// Claude Code in the devRoot and are excluded from PR/issue tracking.
     public var isManager: Bool { kind == .manager }
@@ -149,7 +161,10 @@ public struct Session: Identifiable, Codable, Sendable {
         agentSessionEndedAt: Date? = nil,
         orgGoal: String? = nil,
         ticketPriority: TicketPriority? = nil,
-        reviewAuthor: String? = nil
+        reviewAuthor: String? = nil,
+        workerRunID: String? = nil,
+        workerID: String? = nil,
+        workerRunScratchDir: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -172,6 +187,9 @@ public struct Session: Identifiable, Codable, Sendable {
         self.orgGoal = orgGoal
         self.ticketPriority = ticketPriority
         self.reviewAuthor = reviewAuthor
+        self.workerRunID = workerRunID
+        self.workerID = workerID
+        self.workerRunScratchDir = workerRunScratchDir
     }
 
     /// Parse a GitHub PR URL (`https://github.com/<owner>/<repo>/pull/<number>`)
@@ -213,6 +231,9 @@ public struct Session: Identifiable, Codable, Sendable {
         orgGoal = try container.decodeIfPresent(String.self, forKey: .orgGoal)
         ticketPriority = try container.decodeIfPresent(TicketPriority.self, forKey: .ticketPriority)
         reviewAuthor = try container.decodeIfPresent(String.self, forKey: .reviewAuthor)
+        workerRunID = try container.decodeIfPresent(String.self, forKey: .workerRunID)
+        workerID = try container.decodeIfPresent(String.self, forKey: .workerID)
+        workerRunScratchDir = try container.decodeIfPresent(String.self, forKey: .workerRunScratchDir)
         // CROW-573 renamed `pinned` → `locked`. Prefer the new key, but fall
         // back to the legacy `pinned` key so sessions locked under CROW-569
         // remain locked after upgrade.

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -216,6 +216,8 @@ public enum ParityLedger {
         .write("cleanup-set", cli: "cleanup set"),
         .read("ui-get", cli: "ui get"),
         .write("ui-set", cli: "ui set"),
+        .read("automation-get", cli: "automation get"),
+        .write("automation-set", cli: "automation set"),
         .read("notifications-get", cli: "notifications get"),
         .write("notifications-set", cli: "notifications set"),
         .read(
@@ -267,6 +269,14 @@ public enum ParityLedger {
                 Internal scheduler entry point: fires a job on the daemon's own \
                 timer path, bypassing the enabled/schedule checks a user-initiated \
                 run must honour. `crow job run` is the user-facing verb.
+                """),
+        .read(
+            "runner-status",
+            noCLI: """
+                Read-only snapshot of the Corveil worker runner (corveil/crow#801): \
+                enabled flag, worker id, active/max run counts, whether the API key \
+                is present, and the in-flight runs. The `crow runner` CLI verbs are \
+                a deferred follow-up ticket; the web Settings surface reads it today.
                 """),
 
         // Agent hooks

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -534,5 +534,25 @@ public enum ParityLedger {
                 secret never lands in config.json. Same local-only constraint as \
                 `jiraCredential.username`; no verb exists yet.
                 """),
+
+        // MARK: Exempt — Corveil worker runner (corveil/crow#801)
+
+        // The whole `runner` block is local-only on set-config (its `corveilURL`
+        // is where the env-sourced org API key is sent), and the `crow runner`
+        // CLI verbs are a deferred follow-up — so every leaf is web-Settings /
+        // local-config only today, with no dedicated verb.
+        .field(
+            "runner.enabled",
+            noCLI: """
+                Master switch for the Corveil worker runner (corveil/crow#801). \
+                Local-only on set-config; the `crow runner` verbs are a deferred \
+                follow-up ticket. Web Settings / config.json only today.
+                """),
+        .field("runner.corveilURL", noCLI: "Corveil base URL for the worker runner; local-only (see `runner.enabled`)."),
+        .field("runner.workerID", noCLI: "Stable worker id for claim/heartbeat/complete; local-only (see `runner.enabled`)."),
+        .field("runner.caps", noCLI: "Capabilities this runner advertises (hard claim filter); local-only (see `runner.enabled`)."),
+        .field("runner.kinds", noCLI: "Worker slugs this runner will claim; local-only (see `runner.enabled`)."),
+        .field("runner.maxConcurrentRuns", noCLI: "Per-host concurrency cap; local-only (see `runner.enabled`)."),
+        .field("runner.pollIntervalSeconds", noCLI: "Claim/heartbeat/finish poll cadence; local-only (see `runner.enabled`)."),
     ]
 }

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -216,8 +216,6 @@ public enum ParityLedger {
         .write("cleanup-set", cli: "cleanup set"),
         .read("ui-get", cli: "ui get"),
         .write("ui-set", cli: "ui set"),
-        .read("automation-get", cli: "automation get"),
-        .write("automation-set", cli: "automation set"),
         .read("notifications-get", cli: "notifications get"),
         .write("notifications-set", cli: "notifications set"),
         .read(

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -930,9 +930,12 @@ import Testing
     }
 }
 
-/// A 5th session kind must not be addable without the agents surface noticing —
+/// A new session kind must not be addable without the agents surface noticing —
 /// `allCases` drives the per-role map `crow agents list` reports and the roles
-/// `crow agents set --clear` accepts.
+/// `crow agents set --clear` accepts. `.workerRun` (corveil/crow#801) is listed
+/// like any role, though `SessionService.runWorkerRun` pins it to Claude Code (it
+/// is the only harness that receives the scoped Corveil credentials), so a
+/// per-role override for it is recorded but not honored in slice 1.
 @Test func sessionKindAllCasesCoversEveryRole() {
-    #expect(SessionKind.allCases == [.work, .review, .job, .manager])
+    #expect(SessionKind.allCases == [.work, .review, .job, .manager, .workerRun])
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/RunnerConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/RunnerConfigTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// `RunnerConfig` (corveil/crow#801): forward-compatible decoding, the
+/// env-sourced API key (never a config field), worker-id defaulting, and the
+/// clamped concurrency/poll knobs.
+@Suite("RunnerConfig")
+struct RunnerConfigTests {
+    @Test func decodesWithDefaultsForMissingKeys() throws {
+        let json = Data("{}".utf8)
+        let config = try JSONDecoder().decode(RunnerConfig.self, from: json)
+        #expect(config.enabled == false)
+        #expect(config.corveilURL == "")
+        #expect(config.caps.isEmpty)
+        #expect(config.kinds.isEmpty)
+        #expect(config.maxConcurrentRuns == 1)
+        #expect(config.pollIntervalSeconds == 30)
+    }
+
+    @Test func decodesProvidedFields() throws {
+        let json = Data(#"""
+        {"enabled":true,"corveilURL":"https://corveil.acme.io","workerID":"crow-box-2",
+         "caps":["ontology-write"],"kinds":["tend","summarize"],
+         "maxConcurrentRuns":4,"pollIntervalSeconds":15}
+        """#.utf8)
+        let config = try JSONDecoder().decode(RunnerConfig.self, from: json)
+        #expect(config.enabled)
+        #expect(config.corveilURL == "https://corveil.acme.io")
+        #expect(config.workerID == "crow-box-2")
+        #expect(config.caps == ["ontology-write"])
+        #expect(config.kinds == ["tend", "summarize"])
+        #expect(config.maxConcurrentRuns == 4)
+        #expect(config.pollIntervalSeconds == 15)
+    }
+
+    @Test func hasNoAPIKeyField() throws {
+        // The org secret must never round-trip through config.json.
+        let config = RunnerConfig(enabled: true, corveilURL: "u")
+        let data = try JSONEncoder().encode(config)
+        let json = String(decoding: data, as: UTF8.self).lowercased()
+        #expect(!json.contains("apikey"))
+        #expect(!json.contains("api_key"))
+        #expect(!json.contains("corveil_api_key"))
+    }
+
+    @Test func resolvedWorkerIDUsesConfiguredValue() {
+        let config = RunnerConfig(workerID: "  crow-custom-7  ")
+        #expect(config.resolvedWorkerID(hostName: "ignored") == "crow-custom-7")
+    }
+
+    @Test func resolvedWorkerIDDefaultsFromHostname() {
+        let config = RunnerConfig(workerID: "")
+        #expect(config.resolvedWorkerID(hostName: "Janes-MacBook.local") == "crow-janes-macbook-1")
+    }
+
+    @Test func slugHostNormalizes() {
+        #expect(RunnerConfig.slugHost("Build.Box_02.local") == "build-box-02")
+        #expect(RunnerConfig.slugHost("") == "host")
+    }
+
+    @Test func concurrencyAndPollAreClamped() {
+        let config = RunnerConfig(maxConcurrentRuns: 0, pollIntervalSeconds: 1)
+        #expect(config.effectiveMaxConcurrentRuns == 1)   // never below 1
+        #expect(config.effectivePollIntervalSeconds == 5) // never below 5
+    }
+
+    @Test func decodesAsPartOfAppConfig() throws {
+        let json = Data(#"{"runner":{"enabled":true,"kinds":["tend"]}}"#.utf8)
+        let appConfig = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(appConfig.runner?.enabled == true)
+        #expect(appConfig.runner?.kinds == ["tend"])
+    }
+
+    @Test func appConfigWithoutRunnerBlockDecodesNil() throws {
+        let appConfig = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+        #expect(appConfig.runner == nil)
+    }
+}

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -103,8 +103,9 @@ public struct CursorAgent: CodingAgent {
             // seed always applies, and the auto-permission flags when the opt-in
             // coder-view toggle is on (#586) — both come from `launchArgs`.
             return "\(agentPath)\(launchArgs)\n"
-        case .job, .review:
-            // Jobs and reviews share the same dispatch shape: a pre-written
+        case .job, .review, .workerRun:
+            // Jobs, reviews, and Corveil worker runs share the same dispatch
+            // shape: a pre-written
             // initial prompt file (`.crow-job-prompt.md` / `.crow-review-prompt.md`)
             // is fed as the positional prompt on first launch so Cursor starts
             // working unattended. Cursor's interactive TUI accepts a positional

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -385,6 +385,20 @@ public enum CrowDaemon {
         }
         if let jobScheduler { startJobPoll(scheduler: jobScheduler) }
 
+        // Corveil worker runner (corveil/crow#801) — the Corveil-sourced twin of
+        // the JobScheduler. Like it, `WorkerRunner.start()` wants a `RunLoop.main`
+        // Timer the daemon lacks, so build it here and drive `tick()` from an
+        // explicit async poll. Gated on the same authority (a SessionService-backed
+        // scheduler); the org API key is read from the crowd env, never persisted.
+        let workerRunner: WorkerRunner? = await MainActor.run { () -> WorkerRunner? in
+            guard let sessionService else { return nil }
+            let runner = WorkerRunner(appState: appState, sessionService: sessionService)
+            runner.configProvider = { ConfigStore.loadConfig(devRoot: options.devRoot)?.runner }
+            runner.devRootProvider = { options.devRoot }
+            return runner
+        }
+        if let workerRunner { startRunnerPoll(runner: workerRunner) }
+
         // Delegate any method the daemon's curated router doesn't explicitly own
         // to the app's FULL engine router (hook-event, send, link/ticket ops,
         // resync-jira, get-session, list-worktrees, …). This makes a "missing
@@ -415,6 +429,7 @@ public enum CrowDaemon {
             appState: appState, store: store, git: git, devRoot: options.devRoot,
             cockpit: cockpit, tracker: tracker, allowList: allowList,
             sessionService: sessionService, autoRespond: autoRespond, jobScheduler: jobScheduler,
+            workerRunner: workerRunner,
             rebuildScorecard: rebuildScorecard, fallback: engineFallback)
 
         // Unix socket — lets the existing `crow` CLI talk to the daemon. By
@@ -891,6 +906,22 @@ public enum CrowDaemon {
             while !Task.isCancelled {
                 await MainActor.run { scheduler.tick() }
                 try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
+            }
+        }
+    }
+
+    /// Drive the Corveil worker runner's claim/heartbeat/finish loop headlessly
+    /// (corveil/crow#801). Mirrors `startJobPoll`, but `tick()` is async (each
+    /// step is a `corveil` CLI round-trip) and the cadence follows the runner
+    /// config's poll interval (re-read each loop so a config change takes effect).
+    private static func startRunnerPoll(runner: WorkerRunner) {
+        Task {
+            while !Task.isCancelled {
+                await runner.tick()
+                let seconds = await MainActor.run {
+                    runner.configProvider()?.effectivePollIntervalSeconds ?? 30
+                }
+                try? await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
             }
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -158,6 +158,9 @@ func makeCommandRouter(
     sessionService: SessionService? = nil,
     autoRespond: AutoRespondCoordinator? = nil,
     jobScheduler: JobScheduler? = nil,
+    // Backs the read-only `runner-status` RPC (corveil/crow#801). Nil when no
+    // SessionService-backed runner exists (no tmux).
+    workerRunner: WorkerRunner? = nil,
     // Backs `rebuild-scorecard` (#767). Defined by the daemon where both the
     // SessionService and the telemetry receiver are in scope; nil when telemetry
     // is off (there'd be no DB to rebuild from).
@@ -1420,6 +1423,37 @@ func makeCommandRouter(
             }
             await MainActor.run { jobScheduler.runNow(id) }
             return ["ok": .bool(true)]
+        },
+
+        // Read-only snapshot of the Corveil worker runner (corveil/crow#801):
+        // whether it's enabled, its worker id, the active/max run counts, whether
+        // the org API key is present in the crowd env, and the runs currently in
+        // flight. Reports `enabled=false` when no runner exists (no tmux).
+        "runner-status": { _ in
+            guard let workerRunner else {
+                return [
+                    "enabled": .bool(false),
+                    "active_runs": .int(0),
+                    "max_concurrent": .int(0),
+                    "api_key_present": .bool(false),
+                    "watched": .array([]),
+                ]
+            }
+            let status = await MainActor.run { workerRunner.statusSnapshot() }
+            return [
+                "enabled": .bool(status.enabled),
+                "worker_id": .string(status.workerID),
+                "active_runs": .int(status.activeRuns),
+                "max_concurrent": .int(status.maxConcurrent),
+                "api_key_present": .bool(status.apiKeyPresent),
+                "watched": .array(status.watched.map { run in
+                    .object([
+                        "run_id": .string(run.runID),
+                        "session_id": .string(run.sessionID),
+                        "status": .string(run.status),
+                    ])
+                }),
+            ]
         },
 
         // Job management for `crow job` (CROW-604). Mutating verbs change

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -165,8 +165,10 @@ enum RPCWebSocketHandler {
     ///
     /// `defaults-set` IS gated, but only when the request carries a `binaries`
     /// param — see the case below for why presence and not a diff.
-    /// `defaults.binaries` therefore remains the sole local-only config field,
-    /// now enforced across two methods instead of one.
+    /// `defaults.binaries` is enforced across both `set-config` and `defaults-set`;
+    /// the Corveil worker `runner` block is additionally local-only on `set-config`
+    /// (its `corveilURL` is where the env-sourced org API key is sent, so a remote
+    /// write must not be able to redirect it — corveil/crow#801).
     ///
     /// `agents-get` / `agents-set` (CROW-811) follow that same rule: they read and
     /// write `AppConfig.defaultAgentKind` + `agentsByKind`, which name a harness
@@ -204,7 +206,7 @@ enum RPCWebSocketHandler {
             return "gateway and web-password management is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
-            return "set-config binaries is local-only"
+            return "set-config of agent binaries or the Corveil worker runner is local-only"
         case "defaults-set":
             // The only granular settings RPC that can reach `defaults.binaries`
             // — absolute local paths that execute at the next agent launch.
@@ -235,9 +237,18 @@ enum RPCWebSocketHandler {
         }
     }
 
-    /// True when the incoming `set-config` payload would change agent binary
-    /// overrides relative to what's on disk. Scheduled `jobs` are no longer
+    /// True when the incoming `set-config` payload would change a privileged
+    /// field relative to what's on disk. Scheduled `jobs` are no longer
     /// privileged — an authenticated remote session may edit them (CROW-665).
+    ///
+    /// Privileged fields:
+    /// - `defaults.binaries` — agent binary overrides (host process paths).
+    /// - `runner` — the Corveil worker-runner block (corveil/crow#801). Its
+    ///   `corveilURL` is where the env-sourced org `CORVEIL_API_KEY` is sent on
+    ///   every `corveil` call, so a remote write could redirect the key to an
+    ///   attacker's host; and remotely flipping `enabled` / `caps` / `kinds` would
+    ///   let an authenticated remote session enlist or re-scope this runner. The
+    ///   whole block is therefore local-only (same trust domain as the env key).
     static func setConfigTouchesPrivilegedFields(_ request: JSONRPCRequest, devRoot: String) -> Bool {
         guard let json = request.params?["config"]?.stringValue,
               let data = json.data(using: .utf8),
@@ -247,5 +258,6 @@ enum RPCWebSocketHandler {
         }
         let current = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
         return incoming.defaults.binaries != current.defaults.binaries
+            || incoming.runner != current.runner
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/AgentsHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/AgentsHandlerTests.swift
@@ -73,6 +73,7 @@ import CrowPersistence
             "review": .string("claude-code"),
             "job": .string("claude-code"),
             "manager": .string("claude-code"),
+            "workerRun": .string("claude-code"),
         ]))
         #expect(payload?["config_readable"] == .bool(true))
     }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -880,7 +880,7 @@ import CrowPersistence
             "config": .string(try encode(incoming)),
         ])
         #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot)
-            == "set-config binaries is local-only")
+            == "set-config of agent binaries or the Corveil worker runner is local-only")
         #expect(RPCWebSocketHandler.setConfigTouchesPrivilegedFields(req, devRoot: devRoot))
     }
 
@@ -908,6 +908,24 @@ import CrowPersistence
             #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot) == nil,
                     "\(method) must stay reachable from a remote /rpc peer")
         }
+    }
+
+    @Test func setConfigRunnerChangeIsLocalOnly() throws {
+        // The `runner` block is local-only (corveil/crow#801): its `corveilURL`
+        // is where the env-sourced org API key is sent, so a remote set-config
+        // must not be able to redirect it (or flip enabled / caps / kinds).
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
+
+        var incoming = AppConfig()
+        incoming.runner = RunnerConfig(enabled: true, corveilURL: "https://evil.example")
+        let req = JSONRPCRequest(id: 1, method: "set-config", params: [
+            "config": .string(try encode(incoming)),
+        ])
+        #expect(RPCWebSocketHandler.setConfigTouchesPrivilegedFields(req, devRoot: devRoot))
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: devRoot)
+            == "set-config of agent binaries or the Corveil worker runner is local-only")
     }
 
     @Test func setConfigJobsChangeIsAllowedRemotely() throws {

--- a/Packages/CrowEngine/Sources/CrowEngine/AgentHandoff.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AgentHandoff.swift
@@ -5,6 +5,7 @@ import CrowCore
 public enum AgentHandoffError: Error, LocalizedError, Equatable {
     case sessionNotFound
     case managerNotSupported
+    case workerRunNotSupported
     case sameAgent
     case agentNotRegistered(String)
     case agentBinaryMissing(String)
@@ -18,6 +19,8 @@ public enum AgentHandoffError: Error, LocalizedError, Equatable {
             return "Session not found"
         case .managerNotSupported:
             return "Manager sessions cannot be handed off; change the Manager agent in Settings and restart"
+        case .workerRunNotSupported:
+            return "Corveil worker-run sessions cannot be handed off — only Claude Code receives the scoped Corveil credentials"
         case .sameAgent:
             return "Session is already using that agent"
         case .agentNotRegistered(let kind):

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1185,6 +1185,14 @@ public final class SessionService {
         guard !session.isManager else {
             throw AgentHandoffError.managerNotSupported
         }
+        // Worker-run sessions are pinned to Claude Code because only Claude's
+        // `.claude/settings.local.json` receives the scoped Corveil credentials
+        // (`writeCorveilRunEnv`). A handoff to Cursor/Codex/OpenCode would launch
+        // the remote `prompt_body` under auto-permission WITHOUT that env — refuse
+        // it until per-harness injection ships (corveil/crow#801 review).
+        guard session.kind != .workerRun else {
+            throw AgentHandoffError.workerRunNotSupported
+        }
         let priorKind = session.agentKind
         guard priorKind != targetKind else {
             throw AgentHandoffError.sameAgent
@@ -3201,6 +3209,19 @@ public final class SessionService {
         workerID: String
     ) async -> (sessionID: UUID, terminalID: UUID, scratchDir: String)? {
         let scratchDir = Self.workerRunScratchDir(devRoot: devRoot, runID: run.id)
+
+        // Start from a CLEAN scratch dir. A previous attempt for the same run id
+        // could have left a stale `.crow-run-result.json` (or leftover creds); a
+        // stale result would otherwise be mapped onto `worker-run complete` for
+        // this fresh run (review). `createDirectory` does not clear contents, so
+        // wipe first. If a stale dir genuinely can't be removed, abort rather than
+        // launch into dirty state — the tick-level orphan sweep will retry it.
+        if FileManager.default.fileExists(atPath: scratchDir),
+           !Self.wipeWorkerRunScratch(scratchDir) {
+            NSLog("[SessionService] Worker run '%@': stale scratch dir could not be cleared at %@; aborting",
+                  run.id, scratchDir)
+            return nil
+        }
 
         // Create the scratch dir 0700 (it will hold the scoped API key). Both the
         // `.crow-worker-runs` parent (created here via `withIntermediateDirectories`,

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -972,6 +972,9 @@ public final class SessionService {
         // has its own managerAutoPermissionMode path and is unaffected here.
         let autoPermissionMode =
             (session.kind == .job && appState.jobsAutoPermissionMode) ||
+            // Corveil worker runs are unattended like jobs, so they reuse the
+            // jobs auto-permission toggle (corveil/crow#801).
+            (session.kind == .workerRun && appState.jobsAutoPermissionMode) ||
             (session.kind == .review && appState.reviewAutoPermissionMode) ||
             (session.kind == .work && appState.coderViewAutoPermissionMode)
         // The agent's autoLaunchCommand mirrors this condition — the initial
@@ -979,7 +982,7 @@ public final class SessionService {
         // Compute it here so we know whether to flip `reviewPromptDispatched`
         // (reused as the generic "initial prompt dispatched" gate) after the
         // command goes out.
-        let reviewPromptJustDispatched = (session.kind == .review || session.kind == .job)
+        let reviewPromptJustDispatched = (session.kind == .review || session.kind == .job || session.kind == .workerRun)
             && !session.reviewPromptDispatched
         guard let command = agent.autoLaunchCommand(
             session: session,
@@ -3107,6 +3110,148 @@ public final class SessionService {
         return formatter.string(from: Date())
     }
 
+    // MARK: - Corveil worker runs (corveil/crow#801)
+
+    /// Parent directory for repo-less worker-run scratch workdirs under a dev
+    /// root. Each run gets `{devRoot}/.crow-worker-runs/<runID>`; the whole
+    /// subtree is wiped on finish (it holds the scoped `CORVEIL_API_KEY`).
+    nonisolated static func workerRunsRoot(devRoot: String) -> String {
+        (devRoot as NSString).appendingPathComponent(".crow-worker-runs")
+    }
+
+    /// The scratch workdir for a specific run. Pure path math (unit-testable).
+    nonisolated static func workerRunScratchDir(devRoot: String, runID: String) -> String {
+        (workerRunsRoot(devRoot: devRoot) as NSString)
+            .appendingPathComponent(scratchSlug(runID))
+    }
+
+    /// A filesystem-safe token derived from a run id (ids may be UUIDs or slugs).
+    nonisolated static func scratchSlug(_ runID: String) -> String {
+        var slug = ""
+        var lastDash = false
+        for scalar in runID.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                slug.unicodeScalars.append(scalar)
+                lastDash = false
+            } else if !lastDash {
+                slug.append("-")
+                lastDash = true
+            }
+        }
+        let cleaned = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return cleaned.isEmpty ? "run" : String(cleaned.prefix(64))
+    }
+
+    /// Spin up a repo-less scratch workdir for a claimed Corveil worker run and
+    /// launch the agent in it (corveil/crow#801). Mirrors `runJob`, but with **no
+    /// git worktree**: a throwaway dir under `.crow-worker-runs/` holds the
+    /// wrapped prompt + injected `corveil` credentials, and a *synthetic*
+    /// `SessionWorktree` points the existing launch machinery (`launchAgent`
+    /// hooks/trust/gateway) at that dir. Returns the created session/terminal and
+    /// the scratch dir (for finish-time result read + wipe), or `nil` on setup
+    /// failure.
+    func runWorkerRun(
+        run: WorkerRun,
+        devRoot: String,
+        corveilURL: String,
+        apiKey: String,
+        workerID: String
+    ) async -> (sessionID: UUID, terminalID: UUID, scratchDir: String)? {
+        let scratchDir = Self.workerRunScratchDir(devRoot: devRoot, runID: run.id)
+
+        // Create the scratch dir 0700 (it will hold the scoped API key).
+        do {
+            try FileManager.default.createDirectory(
+                atPath: scratchDir,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } catch {
+            NSLog("[SessionService] Worker run '%@': failed to create scratch dir %@: %@",
+                  run.id, scratchDir, error.localizedDescription)
+            return nil
+        }
+
+        // Write the wrapped prompt to the file the launcher reads on first launch.
+        // As with runJob, a write failure is fatal — an empty `$(cat …)` would
+        // silently launch a blank prompt (CROW-439).
+        let prompt = WorkerRunPrompt.build(run: run, workerID: workerID)
+        let promptPath = (scratchDir as NSString).appendingPathComponent(".crow-job-prompt.md")
+        do {
+            try prompt.write(toFile: promptPath, atomically: true, encoding: .utf8)
+        } catch {
+            NSLog("[SessionService] Worker run '%@': failed to write %@: %@",
+                  run.id, promptPath, error.localizedDescription)
+            Self.wipeWorkerRunScratch(scratchDir)
+            return nil
+        }
+
+        // Inject Corveil credentials + run identity into the scratch dir so the
+        // agent can call `corveil worker-run mcp-call` / `corveil ask` without a
+        // login session. 0600, wiped on finish.
+        ClaudeHookConfigWriter.writeCorveilRunEnv(
+            dirPath: scratchDir,
+            corveilURL: corveilURL,
+            apiKey: apiKey,
+            runID: run.id,
+            workerID: workerID
+        )
+
+        let session = Session(
+            name: "worker-\(run.kind ?? "run")-\(Self.scratchSlug(run.id).prefix(12))",
+            kind: .workerRun,
+            agentKind: appState.agentKind(for: .workerRun),
+            ticketTitle: run.promptTitle,
+            workerRunID: run.id,
+            workerID: workerID,
+            workerRunScratchDir: scratchDir
+        )
+        // Synthetic worktree: no git, but a primary worktree is required for
+        // `launchAgent` to resolve the launch dir. `worktreePath == scratchDir`
+        // is where the prompt file + injected env live.
+        let worktree = SessionWorktree(
+            sessionID: session.id,
+            repoName: "corveil-worker-run",
+            repoPath: scratchDir,
+            worktreePath: scratchDir,
+            branch: "",
+            isPrimary: true
+        )
+        let terminal = SessionTerminal(
+            sessionID: session.id,
+            name: session.agentKind.displayName,
+            cwd: scratchDir,
+            isManaged: true
+        )
+
+        let preparedTerminal = prepareTerminal(terminal, trackReadiness: true)
+
+        appState.sessions.append(session)
+        appState.worktrees[session.id] = [worktree]
+        appState.terminals[session.id] = [preparedTerminal]
+        appState.terminalReadiness[preparedTerminal.id] = .uninitialized
+        appState.autoLaunchTerminals.insert(preparedTerminal.id)
+
+        store.mutate { data in
+            data.sessions.append(session)
+            data.worktrees.append(worktree)
+            data.terminals.append(preparedTerminal)
+        }
+
+        NSLog("[SessionService] Worker run '%@': created session '%@' at %@",
+              run.id, session.name, scratchDir)
+        return (session.id, preparedTerminal.id, scratchDir)
+    }
+
+    /// Recursively remove a worker-run scratch dir. Best-effort — the dir holds
+    /// the scoped `CORVEIL_API_KEY`, so this is the security teardown for a run
+    /// (called on completion and on abnormal exit). No-op if already gone or the
+    /// path is empty.
+    nonisolated static func wipeWorkerRunScratch(_ path: String) {
+        guard !path.isEmpty else { return }
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
     // MARK: - Review Prompt
 
     /// Filename of the initial prompt file the launcher expects for a given
@@ -3120,7 +3265,9 @@ public final class SessionService {
     nonisolated static func initialPromptFileName(for kind: SessionKind) -> String? {
         switch kind {
         case .review: return ".crow-review-prompt.md"
-        case .job:    return ".crow-job-prompt.md"
+        // A Corveil worker run reuses the job prompt-file convention in its
+        // scratch workdir (corveil/crow#801).
+        case .job, .workerRun: return ".crow-job-prompt.md"
         case .work, .manager: return nil
         }
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -3149,7 +3149,12 @@ public final class SessionService {
             .appendingPathComponent(scratchSlug(runID))
     }
 
-    /// A filesystem-safe token derived from a run id (ids may be UUIDs or slugs).
+    /// A filesystem-safe, collision-free token derived from a run id (ids may be
+    /// UUIDs or slugs). The readable part sanitizes the id to alphanumerics/dashes;
+    /// a deterministic hash suffix of the RAW id guarantees uniqueness so two
+    /// distinct ids that sanitize to the same slug (e.g. `aaa!` / `aaa?` → `aaa`)
+    /// never collide onto one scratch dir and clobber each other's prompt/creds
+    /// (review).
     nonisolated static func scratchSlug(_ runID: String) -> String {
         var slug = ""
         var lastDash = false
@@ -3163,7 +3168,21 @@ public final class SessionService {
             }
         }
         let cleaned = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
-        return cleaned.isEmpty ? "run" : String(cleaned.prefix(64))
+        let base = cleaned.isEmpty ? "run" : String(cleaned.prefix(48))
+        return "\(base)-\(fnv1aHex(runID))"
+    }
+
+    /// Deterministic FNV-1a 32-bit hash of a string as 8 lowercase hex chars.
+    /// Stable across processes (unlike Swift's randomized `Hasher`), so a given
+    /// run id always maps to the same scratch dir — required for the reconcile /
+    /// relaunch path to find and wipe it.
+    nonisolated static func fnv1aHex(_ s: String) -> String {
+        var hash: UInt32 = 2_166_136_261
+        for byte in s.utf8 {
+            hash ^= UInt32(byte)
+            hash = hash &* 16_777_619
+        }
+        return String(format: "%08x", hash)
     }
 
     /// Spin up a repo-less scratch workdir for a claimed Corveil worker run and
@@ -3285,22 +3304,37 @@ public final class SessionService {
         return (session.id, preparedTerminal.id, scratchDir)
     }
 
-    /// Recursively remove a worker-run scratch dir. Best-effort — the dir holds
-    /// the scoped `CORVEIL_API_KEY`, so this is the security teardown for a run
-    /// (called on completion, on abnormal exit, and on session delete). No-op if
-    /// already gone or the path is empty.
+    /// Recursively remove a worker-run scratch dir. The dir holds the scoped
+    /// `CORVEIL_API_KEY`, so this is the security teardown for a run (called on
+    /// completion, abnormal exit, and session delete).
+    ///
+    /// Returns `true` when it is safe to stop tracking the dir: it was removed, it
+    /// was already gone, or the path isn't ours to touch (guard refusal). Returns
+    /// `false` only when the dir IS a scratch path but removal genuinely failed
+    /// and it is still on disk — the caller keeps the watch and retries on a later
+    /// tick rather than orphaning the key with no retry (review).
     ///
     /// Defense in depth: refuses any path whose immediate parent is not
     /// `.crow-worker-runs`, so a corrupted/attacker-influenced `workerRunScratchDir`
     /// can never turn this into an arbitrary recursive delete (review).
-    nonisolated static func wipeWorkerRunScratch(_ path: String) {
+    @discardableResult
+    nonisolated static func wipeWorkerRunScratch(_ path: String) -> Bool {
         guard isWorkerRunScratchPath(path) else {
             if !path.isEmpty {
                 NSLog("[SessionService] Refusing to wipe non-scratch path: %@", path)
             }
-            return
+            return true  // not ours to remove — don't loop retrying it
         }
-        try? FileManager.default.removeItem(atPath: path)
+        do {
+            try FileManager.default.removeItem(atPath: path)
+            return true
+        } catch {
+            // Already gone is success; a real failure leaves the key on disk.
+            if !FileManager.default.fileExists(atPath: path) { return true }
+            NSLog("[SessionService] Failed to wipe worker-run scratch %@: %@ (will retry)",
+                  path, error.localizedDescription)
+            return false
+        }
     }
 
     /// Whether `path` is a well-formed worker-run scratch dir: a non-empty path

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -3687,6 +3687,29 @@ public final class SessionService {
         }
     }
 
+    /// Clear a `.workerRun` session's Corveil linkage (`workerRunID` / `workerID`
+    /// / `workerRunScratchDir`) once its run has reached a terminal state and the
+    /// scratch dir is wiped. This severs the session from the finished Corveil
+    /// run so that re-activating it (a remote `set-status … active` is allowed)
+    /// can NOT make the worker runner re-adopt it, re-heartbeat an already-failed
+    /// claim, and hold a concurrency slot — reconcile now sees incomplete linkage
+    /// and fails it closed instead (corveil/crow#801 review).
+    public func clearWorkerRunLinkage(sessionID: UUID) {
+        func apply(_ session: inout Session) {
+            session.workerRunID = nil
+            session.workerID = nil
+            session.workerRunScratchDir = nil
+        }
+        if let idx = appState.sessions.firstIndex(where: { $0.id == sessionID }) {
+            apply(&appState.sessions[idx])
+        }
+        store.mutate { data in
+            if let idx = data.sessions.firstIndex(where: { $0.id == sessionID }) {
+                apply(&data.sessions[idx])
+            }
+        }
+    }
+
     public func setSessionInReview(id: UUID) {
         updateSessionStatus(id, to: .inReview)
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1820,6 +1820,12 @@ public final class SessionService {
         let wts = appState.worktrees(for: id)
         let terminals = appState.terminals(for: id)
         let isReview = session?.kind == .review
+        // A worker-run scratch dir is a standalone directory (repoPath ==
+        // worktreePath, no git), so like a review clone it must be removed
+        // wholesale rather than skipped by the main-checkout guard — and it holds
+        // the scoped CORVEIL_API_KEY, so it must never be orphaned (review).
+        let isWorkerRun = session?.kind == .workerRun
+        let workerScratchDir = session?.workerRunScratchDir
         let items = wts.map {
             WorktreeCleanupItem(
                 repoPath: $0.repoPath,
@@ -1836,7 +1842,12 @@ public final class SessionService {
         // Slow git + filesystem work runs on a background thread so the main actor
         // stays free to render the spinner and respond to other input.
         let cleanupError: String? = await Task.detached(priority: .utility) {
-            Self.performDiskCleanup(items: items, isReview: isReview)
+            let error = Self.performDiskCleanup(items: items, isReview: isReview, isWorkerRun: isWorkerRun)
+            // Belt-and-suspenders: always wipe the scratch dir by its recorded
+            // path too, even if the worktree list was empty or diverged — the
+            // scoped API key must not survive session deletion (review).
+            if let workerScratchDir { Self.wipeWorkerRunScratch(workerScratchDir) }
+            return error
         }.value
 
         if let cleanupError {
@@ -1906,7 +1917,8 @@ public final class SessionService {
     /// Soft failures (branch delete, prune) only get NSLog'd.
     nonisolated static func performDiskCleanup(
         items: [WorktreeCleanupItem],
-        isReview: Bool
+        isReview: Bool,
+        isWorkerRun: Bool = false
     ) -> String? {
         var firstFatalError: String? = nil
 
@@ -1914,13 +1926,17 @@ public final class SessionService {
             // Review clones are standalone `git clone` checkouts (not `git worktree add`
             // artifacts) and always have repoPath == worktreePath, which would otherwise
             // trip the main-checkout guard below and leave the clone orphaned on disk.
-            if isReview {
+            // Worker-run scratch dirs share that shape (no git at all), and additionally
+            // hold the scoped CORVEIL_API_KEY, so they must be removed wholesale too
+            // rather than skipped as a "main checkout" (corveil/crow#801 review).
+            if isReview || isWorkerRun {
+                let label = isWorkerRun ? "worker-run scratch dir" : "review clone"
                 guard FileManager.default.fileExists(atPath: item.worktreePath) else { continue }
                 do {
                     try FileManager.default.removeItem(atPath: item.worktreePath)
-                    CrowLog.info("[SessionService] Cleaned up review clone: \(item.worktreePath)")
+                    CrowLog.info("[SessionService] Cleaned up \(label): \(item.worktreePath)")
                 } catch {
-                    let msg = "Failed to remove review clone: \(error.localizedDescription)"
+                    let msg = "Failed to remove \(label): \(error.localizedDescription)"
                     CrowLog.info("[SessionService] \(msg) (\(item.worktreePath))")
                     if firstFatalError == nil { firstFatalError = msg }
                 }
@@ -3159,16 +3175,24 @@ public final class SessionService {
     ) async -> (sessionID: UUID, terminalID: UUID, scratchDir: String)? {
         let scratchDir = Self.workerRunScratchDir(devRoot: devRoot, runID: run.id)
 
-        // Create the scratch dir 0700 (it will hold the scoped API key).
+        // Create the scratch dir 0700 (it will hold the scoped API key). Both the
+        // `.crow-worker-runs` parent (created here via `withIntermediateDirectories`,
+        // which would otherwise inherit the process umask) and the run dir itself
+        // are chmod'd explicitly after create — `createDirectory(attributes:)`
+        // does NOT re-apply the mode if a directory already exists (review).
         do {
+            let parent = Self.workerRunsRoot(devRoot: devRoot)
             try FileManager.default.createDirectory(
                 atPath: scratchDir,
                 withIntermediateDirectories: true,
                 attributes: [.posixPermissions: 0o700]
             )
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent)
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: scratchDir)
         } catch {
             NSLog("[SessionService] Worker run '%@': failed to create scratch dir %@: %@",
                   run.id, scratchDir, error.localizedDescription)
+            Self.wipeWorkerRunScratch(scratchDir)
             return nil
         }
 
@@ -3188,19 +3212,29 @@ public final class SessionService {
 
         // Inject Corveil credentials + run identity into the scratch dir so the
         // agent can call `corveil worker-run mcp-call` / `corveil ask` without a
-        // login session. 0600, wiped on finish.
-        ClaudeHookConfigWriter.writeCorveilRunEnv(
+        // login session. 0600, wiped on finish. A write failure is FATAL: an
+        // agent launched without the scoped env can't write back (or would reach
+        // for ambient creds), so fail the run rather than launch it blind (review).
+        guard ClaudeHookConfigWriter.writeCorveilRunEnv(
             dirPath: scratchDir,
             corveilURL: corveilURL,
             apiKey: apiKey,
             runID: run.id,
             workerID: workerID
-        )
+        ) else {
+            NSLog("[SessionService] Worker run '%@': failed to inject Corveil credentials; aborting", run.id)
+            Self.wipeWorkerRunScratch(scratchDir)
+            return nil
+        }
 
         let session = Session(
             name: "worker-\(run.kind ?? "run")-\(Self.scratchSlug(run.id).prefix(12))",
             kind: .workerRun,
-            agentKind: appState.agentKind(for: .workerRun),
+            // Slice 1 pins Claude Code: credential injection writes Claude's
+            // `.claude/settings.local.json`, which the other harnesses don't read,
+            // so a non-Claude worker run would launch without its scoped env
+            // (corveil/crow#801 review). Per-harness env injection is a follow-up.
+            agentKind: .claudeCode,
             ticketTitle: run.promptTitle,
             workerRunID: run.id,
             workerID: workerID,
@@ -3245,11 +3279,30 @@ public final class SessionService {
 
     /// Recursively remove a worker-run scratch dir. Best-effort — the dir holds
     /// the scoped `CORVEIL_API_KEY`, so this is the security teardown for a run
-    /// (called on completion and on abnormal exit). No-op if already gone or the
-    /// path is empty.
+    /// (called on completion, on abnormal exit, and on session delete). No-op if
+    /// already gone or the path is empty.
+    ///
+    /// Defense in depth: refuses any path whose immediate parent is not
+    /// `.crow-worker-runs`, so a corrupted/attacker-influenced `workerRunScratchDir`
+    /// can never turn this into an arbitrary recursive delete (review).
     nonisolated static func wipeWorkerRunScratch(_ path: String) {
-        guard !path.isEmpty else { return }
+        guard isWorkerRunScratchPath(path) else {
+            if !path.isEmpty {
+                NSLog("[SessionService] Refusing to wipe non-scratch path: %@", path)
+            }
+            return
+        }
         try? FileManager.default.removeItem(atPath: path)
+    }
+
+    /// Whether `path` is a well-formed worker-run scratch dir: a non-empty path
+    /// whose immediate parent directory is named `.crow-worker-runs`. Pure so the
+    /// safety guard is unit-testable.
+    nonisolated static func isWorkerRunScratchPath(_ path: String) -> Bool {
+        guard !path.isEmpty else { return false }
+        let normalized = (path as NSString).standardizingPath
+        let parent = (normalized as NSString).deletingLastPathComponent
+        return (parent as NSString).lastPathComponent == ".crow-worker-runs"
     }
 
     // MARK: - Review Prompt

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1944,7 +1944,7 @@ public final class SessionService {
                 // this into an arbitrary recursive delete (review — consistent
                 // threat model across both teardown paths).
                 if isWorkerRun && !isWorkerRunScratchPath(item.worktreePath) {
-                    NSLog("[SessionService] Refusing to remove non-scratch worker-run path: \(item.worktreePath)")
+                    CrowLog.info("[SessionService] Refusing to remove non-scratch worker-run path: \(item.worktreePath)")
                     continue
                 }
                 guard FileManager.default.fileExists(atPath: item.worktreePath) else { continue }
@@ -3218,8 +3218,7 @@ public final class SessionService {
         // launch into dirty state — the tick-level orphan sweep will retry it.
         if FileManager.default.fileExists(atPath: scratchDir),
            !Self.wipeWorkerRunScratch(scratchDir) {
-            NSLog("[SessionService] Worker run '%@': stale scratch dir could not be cleared at %@; aborting",
-                  run.id, scratchDir)
+            CrowLog.info("[SessionService] Worker run '\(run.id)': stale scratch dir could not be cleared at \(scratchDir); aborting")
             return nil
         }
 
@@ -3238,8 +3237,7 @@ public final class SessionService {
             try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent)
             try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: scratchDir)
         } catch {
-            NSLog("[SessionService] Worker run '%@': failed to create scratch dir %@: %@",
-                  run.id, scratchDir, error.localizedDescription)
+            CrowLog.error("[SessionService] Worker run '\(run.id)': failed to create scratch dir \(scratchDir): \(error.localizedDescription)")
             Self.wipeWorkerRunScratch(scratchDir)
             return nil
         }
@@ -3252,8 +3250,7 @@ public final class SessionService {
         do {
             try prompt.write(toFile: promptPath, atomically: true, encoding: .utf8)
         } catch {
-            NSLog("[SessionService] Worker run '%@': failed to write %@: %@",
-                  run.id, promptPath, error.localizedDescription)
+            CrowLog.error("[SessionService] Worker run '\(run.id)': failed to write \(promptPath): \(error.localizedDescription)")
             Self.wipeWorkerRunScratch(scratchDir)
             return nil
         }
@@ -3270,7 +3267,7 @@ public final class SessionService {
             runID: run.id,
             workerID: workerID
         ) else {
-            NSLog("[SessionService] Worker run '%@': failed to inject Corveil credentials; aborting", run.id)
+            CrowLog.error("[SessionService] Worker run '\(run.id)': failed to inject Corveil credentials; aborting")
             Self.wipeWorkerRunScratch(scratchDir)
             return nil
         }
@@ -3320,8 +3317,7 @@ public final class SessionService {
             data.terminals.append(preparedTerminal)
         }
 
-        NSLog("[SessionService] Worker run '%@': created session '%@' at %@",
-              run.id, session.name, scratchDir)
+        CrowLog.info("[SessionService] Worker run '\(run.id)': created session '\(session.name)' at \(scratchDir)")
         return (session.id, preparedTerminal.id, scratchDir)
     }
 
@@ -3342,7 +3338,7 @@ public final class SessionService {
     nonisolated static func wipeWorkerRunScratch(_ path: String) -> Bool {
         guard isWorkerRunScratchPath(path) else {
             if !path.isEmpty {
-                NSLog("[SessionService] Refusing to wipe non-scratch path: %@", path)
+                CrowLog.info("[SessionService] Refusing to wipe non-scratch path: \(path)")
             }
             return true  // not ours to remove — don't loop retrying it
         }
@@ -3352,8 +3348,7 @@ public final class SessionService {
         } catch {
             // Already gone is success; a real failure leaves the key on disk.
             if !FileManager.default.fileExists(atPath: path) { return true }
-            NSLog("[SessionService] Failed to wipe worker-run scratch %@: %@ (will retry)",
-                  path, error.localizedDescription)
+            CrowLog.error("[SessionService] Failed to wipe worker-run scratch \(path): \(error.localizedDescription) (will retry)")
             return false
         }
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1931,6 +1931,14 @@ public final class SessionService {
             // rather than skipped as a "main checkout" (corveil/crow#801 review).
             if isReview || isWorkerRun {
                 let label = isWorkerRun ? "worker-run scratch dir" : "review clone"
+                // Worker-run dirs get the same parent-name guard as
+                // `wipeWorkerRunScratch`, so a corrupted `worktreePath` can't turn
+                // this into an arbitrary recursive delete (review — consistent
+                // threat model across both teardown paths).
+                if isWorkerRun && !isWorkerRunScratchPath(item.worktreePath) {
+                    NSLog("[SessionService] Refusing to remove non-scratch worker-run path: \(item.worktreePath)")
+                    continue
+                }
                 guard FileManager.default.fileExists(atPath: item.worktreePath) else { continue }
                 do {
                     try FileManager.default.removeItem(atPath: item.worktreePath)

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -3672,6 +3672,21 @@ public final class SessionService {
     public func completeSession(id: UUID) {        updateSessionStatus(id, to: .completed)
     }
 
+    /// Destroy a session's managed terminal(s), stopping the agent process.
+    /// `completeSession` only flips status — the agent keeps running (and keeps
+    /// the scoped Corveil credentials it read into its environment at launch, so
+    /// it could still call `worker-run mcp-call`). The worker-runner fail-closed
+    /// paths call this so a run Corveil may have re-queued isn't still executing
+    /// locally against the same claim (corveil/crow#801 review).
+    public func stopManagedTerminals(sessionID: UUID) {
+        guard let terminals = appState.terminals[sessionID] else { return }
+        for terminal in terminals where terminal.isManaged {
+            TerminalRouter.destroy(terminal)
+            appState.autoLaunchTerminals.remove(terminal.id)
+            appState.remoteControlActiveTerminals.remove(terminal.id)
+        }
+    }
+
     public func setSessionInReview(id: UUID) {
         updateSessionStatus(id, to: .inReview)
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunPrompt.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunPrompt.swift
@@ -1,0 +1,96 @@
+import Foundation
+import CrowProvider
+
+/// Builds the wrapped launch prompt for a Corveil worker run (corveil/crow#801).
+///
+/// Crow owns the run lifecycle (claim → heartbeat → complete), so the agent's
+/// job is narrower than the manual `worker-runner` skill loop: execute the
+/// snapshotted `prompt_body`, perform any allow-listed write-backs via
+/// `corveil worker-run mcp-call`, and end by writing a machine-readable result
+/// to `.crow-run-result.json`. Crow reads that file on the agent's `.done` hook
+/// and maps it onto `corveil worker-run complete`.
+///
+/// Pure (no I/O) so it's unit-testable.
+enum WorkerRunPrompt {
+    /// The result file the agent must write; Crow reads it on finish.
+    static let resultFileName = ".crow-run-result.json"
+
+    static func build(run: WorkerRun, workerID: String) -> String {
+        var lines: [String] = []
+
+        lines.append("# Corveil worker run")
+        lines.append("")
+        lines.append("You are executing **Corveil worker run `\(run.id)`** as an external Crow runner. "
+            + "Carry out the task below on your own model/subscription. Crow has already claimed this run "
+            + "and is holding the lease for you — do **not** call `worker-run claim`, `heartbeat`, or `complete`; "
+            + "Crow does that. Your only Corveil calls are the allow-listed write-backs described below.")
+        lines.append("")
+
+        lines.append("## Task")
+        lines.append("")
+        let body = (run.promptBody ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        lines.append(body.isEmpty ? "_(This run carries no prompt body.)_" : body)
+        lines.append("")
+
+        lines.append(contentsOf: writebackSection(run: run, workerID: workerID))
+
+        lines.append("## Finishing")
+        lines.append("")
+        lines.append("When you are done, write your result as JSON to `\(resultFileName)` in this directory. "
+            + "This is how Crow reports your outcome back to Corveil — a run with no result file is completed "
+            + "with an error. Shape:")
+        lines.append("")
+        lines.append("```json")
+        lines.append("""
+        {
+          "title": "one-line summary of what you did",
+          "content": "what you changed and why (the human-readable result)",
+          "output": { "entities_written": 0 },
+          "error": ""
+        }
+        """)
+        lines.append("```")
+        lines.append("")
+        lines.append("- `title` / `content` are required on success. `output` is an optional typed object. "
+            + "Leave `error` empty (or omit it) on success.")
+        lines.append("- If the task **failed**, set `error` to a concise reason and leave the rest as-is; "
+            + "Crow will fail the run with that message.")
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// The write-back guidance block, derived from the run's snapshotted policy.
+    private static func writebackSection(run: WorkerRun, workerID: String) -> [String] {
+        var lines: [String] = ["## Write-backs"]
+        lines.append("")
+        let policy = run.writebackPolicy ?? [:]
+        guard !policy.isEmpty else {
+            lines.append("This run grants **no** write-back tools. Produce your result and finish; do not "
+                + "attempt any `worker-run mcp-call` (it will be rejected).")
+            lines.append("")
+            return lines
+        }
+
+        lines.append("All state changes go through Corveil so no credentials live on this host. Call an "
+            + "allow-listed tool with:")
+        lines.append("")
+        lines.append("```")
+        lines.append("corveil worker-run mcp-call \(run.id) \\")
+        lines.append("  --worker-id \(workerID) \\")
+        lines.append("  --server <server> --tool <tool> --args '<json>'")
+        lines.append("```")
+        lines.append("")
+        lines.append("Permitted server/tool pairs for this run:")
+        for server in policy.keys.sorted() {
+            guard let binding = policy[server] else { continue }
+            let tools = binding.allowed.isEmpty ? "(none)" : binding.allowed.joined(separator: ", ")
+            let dryRun = binding.dryRun ? "  _(dry-run: calls are previewed, not executed)_" : ""
+            lines.append("- **\(server)** → \(tools)\(dryRun)")
+        }
+        lines.append("")
+        lines.append("Rules: respect dry-run bindings (a preview is not a write); a `403` means the call is "
+            + "outside policy — stop, don't retry. Every ontology write needs a concise `reason`.")
+        lines.append("")
+        return lines
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -48,8 +48,9 @@ public final class WorkerRunner {
     /// Grace after the prompt is delivered before a run may auto-complete
     /// (mirrors `JobScheduler.finishSettleDelay`).
     private let finishSettleDelay: TimeInterval = 20
-    /// Safety cap so a stuck run can't linger forever.
-    private let maxWatchDuration: TimeInterval = 12 * 3600
+    /// Safety cap so a stuck run can't linger forever. `var` (not `let`) only so
+    /// tests can shrink it to force the timeout path without waiting 12h.
+    var maxWatchDuration: TimeInterval = 12 * 3600
     /// Max polls (× 5s) to observe `.agentLaunched` before giving up on stamping
     /// the settle window for a run.
     private let maxLaunchWaitPolls = 60
@@ -208,9 +209,10 @@ public final class WorkerRunner {
     /// maps the outcome onto `corveil worker-run complete`.
     private func checkFinishedRuns(backend: CorveilWorkerBackend, now: Date) async {
         for (sessionID, run) in watchedRuns {
+            let status = appState.sessions.first(where: { $0.id == sessionID })?.status
             let decision = JobScheduler.finishDecision(
                 now: now,
-                status: appState.sessions.first(where: { $0.id == sessionID })?.status,
+                status: status,
                 startedAt: run.startedAt,
                 promptsDeliveredAt: run.promptsDeliveredAt,
                 readiness: appState.terminalReadiness[run.terminalID],
@@ -231,16 +233,40 @@ public final class WorkerRunner {
                 SessionService.wipeWorkerRunScratch(run.scratchDir)
                 watchedRuns[sessionID] = nil
             case .stopWatching:
-                // Session gone / no longer active / timed out — best-effort fail
-                // the Corveil run so the queue isn't left hanging, then wipe.
-                await complete(
-                    backend: backend, run: run,
-                    args: WorkerRunCompletion.CompleteArgs(error: "run aborted on runner before completion")
-                )
-                SessionService.wipeWorkerRunScratch(run.scratchDir)
-                watchedRuns[sessionID] = nil
+                await stopWatching(run: run, sessionID: sessionID, status: status, backend: backend)
             }
         }
+    }
+
+    /// Handle a run we've stopped watching. There are three sub-cases behind
+    /// `finishDecision`'s `.stopWatching`, distinguished by the session status:
+    ///
+    /// - **Still `.active` (max-duration timeout):** the run overran the watch
+    ///   cap. Fail it on Corveil AND `completeSession` — moving it off `.active` is
+    ///   essential, because otherwise the next tick's `reconcileUnwatchedWorkerRuns`
+    ///   re-adopts it and resets `startedAt`, so the 12h cap never sticks and the
+    ///   run becomes a zombie permanently holding a `maxConcurrentRuns` slot while
+    ///   re-heartbeating an already-completed Corveil run (review).
+    /// - **Deleted (`nil`):** `deleteSession` already tore down the local session +
+    ///   scratch dir; just best-effort fail the Corveil run so the queue isn't hung.
+    /// - **User-moved off `.active` (paused/archived/…):** leave the Corveil run to
+    ///   the lease-expiry abandonment sweep; only wipe the local secret.
+    ///
+    /// Every case wipes the scratch dir and drops the watch.
+    private func stopWatching(run: WorkerRunWatch, sessionID: UUID, status: SessionStatus?, backend: CorveilWorkerBackend) async {
+        switch status {
+        case .active:
+            await complete(backend: backend, run: run,
+                           args: .init(error: "run exceeded the runner's max watch duration"))
+            sessionService.completeSession(id: sessionID)
+        case nil:
+            await complete(backend: backend, run: run,
+                           args: .init(error: "run aborted on runner before completion"))
+        default:
+            break  // user moved it off active — lease expiry fails it on Corveil.
+        }
+        SessionService.wipeWorkerRunScratch(run.scratchDir)
+        watchedRuns[sessionID] = nil
     }
 
     private func complete(backend: CorveilWorkerBackend, run: WorkerRunWatch, args: WorkerRunCompletion.CompleteArgs) async {

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -70,6 +70,9 @@ public final class WorkerRunner {
     private var timer: Timer?
     /// One-shot log guard so a missing API key warns once, not every tick.
     private var warnedMissingKey = false
+    /// One-shot log guard so a persistent list/auth failure warns once, not every
+    /// tick — reset on the first successful list so a transient blip re-warns.
+    private var warnedListError = false
 
     public init(appState: AppState, sessionService: SessionService) {
         self.appState = appState
@@ -78,8 +81,13 @@ public final class WorkerRunner {
 
     // MARK: - Lifecycle
 
-    /// Start the desktop-app timer loop. The headless daemon instead drives
-    /// `tick()` from its own async poll (no `RunLoop.main`).
+    /// Start a `RunLoop.main` timer loop, for a future desktop-app host.
+    ///
+    /// Currently **unused**: this slice is daemon-first, and `crowd` drives
+    /// `tick()` from its own async poll (`CrowDaemon.startRunnerPoll`) because it
+    /// has no `RunLoop.main`. Kept for parity with `JobScheduler.start()` so the
+    /// desktop app can adopt the runner later; nothing wires it today, so the
+    /// desktop app does not claim worker runs (corveil/crow#801 review).
     public func start() {
         let interval = TimeInterval(configProvider()?.effectivePollIntervalSeconds ?? 30)
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
@@ -99,11 +107,37 @@ public final class WorkerRunner {
     /// up to the per-host cap. Async (unlike `JobScheduler.tick`) because every
     /// step is a `corveil` CLI round-trip. Re-entrancy-guarded so a slow network
     /// tick isn't overlapped by the next poll.
+    ///
+    /// **Teardown always runs; only claiming is gated.** Reconcile + heartbeat +
+    /// finish/wipe of already-watched (or persisted, post-relaunch) runs happen
+    /// every tick regardless of `enabled` / API-key presence — otherwise
+    /// disabling the runner or unsetting the key mid-run would abandon the local
+    /// secret teardown, leaving the scoped `CORVEIL_API_KEY` on disk (review). New
+    /// claims are gated at the bottom.
     public func tick() async {
         guard !ticking else { return }
-        guard let config = configProvider(), config.enabled else { return }
+        guard let config = configProvider() else { return }
         guard let devRoot = devRootProvider() else { return }
+
+        ticking = true
+        defer { ticking = false }
+
         let apiKey = (apiKeyProvider() ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let workerID = config.resolvedWorkerID()
+        let url = config.corveilURL.isEmpty ? (envURLProvider() ?? "") : config.corveilURL
+        let backend = makeBackend(CorveilWorkerConfig(url: url, apiKey: apiKey))
+        let now = Date()
+
+        // Teardown of existing runs — always, even when disabled / key missing.
+        // Without a key the Corveil-side `complete`/`heartbeat` best-efforts fail
+        // (logged), but the local `completeSession` + scratch-dir wipe still run,
+        // which is the security-critical part.
+        reconcileUnwatchedWorkerRuns(now: now)
+        await heartbeatWatched(backend: backend, now: now)
+        await checkFinishedRuns(backend: backend, now: now)
+
+        // New claims are gated on the runner being enabled with a usable key.
+        guard config.enabled else { return }
         guard !apiKey.isEmpty else {
             if !warnedMissingKey {
                 NSLog("[WorkerRunner] runner enabled but CORVEIL_API_KEY is not set in the crowd environment; idle")
@@ -112,18 +146,6 @@ public final class WorkerRunner {
             return
         }
         warnedMissingKey = false
-
-        ticking = true
-        defer { ticking = false }
-
-        let workerID = config.resolvedWorkerID()
-        let url = config.corveilURL.isEmpty ? (envURLProvider() ?? "") : config.corveilURL
-        let backend = makeBackend(CorveilWorkerConfig(url: url, apiKey: apiKey))
-        let now = Date()
-
-        reconcileUnwatchedWorkerRuns(now: now)
-        await heartbeatWatched(backend: backend, now: now)
-        await checkFinishedRuns(backend: backend, now: now)
         await claimIfCapacity(config: config, backend: backend, devRoot: devRoot, url: url, apiKey: apiKey, workerID: workerID)
     }
 
@@ -224,6 +246,25 @@ public final class WorkerRunner {
 
     // MARK: - Claim
 
+    /// List claimable runs, surfacing errors instead of swallowing them. A
+    /// misconfiguration (`unauthenticated` / `featureDisabled`) otherwise looks
+    /// identical to "queue empty" and the runner idles silently forever; warn
+    /// once (reset on the next success) so the failure is visible in the log.
+    private func listClaimableSurfacing(backend: CorveilWorkerBackend, kind: String?, caps: [String]) async -> [WorkerRun] {
+        do {
+            let runs = try await backend.listClaimable(kind: kind, caps: caps)
+            warnedListError = false
+            return runs
+        } catch {
+            if !warnedListError {
+                NSLog("[WorkerRunner] listClaimable failed (kind=%@): %@ — runner will keep retrying",
+                      kind ?? "*", String(describing: error))
+                warnedListError = true
+            }
+            return []
+        }
+    }
+
     private func claimIfCapacity(
         config: RunnerConfig, backend: CorveilWorkerBackend,
         devRoot: String, url: String, apiKey: String, workerID: String
@@ -235,10 +276,10 @@ public final class WorkerRunner {
         // fan out across configured kinds; an empty `kinds` lists any kind.
         var candidates: [WorkerRun] = []
         if config.kinds.isEmpty {
-            candidates = (try? await backend.listClaimable(kind: nil, caps: config.caps)) ?? []
+            candidates = await listClaimableSurfacing(backend: backend, kind: nil, caps: config.caps)
         } else {
             for kind in config.kinds {
-                candidates += (try? await backend.listClaimable(kind: kind, caps: config.caps)) ?? []
+                candidates += await listClaimableSurfacing(backend: backend, kind: kind, caps: config.caps)
             }
         }
 
@@ -248,7 +289,6 @@ public final class WorkerRunner {
             candidateIDs: candidates.map(\.id), inFlight: inFlight
         )
         guard !plan.isEmpty else { return }
-        let byID = Dictionary(candidates.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
 
         for runID in plan {
             guard watchedRuns.count < cap else { break }

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -1,0 +1,422 @@
+import Foundation
+import CrowCore
+import CrowProvider
+
+/// Drives Corveil worker runs as a native Crow runner (corveil/crow#801).
+///
+/// The Corveil twin of `JobScheduler`: instead of local `config.json` jobs, it
+/// polls a Corveil queue for claimable worker runs, claims up to a per-host cap,
+/// executes each in a repo-less scratch workdir (`SessionService.runWorkerRun`),
+/// holds the lease with heartbeats, and — reusing `JobScheduler.finishDecision`
+/// — maps the agent's `.done` onto `corveil worker-run complete`. Crow owns the
+/// claim → heartbeat → complete lifecycle; the agent only does allow-listed
+/// write-backs. Local jobs are unaffected: this source is additive.
+///
+/// Reachability: the org-scoped `CORVEIL_API_KEY` is sourced from the crowd
+/// process env (never persisted); with no key present the loop is inert.
+@MainActor
+public final class WorkerRunner {
+    private let appState: AppState
+    private let sessionService: SessionService
+
+    // MARK: - Injection
+
+    /// Current runner config (from `AppConfig.runner`). Nil/`disabled` ⇒ inert.
+    public var configProvider: () -> RunnerConfig? = { nil }
+    /// The configured dev root (scratch dirs live under it).
+    public var devRootProvider: () -> String? = { nil }
+    /// The org-scoped API key, sourced from the crowd env. Blank ⇒ inert.
+    public var apiKeyProvider: () -> String? = { ProcessInfo.processInfo.environment["CORVEIL_API_KEY"] }
+    /// Fallback `CORVEIL_URL` when the config omits it.
+    public var envURLProvider: () -> String? = { ProcessInfo.processInfo.environment["CORVEIL_URL"] }
+    /// Builds the Corveil worker backend for a resolved config. Overridable in
+    /// tests to inject a fake `ShellRunner`.
+    public var makeBackend: @Sendable (CorveilWorkerConfig) -> CorveilWorkerBackend = { config in
+        CorveilWorkerBackend(shellRunner: ProcessShellRunner(), config: config)
+    }
+
+    // MARK: - Tunables
+
+    /// Lease requested on claim/heartbeat (matches Corveil's 30m default).
+    private let leaseSeconds = 1800
+    /// Re-heartbeat once a watched run is this old since its last beat — well
+    /// under the 30m lease so a slow tick can't drop a live run.
+    private let heartbeatInterval: TimeInterval = 600
+    /// Grace after the prompt is delivered before a run may auto-complete
+    /// (mirrors `JobScheduler.finishSettleDelay`).
+    private let finishSettleDelay: TimeInterval = 20
+    /// Safety cap so a stuck run can't linger forever.
+    private let maxWatchDuration: TimeInterval = 12 * 3600
+    /// Max polls (× 5s) to observe `.agentLaunched` before giving up on stamping
+    /// the settle window for a run.
+    private let maxLaunchWaitPolls = 60
+
+    // MARK: - State
+
+    /// A claimed run being executed + watched for completion, keyed by session id.
+    struct WorkerRunWatch {
+        let runID: String
+        let workerID: String
+        let scratchDir: String
+        let terminalID: UUID
+        let startedAt: Date
+        /// Set once the prompt has launched; until then not eligible to finish.
+        var promptsDeliveredAt: Date?
+        var lastHeartbeatAt: Date
+    }
+    private var watchedRuns: [UUID: WorkerRunWatch] = [:]
+    /// Guards against a slow claim being re-entered by the next tick.
+    private var ticking = false
+    private var timer: Timer?
+    /// One-shot log guard so a missing API key warns once, not every tick.
+    private var warnedMissingKey = false
+
+    public init(appState: AppState, sessionService: SessionService) {
+        self.appState = appState
+        self.sessionService = sessionService
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start the desktop-app timer loop. The headless daemon instead drives
+    /// `tick()` from its own async poll (no `RunLoop.main`).
+    public func start() {
+        let interval = TimeInterval(configProvider()?.effectivePollIntervalSeconds ?? 30)
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.tick() }
+        }
+        timer?.tolerance = interval / 4
+    }
+
+    public func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: - Tick
+
+    /// One evaluation: adopt/heartbeat/finish watched runs, then claim new ones
+    /// up to the per-host cap. Async (unlike `JobScheduler.tick`) because every
+    /// step is a `corveil` CLI round-trip. Re-entrancy-guarded so a slow network
+    /// tick isn't overlapped by the next poll.
+    public func tick() async {
+        guard !ticking else { return }
+        guard let config = configProvider(), config.enabled else { return }
+        guard let devRoot = devRootProvider() else { return }
+        let apiKey = (apiKeyProvider() ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else {
+            if !warnedMissingKey {
+                NSLog("[WorkerRunner] runner enabled but CORVEIL_API_KEY is not set in the crowd environment; idle")
+                warnedMissingKey = true
+            }
+            return
+        }
+        warnedMissingKey = false
+
+        ticking = true
+        defer { ticking = false }
+
+        let workerID = config.resolvedWorkerID()
+        let url = config.corveilURL.isEmpty ? (envURLProvider() ?? "") : config.corveilURL
+        let backend = makeBackend(CorveilWorkerConfig(url: url, apiKey: apiKey))
+        let now = Date()
+
+        reconcileUnwatchedWorkerRuns(now: now)
+        await heartbeatWatched(backend: backend, now: now)
+        await checkFinishedRuns(backend: backend, now: now)
+        await claimIfCapacity(config: config, backend: backend, devRoot: devRoot, url: url, apiKey: apiKey, workerID: workerID)
+    }
+
+    // MARK: - Reconcile (relaunch recovery)
+
+    /// Adopt any active `.workerRun` session we aren't watching — e.g. `crowd`
+    /// was relaunched mid-run and lost the in-memory watch. The persisted
+    /// `workerRunID` / `workerID` / `workerRunScratchDir` let us still complete
+    /// the Corveil run and wipe the scratch dir. Stamps `startedAt` /
+    /// `promptsDeliveredAt` at `now` so the settle window re-applies (same
+    /// rationale as `JobScheduler.reconcileUnwatchedJobs`).
+    private func reconcileUnwatchedWorkerRuns(now: Date) {
+        for session in appState.sessions where session.kind == .workerRun
+            && session.status == .active
+            && watchedRuns[session.id] == nil {
+            guard let runID = session.workerRunID, let workerID = session.workerID,
+                  let scratchDir = session.workerRunScratchDir,
+                  let terminalID = appState.terminals[session.id]?.first(where: { $0.isManaged })?.id
+            else { continue }
+            watchedRuns[session.id] = WorkerRunWatch(
+                runID: runID,
+                workerID: workerID,
+                scratchDir: scratchDir,
+                terminalID: terminalID,
+                startedAt: now,
+                promptsDeliveredAt: now,
+                lastHeartbeatAt: now
+            )
+        }
+    }
+
+    // MARK: - Heartbeat
+
+    private func heartbeatWatched(backend: CorveilWorkerBackend, now: Date) async {
+        for (sessionID, run) in watchedRuns {
+            guard now.timeIntervalSince(run.lastHeartbeatAt) >= heartbeatInterval else { continue }
+            do {
+                try await backend.heartbeat(run.runID, workerID: run.workerID, leaseSeconds: leaseSeconds)
+                watchedRuns[sessionID]?.lastHeartbeatAt = now
+            } catch {
+                NSLog("[WorkerRunner] heartbeat failed for run %@: %@", run.runID, String(describing: error))
+            }
+        }
+    }
+
+    // MARK: - Finish → complete
+
+    /// Auto-complete watched runs whose agent has finished. Reuses
+    /// `JobScheduler.finishDecision` (the same `.done` + settle-window logic) and
+    /// maps the outcome onto `corveil worker-run complete`.
+    private func checkFinishedRuns(backend: CorveilWorkerBackend, now: Date) async {
+        for (sessionID, run) in watchedRuns {
+            let decision = JobScheduler.finishDecision(
+                now: now,
+                status: appState.sessions.first(where: { $0.id == sessionID })?.status,
+                startedAt: run.startedAt,
+                promptsDeliveredAt: run.promptsDeliveredAt,
+                readiness: appState.terminalReadiness[run.terminalID],
+                activityState: appState.hookState(for: sessionID).activityState,
+                finishSettleDelay: finishSettleDelay,
+                maxWatchDuration: maxWatchDuration
+            )
+            switch decision {
+            case .keepWaiting:
+                continue
+            case .complete:
+                let result = WorkerRunResult.decode(
+                    fromFile: (run.scratchDir as NSString).appendingPathComponent(WorkerRunPrompt.resultFileName)
+                )
+                let args = WorkerRunCompletion.map(result: result)
+                await complete(backend: backend, run: run, args: args)
+                sessionService.completeSession(id: sessionID)
+                SessionService.wipeWorkerRunScratch(run.scratchDir)
+                watchedRuns[sessionID] = nil
+            case .stopWatching:
+                // Session gone / no longer active / timed out — best-effort fail
+                // the Corveil run so the queue isn't left hanging, then wipe.
+                await complete(
+                    backend: backend, run: run,
+                    args: WorkerRunCompletion.CompleteArgs(error: "run aborted on runner before completion")
+                )
+                SessionService.wipeWorkerRunScratch(run.scratchDir)
+                watchedRuns[sessionID] = nil
+            }
+        }
+    }
+
+    private func complete(backend: CorveilWorkerBackend, run: WorkerRunWatch, args: WorkerRunCompletion.CompleteArgs) async {
+        do {
+            try await backend.complete(
+                run.runID, workerID: run.workerID,
+                title: args.title, content: args.content, output: args.output, error: args.error
+            )
+        } catch {
+            NSLog("[WorkerRunner] complete failed for run %@: %@", run.runID, String(describing: error))
+        }
+    }
+
+    // MARK: - Claim
+
+    private func claimIfCapacity(
+        config: RunnerConfig, backend: CorveilWorkerBackend,
+        devRoot: String, url: String, apiKey: String, workerID: String
+    ) async {
+        let cap = config.effectiveMaxConcurrentRuns
+        guard watchedRuns.count < cap else { return }
+
+        // Gather claimable candidates. The API's `--kind` is single-valued, so
+        // fan out across configured kinds; an empty `kinds` lists any kind.
+        var candidates: [WorkerRun] = []
+        if config.kinds.isEmpty {
+            candidates = (try? await backend.listClaimable(kind: nil, caps: config.caps)) ?? []
+        } else {
+            for kind in config.kinds {
+                candidates += (try? await backend.listClaimable(kind: kind, caps: config.caps)) ?? []
+            }
+        }
+
+        let inFlight = Set(watchedRuns.values.map(\.runID))
+        let plan = Self.claimPlan(
+            activeCount: watchedRuns.count, cap: cap,
+            candidateIDs: candidates.map(\.id), inFlight: inFlight
+        )
+        guard !plan.isEmpty else { return }
+        let byID = Dictionary(candidates.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+
+        for runID in plan {
+            guard watchedRuns.count < cap else { break }
+            do {
+                let claimed = try await backend.claim(runID, workerID: workerID, leaseSeconds: leaseSeconds)
+                // `claim` returns the full row, but fetch the snapshot if the
+                // prompt body wasn't inlined.
+                let full: WorkerRun
+                if (claimed.promptBody ?? "").isEmpty {
+                    full = (try? await backend.get(runID)) ?? claimed
+                } else {
+                    full = claimed
+                }
+                await launchClaimed(full, backend: backend, devRoot: devRoot, url: url, apiKey: apiKey, workerID: workerID)
+            } catch WorkerRunError.unclaimable {
+                // Lost the race — someone else claimed it. Try the next.
+                continue
+            } catch {
+                NSLog("[WorkerRunner] claim failed for run %@: %@", runID, String(describing: error))
+                continue
+            }
+        }
+    }
+
+    /// Spin up the scratch workdir + session for a just-claimed run and begin
+    /// watching it. If setup fails, fail the Corveil run so it isn't left held.
+    private func launchClaimed(
+        _ run: WorkerRun, backend: CorveilWorkerBackend,
+        devRoot: String, url: String, apiKey: String, workerID: String
+    ) async {
+        guard let result = await sessionService.runWorkerRun(
+            run: run, devRoot: devRoot, corveilURL: url, apiKey: apiKey, workerID: workerID
+        ) else {
+            try? await backend.complete(
+                run.id, workerID: workerID,
+                title: nil, content: nil, output: nil,
+                error: "runner failed to start the run"
+            )
+            return
+        }
+        let now = Date()
+        watchedRuns[result.sessionID] = WorkerRunWatch(
+            runID: run.id,
+            workerID: workerID,
+            scratchDir: result.scratchDir,
+            terminalID: result.terminalID,
+            startedAt: now,
+            promptsDeliveredAt: nil,
+            lastHeartbeatAt: now
+        )
+        markPromptsDeliveredWhenLaunched(sessionID: result.sessionID, terminalID: result.terminalID, polls: 0)
+    }
+
+    // MARK: - Prompt-delivery watch (single prompt)
+
+    /// A worker run has exactly one (wrapped) prompt, launched with the agent, so
+    /// it's "delivered" as soon as the terminal reports `.agentLaunched`. Poll
+    /// until then (bounded), then stamp the settle window. Mirrors
+    /// `JobScheduler.waitForAgentLaunched` + `markPromptsDelivered`.
+    private func markPromptsDeliveredWhenLaunched(sessionID: UUID, terminalID: UUID, polls: Int) {
+        guard watchedRuns[sessionID] != nil else { return }
+        if appState.terminalReadiness[terminalID] == .agentLaunched {
+            watchedRuns[sessionID]?.promptsDeliveredAt = Date()
+            return
+        }
+        guard polls < maxLaunchWaitPolls else {
+            NSLog("[WorkerRunner] gave up waiting for agent launch on %@", terminalID.uuidString)
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+            self?.markPromptsDeliveredWhenLaunched(sessionID: sessionID, terminalID: terminalID, polls: polls + 1)
+        }
+    }
+
+    // MARK: - Claim planning (pure)
+
+    /// Which candidate run ids to claim this tick: the first `cap - activeCount`
+    /// candidates not already in flight (deduped, order preserved). Pure so it's
+    /// unit-testable without any Corveil round-trip.
+    nonisolated static func claimPlan(activeCount: Int, cap: Int, candidateIDs: [String], inFlight: Set<String>) -> [String] {
+        let slots = max(0, cap - activeCount)
+        guard slots > 0 else { return [] }
+        var seen = Set<String>()
+        var plan: [String] = []
+        for id in candidateIDs {
+            if inFlight.contains(id) || seen.contains(id) { continue }
+            seen.insert(id)
+            plan.append(id)
+            if plan.count >= slots { break }
+        }
+        return plan
+    }
+
+    // MARK: - Status (for the runner-status RPC)
+
+    public struct WatchedRunInfo: Sendable, Equatable {
+        public let runID: String
+        public let sessionID: String
+        public let status: String
+    }
+
+    public struct Status: Sendable, Equatable {
+        public let enabled: Bool
+        public let workerID: String
+        public let activeRuns: Int
+        public let maxConcurrent: Int
+        public let apiKeyPresent: Bool
+        public let watched: [WatchedRunInfo]
+    }
+
+    /// Read-only snapshot for the `runner-status` RPC.
+    public func statusSnapshot() -> Status {
+        let config = configProvider()
+        let apiKeyPresent = !((apiKeyProvider() ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        let watched = watchedRuns.map { sessionID, run in
+            WatchedRunInfo(
+                runID: run.runID,
+                sessionID: sessionID.uuidString,
+                status: appState.sessions.first(where: { $0.id == sessionID })?.status.rawValue ?? "unknown"
+            )
+        }
+        return Status(
+            enabled: config?.enabled ?? false,
+            workerID: config?.resolvedWorkerID() ?? "",
+            activeRuns: watchedRuns.count,
+            maxConcurrent: config?.effectiveMaxConcurrentRuns ?? 0,
+            apiKeyPresent: apiKeyPresent,
+            watched: watched.sorted { $0.runID < $1.runID }
+        )
+    }
+}
+
+/// Maps a run's `.crow-run-result.json` (or its absence) onto the arguments for
+/// `corveil worker-run complete`. Pure so it's unit-testable (corveil/crow#801).
+enum WorkerRunCompletion {
+    struct CompleteArgs: Equatable {
+        var title: String?
+        var content: String?
+        var output: String?
+        var error: String?
+
+        init(title: String? = nil, content: String? = nil, output: String? = nil, error: String? = nil) {
+            self.title = title
+            self.content = content
+            self.output = output
+            self.error = error
+        }
+    }
+
+    static func map(result: WorkerRunResult?) -> CompleteArgs {
+        // No result file ⇒ the agent finished without reporting ⇒ fail the run.
+        guard let result else {
+            return CompleteArgs(error: "agent finished without producing a result")
+        }
+        // Agent self-reported a failure.
+        if let err = result.error, !err.isEmpty {
+            return CompleteArgs(error: err)
+        }
+        // Success requires at least a title or content; an empty success is
+        // treated as a failure so a blank run isn't silently marked completed.
+        let hasTitle = !(result.title ?? "").isEmpty
+        let hasContent = !(result.content ?? "").isEmpty
+        guard hasTitle || hasContent else {
+            return CompleteArgs(output: result.output, error: "agent produced an empty result")
+        }
+        return CompleteArgs(
+            title: result.title, content: result.content,
+            output: result.output, error: nil
+        )
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -21,7 +21,10 @@ public final class WorkerRunner {
 
     // MARK: - Injection
 
-    /// Current runner config (from `AppConfig.runner`). Nil/`disabled` ⇒ inert.
+    /// Current runner config (from `AppConfig.runner`). Nil (no `runner` block or
+    /// a failed config load) or `disabled` ⇒ **no new claims**, but teardown of
+    /// existing/persisted runs still runs each `tick()` so secrets are never
+    /// orphaned (review).
     public var configProvider: () -> RunnerConfig? = { nil }
     /// The configured dev root (scratch dirs live under it).
     public var devRootProvider: () -> String? = { nil }
@@ -110,34 +113,41 @@ public final class WorkerRunner {
     ///
     /// **Teardown always runs; only claiming is gated.** Reconcile + heartbeat +
     /// finish/wipe of already-watched (or persisted, post-relaunch) runs happen
-    /// every tick regardless of `enabled` / API-key presence — otherwise
-    /// disabling the runner or unsetting the key mid-run would abandon the local
-    /// secret teardown, leaving the scoped `CORVEIL_API_KEY` on disk (review). New
-    /// claims are gated at the bottom.
+    /// every tick regardless of config presence / `enabled` / API-key / dev-root —
+    /// otherwise disabling the runner (by flipping `enabled`, **removing the whole
+    /// `runner` block**, or a transient `ConfigStore.loadConfig` failure that
+    /// makes `configProvider()` return nil) would abandon the local secret
+    /// teardown, leaving the scoped `CORVEIL_API_KEY` on disk (review). Teardown
+    /// needs none of those — each watch carries its own `workerID` and absolute
+    /// scratch path — so it runs first, then claiming is gated at the bottom.
     public func tick() async {
         guard !ticking else { return }
-        guard let config = configProvider() else { return }
-        guard let devRoot = devRootProvider() else { return }
-
         ticking = true
         defer { ticking = false }
 
+        // A nil config (no `runner` block, or a failed config load) means "don't
+        // claim new work", NOT "skip teardown" — default to a disabled config so
+        // the teardown below never depends on config presence.
+        let config = configProvider() ?? RunnerConfig()
         let apiKey = (apiKeyProvider() ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let workerID = config.resolvedWorkerID()
         let url = config.corveilURL.isEmpty ? (envURLProvider() ?? "") : config.corveilURL
         let backend = makeBackend(CorveilWorkerConfig(url: url, apiKey: apiKey))
         let now = Date()
 
-        // Teardown of existing runs — always, even when disabled / key missing.
-        // Without a key the Corveil-side `complete`/`heartbeat` best-efforts fail
-        // (logged), but the local `completeSession` + scratch-dir wipe still run,
-        // which is the security-critical part.
+        // Teardown of existing runs — always, independent of config/enabled/key/
+        // devRoot. Uses each watch's own stored `workerID` + absolute scratch
+        // path. Without a key the Corveil-side `complete`/`heartbeat` best-efforts
+        // fail (logged), but the local `completeSession` + scratch-dir wipe still
+        // run, which is the security-critical part.
         reconcileUnwatchedWorkerRuns(now: now)
         await heartbeatWatched(backend: backend, now: now)
         await checkFinishedRuns(backend: backend, now: now)
 
-        // New claims are gated on the runner being enabled with a usable key.
+        // New claims are gated on the runner being enabled, a dev root (to place
+        // scratch dirs), and a usable key.
         guard config.enabled else { return }
+        guard let devRoot = devRootProvider() else { return }
+        let workerID = config.resolvedWorkerID()
         guard !apiKey.isEmpty else {
             if !warnedMissingKey {
                 NSLog("[WorkerRunner] runner enabled but CORVEIL_API_KEY is not set in the crowd environment; idle")

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -105,6 +105,17 @@ public final class WorkerRunner {
         timer = nil
     }
 
+    /// Build a Corveil backend from the current config + env. Shared by `tick()`
+    /// and the out-of-tick launch-timeout teardown so both authenticate the same
+    /// way (a nil config resolves to a disabled default — teardown never depends
+    /// on config presence).
+    private func currentBackend() -> CorveilWorkerBackend {
+        let config = configProvider() ?? RunnerConfig()
+        let apiKey = (apiKeyProvider() ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let url = config.corveilURL.isEmpty ? (envURLProvider() ?? "") : config.corveilURL
+        return makeBackend(CorveilWorkerConfig(url: url, apiKey: apiKey))
+    }
+
     // MARK: - Tick
 
     /// One evaluation: adopt/heartbeat/finish watched runs, then claim new ones
@@ -132,7 +143,7 @@ public final class WorkerRunner {
         let config = configProvider() ?? RunnerConfig()
         let apiKey = (apiKeyProvider() ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let url = config.corveilURL.isEmpty ? (envURLProvider() ?? "") : config.corveilURL
-        let backend = makeBackend(CorveilWorkerConfig(url: url, apiKey: apiKey))
+        let backend = currentBackend()
         let now = Date()
 
         // Teardown of existing runs — always, independent of config/enabled/key/
@@ -230,11 +241,22 @@ public final class WorkerRunner {
                 let args = WorkerRunCompletion.map(result: result)
                 await complete(backend: backend, run: run, args: args)
                 sessionService.completeSession(id: sessionID)
-                SessionService.wipeWorkerRunScratch(run.scratchDir)
-                watchedRuns[sessionID] = nil
+                wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
             case .stopWatching:
                 await stopWatching(run: run, sessionID: sessionID, status: status, backend: backend)
             }
+        }
+    }
+
+    /// Wipe the scratch dir and drop the watch — but **only if the wipe
+    /// succeeded**. A failed wipe keeps the watch so a later tick re-evaluates and
+    /// retries; the session has already been moved off `.active`, so it resolves
+    /// to `.stopWatching` (no repeated Corveil calls) and just re-attempts the
+    /// wipe. This prevents a transient remove failure from orphaning the scoped
+    /// API key with no retry (review).
+    private func wipeAndDrop(sessionID: UUID, scratchDir: String) {
+        if SessionService.wipeWorkerRunScratch(scratchDir) {
+            watchedRuns[sessionID] = nil
         }
     }
 
@@ -265,8 +287,7 @@ public final class WorkerRunner {
         default:
             break  // user moved it off active — lease expiry fails it on Corveil.
         }
-        SessionService.wipeWorkerRunScratch(run.scratchDir)
-        watchedRuns[sessionID] = nil
+        wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
     }
 
     private func complete(backend: CorveilWorkerBackend, run: WorkerRunWatch, args: WorkerRunCompletion.CompleteArgs) async {
@@ -384,6 +405,13 @@ public final class WorkerRunner {
     /// it's "delivered" as soon as the terminal reports `.agentLaunched`. Poll
     /// until then (bounded), then stamp the settle window. Mirrors
     /// `JobScheduler.waitForAgentLaunched` + `markPromptsDelivered`.
+    ///
+    /// On expiry (the agent never reached `.agentLaunched` within the launch
+    /// window) the run is **torn down**, not just logged: with `promptsDeliveredAt`
+    /// left nil, `finishDecision` would return `.keepWaiting` until the 12h
+    /// `maxWatchDuration`, so a stuck launch would otherwise hold a
+    /// `maxConcurrentRuns` slot and keep heartbeating for hours (review). Failing
+    /// it here frees the slot immediately.
     private func markPromptsDeliveredWhenLaunched(sessionID: UUID, terminalID: UUID, polls: Int) {
         guard watchedRuns[sessionID] != nil else { return }
         if appState.terminalReadiness[terminalID] == .agentLaunched {
@@ -391,12 +419,24 @@ public final class WorkerRunner {
             return
         }
         guard polls < maxLaunchWaitPolls else {
-            NSLog("[WorkerRunner] gave up waiting for agent launch on %@", terminalID.uuidString)
+            NSLog("[WorkerRunner] agent never launched for session %@; failing the run", sessionID.uuidString)
+            Task { @MainActor [weak self] in await self?.handleLaunchTimeout(sessionID: sessionID) }
             return
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
             self?.markPromptsDeliveredWhenLaunched(sessionID: sessionID, terminalID: terminalID, polls: polls + 1)
         }
+    }
+
+    /// Tear down a run whose agent never launched: fail it on Corveil, complete
+    /// the local session, and wipe the scratch dir (dropping the watch only once
+    /// the wipe succeeds). Same shape as the max-duration timeout path.
+    private func handleLaunchTimeout(sessionID: UUID) async {
+        guard let run = watchedRuns[sessionID] else { return }
+        await complete(backend: currentBackend(), run: run,
+                       args: .init(error: "agent failed to launch on the runner"))
+        sessionService.completeSession(id: sessionID)
+        wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
     }
 
     // MARK: - Claim planning (pure)

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -318,6 +318,10 @@ public final class WorkerRunner {
     private func wipeAndDrop(sessionID: UUID, scratchDir: String) {
         if SessionService.wipeWorkerRunScratch(scratchDir) {
             watchedRuns[sessionID] = nil
+            // Sever the session from the now-finished Corveil run so re-activating
+            // it (a remote `set-status … active`) can't make reconcile re-adopt +
+            // re-heartbeat a dead claim and hold a slot (review).
+            sessionService.clearWorkerRunLinkage(sessionID: sessionID)
         }
     }
 
@@ -345,10 +349,13 @@ public final class WorkerRunner {
     ///   re-heartbeating an already-completed Corveil run (review).
     /// - **Deleted (`nil`):** `deleteSession` already tore down the local session +
     ///   scratch dir; just best-effort fail the Corveil run so the queue isn't hung.
-    /// - **User-moved off `.active` (paused/archived/…):** leave the Corveil run to
-    ///   the lease-expiry abandonment sweep; only wipe the local secret.
+    /// - **User-moved off `.active` (paused/archived/…):** fail the Corveil claim
+    ///   AND stop the agent — don't leave it running with the in-process key while
+    ///   heartbeats stop and the lease lapses (another runner could then claim the
+    ///   same run). The user's chosen status is preserved (no `completeSession`).
     ///
-    /// Every case wipes the scratch dir and drops the watch.
+    /// Every case wipes the scratch dir, drops the watch, and (via `wipeAndDrop`)
+    /// clears the session's Corveil linkage so a later re-activation can't re-adopt it.
     private func stopWatching(run: WorkerRunWatch, sessionID: UUID, status: SessionStatus?, backend: CorveilWorkerBackend) async {
         switch status {
         case .active:

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -169,7 +169,7 @@ public final class WorkerRunner {
         let workerID = config.resolvedWorkerID()
         guard !apiKey.isEmpty else {
             if !warnedMissingKey {
-                NSLog("[WorkerRunner] runner enabled but CORVEIL_API_KEY is not set in the crowd environment; idle")
+                CrowLog.info("[WorkerRunner] runner enabled but CORVEIL_API_KEY is not set in the crowd environment; idle")
                 warnedMissingKey = true
             }
             return
@@ -205,8 +205,7 @@ public final class WorkerRunner {
                    !SessionService.wipeWorkerRunScratch(scratchDir) {
                     continue
                 }
-                NSLog("[WorkerRunner] worker-run session %@ has incomplete linkage; failing closed",
-                      session.id.uuidString)
+                CrowLog.info("[WorkerRunner] worker-run session \(session.id.uuidString) has incomplete linkage; failing closed")
                 sessionService.completeSession(id: session.id)
                 continue
             }
@@ -243,7 +242,7 @@ public final class WorkerRunner {
         for entry in entries {
             let path = (root as NSString).appendingPathComponent(entry)
             guard !live.contains(path) else { continue }
-            NSLog("[WorkerRunner] sweeping orphan worker-run scratch dir %@", path)
+            CrowLog.info("[WorkerRunner] sweeping orphan worker-run scratch dir \(path)")
             SessionService.wipeWorkerRunScratch(path)
         }
     }
@@ -257,7 +256,7 @@ public final class WorkerRunner {
                 try await backend.heartbeat(run.runID, workerID: run.workerID, leaseSeconds: leaseSeconds)
                 watchedRuns[sessionID]?.lastHeartbeatAt = now
             } catch {
-                NSLog("[WorkerRunner] heartbeat failed for run %@: %@", run.runID, String(describing: error))
+                CrowLog.error("[WorkerRunner] heartbeat failed for run \(run.runID): \(String(describing: error))")
             }
         }
     }
@@ -275,8 +274,7 @@ public final class WorkerRunner {
             // would open a duplicate-runner / racing-write window (review). Stop:
             // fail the dead claim, complete the local session, free the slot.
             if now.timeIntervalSince(run.lastHeartbeatAt) >= TimeInterval(leaseSeconds) {
-                NSLog("[WorkerRunner] lease lost for run %@ (no successful heartbeat within %ds); failing",
-                      run.runID, leaseSeconds)
+                CrowLog.info("[WorkerRunner] lease lost for run \(run.runID) (no successful heartbeat within \(leaseSeconds)s); failing")
                 await failClosed(run: run, sessionID: sessionID, backend: backend,
                                  reason: "lease lost — runner could not heartbeat within the lease window")
                 continue
@@ -387,7 +385,7 @@ public final class WorkerRunner {
                 title: args.title, content: args.content, output: args.output, error: args.error
             )
         } catch {
-            NSLog("[WorkerRunner] complete failed for run %@: %@", run.runID, String(describing: error))
+            CrowLog.error("[WorkerRunner] complete failed for run \(run.runID): \(String(describing: error))")
         }
     }
 
@@ -404,8 +402,7 @@ public final class WorkerRunner {
             return runs
         } catch {
             if !warnedListError {
-                NSLog("[WorkerRunner] listClaimable failed (kind=%@): %@ — runner will keep retrying",
-                      kind ?? "*", String(describing: error))
+                CrowLog.error("[WorkerRunner] listClaimable failed (kind=\(kind ?? "*")): \(String(describing: error)) — runner will keep retrying")
                 warnedListError = true
             }
             return []
@@ -454,7 +451,7 @@ public final class WorkerRunner {
                 // Lost the race — someone else claimed it. Try the next.
                 continue
             } catch {
-                NSLog("[WorkerRunner] claim failed for run %@: %@", runID, String(describing: error))
+                CrowLog.error("[WorkerRunner] claim failed for run \(runID): \(String(describing: error))")
                 continue
             }
         }
@@ -509,7 +506,7 @@ public final class WorkerRunner {
             return
         }
         guard polls < maxLaunchWaitPolls else {
-            NSLog("[WorkerRunner] agent never launched for session %@; failing the run", sessionID.uuidString)
+            CrowLog.info("[WorkerRunner] agent never launched for session \(sessionID.uuidString); failing the run")
             Task { @MainActor [weak self] in await self?.handleLaunchTimeout(sessionID: sessionID) }
             return
         }

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -152,6 +152,11 @@ public final class WorkerRunner {
         // fail (logged), but the local `completeSession` + scratch-dir wipe still
         // run, which is the security-critical part.
         reconcileUnwatchedWorkerRuns(now: now)
+        // Backstop for crash / failed-wipe orphans: remove any scratch dir with no
+        // live `.workerRun` session (e.g. `crowd` died after `writeCorveilRunEnv`
+        // but before persisting the session). Needs a dev root to locate the
+        // scratch root; skipped when unavailable (rare).
+        if let devRoot = devRootProvider() { sweepOrphanScratchDirs(devRoot: devRoot) }
         await heartbeatWatched(backend: backend, now: now)
         await checkFinishedRuns(backend: backend, now: now)
 
@@ -196,6 +201,32 @@ public final class WorkerRunner {
                 promptsDeliveredAt: now,
                 lastHeartbeatAt: now
             )
+        }
+    }
+
+    // MARK: - Orphan sweep
+
+    /// Remove scratch dirs under `.crow-worker-runs/` that no live `.workerRun`
+    /// session references. Backstop for the case a run's scratch dir (holding the
+    /// scoped `CORVEIL_API_KEY`) was created but its session never persisted — a
+    /// crash between `writeCorveilRunEnv` and `store.mutate`, or a setup-failure
+    /// wipe that itself failed — leaving an orphan no reconcile/watch can reach.
+    ///
+    /// "Live" = referenced by any `.workerRun` session currently in `appState`
+    /// (regardless of status: a completed session whose wipe is still retrying
+    /// keeps its dir, and its watch handles the retry). A dir is swept only when
+    /// no such session claims it.
+    private func sweepOrphanScratchDirs(devRoot: String) {
+        let root = SessionService.workerRunsRoot(devRoot: devRoot)
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: root) else { return }
+        let live = Set(appState.sessions
+            .filter { $0.kind == .workerRun }
+            .compactMap { $0.workerRunScratchDir })
+        for entry in entries {
+            let path = (root as NSString).appendingPathComponent(entry)
+            guard !live.contains(path) else { continue }
+            NSLog("[WorkerRunner] sweeping orphan worker-run scratch dir %@", path)
+            SessionService.wipeWorkerRunScratch(path)
         }
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -323,11 +323,13 @@ public final class WorkerRunner {
 
     /// Terminal fail-closed teardown for a still-`.active` run we can no longer
     /// safely execute (lost lease, launch timeout, max-duration timeout): fail the
-    /// Corveil claim, move the session off `.active` (so reconcile won't re-adopt
-    /// it), and wipe+drop. Shared so every fail path frees the concurrency slot
-    /// identically.
+    /// Corveil claim, **stop the agent** (so it can't keep using its in-process
+    /// credentials against a claim Corveil may have re-queued), move the session
+    /// off `.active` (so reconcile won't re-adopt it), and wipe+drop. Shared so
+    /// every fail path frees the concurrency slot identically.
     private func failClosed(run: WorkerRunWatch, sessionID: UUID, backend: CorveilWorkerBackend, reason: String) async {
         await complete(backend: backend, run: run, args: .init(error: reason))
+        sessionService.stopManagedTerminals(sessionID: sessionID)
         sessionService.completeSession(id: sessionID)
         wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
     }
@@ -353,12 +355,20 @@ public final class WorkerRunner {
             await failClosed(run: run, sessionID: sessionID, backend: backend,
                              reason: "run exceeded the runner's max watch duration")
         case nil:
+            // Deleted — `deleteSession` already destroyed the terminals and tore
+            // down locally; just best-effort fail the Corveil run.
             await complete(backend: backend, run: run,
                            args: .init(error: "run aborted on runner before completion"))
             wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
         default:
-            // User moved it off active — lease expiry fails it on Corveil; only
-            // wipe the local secret.
+            // User moved it off `.active` (paused/archived/…). Don't leave the
+            // agent running with the scoped key while we stop heartbeating (the
+            // lease can then lapse and another runner claim the same run): fail the
+            // Corveil claim AND stop the agent. Preserve the user's chosen status
+            // (no `completeSession`) (review).
+            await complete(backend: backend, run: run,
+                           args: .init(error: "run abandoned — session moved out of active on the runner"))
+            sessionService.stopManagedTerminals(sessionID: sessionID)
             wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
         }
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/WorkerRunner.swift
@@ -40,8 +40,10 @@ public final class WorkerRunner {
 
     // MARK: - Tunables
 
-    /// Lease requested on claim/heartbeat (matches Corveil's 30m default).
-    private let leaseSeconds = 1800
+    /// Lease requested on claim/heartbeat (matches Corveil's 30m default), and
+    /// the window after which a run with no successful heartbeat is failed closed.
+    /// `var` (not `let`) only so tests can shrink it to force the lost-lease path.
+    var leaseSeconds = 1800
     /// Re-heartbeat once a watched run is this old since its last beat — well
     /// under the 30m lease so a slow tick can't drop a live run.
     private let heartbeatInterval: TimeInterval = 600
@@ -191,7 +193,23 @@ public final class WorkerRunner {
             guard let runID = session.workerRunID, let workerID = session.workerID,
                   let scratchDir = session.workerRunScratchDir,
                   let terminalID = appState.terminals[session.id]?.first(where: { $0.isManaged })?.id
-            else { continue }
+            else {
+                // Incomplete linkage — we can't drive this run to completion, and
+                // (if it has a scratch dir) the orphan sweep won't touch a dir a
+                // live session still references. Fail-closed LOCALLY so the scoped
+                // key isn't stranded: wipe the scratch dir, then move the session
+                // off `.active`. If the wipe fails, keep it active so a later
+                // reconcile retries rather than leaving the key referenced by a
+                // completed session (review).
+                if let scratchDir = session.workerRunScratchDir, !scratchDir.isEmpty,
+                   !SessionService.wipeWorkerRunScratch(scratchDir) {
+                    continue
+                }
+                NSLog("[WorkerRunner] worker-run session %@ has incomplete linkage; failing closed",
+                      session.id.uuidString)
+                sessionService.completeSession(id: session.id)
+                continue
+            }
             watchedRuns[session.id] = WorkerRunWatch(
                 runID: runID,
                 workerID: workerID,
@@ -251,6 +269,18 @@ public final class WorkerRunner {
     /// maps the outcome onto `corveil worker-run complete`.
     private func checkFinishedRuns(backend: CorveilWorkerBackend, now: Date) async {
         for (sessionID, run) in watchedRuns {
+            // Fail-closed on a lost lease: if no heartbeat has succeeded within the
+            // lease window, Corveil may have expired our claim and re-queued the
+            // run to another runner. Continuing to execute (and calling `mcp-call`)
+            // would open a duplicate-runner / racing-write window (review). Stop:
+            // fail the dead claim, complete the local session, free the slot.
+            if now.timeIntervalSince(run.lastHeartbeatAt) >= TimeInterval(leaseSeconds) {
+                NSLog("[WorkerRunner] lease lost for run %@ (no successful heartbeat within %ds); failing",
+                      run.runID, leaseSeconds)
+                await failClosed(run: run, sessionID: sessionID, backend: backend,
+                                 reason: "lease lost — runner could not heartbeat within the lease window")
+                continue
+            }
             let status = appState.sessions.first(where: { $0.id == sessionID })?.status
             let decision = JobScheduler.finishDecision(
                 now: now,
@@ -291,6 +321,17 @@ public final class WorkerRunner {
         }
     }
 
+    /// Terminal fail-closed teardown for a still-`.active` run we can no longer
+    /// safely execute (lost lease, launch timeout, max-duration timeout): fail the
+    /// Corveil claim, move the session off `.active` (so reconcile won't re-adopt
+    /// it), and wipe+drop. Shared so every fail path frees the concurrency slot
+    /// identically.
+    private func failClosed(run: WorkerRunWatch, sessionID: UUID, backend: CorveilWorkerBackend, reason: String) async {
+        await complete(backend: backend, run: run, args: .init(error: reason))
+        sessionService.completeSession(id: sessionID)
+        wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
+    }
+
     /// Handle a run we've stopped watching. There are three sub-cases behind
     /// `finishDecision`'s `.stopWatching`, distinguished by the session status:
     ///
@@ -309,16 +350,17 @@ public final class WorkerRunner {
     private func stopWatching(run: WorkerRunWatch, sessionID: UUID, status: SessionStatus?, backend: CorveilWorkerBackend) async {
         switch status {
         case .active:
-            await complete(backend: backend, run: run,
-                           args: .init(error: "run exceeded the runner's max watch duration"))
-            sessionService.completeSession(id: sessionID)
+            await failClosed(run: run, sessionID: sessionID, backend: backend,
+                             reason: "run exceeded the runner's max watch duration")
         case nil:
             await complete(backend: backend, run: run,
                            args: .init(error: "run aborted on runner before completion"))
+            wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
         default:
-            break  // user moved it off active — lease expiry fails it on Corveil.
+            // User moved it off active — lease expiry fails it on Corveil; only
+            // wipe the local secret.
+            wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
         }
-        wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
     }
 
     private func complete(backend: CorveilWorkerBackend, run: WorkerRunWatch, args: WorkerRunCompletion.CompleteArgs) async {
@@ -464,10 +506,8 @@ public final class WorkerRunner {
     /// the wipe succeeds). Same shape as the max-duration timeout path.
     private func handleLaunchTimeout(sessionID: UUID) async {
         guard let run = watchedRuns[sessionID] else { return }
-        await complete(backend: currentBackend(), run: run,
-                       args: .init(error: "agent failed to launch on the runner"))
-        sessionService.completeSession(id: sessionID)
-        wipeAndDrop(sessionID: sessionID, scratchDir: run.scratchDir)
+        await failClosed(run: run, sessionID: sessionID, backend: currentBackend(),
+                         reason: "agent failed to launch on the runner")
     }
 
     // MARK: - Claim planning (pure)

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AgentsRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AgentsRPCSupportTests.swift
@@ -307,6 +307,7 @@ struct AgentsRPCSupportTests {
             "review": .string("codex"),
             "job": .string("claude-code"),
             "manager": .string("claude-code"),
+            "workerRun": .string("claude-code"),
         ]))
         #expect(json?["config_readable"] == .bool(true))
     }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceDiskCleanupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceDiskCleanupTests.swift
@@ -93,9 +93,13 @@ struct SessionServiceDiskCleanupTests {
     /// (repoPath == worktreePath, isMainCheckout true) and holds the scoped
     /// CORVEIL_API_KEY, so `isWorkerRun` must remove it wholesale rather than
     /// skip it as a "main checkout" (corveil/crow#801 review — the Red finding).
+    /// A scratch dir under `.crow-worker-runs` is removed wholesale despite the
+    /// main-checkout shape (repoPath == worktreePath, isMainCheckout true).
     @Test func deletesWorkerRunScratchDirDespiteMainCheckoutShape() {
-        let scratch = Self.makeTempDir(name: "worker-run-scratch")
-        defer { try? FileManager.default.removeItem(at: scratch) }
+        let root = Self.makeTempDir(name: "wr-dev").appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-abc")
+        try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
         // Seed the secret file the finding is about.
         FileManager.default.createFile(
             atPath: scratch.appendingPathComponent("settings.local.json").path,
@@ -114,9 +118,27 @@ struct SessionServiceDiskCleanupTests {
         #expect(!FileManager.default.fileExists(atPath: scratch.path))
     }
 
+    /// The same parent-name guard as `wipeWorkerRunScratch` applies here: a
+    /// worker-run item whose path is NOT under `.crow-worker-runs` is refused, so
+    /// a corrupted `worktreePath` can't trigger an arbitrary recursive delete
+    /// (review — consistent threat model across both teardown paths).
+    @Test func refusesWorkerRunRemovalOutsideCrowWorkerRuns() {
+        let victim = Self.makeTempDir(name: "not-a-scratch")
+        defer { try? FileManager.default.removeItem(at: victim) }
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: victim.path, worktreePath: victim.path, branch: "", isMainCheckout: true
+        )
+
+        let error = SessionService.performDiskCleanup(items: [item], isReview: false, isWorkerRun: true)
+
+        #expect(error == nil)  // refusal is not a fatal cleanup error
+        #expect(FileManager.default.fileExists(atPath: victim.path))  // NOT removed
+    }
+
     @Test func workerRunCleanupIsIdempotentWhenAlreadyGone() {
-        let scratch = Self.makeTempDir(name: "worker-run-gone")
-        try? FileManager.default.removeItem(at: scratch)
+        let scratch = Self.makeTempDir(name: "wr-dev-gone")
+            .appendingPathComponent(".crow-worker-runs").appendingPathComponent("run-gone")
+        // Never created — parent-name is valid but the dir doesn't exist.
         let item = SessionService.WorktreeCleanupItem(
             repoPath: scratch.path, worktreePath: scratch.path, branch: "", isMainCheckout: true
         )

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceDiskCleanupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceDiskCleanupTests.swift
@@ -88,4 +88,39 @@ struct SessionServiceDiskCleanupTests {
         #expect(!FileManager.default.fileExists(atPath: clone.path))
         #expect(FileManager.default.fileExists(atPath: parent.path))
     }
+
+    /// A worker-run scratch dir has the same standalone shape as a review clone
+    /// (repoPath == worktreePath, isMainCheckout true) and holds the scoped
+    /// CORVEIL_API_KEY, so `isWorkerRun` must remove it wholesale rather than
+    /// skip it as a "main checkout" (corveil/crow#801 review — the Red finding).
+    @Test func deletesWorkerRunScratchDirDespiteMainCheckoutShape() {
+        let scratch = Self.makeTempDir(name: "worker-run-scratch")
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        // Seed the secret file the finding is about.
+        FileManager.default.createFile(
+            atPath: scratch.appendingPathComponent("settings.local.json").path,
+            contents: Data(#"{"env":{"CORVEIL_API_KEY":"sk-secret"}}"#.utf8))
+
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: scratch.path,
+            worktreePath: scratch.path,
+            branch: "",
+            isMainCheckout: true  // synthetic worktree trips this; must be overridden
+        )
+
+        let error = SessionService.performDiskCleanup(items: [item], isReview: false, isWorkerRun: true)
+
+        #expect(error == nil)
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))
+    }
+
+    @Test func workerRunCleanupIsIdempotentWhenAlreadyGone() {
+        let scratch = Self.makeTempDir(name: "worker-run-gone")
+        try? FileManager.default.removeItem(at: scratch)
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: scratch.path, worktreePath: scratch.path, branch: "", isMainCheckout: true
+        )
+        let error = SessionService.performDiskCleanup(items: [item], isReview: false, isWorkerRun: true)
+        #expect(error == nil)
+    }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunPromptTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunPromptTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+import CrowProvider
+@testable import CrowEngine
+
+/// The wrapped launch prompt Crow writes for a claimed Corveil worker run
+/// (corveil/crow#801). It must carry the snapshotted `prompt_body`, tell the
+/// agent which write-back tools are permitted (and how to call them under the
+/// right run id + worker id), and require the machine-readable result file Crow
+/// reads on finish.
+@Suite("WorkerRunPrompt")
+struct WorkerRunPromptTests {
+    private func run(
+        id: String = "run-42",
+        body: String? = "Do the important thing",
+        policy: [String: WritebackBinding]? = nil
+    ) -> WorkerRun {
+        WorkerRun(id: id, kind: "tend", promptBody: body, writebackPolicy: policy)
+    }
+
+    @Test func includesPromptBodyAndRunID() {
+        let prompt = WorkerRunPrompt.build(run: run(), workerID: "crow-host-1")
+        #expect(prompt.contains("Do the important thing"))
+        #expect(prompt.contains("run-42"))
+    }
+
+    @Test func instructsWritingTheResultFile() {
+        let prompt = WorkerRunPrompt.build(run: run(), workerID: "crow-host-1")
+        #expect(prompt.contains(WorkerRunPrompt.resultFileName))
+        #expect(WorkerRunPrompt.resultFileName == ".crow-run-result.json")
+    }
+
+    @Test func tellsAgentNotToClaimOrComplete() {
+        // Crow owns claim/heartbeat/complete — the agent must not.
+        let prompt = WorkerRunPrompt.build(run: run(), workerID: "crow-host-1")
+        #expect(prompt.lowercased().contains("do not"))
+        #expect(prompt.contains("complete"))
+    }
+
+    @Test func listsAllowedWritebackToolsWithWorkerID() {
+        let policy = ["ontology": WritebackBinding(allowed: ["ontology_update_entity"], dryRun: false)]
+        let prompt = WorkerRunPrompt.build(run: run(policy: policy), workerID: "crow-host-9")
+        #expect(prompt.contains("worker-run mcp-call"))
+        #expect(prompt.contains("crow-host-9"))
+        #expect(prompt.contains("ontology"))
+        #expect(prompt.contains("ontology_update_entity"))
+    }
+
+    @Test func flagsDryRunBindings() {
+        let policy = ["ontology": WritebackBinding(allowed: ["ontology_update_entity"], dryRun: true)]
+        let prompt = WorkerRunPrompt.build(run: run(policy: policy), workerID: "w")
+        #expect(prompt.lowercased().contains("dry-run"))
+    }
+
+    @Test func statesNoWritebacksWhenPolicyEmpty() {
+        let prompt = WorkerRunPrompt.build(run: run(policy: nil), workerID: "w")
+        #expect(prompt.contains("no** write-back") || prompt.lowercased().contains("no write-back"))
+    }
+
+    @Test func handlesEmptyPromptBodyGracefully() {
+        let prompt = WorkerRunPrompt.build(run: run(body: nil), workerID: "w")
+        #expect(prompt.contains("no prompt body"))
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -122,18 +122,45 @@ struct WorkerRunScratchTests {
         #expect(SessionService.scratchSlug("") == "run")
     }
 
-    @Test func wipeRemovesTheScratchDir() throws {
-        let base = FileManager.default.temporaryDirectory
-            .appendingPathComponent("wr-scratch-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
-        FileManager.default.createFile(atPath: base.appendingPathComponent("secret.env").path, contents: Data("k".utf8))
-        #expect(FileManager.default.fileExists(atPath: base.path))
+    @Test func wipeRemovesScratchDirUnderCrowWorkerRuns() throws {
+        // Only paths whose parent is `.crow-worker-runs` are wiped (the guard).
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dev-\(UUID().uuidString)")
+            .appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-abc")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        FileManager.default.createFile(atPath: scratch.appendingPathComponent("secret.env").path, contents: Data("k".utf8))
+        #expect(FileManager.default.fileExists(atPath: scratch.path))
 
-        SessionService.wipeWorkerRunScratch(base.path)
-        #expect(!FileManager.default.fileExists(atPath: base.path))
+        SessionService.wipeWorkerRunScratch(scratch.path)
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))
 
         // Idempotent + safe on empty input.
-        SessionService.wipeWorkerRunScratch(base.path)
+        SessionService.wipeWorkerRunScratch(scratch.path)
         SessionService.wipeWorkerRunScratch("")
+    }
+
+    @Test func isWorkerRunScratchPathAcceptsOnlyScratchDirs() {
+        #expect(SessionService.isWorkerRunScratchPath("/dev/root/.crow-worker-runs/run-42"))
+        #expect(SessionService.isWorkerRunScratchPath("/dev/root/.crow-worker-runs/run-42/"))  // trailing slash normalized
+        // Reject anything whose immediate parent isn't `.crow-worker-runs`.
+        #expect(!SessionService.isWorkerRunScratchPath("/dev/root/.crow-worker-runs"))  // the parent itself
+        #expect(!SessionService.isWorkerRunScratchPath("/etc/passwd"))
+        #expect(!SessionService.isWorkerRunScratchPath("/dev/root/worktrees/repo-42"))
+        #expect(!SessionService.isWorkerRunScratchPath(""))
+    }
+
+    @Test func wipeRefusesPathsOutsideCrowWorkerRuns() throws {
+        // A corrupted scratch-dir path must never turn the wipe into an arbitrary
+        // recursive delete (defense-in-depth, review).
+        let victim = FileManager.default.temporaryDirectory
+            .appendingPathComponent("not-a-scratch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: victim, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: victim) }
+
+        SessionService.wipeWorkerRunScratch(victim.path)
+        // Refused — still present.
+        #expect(FileManager.default.fileExists(atPath: victim.path))
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -217,6 +217,50 @@ struct WorkerRunnerTickTeardownTests {
         #expect(snap.enabled == false)  // nil config surfaces as disabled
     }
 
+    /// A max-duration timeout on a still-`.active` run must move the session OFF
+    /// `.active` (via completeSession) and wipe the scratch dir — otherwise the
+    /// next tick's reconcile re-adopts it, resets `startedAt`, and it becomes a
+    /// zombie permanently holding a concurrency slot (review — the Yellow).
+    @Test func timeoutOnActiveRunCompletesSessionAndDoesNotReAdopt() async throws {
+        let (runner, appState) = makeRunner()
+        runner.maxWatchDuration = 0            // any active watched run times out immediately
+        runner.configProvider = { RunnerConfig(enabled: true) }
+        runner.apiKeyProvider = { "sk-test" }
+        runner.devRootProvider = { "/tmp/dev" }
+
+        // Real scratch dir under `.crow-worker-runs` so the wipe is observable and
+        // passes the parent-name guard.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-timeout-\(UUID().uuidString)")
+            .appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-timeout")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        FileManager.default.createFile(atPath: scratch.appendingPathComponent("settings.local.json").path,
+                                       contents: Data(#"{"env":{"CORVEIL_API_KEY":"k"}}"#.utf8))
+
+        let session = Session(
+            name: "wr-timeout", status: .active, kind: .workerRun,
+            workerRunID: "run-timeout", workerID: "crow-x-1",
+            workerRunScratchDir: scratch.path
+        )
+        appState.sessions.append(session)
+        appState.terminals[session.id] = [
+            SessionTerminal(sessionID: session.id, name: "t", cwd: scratch.path, isManaged: true)
+        ]
+
+        await runner.tick()
+
+        // Session moved off .active, watch dropped, secret wiped.
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .completed)
+        #expect(runner.statusSnapshot().watched.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))
+
+        // A second tick must NOT re-adopt it (status is now .completed, not .active).
+        await runner.tick()
+        #expect(runner.statusSnapshot().watched.isEmpty)
+    }
+
     /// With config present but `enabled: false`, teardown likewise still runs.
     @Test func disabledConfigStillReconcilesInFlightRun() async {
         let (runner, appState) = makeRunner()

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowPersistence
 import CrowProvider
 @testable import CrowEngine
 
@@ -162,5 +163,78 @@ struct WorkerRunScratchTests {
         SessionService.wipeWorkerRunScratch(victim.path)
         // Refused — still present.
         #expect(FileManager.default.fileExists(atPath: victim.path))
+    }
+}
+
+/// A no-op `ShellRunner` so `tick()` can never spawn a real `corveil` process.
+private struct NoopShellRunner: ShellRunner {
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String { "" }
+}
+
+/// `tick()`-level teardown gating (corveil/crow#801 review). Teardown of
+/// existing/persisted runs must run even when the runner config is absent — a
+/// removed `runner` block (or a failed config load) makes `configProvider()`
+/// return nil, and gating teardown on that would orphan the scoped API key.
+@Suite("WorkerRunner tick teardown gating")
+@MainActor
+struct WorkerRunnerTickTeardownTests {
+    private func makeRunner() -> (WorkerRunner, AppState) {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wr-tick-\(UUID().uuidString)")
+        let appState = AppState()
+        let service = SessionService(store: JSONStore(directory: tmp), appState: appState, hostBridge: NoopHostBridge())
+        let runner = WorkerRunner(appState: appState, sessionService: service)
+        runner.makeBackend = { config in CorveilWorkerBackend(shellRunner: NoopShellRunner(), config: config) }
+        return (runner, appState)
+    }
+
+    /// Seed a persisted active `.workerRun` session with a managed terminal, then
+    /// tick with a **nil config** (and no key / no dev root). Reconcile must still
+    /// adopt it into the watch set — proving teardown isn't gated on config.
+    @Test func nilConfigStillReconcilesInFlightRun() async {
+        let (runner, appState) = makeRunner()
+        runner.configProvider = { nil }          // no `runner` block at all
+        runner.apiKeyProvider = { nil }          // no key
+        runner.envURLProvider = { nil }
+        runner.devRootProvider = { nil }         // no dev root
+
+        let session = Session(
+            name: "wr-1", status: .active, kind: .workerRun,
+            workerRunID: "run-1", workerID: "crow-x-1",
+            workerRunScratchDir: "/tmp/dev/.crow-worker-runs/run-1"
+        )
+        appState.sessions.append(session)
+        appState.terminals[session.id] = [
+            SessionTerminal(sessionID: session.id, name: "t", cwd: "/tmp", isManaged: true)
+        ]
+
+        await runner.tick()
+
+        // Adopted despite nil config / no key / no dev root — so its finish/wipe
+        // will be driven on subsequent ticks rather than abandoned.
+        let snap = runner.statusSnapshot()
+        #expect(snap.watched.contains { $0.runID == "run-1" })
+        #expect(snap.enabled == false)  // nil config surfaces as disabled
+    }
+
+    /// With config present but `enabled: false`, teardown likewise still runs.
+    @Test func disabledConfigStillReconcilesInFlightRun() async {
+        let (runner, appState) = makeRunner()
+        runner.configProvider = { RunnerConfig(enabled: false) }
+        runner.apiKeyProvider = { nil }
+        runner.devRootProvider = { "/tmp/dev" }
+
+        let session = Session(
+            name: "wr-2", status: .active, kind: .workerRun,
+            workerRunID: "run-2", workerID: "crow-x-1",
+            workerRunScratchDir: "/tmp/dev/.crow-worker-runs/run-2"
+        )
+        appState.sessions.append(session)
+        appState.terminals[session.id] = [
+            SessionTerminal(sessionID: session.id, name: "t", cwd: "/tmp", isManaged: true)
+        ]
+
+        await runner.tick()
+        #expect(runner.statusSnapshot().watched.contains { $0.runID == "run-2" })
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowProvider
+@testable import CrowEngine
+
+/// The pure decision + mapping logic of the Corveil worker runner
+/// (corveil/crow#801): which claimable runs to pick under the per-host cap, and
+/// how a run's `.crow-run-result.json` (or its absence) maps onto
+/// `corveil worker-run complete` arguments. Kept pure so they need no Corveil
+/// round-trip or live `AppState`.
+@Suite("WorkerRunner claim planning")
+struct WorkerRunnerClaimPlanTests {
+    @Test func claimsUpToRemainingCapacity() {
+        let plan = WorkerRunner.claimPlan(
+            activeCount: 1, cap: 3, candidateIDs: ["a", "b", "c", "d"], inFlight: []
+        )
+        #expect(plan == ["a", "b"])  // 3 - 1 = 2 slots
+    }
+
+    @Test func noSlotsWhenAtCap() {
+        let plan = WorkerRunner.claimPlan(
+            activeCount: 2, cap: 2, candidateIDs: ["a", "b"], inFlight: []
+        )
+        #expect(plan.isEmpty)
+    }
+
+    @Test func skipsInFlightAndDuplicates() {
+        let plan = WorkerRunner.claimPlan(
+            activeCount: 0, cap: 5, candidateIDs: ["a", "a", "b", "c"], inFlight: ["b"]
+        )
+        #expect(plan == ["a", "c"])
+    }
+
+    @Test func capIsNeverNegative() {
+        let plan = WorkerRunner.claimPlan(
+            activeCount: 5, cap: 1, candidateIDs: ["a"], inFlight: []
+        )
+        #expect(plan.isEmpty)
+    }
+
+    @Test func preservesCandidateOrder() {
+        let plan = WorkerRunner.claimPlan(
+            activeCount: 0, cap: 2, candidateIDs: ["z", "y", "x"], inFlight: []
+        )
+        #expect(plan == ["z", "y"])
+    }
+}
+
+@Suite("WorkerRun completion mapping")
+struct WorkerRunCompletionTests {
+    @Test func missingResultCompletesWithError() {
+        let args = WorkerRunCompletion.map(result: nil)
+        #expect(args.error == "agent finished without producing a result")
+        #expect(args.title == nil && args.content == nil)
+    }
+
+    @Test func selfReportedErrorPropagates() {
+        let result = WorkerRunResult(title: "x", content: "y", output: nil, error: "it broke")
+        let args = WorkerRunCompletion.map(result: result)
+        #expect(args.error == "it broke")
+        // Error wins — success fields are dropped so the run is marked failed.
+        #expect(args.title == nil)
+    }
+
+    @Test func successCarriesTitleContentOutput() {
+        let result = WorkerRunResult(title: "Tidied", content: "3 entities", output: #"{"n":3}"#, error: nil)
+        let args = WorkerRunCompletion.map(result: result)
+        #expect(args.error == nil)
+        #expect(args.title == "Tidied")
+        #expect(args.content == "3 entities")
+        #expect(args.output == #"{"n":3}"#)
+    }
+
+    @Test func emptySuccessIsTreatedAsFailure() {
+        let result = WorkerRunResult(title: "", content: "", output: nil, error: "")
+        let args = WorkerRunCompletion.map(result: result)
+        #expect(args.error == "agent produced an empty result")
+    }
+
+    @Test func titleOnlyIsAValidSuccess() {
+        let result = WorkerRunResult(title: "Just a title", content: nil, output: nil, error: nil)
+        let args = WorkerRunCompletion.map(result: result)
+        #expect(args.error == nil)
+        #expect(args.title == "Just a title")
+    }
+}
+
+@Suite("WorkerRunResult decoding")
+struct WorkerRunResultDecodeTests {
+    @Test func decodesFlatFields() {
+        let data = Data(#"{"title":"T","content":"C","error":""}"#.utf8)
+        let result = WorkerRunResult.decode(fromJSON: data)
+        #expect(result?.title == "T")
+        #expect(result?.content == "C")
+        #expect(result?.error == "")
+    }
+
+    @Test func reserializesNestedOutputObjectToString() {
+        let data = Data(#"{"title":"T","content":"C","output":{"entities_written":3}}"#.utf8)
+        let result = WorkerRunResult.decode(fromJSON: data)
+        let output = try? #require(result?.output)
+        // Nested object is re-encoded to a compact JSON string for `--output`.
+        #expect(output?.contains("\"entities_written\"") == true)
+        #expect(output?.contains("3") == true)
+    }
+
+    @Test func returnsNilOnGarbage() {
+        #expect(WorkerRunResult.decode(fromJSON: Data("not json".utf8)) == nil)
+    }
+}
+
+@Suite("Worker-run scratch dir + cleanup")
+struct WorkerRunScratchTests {
+    @Test func scratchDirLivesUnderDevRootWorkerRunsFolder() {
+        let dir = SessionService.workerRunScratchDir(devRoot: "/dev/root", runID: "abc-123")
+        #expect(dir == "/dev/root/.crow-worker-runs/abc-123")
+    }
+
+    @Test func scratchSlugSanitizesUnsafeIds() {
+        #expect(SessionService.scratchSlug("Run/../42?x") == "run-42-x")
+        #expect(SessionService.scratchSlug("") == "run")
+    }
+
+    @Test func wipeRemovesTheScratchDir() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-scratch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: base.appendingPathComponent("secret.env").path, contents: Data("k".utf8))
+        #expect(FileManager.default.fileExists(atPath: base.path))
+
+        SessionService.wipeWorkerRunScratch(base.path)
+        #expect(!FileManager.default.fileExists(atPath: base.path))
+
+        // Idempotent + safe on empty input.
+        SessionService.wipeWorkerRunScratch(base.path)
+        SessionService.wipeWorkerRunScratch("")
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -109,6 +109,20 @@ struct WorkerRunResultDecodeTests {
     @Test func returnsNilOnGarbage() {
         #expect(WorkerRunResult.decode(fromJSON: Data("not json".utf8)) == nil)
     }
+
+    @Test func preservesStringTypedOutput() {
+        // A string `output` must NOT be dropped (JSONSerialization rejects a
+        // top-level String) — it's passed through verbatim (review).
+        let data = Data(#"{"title":"T","content":"C","output":"all done"}"#.utf8)
+        let result = WorkerRunResult.decode(fromJSON: data)
+        #expect(result?.output == "all done")
+    }
+
+    @Test func stringifiesScalarOutput() {
+        let data = Data(#"{"title":"T","content":"C","output":3}"#.utf8)
+        let result = WorkerRunResult.decode(fromJSON: data)
+        #expect(result?.output == "3")
+    }
 }
 
 @Suite("Worker-run scratch dir + cleanup")
@@ -461,6 +475,18 @@ struct WorkerRunnerTickTeardownTests {
         #expect(!appState.autoLaunchTerminals.contains(term.id))              // agent stopped
         // User's chosen status is preserved (NOT forced to .completed).
         #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .paused)
+        // Linkage cleared so a re-activation can't re-adopt the finished run.
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.workerRunID == nil)
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.workerRunScratchDir == nil)
+
+        // Re-activate the session (a remote set-status is allowed): reconcile must
+        // NOT re-adopt/re-heartbeat it — it fails closed to .completed instead.
+        if let idx = appState.sessions.firstIndex(where: { $0.id == session.id }) {
+            appState.sessions[idx].status = .active
+        }
+        await runner.tick()
+        #expect(runner.statusSnapshot().watched.isEmpty)
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .completed)
     }
 
     /// An active `.workerRun` session with incomplete linkage (here: no managed

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -114,13 +114,27 @@ struct WorkerRunResultDecodeTests {
 @Suite("Worker-run scratch dir + cleanup")
 struct WorkerRunScratchTests {
     @Test func scratchDirLivesUnderDevRootWorkerRunsFolder() {
+        // A UUID-shaped id sanitizes to itself (dashes preserved) + a hash suffix.
         let dir = SessionService.workerRunScratchDir(devRoot: "/dev/root", runID: "abc-123")
-        #expect(dir == "/dev/root/.crow-worker-runs/abc-123")
+        #expect(dir == "/dev/root/.crow-worker-runs/\(SessionService.scratchSlug("abc-123"))")
+        #expect(dir.hasPrefix("/dev/root/.crow-worker-runs/abc-123-"))
     }
 
     @Test func scratchSlugSanitizesUnsafeIds() {
-        #expect(SessionService.scratchSlug("Run/../42?x") == "run-42-x")
-        #expect(SessionService.scratchSlug("") == "run")
+        // Readable, path-safe base + deterministic hash suffix.
+        #expect(SessionService.scratchSlug("Run/../42?x").hasPrefix("run-42-x-"))
+        #expect(SessionService.scratchSlug("").hasPrefix("run-"))
+        // Deterministic across calls.
+        #expect(SessionService.scratchSlug("abc-123") == SessionService.scratchSlug("abc-123"))
+    }
+
+    @Test func scratchSlugAvoidsCollisionsForDistinctRawIds() {
+        // Distinct ids that sanitize to the same readable slug must NOT collide.
+        let a = SessionService.scratchSlug("aaa!")
+        let b = SessionService.scratchSlug("aaa?")
+        #expect(a != b)
+        #expect(a.hasPrefix("aaa-"))
+        #expect(b.hasPrefix("aaa-"))
     }
 
     @Test func wipeRemovesScratchDirUnderCrowWorkerRuns() throws {
@@ -258,6 +272,57 @@ struct WorkerRunnerTickTeardownTests {
 
         // A second tick must NOT re-adopt it (status is now .completed, not .active).
         await runner.tick()
+        #expect(runner.statusSnapshot().watched.isEmpty)
+    }
+
+    /// A failed scratch-dir wipe must NOT drop the watch — the key would then sit
+    /// on disk with no retry (completed sessions are skipped by reconcile). The
+    /// watch is kept so a later tick retries the wipe (review, Yellow 1).
+    @Test func failedWipeKeepsWatchThenRetriesOnceUnblocked() async throws {
+        // Perms are ignored under root, which would defeat the forced-failure.
+        try #require(getuid() != 0)
+
+        let (runner, appState) = makeRunner()
+        runner.maxWatchDuration = 0
+        runner.configProvider = { RunnerConfig(enabled: true) }
+        runner.apiKeyProvider = { "sk-test" }
+        runner.devRootProvider = { "/tmp/dev" }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-lock-\(UUID().uuidString)")
+            .appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-locked")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: scratch.appendingPathComponent("settings.local.json").path,
+                                       contents: Data("k".utf8))
+        // Read-only parent so the child dir cannot be unlinked → removeItem fails.
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: root.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let session = Session(
+            name: "wr-locked", status: .active, kind: .workerRun,
+            workerRunID: "run-locked", workerID: "crow-x-1",
+            workerRunScratchDir: scratch.path
+        )
+        appState.sessions.append(session)
+        appState.terminals[session.id] = [
+            SessionTerminal(sessionID: session.id, name: "t", cwd: scratch.path, isManaged: true)
+        ]
+
+        await runner.tick()
+
+        // Session completed, but the wipe failed → watch KEPT (key still on disk).
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .completed)
+        #expect(FileManager.default.fileExists(atPath: scratch.path))
+        #expect(runner.statusSnapshot().watched.contains { $0.runID == "run-locked" })
+
+        // Unblock removal; the next tick retries the wipe and finally drops it.
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        await runner.tick()
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))
         #expect(runner.statusSnapshot().watched.isEmpty)
     }
 

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -406,16 +406,61 @@ struct WorkerRunnerTickTeardownTests {
             name: "wr-lease", status: .active, kind: .workerRun,
             workerRunID: "run-lease", workerID: "crow-x-1", workerRunScratchDir: scratch.path
         )
+        let term = SessionTerminal(sessionID: session.id, name: "t", cwd: scratch.path, isManaged: true)
         appState.sessions.append(session)
-        appState.terminals[session.id] = [
-            SessionTerminal(sessionID: session.id, name: "t", cwd: scratch.path, isManaged: true)
-        ]
+        appState.terminals[session.id] = [term]
+        appState.autoLaunchTerminals.insert(term.id)   // observe the agent being stopped
 
         await runner.tick()
 
         #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .completed)
         #expect(runner.statusSnapshot().watched.isEmpty)
         #expect(!FileManager.default.fileExists(atPath: scratch.path))
+        // Fail-closed stops the agent so it can't keep using its in-process key.
+        #expect(!appState.autoLaunchTerminals.contains(term.id))
+    }
+
+    /// A user moving a watched run off `.active` (paused/archived) must fail the
+    /// Corveil claim AND stop the agent — not just wipe — so it can't keep using
+    /// its in-process key while the lapsing lease lets another runner claim the
+    /// run (review). The user's chosen status is preserved (not completed).
+    @Test func userPausedRunFailsClaimAndStopsAgent() async throws {
+        let (runner, appState) = makeRunner()
+        runner.configProvider = { RunnerConfig(enabled: true) }
+        runner.apiKeyProvider = { "sk-test" }
+        runner.devRootProvider = { "/tmp/dev" }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-paused-\(UUID().uuidString)")
+            .appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-paused")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = Session(
+            name: "wr-paused", status: .active, kind: .workerRun,
+            workerRunID: "run-paused", workerID: "crow-x-1", workerRunScratchDir: scratch.path
+        )
+        let term = SessionTerminal(sessionID: session.id, name: "t", cwd: scratch.path, isManaged: true)
+        appState.sessions.append(session)
+        appState.terminals[session.id] = [term]
+        appState.autoLaunchTerminals.insert(term.id)
+
+        // Tick 1 adopts the active run into the watch set.
+        await runner.tick()
+        #expect(runner.statusSnapshot().watched.contains { $0.runID == "run-paused" })
+
+        // User pauses it; tick 2 must fail-close it (stopWatching default case).
+        if let idx = appState.sessions.firstIndex(where: { $0.id == session.id }) {
+            appState.sessions[idx].status = .paused
+        }
+        await runner.tick()
+
+        #expect(runner.statusSnapshot().watched.isEmpty)                       // watch dropped
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))         // secret wiped
+        #expect(!appState.autoLaunchTerminals.contains(term.id))              // agent stopped
+        // User's chosen status is preserved (NOT forced to .completed).
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .paused)
     }
 
     /// An active `.workerRun` session with incomplete linkage (here: no managed

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -367,16 +367,89 @@ struct WorkerRunnerTickTeardownTests {
         runner.apiKeyProvider = { nil }
         runner.devRootProvider = { devRoot.path }
 
-        // A live .workerRun session references only `keep`.
-        appState.sessions.append(Session(
+        // A live, FULLY-LINKED .workerRun session references only `keep` (a
+        // managed terminal is required so reconcile adopts it rather than
+        // fail-closing it for incomplete linkage).
+        let live = Session(
             name: "live", status: .active, kind: .workerRun,
             workerRunID: "run-live", workerID: "w", workerRunScratchDir: keep.path
-        ))
+        )
+        appState.sessions.append(live)
+        appState.terminals[live.id] = [
+            SessionTerminal(sessionID: live.id, name: "t", cwd: keep.path, isManaged: true)
+        ]
 
         await runner.tick()
 
         #expect(FileManager.default.fileExists(atPath: keep.path))       // referenced → kept
         #expect(!FileManager.default.fileExists(atPath: orphan.path))    // orphan → swept
+    }
+
+    /// A run whose lease has lapsed (no successful heartbeat within `leaseSeconds`)
+    /// is failed closed — completed, wiped, slot freed — so Crow doesn't keep
+    /// executing a claim Corveil may have re-queued to another runner (review).
+    @Test func lostLeaseFailsRunClosed() async throws {
+        let (runner, appState) = makeRunner()
+        runner.leaseSeconds = 0                 // any watched run is instantly "lease-lost"
+        runner.configProvider = { RunnerConfig(enabled: true) }
+        runner.apiKeyProvider = { "sk-test" }
+        runner.devRootProvider = { "/tmp/dev" }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-lease-\(UUID().uuidString)")
+            .appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-lease")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = Session(
+            name: "wr-lease", status: .active, kind: .workerRun,
+            workerRunID: "run-lease", workerID: "crow-x-1", workerRunScratchDir: scratch.path
+        )
+        appState.sessions.append(session)
+        appState.terminals[session.id] = [
+            SessionTerminal(sessionID: session.id, name: "t", cwd: scratch.path, isManaged: true)
+        ]
+
+        await runner.tick()
+
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .completed)
+        #expect(runner.statusSnapshot().watched.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))
+    }
+
+    /// An active `.workerRun` session with incomplete linkage (here: no managed
+    /// terminal) can't be driven, and the orphan sweep won't remove a dir a live
+    /// session references. Reconcile must fail it closed — wipe the scratch dir
+    /// and move the session off `.active` — rather than skipping it forever and
+    /// stranding the key (review).
+    @Test func incompleteLinkageIsFailedClosed() async throws {
+        let (runner, appState) = makeRunner()
+        runner.configProvider = { nil }
+        runner.apiKeyProvider = { nil }
+        runner.devRootProvider = { "/tmp/dev" }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-incomplete-\(UUID().uuidString)")
+            .appendingPathComponent(".crow-worker-runs")
+        let scratch = root.appendingPathComponent("run-incomplete")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: scratch.appendingPathComponent("settings.local.json").path,
+                                       contents: Data("k".utf8))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Active worker-run session WITH a scratch dir but NO managed terminal.
+        let session = Session(
+            name: "wr-incomplete", status: .active, kind: .workerRun,
+            workerRunID: "run-incomplete", workerID: "crow-x-1", workerRunScratchDir: scratch.path
+        )
+        appState.sessions.append(session)
+
+        await runner.tick()
+
+        #expect(appState.sessions.first(where: { $0.id == session.id })?.status == .completed)
+        #expect(!FileManager.default.fileExists(atPath: scratch.path))  // key wiped, not stranded
+        #expect(runner.statusSnapshot().watched.isEmpty)               // never adopted
     }
 
     /// With config present but `enabled: false`, teardown likewise still runs.

--- a/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/WorkerRunnerTests.swift
@@ -185,6 +185,29 @@ private struct NoopShellRunner: ShellRunner {
     func run(args: [String], env: [String: String], cwd: String?) async throws -> String { "" }
 }
 
+/// A `.workerRun` session is pinned to Claude Code (only Claude receives the
+/// scoped Corveil env), so it must refuse an agent handoff — otherwise a handoff
+/// would launch the remote prompt under auto-permission without credentials
+/// (review, Yellow 3).
+@Suite("WorkerRun handoff refusal")
+@MainActor
+struct WorkerRunHandoffTests {
+    @Test func handoffAgentRefusesWorkerRunSessions() async {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wr-handoff-\(UUID().uuidString)")
+        let appState = AppState()
+        let service = SessionService(store: JSONStore(directory: tmp), appState: appState, hostBridge: NoopHostBridge())
+
+        let session = Session(name: "wr", status: .active, kind: .workerRun, agentKind: .claudeCode,
+                              workerRunID: "run-1", workerID: "w")
+        appState.sessions.append(session)
+
+        await #expect(throws: AgentHandoffError.workerRunNotSupported) {
+            _ = try await service.handoffAgent(sessionID: session.id, to: .codex)
+        }
+    }
+}
+
 /// `tick()`-level teardown gating (corveil/crow#801 review). Teardown of
 /// existing/persisted runs must run even when the runner config is absent — a
 /// removed `runner` block (or a failed config load) makes `configProvider()`
@@ -324,6 +347,36 @@ struct WorkerRunnerTickTeardownTests {
         await runner.tick()
         #expect(!FileManager.default.fileExists(atPath: scratch.path))
         #expect(runner.statusSnapshot().watched.isEmpty)
+    }
+
+    /// The orphan sweep removes a scratch dir with no matching `.workerRun`
+    /// session (crash / failed-wipe orphan holding the scoped key) while keeping
+    /// one that a live session still references (review, Yellow 1 backstop).
+    @Test func tickSweepsOrphanScratchDirsButKeepsLiveOnes() async throws {
+        let (runner, appState) = makeRunner()
+        let devRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wr-sweep-\(UUID().uuidString)")
+        let wrRoot = devRoot.appendingPathComponent(".crow-worker-runs")
+        let keep = wrRoot.appendingPathComponent("run-live")
+        let orphan = wrRoot.appendingPathComponent("run-orphan")
+        try FileManager.default.createDirectory(at: keep, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: orphan, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+
+        runner.configProvider = { nil }   // sweep runs during teardown regardless
+        runner.apiKeyProvider = { nil }
+        runner.devRootProvider = { devRoot.path }
+
+        // A live .workerRun session references only `keep`.
+        appState.sessions.append(Session(
+            name: "live", status: .active, kind: .workerRun,
+            workerRunID: "run-live", workerID: "w", workerRunScratchDir: keep.path
+        ))
+
+        await runner.tick()
+
+        #expect(FileManager.default.fileExists(atPath: keep.path))       // referenced → kept
+        #expect(!FileManager.default.fileExists(atPath: orphan.path))    // orphan → swept
     }
 
     /// With config present but `enabled: false`, teardown likewise still runs.

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
@@ -82,7 +82,7 @@ public struct OpenCodeAgent: CodingAgent {
             // `TerminalRouter.send`). OpenCode has no `--rc`/`--name` analog
             // anyway.
             return "\(opencodePath)\n"
-        case .job, .review:
+        case .job, .review, .workerRun:
             // First launch: headless `run` consumes the prompt file, then
             // `; --continue` opens the interactive TUI (#547). Subsequent
             // restarts skip the headless re-run and resume the TUI only.
@@ -94,7 +94,8 @@ public struct OpenCodeAgent: CodingAgent {
             // inlines the crow-review-pr SKILL body for OpenCode (same as
             // Cursor) so the CLI gets a self-contained brief — OpenCode has
             // no Crow slash-command engine.
-            let autoForJob = (session.kind == .job) && autoPermissionMode
+            // Worker runs auto-approve like jobs (corveil/crow#801).
+            let autoForJob = (session.kind == .job || session.kind == .workerRun) && autoPermissionMode
             let tuiSupportsAuto = autoForJob
                 ? OpenCodeLaunchArgs.tuiSupportsAuto(binary: opencodePath)
                 : false

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/CorveilWorkerBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/CorveilWorkerBackend.swift
@@ -1,0 +1,209 @@
+import Foundation
+import CrowCore
+
+/// Configuration for the Corveil worker-runner surface.
+///
+/// Unlike `CorveilConfig` (which relies on ambient `corveil login` state for the
+/// task tracker), the runner authenticates with an **org-scoped API key** so it
+/// can claim work as a stable `worker_id`. Both values are sourced from the
+/// crowd process environment (`CORVEIL_URL` / `CORVEIL_API_KEY`) and are **never
+/// persisted to disk** — they're threaded in here and passed to the `corveil`
+/// CLI as env on each call. See corveil/crow#801 + Corveil ADR-0020/0014.
+public struct CorveilWorkerConfig: Sendable, Equatable {
+    /// Corveil base URL (`CORVEIL_URL`). Empty ⇒ let the CLI use its own default.
+    public let url: String
+    /// Org-scoped API key (`CORVEIL_API_KEY`). Empty ⇒ the runner is misconfigured.
+    public let apiKey: String
+
+    public init(url: String, apiKey: String) {
+        self.url = url
+        self.apiKey = apiKey
+    }
+
+    /// The env dictionary to pass to `corveil` invocations. Empty values are
+    /// omitted so the CLI falls back to ambient state rather than seeing a blank.
+    public var env: [String: String] {
+        var e: [String: String] = [:]
+        if !url.isEmpty { e["CORVEIL_URL"] = url }
+        if !apiKey.isEmpty { e["CORVEIL_API_KEY"] = apiKey }
+        return e
+    }
+
+    public var hasAPIKey: Bool { !apiKey.isEmpty }
+}
+
+/// Why a `worker-run` CLI call failed, distinguished so the runner loop can
+/// react correctly (skip vs stop vs surface).
+public enum WorkerRunError: Error, Equatable {
+    /// `claim` lost the race (HTTP 409) — the run is already claimed. Pick another.
+    case unclaimable
+    /// `plan.FeatureCrowWorkers` is off for this org (HTTP 404 `feature_disabled`).
+    case featureDisabled
+    /// The org-scoped API key is missing/invalid.
+    case unauthenticated
+    /// The CLI emitted output that couldn't be parsed as a `WorkerRun`.
+    case badResponse(String)
+    /// Any other non-zero exit.
+    case commandFailed(String)
+}
+
+/// `corveil worker-run …` CLI wrapper — the native successor to the manual
+/// `worker-runner` skill loop. Structured like ``CorveilTaskBackend``: it wraps
+/// the `corveil` CLI through a ``ShellRunner`` (so it's unit-testable with a
+/// fake) and passes the runner's org-scoped credentials as env.
+///
+/// Crow owns the claim → heartbeat → complete lifecycle; the agent (running in a
+/// scratch workdir) performs allow-listed write-backs directly via
+/// `worker-run mcp-call`. See corveil/crow#801.
+public struct CorveilWorkerBackend: Sendable {
+    private let shellRunner: ShellRunner
+    private let config: CorveilWorkerConfig
+
+    public init(shellRunner: ShellRunner, config: CorveilWorkerConfig) {
+        self.shellRunner = shellRunner
+        self.config = config
+    }
+
+    // MARK: - Verbs
+
+    /// List claimable runs matching this runner's routing (`--kind`, `--caps`).
+    /// `caps` is only sent when non-empty; passing an empty array here does NOT
+    /// send `--caps` (which would opt into the "no-cap runs only" subset filter).
+    public func listClaimable(kind: String?, caps: [String], limit: Int? = nil) async throws -> [WorkerRun] {
+        var args = ["corveil", "worker-run", "list", "--claimable", "--json"]
+        if let kind, !kind.isEmpty {
+            args += ["--kind", kind]
+        }
+        if !caps.isEmpty {
+            args += ["--caps", caps.joined(separator: ",")]
+        }
+        if let limit {
+            args += ["--limit", String(limit)]
+        }
+        let output = try await run(args)
+        return Self.parseRuns(output)
+    }
+
+    /// Full snapshot for one run (prompt body + write-back policy).
+    public func get(_ id: String) async throws -> WorkerRun {
+        let output = try await run(["corveil", "worker-run", "get", id, "--json"])
+        return try Self.parseRun(output)
+    }
+
+    /// Atomically claim a queued run. Throws ``WorkerRunError/unclaimable`` on a
+    /// 409 (someone else won the race) so the caller can move to the next one.
+    public func claim(_ id: String, workerID: String, leaseSeconds: Int) async throws -> WorkerRun {
+        let output = try await run([
+            "corveil", "worker-run", "claim", id,
+            "--worker-id", workerID,
+            "--lease-seconds", String(leaseSeconds),
+            "--json",
+        ])
+        return try Self.parseRun(output)
+    }
+
+    /// Extend the lease (and promote `claimed → running`). Best-effort — the
+    /// caller heartbeats on a timer and a single miss isn't fatal.
+    public func heartbeat(_ id: String, workerID: String, leaseSeconds: Int) async throws {
+        _ = try await run([
+            "corveil", "worker-run", "heartbeat", id,
+            "--worker-id", workerID,
+            "--lease-seconds", String(leaseSeconds),
+            "--json",
+        ])
+    }
+
+    /// Terminal transition. A non-empty `error` marks the run failed (skips
+    /// delivery); otherwise it's completed with the given title/content/output.
+    public func complete(
+        _ id: String,
+        workerID: String,
+        title: String?,
+        content: String?,
+        output: String?,
+        error: String?
+    ) async throws {
+        var args = [
+            "corveil", "worker-run", "complete", id,
+            "--worker-id", workerID,
+            "--json",
+        ]
+        if let error, !error.isEmpty {
+            args += ["--error", error]
+        } else {
+            if let title { args += ["--title", title] }
+            if let content { args += ["--content", content] }
+            if let output, !output.isEmpty { args += ["--output", output] }
+        }
+        _ = try await run(args)
+    }
+
+    // MARK: - Shell
+
+    /// Run a `corveil` invocation with the runner's credentials as env, mapping
+    /// shell failures to typed ``WorkerRunError``s.
+    private func run(_ args: [String]) async throws -> String {
+        do {
+            return try await shellRunner.run(args: args, env: config.env, cwd: NSHomeDirectory())
+        } catch let ShellRunnerError.nonZeroExit(_, output) {
+            throw Self.classify(output)
+        }
+    }
+
+    /// Map CLI stderr/stdout onto a typed error. The `worker-run` verbs surface
+    /// HTTP status via the error envelope's `code`/message text.
+    static func classify(_ output: String) -> WorkerRunError {
+        let lower = output.lowercased()
+        if lower.contains("feature_disabled") || lower.contains("feature disabled") {
+            return .featureDisabled
+        }
+        if lower.contains("409") || lower.contains("conflict") || lower.contains("unclaimable") {
+            return .unclaimable
+        }
+        if CorveilTaskBackend.looksUnauthenticated(output)
+            || lower.contains("unauthorized")
+            || lower.contains("forbidden")
+            || lower.contains("invalid api key") {
+            return .unauthenticated
+        }
+        return .commandFailed(output)
+    }
+
+    // MARK: - Parsing
+
+    /// Parse a single `WorkerRun` object from CLI JSON.
+    static func parseRun(_ output: String) throws -> WorkerRun {
+        guard let data = output.data(using: .utf8) else {
+            throw WorkerRunError.badResponse(output)
+        }
+        // `list` returns an array, `get`/`claim` a bare object; tolerate an
+        // array-of-one here too.
+        let decoder = JSONDecoder()
+        if let run = try? decoder.decode(WorkerRun.self, from: data) {
+            return run
+        }
+        if let runs = try? decoder.decode([WorkerRun].self, from: data), let first = runs.first {
+            return first
+        }
+        throw WorkerRunError.badResponse(output)
+    }
+
+    /// Parse an array of `WorkerRun`s from `list` output (tolerates a bare object).
+    static func parseRuns(_ output: String) -> [WorkerRun] {
+        guard let data = output.data(using: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        if let runs = try? decoder.decode([WorkerRun].self, from: data) {
+            return runs
+        }
+        // Some CLIs wrap the list as `{ "runs": [...] }`.
+        if let wrapper = try? decoder.decode(WorkerRunList.self, from: data) {
+            return wrapper.runs
+        }
+        if let run = try? decoder.decode(WorkerRun.self, from: data) {
+            return [run]
+        }
+        return []
+    }
+
+    private struct WorkerRunList: Codable { let runs: [WorkerRun] }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/CorveilWorkerBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/CorveilWorkerBackend.swift
@@ -115,6 +115,11 @@ public struct CorveilWorkerBackend: Sendable {
 
     /// Terminal transition. A non-empty `error` marks the run failed (skips
     /// delivery); otherwise it's completed with the given title/content/output.
+    ///
+    /// Note: `content`/`output` are passed as argv, so a very large payload could
+    /// hit the platform `ARG_MAX` limit. Fine for typical result summaries;
+    /// bulky-payload runs would want a stdin/file transport (deferred follow-up,
+    /// corveil/crow#801 review).
     public func complete(
         _ id: String,
         workerID: String,

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/CorveilWorkerBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/CorveilWorkerBackend.swift
@@ -81,7 +81,7 @@ public struct CorveilWorkerBackend: Sendable {
             args += ["--limit", String(limit)]
         }
         let output = try await run(args)
-        return Self.parseRuns(output)
+        return try Self.parseRuns(output)
     }
 
     /// Full snapshot for one run (prompt body + write-back policy).
@@ -193,9 +193,21 @@ public struct CorveilWorkerBackend: Sendable {
         throw WorkerRunError.badResponse(output)
     }
 
-    /// Parse an array of `WorkerRun`s from `list` output (tolerates a bare object).
-    static func parseRuns(_ output: String) -> [WorkerRun] {
-        guard let data = output.data(using: .utf8) else { return [] }
+    /// Parse an array of `WorkerRun`s from `list` output (tolerates a bare object
+    /// or a `{ "runs": [...] }` wrapper).
+    ///
+    /// Throws ``WorkerRunError/badResponse`` when stdout is **non-empty but
+    /// unparseable**: a truly empty queue emits `""` / `[]` / `{"runs":[]}` (all
+    /// of which parse to an empty array), so anything else that fails to decode is
+    /// CLI schema drift, not an empty queue. Without this, malformed output that
+    /// still exits 0 would silently look like "nothing to claim" and idle the
+    /// runner forever (review).
+    static func parseRuns(_ output: String) throws -> [WorkerRun] {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }  // no output ⇒ empty queue
+        guard let data = trimmed.data(using: .utf8) else {
+            throw WorkerRunError.badResponse(output)
+        }
         let decoder = JSONDecoder()
         if let runs = try? decoder.decode([WorkerRun].self, from: data) {
             return runs
@@ -207,7 +219,7 @@ public struct CorveilWorkerBackend: Sendable {
         if let run = try? decoder.decode(WorkerRun.self, from: data) {
             return [run]
         }
-        return []
+        throw WorkerRunError.badResponse(output)  // non-empty + unparseable ⇒ schema drift
     }
 
     private struct WorkerRunList: Codable { let runs: [WorkerRun] }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/WorkerRun.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/WorkerRun.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// A Corveil worker-run envelope, as returned by the `corveil worker-run …` CLI
+/// (a projection of the `/api/worker-runs` JSON — see Corveil ADR-0020).
+///
+/// A worker run is the Corveil-sourced twin of a local `JobConfig` run: a
+/// prompt snapshotted at enqueue that an external Crow runner claims, executes
+/// on its own subscription, and completes — with allow-listed write-backs
+/// routed through Corveil (`worker-run mcp-call`) so no org secrets live on the
+/// runner. Crow only reads the fields it needs to execute and complete a run;
+/// unknown fields are ignored (forward-compatible decoding).
+public struct WorkerRun: Codable, Sendable, Equatable {
+    /// Run id (the token passed to every `worker-run` verb).
+    public let id: String
+    /// Denormalized worker slug — the routing `kind` a runner filters on.
+    public let kind: String?
+    /// Resolved prompt (template vars already applied at enqueue). The body the
+    /// agent executes; `nil`/empty means the run carries nothing to run.
+    public let promptTitle: String?
+    public let promptBody: String?
+    /// Per-server write-back allow-list snapshot:
+    /// `{ "<server>": { "allowed": [...], "dry_run": bool } }`. Surfaced so the
+    /// wrapped prompt can tell the agent which `mcp-call` tools are permitted.
+    public let writebackPolicy: [String: WritebackBinding]?
+    /// Hard claim filter — a runner must advertise all of these caps.
+    public let requiredCaps: [String]?
+    /// Lifecycle: `queued | claimed | running | completed | failed`.
+    public let status: String?
+    /// Active claim (present once claimed), or `nil` when queued/terminal.
+    public let claim: WorkerRunClaim?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, kind, status, claim
+        case promptTitle = "prompt_title"
+        case promptBody = "prompt_body"
+        case writebackPolicy = "writeback_policy"
+        case requiredCaps = "required_caps"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        kind = try c.decodeIfPresent(String.self, forKey: .kind)
+        status = try c.decodeIfPresent(String.self, forKey: .status)
+        claim = try c.decodeIfPresent(WorkerRunClaim.self, forKey: .claim)
+        promptTitle = try c.decodeIfPresent(String.self, forKey: .promptTitle)
+        promptBody = try c.decodeIfPresent(String.self, forKey: .promptBody)
+        writebackPolicy = try c.decodeIfPresent([String: WritebackBinding].self, forKey: .writebackPolicy)
+        requiredCaps = try c.decodeIfPresent([String].self, forKey: .requiredCaps)
+    }
+
+    public init(
+        id: String,
+        kind: String? = nil,
+        promptTitle: String? = nil,
+        promptBody: String? = nil,
+        writebackPolicy: [String: WritebackBinding]? = nil,
+        requiredCaps: [String]? = nil,
+        status: String? = nil,
+        claim: WorkerRunClaim? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.promptTitle = promptTitle
+        self.promptBody = promptBody
+        self.writebackPolicy = writebackPolicy
+        self.requiredCaps = requiredCaps
+        self.status = status
+        self.claim = claim
+    }
+}
+
+/// One server's write-back grant inside a run's `writeback_policy`.
+public struct WritebackBinding: Codable, Sendable, Equatable {
+    public let allowed: [String]
+    public let dryRun: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case allowed
+        case dryRun = "dry_run"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        allowed = try c.decodeIfPresent([String].self, forKey: .allowed) ?? []
+        dryRun = try c.decodeIfPresent(Bool.self, forKey: .dryRun) ?? false
+    }
+
+    public init(allowed: [String], dryRun: Bool = false) {
+        self.allowed = allowed
+        self.dryRun = dryRun
+    }
+}
+
+/// The `claim` JSONB on a claimed/running run.
+public struct WorkerRunClaim: Codable, Sendable, Equatable {
+    public let workerID: String?
+    public let leaseExpiresAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case workerID = "worker_id"
+        case leaseExpiresAt = "lease_expires_at"
+    }
+
+    public init(workerID: String?, leaseExpiresAt: String? = nil) {
+        self.workerID = workerID
+        self.leaseExpiresAt = leaseExpiresAt
+    }
+}
+
+/// The agent's final result for a run, read by Crow from
+/// `<scratchDir>/.crow-run-result.json` on `.done` and mapped to
+/// `corveil worker-run complete` (Crow owns the terminal Corveil calls).
+public struct WorkerRunResult: Codable, Sendable, Equatable {
+    public let title: String?
+    public let content: String?
+    /// Typed result blob, re-serialized verbatim into `complete --output`.
+    public let output: String?
+    /// Non-empty ⇒ the agent reported a failure ⇒ `complete --error`.
+    public let error: String?
+
+    public init(title: String?, content: String?, output: String? = nil, error: String? = nil) {
+        self.title = title
+        self.content = content
+        self.output = output
+        self.error = error
+    }
+
+    /// Decode a `.crow-run-result.json` payload from raw bytes. `output` may be a
+    /// nested JSON object; it's re-encoded to a compact string so it can be
+    /// handed straight to `worker-run complete --output`. Pure (no filesystem)
+    /// so it's unit-testable.
+    public static func decode(fromJSON data: Data) -> WorkerRunResult? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let title = obj["title"] as? String
+        let content = obj["content"] as? String
+        let error = obj["error"] as? String
+        var output: String?
+        if let outObj = obj["output"], !(outObj is NSNull) {
+            output = (try? JSONSerialization.data(withJSONObject: outObj))
+                .flatMap { String(data: $0, encoding: .utf8) }
+        }
+        return WorkerRunResult(title: title, content: content, output: output, error: error)
+    }
+
+    /// Read and decode `<scratchDir>/.crow-run-result.json`, or `nil` if the file
+    /// is missing/unparseable (⇒ the caller completes the run with `--error`).
+    public static func decode(fromFile path: String) -> WorkerRunResult? {
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        return decode(fromJSON: data)
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/WorkerRun.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/WorkerRun.swift
@@ -126,10 +126,12 @@ public struct WorkerRunResult: Codable, Sendable, Equatable {
         self.error = error
     }
 
-    /// Decode a `.crow-run-result.json` payload from raw bytes. `output` may be a
-    /// nested JSON object; it's re-encoded to a compact string so it can be
-    /// handed straight to `worker-run complete --output`. Pure (no filesystem)
-    /// so it's unit-testable.
+    /// Decode a `.crow-run-result.json` payload from raw bytes. `output` is
+    /// preserved for `worker-run complete --output`: a nested object/array is
+    /// re-encoded to compact JSON, a string is passed through verbatim, and any
+    /// other scalar is stringified — so a string-typed `output` is never silently
+    /// dropped (`JSONSerialization.data(withJSONObject:)` rejects a top-level
+    /// String) (review). Pure (no filesystem) so it's unit-testable.
     public static func decode(fromJSON data: Data) -> WorkerRunResult? {
         guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
@@ -139,8 +141,14 @@ public struct WorkerRunResult: Codable, Sendable, Equatable {
         let error = obj["error"] as? String
         var output: String?
         if let outObj = obj["output"], !(outObj is NSNull) {
-            output = (try? JSONSerialization.data(withJSONObject: outObj))
-                .flatMap { String(data: $0, encoding: .utf8) }
+            if let s = outObj as? String {
+                output = s
+            } else if JSONSerialization.isValidJSONObject(outObj),
+                      let data = try? JSONSerialization.data(withJSONObject: outObj) {
+                output = String(data: data, encoding: .utf8)
+            } else {
+                output = String(describing: outObj)  // number/bool scalar
+            }
         }
         return WorkerRunResult(title: title, content: content, output: output, error: error)
     }

--- a/Packages/CrowProvider/Tests/CrowProviderTests/CorveilWorkerBackendTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/CorveilWorkerBackendTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+import CrowCore
+@testable import CrowProvider
+
+/// Exercises `CorveilWorkerBackend` against `FakeShellRunner` (reused from
+/// `BackendsTests`) — the ADR 0005 testability bar. Asserts the exact `corveil
+/// worker-run` argv + env for each verb plus JSON parsing and the typed error
+/// mapping, without spawning real `corveil` (corveil/crow#801).
+final class CorveilWorkerBackendTests: XCTestCase {
+
+    private let config = CorveilWorkerConfig(url: "https://corveil.acme.io", apiKey: "sk-test-123")
+
+    private func backend(_ fake: FakeShellRunner) -> CorveilWorkerBackend {
+        CorveilWorkerBackend(shellRunner: fake, config: config)
+    }
+
+    // MARK: - Credentials as env
+
+    func testPassesCorveilURLAndAPIKeyAsEnv() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("[]")]
+        _ = try await backend(fake).listClaimable(kind: nil, caps: [])
+        let call = try XCTUnwrap(fake.calls.first)
+        XCTAssertEqual(call.env["CORVEIL_URL"], "https://corveil.acme.io")
+        XCTAssertEqual(call.env["CORVEIL_API_KEY"], "sk-test-123")
+    }
+
+    func testEmptyCredentialsAreOmittedFromEnv() {
+        let empty = CorveilWorkerConfig(url: "", apiKey: "")
+        XCTAssertTrue(empty.env.isEmpty)
+        XCTAssertFalse(empty.hasAPIKey)
+        XCTAssertTrue(CorveilWorkerConfig(url: "u", apiKey: "k").hasAPIKey)
+    }
+
+    // MARK: - list
+
+    func testListClaimableBuildsClaimableArgvWithKindAndCaps() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"[{"id":"r1","kind":"tend-ontology","status":"queued"}]"#)]
+        let runs = try await backend(fake).listClaimable(kind: "tend-ontology", caps: ["ontology-write", "search"])
+
+        XCTAssertEqual(runs.count, 1)
+        XCTAssertEqual(runs.first?.id, "r1")
+        XCTAssertEqual(runs.first?.kind, "tend-ontology")
+
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        XCTAssertEqual(Array(args.prefix(4)), ["corveil", "worker-run", "list", "--claimable"])
+        XCTAssertTrue(args.contains("--json"))
+        XCTAssertEqual(args[args.firstIndex(of: "--kind")! + 1], "tend-ontology")
+        // caps are comma-joined into a single flag value.
+        XCTAssertEqual(args[args.firstIndex(of: "--caps")! + 1], "ontology-write,search")
+    }
+
+    func testListClaimableOmitsKindAndCapsWhenEmpty() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("[]")]
+        _ = try await backend(fake).listClaimable(kind: nil, caps: [])
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        // Passing an empty caps array must NOT send `--caps` (that would opt into
+        // the "no-cap runs only" subset filter).
+        XCTAssertFalse(args.contains("--caps"))
+        XCTAssertFalse(args.contains("--kind"))
+    }
+
+    func testListToleratesRunsWrapperObject() {
+        let runs = CorveilWorkerBackend.parseRuns(#"{"runs":[{"id":"a"},{"id":"b"}]}"#)
+        XCTAssertEqual(runs.map(\.id), ["a", "b"])
+    }
+
+    // MARK: - get / claim
+
+    func testGetParsesFullSnapshot() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"""
+        {"id":"r7","kind":"tend","prompt_title":"Tidy","prompt_body":"Do the thing",
+         "required_caps":["ontology-write"],
+         "writeback_policy":{"ontology":{"allowed":["ontology_update_entity"],"dry_run":false}},
+         "status":"claimed","claim":{"worker_id":"crow-host-1","lease_expires_at":"2026-07-24T00:00:00Z"}}
+        """#)]
+        let run = try await backend(fake).get("r7")
+        XCTAssertEqual(run.promptBody, "Do the thing")
+        XCTAssertEqual(run.requiredCaps, ["ontology-write"])
+        XCTAssertEqual(run.writebackPolicy?["ontology"]?.allowed, ["ontology_update_entity"])
+        XCTAssertEqual(run.writebackPolicy?["ontology"]?.dryRun, false)
+        XCTAssertEqual(run.claim?.workerID, "crow-host-1")
+
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        XCTAssertEqual(Array(args.prefix(3)), ["corveil", "worker-run", "get"])
+        XCTAssertTrue(args.contains("r7"))
+    }
+
+    func testClaimBuildsArgvWithWorkerIDAndLease() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"{"id":"r1","status":"claimed","claim":{"worker_id":"w1"}}"#)]
+        let run = try await backend(fake).claim("r1", workerID: "w1", leaseSeconds: 1800)
+        XCTAssertEqual(run.status, "claimed")
+
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        XCTAssertEqual(Array(args.prefix(3)), ["corveil", "worker-run", "claim"])
+        XCTAssertEqual(args[args.firstIndex(of: "--worker-id")! + 1], "w1")
+        XCTAssertEqual(args[args.firstIndex(of: "--lease-seconds")! + 1], "1800")
+    }
+
+    func testClaimMapsConflictToUnclaimable() async {
+        let fake = FakeShellRunner()
+        fake.responses = [.failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: #"{"code":"conflict","message":"already claimed"}"#))]
+        do {
+            _ = try await backend(fake).claim("r1", workerID: "w1", leaseSeconds: 1800)
+            XCTFail("expected throw")
+        } catch WorkerRunError.unclaimable {
+            // expected
+        } catch {
+            XCTFail("expected unclaimable, got \(error)")
+        }
+    }
+
+    // MARK: - heartbeat
+
+    func testHeartbeatBuildsArgv() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("{}")]
+        try await backend(fake).heartbeat("r1", workerID: "w1", leaseSeconds: 900)
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        XCTAssertEqual(Array(args.prefix(3)), ["corveil", "worker-run", "heartbeat"])
+        XCTAssertEqual(args[args.firstIndex(of: "--worker-id")! + 1], "w1")
+        XCTAssertEqual(args[args.firstIndex(of: "--lease-seconds")! + 1], "900")
+    }
+
+    // MARK: - complete
+
+    func testCompleteSuccessSendsTitleContentOutputNotError() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("{}")]
+        try await backend(fake).complete(
+            "r1", workerID: "w1",
+            title: "Did it", content: "changed 3 entities", output: #"{"entities_written":3}"#, error: nil
+        )
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        XCTAssertEqual(Array(args.prefix(3)), ["corveil", "worker-run", "complete"])
+        XCTAssertEqual(args[args.firstIndex(of: "--title")! + 1], "Did it")
+        XCTAssertEqual(args[args.firstIndex(of: "--content")! + 1], "changed 3 entities")
+        XCTAssertEqual(args[args.firstIndex(of: "--output")! + 1], #"{"entities_written":3}"#)
+        XCTAssertFalse(args.contains("--error"))
+    }
+
+    func testCompleteWithErrorSendsErrorAndSkipsTitle() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("{}")]
+        try await backend(fake).complete(
+            "r1", workerID: "w1",
+            title: "ignored", content: "ignored", output: "{}", error: "it broke"
+        )
+        let args = try XCTUnwrap(fake.calls.first?.args)
+        XCTAssertEqual(args[args.firstIndex(of: "--error")! + 1], "it broke")
+        XCTAssertFalse(args.contains("--title"))
+        XCTAssertFalse(args.contains("--content"))
+    }
+
+    // MARK: - error classification
+
+    func testClassifyFeatureDisabled() {
+        XCTAssertEqual(CorveilWorkerBackend.classify(#"{"code":"feature_disabled"}"#), .featureDisabled)
+    }
+
+    func testClassifyUnauthenticated() {
+        XCTAssertEqual(CorveilWorkerBackend.classify("please run corveil login"), .unauthenticated)
+        XCTAssertEqual(CorveilWorkerBackend.classify("HTTP 401 unauthorized"), .unauthenticated)
+    }
+
+    func testClassifyFallsBackToCommandFailed() {
+        XCTAssertEqual(CorveilWorkerBackend.classify("some other boom"), .commandFailed("some other boom"))
+    }
+
+    func testFeatureDisabledSurfacesFromList() async {
+        let fake = FakeShellRunner()
+        fake.responses = [.failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "feature_disabled"))]
+        do {
+            _ = try await backend(fake).listClaimable(kind: nil, caps: [])
+            XCTFail("expected throw")
+        } catch WorkerRunError.featureDisabled {
+            // expected
+        } catch {
+            XCTFail("expected featureDisabled, got \(error)")
+        }
+    }
+}

--- a/Packages/CrowProvider/Tests/CrowProviderTests/CorveilWorkerBackendTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/CorveilWorkerBackendTests.swift
@@ -62,9 +62,38 @@ final class CorveilWorkerBackendTests: XCTestCase {
         XCTAssertFalse(args.contains("--kind"))
     }
 
-    func testListToleratesRunsWrapperObject() {
-        let runs = CorveilWorkerBackend.parseRuns(#"{"runs":[{"id":"a"},{"id":"b"}]}"#)
+    func testListToleratesRunsWrapperObject() throws {
+        let runs = try CorveilWorkerBackend.parseRuns(#"{"runs":[{"id":"a"},{"id":"b"}]}"#)
         XCTAssertEqual(runs.map(\.id), ["a", "b"])
+    }
+
+    func testParseRunsTreatsEmptyOutputAsEmptyQueue() throws {
+        XCTAssertEqual(try CorveilWorkerBackend.parseRuns("").count, 0)
+        XCTAssertEqual(try CorveilWorkerBackend.parseRuns("   \n").count, 0)
+        XCTAssertEqual(try CorveilWorkerBackend.parseRuns("[]").count, 0)
+        XCTAssertEqual(try CorveilWorkerBackend.parseRuns(#"{"runs":[]}"#).count, 0)
+    }
+
+    func testParseRunsThrowsOnUnparseableNonEmptyOutput() {
+        // Schema drift / wrapper change that still exits 0 must NOT look like an
+        // empty queue — it throws so the runner surfaces the failure.
+        XCTAssertThrowsError(try CorveilWorkerBackend.parseRuns("not json at all")) { error in
+            XCTAssertEqual(error as? WorkerRunError, .badResponse("not json at all"))
+        }
+        XCTAssertThrowsError(try CorveilWorkerBackend.parseRuns(#"{"unexpected":"shape"}"#))
+    }
+
+    func testListClaimableSurfacesUnparseableOutputAsError() async {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("garbage-not-json")]
+        do {
+            _ = try await backend(fake).listClaimable(kind: nil, caps: [])
+            XCTFail("expected throw on unparseable list output")
+        } catch let error as WorkerRunError {
+            XCTAssertEqual(error, .badResponse("garbage-not-json"))
+        } catch {
+            XCTFail("expected WorkerRunError.badResponse, got \(error)")
+        }
     }
 
     // MARK: - get / claim

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -229,7 +229,7 @@ An agent kind that is not currently available is rejected and nothing is written
 | `--review` | `<review>` | no | Agent for PR-review sessions |
 | `--job` | `<job>` | no | Agent for scheduled-job sessions |
 | `--manager` | `<manager>` | no | Agent for the Manager session |
-| `--clear` | `<clear>` _(repeatable)_ | no | Role whose override to remove, falling back to the default (repeatable). Values: `work`, `review`, `job`, `manager`. |
+| `--clear` | `<clear>` _(repeatable)_ | no | Role whose override to remove, falling back to the default (repeatable). Values: `work`, `review`, `job`, `manager`, `workerRun`. |
 
 ---
 


### PR DESCRIPTION
Advances **#801** — the Crow half of the Corveil worker-runner initiative. Corveil **Phase 1 is merged** (worker-runs API/CLI + the `worker-runner` skill), so this is real integration against live surfaces, not a paper design. Ships a coherent **first slice** end-to-end; follow-ups filed separately.

## What this does

Makes Crow a first-class **runner for Corveil worker runs**, alongside its existing local `config.json` jobs. A Crow job and a Corveil worker run are the same shape — session → agent → prompt → `.done` → complete — differing only in **source**. The Corveil source is **additive**; local jobs are unchanged.

### Slice 1 (this PR)
- **§1 Runner mode / claim loop** — new `@MainActor WorkerRunner` (CrowEngine), the Corveil twin of `JobScheduler`: polls a Corveil queue for claimable runs, claims up to a per-host cap, holds the lease with heartbeats, driven by the daemon's headless poll (`startRunnerPoll`). Corveil is reached via the merged `corveil worker-run …` CLI (`CorveilWorkerBackend`, CrowProvider), authenticating with an **org-scoped API key sourced from the crowd process env** (`CORVEIL_API_KEY`) — never persisted to `config.json`.
- **§2 Repo-less scratch-workdir execution** (ADR-0020 §Q3) — `SessionService.runWorkerRun` spins up a throwaway dir under `{devRoot}/.crow-worker-runs/<runID>` (**no git worktree**) holding the wrapped prompt + injected `corveil` credentials (`writeCorveilRunEnv`, 0600), with a **synthetic `SessionWorktree`** so the existing `launchAgent` machinery (hooks/trust/gateway) drives it unchanged. The scratch dir is **wiped on completion and on abort** (it holds the scoped `CORVEIL_API_KEY`).
- **§3 Completion mapping** — reuses `JobScheduler.finishDecision` (the same `.done` + settle-window logic); on finish, **Crow** reads the agent's `.crow-run-result.json` and maps it onto `corveil worker-run complete` (or `--error` on failure / a missing result). Crow owns claim/heartbeat/complete; the agent only performs allow-listed write-backs via `worker-run mcp-call`.
- **§5 Per-host concurrency cap** (lifted from the open question) — `RunnerConfig.maxConcurrentRuns` bounds in-flight runs: the Crow side paired with Corveil's staleness SLO (**corveil#1834**).

Plus: new `SessionKind.workerRun` (+ persisted run linkage on `Session` so a relaunched `crowd` still completes the run and wipes the scratch dir), a `runner` block in `AppConfig`, and a read-only `runner-status` RPC.

## Enabling it
Start `crowd` with `CORVEIL_URL` + `CORVEIL_API_KEY` in its env, and a `runner` block in `{devRoot}/.claude/config.json`:
```json
{ "runner": { "enabled": true, "kinds": ["tend-ontology"], "caps": ["ontology-write"], "maxConcurrentRuns": 1 } }
```
Requires a `plan.FeatureCrowWorkers`-enabled org (else the CLI returns `feature_disabled` and the runner stays idle).

## Tests
Claim planning; completion mapping + result decode; wrapped-prompt builder; `CorveilWorkerBackend` argv/env/error mapping (`FakeShellRunner`); `RunnerConfig` decode + worker-id defaulting; `writeCorveilRunEnv` 0600 injection; scratch-dir path + cleanup. `make test` is green except one **pre-existing, environment-dependent** tmux integration test (`retryReadinessEmitsTimedOutWhenSentinelMissing`), confirmed failing on the clean baseline and unrelated to this change.

## Deferred to sibling follow-ups (to be filed & assigned @dhilgaertner)
- `crow runner register/start/stop/status` CLI verbs (+ RPC).
- Full **§4** unification of local `JobConfig` and Corveil-sourced runs through one execution path.
- Routing/labels beyond `kind`+`caps` (ADR-0014 leaves claiming largely unrouted in v1).
- A formal session **link** to the Corveil run (currently surfaced via the persisted `workerRunID` + run title + completed status).
- Non-Claude harness parity for the scratch-workdir path (ADR-0015 tiers; MCP wiring gaps).

Closes part of #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i943aSjQRtLjgHy2god79
