### PR TITLE
Fix stale crow:merge label view (icon + auto-merge)

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -784,6 +784,14 @@ public final class IssueTracker {
     /// OPEN→MERGED demotion mid-refresh still carries the checks/reviews
     /// from the OPEN record (the stale-PR follow-up query leaves those
     /// fields empty).
+    ///
+    /// Labels are **unioned** rather than picked from one side (#838): a
+    /// freshly added `crow:merge` can arrive on whichever record wins the
+    /// state rank, so choosing one side's array wholesale silently dropped it
+    /// (e.g. a stale winner with a pre-label label set shadowing the fresh
+    /// loser). Both the merge icon (`hasMergeLabel`) and the auto-merge watcher
+    /// (`autoMergeSkipReason`) read this field, so a label GitHub reports on
+    /// either record must survive the merge.
     nonisolated static func mergePRRecords(_ lhs: ViewerPR, _ rhs: ViewerPR) -> ViewerPR {
         let (winner, loser) = stateRank(lhs.state) >= stateRank(rhs.state)
             ? (lhs, rhs) : (rhs, lhs)
@@ -799,7 +807,7 @@ public final class IssueTracker {
             headRefOid: winner.headRefOid.isEmpty ? loser.headRefOid : winner.headRefOid,
             baseRefName: winner.baseRefName.isEmpty ? loser.baseRefName : winner.baseRefName,
             repoNameWithOwner: winner.repoNameWithOwner.isEmpty ? loser.repoNameWithOwner : winner.repoNameWithOwner,
-            labels: winner.labels.isEmpty ? loser.labels : winner.labels,
+            labels: Self.unionLabels(winner.labels, loser.labels),
             linkedIssueReferences: winner.linkedIssueReferences.isEmpty ? loser.linkedIssueReferences : winner.linkedIssueReferences,
             checksState: winner.checksState.isEmpty ? loser.checksState : winner.checksState,
             failedCheckNames: winner.failedCheckNames.isEmpty ? loser.failedCheckNames : winner.failedCheckNames,
@@ -808,6 +816,21 @@ public final class IssueTracker {
             lastSubstantiveCommitAt: winner.lastSubstantiveCommitAt ?? loser.lastSubstantiveCommitAt,
             mergeCommitOid: winner.mergeCommitOid ?? loser.mergeCommitOid
         )
+    }
+
+    /// Union two label arrays, preserving `primary` order and appending any
+    /// `secondary` label whose name isn't already present. Dedup is
+    /// case-insensitive by `name` — matching how `autoMergeLabel` is compared
+    /// everywhere else — so a `crow:merge`/`Crow:Merge` clash collapses to one
+    /// entry rather than duplicating.
+    nonisolated static func unionLabels(_ primary: [LabelInfo], _ secondary: [LabelInfo]) -> [LabelInfo] {
+        guard !secondary.isEmpty else { return primary }
+        var seen = Set(primary.map { $0.name.lowercased() })
+        var out = primary
+        for label in secondary where seen.insert(label.name.lowercased()).inserted {
+            out.append(label)
+        }
+        return out
     }
 
     /// Collapse duplicate URLs using `mergePRRecords`, preserving first-seen
@@ -943,9 +966,12 @@ public final class IssueTracker {
     /// `gh`/`glab` call, GitLab MRs go through one REST call per
     /// MR (with `GITLAB_HOST` set per host). A failure on either side marks
     /// the result incomplete but doesn't suppress the other side's PRs.
-    /// Returns minimal `ViewerPR` records — only `state`, `url`, repo, and
-    /// branch refs are populated; checks/reviews are left empty since
-    /// they're moot for closed PRs.
+    /// Returns minimal `ViewerPR` records — `state`, `url`, repo, branch refs,
+    /// and `labels` are populated; checks/reviews are left empty since they're
+    /// moot for closed PRs. Labels are fetched (#838) so a session-linked PR
+    /// that flows through the stale path — rather than the open-viewer query —
+    /// still carries its `crow:merge` label into `dedupedByURL`/`mergePRRecords`
+    /// instead of shadowing the fresh label with an empty set.
     private func fetchStalePRStates(urls: [String]) async -> StalePRFetchResult {
         // Bucket URLs by (provider, host). GitLab self-hosted needs the host so the
         // backend pins the right GITLAB_HOST env var.
@@ -3539,6 +3565,14 @@ public final class IssueTracker {
             try await backend.ensureMergeLabel(repo: repo)
             try await backend.addMergeLabel(prURL: prLink.url)
             NSLog("[Crow] Added crow:merge to %@", prLink.url as NSString)
+            // Optimistically flip the merge icon so the user sees the label
+            // land immediately, rather than waiting for — and getting stuck
+            // behind — the next full poll's snapshot (#838). The subsequent
+            // refresh re-fetches the PR and confirms/keeps this flag.
+            appState.prStatus[sessionID]?.hasMergeLabel = true
+            // Targeted re-fetch so the auto-merge watcher re-evaluates promptly
+            // with the label present instead of on the next scheduled poll.
+            await refresh()
         } catch {
             print("[IssueTracker] addMergeLabel failed for \(prLink.url): \(error.localizedDescription.prefix(200))")
         }

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -241,6 +241,20 @@ public final class IssueTracker {
     /// real-world telemetry calls for it.
     nonisolated static let needsRefineCooldown: TimeInterval = 7 * 60
 
+    /// Sessions whose PR just had `crow:merge` added via `addMergeLabel` but
+    /// whose next fetched snapshot may not yet reflect it (#838). Two windows
+    /// leave a fresh label temporarily invisible: an in-flight poll that
+    /// *started before* the add will overwrite `prStatus` in `applyPRStatuses`
+    /// with pre-label data (clearing the optimistic flag), and GitHub's
+    /// read-your-write consistency lag. While a session sits here,
+    /// `applyPRStatuses` keeps its merge icon lit (ORs `hasMergeLabel`) and
+    /// drops the marker the moment a fetched record actually confirms the label
+    /// — so the icon never flickers off between the add and the durable
+    /// stale-query/union fixes catching up. Ephemeral; pruned to live sessions.
+    /// Internal (not private) so `@testable` tests can seed it without driving
+    /// a full `addMergeLabel` (which needs a live backend + `gh` call).
+    var pendingMergeLabelSessions: Set<UUID> = []
+
     /// Guards the GitHub-scope console warning so it fires once per session.
     private var didLogGitHubScopeWarning = false
 
@@ -1787,8 +1801,25 @@ public final class IssueTracker {
             guard let pr = byURL[prLink.url] else { continue }
             livePRURLs.insert(prLink.url)
 
-            let newStatus = Self.buildPRStatus(from: pr)
+            var newStatus = Self.buildPRStatus(from: pr)
             let oldStatus = previousPRStatus[session.id]
+
+            // #838: after a successful `addMergeLabel`, keep the merge icon lit
+            // until a fetch actually confirms `crow:merge`. An in-flight poll
+            // that started before the add carries pre-label data and would
+            // otherwise clear the optimistic flag here; GitHub's read-your-write
+            // lag can do the same. Once a snapshot reports the label, the
+            // durable path (stale-query labels + `unionLabels`) has caught up —
+            // drop the marker so a genuine later removal isn't masked. Applied
+            // before the assignments below; `hasMergeLabel` isn't a transition
+            // input, so this doesn't affect checks-failing/needs-refine edges.
+            if pendingMergeLabelSessions.contains(session.id) {
+                if newStatus.hasMergeLabel {
+                    pendingMergeLabelSessions.remove(session.id)
+                } else {
+                    newStatus.hasMergeLabel = true
+                }
+            }
 
             // Checks-failing edge: fire only when transitioning from
             // non-failing to failing. `transitions(from:to:…)` returns at
@@ -1852,6 +1883,12 @@ public final class IssueTracker {
         if !seenPRs.isEmpty { seenPRs.formIntersection(livePRURLs) }
         lastRefineDispatchAt = lastRefineDispatchAt.filter { livePRURLs.contains($0.key) }
         lastNotifiedChangesRequestedAt = lastNotifiedChangesRequestedAt.filter { livePRURLs.contains($0.key) }
+        // Drop pending merge-label markers for sessions that no longer exist
+        // (deleted mid-window). Keyed by session, so intersect with live
+        // sessions rather than PR URLs (#838).
+        if !pendingMergeLabelSessions.isEmpty {
+            pendingMergeLabelSessions.formIntersection(Set(sessionsWithPRs.map { $0.id }))
+        }
 
         if !transitions.isEmpty {
             onPRStatusTransitions?(transitions)
@@ -3567,8 +3604,11 @@ public final class IssueTracker {
             NSLog("[Crow] Added crow:merge to %@", prLink.url as NSString)
             // Optimistically flip the merge icon so the user sees the label
             // land immediately, rather than waiting for — and getting stuck
-            // behind — the next full poll's snapshot (#838). The subsequent
-            // refresh re-fetches the PR and confirms/keeps this flag.
+            // behind — the next full poll's snapshot (#838). The sticky marker
+            // keeps it lit across a poll that started *before* this add (which
+            // would otherwise overwrite `prStatus` with pre-label data) until a
+            // fetch confirms the label; `applyPRStatuses` clears it then.
+            pendingMergeLabelSessions.insert(sessionID)
             appState.prStatus[sessionID]?.hasMergeLabel = true
             // Targeted re-fetch so the auto-merge watcher re-evaluates promptly
             // with the label present instead of on the next scheduled poll.

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoMergeTests.swift
@@ -135,6 +135,25 @@ struct IssueTrackerAutoMergeTests {
         #expect(IssueTracker.autoMergeSkipReason(pr: makePR(), session: makeSession()) == nil)
     }
 
+    @Test func gainingCrowMergeLabelFlipsIconAndClearsNoMergeLabelSkip() {
+        // #838 acceptance criterion (a): the exact before/after a right-click
+        // "Add label crow:merge to PR" produces. Before the label lands both
+        // consumers reject the PR; once the fresh label is present on the
+        // record, the icon flag flips true and the watcher stops skipping —
+        // a green, open, non-draft, viewer PR now dispatches.
+        let session = makeSession()
+
+        let before = makePR(labels: [Self.otherLabel])
+        #expect(!IssueTracker.buildPRStatus(from: before).hasMergeLabel)
+        #expect(IssueTracker.autoMergeSkipReason(pr: before, session: session) == .noMergeLabel)
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: before, session: session))
+
+        let after = makePR(labels: [Self.otherLabel, Self.crowMergeLabel])
+        #expect(IssueTracker.buildPRStatus(from: after).hasMergeLabel)
+        #expect(IssueTracker.autoMergeSkipReason(pr: after, session: session) == nil)
+        #expect(IssueTracker.shouldAttemptAutoMerge(pr: after, session: session))
+    }
+
     @Test func skipReasonNamesEachGuard() {
         let cases: [(IssueTracker.ViewerPR, Session, IssueTracker.AutoMergeSkipReason)] = [
             (makePR(), makeSession(autoMergeEnabledAt: Date()), .alreadyEnabled),

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
@@ -172,4 +172,65 @@ struct IssueTrackerDedupTests {
         let mergedNoTs = makeViewerPR(url: url, state: "MERGED")
         #expect(IssueTracker.mergePRRecords(open, mergedNoTs).lastSubstantiveCommitAt == openTs)
     }
+
+    // MARK: - #838 label union: a merge must never drop a label GitHub reports
+
+    private static let crowMerge = LabelInfo(name: "crow:merge", color: "0E8A16")
+    private static let docs = LabelInfo(name: "documentation", color: "ffffff")
+
+    private func hasCrowMerge(_ pr: IssueTracker.ViewerPR) -> Bool {
+        pr.labels.contains { $0.name.caseInsensitiveCompare("crow:merge") == .orderedSame }
+    }
+
+    @Test func mergePRRecordsUnionsLabelsSoWinnerCannotShadowFreshLabel() {
+        // The regression the old `winner.labels.isEmpty ? loser : winner`
+        // caused: the higher-rank winner carries a stale, NON-empty label set
+        // (just `documentation`) while the loser carries the freshly added
+        // `crow:merge`. One-side-wins dropped it; the union must keep it.
+        let url = "https://github.com/corveil/crow/pull/836"
+        let staleWinner = makeViewerPR(url: url, state: "MERGED", labels: [Self.docs])
+        let freshLoser = makeViewerPR(url: url, state: "OPEN", labels: [Self.crowMerge])
+        #expect(hasCrowMerge(IssueTracker.mergePRRecords(staleWinner, freshLoser)))
+        // Order-independent: same result whichever side is passed first.
+        #expect(hasCrowMerge(IssueTracker.mergePRRecords(freshLoser, staleWinner)))
+    }
+
+    @Test func mergePRRecordsBackfillsLabelsFromEitherSide() {
+        // Symmetric empty cases the union must still satisfy: a stale record
+        // with no labels (the pre-#838 stale-PR query) must not erase the
+        // fresh label on the other record, regardless of merge order.
+        let url = "https://github.com/corveil/crow/pull/836"
+        let labeled = makeViewerPR(url: url, state: "OPEN", labels: [Self.crowMerge])
+        let empty = makeViewerPR(url: url, state: "MERGED", labels: [])
+        #expect(hasCrowMerge(IssueTracker.mergePRRecords(labeled, empty)))
+        #expect(hasCrowMerge(IssueTracker.mergePRRecords(empty, labeled)))
+    }
+
+    @Test func mergePRRecordsDeduplicatesLabelsAcrossRecords() {
+        // Both records carry the label (case-differing): the union collapses
+        // to a single entry, matching the case-insensitive `crow:merge` rule.
+        let url = "https://github.com/corveil/crow/pull/836"
+        let a = makeViewerPR(url: url, state: "OPEN", labels: [Self.crowMerge, Self.docs])
+        let b = makeViewerPR(url: url, state: "MERGED", labels: [LabelInfo(name: "Crow:Merge", color: nil)])
+        let merged = IssueTracker.mergePRRecords(a, b)
+        let crowMergeCount = merged.labels.filter {
+            $0.name.caseInsensitiveCompare("crow:merge") == .orderedSame
+        }.count
+        #expect(crowMergeCount == 1)
+        #expect(merged.labels.count == 2) // crow:merge + documentation, no dup
+    }
+
+    @Test func dedupedByURLUnionsLabelsAcrossViewerAndStaleRecords() {
+        // End-to-end assembly guard: the same PR arriving once from the
+        // open-viewer query (labels present) and once from the stale path
+        // (labels empty pre-#838) must dedupe to a single record that still
+        // reports `crow:merge` — neither the merge icon nor the auto-merge
+        // watcher can see the label if this drops it.
+        let url = "https://github.com/corveil/crow/pull/836"
+        let viewer = makeViewerPR(url: url, state: "OPEN", labels: [Self.crowMerge])
+        let stale = makeViewerPR(url: url, state: "MERGED", labels: [])
+        let deduped = IssueTracker.dedupedByURL([viewer, stale])
+        #expect(deduped.count == 1)
+        #expect(hasCrowMerge(deduped[0]))
+    }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerMergeLabelStickyTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerMergeLabelStickyTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowProvider
+@testable import CrowEngine
+
+/// #838 regression: after a successful `addMergeLabel`, the merge icon must
+/// stay lit until a fetch actually confirms `crow:merge`. The failure it
+/// guards: an in-flight poll that started *before* the label was added
+/// overwrites `appState.prStatus` in `applyPRStatuses` with pre-label data,
+/// clearing the optimistic flag and re-introducing "stuck until the next
+/// scheduled poll". The sticky `pendingMergeLabelSessions` marker ORs
+/// `hasMergeLabel` across that clobber and clears itself once the label lands.
+@Suite("IssueTracker crow:merge sticky optimistic flag (#838)")
+@MainActor
+struct IssueTrackerMergeLabelStickyTests {
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-merge-sticky-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private static let crowMergeLabel = LabelInfo(name: "crow:merge", color: "0E8A16")
+    private static let prURL = "https://github.com/corveil/crow/pull/836"
+
+    private func makeTracker() -> (tracker: IssueTracker, sessionID: UUID, state: AppState) {
+        let state = AppState()
+        let session = Session(name: "feature/merge-sticky", kind: .work)
+        state.sessions = [session]
+        state.links[session.id] = [
+            SessionLink(sessionID: session.id, label: "PR #836", url: Self.prURL, linkType: .pr)
+        ]
+        let tracker = IssueTracker(appState: state, providerManager: ProviderManager(), store: Self.tempStore())
+        return (tracker, session.id, state)
+    }
+
+    private func makePR(labels: [LabelInfo]) -> PRRecord {
+        PRRecord(
+            number: 836,
+            url: Self.prURL,
+            state: "OPEN",
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "APPROVED",
+            isDraft: false,
+            headRefName: "feature/merge-sticky",
+            headRefOid: "abc1234",
+            baseRefName: "main",
+            repoNameWithOwner: "corveil/crow",
+            labels: labels,
+            linkedIssueReferences: [],
+            checksState: "SUCCESS",
+            failedCheckNames: [],
+            latestReviewStates: ["APPROVED"]
+        )
+    }
+
+    @Test func stickyMarkerKeepsIconLitWhenInFlightPollLacksTheLabel() {
+        // Simulates the clobber: a poll whose payload predates the label add
+        // (labels: []) lands while the session is marked pending.
+        let (tracker, sessionID, state) = makeTracker()
+        tracker.pendingMergeLabelSessions = [sessionID]
+
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [])])
+
+        // Icon stays lit despite the stale snapshot...
+        #expect(state.prStatus[sessionID]?.hasMergeLabel == true)
+        // ...and the marker persists until a fetch confirms the label.
+        #expect(tracker.pendingMergeLabelSessions.contains(sessionID))
+    }
+
+    @Test func stickyMarkerClearsOnceAFetchConfirmsTheLabel() {
+        // Durable path (stale-query labels + union) catches up: the next
+        // snapshot carries crow:merge, so the marker is dropped and the flag
+        // now stands on real data.
+        let (tracker, sessionID, state) = makeTracker()
+        tracker.pendingMergeLabelSessions = [sessionID]
+
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [Self.crowMergeLabel])])
+
+        #expect(state.prStatus[sessionID]?.hasMergeLabel == true)
+        #expect(!tracker.pendingMergeLabelSessions.contains(sessionID))
+    }
+
+    @Test func clobberThenConfirmKeepsIconLitThroughout() {
+        // The full sequence: pending → stale poll (no label, sticky lit) →
+        // real poll (label present, marker clears). The icon is true at every
+        // step, so the user never sees it flicker off.
+        let (tracker, sessionID, state) = makeTracker()
+        tracker.pendingMergeLabelSessions = [sessionID]
+
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [])])
+        #expect(state.prStatus[sessionID]?.hasMergeLabel == true)
+
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [Self.crowMergeLabel])])
+        #expect(state.prStatus[sessionID]?.hasMergeLabel == true)
+        #expect(!tracker.pendingMergeLabelSessions.contains(sessionID))
+    }
+
+    @Test func afterClearAGenuineLabelRemovalIsReflected() {
+        // Once the marker is cleared, the sticky path must not mask a real
+        // later removal — hasMergeLabel follows the fetched data again.
+        let (tracker, sessionID, state) = makeTracker()
+        tracker.pendingMergeLabelSessions = [sessionID]
+
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [Self.crowMergeLabel])]) // confirms + clears
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [])])                    // label removed
+
+        #expect(state.prStatus[sessionID]?.hasMergeLabel == false)
+        #expect(!tracker.pendingMergeLabelSessions.contains(sessionID))
+    }
+
+    @Test func markerForADeletedSessionIsPruned() {
+        // A session deleted mid-window must not leak its marker. applyPRStatuses
+        // intersects pending markers with live sessions each pass.
+        let (tracker, sessionID, _) = makeTracker()
+        let ghostID = UUID() // never in appState.sessions
+        tracker.pendingMergeLabelSessions = [sessionID, ghostID]
+
+        tracker.applyPRStatuses(viewerPRs: [makePR(labels: [])])
+
+        #expect(!tracker.pendingMergeLabelSessions.contains(ghostID))
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -27,7 +27,9 @@ public struct PRRef: Sendable, Hashable {
 /// - reconcile branch matches (`CodeBackend.findRecentPRsForBranches`)
 ///
 /// Not every field is populated by every call — for example, `prStates` skips
-/// labels/checks because the stale-PR query doesn't fetch them. Callers merge
+/// checks/reviews because they're moot for the closed PRs that query targets.
+/// (It does fetch `labels`, since a session-linked PR reached only via the
+/// stale path must still carry its `crow:merge` label — #838.) Callers merge
 /// records by URL using the `merge` helper to fill in gaps as more data
 /// arrives.
 public struct PRRecord: Sendable {

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -28,10 +28,11 @@ public struct PRRef: Sendable, Hashable {
 ///
 /// Not every field is populated by every call — for example, `prStates` skips
 /// checks/reviews because they're moot for the closed PRs that query targets.
-/// (It does fetch `labels`, since a session-linked PR reached only via the
-/// stale path must still carry its `crow:merge` label — #838.) Callers merge
-/// records by URL using the `merge` helper to fill in gaps as more data
-/// arrives.
+/// (GitHub's `prStates` does fetch `labels`, since a session-linked PR reached
+/// only via the stale path must still carry its `crow:merge` label — #838;
+/// GitLab's stale-MR path still omits them, which is fine while auto-merge is
+/// GitHub-only.) Callers merge records by URL using the `merge` helper to fill
+/// in gaps as more data arrives.
 public struct PRRecord: Sendable {
     public let number: Int
     public let url: String

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -108,6 +108,7 @@ public struct GitHubCodeBackend: CodeBackend {
                   headRefName headRefOid baseRefName
                   mergeCommit { oid }
                   repository { nameWithOwner }
+                  labels(first: 20) { nodes { name color } }
                 }
               }
             """)


### PR DESCRIPTION
Closes #838

## Problem

Right-clicking a session → **"Add label crow:merge to PR"** added the label on GitHub but the session never showed the merge icon and auto-merge kept skipping with `no-crow-merge-label`. Both symptoms read the same in-memory `ViewerPR.labels` field via two consumers — `buildPRStatus`'s `hasMergeLabel` (icon) and `autoMergeSkipReason` (watcher). Three independent defects starved that field of the freshly added label.

## Root causes & fixes

1. **`addMergeLabel` never updated local state or re-fetched.** It added the label to GitHub, logged, and only cleared the loading flag — so the icon and watcher stayed on the previous poll's snapshot. It now optimistically flips `PRStatus.hasMergeLabel` and triggers a targeted `refresh()` on success so the watcher re-evaluates promptly (same entry point as manual ⌘R refresh).
2. **The stale-PR query stripped labels.** `refresh()` assembles `dedupedByURL(viewerPRs + stalePRs)`, but `GitHubCodeBackend.prStates` didn't select `labels`, so any session-linked PR reaching the stale path carried `labels: []`. The query now selects `labels(first: 20) { nodes { name color } }`; `parsePRNode` already parses them (no parser change).
3. **`mergePRRecords` picked one side's labels wholesale.** `winner.labels.isEmpty ? loser.labels : winner.labels` let a stale winner with a non-empty pre-label set shadow the fresh `crow:merge` on the loser. It now **unions** labels (case-insensitive dedup by name) so a `crow:merge` on either record survives.

## Tests

- `IssueTrackerAutoMergeTests`: a PR gaining `crow:merge` flips `hasMergeLabel` true and clears the `.noMergeLabel` skip (→ `shouldAttemptAutoMerge`).
- `IssueTrackerDedupTests`: `mergePRRecords`/`dedupedByURL` union labels across duplicate records (winner-shadows-fresh, empty-either-side, dedup, viewer+stale assembly) — never dropping a GitHub-reported label.

All 330 CrowEngine + 52 CrowProvider tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeChUyExqvrrHwDEuFo3rg