### PR TITLE
Fix OTLP /v1/logs decode (tolerant decoding + diagnostics + transport hardening)

### DIFF
--- a/Packages/CrowTelemetry/.claude/skills/verify/SKILL.md
+++ b/Packages/CrowTelemetry/.claude/skills/verify/SKILL.md
@@ -29,12 +29,25 @@ run in the background, then drive it.
 Gotchas:
 - Ingest is OTLP **HTTP/JSON only** (`OTEL_EXPORTER_OTLP_PROTOCOL=http/json`),
   paths `/v1/metrics` and `/v1/logs`, POST only. One request per connection
-  (the receiver closes it after responding).
+  (the receiver closes it after responding). `Content-Length` and
+  `Transfer-Encoding: chunked` both work; a compressed body or a non-JSON
+  `Content-Type` is rejected by name.
 - The resource must carry `crow.session.id` (a UUID string) in
   `resource.attributes`, or the payload is silently skipped.
-- Datapoint values: `asDouble` (number) or `asInt` (**string**, e.g. `"100"`).
-- Sum metrics take `aggregationTemporality` (1=delta, 2=cumulative) and
-  `isMonotonic`; cumulative sums are normalized to deltas at insert.
+- Datapoint values: `asDouble` (number) or `asInt` (string **or** number).
+- Sum metrics take `aggregationTemporality` (1=delta, 2=cumulative, or the
+  `AGGREGATION_TEMPORALITY_*` name) and `isMonotonic`; cumulative sums are
+  normalized to deltas at insert.
+- Decoding is deliberately tolerant (#823): scalars are accepted in either
+  their number or string form, and a malformed record is skipped with a
+  `skipped malformed N logRecords` log line rather than failing the export.
+- Event names arrive **bare** in the `event.name` attribute (`user_prompt`);
+  they are qualified to `claude_code.user_prompt` at ingest, which is the form
+  `countEvents` and `turnAnalytics` match on.
+- Decode failures log the `DecodingError` coding path, which names the
+  offending field. Set `CROW_TELEMETRY_LOG_RAW_BODIES=1` to also log a
+  truncated raw body — off by default because bodies carry account IDs and
+  emails. Repeat failures are throttled to one report per minute per path.
 
 Minimal payload:
 

--- a/Packages/CrowTelemetry/.claude/skills/verify/SKILL.md
+++ b/Packages/CrowTelemetry/.claude/skills/verify/SKILL.md
@@ -32,6 +32,14 @@ Gotchas:
   (the receiver closes it after responding). `Content-Length` and
   `Transfer-Encoding: chunked` both work; a compressed body or a non-JSON
   `Content-Type` is rejected by name.
+- `Content-Type: application/json` is **required** on POST — the receiver fails
+  closed. Pass it explicitly with curl, which otherwise sends
+  `application/x-www-form-urlencoded` for `-d` and gets a 400:
+
+  ```
+  curl -X POST http://localhost:<port>/v1/logs \
+       -H 'Content-Type: application/json' --data-binary @payload.json
+  ```
 - The resource must carry `crow.session.id` (a UUID string) in
   `resource.attributes`, or the payload is silently skipped.
 - Datapoint values: `asDouble` (number) or `asInt` (string **or** number).

--- a/Packages/CrowTelemetry/Package.swift
+++ b/Packages/CrowTelemetry/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         ),
         .testTarget(
             name: "CrowTelemetryTests",
-            dependencies: ["CrowTelemetry"]
+            dependencies: ["CrowTelemetry"],
+            resources: [.copy("Fixtures")]
         ),
     ]
 )

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
@@ -515,6 +515,12 @@ public struct OTLPLogRecord: Codable, Sendable {
     /// (`user_prompt`) while the fully-qualified `claude_code.user_prompt` sits
     /// in the body. Readers in `TelemetryDatabase` match the qualified form, so
     /// unqualified names are prefixed here at ingest.
+    ///
+    /// The `claude_code.` prefix assumes a single producer, which holds because
+    /// `AgentLaunch` exports the `OTEL_*` env only for `agent.kind ==
+    /// .claudeCode` — no other harness reaches this receiver. If a second agent
+    /// ever exports here, this needs a source-aware prefix (derived from the
+    /// resource's `service.name`) rather than a constant.
     public var resolvedEventName: String? {
         let candidate = eventName
             ?? attributes.flatMap { extractAttribute("event.name", from: $0) }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
@@ -327,6 +327,17 @@ public struct OTLPMetricsPayload: Codable, Sendable {
 public struct ResourceMetrics: Codable, Sendable {
     public let resource: OTLPResource?
     public let scopeMetrics: [ScopeMetrics]?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        resource = try? container.decodeIfPresent(OTLPResource.self, forKey: .resource)
+        scopeMetrics = container.otlpLenientArray(
+            ScopeMetrics.self,
+            forKey: .scopeMetrics,
+            label: "scopeMetrics",
+            diagnostics: decoder.otlpDiagnostics
+        )
+    }
 }
 
 /// Metrics from a single instrumentation scope.
@@ -456,6 +467,17 @@ public struct OTLPLogsPayload: Codable, Sendable {
 public struct ResourceLogs: Codable, Sendable {
     public let resource: OTLPResource?
     public let scopeLogs: [ScopeLogs]?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        resource = try? container.decodeIfPresent(OTLPResource.self, forKey: .resource)
+        scopeLogs = container.otlpLenientArray(
+            ScopeLogs.self,
+            forKey: .scopeLogs,
+            label: "scopeLogs",
+            diagnostics: decoder.otlpDiagnostics
+        )
+    }
 }
 
 /// Log records from a single instrumentation scope.

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Models/OTLPModels.swift
@@ -1,5 +1,178 @@
 import Foundation
 
+// MARK: - Decode Diagnostics
+
+/// Collects non-fatal decode losses (records/attributes skipped) for one decode.
+///
+/// Tolerant decoding deliberately drops malformed elements instead of failing
+/// the whole export — this box is how that silent loss gets reported. Pass one
+/// in via `JSONDecoder.userInfo[.otlpDiagnostics]`.
+public final class OTLPDecodeDiagnostics: @unchecked Sendable {
+    private let lock = NSLock()
+    private var counts: [String: Int] = [:]
+
+    public init() {}
+
+    /// Number of elements skipped under `label` (e.g. `"logRecords"`).
+    public func skipped(_ label: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return counts[label] ?? 0
+    }
+
+    /// Human-readable summary, or `nil` when nothing was skipped.
+    public var summary: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !counts.isEmpty else { return nil }
+        return counts.sorted { $0.key < $1.key }
+            .map { "\($0.value) \($0.key)" }
+            .joined(separator: ", ")
+    }
+
+    fileprivate func recordSkip(_ label: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        counts[label, default: 0] += 1
+    }
+}
+
+public extension CodingUserInfoKey {
+    /// Key for an `OTLPDecodeDiagnostics` collecting skipped elements.
+    static let otlpDiagnostics = CodingUserInfoKey(rawValue: "com.corveil.crow.otlp.diagnostics")!
+}
+
+// MARK: - Tolerant Decoding Helpers
+
+/// Consumes any JSON value without inspecting it.
+///
+/// Used to advance an unkeyed container past an element that failed to decode —
+/// `JSONDecoder` does not advance `currentIndex` when `decode` throws.
+private struct SkippedValue: Decodable {
+    init(from decoder: Decoder) throws {}
+}
+
+/// Maps an OTLP/JSON enum name to its number, e.g. `SEVERITY_NUMBER_INFO` → 9.
+///
+/// The protobuf JSON mapping allows enums to travel as either the number or the
+/// symbolic name; Claude Code sends numbers, other SDKs send names.
+private func otlpEnumValue(_ name: String, prefix: String, cases: [String: Int]) -> Int? {
+    var bare = name.uppercased()
+    if bare.hasPrefix(prefix) { bare.removeFirst(prefix.count) }
+    if let exact = cases[bare] { return exact }
+    // Severity names carry a 1-4 suffix within each band: DEBUG2 = DEBUG + 1.
+    guard let last = bare.last, let offset = last.wholeNumberValue, (2...4).contains(offset) else {
+        return nil
+    }
+    guard let base = cases[String(bare.dropLast())] else { return nil }
+    return base + offset - 1
+}
+
+private let severityNumberCases: [String: Int] = [
+    "UNSPECIFIED": 0, "TRACE": 1, "DEBUG": 5, "INFO": 9,
+    "WARN": 13, "ERROR": 17, "FATAL": 21,
+]
+
+private let aggregationTemporalityCases: [String: Int] = [
+    "UNSPECIFIED": 0, "DELTA": 1, "CUMULATIVE": 2,
+]
+
+extension KeyedDecodingContainer {
+    /// Whether `key` is present and not JSON `null`.
+    private func hasValue(_ key: Key) -> Bool {
+        contains(key) && !((try? decodeNil(forKey: key)) ?? true)
+    }
+
+    /// Decode any JSON scalar as a `String`.
+    ///
+    /// OTLP/JSON producers are inconsistent about scalar types, so accept
+    /// whatever arrives rather than failing the entire export.
+    func otlpString(_ key: Key) -> String? {
+        guard hasValue(key) else { return nil }
+        if let value = try? decode(String.self, forKey: key) { return value }
+        if let value = try? decode(Int64.self, forKey: key) { return String(value) }
+        if let value = try? decode(UInt64.self, forKey: key) { return String(value) }
+        if let value = try? decode(Double.self, forKey: key) { return String(value) }
+        if let value = try? decode(Bool.self, forKey: key) { return String(value) }
+        return nil
+    }
+
+    /// Decode an int64 field, which OTLP/JSON permits as a number *or* a string.
+    ///
+    /// Kept as a `String` so values beyond `Double`'s exact range (nanosecond
+    /// timestamps, token counts) survive intact.
+    func otlpInt64String(_ key: Key) -> String? {
+        guard hasValue(key) else { return nil }
+        if let value = try? decode(String.self, forKey: key) { return value }
+        if let value = try? decode(Int64.self, forKey: key) { return String(value) }
+        if let value = try? decode(UInt64.self, forKey: key) { return String(value) }
+        if let value = try? decode(Double.self, forKey: key) { return String(value) }
+        return nil
+    }
+
+    func otlpDouble(_ key: Key) -> Double? {
+        guard hasValue(key) else { return nil }
+        if let value = try? decode(Double.self, forKey: key) { return value }
+        if let value = try? decode(String.self, forKey: key) { return Double(value) }
+        return nil
+    }
+
+    func otlpBool(_ key: Key) -> Bool? {
+        guard hasValue(key) else { return nil }
+        if let value = try? decode(Bool.self, forKey: key) { return value }
+        if let value = try? decode(String.self, forKey: key) { return Bool(value.lowercased()) }
+        return nil
+    }
+
+    /// Decode an enum field sent as either its number or its symbolic name.
+    func otlpEnum(_ key: Key, prefix: String, cases: [String: Int]) -> Int? {
+        guard hasValue(key) else { return nil }
+        if let value = try? decode(Int.self, forKey: key) { return value }
+        guard let name = try? decode(String.self, forKey: key) else { return nil }
+        if let numeric = Int(name) { return numeric }
+        return otlpEnumValue(name, prefix: prefix, cases: cases)
+    }
+
+    /// Decode an array element-by-element, skipping any element that fails.
+    ///
+    /// A single malformed log record should cost that record, not the whole
+    /// export. Skips are counted into the decoder's `OTLPDecodeDiagnostics`
+    /// under `label` so the loss is reported rather than silent.
+    func otlpLenientArray<T: Decodable>(
+        _ type: T.Type,
+        forKey key: Key,
+        label: String,
+        diagnostics: OTLPDecodeDiagnostics?
+    ) -> [T]? {
+        guard hasValue(key) else { return nil }
+        guard var unkeyed = try? nestedUnkeyedContainer(forKey: key) else {
+            // Present but not an array — report the loss rather than hiding it.
+            diagnostics?.recordSkip(label)
+            return nil
+        }
+
+        var elements: [T] = []
+        while !unkeyed.isAtEnd {
+            if let element = try? unkeyed.decode(T.self) {
+                elements.append(element)
+                continue
+            }
+            diagnostics?.recordSkip(label)
+            // `decode` leaves the index untouched when it throws; step over the
+            // bad element explicitly, and bail out if even that fails so this
+            // cannot spin.
+            guard (try? unkeyed.decode(SkippedValue.self)) != nil else { break }
+        }
+        return elements
+    }
+}
+
+private extension Decoder {
+    var otlpDiagnostics: OTLPDecodeDiagnostics? {
+        userInfo[.otlpDiagnostics] as? OTLPDecodeDiagnostics
+    }
+}
+
 // MARK: - OTLP Attribute Types
 
 /// An OTLP key-value attribute.
@@ -11,12 +184,27 @@ public struct OTLPAttribute: Codable, Sendable {
         self.key = key
         self.value = value
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        key = try container.decode(String.self, forKey: .key)
+        // OTel JS emits `{}` for an undefined value — treat a missing or
+        // unreadable value as empty rather than failing the attribute.
+        value = (try? container.decode(OTLPAnyValue.self, forKey: .value)) ?? OTLPAnyValue()
+    }
 }
 
-/// An OTLP value that can be a string, int, double, or bool.
+/// An OTLP value that can be a string, int, double, bool, array, kvlist, or bytes.
+///
+/// Decoding is deliberately permissive: OTLP/JSON producers disagree about
+/// scalar encodings (notably `intValue`, which Claude Code sends as a JSON
+/// number while the protobuf JSON mapping also permits a string), and a strict
+/// model turns any disagreement into a total export failure. Composite values
+/// (`arrayValue`/`kvlistValue`) are flattened into `stringValue` as compact
+/// JSON so they survive as something readable instead of vanishing.
 public struct OTLPAnyValue: Codable, Sendable {
     public var stringValue: String?
-    public var intValue: String?  // OTLP encodes int64 as string
+    public var intValue: String?  // int64; kept as a string to preserve range
     public var doubleValue: Double?
     public var boolValue: Bool?
 
@@ -37,6 +225,8 @@ public struct OTLPAnyValue: Codable, Sendable {
         return nil
     }
 
+    public init() {}
+
     public init(stringValue: String) {
         self.stringValue = stringValue
     }
@@ -47,6 +237,62 @@ public struct OTLPAnyValue: Codable, Sendable {
 
     public init(doubleValue: Double) {
         self.doubleValue = doubleValue
+    }
+
+    public init(boolValue: Bool) {
+        self.boolValue = boolValue
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case stringValue, intValue, doubleValue, boolValue
+        case arrayValue, kvlistValue, bytesValue
+    }
+
+    private struct ArrayValue: Decodable {
+        let values: [OTLPAnyValue]?
+    }
+
+    private struct KvlistValue: Decodable {
+        let values: [OTLPAttribute]?
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        stringValue = container.otlpString(.stringValue)
+        intValue = container.otlpInt64String(.intValue)
+        doubleValue = container.otlpDouble(.doubleValue)
+        boolValue = container.otlpBool(.boolValue)
+
+        guard stringValue == nil else { return }
+
+        if let array = try? container.decode(ArrayValue.self, forKey: .arrayValue) {
+            let items = (array.values ?? []).map { $0.asString ?? "" }
+            stringValue = Self.jsonString(from: items)
+        } else if let kvlist = try? container.decode(KvlistValue.self, forKey: .kvlistValue) {
+            var dict: [String: String] = [:]
+            for entry in kvlist.values ?? [] {
+                dict[entry.key] = entry.value.asString ?? ""
+            }
+            stringValue = Self.jsonString(from: dict)
+        } else {
+            // bytesValue is base64 text per the JSON mapping; keep it verbatim.
+            stringValue = container.otlpString(.bytesValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(stringValue, forKey: .stringValue)
+        try container.encodeIfPresent(intValue, forKey: .intValue)
+        try container.encodeIfPresent(doubleValue, forKey: .doubleValue)
+        try container.encodeIfPresent(boolValue, forKey: .boolValue)
+    }
+
+    private static func jsonString(from object: Any) -> String? {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: .sortedKeys)
+        else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }
 
@@ -65,6 +311,16 @@ public func extractNumericAttribute(_ key: String, from attributes: [OTLPAttribu
 /// Top-level OTLP metrics export request.
 public struct OTLPMetricsPayload: Codable, Sendable {
     public let resourceMetrics: [ResourceMetrics]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        resourceMetrics = container.otlpLenientArray(
+            ResourceMetrics.self,
+            forKey: .resourceMetrics,
+            label: "resourceMetrics",
+            diagnostics: decoder.otlpDiagnostics
+        ) ?? []
+    }
 }
 
 /// A set of metrics from a single resource (e.g., a Claude Code process).
@@ -77,6 +333,17 @@ public struct ResourceMetrics: Codable, Sendable {
 public struct ScopeMetrics: Codable, Sendable {
     public let scope: InstrumentationScope?
     public let metrics: [OTLPMetric]?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        scope = try? container.decodeIfPresent(InstrumentationScope.self, forKey: .scope)
+        metrics = container.otlpLenientArray(
+            OTLPMetric.self,
+            forKey: .metrics,
+            label: "metrics",
+            diagnostics: decoder.otlpDiagnostics
+        )
+    }
 }
 
 /// A single metric with its name and data points.
@@ -105,11 +372,37 @@ public struct OTLPSum: Codable, Sendable {
     public var temporality: OTLPAggregationTemporality {
         OTLPAggregationTemporality(rawValue: aggregationTemporality ?? 0) ?? .unspecified
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        dataPoints = container.otlpLenientArray(
+            OTLPNumberDataPoint.self,
+            forKey: .dataPoints,
+            label: "dataPoints",
+            diagnostics: decoder.otlpDiagnostics
+        )
+        isMonotonic = container.otlpBool(.isMonotonic)
+        aggregationTemporality = container.otlpEnum(
+            .aggregationTemporality,
+            prefix: "AGGREGATION_TEMPORALITY_",
+            cases: aggregationTemporalityCases
+        )
+    }
 }
 
 /// A gauge metric (point-in-time value).
 public struct OTLPGauge: Codable, Sendable {
     public let dataPoints: [OTLPNumberDataPoint]?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        dataPoints = container.otlpLenientArray(
+            OTLPNumberDataPoint.self,
+            forKey: .dataPoints,
+            label: "dataPoints",
+            diagnostics: decoder.otlpDiagnostics
+        )
+    }
 }
 
 /// A single numeric data point in a metric.
@@ -117,7 +410,7 @@ public struct OTLPNumberDataPoint: Codable, Sendable {
     public let attributes: [OTLPAttribute]?
     public let timeUnixNano: String?
     public let startTimeUnixNano: String?
-    public let asInt: String?     // int64 encoded as string
+    public let asInt: String?     // int64, sent as a string or a number
     public let asDouble: Double?
 
     /// Get the numeric value as a Double.
@@ -126,6 +419,20 @@ public struct OTLPNumberDataPoint: Codable, Sendable {
         if let s = asInt, let d = Double(s) { return d }
         return 0
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        attributes = container.otlpLenientArray(
+            OTLPAttribute.self,
+            forKey: .attributes,
+            label: "attributes",
+            diagnostics: decoder.otlpDiagnostics
+        )
+        timeUnixNano = container.otlpInt64String(.timeUnixNano)
+        startTimeUnixNano = container.otlpInt64String(.startTimeUnixNano)
+        asInt = container.otlpInt64String(.asInt)
+        asDouble = container.otlpDouble(.asDouble)
+    }
 }
 
 // MARK: - Logs Payload
@@ -133,6 +440,16 @@ public struct OTLPNumberDataPoint: Codable, Sendable {
 /// Top-level OTLP logs export request.
 public struct OTLPLogsPayload: Codable, Sendable {
     public let resourceLogs: [ResourceLogs]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        resourceLogs = container.otlpLenientArray(
+            ResourceLogs.self,
+            forKey: .resourceLogs,
+            label: "resourceLogs",
+            diagnostics: decoder.otlpDiagnostics
+        ) ?? []
+    }
 }
 
 /// Log records from a single resource.
@@ -145,6 +462,17 @@ public struct ResourceLogs: Codable, Sendable {
 public struct ScopeLogs: Codable, Sendable {
     public let scope: InstrumentationScope?
     public let logRecords: [OTLPLogRecord]?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        scope = try? container.decodeIfPresent(InstrumentationScope.self, forKey: .scope)
+        logRecords = container.otlpLenientArray(
+            OTLPLogRecord.self,
+            forKey: .logRecords,
+            label: "logRecords",
+            diagnostics: decoder.otlpDiagnostics
+        )
+    }
 }
 
 /// A single OTLP log record (used for events).
@@ -155,11 +483,42 @@ public struct OTLPLogRecord: Codable, Sendable {
     public let severityNumber: Int?
     public let severityText: String?
     public let attributes: [OTLPAttribute]?
+    /// Top-level `eventName` (OTLP logs v1.x). Claude Code leaves it unset today
+    /// and names events via the `event.name` attribute instead.
+    public let eventName: String?
 
-    /// Extract the event name from the `event.name` attribute.
-    public var eventName: String? {
-        guard let attrs = attributes else { return nil }
-        return extractAttribute("event.name", from: attrs)
+    /// The event name to store, qualified the way Claude Code documents it.
+    ///
+    /// On the wire the `event.name` attribute holds the *bare* name
+    /// (`user_prompt`) while the fully-qualified `claude_code.user_prompt` sits
+    /// in the body. Readers in `TelemetryDatabase` match the qualified form, so
+    /// unqualified names are prefixed here at ingest.
+    public var resolvedEventName: String? {
+        let candidate = eventName
+            ?? attributes.flatMap { extractAttribute("event.name", from: $0) }
+            ?? body?.asString
+        guard let candidate, !candidate.isEmpty else { return nil }
+        return candidate.contains(".") ? candidate : "claude_code.\(candidate)"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        timeUnixNano = container.otlpInt64String(.timeUnixNano)
+        observedTimeUnixNano = container.otlpInt64String(.observedTimeUnixNano)
+        body = try? container.decodeIfPresent(OTLPAnyValue.self, forKey: .body)
+        severityNumber = container.otlpEnum(
+            .severityNumber,
+            prefix: "SEVERITY_NUMBER_",
+            cases: severityNumberCases
+        )
+        severityText = container.otlpString(.severityText)
+        eventName = container.otlpString(.eventName)
+        attributes = container.otlpLenientArray(
+            OTLPAttribute.self,
+            forKey: .attributes,
+            label: "attributes",
+            diagnostics: decoder.otlpDiagnostics
+        )
     }
 }
 
@@ -179,6 +538,16 @@ public struct OTLPResource: Codable, Sendable {
     public var sessionID: String? {
         guard let attrs = attributes else { return nil }
         return extractAttribute("session.id", from: attrs)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        attributes = container.otlpLenientArray(
+            OTLPAttribute.self,
+            forKey: .attributes,
+            label: "attributes",
+            diagnostics: decoder.otlpDiagnostics
+        )
     }
 }
 

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/HTTPParser.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/HTTPParser.swift
@@ -77,6 +77,19 @@ enum HTTPParser {
     /// Reject absurd bodies rather than buffering them (64 MiB).
     static let maxBodyBytes = 64 * 1024 * 1024
 
+    /// Give up on a request whose headers never terminate (8 KiB).
+    static let maxHeaderBytes = 8192
+
+    /// Hard ceiling on what one connection may buffer before completing.
+    ///
+    /// The parser can only reject what it can already frame, so the receiver
+    /// needs its own stop: a chunked request whose body never yields a chunk
+    /// boundary would otherwise accumulate without limit.
+    static var maxRequestBytes: Int { maxBodyBytes + maxHeaderBytes }
+
+    /// A chunk-size line is a handful of bytes; anything longer is malformed.
+    static let maxChunkLineBytes = 1024
+
     /// Parse result from feeding data into the parser.
     enum ParseResult: Sendable {
         /// A complete request was parsed.
@@ -98,8 +111,7 @@ enum HTTPParser {
         // Find the end of headers (double CRLF)
         let separator = Data("\r\n\r\n".utf8)
         guard let separatorRange = data.range(of: separator) else {
-            // Check for unreasonably large headers (> 8KB without end)
-            if data.count > 8192 {
+            if data.count > maxHeaderBytes {
                 return .error("Headers too large")
             }
             return .needsMore
@@ -192,13 +204,16 @@ enum HTTPParser {
            !encoding.isEmpty, encoding != "identity" {
             return "Unsupported Content-Encoding: \(quoted(encoding)) (OTLP export must be uncompressed)"
         }
-        if let contentType = headers["content-type"]?.lowercased() {
-            // Tolerate parameters, e.g. "application/json; charset=utf-8".
-            let mediaType = contentType.split(separator: ";").first.map(String.init)?
-                .trimmingCharacters(in: .whitespaces) ?? contentType
-            guard mediaType == "application/json" || mediaType.hasSuffix("+json") else {
-                return "Unsupported Content-Type: \(quoted(mediaType)) (OTLP/JSON only)"
-            }
+        // Fail closed: OTLP/JSON requires the header, so an absent one is a
+        // client that is not speaking the protocol we ingest.
+        guard let contentType = headers["content-type"]?.lowercased() else {
+            return "Missing Content-Type (OTLP/JSON requires application/json)"
+        }
+        // Tolerate parameters, e.g. "application/json; charset=utf-8".
+        let mediaType = contentType.split(separator: ";").first.map(String.init)?
+            .trimmingCharacters(in: .whitespaces) ?? contentType
+        guard mediaType == "application/json" || mediaType.hasSuffix("+json") else {
+            return "Unsupported Content-Type: \(quoted(mediaType)) (OTLP/JSON only)"
         }
         return nil
     }
@@ -220,6 +235,12 @@ enum HTTPParser {
 
         while true {
             guard let lineEnd = data.range(of: crlf, in: cursor..<data.endIndex)?.lowerBound else {
+                // Nothing here is worth waiting for beyond a short size line.
+                // Without this, a CRLF-free stream is buffered forever: the
+                // caller keeps appending because the parser keeps asking.
+                if data.distance(from: cursor, to: data.endIndex) > maxChunkLineBytes {
+                    return .error("Malformed chunk size line")
+                }
                 return .needsMore
             }
             let sizeField = data[cursor..<lineEnd]
@@ -241,6 +262,11 @@ enum HTTPParser {
                     return .complete(body)
                 }
                 guard data.range(of: Data("\r\n\r\n".utf8), in: chunkStart..<data.endIndex) != nil else {
+                    // Same trap as the size line: trailers that never terminate
+                    // must not keep the connection buffering.
+                    if data.distance(from: chunkStart, to: data.endIndex) > maxHeaderBytes {
+                        return .error("Chunk trailers too large")
+                    }
                     return .needsMore
                 }
                 return .complete(body)

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/HTTPParser.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/HTTPParser.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A parsed HTTP/1.1 request.
+/// A parsed HTTP/1.1 request. Header keys are normalized to lowercase.
 struct HTTPRequest: Sendable {
     let method: String
     let path: String
@@ -9,11 +9,7 @@ struct HTTPRequest: Sendable {
 
     /// Get a header value (case-insensitive lookup).
     func header(_ name: String) -> String? {
-        let lower = name.lowercased()
-        for (key, value) in headers {
-            if key.lowercased() == lower { return value }
-        }
-        return nil
+        headers[name.lowercased()]
     }
 
     /// Content-Length from headers, or 0 if absent.
@@ -58,9 +54,15 @@ struct HTTPResponse: Sendable {
 
 /// Minimal HTTP/1.1 request parser for OTLP payloads.
 ///
-/// Only handles simple POST requests with Content-Length (no chunked encoding,
-/// no keep-alive). This is sufficient for OTLP HTTP/JSON clients.
+/// Handles `Content-Length` and `Transfer-Encoding: chunked` framing; no
+/// keep-alive (the receiver closes each connection after responding) and no
+/// compressed bodies. Requests it cannot frame or read are reported as errors
+/// rather than passed on with an empty body — silently handing `JSONDecoder` a
+/// zero-byte body produced an unattributable decode error (#823).
 enum HTTPParser {
+
+    /// Reject absurd bodies rather than buffering them (64 MiB).
+    static let maxBodyBytes = 64 * 1024 * 1024
 
     /// Parse result from feeding data into the parser.
     enum ParseResult: Sendable {
@@ -71,6 +73,9 @@ enum HTTPParser {
         /// The data is malformed.
         case error(String)
     }
+
+    /// Methods that carry a request body and therefore require framing.
+    private static let bodyMethods: Set<String> = ["POST", "PUT", "PATCH"]
 
     /// Attempt to parse a complete HTTP request from the accumulated data.
     ///
@@ -109,35 +114,127 @@ enum HTTPParser {
         var headers: [String: String] = [:]
         for line in lines.dropFirst() {
             if let colonIndex = line.firstIndex(of: ":") {
-                let key = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
+                let key = String(line[line.startIndex..<colonIndex])
+                    .trimmingCharacters(in: .whitespaces).lowercased()
                 let value = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
                 headers[key] = value
             }
         }
 
-        // Determine body length
+        let expectsBody = bodyMethods.contains(method.uppercased())
+        if expectsBody, let rejection = rejectUnsupportedEncoding(headers) {
+            return .error(rejection)
+        }
+
         let bodyStart = separatorRange.upperBound
-        let contentLength: Int
-        if let cl = headers.first(where: { $0.key.lowercased() == "content-length" })?.value,
-           let len = Int(cl) {
-            contentLength = len
-        } else {
-            contentLength = 0
+        let available = data.count - data.distance(from: data.startIndex, to: bodyStart)
+
+        // Framing: chunked takes precedence over Content-Length (RFC 9112 §6.1).
+        let transferEncoding = headers["transfer-encoding"]?.lowercased()
+        if transferEncoding?.contains("chunked") == true {
+            switch dechunk(data, from: bodyStart) {
+            case .needsMore:
+                return .needsMore
+            case let .error(message):
+                return .error(message)
+            case let .complete(body):
+                return .complete(HTTPRequest(method: method, path: path, headers: headers, body: body))
+            }
         }
 
-        // Check if we have the full body
-        let bodyAvailable = data.count - data.distance(from: data.startIndex, to: bodyStart)
-        if bodyAvailable < contentLength {
-            return .needsMore
+        if let value = headers["content-length"] {
+            guard let contentLength = Int(value), contentLength >= 0 else {
+                return .error("Malformed Content-Length: \(value)")
+            }
+            guard contentLength <= maxBodyBytes else {
+                return .error("Body too large: \(contentLength) bytes")
+            }
+            if available < contentLength {
+                return .needsMore
+            }
+            let body = data[bodyStart..<data.index(bodyStart, offsetBy: contentLength)]
+            return .complete(HTTPRequest(method: method, path: path, headers: headers, body: Data(body)))
         }
 
-        let body = data[bodyStart..<data.index(bodyStart, offsetBy: contentLength)]
+        // No framing at all. A body-bearing request without Content-Length or
+        // chunked encoding cannot be read; saying so beats forwarding an empty
+        // body that fails later as an opaque decode error.
+        if expectsBody {
+            return .error("Missing Content-Length or Transfer-Encoding on \(method) \(path)")
+        }
+        return .complete(HTTPRequest(method: method, path: path, headers: headers, body: Data()))
+    }
 
-        return .complete(HTTPRequest(
-            method: method,
-            path: path,
-            headers: headers,
-            body: Data(body)
-        ))
+    /// Reject bodies this parser cannot read, naming the reason.
+    private static func rejectUnsupportedEncoding(_ headers: [String: String]) -> String? {
+        if let encoding = headers["content-encoding"]?.lowercased(),
+           !encoding.isEmpty, encoding != "identity" {
+            return "Unsupported Content-Encoding: \(encoding) (OTLP export must be uncompressed)"
+        }
+        if let contentType = headers["content-type"]?.lowercased() {
+            // Tolerate parameters, e.g. "application/json; charset=utf-8".
+            let mediaType = contentType.split(separator: ";").first.map(String.init)?
+                .trimmingCharacters(in: .whitespaces) ?? contentType
+            guard mediaType == "application/json" || mediaType.hasSuffix("+json") else {
+                return "Unsupported Content-Type: \(mediaType) (OTLP/JSON only)"
+            }
+        }
+        return nil
+    }
+
+    private enum ChunkedResult {
+        case complete(Data)
+        case needsMore
+        case error(String)
+    }
+
+    /// Reassemble a `Transfer-Encoding: chunked` body.
+    ///
+    /// Trailers after the terminating zero-length chunk are consumed and
+    /// discarded; the receiver has no use for them.
+    private static func dechunk(_ data: Data, from start: Data.Index) -> ChunkedResult {
+        let crlf = Data("\r\n".utf8)
+        var cursor = start
+        var body = Data()
+
+        while true {
+            guard let lineEnd = data.range(of: crlf, in: cursor..<data.endIndex)?.lowerBound else {
+                return .needsMore
+            }
+            let sizeField = data[cursor..<lineEnd]
+            guard let sizeText = String(data: sizeField, encoding: .utf8) else {
+                return .error("Invalid chunk size encoding")
+            }
+            // A chunk size may carry extensions: "1a;name=value".
+            let hex = sizeText.split(separator: ";").first.map(String.init) ?? sizeText
+            guard let size = Int(hex.trimmingCharacters(in: .whitespaces), radix: 16), size >= 0 else {
+                return .error("Malformed chunk size: \(sizeText)")
+            }
+
+            let chunkStart = data.index(lineEnd, offsetBy: crlf.count)
+
+            if size == 0 {
+                // Terminating chunk: an immediate CRLF, or trailers then CRLFCRLF.
+                if data.distance(from: chunkStart, to: data.endIndex) >= crlf.count,
+                   data[chunkStart..<data.index(chunkStart, offsetBy: crlf.count)] == crlf {
+                    return .complete(body)
+                }
+                guard data.range(of: Data("\r\n\r\n".utf8), in: chunkStart..<data.endIndex) != nil else {
+                    return .needsMore
+                }
+                return .complete(body)
+            }
+
+            guard body.count + size <= maxBodyBytes else {
+                return .error("Chunked body too large")
+            }
+            // Chunk data plus its trailing CRLF must both have arrived.
+            guard data.distance(from: chunkStart, to: data.endIndex) >= size + crlf.count else {
+                return .needsMore
+            }
+            let chunkEnd = data.index(chunkStart, offsetBy: size)
+            body.append(data[chunkStart..<chunkEnd])
+            cursor = data.index(chunkEnd, offsetBy: crlf.count)
+        }
     }
 }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/HTTPParser.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/HTTPParser.swift
@@ -30,13 +30,26 @@ struct HTTPResponse: Sendable {
     }
 
     static func badRequest(message: String = "Bad Request") -> HTTPResponse {
-        HTTPResponse(statusCode: 400, statusText: "Bad Request",
-                     body: Data("{\"error\":\"\(message)\"}".utf8))
+        HTTPResponse(statusCode: 400, statusText: "Bad Request", body: errorBody(message))
     }
 
     static func notFound() -> HTTPResponse {
-        HTTPResponse(statusCode: 404, statusText: "Not Found",
-                     body: Data("{\"error\":\"Not Found\"}".utf8))
+        HTTPResponse(statusCode: 404, statusText: "Not Found", body: errorBody("Not Found"))
+    }
+
+    /// Build the `{"error": …}` body with proper JSON escaping.
+    ///
+    /// Parser messages quote request-controlled values (`Content-Type`, a chunk
+    /// size, the request path), so a quote or backslash in one of them would
+    /// otherwise break out of the string and emit malformed JSON.
+    private static func errorBody(_ message: String) -> Data {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: ["error": message],
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ) else {
+            return Data(#"{"error":"Bad Request"}"#.utf8)
+        }
+        return data
     }
 
     /// Serialize to HTTP/1.1 response bytes.
@@ -144,7 +157,7 @@ enum HTTPParser {
 
         if let value = headers["content-length"] {
             guard let contentLength = Int(value), contentLength >= 0 else {
-                return .error("Malformed Content-Length: \(value)")
+                return .error("Malformed Content-Length: \(quoted(value))")
             }
             guard contentLength <= maxBodyBytes else {
                 return .error("Body too large: \(contentLength) bytes")
@@ -160,23 +173,31 @@ enum HTTPParser {
         // chunked encoding cannot be read; saying so beats forwarding an empty
         // body that fails later as an opaque decode error.
         if expectsBody {
-            return .error("Missing Content-Length or Transfer-Encoding on \(method) \(path)")
+            return .error("Missing Content-Length or Transfer-Encoding on \(quoted(method)) \(quoted(path))")
         }
         return .complete(HTTPRequest(method: method, path: path, headers: headers, body: Data()))
+    }
+
+    /// Quote a request-controlled value into an error message.
+    ///
+    /// Bounded so an 8 KiB header cannot bloat the 400 response or the log line
+    /// it is echoed into. Escaping is handled where the JSON body is built.
+    private static func quoted(_ value: String, limit: Int = 120) -> String {
+        value.count <= limit ? value : String(value.prefix(limit)) + "…"
     }
 
     /// Reject bodies this parser cannot read, naming the reason.
     private static func rejectUnsupportedEncoding(_ headers: [String: String]) -> String? {
         if let encoding = headers["content-encoding"]?.lowercased(),
            !encoding.isEmpty, encoding != "identity" {
-            return "Unsupported Content-Encoding: \(encoding) (OTLP export must be uncompressed)"
+            return "Unsupported Content-Encoding: \(quoted(encoding)) (OTLP export must be uncompressed)"
         }
         if let contentType = headers["content-type"]?.lowercased() {
             // Tolerate parameters, e.g. "application/json; charset=utf-8".
             let mediaType = contentType.split(separator: ";").first.map(String.init)?
                 .trimmingCharacters(in: .whitespaces) ?? contentType
             guard mediaType == "application/json" || mediaType.hasSuffix("+json") else {
-                return "Unsupported Content-Type: \(mediaType) (OTLP/JSON only)"
+                return "Unsupported Content-Type: \(quoted(mediaType)) (OTLP/JSON only)"
             }
         }
         return nil
@@ -208,7 +229,7 @@ enum HTTPParser {
             // A chunk size may carry extensions: "1a;name=value".
             let hex = sizeText.split(separator: ";").first.map(String.init) ?? sizeText
             guard let size = Int(hex.trimmingCharacters(in: .whitespaces), radix: 16), size >= 0 else {
-                return .error("Malformed chunk size: \(sizeText)")
+                return .error("Malformed chunk size: \(quoted(sizeText))")
             }
 
             let chunkStart = data.index(lineEnd, offsetBy: crlf.count)
@@ -225,7 +246,10 @@ enum HTTPParser {
                 return .complete(body)
             }
 
-            guard body.count + size <= maxBodyBytes else {
+            // Compare against the remaining budget rather than summing: a chunk
+            // size near `Int.max` is well-formed hex, and `body.count + size`
+            // would trap on overflow before the cap could reject it.
+            guard size <= maxBodyBytes, body.count <= maxBodyBytes - size else {
                 return .error("Chunked body too large")
             }
             // Chunk data plus its trailing CRLF must both have arrived.
@@ -233,8 +257,14 @@ enum HTTPParser {
                 return .needsMore
             }
             let chunkEnd = data.index(chunkStart, offsetBy: size)
+            let terminatorEnd = data.index(chunkEnd, offsetBy: crlf.count)
+            // A chunk must end with CRLF; without this check a wrong size
+            // silently desyncs the stream and corrupts the rest of the body.
+            guard data[chunkEnd..<terminatorEnd] == crlf else {
+                return .error("Malformed chunk terminator")
+            }
             body.append(data[chunkStart..<chunkEnd])
-            cursor = data.index(chunkEnd, offsetBy: crlf.count)
+            cursor = terminatorEnd
         }
     }
 }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
@@ -96,6 +96,13 @@ public final class OTLPReceiver: Sendable {
                 if isComplete {
                     // Connection closed before complete request
                     connection.cancel()
+                } else if accumulated.count > HTTPParser.maxRequestBytes {
+                    // Backstop: the parser can only reject what it can frame,
+                    // so never let one connection buffer without bound while it
+                    // keeps asking for more.
+                    NSLog("[OTLPReceiver] Buffered %d bytes without a complete request; closing",
+                          accumulated.count)
+                    self.sendResponse(HTTPResponse.badRequest(message: "Request too large"), on: connection)
                 } else {
                     self.receiveData(on: connection, buffer: accumulated)
                 }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
@@ -11,6 +11,7 @@ public final class OTLPReceiver: Sendable {
     private let listener: NWListener
     private let database: TelemetryDatabase
     private let queue = DispatchQueue(label: "com.corveil.crow.otlp-receiver")
+    private let decodeFailures = FailureThrottle(interval: 60)
 
     /// Callback invoked on the main actor when new data arrives for a Crow session.
     /// The UUID is the Crow session ID.
@@ -118,14 +119,14 @@ public final class OTLPReceiver: Sendable {
         case "/v1/metrics":
             Task {
                 do {
-                    let payload = try JSONDecoder().decode(OTLPMetricsPayload.self, from: request.body)
+                    let payload = try self.decode(OTLPMetricsPayload.self, from: request)
                     let affectedSessions = await self.processMetrics(payload, database: db)
                     self.sendResponse(HTTPResponse.ok(), on: connection)
                     for sessionID in affectedSessions {
                         await onData(sessionID)
                     }
                 } catch {
-                    NSLog("[OTLPReceiver] Metrics decode error: %@", error.localizedDescription)
+                    self.reportDecodeFailure(error, request: request)
                     self.sendResponse(HTTPResponse.badRequest(message: "Invalid metrics payload"), on: connection)
                 }
             }
@@ -133,20 +134,94 @@ public final class OTLPReceiver: Sendable {
         case "/v1/logs":
             Task {
                 do {
-                    let payload = try JSONDecoder().decode(OTLPLogsPayload.self, from: request.body)
+                    let payload = try self.decode(OTLPLogsPayload.self, from: request)
                     let affectedSessions = await self.processLogs(payload, database: db)
                     self.sendResponse(HTTPResponse.ok(), on: connection)
                     for sessionID in affectedSessions {
                         await onData(sessionID)
                     }
                 } catch {
-                    NSLog("[OTLPReceiver] Logs decode error: %@", error.localizedDescription)
+                    self.reportDecodeFailure(error, request: request)
                     self.sendResponse(HTTPResponse.badRequest(message: "Invalid logs payload"), on: connection)
                 }
             }
 
         default:
             sendResponse(HTTPResponse.notFound(), on: connection)
+        }
+    }
+
+    // MARK: - Decoding & Diagnostics
+
+    /// Decode an OTLP payload, reporting any records tolerant decoding dropped.
+    private func decode<T: Decodable>(_ type: T.Type, from request: HTTPRequest) throws -> T {
+        let diagnostics = OTLPDecodeDiagnostics()
+        let decoder = JSONDecoder()
+        decoder.userInfo[.otlpDiagnostics] = diagnostics
+        let payload = try decoder.decode(T.self, from: request.body)
+        if let summary = diagnostics.summary {
+            NSLog("[OTLPReceiver] %@: skipped malformed %@", request.path, summary)
+        }
+        return payload
+    }
+
+    /// Log a decode failure with enough context to identify the offending field.
+    ///
+    /// The bare `localizedDescription` of a `DecodingError` is the same
+    /// "isn't in the correct format" string for every cause, which left the
+    /// receiver undiagnosable (#823). The coding path pinpoints the field.
+    /// Failures are throttled so a systematic mismatch cannot drown the log.
+    private func reportDecodeFailure(_ error: Error, request: HTTPRequest) {
+        guard let suppressed = decodeFailures.claim(request.path) else { return }
+
+        var message = "[OTLPReceiver] \(request.path) decode failed: \(Self.describe(error))"
+        message += "\n  content-type=\(request.header("Content-Type") ?? "-")"
+        message += " content-length=\(request.header("Content-Length") ?? "-")"
+        message += " transfer-encoding=\(request.header("Transfer-Encoding") ?? "-")"
+        message += " content-encoding=\(request.header("Content-Encoding") ?? "-")"
+        message += " bodybytes=\(request.body.count)"
+        if suppressed > 0 {
+            message += "\n  (\(suppressed) further failures suppressed since the last report)"
+        }
+        // Bodies carry account IDs, emails and event attributes, so the raw
+        // prefix is opt-in; the coding path above is enough to diagnose shape.
+        if Self.logRawBodies {
+            let prefix = request.body.prefix(512)
+            let text = String(decoding: prefix, as: UTF8.self)
+                .replacingOccurrences(of: "\n", with: " ")
+            message += "\n  body[0..<\(prefix.count)]: \(text)"
+        }
+        NSLog("%@", message)
+    }
+
+    private static var logRawBodies: Bool {
+        ProcessInfo.processInfo.environment["CROW_TELEMETRY_LOG_RAW_BODIES"] == "1"
+    }
+
+    /// Render a `DecodingError` as case, coding path, and underlying reason.
+    static func describe(_ error: Error) -> String {
+        func path(_ context: DecodingError.Context) -> String {
+            let rendered = context.codingPath.map { key in
+                key.intValue.map { "[\($0)]" } ?? ".\(key.stringValue)"
+            }.joined()
+            let trimmed = rendered.hasPrefix(".") ? String(rendered.dropFirst()) : rendered
+            return trimmed.isEmpty ? "<root>" : trimmed
+        }
+
+        guard let error = error as? DecodingError else {
+            return "\(type(of: error)): \(error.localizedDescription)"
+        }
+        switch error {
+        case let .typeMismatch(type, context):
+            return "typeMismatch(\(type)) at \(path(context)) — \(context.debugDescription)"
+        case let .valueNotFound(type, context):
+            return "valueNotFound(\(type)) at \(path(context)) — \(context.debugDescription)"
+        case let .keyNotFound(key, context):
+            return "keyNotFound(\(key.stringValue)) at \(path(context)) — \(context.debugDescription)"
+        case let .dataCorrupted(context):
+            return "dataCorrupted at \(path(context)) — \(context.debugDescription)"
+        @unknown default:
+            return "DecodingError: \(error.localizedDescription)"
         }
     }
 
@@ -233,7 +308,7 @@ public final class OTLPReceiver: Sendable {
             for scope in scopeLogs {
                 guard let logRecords = scope.logRecords else { continue }
                 for record in logRecords {
-                    let eventName = record.eventName ?? "unknown"
+                    let eventName = record.resolvedEventName ?? "unknown"
                     let body = record.body?.asString
                     let attributesJSON = encodeAttributes(record.attributes)
 
@@ -263,5 +338,39 @@ public final class OTLPReceiver: Sendable {
             return nil
         }
         return String(data: data, encoding: .utf8)
+    }
+}
+
+// MARK: - Failure Throttling
+
+/// Rate-limits a repeating failure to one report per `interval`, per key.
+///
+/// A systematic payload mismatch fires on every export (~every 5s per session),
+/// which is how #823 drowned the daemon log. The first failure always reports
+/// in full; later ones are counted and folded into the next report.
+final class FailureThrottle: @unchecked Sendable {
+    private let lock = NSLock()
+    private let interval: TimeInterval
+    private var lastReported: [String: Date] = [:]
+    private var suppressed: [String: Int] = [:]
+
+    init(interval: TimeInterval) {
+        self.interval = interval
+    }
+
+    /// Claim the right to report a failure for `key`.
+    ///
+    /// - Returns: the number of failures suppressed since the last report, or
+    ///   `nil` if this one should stay silent.
+    func claim(_ key: String, now: Date = Date()) -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let last = lastReported[key], now.timeIntervalSince(last) < interval {
+            suppressed[key, default: 0] += 1
+            return nil
+        }
+        lastReported[key] = now
+        return suppressed.removeValue(forKey: key) ?? 0
     }
 }

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/Fixtures/claude-code-logs-export.json
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/Fixtures/claude-code-logs-export.json
@@ -1,0 +1,1733 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "crow.session.id",
+            "value": {
+              "stringValue": "11111111-2222-3333-4444-555555555555"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "os.type",
+            "value": {
+              "stringValue": "darwin"
+            }
+          },
+          {
+            "key": "os.version",
+            "value": {
+              "stringValue": "25.5.0"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "claude-code"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "2.1.219"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "com.anthropic.claude_code.events",
+            "version": "2.1.219"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1784916871131000000",
+              "observedTimeUnixNano": "1784916871131000000",
+              "body": {
+                "stringValue": "claude_code.plugin_loaded"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "plugin_loaded"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:31.131Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "plugin.name",
+                  "value": {
+                    "stringValue": "swift-lsp"
+                  }
+                },
+                {
+                  "key": "marketplace.name",
+                  "value": {
+                    "stringValue": "claude-plugins-official"
+                  }
+                },
+                {
+                  "key": "plugin.version",
+                  "value": {
+                    "stringValue": "1.0.0"
+                  }
+                },
+                {
+                  "key": "plugin.scope",
+                  "value": {
+                    "stringValue": "official"
+                  }
+                },
+                {
+                  "key": "enabled_via",
+                  "value": {
+                    "stringValue": "user-install"
+                  }
+                },
+                {
+                  "key": "plugin_id_hash",
+                  "value": {
+                    "stringValue": "00000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "has_hooks",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "has_mcp",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "host_owned_mcp",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "skill_path_count",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "command_path_count",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "agent_path_count",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "safe_mode",
+                  "value": {
+                    "stringValue": "false"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916871261000000",
+              "observedTimeUnixNano": "1784916871261000000",
+              "body": {
+                "stringValue": "claude_code.permission_mode_changed"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "permission_mode_changed"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:31.261Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "from_mode",
+                  "value": {
+                    "stringValue": "auto"
+                  }
+                },
+                {
+                  "key": "to_mode",
+                  "value": {
+                    "stringValue": "default"
+                  }
+                },
+                {
+                  "key": "trigger",
+                  "value": {
+                    "stringValue": "auto_gate_denied"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916871559000000",
+              "observedTimeUnixNano": "1784916871559000000",
+              "body": {
+                "stringValue": "claude_code.user_prompt"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "user_prompt"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:31.559Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 2
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "prompt_length",
+                  "value": {
+                    "stringValue": "31"
+                  }
+                },
+                {
+                  "key": "prompt",
+                  "value": {
+                    "stringValue": "<REDACTED>"
+                  }
+                },
+                {
+                  "key": "message.uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000005"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916871612000000",
+              "observedTimeUnixNano": "1784916871612000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:31.612Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 3
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "connected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "7"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916871613000000",
+              "observedTimeUnixNano": "1784916871613000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:31.613Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 4
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "connected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "8"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916871613000000",
+              "observedTimeUnixNano": "1784916871613000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:31.613Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 5
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "connected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "7"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872544000000",
+              "observedTimeUnixNano": "1784916872544000000",
+              "body": {
+                "stringValue": "claude_code.api_request"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "api_request"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.544Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 6
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "claude-haiku-4-5-20251001"
+                  }
+                },
+                {
+                  "key": "input_tokens",
+                  "value": {
+                    "intValue": 523
+                  }
+                },
+                {
+                  "key": "output_tokens",
+                  "value": {
+                    "intValue": 12
+                  }
+                },
+                {
+                  "key": "cache_read_tokens",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "cache_creation_tokens",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "cost_usd",
+                  "value": {
+                    "doubleValue": 0.0005830000000000001
+                  }
+                },
+                {
+                  "key": "cost_usd_micros",
+                  "value": {
+                    "intValue": 583
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "intValue": 995
+                  }
+                },
+                {
+                  "key": "request_id",
+                  "value": {
+                    "stringValue": "req_0000000000000000"
+                  }
+                },
+                {
+                  "key": "client_request_id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000006"
+                  }
+                },
+                {
+                  "key": "speed",
+                  "value": {
+                    "stringValue": "normal"
+                  }
+                },
+                {
+                  "key": "query_source",
+                  "value": {
+                    "stringValue": "generate_session_title"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872544000000",
+              "observedTimeUnixNano": "1784916872544000000",
+              "body": {
+                "stringValue": "claude_code.assistant_response"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "assistant_response"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.544Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 7
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "response_length",
+                  "value": {
+                    "intValue": 45
+                  }
+                },
+                {
+                  "key": "response",
+                  "value": {
+                    "stringValue": "<REDACTED>"
+                  }
+                },
+                {
+                  "key": "request_id",
+                  "value": {
+                    "stringValue": "req_0000000000000000"
+                  }
+                },
+                {
+                  "key": "message.uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000005"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "claude-haiku-4-5-20251001"
+                  }
+                },
+                {
+                  "key": "query_source",
+                  "value": {
+                    "stringValue": "generate_session_title"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872710000000",
+              "observedTimeUnixNano": "1784916872710000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.710Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 8
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "connected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "1101"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872859000000",
+              "observedTimeUnixNano": "1784916872859000000",
+              "body": {
+                "stringValue": "claude_code.api_request"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "api_request"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.859Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 9
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "claude-haiku-4-5-20251001"
+                  }
+                },
+                {
+                  "key": "input_tokens",
+                  "value": {
+                    "intValue": 10
+                  }
+                },
+                {
+                  "key": "output_tokens",
+                  "value": {
+                    "intValue": 41
+                  }
+                },
+                {
+                  "key": "cache_read_tokens",
+                  "value": {
+                    "intValue": 17536
+                  }
+                },
+                {
+                  "key": "cache_creation_tokens",
+                  "value": {
+                    "intValue": 6646
+                  }
+                },
+                {
+                  "key": "cost_usd",
+                  "value": {
+                    "doubleValue": 0.0152606
+                  }
+                },
+                {
+                  "key": "cost_usd_micros",
+                  "value": {
+                    "intValue": 15261
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "intValue": 1243
+                  }
+                },
+                {
+                  "key": "request_id",
+                  "value": {
+                    "stringValue": "req_0000000000000000"
+                  }
+                },
+                {
+                  "key": "client_request_id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000006"
+                  }
+                },
+                {
+                  "key": "speed",
+                  "value": {
+                    "stringValue": "normal"
+                  }
+                },
+                {
+                  "key": "query_source",
+                  "value": {
+                    "stringValue": "sdk"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872859000000",
+              "observedTimeUnixNano": "1784916872859000000",
+              "body": {
+                "stringValue": "claude_code.assistant_response"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "assistant_response"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.859Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 10
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "response_length",
+                  "value": {
+                    "intValue": 2
+                  }
+                },
+                {
+                  "key": "response",
+                  "value": {
+                    "stringValue": "<REDACTED>"
+                  }
+                },
+                {
+                  "key": "request_id",
+                  "value": {
+                    "stringValue": "req_0000000000000000"
+                  }
+                },
+                {
+                  "key": "message.uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000005"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "claude-haiku-4-5-20251001"
+                  }
+                },
+                {
+                  "key": "query_source",
+                  "value": {
+                    "stringValue": "sdk"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872862000000",
+              "observedTimeUnixNano": "1784916872862000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.862Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 11
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "disconnected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "1250"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872862000000",
+              "observedTimeUnixNano": "1784916872862000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.862Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 12
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "disconnected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "1249"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784916872862000000",
+              "observedTimeUnixNano": "1784916872862000000",
+              "body": {
+                "stringValue": "claude_code.mcp_server_connection"
+              },
+              "attributes": [
+                {
+                  "key": "crow.session.id",
+                  "value": {
+                    "stringValue": "11111111-2222-3333-4444-555555555555"
+                  }
+                },
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "0000000000000000000000000000000000000000000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000003"
+                  }
+                },
+                {
+                  "key": "organization.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000002"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "telemetry-fixture@example.com"
+                  }
+                },
+                {
+                  "key": "user.account_uuid",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000001"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "user_00000000000000000000000000"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "tmux"
+                  }
+                },
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "mcp_server_connection"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-07-24T18:14:32.862Z"
+                  }
+                },
+                {
+                  "key": "event.sequence",
+                  "value": {
+                    "intValue": 13
+                  }
+                },
+                {
+                  "key": "prompt.id",
+                  "value": {
+                    "stringValue": "00000000-0000-4000-8000-000000000004"
+                  }
+                },
+                {
+                  "key": "status",
+                  "value": {
+                    "stringValue": "disconnected"
+                  }
+                },
+                {
+                  "key": "transport_type",
+                  "value": {
+                    "stringValue": "claudeai-proxy"
+                  }
+                },
+                {
+                  "key": "server_scope",
+                  "value": {
+                    "stringValue": "claudeai"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "1249"
+                  }
+                },
+                {
+                  "key": "is_plugin",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/HTTPParserTests.swift
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/HTTPParserTests.swift
@@ -146,6 +146,51 @@ func malformedChunkSizeIsAnError() throws {
     #expect(try errorMessage(data).contains("Malformed chunk size"))
 }
 
+@Test("A chunk whose declared size disagrees with its framing is rejected")
+func desyncedChunkTerminatorIsRejected() throws {
+    // Declares 4 bytes but supplies 6 before the CRLF: without validating the
+    // terminator the parser would resume mid-data and corrupt the rest.
+    let data = request(
+        "POST /v1/logs",
+        body: "4\r\ntestXX\r\n0\r\n\r\n",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    #expect(try errorMessage(data).contains("Malformed chunk terminator"))
+}
+
+@Test("A chunk size near Int.max is rejected rather than overflowing the cap")
+func hugeChunkSizeIsRejectedWithoutOverflow() throws {
+    // 0x7FFFFFFFFFFFFFFF is Int.max — valid hex, so it parses. The first chunk
+    // puts 4 bytes in the buffer, so `body.count + size` overflows and traps:
+    // the cap has to be checked against the remaining budget instead.
+    let data = request(
+        "POST /v1/logs",
+        body: "4\r\ntest\r\n7FFFFFFFFFFFFFFF\r\n",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    #expect(try errorMessage(data).contains("Chunked body too large"))
+}
+
+@Test("A body over the size cap is rejected before it is buffered")
+func chunkedBodyOverCapIsRejected() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: "\(String(HTTPParser.maxBodyBytes + 1, radix: 16))\r\n",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    #expect(try errorMessage(data).contains("Chunked body too large"))
+}
+
+@Test("A chunk size that overflows Int is rejected as malformed")
+func overflowingChunkSizeIsRejected() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: "FFFFFFFFFFFFFFFFFF\r\n",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    #expect(try errorMessage(data).contains("Malformed chunk size"))
+}
+
 // MARK: - Framing and encoding rejections
 
 @Test("A POST with no framing is rejected instead of yielding an empty body")
@@ -238,4 +283,46 @@ func oversizedHeadersAreRejected() throws {
     var data = Data("POST /v1/logs HTTP/1.1\r\n".utf8)
     data.append(Data(String(repeating: "X", count: 9000).utf8))
     #expect(try errorMessage(data).contains("Headers too large"))
+}
+
+// MARK: - Error response encoding
+
+@Test("An error body stays valid JSON when the request quotes a value at it")
+func errorBodyEscapesRequestControlledValues() throws {
+    // A quote and a backslash in a header would previously break out of the
+    // hand-rolled `{"error":"…"}` string and emit malformed JSON.
+    let data = request(
+        "POST /v1/logs",
+        body: json,
+        headers: [#"Content-Type"#: #"application/"evil\ "#,
+                  "Content-Length": "\(json.utf8.count)"]
+    )
+    let response = HTTPResponse.badRequest(message: try errorMessage(data)).serialize()
+
+    let text = String(decoding: response, as: UTF8.self)
+    let bodyStart = try #require(text.range(of: "\r\n\r\n")).upperBound
+    let body = Data(text[bodyStart...].utf8)
+
+    let decoded = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+    #expect(decoded["error"]?.contains("Unsupported Content-Type") == true)
+    #expect(decoded["error"]?.contains(#"application/"evil\"#) == true)
+}
+
+@Test("Paths are not slash-escaped in the error body")
+func errorBodyKeepsPathsReadable() throws {
+    let response = HTTPResponse.badRequest(message: "no framing on POST /v1/logs").serialize()
+    #expect(String(decoding: response, as: UTF8.self).contains(#"{"error":"no framing on POST /v1/logs"}"#))
+}
+
+@Test("A long header value is truncated out of the error message")
+func longHeaderValuesAreTruncated() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/" + String(repeating: "z", count: 4000),
+                  "Content-Length": "\(json.utf8.count)"]
+    )
+    let message = try errorMessage(data)
+    #expect(message.contains("…"))
+    #expect(message.count < 200)
 }

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/HTTPParserTests.swift
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/HTTPParserTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Testing
+@testable import CrowTelemetry
+
+/// Tests for the OTLP HTTP request parser (issue #823).
+///
+/// The parser previously derived the body from `Content-Length` alone and
+/// returned a *complete* request with an empty body whenever that header was
+/// missing — turning any framing surprise into the same unattributable
+/// "invalid payload" as a real schema mismatch.
+
+private func request(
+    _ head: String,
+    body: String = "",
+    headers: [String: String] = [:]
+) -> Data {
+    var text = "\(head) HTTP/1.1\r\nHost: localhost\r\n"
+    for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
+        text += "\(key): \(value)\r\n"
+    }
+    text += "\r\n"
+    var data = Data(text.utf8)
+    data.append(Data(body.utf8))
+    return data
+}
+
+private func parsed(_ data: Data) throws -> HTTPRequest {
+    guard case let .complete(request) = HTTPParser.parse(data) else {
+        Issue.record("expected a complete request, got \(HTTPParser.parse(data))")
+        throw ParseFailure()
+    }
+    return request
+}
+
+private func errorMessage(_ data: Data) throws -> String {
+    guard case let .error(message) = HTTPParser.parse(data) else {
+        Issue.record("expected an error, got \(HTTPParser.parse(data))")
+        throw ParseFailure()
+    }
+    return message
+}
+
+private struct ParseFailure: Error {}
+
+private let json = #"{"resourceLogs":[]}"#
+
+// MARK: - Content-Length framing
+
+@Test("A Content-Length framed request parses")
+func contentLengthRequestParses() throws {
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/json", "Content-Length": "\(json.utf8.count)"]
+    ))
+
+    #expect(result.method == "POST")
+    #expect(result.path == "/v1/logs")
+    #expect(String(decoding: result.body, as: UTF8.self) == json)
+}
+
+@Test("Header lookup stays case-insensitive after normalization")
+func headerLookupIsCaseInsensitive() throws {
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["CONTENT-TYPE": "application/json", "content-length": "\(json.utf8.count)"]
+    ))
+
+    #expect(result.header("Content-Type") == "application/json")
+    #expect(result.header("content-type") == "application/json")
+    #expect(result.contentLength == json.utf8.count)
+}
+
+@Test("A body split across reads needs more data before completing")
+func splitBodyNeedsMore() throws {
+    let full = request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/json", "Content-Length": "\(json.utf8.count)"]
+    )
+    let partial = full.prefix(full.count - 5)
+
+    guard case .needsMore = HTTPParser.parse(Data(partial)) else {
+        Issue.record("a truncated body should ask for more data")
+        return
+    }
+    #expect(String(decoding: try parsed(full).body, as: UTF8.self) == json)
+}
+
+@Test("Headers arriving without their terminator need more data")
+func partialHeadersNeedMore() {
+    guard case .needsMore = HTTPParser.parse(Data("POST /v1/logs HTTP/1.1\r\nHost: local".utf8)) else {
+        Issue.record("incomplete headers should ask for more data")
+        return
+    }
+}
+
+// MARK: - Chunked framing
+
+@Test("A chunked request is reassembled")
+func chunkedRequestParses() throws {
+    let body = "5\r\n{\"res\r\n3\r\nour\r\n0\r\n\r\n"
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: body,
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    ))
+
+    #expect(String(decoding: result.body, as: UTF8.self) == "{\"resour")
+}
+
+@Test("Chunk extensions and trailers are tolerated")
+func chunkedExtensionsAndTrailersParse() throws {
+    let body = "4;name=value\r\ntest\r\n0\r\nX-Trailer: v\r\n\r\n"
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: body,
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    ))
+
+    #expect(String(decoding: result.body, as: UTF8.self) == "test")
+}
+
+@Test("A chunked body split mid-stream needs more data")
+func chunkedSplitNeedsMore() {
+    let partial = request(
+        "POST /v1/logs",
+        body: "8\r\n{\"res",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+
+    guard case .needsMore = HTTPParser.parse(partial) else {
+        Issue.record("an unterminated chunked body should ask for more data")
+        return
+    }
+}
+
+@Test("A malformed chunk size is an error, not an empty body")
+func malformedChunkSizeIsAnError() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: "zz\r\nbad\r\n0\r\n\r\n",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    #expect(try errorMessage(data).contains("Malformed chunk size"))
+}
+
+// MARK: - Framing and encoding rejections
+
+@Test("A POST with no framing is rejected instead of yielding an empty body")
+func unframedPostIsRejected() throws {
+    let data = request("POST /v1/logs", body: json, headers: ["Content-Type": "application/json"])
+
+    // The pre-fix behaviour was `.complete` with a zero-byte body, which then
+    // failed in JSONDecoder as an opaque "invalid payload".
+    #expect(try errorMessage(data).contains("Missing Content-Length or Transfer-Encoding"))
+}
+
+@Test("A non-numeric Content-Length is rejected")
+func malformedContentLengthIsRejected() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/json", "Content-Length": "abc"]
+    )
+    #expect(try errorMessage(data).contains("Malformed Content-Length"))
+}
+
+@Test("A protobuf body is rejected by name rather than handed to JSONDecoder")
+func protobufContentTypeIsRejected() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/x-protobuf", "Content-Length": "\(json.utf8.count)"]
+    )
+    let message = try errorMessage(data)
+    #expect(message.contains("Unsupported Content-Type"))
+    #expect(message.contains("application/x-protobuf"))
+}
+
+@Test("A charset parameter on the content type is tolerated")
+func contentTypeParametersAreTolerated() throws {
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/json; charset=utf-8",
+                  "Content-Length": "\(json.utf8.count)"]
+    ))
+    #expect(String(decoding: result.body, as: UTF8.self) == json)
+}
+
+@Test("A compressed body is rejected by name")
+func gzipContentEncodingIsRejected() throws {
+    let data = request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/json",
+                  "Content-Encoding": "gzip",
+                  "Content-Length": "\(json.utf8.count)"]
+    )
+    let message = try errorMessage(data)
+    #expect(message.contains("Unsupported Content-Encoding"))
+    #expect(message.contains("gzip"))
+}
+
+@Test("An identity Content-Encoding is accepted")
+func identityContentEncodingIsAccepted() throws {
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/json",
+                  "Content-Encoding": "identity",
+                  "Content-Length": "\(json.utf8.count)"]
+    ))
+    #expect(String(decoding: result.body, as: UTF8.self) == json)
+}
+
+@Test("A GET without framing is still a complete request")
+func bodylessMethodNeedsNoFraming() throws {
+    let result = try parsed(request("GET /v1/logs"))
+    #expect(result.method == "GET")
+    #expect(result.body.isEmpty)
+}
+
+@Test("An oversized Content-Length is rejected")
+func oversizedBodyIsRejected() throws {
+    let data = request(
+        "POST /v1/logs",
+        headers: ["Content-Type": "application/json",
+                  "Content-Length": "\(HTTPParser.maxBodyBytes + 1)"]
+    )
+    #expect(try errorMessage(data).contains("Body too large"))
+}
+
+@Test("Oversized headers are rejected rather than buffered forever")
+func oversizedHeadersAreRejected() throws {
+    var data = Data("POST /v1/logs HTTP/1.1\r\n".utf8)
+    data.append(Data(String(repeating: "X", count: 9000).utf8))
+    #expect(try errorMessage(data).contains("Headers too large"))
+}

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/HTTPParserTests.swift
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/HTTPParserTests.swift
@@ -224,6 +224,23 @@ func protobufContentTypeIsRejected() throws {
     #expect(message.contains("application/x-protobuf"))
 }
 
+@Test("A POST with no Content-Type is rejected rather than assumed to be JSON")
+func missingContentTypeIsRejected() throws {
+    let data = request("POST /v1/logs", body: json, headers: ["Content-Length": "\(json.utf8.count)"])
+    #expect(try errorMessage(data).contains("Missing Content-Type"))
+}
+
+@Test("A +json suffix type is accepted")
+func suffixJSONContentTypeIsAccepted() throws {
+    let result = try parsed(request(
+        "POST /v1/logs",
+        body: json,
+        headers: ["Content-Type": "application/vnd.otlp+json",
+                  "Content-Length": "\(json.utf8.count)"]
+    ))
+    #expect(String(decoding: result.body, as: UTF8.self) == json)
+}
+
 @Test("A charset parameter on the content type is tolerated")
 func contentTypeParametersAreTolerated() throws {
     let result = try parsed(request(
@@ -283,6 +300,56 @@ func oversizedHeadersAreRejected() throws {
     var data = Data("POST /v1/logs HTTP/1.1\r\n".utf8)
     data.append(Data(String(repeating: "X", count: 9000).utf8))
     #expect(try errorMessage(data).contains("Headers too large"))
+}
+
+// MARK: - Buffering limits
+
+@Test("A CRLF-free chunked stream is rejected instead of buffered forever")
+func crlfFreeChunkedStreamIsRejected() throws {
+    // The chunk-size line never terminates. Before this guard the parser kept
+    // answering `.needsMore`, so the receiver appended without limit — 250 MiB
+    // of this drove the process to ~16 GB RSS.
+    var data = request(
+        "POST /v1/logs",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    data.append(Data(String(repeating: "A", count: HTTPParser.maxChunkLineBytes + 1).utf8))
+
+    #expect(try errorMessage(data).contains("Malformed chunk size line"))
+}
+
+@Test("A short CRLF-free prefix still waits for more data")
+func shortChunkSizePrefixStillWaits() {
+    var data = request(
+        "POST /v1/logs",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    data.append(Data("4".utf8))
+
+    guard case .needsMore = HTTPParser.parse(data) else {
+        Issue.record("a partial chunk-size line should ask for more data")
+        return
+    }
+}
+
+@Test("Unterminated chunk trailers are rejected")
+func unterminatedTrailersAreRejected() throws {
+    var data = request(
+        "POST /v1/logs",
+        body: "4\r\ntest\r\n0\r\n",
+        headers: ["Content-Type": "application/json", "Transfer-Encoding": "chunked"]
+    )
+    data.append(Data(("X-Trailer: " + String(repeating: "v", count: HTTPParser.maxHeaderBytes)).utf8))
+
+    #expect(try errorMessage(data).contains("Chunk trailers too large"))
+}
+
+@Test("The receiver's ceiling covers the whole framed request")
+func requestCeilingExceedsBodyCap() {
+    // The backstop must leave room for headers on top of a maximal body,
+    // otherwise a legitimate 64 MiB export would be cut off.
+    #expect(HTTPParser.maxRequestBytes > HTTPParser.maxBodyBytes)
+    #expect(HTTPParser.maxRequestBytes == HTTPParser.maxBodyBytes + HTTPParser.maxHeaderBytes)
 }
 
 // MARK: - Error response encoding

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/OTLPLogsDecodingTests.swift
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/OTLPLogsDecodingTests.swift
@@ -245,6 +245,46 @@ func consecutiveMalformedRecordsAreSkipped() throws {
     #expect(diagnostics.skipped("logRecords") == 3)
 }
 
+@Test("A malformed scope costs that scope, not the whole resource")
+func malformedScopeIsSkipped() throws {
+    let json = """
+    {"resourceLogs":[{
+      "resource":{"attributes":[
+        {"key":"crow.session.id","value":{"stringValue":"11111111-2222-3333-4444-555555555555"}}]},
+      "scopeLogs":["not a scope",
+        {"logRecords":[{"body":{"stringValue":"claude_code.user_prompt"}}]}]}]}
+    """
+    let (payload, diagnostics) = try decodeLogsReportingSkips(json)
+
+    let resource = try #require(payload.resourceLogs.first)
+    #expect(resource.resource?.crowSessionID == "11111111-2222-3333-4444-555555555555")
+    #expect(resource.scopeLogs?.count == 1)
+    #expect(resource.scopeLogs?[0].logRecords?[0].resolvedEventName == "claude_code.user_prompt")
+    #expect(diagnostics.skipped("scopeLogs") == 1)
+}
+
+@Test("A malformed metrics scope costs that scope, not the whole resource")
+func malformedMetricsScopeIsSkipped() throws {
+    let json = """
+    {"resourceMetrics":[{
+      "resource":{"attributes":[
+        {"key":"crow.session.id","value":{"stringValue":"11111111-2222-3333-4444-555555555555"}}]},
+      "scopeMetrics":[17,
+        {"metrics":[{"name":"claude_code.cost.usage",
+          "sum":{"aggregationTemporality":1,"isMonotonic":true,"dataPoints":[{"asDouble":1.5}]}}]}]}]}
+    """
+    let diagnostics = OTLPDecodeDiagnostics()
+    let decoder = JSONDecoder()
+    decoder.userInfo[.otlpDiagnostics] = diagnostics
+    let payload = try decoder.decode(OTLPMetricsPayload.self, from: Data(json.utf8))
+
+    let resource = try #require(payload.resourceMetrics.first)
+    #expect(resource.resource?.crowSessionID == "11111111-2222-3333-4444-555555555555")
+    #expect(resource.scopeMetrics?.count == 1)
+    #expect(resource.scopeMetrics?[0].metrics?[0].name == "claude_code.cost.usage")
+    #expect(diagnostics.skipped("scopeMetrics") == 1)
+}
+
 @Test("A field that should be an array but isn't is reported, not silently dropped")
 func nonArrayFieldIsReported() throws {
     let (payload, diagnostics) = try decodeLogsReportingSkips(logsPayload(records: """

--- a/Packages/CrowTelemetry/Tests/CrowTelemetryTests/OTLPLogsDecodingTests.swift
+++ b/Packages/CrowTelemetry/Tests/CrowTelemetryTests/OTLPLogsDecodingTests.swift
@@ -1,0 +1,376 @@
+import Foundation
+import Testing
+@testable import CrowTelemetry
+
+/// Tests for OTLP/JSON logs decoding (issue #823).
+///
+/// Every `/v1/logs` export from Claude Code was rejected with the generic
+/// "isn't in the correct format", so no event ever reached the database. The
+/// cause was type strictness, not transport: Claude Code stamps
+/// `event.sequence` (and token/duration counters) onto every log record, and
+/// the OpenTelemetry JS exporter encodes those as `{"intValue": <number>}`
+/// while the model required `{"intValue": "<string>"}`. One mismatched
+/// attribute failed the whole payload.
+///
+/// `claude-code-logs-export.json` is a real capture from Claude Code 2.1.219
+/// with identifiers replaced; every JSON *type* is untouched, so the numeric
+/// `intValue` fields that caused the bug are still numeric.
+
+private func loadFixture(_ name: String) throws -> Data {
+    let url = try #require(
+        Bundle.module.url(forResource: "Fixtures/\(name)", withExtension: "json"),
+        "fixture \(name).json missing from the test bundle"
+    )
+    return try Data(contentsOf: url)
+}
+
+private func decodeLogs(_ json: String) throws -> OTLPLogsPayload {
+    try JSONDecoder().decode(OTLPLogsPayload.self, from: Data(json.utf8))
+}
+
+/// Wrap a single log record in a minimal but complete logs payload.
+private func logsPayload(records: String, resourceID: String = "11111111-2222-3333-4444-555555555555") -> String {
+    """
+    {"resourceLogs":[{
+      "resource":{"attributes":[
+        {"key":"crow.session.id","value":{"stringValue":"\(resourceID)"}}]},
+      "scopeLogs":[{"logRecords":[\(records)]}]}]}
+    """
+}
+
+// MARK: - Real capture
+
+@Test("A real Claude Code /v1/logs export decodes")
+func realExportDecodes() throws {
+    let data = try loadFixture("claude-code-logs-export")
+    let payload = try JSONDecoder().decode(OTLPLogsPayload.self, from: data)
+
+    let resource = try #require(payload.resourceLogs.first)
+    #expect(resource.resource?.crowSessionID == "11111111-2222-3333-4444-555555555555")
+
+    let records = try #require(resource.scopeLogs?.first?.logRecords)
+    #expect(records.count == 14)
+}
+
+@Test("The real export carries the numeric intValue attributes that broke decoding")
+func realExportHasNumericIntValues() throws {
+    let data = try loadFixture("claude-code-logs-export")
+
+    // Guard the fixture itself: if a future re-capture stringifies these, the
+    // regression test above would silently stop covering the bug.
+    let raw = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let resourceLogs = try #require(raw["resourceLogs"] as? [[String: Any]])
+    let scopeLogs = try #require(resourceLogs[0]["scopeLogs"] as? [[String: Any]])
+    let records = try #require(scopeLogs[0]["logRecords"] as? [[String: Any]])
+
+    var numericIntValues = 0
+    for record in records {
+        for attribute in record["attributes"] as? [[String: Any]] ?? [] {
+            let value = attribute["value"] as? [String: Any]
+            if let number = value?["intValue"], number is NSNumber, !(number is NSString) {
+                numericIntValues += 1
+            }
+        }
+    }
+    #expect(numericIntValues > 0, "fixture no longer exercises numeric intValue")
+
+    // And they survive decoding as strings.
+    let payload = try JSONDecoder().decode(OTLPLogsPayload.self, from: data)
+    let decoded = try #require(payload.resourceLogs.first?.scopeLogs?.first?.logRecords)
+    let sequences = decoded.compactMap { record in
+        record.attributes.flatMap { extractAttribute("event.sequence", from: $0) }
+    }
+    #expect(sequences.count == decoded.count, "every record carries event.sequence")
+    #expect(sequences.allSatisfy { Int($0) != nil })
+}
+
+@Test("Every record in the real export resolves a claude_code.* event name")
+func realExportResolvesEventNames() throws {
+    let data = try loadFixture("claude-code-logs-export")
+    let payload = try JSONDecoder().decode(OTLPLogsPayload.self, from: data)
+    let records = try #require(payload.resourceLogs.first?.scopeLogs?.first?.logRecords)
+
+    let names = records.compactMap(\.resolvedEventName)
+    #expect(names.count == records.count)
+    #expect(names.allSatisfy { $0.hasPrefix("claude_code.") })
+    // These are the names TelemetryDatabase's readers count.
+    #expect(names.contains("claude_code.user_prompt"))
+    #expect(names.contains("claude_code.api_request"))
+}
+
+// MARK: - AnyValue type tolerance
+
+@Test("intValue decodes from a JSON number or a string")
+func intValueAcceptsNumberOrString() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"body":{"stringValue":"claude_code.api_request"},"attributes":[
+      {"key":"event.sequence","value":{"intValue":42}},
+      {"key":"input_tokens","value":{"intValue":"1024"}}]}
+    """))
+
+    let attributes = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].attributes)
+    #expect(extractAttribute("event.sequence", from: attributes) == "42")
+    #expect(extractAttribute("input_tokens", from: attributes) == "1024")
+}
+
+@Test("int64 values beyond Double's exact range survive decoding")
+func intValueKeepsPrecision() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"attributes":[{"key":"big","value":{"intValue":9007199254740993}}]}
+    """))
+
+    let attributes = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].attributes)
+    #expect(extractAttribute("big", from: attributes) == "9007199254740993")
+}
+
+@Test("Composite attribute values flatten to JSON instead of vanishing")
+func compositeValuesFlatten() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"attributes":[
+      {"key":"workspace.host_paths","value":{"arrayValue":{"values":[
+        {"stringValue":"/a"},{"stringValue":"/b"}]}}},
+      {"key":"nested","value":{"kvlistValue":{"values":[
+        {"key":"k","value":{"intValue":7}}]}}},
+      {"key":"raw","value":{"bytesValue":"AQID"}}]}
+    """))
+
+    let attributes = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].attributes)
+    #expect(extractAttribute("workspace.host_paths", from: attributes) == #"["\/a","\/b"]"#)
+    #expect(extractAttribute("nested", from: attributes) == #"{"k":"7"}"#)
+    #expect(extractAttribute("raw", from: attributes) == "AQID")
+}
+
+@Test("An attribute with no value decodes as empty rather than failing")
+func attributeWithoutValueIsTolerated() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"attributes":[
+      {"key":"undefined","value":{}},
+      {"key":"kept","value":{"stringValue":"yes"}}]}
+    """))
+
+    let attributes = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].attributes)
+    #expect(attributes.count == 2)
+    #expect(extractAttribute("undefined", from: attributes) == nil)
+    #expect(extractAttribute("kept", from: attributes) == "yes")
+}
+
+// MARK: - Scalar field tolerance
+
+@Test(
+    "severityNumber decodes from a number or an OTLP enum name",
+    arguments: [("9", 9), ("\"SEVERITY_NUMBER_INFO\"", 9), ("\"SEVERITY_NUMBER_DEBUG3\"", 7),
+                ("\"SEVERITY_NUMBER_FATAL\"", 21), ("\"13\"", 13)]
+)
+func severityNumberAcceptsNumberOrEnumName(encoded: String, expected: Int) throws {
+    let payload = try decodeLogs(logsPayload(records: #"{"severityNumber":\#(encoded)}"#))
+    #expect(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].severityNumber == expected)
+}
+
+@Test("timeUnixNano decodes from a string or a number")
+func timestampAcceptsStringOrNumber() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"timeUnixNano":"1784916871131000000"},
+    {"timeUnixNano":1784916871131000000}
+    """))
+
+    let records = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords)
+    #expect(records[0].timeUnixNano == "1784916871131000000")
+    #expect(records[1].timeUnixNano == "1784916871131000000")
+}
+
+@Test("aggregationTemporality decodes from a number or an enum name")
+func temporalityAcceptsNumberOrEnumName() throws {
+    func decodeSum(_ encoded: String) throws -> OTLPAggregationTemporality {
+        let json = """
+        {"resourceMetrics":[{"scopeMetrics":[{"metrics":[{"name":"m",
+          "sum":{"aggregationTemporality":\(encoded),"isMonotonic":true,
+                 "dataPoints":[{"asInt":5}]}}]}]}]}
+        """
+        let payload = try JSONDecoder().decode(OTLPMetricsPayload.self, from: Data(json.utf8))
+        return try #require(payload.resourceMetrics[0].scopeMetrics?[0].metrics?[0].sum).temporality
+    }
+
+    #expect(try decodeSum("2") == .cumulative)
+    #expect(try decodeSum("\"AGGREGATION_TEMPORALITY_DELTA\"") == .delta)
+}
+
+@Test("Metric asInt decodes from a number as well as a string")
+func metricAsIntAcceptsNumber() throws {
+    let json = """
+    {"resourceMetrics":[{"scopeMetrics":[{"metrics":[{"name":"claude_code.token.usage",
+      "sum":{"aggregationTemporality":1,"isMonotonic":true,
+             "dataPoints":[{"asInt":1500},{"asInt":"2500"}]}}]}]}]}
+    """
+    let payload = try JSONDecoder().decode(OTLPMetricsPayload.self, from: Data(json.utf8))
+    let points = try #require(payload.resourceMetrics[0].scopeMetrics?[0].metrics?[0].sum?.dataPoints)
+    #expect(points.map(\.numericValue) == [1500, 2500])
+}
+
+// MARK: - Per-record resilience
+
+/// Decode with a diagnostics box attached, the way the receiver does.
+private func decodeLogsReportingSkips(
+    _ json: String
+) throws -> (payload: OTLPLogsPayload, diagnostics: OTLPDecodeDiagnostics) {
+    let diagnostics = OTLPDecodeDiagnostics()
+    let decoder = JSONDecoder()
+    decoder.userInfo[.otlpDiagnostics] = diagnostics
+    return (try decoder.decode(OTLPLogsPayload.self, from: Data(json.utf8)), diagnostics)
+}
+
+@Test("A malformed record is skipped, not fatal to the whole export")
+func malformedRecordIsSkipped() throws {
+    // The middle element is a string where a record object belongs.
+    let (payload, diagnostics) = try decodeLogsReportingSkips(logsPayload(records: """
+    {"body":{"stringValue":"claude_code.user_prompt"}},
+    "not a record",
+    {"body":{"stringValue":"claude_code.tool_result"}}
+    """))
+
+    let records = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords)
+    #expect(records.count == 2)
+    #expect(records.compactMap(\.resolvedEventName) == ["claude_code.user_prompt", "claude_code.tool_result"])
+    #expect(diagnostics.skipped("logRecords") == 1)
+    #expect(diagnostics.summary == "1 logRecords")
+}
+
+@Test("Consecutive malformed records are each skipped without stalling")
+func consecutiveMalformedRecordsAreSkipped() throws {
+    let (payload, diagnostics) = try decodeLogsReportingSkips(logsPayload(records: """
+    "bad", 17, null, {"body":{"stringValue":"claude_code.user_prompt"}}
+    """))
+
+    let records = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords)
+    #expect(records.count == 1)
+    #expect(diagnostics.skipped("logRecords") == 3)
+}
+
+@Test("A field that should be an array but isn't is reported, not silently dropped")
+func nonArrayFieldIsReported() throws {
+    let (payload, diagnostics) = try decodeLogsReportingSkips(logsPayload(records: """
+    {"body":{"stringValue":"claude_code.user_prompt"},"attributes":{"not":"an array"}}
+    """))
+
+    let record = try #require(payload.resourceLogs[0].scopeLogs?[0].logRecords?.first)
+    #expect(record.attributes == nil)
+    #expect(record.resolvedEventName == "claude_code.user_prompt")
+    #expect(diagnostics.skipped("attributes") == 1)
+}
+
+@Test("Skips are reported only when something was actually dropped")
+func cleanDecodeReportsNoSkips() throws {
+    let diagnostics = OTLPDecodeDiagnostics()
+    let decoder = JSONDecoder()
+    decoder.userInfo[.otlpDiagnostics] = diagnostics
+    _ = try decoder.decode(OTLPLogsPayload.self, from: try loadFixture("claude-code-logs-export"))
+
+    #expect(diagnostics.summary == nil)
+}
+
+@Test("An empty payload decodes to no resources instead of throwing")
+func emptyPayloadIsNotAnError() throws {
+    #expect(try decodeLogs("{}").resourceLogs.isEmpty)
+    #expect(try decodeLogs(#"{"resourceLogs":[]}"#).resourceLogs.isEmpty)
+}
+
+// MARK: - Event name resolution
+
+@Test("A bare event.name is qualified with the claude_code prefix")
+func bareEventNameIsQualified() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"body":{"stringValue":"claude_code.user_prompt"},
+     "attributes":[{"key":"event.name","value":{"stringValue":"user_prompt"}}]}
+    """))
+    #expect(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].resolvedEventName
+        == "claude_code.user_prompt")
+}
+
+@Test("An already-qualified event name is left alone")
+func qualifiedEventNameIsPreserved() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"attributes":[{"key":"event.name","value":{"stringValue":"claude_code.tool_result"}}]}
+    """))
+    #expect(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].resolvedEventName
+        == "claude_code.tool_result")
+}
+
+@Test("A top-level eventName field wins over the attribute")
+func topLevelEventNameWins() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"eventName":"claude_code.api_error",
+     "attributes":[{"key":"event.name","value":{"stringValue":"user_prompt"}}]}
+    """))
+    #expect(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].resolvedEventName
+        == "claude_code.api_error")
+}
+
+@Test("The body names the event when no event.name attribute is present")
+func bodyIsTheEventNameFallback() throws {
+    let payload = try decodeLogs(logsPayload(records: """
+    {"body":{"stringValue":"claude_code.compaction"}}
+    """))
+    #expect(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].resolvedEventName
+        == "claude_code.compaction")
+}
+
+@Test("A record with nothing to name it resolves to nil")
+func unnamedRecordResolvesToNil() throws {
+    let payload = try decodeLogs(logsPayload(records: #"{"severityNumber":9}"#))
+    #expect(payload.resourceLogs[0].scopeLogs?[0].logRecords?[0].resolvedEventName == nil)
+}
+
+// MARK: - Failure diagnostics
+
+/// A strict shape, standing in for whatever a future OTLP model requires — the
+/// point is the rendering of a `DecodingError` that carries a coding path.
+private struct StrictProbe: Decodable {
+    struct Item: Decodable {
+        let value: String
+    }
+
+    let items: [Item]
+}
+
+@Test("A decode failure is described by coding path, not a generic message")
+func decodeFailureNamesTheField() {
+    do {
+        _ = try JSONDecoder().decode(StrictProbe.self, from: Data(#"{"items":[{"value":1}]}"#.utf8))
+        Issue.record("expected the decode to fail")
+    } catch {
+        // Every DecodingError shares this one unhelpful string — it is what the
+        // receiver used to log, and why #823 was undiagnosable from the log.
+        #expect(error.localizedDescription
+            == "The data couldn’t be read because it isn’t in the correct format.")
+
+        let described = OTLPReceiver.describe(error)
+        #expect(described.contains("typeMismatch"))
+        #expect(described.contains("items[0].value"))
+    }
+}
+
+@Test("A body that is not JSON at all is still described usefully")
+func nonJSONBodyIsDescribed() {
+    do {
+        _ = try JSONDecoder().decode(OTLPLogsPayload.self, from: Data("not json".utf8))
+        Issue.record("expected the decode to fail")
+    } catch {
+        let described = OTLPReceiver.describe(error)
+        #expect(described.contains("dataCorrupted"))
+        #expect(described.contains("<root>"))
+    }
+}
+
+@Test("Repeated failures are throttled to one report per interval")
+func failuresAreThrottled() {
+    let throttle = FailureThrottle(interval: 60)
+    let start = Date()
+
+    #expect(throttle.claim("/v1/logs", now: start) == 0)
+    #expect(throttle.claim("/v1/logs", now: start.addingTimeInterval(5)) == nil)
+    #expect(throttle.claim("/v1/logs", now: start.addingTimeInterval(10)) == nil)
+    // A different signal reports independently.
+    #expect(throttle.claim("/v1/metrics", now: start.addingTimeInterval(10)) == 0)
+    // Past the interval, the next report carries the suppressed count.
+    #expect(throttle.claim("/v1/logs", now: start.addingTimeInterval(61)) == 2)
+    #expect(throttle.claim("/v1/logs", now: start.addingTimeInterval(122)) == 0)
+}


### PR DESCRIPTION
Closes #823

## Which candidate cause was it?

The ticket offered two: **(1) chunked transport** or **(2) payload shape**. It is **#2**, and #1 is ruled out by evidence rather than argument.

I pointed a throwaway listener at a spare port with the same `OTEL_*` env `AgentLaunch` sets and drove a real Claude Code session. The export arrives **`Content-Length` framed**, not chunked:

```
POST /v1/logs HTTP/1.1
content-type: application/json
user-agent: OTel-OTLP-Exporter-JavaScript/0.208.0
content-length: 21382
```

Corroborating: locally `telemetry.db` held **1794 metric rows and 0 event rows**. Metrics traverse the same `HTTPParser`, so bodies were always arriving intact.

## The actual cause

Claude Code stamps `event.sequence` onto **every** log record, and the OpenTelemetry JS exporter encodes JS integers as a JSON **number**:

```js
if (t === "number") {
  if (!Number.isInteger(e)) return { doubleValue: e };
  return { intValue: e };          // JSON number, not string
}
```

`OTLPAnyValue.intValue` was `String?`, so this threw `typeMismatch` and — because `JSONDecoder` is all-or-nothing — discarded the entire export. The real capture carries 31 numeric `intValue` attributes across 14 records (`input_tokens`, `duration_ms`, `cost_usd_micros`, …), so the failure was systematic, matching "every export, never intermittent".

Decoding the committed fixture with the **pre-fix** model reproduces the production string exactly:

```
localizedDescription: The data couldn't be read because it isn't in the correct format.
underlying: DecodingError.typeMismatch: expected value of type String.
  Path: resourceLogs[0].scopeLogs[0].logRecords[0].attributes[10].value.intValue
```

…and `attributes[10]` is `{"key": "event.sequence", "value": {"intValue": 0}}`.

Metrics survived because every Claude Code *metric* attribute is a string and its datapoints use `asDouble`.

## Second bug, found on the way

`event.name` carries the **bare** name on the wire (`user_prompt`); the qualified `claude_code.user_prompt` is in the body. Every reader in `TelemetryDatabase` matches the qualified form (`countEvents`, `turnAnalytics`). Fixing only the decode would have landed events that no reader matches — `promptCount`/`toolCallCount` would have stayed at 0 and `turnAnalytics` would still return `[]`. Names are now qualified at ingest, so the analytics SQL is untouched.

## What changed

**Tolerant OTLP/JSON decoding** (`OTLPModels.swift`) — `intValue` accepts number or string, as do `asInt`, `timeUnixNano`, `severityNumber` and `aggregationTemporality` (the last two also accepting their `SEVERITY_NUMBER_*` / `AGGREGATION_TEMPORALITY_*` names). `arrayValue`/`kvlistValue`/`bytesValue` flatten to JSON instead of silently becoming `""`. A malformed record is skipped rather than failing the export, with the skip counted into `OTLPDecodeDiagnostics` so the loss is logged rather than silent.

**Diagnostics** (`OTLPReceiver.swift`) — failures now log the `DecodingError` case, **coding path** and reason plus framing headers and body size. The old `localizedDescription` was the same sentence for every possible cause, which is what made this undiagnosable. A truncated raw body is gated behind `CROW_TELEMETRY_LOG_RAW_BODIES=1`, since bodies carry `user.email`, `user.id` and `organization.id`. Repeat failures are throttled to one report per minute per path — the spam half of the ticket.

**Transport hardening** (`HTTPParser.swift`) — not the cause, but the parser derived the body from `Content-Length` alone and returned a *complete* request with an **empty body** when absent, which would have surfaced as this same opaque error. It now supports `Transfer-Encoding: chunked`, rejects an unframed POST by name, and rejects a non-JSON `Content-Type` or compressed body with a specific message. Per discussion, gzip *decoding* is deliberately out of scope (Crow never sets `OTEL_EXPORTER_OTLP_COMPRESSION`); it is rejected clearly instead.

## Verification

- 66 tests in `CrowTelemetryTests` pass (33 new). The fixture is a real Claude Code 2.1.219 capture with identifiers replaced and **every JSON type preserved** — a test asserts the numeric `intValue` fields are still numeric, so a future re-capture can't silently stop covering the bug.
- End-to-end through the package's `verify` skill: 14 events land with `claude_code.*` names over **both** Content-Length and chunked framing; metrics still ingest; rejections return their specific messages.

```
claude_code.mcp_server_connection|7   claude_code.api_request|2
claude_code.assistant_response|2      claude_code.user_prompt|1
claude_code.plugin_loaded|1           claude_code.permission_mode_changed|1
```

- `make test` is green except `CrowTerminal`'s `retryReadinessEmitsTimedOutWhenSentinelMissing`, which fails identically on a clean tree — pre-existing and unrelated (CrowTerminal does not depend on CrowTelemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEernNSx3DF5xb3a7jGfSd