### PR TITLE
OpenCode adapter: Jira MCP, per-project plugins, version-aware auto-probe (#831)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -113,10 +113,15 @@ enum LaunchScaffold {
                 }
                 // Mirror the user's Claude `jira` MCP into OpenCode's global
                 // config so OpenCode sessions get the same `jira_*` tools
-                // (parity with Claude; CROW-831). No-op when the user has no
-                // Claude Jira MCP to mirror.
-                attempt("OpenCode Jira MCP registration") {
-                    OpenCodeMCPConfigWriter.installGlobalMCPConfig(configHome: configHome)
+                // (parity with Claude; CROW-831). Never throws — it returns an
+                // Outcome — so inspect and log non-success directly rather than
+                // through `attempt`, whose catch branch would never fire.
+                let mcpOutcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(configHome: configHome)
+                switch mcpOutcome {
+                case .registered, .removed, .unchanged, .noSource:
+                    CrowDaemon.log("OpenCode Jira MCP registration: \(mcpOutcome)")
+                case .skippedUnparseable, .failed:
+                    CrowDaemon.log("WARNING: OpenCode Jira MCP registration: \(mcpOutcome)")
                 }
             }
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -111,6 +111,13 @@ enum LaunchScaffold {
                 attempt("OpenCode global config install") {
                     try OpenCodeHookConfigWriter.installGlobalConfig(configHome: configHome, crowPath: crowPath)
                 }
+                // Mirror the user's Claude `jira` MCP into OpenCode's global
+                // config so OpenCode sessions get the same `jira_*` tools
+                // (parity with Claude; CROW-831). No-op when the user has no
+                // Claude Jira MCP to mirror.
+                attempt("OpenCode Jira MCP registration") {
+                    OpenCodeMCPConfigWriter.installGlobalMCPConfig(configHome: configHome)
+                }
             }
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -102,27 +102,29 @@ enum LaunchScaffold {
 
         if AgentRegistry.shared.agent(for: .openCode) != nil {
             attempt("OpenCode scaffold") { try OpenCodeScaffolder.scaffold(devRoot: devRoot) }
+            // XDG spec: an empty `XDG_CONFIG_HOME` is treated as unset, so fall
+            // through to ~/.config/opencode rather than a relative path.
+            let configHome = nonEmptyEnv("XDG_CONFIG_HOME")
+                .map { ($0 as NSString).appendingPathComponent("opencode") }
+                ?? NSString(string: "~/.config/opencode").expandingTildeInPath
+            // The state-bridge plugin needs the `crow` binary; the MCP mirror
+            // does not — so gate only the former on `crowPath`.
             if let crowPath {
-                // XDG spec: an empty `XDG_CONFIG_HOME` is treated as unset, so
-                // fall through to ~/.config/opencode rather than a relative path.
-                let configHome = nonEmptyEnv("XDG_CONFIG_HOME")
-                    .map { ($0 as NSString).appendingPathComponent("opencode") }
-                    ?? NSString(string: "~/.config/opencode").expandingTildeInPath
                 attempt("OpenCode global config install") {
                     try OpenCodeHookConfigWriter.installGlobalConfig(configHome: configHome, crowPath: crowPath)
                 }
-                // Mirror the user's Claude `jira` MCP into OpenCode's global
-                // config so OpenCode sessions get the same `jira_*` tools
-                // (parity with Claude; CROW-831). Never throws — it returns an
-                // Outcome — so inspect and log non-success directly rather than
-                // through `attempt`, whose catch branch would never fire.
-                let mcpOutcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(configHome: configHome)
-                switch mcpOutcome {
-                case .registered, .removed, .unchanged, .noSource:
-                    CrowDaemon.log("OpenCode Jira MCP registration: \(mcpOutcome)")
-                case .skippedUnparseable, .failed:
-                    CrowDaemon.log("WARNING: OpenCode Jira MCP registration: \(mcpOutcome)")
-                }
+            }
+            // Mirror the user's Claude `jira` MCP into OpenCode's global config
+            // so OpenCode sessions get the same `jira_*` tools (parity with
+            // Claude; CROW-831). Never throws — it returns an Outcome — so
+            // inspect and log non-success directly rather than through
+            // `attempt`, whose catch branch would never fire.
+            let mcpOutcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(configHome: configHome)
+            switch mcpOutcome {
+            case .registered, .removed, .unchanged, .skippedUserOwned, .noSource:
+                CrowDaemon.log("OpenCode Jira MCP registration: \(mcpOutcome)")
+            case .skippedUnparseable, .failed:
+                CrowDaemon.log("WARNING: OpenCode Jira MCP registration: \(mcpOutcome)")
             }
         }
     }

--- a/Packages/CrowOpenCode/Package.swift
+++ b/Packages/CrowOpenCode/Package.swift
@@ -9,19 +9,9 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../CrowCore"),
-        // SHA-256 for the MCP-mirror provenance digest (so the sidecar records a
-        // hash, not a third plaintext copy of the Jira token). Already resolved
-        // repo-wide via CrowDaemon's web-auth PBKDF2 (CROW-593).
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
     ],
     targets: [
-        .target(
-            name: "CrowOpenCode",
-            dependencies: [
-                "CrowCore",
-                .product(name: "Crypto", package: "swift-crypto"),
-            ]
-        ),
+        .target(name: "CrowOpenCode", dependencies: ["CrowCore"]),
         .testTarget(name: "CrowOpenCodeTests", dependencies: ["CrowOpenCode"]),
     ]
 )

--- a/Packages/CrowOpenCode/Package.swift
+++ b/Packages/CrowOpenCode/Package.swift
@@ -9,9 +9,19 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../CrowCore"),
+        // SHA-256 for the MCP-mirror provenance digest (so the sidecar records a
+        // hash, not a third plaintext copy of the Jira token). Already resolved
+        // repo-wide via CrowDaemon's web-auth PBKDF2 (CROW-593).
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
     ],
     targets: [
-        .target(name: "CrowOpenCode", dependencies: ["CrowCore"]),
+        .target(
+            name: "CrowOpenCode",
+            dependencies: [
+                "CrowCore",
+                .product(name: "Crypto", package: "swift-crypto"),
+            ]
+        ),
         .testTarget(name: "CrowOpenCodeTests", dependencies: ["CrowOpenCode"]),
     ]
 )

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
@@ -20,8 +20,10 @@ import CrowCore
 ///     pipes bind fd 0 and break keyboard input; `--prompt` may only pre-fill.
 ///  2. **State hooks are a JS plugin, not a `hooks.json`.** OpenCode has no
 ///     command-based hook file; `OpenCodeHookConfigWriter` installs a plugin
-///     into `~/.config/opencode/plugins/` that shells out to `crow
-///     hook-event`. See that type for details.
+///     into the worktree's `.opencode/plugins/` with the session UUID baked in
+///     (a global fallback in `~/.config/opencode/plugins/` covers hand-started
+///     sessions and self-suppresses when the per-project plugin is present).
+///     See that type for details.
 ///
 /// OpenCode has no `--rc`/`--name`/`--permission-mode` analog. The closest
 /// permission knob is `--auto` / `--dangerously-skip-permissions`, probed via

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
@@ -5,16 +5,36 @@ import CrowCore
 /// command-based hook file like Claude Code's `settings.json` or Cursor's
 /// `hooks.json`; instead it auto-loads JS/TS **plugins** from
 /// `~/.config/opencode/plugins/` (global) and `<project>/.opencode/plugins/`
-/// (per-project). MVP is global-only, matching Codex/Cursor's scope.
+/// (per-project). Upstream globs `{plugin,plugins}` (`plugin.ts@v1.18.4:21`),
+/// so either spelling loads; Crow's writer uses `plugins/`.
 ///
-/// So `installGlobalConfig` writes a single plugin file,
-/// `crow-hooks.js`, that subscribes to OpenCode's `event` bus plus the
-/// `tool.execute.before/after` and `permission.ask` hooks and shells out
-/// (via Bun's `$`) to `crow hook-event --agent opencode --event <PascalName>`,
-/// piping a JSON payload with the worktree `cwd` on stdin — exactly the shape
-/// the crow server's `hook-event` RPC expects (it resolves the session by
-/// matching `cwd` against registered worktree paths, the same mechanism
-/// Codex's global hooks use).
+/// **Two scopes, one plugin body (CROW-831):**
+///
+///  - **Per-project (primary).** `writeHookConfig` writes
+///    `<worktree>/.opencode/plugins/crow-hooks.js` with the Crow **session
+///    UUID baked in**, so each worktree emits `crow hook-event --session
+///    <uuid> …`. Resolution is exact — no cwd matching — which closes the
+///    shared-`cwd` collision two sessions rooted at (or resolving to) the same
+///    path could otherwise hit. Every Crow-launched OpenCode session
+///    (`.work`/`.job`/`.review`) flows through `AgentLaunch` →
+///    `writeHookConfig`, so all of them get a session-scoped plugin.
+///
+///  - **Global (fallback).** `installGlobalConfig` still writes a single
+///    `<configHome>/plugins/crow-hooks.js` with **no** session UUID; it
+///    resolves the session by matching the worktree `cwd` against registered
+///    worktree paths (the same mechanism Codex's global hooks use). This
+///    covers a `opencode` a user starts *by hand* in a terminal Crow didn't
+///    auto-launch. To avoid **double emission** — OpenCode dedups plugins by
+///    file URL, so the global and per-project files are distinct and *both*
+///    load — the global plugin self-suppresses (returns no hooks) whenever a
+///    per-project `crow-hooks.js` exists in the cwd. So in a Crow worktree only
+///    the session-scoped plugin ever fires.
+///
+/// Both variants subscribe to OpenCode's `event` bus plus the
+/// `tool.execute.before/after` and `permission.ask` hooks and shell out (via
+/// Bun's `$`) to `crow hook-event --agent opencode --event <PascalName>`,
+/// piping a JSON payload (`{ cwd, … }`) on stdin — the shape the crow server's
+/// `hook-event` RPC expects.
 ///
 /// The plugin maps OpenCode's event/hook vocabulary onto Crow's canonical
 /// PascalCase names so `OpenCodeSignalSource` can share Claude/Codex/Cursor's
@@ -36,65 +56,115 @@ import CrowCore
 /// `permission.ask` hook fires exactly when OpenCode requests a decision; we
 /// only observe it (never set `output.status`), so the user's/agent's choice
 /// still stands.
-///
-/// CROW-545 gap: the event *names* are now verified, but the *timing/semantics*
-/// (esp. whether `session.idle` is the right "done" signal for interactive
-/// TUI sessions) should still be confirmed empirically at runtime — the same
-/// caveat Cursor's writer carries for `afterAgentResponse`.
-///
-/// Because `HookConfigWriter`'s per-session API doesn't fit OpenCode's
-/// global model, the per-session methods are intentionally no-ops — real
-/// work happens via the static `installGlobalConfig` call at app launch.
 public struct OpenCodeHookConfigWriter: HookConfigWriter {
 
     public init() {}
 
-    // MARK: - HookConfigWriter Conformance (no-ops)
+    // MARK: - HookConfigWriter Conformance (per-project plugin)
 
-    /// No-op. OpenCode plugins are global, not per-worktree — see
-    /// `installGlobalConfig`. Per-project `<worktree>/.opencode/plugins/` is
-    /// deferred to a follow-up; MVP stays global-only.
-    public func writeHookConfig(worktreePath: String, sessionID: UUID, crowPath: String) throws {}
+    /// Install `<worktreePath>/.opencode/plugins/crow-hooks.js` with
+    /// `sessionID` baked in, so this worktree's OpenCode emits
+    /// `crow hook-event --session <sessionID> …`. Idempotent — we own this
+    /// single-purpose file and overwrite it wholesale, so there's nothing to
+    /// merge. Called from the `AgentLaunch` path on every OpenCode launch.
+    public func writeHookConfig(worktreePath: String, sessionID: UUID, crowPath: String) throws {
+        let pluginsDir = Self.worktreePluginsDir(worktreePath)
+        try FileManager.default.createDirectory(atPath: pluginsDir, withIntermediateDirectories: true)
+        let pluginPath = (pluginsDir as NSString).appendingPathComponent(Self.pluginFileName)
+        let content = Self.pluginSource(crowPath: crowPath, sessionID: sessionID)
+        try content.write(to: URL(fileURLWithPath: pluginPath), atomically: true, encoding: .utf8)
+    }
 
-    /// No-op. The global plugin stays in place when individual sessions are
-    /// deleted; it serves all sessions.
-    public func removeHookConfig(worktreePath: String) {}
+    /// Remove the per-project plugin from a worktree's `.opencode/plugins/`,
+    /// leaving any user-authored plugins in that directory untouched. Best
+    /// effort: also prunes the `plugins`/`.opencode` dirs when they're left
+    /// empty (i.e. Crow created them), so tearing a session down leaves no
+    /// trace, but never touches a directory that still holds other files.
+    public func removeHookConfig(worktreePath: String) {
+        let pluginsDir = Self.worktreePluginsDir(worktreePath)
+        let pluginPath = (pluginsDir as NSString).appendingPathComponent(Self.pluginFileName)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: pluginPath) else { return }
+        try? fm.removeItem(atPath: pluginPath)
+        Self.removeIfEmpty(pluginsDir)
+        Self.removeIfEmpty((worktreePath as NSString).appendingPathComponent(".opencode"))
+    }
 
-    // MARK: - Global Configuration
+    // MARK: - Global Configuration (fallback)
 
     /// Install or refresh `<configHome>/plugins/crow-hooks.js`. `configHome`
     /// is OpenCode's config dir (default `~/.config/opencode`, honoring
     /// `XDG_CONFIG_HOME`). Idempotent — we own this single-purpose file and
-    /// overwrite it wholesale on every launch, so there's nothing to merge
-    /// (unlike Cursor's shared `hooks.json`).
+    /// overwrite it wholesale on every launch. The global plugin carries no
+    /// session UUID and self-suppresses when a per-project plugin is present
+    /// (see the type doc), so it only ever fires for hand-started sessions.
     public static func installGlobalConfig(configHome: String, crowPath: String) throws {
-        let pluginsDir = (configHome as NSString).appendingPathComponent("plugins")
+        let pluginsDir = globalPluginsDir(configHome)
         try FileManager.default.createDirectory(atPath: pluginsDir, withIntermediateDirectories: true)
-        let pluginPath = (pluginsDir as NSString).appendingPathComponent("crow-hooks.js")
-        let content = pluginSource(crowPath: crowPath)
+        let pluginPath = (pluginsDir as NSString).appendingPathComponent(pluginFileName)
+        let content = pluginSource(crowPath: crowPath, sessionID: nil)
         try content.write(to: URL(fileURLWithPath: pluginPath), atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Plugin Source
+
+    static let pluginFileName = "crow-hooks.js"
+
+    /// `<configHome>/plugins` — the global config home already ends at
+    /// `…/opencode`, so no `.opencode` segment is added.
+    private static func globalPluginsDir(_ configHome: String) -> String {
+        (configHome as NSString).appendingPathComponent("plugins")
+    }
+
+    /// `<worktree>/.opencode/plugins` — per-project scope adds the `.opencode`
+    /// segment OpenCode discovers project config/plugins under.
+    private static func worktreePluginsDir(_ worktree: String) -> String {
+        let opencodeDir = (worktree as NSString).appendingPathComponent(".opencode")
+        return (opencodeDir as NSString).appendingPathComponent("plugins")
+    }
+
+    private static func removeIfEmpty(_ dir: String) {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: dir), contents.isEmpty else { return }
+        try? fm.removeItem(atPath: dir)
     }
 
     /// The JS plugin body, with `crowPath` baked in as a string literal
     /// (mirrors how Cursor bakes `crowPath` into its `hooks.json` commands).
-    /// Written as plain `.js` so it needs no `@opencode-ai/plugin` types or
-    /// a build step — OpenCode runs it directly on Bun.
-    static func pluginSource(crowPath: String) -> String {
+    /// Written as plain `.js` so it needs no `@opencode-ai/plugin` types or a
+    /// build step — OpenCode runs it directly on Bun.
+    ///
+    /// When `sessionID` is non-nil the emit carries `--session <uuid>` (exact
+    /// resolution, per-project scope). When nil the emit omits it and the
+    /// server resolves by cwd match (global fallback scope), and the plugin
+    /// self-suppresses if a per-project plugin exists in the cwd.
+    static func pluginSource(crowPath: String, sessionID: UUID? = nil) -> String {
         let crow = jsStringLiteral(crowPath)
+        let session = jsStringLiteral(sessionID?.uuidString ?? "")
+        let scopeNote = sessionID != nil
+            ? "session-scoped (UUID baked in below)"
+            : "global fallback (resolves by cwd; defers to a per-project plugin)"
         return """
         // Crow ↔ OpenCode hook bridge — auto-generated by Crow (safe to delete).
+        // Scope: \(scopeNote).
         // Forwards OpenCode lifecycle events to the running Crow app so session
         // cards reflect agent state. Regenerated on every Crow launch.
         //
-        // Each emit pipes a JSON payload ({ cwd, ... }) to `crow hook-event`;
-        // the crow server resolves the Crow session by matching `cwd` against
-        // registered worktree paths, so no session UUID is needed here.
+        // Each emit pipes a JSON payload ({ cwd, ... }) to `crow hook-event`.
+        // With a session UUID we pass `--session <uuid>` so the crow server
+        // resolves the session exactly; without one it matches `cwd` against
+        // registered worktree paths.
         const CROW = \(crow);
+        const SESSION = \(session);
 
         async function emit($, cwd, event, extra) {
           try {
             const payload = JSON.stringify(Object.assign({ cwd }, extra || {}));
-            await $`echo ${payload} | ${CROW} hook-event --agent opencode --event ${event}`.quiet();
+            if (SESSION) {
+              await $`echo ${payload} | ${CROW} hook-event --session ${SESSION} --agent opencode --event ${event}`.quiet();
+            } else {
+              await $`echo ${payload} | ${CROW} hook-event --agent opencode --event ${event}`.quiet();
+            }
           } catch (_) {
             // Fire-and-forget: a hook failure (e.g. Crow not running) must
             // never disrupt OpenCode.
@@ -105,6 +175,18 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
           // Prefer the git worktree path — that's what Crow registers and
           // matches on. Fall back to the process cwd.
           const cwd = worktree || directory;
+          // Global fallback only: if this worktree has a session-scoped Crow
+          // plugin, defer to it. OpenCode loads both (they are distinct file
+          // URLs), so without this guard the same event would emit twice.
+          if (!SESSION) {
+            try {
+              if (await Bun.file(cwd + "/.opencode/plugins/crow-hooks.js").exists()) {
+                return {};
+              }
+            } catch (_) {
+              // Bun.file unavailable / unreadable — fall through and emit.
+            }
+          }
           return {
             event: async ({ event }) => {
               switch (event.type) {

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
@@ -92,7 +92,10 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
         let pluginsDir = Self.worktreePluginsDir(worktreePath)
         let pluginPath = (pluginsDir as NSString).appendingPathComponent(Self.pluginFileName)
         let fm = FileManager.default
-        guard fm.fileExists(atPath: pluginPath) else { return }
+        // Remove the plugin if it's still there — but don't early-return when it
+        // isn't: a user who took the "safe to delete" header at its word and
+        // removed `crow-hooks.js` by hand must not be left with an orphaned,
+        // self-ignoring `.gitignore` that `git status` can't even surface.
         try? fm.removeItem(atPath: pluginPath)
         // Drop our `.gitignore` only if it still holds exactly our content — a
         // user may have replaced it with their own rules (same provenance

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
@@ -82,21 +82,23 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
     }
 
     /// Remove the per-project plugin from a worktree's `.opencode/plugins/`,
-    /// leaving any user-authored plugins in that directory untouched. Best
-    /// effort: also removes our self-scoped `.gitignore` and prunes the
-    /// `plugins`/`.opencode` dirs when they're left empty (i.e. Crow created
-    /// them), so tearing a session down leaves no trace, but never touches a
-    /// directory that still holds other files.
+    /// leaving any user-authored files (plugins *and* a hand-written
+    /// `.gitignore`) untouched. Best effort: removes our own `.gitignore` when
+    /// it still carries exactly our content, and prunes the `plugins`/`.opencode`
+    /// dirs when they're left empty (i.e. Crow created them), so tearing a
+    /// session down leaves no trace — but never touches a file or directory that
+    /// isn't ours.
     public func removeHookConfig(worktreePath: String) {
         let pluginsDir = Self.worktreePluginsDir(worktreePath)
         let pluginPath = (pluginsDir as NSString).appendingPathComponent(Self.pluginFileName)
         let fm = FileManager.default
         guard fm.fileExists(atPath: pluginPath) else { return }
         try? fm.removeItem(atPath: pluginPath)
-        // Drop our `.gitignore` only if it's the sole remaining entry (i.e. Crow
-        // owns the dir); a user plugin alongside means leave everything.
+        // Drop our `.gitignore` only if it still holds exactly our content — a
+        // user may have replaced it with their own rules (same provenance
+        // discipline as writeGitignore).
         let gitignorePath = (pluginsDir as NSString).appendingPathComponent(".gitignore")
-        if (try? fm.contentsOfDirectory(atPath: pluginsDir)) == [".gitignore"] {
+        if (try? String(contentsOfFile: gitignorePath, encoding: .utf8)) == Self.gitignoreBody {
             try? fm.removeItem(atPath: gitignorePath)
         }
         Self.removeIfEmpty(pluginsDir)
@@ -142,18 +144,29 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
         try? fm.removeItem(atPath: dir)
     }
 
+    /// The exact body Crow writes to `.opencode/plugins/.gitignore`. A single
+    /// source of truth so `writeGitignore` and `removeHookConfig` agree on what
+    /// "ours" means when deciding whether it's safe to write/delete.
+    static let gitignoreBody = """
+    # Crow-generated — safe to delete.
+    \(pluginFileName)
+    .gitignore
+    """
+
     /// Write a self-scoped `.gitignore` into `dir` that ignores Crow's generated
     /// plugin (and the `.gitignore` itself), so an agent's `git add -A` in the
-    /// worktree never stages them. Idempotent; best effort (a failure just means
-    /// the files remain stageable, the pre-existing behavior).
+    /// worktree never stages them. `.opencode/plugins/` is the *user's*
+    /// directory (their own plugins live there), so this never clobbers a
+    /// pre-existing `.gitignore` — it writes only into an empty slot or over our
+    /// own previous body. Idempotent; best effort.
     private static func writeGitignore(inDir dir: String) {
         let path = (dir as NSString).appendingPathComponent(".gitignore")
-        let body = """
-        # Crow-generated — safe to delete.
-        \(pluginFileName)
-        .gitignore
-        """
-        try? body.write(to: URL(fileURLWithPath: path), atomically: true, encoding: .utf8)
+        if let existing = try? String(contentsOfFile: path, encoding: .utf8),
+           existing != gitignoreBody {
+            // A `.gitignore` we didn't write (user's own rules) — leave it.
+            return
+        }
+        try? gitignoreBody.write(to: URL(fileURLWithPath: path), atomically: true, encoding: .utf8)
     }
 
     /// The JS plugin body, with `crowPath` baked in as a string literal

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
@@ -73,19 +73,32 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
         let pluginPath = (pluginsDir as NSString).appendingPathComponent(Self.pluginFileName)
         let content = Self.pluginSource(crowPath: crowPath, sessionID: sessionID)
         try content.write(to: URL(fileURLWithPath: pluginPath), atomically: true, encoding: .utf8)
+        // The plugin embeds the absolute `crow` path and the session UUID and
+        // lives inside the user's git worktree, where an agent's `git add -A`
+        // could stage it. A self-scoped `.gitignore` keeps our generated files
+        // out of the index without touching OpenCode's own `.opencode/.gitignore`
+        // (a level up, which upstream manages).
+        Self.writeGitignore(inDir: pluginsDir)
     }
 
     /// Remove the per-project plugin from a worktree's `.opencode/plugins/`,
     /// leaving any user-authored plugins in that directory untouched. Best
-    /// effort: also prunes the `plugins`/`.opencode` dirs when they're left
-    /// empty (i.e. Crow created them), so tearing a session down leaves no
-    /// trace, but never touches a directory that still holds other files.
+    /// effort: also removes our self-scoped `.gitignore` and prunes the
+    /// `plugins`/`.opencode` dirs when they're left empty (i.e. Crow created
+    /// them), so tearing a session down leaves no trace, but never touches a
+    /// directory that still holds other files.
     public func removeHookConfig(worktreePath: String) {
         let pluginsDir = Self.worktreePluginsDir(worktreePath)
         let pluginPath = (pluginsDir as NSString).appendingPathComponent(Self.pluginFileName)
         let fm = FileManager.default
         guard fm.fileExists(atPath: pluginPath) else { return }
         try? fm.removeItem(atPath: pluginPath)
+        // Drop our `.gitignore` only if it's the sole remaining entry (i.e. Crow
+        // owns the dir); a user plugin alongside means leave everything.
+        let gitignorePath = (pluginsDir as NSString).appendingPathComponent(".gitignore")
+        if (try? fm.contentsOfDirectory(atPath: pluginsDir)) == [".gitignore"] {
+            try? fm.removeItem(atPath: gitignorePath)
+        }
         Self.removeIfEmpty(pluginsDir)
         Self.removeIfEmpty((worktreePath as NSString).appendingPathComponent(".opencode"))
     }
@@ -127,6 +140,20 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(atPath: dir), contents.isEmpty else { return }
         try? fm.removeItem(atPath: dir)
+    }
+
+    /// Write a self-scoped `.gitignore` into `dir` that ignores Crow's generated
+    /// plugin (and the `.gitignore` itself), so an agent's `git add -A` in the
+    /// worktree never stages them. Idempotent; best effort (a failure just means
+    /// the files remain stageable, the pre-existing behavior).
+    private static func writeGitignore(inDir dir: String) {
+        let path = (dir as NSString).appendingPathComponent(".gitignore")
+        let body = """
+        # Crow-generated — safe to delete.
+        \(pluginFileName)
+        .gitignore
+        """
+        try? body.write(to: URL(fileURLWithPath: path), atomically: true, encoding: .utf8)
     }
 
     /// The JS plugin body, with `crowPath` baked in as a string literal

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
@@ -10,8 +10,48 @@ public enum OpenCodeLaunchArgs {
     /// omits an optional flag, never breaks launch.
     private nonisolated(unsafe) static var tuiAutoFlagCache: [String: Bool] = [:]
     private nonisolated(unsafe) static var runHelpCache: [String: String] = [:]
+    private nonisolated(unsafe) static var versionCache: [String: SemVer?] = [:]
 
     private static let helpProbeTimeoutSeconds: TimeInterval = 5
+
+    /// The first `opencode` release that re-added the top-level TUI `--auto`
+    /// flag. It was present pre-`1.17`, **removed across the `1.17.x` window**,
+    /// then re-added in `1.18.0` (2026-07-14; verified `sst/opencode`
+    /// `tui.ts@v1.18.4`). Below this, the TUI `--help` probe for `--auto` can
+    /// only ever answer "no" — so we short-circuit it (CROW-831). At/above it we
+    /// still probe, so a *future* upstream flip is caught without a code change.
+    static let tuiAutoReintroducedVersion = SemVer(1, 18, 0)
+
+    /// A parsed `MAJOR.MINOR.PATCH`, compared field-by-field.
+    struct SemVer: Comparable, Equatable {
+        let major, minor, patch: Int
+        init(_ major: Int, _ minor: Int, _ patch: Int) {
+            self.major = major; self.minor = minor; self.patch = patch
+        }
+        static func < (lhs: SemVer, rhs: SemVer) -> Bool {
+            (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+        }
+    }
+
+    /// Parse the leading `MAJOR.MINOR.PATCH` out of `opencode --version` output
+    /// (e.g. `"1.17.10"`, or `"opencode 1.18.4"`). Returns `nil` when no such
+    /// triple is present, in which case callers must fall back to probing.
+    static func parseVersion(_ text: String) -> SemVer? {
+        // First run of `digits.digits.digits` anywhere in the string.
+        guard let range = text.range(
+            of: #"\d+\.\d+\.\d+"#, options: .regularExpression) else { return nil }
+        let parts = text[range].split(separator: ".").compactMap { Int($0) }
+        guard parts.count == 3 else { return nil }
+        return SemVer(parts[0], parts[1], parts[2])
+    }
+
+    /// Whether a known installed `version` predates the TUI `--auto`
+    /// reintroduction — i.e. the top-level `--auto` probe is guaranteed to miss
+    /// and can be skipped. `nil` version means "unknown", so we do *not* skip.
+    static func tuiAutoKnownAbsent(version: SemVer?) -> Bool {
+        guard let version else { return false }
+        return version < tuiAutoReintroducedVersion
+    }
 
     /// POSIX single-quote escape for paths interpolated into shell commands.
     public static func shellQuote(_ s: String) -> String {
@@ -38,6 +78,13 @@ public enum OpenCodeLaunchArgs {
 
     /// Probe the installed binary once and cache the result. Only call when
     /// an auto-approve suffix is actually needed — each probe spawns a subprocess.
+    ///
+    /// Version-narrowed (CROW-831): on builds older than
+    /// `tuiAutoReintroducedVersion` the TUI `--auto` flag is *known absent*, so
+    /// we answer `false` from the (cheaper) `--version` string alone and skip
+    /// the dead-weight `opencode --help` parse. On `≥1.18` and on unparseable
+    /// versions we still run the `--help` probe, so an upstream flip is caught
+    /// without a code change (the probe was never wrong on `≥1.18`).
     public static func tuiSupportsAuto(binary: String) -> Bool {
         cacheLock.lock()
         if let cached = tuiAutoFlagCache[binary] {
@@ -46,13 +93,40 @@ public enum OpenCodeLaunchArgs {
         }
         cacheLock.unlock()
 
-        let help = (try? runHelp(binary: binary, subcommand: nil)) ?? ""
-        let supports = parseTUISupportsAuto(from: help)
+        let supports: Bool
+        if tuiAutoKnownAbsent(version: installedVersion(binary: binary)) {
+            // Known `<1.18`: the top-level `--auto` flag does not exist. No point
+            // spawning `opencode --help` to confirm the absence.
+            supports = false
+        } else {
+            let help = (try? runHelp(binary: binary, subcommand: nil)) ?? ""
+            supports = parseTUISupportsAuto(from: help)
+        }
 
         cacheLock.lock()
         tuiAutoFlagCache[binary] = supports
         cacheLock.unlock()
         return supports
+    }
+
+    /// Cached parsed `opencode --version` for the installed binary. Returns
+    /// `nil` (and caches it) when the binary can't be run or its output has no
+    /// `MAJOR.MINOR.PATCH` — callers then fall back to the `--help` probe.
+    static func installedVersion(binary: String) -> SemVer? {
+        cacheLock.lock()
+        if let cached = versionCache[binary] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let version = (try? runHelp(binary: binary, subcommand: nil, versionOnly: true))
+            .flatMap { parseVersion($0) }
+
+        cacheLock.lock()
+        versionCache[binary] = version
+        cacheLock.unlock()
+        return version
     }
 
     /// Cached `opencode run --help` text for the installed binary. Only call
@@ -79,6 +153,7 @@ public enum OpenCodeLaunchArgs {
         defer { cacheLock.unlock() }
         tuiAutoFlagCache.removeAll()
         runHelpCache.removeAll()
+        versionCache.removeAll()
     }
 
     /// TUI auto-approve suffix when the installed build supports `--auto`.
@@ -128,11 +203,17 @@ public enum OpenCodeLaunchArgs {
         return "\(binary) --continue\(flags)\n"
     }
 
-    private static func runHelp(binary: String, subcommand: String?) throws -> String {
+    private static func runHelp(
+        binary: String,
+        subcommand: String?,
+        versionOnly: Bool = false
+    ) throws -> String {
         let process = Process()
         let pipe = Pipe()
         process.executableURL = URL(fileURLWithPath: binary)
-        if let subcommand {
+        if versionOnly {
+            process.arguments = ["--version"]
+        } else if let subcommand {
             process.arguments = [subcommand, "--help"]
         } else {
             process.arguments = ["--help"]

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
@@ -17,10 +17,17 @@ public enum OpenCodeLaunchArgs {
     /// The first `opencode` release that re-added the top-level TUI `--auto`
     /// flag. It was present pre-`1.17`, **removed across the `1.17.x` window**,
     /// then re-added in `1.18.0` (2026-07-14; verified `sst/opencode`
-    /// `tui.ts@v1.18.4`). Below this, the TUI `--help` probe for `--auto` can
-    /// only ever answer "no" — so we short-circuit it (CROW-831). At/above it we
-    /// still probe, so a *future* upstream flip is caught without a code change.
+    /// `tui.ts@v1.18.4`). Only within `[tuiAutoRemovedVersion,
+    /// tuiAutoReintroducedVersion)` can the TUI `--help` probe for `--auto`
+    /// answer only "no" — so we short-circuit it there (CROW-831). Outside that
+    /// window we still probe, so a *future* upstream flip is caught without a
+    /// code change.
     static let tuiAutoReintroducedVersion = SemVer(1, 18, 0)
+
+    /// The first `1.17.x` release where the top-level TUI `--auto` flag was
+    /// dropped. Below this (`< 1.17`) the flag was still present, so the probe
+    /// must run — do **not** treat those builds as "known absent".
+    static let tuiAutoRemovedVersion = SemVer(1, 17, 0)
 
     /// A parsed `MAJOR.MINOR.PATCH`, compared field-by-field.
     struct SemVer: Comparable, Equatable {
@@ -45,12 +52,14 @@ public enum OpenCodeLaunchArgs {
         return SemVer(parts[0], parts[1], parts[2])
     }
 
-    /// Whether a known installed `version` predates the TUI `--auto`
-    /// reintroduction — i.e. the top-level `--auto` probe is guaranteed to miss
-    /// and can be skipped. `nil` version means "unknown", so we do *not* skip.
+    /// Whether a known installed `version` falls in the window where the TUI
+    /// `--auto` flag was dropped — `[1.17.0, 1.18.0)` — so the top-level
+    /// `--auto` probe is guaranteed to miss and can be skipped. Builds `<1.17`
+    /// still had the flag and `≥1.18` re-added it, so both fall through to the
+    /// probe; a `nil` version is "unknown" and never skipped.
     static func tuiAutoKnownAbsent(version: SemVer?) -> Bool {
         guard let version else { return false }
-        return version < tuiAutoReintroducedVersion
+        return version >= tuiAutoRemovedVersion && version < tuiAutoReintroducedVersion
     }
 
     /// POSIX single-quote escape for paths interpolated into shell commands.

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
@@ -88,12 +88,13 @@ public enum OpenCodeLaunchArgs {
     /// Probe the installed binary once and cache the result. Only call when
     /// an auto-approve suffix is actually needed — each probe spawns a subprocess.
     ///
-    /// Version-narrowed (CROW-831): on builds older than
-    /// `tuiAutoReintroducedVersion` the TUI `--auto` flag is *known absent*, so
+    /// Version-narrowed (CROW-831): on builds inside the `[1.17.0, 1.18.0)`
+    /// window where the TUI `--auto` flag was dropped, it is *known absent*, so
     /// we answer `false` from the (cheaper) `--version` string alone and skip
-    /// the dead-weight `opencode --help` parse. On `≥1.18` and on unparseable
-    /// versions we still run the `--help` probe, so an upstream flip is caught
-    /// without a code change (the probe was never wrong on `≥1.18`).
+    /// the dead-weight `opencode --help` parse. On `<1.17` (flag still present),
+    /// `≥1.18` (flag re-added), and unparseable versions we still run the
+    /// `--help` probe, so a flip in either direction is caught without a code
+    /// change.
     public static func tuiSupportsAuto(binary: String) -> Bool {
         cacheLock.lock()
         if let cached = tuiAutoFlagCache[binary] {
@@ -104,8 +105,8 @@ public enum OpenCodeLaunchArgs {
 
         let supports: Bool
         if tuiAutoKnownAbsent(version: installedVersion(binary: binary)) {
-            // Known `<1.18`: the top-level `--auto` flag does not exist. No point
-            // spawning `opencode --help` to confirm the absence.
+            // Known `[1.17.0, 1.18.0)`: the top-level `--auto` flag does not
+            // exist. No point spawning `opencode --help` to confirm the absence.
             supports = false
         } else {
             let help = (try? runHelp(binary: binary, subcommand: nil)) ?? ""

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLauncher.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLauncher.swift
@@ -52,11 +52,17 @@ public actor OpenCodeLauncher {
                 lines.append("```")
             case .jira:
                 if let key = Validation.jiraKey(from: url) {
+                    // Prefer the `jira` MCP (parity with Claude — Crow mirrors
+                    // it into OpenCode's config, CROW-831); fall back to `acli`
+                    // when the MCP isn't registered.
+                    lines.append("Fetch this work item via the **`jira` MCP server** if available — call `jira_get_issue` for key `\(key)` (and the other `jira_*` tools for any create/assign/transition/comment).")
+                    lines.append("")
+                    lines.append("If the `jira` MCP isn't available, fall back to `acli`:")
                     lines.append("```bash")
                     lines.append("acli jira workitem view \(key) --fields summary,status,description,comment")
                     lines.append("```")
                 } else {
-                    lines.append("URL: \(url)")
+                    lines.append("URL: \(url) — fetch it via the `jira` MCP server (`jira_get_issue`).")
                 }
             case .corveil, nil:
                 lines.append("URL: \(url)")

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Registers the Jira MCP server into OpenCode's config so OpenCode sessions
+/// get the same `jira_*` tools Claude Code sessions do — parity with Claude
+/// (CROW-831).
+///
+/// **Where the spec comes from.** Post-CROW-528 Crow does *not* provision or
+/// store a Jira MCP itself; Claude Code sessions inherit a user-provisioned
+/// global `jira` server from `~/.claude.json` (`mcpServers.jira`). So "parity
+/// with Claude" here means: mirror *that* server into OpenCode. If the user has
+/// no `jira` MCP configured for Claude, this is a no-op — OpenCode gets nothing,
+/// exactly as Claude would.
+///
+/// **Where it's written.** OpenCode merges every global config file it finds —
+/// `config.json`, `opencode.json`, **and** `opencode.jsonc`
+/// (`config.ts@v1.18.4:258-260`) — so Crow writes a dedicated, Crow-owned
+/// `<configHome>/opencode.json`. That keeps us off the user's hand-edited
+/// `opencode.jsonc` (whose comments a JSON round-trip would strip) while still
+/// being loaded. Scope is **global**, matching the org-wide single-Jira-account
+/// model (one `jira` server serves every session).
+///
+/// The write merges: it preserves `$schema`, any other `mcp` entries, and every
+/// other key already in `opencode.json`, and refuses to touch a file that isn't
+/// a JSON object. Idempotent — re-running rewrites only the `mcp.jira` entry.
+public enum OpenCodeMCPConfigWriter {
+
+    /// The MCP server name. Matches Claude's `jira` key so the `jira_*` tool
+    /// names the prompts reference resolve identically across harnesses.
+    static let serverName = "jira"
+
+    public enum Outcome: Equatable {
+        /// The `mcp.jira` entry was written/updated in `opencode.json`.
+        case registered
+        /// `opencode.json` already carried an identical `mcp.jira`; nothing written.
+        case unchanged
+        /// No `jira` MCP server in the Claude config to mirror; nothing written.
+        case noSource
+        /// A target/source file exists but isn't a JSON object; refused to touch it.
+        case skippedUnparseable
+        /// Read or write failed.
+        case failed(String)
+    }
+
+    /// Mirror the user's Claude `jira` MCP into `<configHome>/opencode.json`.
+    /// Pass `claudeJSONPath` to read a different Claude config (tests); `nil`
+    /// uses the real `~/.claude.json`.
+    @discardableResult
+    public static func installGlobalMCPConfig(
+        configHome: String,
+        claudeJSONPath: String? = nil
+    ) -> Outcome {
+        let fm = FileManager.default
+
+        // 1. Read the source `jira` server from the Claude config.
+        let claudePath = claudeJSONPath
+            ?? fm.homeDirectoryForCurrentUser.appendingPathComponent(".claude.json").path
+        let sourceServer: [String: Any]?
+        switch readClaudeJiraServer(claudeJSONPath: claudePath) {
+        case .success(let server): sourceServer = server
+        case .unparseable: return .skippedUnparseable
+        }
+        guard let sourceServer, let openCodeServer = translateClaudeServer(sourceServer) else {
+            return .noSource
+        }
+
+        // 2. Merge into the Crow-owned `opencode.json`.
+        let targetPath = (configHome as NSString).appendingPathComponent("opencode.json")
+        var root: [String: Any] = ["$schema": "https://opencode.ai/config.json"]
+        if fm.fileExists(atPath: targetPath) {
+            guard let data = fm.contents(atPath: targetPath),
+                  let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            else {
+                NSLog("[OpenCodeMCPConfigWriter] %@ exists but is not a JSON object; refusing to modify it", targetPath)
+                return .skippedUnparseable
+            }
+            root = parsed
+        }
+
+        var mcp = root["mcp"] as? [String: Any] ?? [:]
+        if let existing = mcp[serverName] as? [String: Any],
+           NSDictionary(dictionary: existing).isEqual(to: openCodeServer) {
+            return .unchanged
+        }
+        mcp[serverName] = openCodeServer
+        root["mcp"] = mcp
+
+        do {
+            try fm.createDirectory(atPath: configHome, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(
+                withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: targetPath), options: .atomic)
+        } catch {
+            NSLog("[OpenCodeMCPConfigWriter] Failed to write %@: %@", targetPath, error.localizedDescription)
+            return .failed(error.localizedDescription)
+        }
+        return .registered
+    }
+
+    // MARK: - Source
+
+    enum ClaudeReadResult {
+        case success([String: Any]?)
+        case unparseable
+    }
+
+    /// The `mcpServers.jira` object from `~/.claude.json`, or `nil` when absent.
+    /// A file that exists but isn't a JSON object is reported as `.unparseable`
+    /// so the caller refuses to proceed (rather than silently overwriting).
+    static func readClaudeJiraServer(claudeJSONPath: String) -> ClaudeReadResult {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: claudeJSONPath) else { return .success(nil) }
+        guard let data = fm.contents(atPath: claudeJSONPath),
+              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else {
+            NSLog("[OpenCodeMCPConfigWriter] %@ exists but is not a JSON object; ignoring", claudeJSONPath)
+            return .unparseable
+        }
+        let servers = root["mcpServers"] as? [String: Any]
+        return .success(servers?[serverName] as? [String: Any])
+    }
+
+    // MARK: - Translation
+
+    /// Translate a Claude Code MCP server object into OpenCode's `mcp` entry
+    /// shape. Returns `nil` when the source has neither a `url` (remote) nor a
+    /// `command` (local) — i.e. nothing we can faithfully mirror.
+    ///
+    /// Claude local:  `{ command: "uvx", args: [...], env: {...} }`
+    ///   → OpenCode:  `{ type: "local", command: ["uvx", ...args], environment: {...}, enabled: true }`
+    /// Claude remote: `{ type: "http"|"sse", url: "...", headers: {...} }`
+    ///   → OpenCode:  `{ type: "remote", url: "...", headers: {...}, enabled: true }`
+    static func translateClaudeServer(_ server: [String: Any]) -> [String: Any]? {
+        let claudeType = (server["type"] as? String)?.lowercased()
+        let isRemote = server["url"] is String
+            && (claudeType == "http" || claudeType == "sse" || server["command"] == nil)
+
+        if isRemote, let url = server["url"] as? String {
+            var out: [String: Any] = ["type": "remote", "url": url, "enabled": true]
+            if let headers = server["headers"] as? [String: Any], !headers.isEmpty {
+                out["headers"] = headers
+            }
+            return out
+        }
+
+        if let command = server["command"] as? String {
+            var argv: [String] = [command]
+            if let args = server["args"] as? [String] {
+                argv.append(contentsOf: args)
+            } else if let args = server["args"] as? [Any] {
+                argv.append(contentsOf: args.compactMap { $0 as? String })
+            }
+            var out: [String: Any] = ["type": "local", "command": argv, "enabled": true]
+            if let env = server["env"] as? [String: Any], !env.isEmpty {
+                out["environment"] = env
+            }
+            return out
+        }
+
+        return nil
+    }
+}

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -22,6 +22,12 @@ import Foundation
 /// The write merges: it preserves `$schema`, any other `mcp` entries, and every
 /// other key already in `opencode.json`, and refuses to touch a file that isn't
 /// a JSON object. Idempotent — re-running rewrites only the `mcp.jira` entry.
+/// It **un-mirrors**: when the source `jira` server disappears from the Claude
+/// config, the previously-written `mcp.jira` is dropped so a stale server never
+/// lingers. A user's explicit `enabled: false` on the mirrored entry is
+/// preserved across launches. The file is written `0600` — the mirrored
+/// `environment`/`headers` carry the same secrets `~/.claude.json` (itself
+/// `0600`) does.
 public enum OpenCodeMCPConfigWriter {
 
     /// The MCP server name. Matches Claude's `jira` key so the `jira_*` tool
@@ -31,9 +37,13 @@ public enum OpenCodeMCPConfigWriter {
     public enum Outcome: Equatable {
         /// The `mcp.jira` entry was written/updated in `opencode.json`.
         case registered
+        /// The source `jira` server is gone and the previously-mirrored
+        /// `mcp.jira` entry was dropped from `opencode.json` (un-mirror).
+        case removed
         /// `opencode.json` already carried an identical `mcp.jira`; nothing written.
         case unchanged
-        /// No `jira` MCP server in the Claude config to mirror; nothing written.
+        /// No `jira` MCP server in the Claude config to mirror, and nothing
+        /// stale to remove; nothing written.
         case noSource
         /// A target/source file exists but isn't a JSON object; refused to touch it.
         case skippedUnparseable
@@ -44,6 +54,13 @@ public enum OpenCodeMCPConfigWriter {
     /// Mirror the user's Claude `jira` MCP into `<configHome>/opencode.json`.
     /// Pass `claudeJSONPath` to read a different Claude config (tests); `nil`
     /// uses the real `~/.claude.json`.
+    ///
+    /// Lifecycle parity with Claude (CROW-831 review): when the source `jira`
+    /// server *disappears* from the Claude config, the previously-mirrored
+    /// `mcp.jira` is removed from `opencode.json` too — so a stale (and possibly
+    /// credential-bearing) server never lingers after the user drops it from
+    /// Claude. Crow owns the `mcp.jira` key in this file; user-authored MCP
+    /// servers belong in `opencode.jsonc` (or under a different name).
     @discardableResult
     public static func installGlobalMCPConfig(
         configHome: String,
@@ -51,7 +68,9 @@ public enum OpenCodeMCPConfigWriter {
     ) -> Outcome {
         let fm = FileManager.default
 
-        // 1. Read the source `jira` server from the Claude config.
+        // 1. Read the source `jira` server from the Claude config. Distinguish
+        //    "absent" (→ un-mirror) from "present but untranslatable" (→ leave
+        //    the mirror alone) from "unparseable" (→ refuse).
         let claudePath = claudeJSONPath
             ?? fm.homeDirectoryForCurrentUser.appendingPathComponent(".claude.json").path
         let sourceServer: [String: Any]?
@@ -59,14 +78,12 @@ public enum OpenCodeMCPConfigWriter {
         case .success(let server): sourceServer = server
         case .unparseable: return .skippedUnparseable
         }
-        guard let sourceServer, let openCodeServer = translateClaudeServer(sourceServer) else {
-            return .noSource
-        }
 
-        // 2. Merge into the Crow-owned `opencode.json`.
+        // 2. Load the Crow-owned `opencode.json` (if any).
         let targetPath = (configHome as NSString).appendingPathComponent("opencode.json")
+        let targetExists = fm.fileExists(atPath: targetPath)
         var root: [String: Any] = ["$schema": "https://opencode.ai/config.json"]
-        if fm.fileExists(atPath: targetPath) {
+        if targetExists {
             guard let data = fm.contents(atPath: targetPath),
                   let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
             else {
@@ -75,25 +92,62 @@ public enum OpenCodeMCPConfigWriter {
             }
             root = parsed
         }
-
         var mcp = root["mcp"] as? [String: Any] ?? [:]
+
+        // 3a. Source gone → drop any stale mirror we wrote.
+        guard let sourceServer, let translated = translateClaudeServer(sourceServer) else {
+            guard mcp[serverName] != nil else { return .noSource }
+            mcp.removeValue(forKey: serverName)
+            if mcp.isEmpty {
+                root.removeValue(forKey: "mcp")
+            } else {
+                root["mcp"] = mcp
+            }
+            return write(root, to: targetPath, configHome: configHome, fm: fm) ?? .removed
+        }
+
+        // 3b. Source present → register/update. Preserve a user's explicit
+        //     `enabled` value so disabling the mirror in `opencode.json` sticks
+        //     across launches (we only ever *default* it to true on first write).
+        var openCodeServer = translated
+        if let existing = mcp[serverName] as? [String: Any],
+           let userEnabled = existing["enabled"] {
+            openCodeServer["enabled"] = userEnabled
+        }
         if let existing = mcp[serverName] as? [String: Any],
            NSDictionary(dictionary: existing).isEqual(to: openCodeServer) {
             return .unchanged
         }
         mcp[serverName] = openCodeServer
         root["mcp"] = mcp
+        return write(root, to: targetPath, configHome: configHome, fm: fm) ?? .registered
+    }
 
+    /// Write `root` as pretty JSON to `path`, owner-only. `mcp.<name>` mirrors
+    /// Claude's `environment`/`headers`, which carry secrets (e.g. a Jira API
+    /// token), and `~/.claude.json` is `0600` — so match it. `.atomic` renames a
+    /// fresh temp file over the target, resetting its mode to the umask default
+    /// (~`0644`), so the `setAttributes` is required, not belt-and-braces
+    /// (`Scaffolder.swift:177`, `ClaudeHookConfigWriter.writeGatewayEnv:147`).
+    /// Returns `.failed` on error, or `nil` on success (the caller supplies the
+    /// success outcome).
+    private static func write(
+        _ root: [String: Any],
+        to path: String,
+        configHome: String,
+        fm: FileManager
+    ) -> Outcome? {
         do {
             try fm.createDirectory(atPath: configHome, withIntermediateDirectories: true)
             let data = try JSONSerialization.data(
                 withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
-            try data.write(to: URL(fileURLWithPath: targetPath), options: .atomic)
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+            return nil
         } catch {
-            NSLog("[OpenCodeMCPConfigWriter] Failed to write %@: %@", targetPath, error.localizedDescription)
+            NSLog("[OpenCodeMCPConfigWriter] Failed to write %@: %@", path, error.localizedDescription)
             return .failed(error.localizedDescription)
         }
-        return .registered
     }
 
     // MARK: - Source

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -115,7 +115,7 @@ public enum OpenCodeMCPConfigWriter {
             openCodeServer["enabled"] = userEnabled
         }
         if let existing = mcp[serverName] as? [String: Any],
-           NSDictionary(dictionary: existing).isEqual(to: openCodeServer) {
+           jsonEqual(existing, openCodeServer) {
             return .unchanged
         }
         mcp[serverName] = openCodeServer
@@ -211,5 +211,20 @@ public enum OpenCodeMCPConfigWriter {
         }
 
         return nil
+    }
+
+    /// Structural equality via canonical JSON bytes. `NSDictionary.isEqual`
+    /// can't be used here: on swift-corelibs-foundation (Linux CI) it does not
+    /// deep-equate a Swift `[String]` against a JSON-decoded `NSArray`, nor a
+    /// `Bool` against an `NSNumber`, so a freshly-built server never compared
+    /// equal to the same server round-tripped through `opencode.json` — the
+    /// idempotency check always fired and rewrote the file. Serializing both
+    /// with `.sortedKeys` normalizes every value type identically on macOS and
+    /// Linux, so the comparison is stable cross-platform.
+    private static func jsonEqual(_ a: [String: Any], _ b: [String: Any]) -> Bool {
+        guard let da = try? JSONSerialization.data(withJSONObject: a, options: [.sortedKeys]),
+              let db = try? JSONSerialization.data(withJSONObject: b, options: [.sortedKeys])
+        else { return false }
+        return da == db
     }
 }

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -22,12 +22,23 @@ import Foundation
 /// The write merges: it preserves `$schema`, any other `mcp` entries, and every
 /// other key already in `opencode.json`, and refuses to touch a file that isn't
 /// a JSON object. Idempotent — re-running rewrites only the `mcp.jira` entry.
-/// It **un-mirrors**: when the source `jira` server disappears from the Claude
-/// config, the previously-written `mcp.jira` is dropped so a stale server never
-/// lingers. A user's explicit `enabled: false` on the mirrored entry is
-/// preserved across launches. The file is written `0600` — the mirrored
+///
+/// **Provenance (CROW-831 review round 2).** `~/.config/opencode/opencode.json`
+/// is OpenCode's own documented global config path — exactly where an
+/// OpenCode-primary user's hand-configured `jira` server (or `opencode mcp add`)
+/// already lands. So Crow keeps a sidecar record of the exact entry it last
+/// wrote (`~/.local/share/crow/opencode-mcp-mirror.json`, `0600`) and only ever
+/// touches `mcp.jira` when the on-disk entry still matches that record. A
+/// user-authored `jira` (no record) or one the user has since edited (record
+/// mismatch) is left completely alone — never overwritten by the mirror, never
+/// deleted on un-mirror. That also *is* the opt-out: editing the entry (e.g.
+/// `enabled: false`) makes it "not ours", so it stops being managed.
+///
+/// It **un-mirrors**: when the source `jira` disappears from the Claude config,
+/// a mirror Crow wrote is dropped so a stale (possibly credential-bearing)
+/// server never lingers. The file is written `0600` — the mirrored
 /// `environment`/`headers` carry the same secrets `~/.claude.json` (itself
-/// `0600`) does.
+/// `0600`) does; the sidecar record holds the same entry and is `0600` too.
 public enum OpenCodeMCPConfigWriter {
 
     /// The MCP server name. Matches Claude's `jira` key so the `jira_*` tool
@@ -42,6 +53,9 @@ public enum OpenCodeMCPConfigWriter {
         case removed
         /// `opencode.json` already carried an identical `mcp.jira`; nothing written.
         case unchanged
+        /// A `mcp.jira` exists that Crow did not write (user-authored, or one the
+        /// user has since edited); left untouched — not overwritten, not deleted.
+        case skippedUserOwned
         /// No `jira` MCP server in the Claude config to mirror, and nothing
         /// stale to remove; nothing written.
         case noSource
@@ -52,19 +66,14 @@ public enum OpenCodeMCPConfigWriter {
     }
 
     /// Mirror the user's Claude `jira` MCP into `<configHome>/opencode.json`.
-    /// Pass `claudeJSONPath` to read a different Claude config (tests); `nil`
-    /// uses the real `~/.claude.json`.
-    ///
-    /// Lifecycle parity with Claude (CROW-831 review): when the source `jira`
-    /// server *disappears* from the Claude config, the previously-mirrored
-    /// `mcp.jira` is removed from `opencode.json` too — so a stale (and possibly
-    /// credential-bearing) server never lingers after the user drops it from
-    /// Claude. Crow owns the `mcp.jira` key in this file; user-authored MCP
-    /// servers belong in `opencode.jsonc` (or under a different name).
+    /// Pass `claudeJSONPath` / `mirrorRecordPath` to redirect the source and the
+    /// provenance sidecar (tests); `nil` uses the real `~/.claude.json` and
+    /// `~/.local/share/crow/opencode-mcp-mirror.json`.
     @discardableResult
     public static func installGlobalMCPConfig(
         configHome: String,
-        claudeJSONPath: String? = nil
+        claudeJSONPath: String? = nil,
+        mirrorRecordPath: String? = nil
     ) -> Outcome {
         let fm = FileManager.default
 
@@ -81,9 +90,8 @@ public enum OpenCodeMCPConfigWriter {
 
         // 2. Load the Crow-owned `opencode.json` (if any).
         let targetPath = (configHome as NSString).appendingPathComponent("opencode.json")
-        let targetExists = fm.fileExists(atPath: targetPath)
         var root: [String: Any] = ["$schema": "https://opencode.ai/config.json"]
-        if targetExists {
+        if fm.fileExists(atPath: targetPath) {
             guard let data = fm.contents(atPath: targetPath),
                   let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
             else {
@@ -93,34 +101,71 @@ public enum OpenCodeMCPConfigWriter {
             root = parsed
         }
         var mcp = root["mcp"] as? [String: Any] ?? [:]
+        let existing = mcp[serverName] as? [String: Any]
 
-        // 3a. Source gone → drop any stale mirror we wrote.
-        guard let sourceServer, let translated = translateClaudeServer(sourceServer) else {
-            guard mcp[serverName] != nil else { return .noSource }
+        // 3. Provenance: is the on-disk entry the exact one Crow last wrote?
+        let recordPath = mirrorRecordPath ?? Self.defaultMirrorRecordPath()
+        var record = readMirrorRecord(path: recordPath)
+        let recorded = record[serverName] as? [String: Any]
+        let entryIsOurs = existing != nil && recorded != nil && jsonEqual(existing!, recorded!)
+
+        // 4a. Source absent → un-mirror, but only an entry we actually wrote.
+        if sourceServer == nil {
+            guard existing != nil else {
+                // Nothing in config; drop any now-stale record.
+                if record[serverName] != nil {
+                    record.removeValue(forKey: serverName)
+                    writeMirrorRecord(record, path: recordPath, fm: fm)
+                }
+                return .noSource
+            }
+            guard entryIsOurs else {
+                NSLog("[OpenCodeMCPConfigWriter] mcp.%@ not written by Crow; leaving it alone", serverName)
+                return .skippedUserOwned
+            }
             mcp.removeValue(forKey: serverName)
             if mcp.isEmpty {
                 root.removeValue(forKey: "mcp")
             } else {
                 root["mcp"] = mcp
             }
-            return write(root, to: targetPath, configHome: configHome, fm: fm) ?? .removed
+            if let failure = write(root, to: targetPath, configHome: configHome, fm: fm) {
+                return failure
+            }
+            record.removeValue(forKey: serverName)
+            writeMirrorRecord(record, path: recordPath, fm: fm)
+            return .removed
         }
 
-        // 3b. Source present → register/update. Preserve a user's explicit
-        //     `enabled` value so disabling the mirror in `opencode.json` sticks
-        //     across launches (we only ever *default* it to true on first write).
-        var openCodeServer = translated
-        if let existing = mcp[serverName] as? [String: Any],
-           let userEnabled = existing["enabled"] {
-            openCodeServer["enabled"] = userEnabled
+        // 4b. Source present but untranslatable (e.g. a half-edited entry) →
+        //     leave the mirror alone rather than deleting it.
+        guard let translated = translateClaudeServer(sourceServer!) else {
+            NSLog("[OpenCodeMCPConfigWriter] Claude mcpServers.%@ present but not translatable; leaving OpenCode config unchanged", serverName)
+            return .noSource
         }
-        if let existing = mcp[serverName] as? [String: Any],
-           jsonEqual(existing, openCodeServer) {
+
+        // 4c. Source present + translatable → register/update, but never clobber
+        //     a user-authored entry (or the user's edits to ours).
+        if existing != nil, !entryIsOurs {
+            NSLog("[OpenCodeMCPConfigWriter] mcp.%@ not written by Crow; not overwriting", serverName)
+            return .skippedUserOwned
+        }
+        if let existing, jsonEqual(existing, translated) {
+            // Already exactly our desired state; keep the record in sync.
+            if recorded == nil || !jsonEqual(recorded!, translated) {
+                record[serverName] = translated
+                writeMirrorRecord(record, path: recordPath, fm: fm)
+            }
             return .unchanged
         }
-        mcp[serverName] = openCodeServer
+        mcp[serverName] = translated
         root["mcp"] = mcp
-        return write(root, to: targetPath, configHome: configHome, fm: fm) ?? .registered
+        if let failure = write(root, to: targetPath, configHome: configHome, fm: fm) {
+            return failure
+        }
+        record[serverName] = translated
+        writeMirrorRecord(record, path: recordPath, fm: fm)
+        return .registered
     }
 
     /// Write `root` as pretty JSON to `path`, owner-only. `mcp.<name>` mirrors
@@ -147,6 +192,46 @@ public enum OpenCodeMCPConfigWriter {
         } catch {
             NSLog("[OpenCodeMCPConfigWriter] Failed to write %@: %@", path, error.localizedDescription)
             return .failed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Provenance record
+
+    /// `~/.local/share/crow/opencode-mcp-mirror.json` — Crow's own state dir
+    /// (alongside `crow.sock`), never the user's config. Holds the exact entry
+    /// Crow last wrote per server name, so the register/remove paths can tell
+    /// "ours" from "user-authored".
+    static func defaultMirrorRecordPath() -> String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/crow/opencode-mcp-mirror.json").path
+    }
+
+    /// Read the provenance sidecar. Missing or unparseable → empty (fail open:
+    /// with no record every entry reads as "not ours", so we never delete or
+    /// overwrite — the safe direction).
+    static func readMirrorRecord(path: String) -> [String: Any] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: path),
+              let data = fm.contents(atPath: path),
+              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return [:] }
+        return root
+    }
+
+    /// Persist the provenance sidecar `0600` (it carries the same
+    /// `environment`/`headers` secrets the mirror does). Best effort — a failure
+    /// only means the next run re-evaluates provenance and, lacking a record,
+    /// treats the entry as user-owned (safe: leaves it alone).
+    static func writeMirrorRecord(_ record: [String: Any], path: String, fm: FileManager) {
+        do {
+            let dir = (path as NSString).deletingLastPathComponent
+            try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(
+                withJSONObject: record, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+        } catch {
+            NSLog("[OpenCodeMCPConfigWriter] Failed to write mirror record %@: %@", path, error.localizedDescription)
         }
     }
 

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -1,4 +1,3 @@
-import Crypto
 import Foundation
 
 /// Registers the Jira MCP server into OpenCode's config so OpenCode sessions
@@ -27,21 +26,22 @@ import Foundation
 /// **Provenance (CROW-831 review round 2).** `~/.config/opencode/opencode.json`
 /// is OpenCode's own documented global config path — exactly where an
 /// OpenCode-primary user's hand-configured `jira` server (or `opencode mcp add`)
-/// already lands. So Crow keeps a sidecar recording the SHA-256 digest of the
-/// entry it last wrote (`~/.local/share/crow/opencode-mcp-mirror.json`, `0600`)
-/// and only ever touches `mcp.jira` when the on-disk entry still hashes to that
-/// digest. A user-authored `jira` (no record) or one the user has since edited
-/// or deleted (digest mismatch / entry gone) is left completely alone — never
-/// overwritten by the mirror, never deleted on un-mirror, never re-added after a
-/// manual delete. That *is* the opt-out: editing or removing the entry makes it
-/// "not ours", so it stops being managed.
+/// already lands. So Crow keeps a sidecar recording the exact entry it last
+/// wrote (`~/.local/share/crow/opencode-mcp-mirror.json`, `0600`) and only ever
+/// touches `mcp.jira` when the on-disk entry still matches that record. A
+/// user-authored `jira` (no record) or one the user has since edited or deleted
+/// (record mismatch / entry gone) is left completely alone — never overwritten
+/// by the mirror, never deleted on un-mirror, never re-added after a manual
+/// delete. That *is* the opt-out: editing or removing the entry makes it "not
+/// ours", so it stops being managed.
 ///
 /// It **un-mirrors**: when the source `jira` disappears from the Claude config,
 /// a mirror Crow wrote is dropped so a stale (possibly credential-bearing)
-/// server never lingers. The `opencode.json` file is written `0600` — the
-/// mirrored `environment`/`headers` carry the same secrets `~/.claude.json`
-/// (itself `0600`) does. The sidecar stores only digests (no token) and is
-/// `0600` too.
+/// server never lingers. Both `opencode.json` and the sidecar are written `0600`
+/// — the mirrored `environment`/`headers` carry the same secrets `~/.claude.json`
+/// (itself `0600`) does. (A digest-only sidecar would avoid the third on-disk
+/// copy, but swift-crypto's BoringSSL interop breaks the Linux CI link; all
+/// three files are `0600`, so this is a duplicated-secret note, not a leak.)
 public enum OpenCodeMCPConfigWriter {
 
     /// The MCP server name. Matches Claude's `jira` key so the `jira_*` tool
@@ -106,14 +106,15 @@ public enum OpenCodeMCPConfigWriter {
         var mcp = root["mcp"] as? [String: Any] ?? [:]
         let existing = mcp[serverName] as? [String: Any]
 
-        // 3. Provenance: does the on-disk entry hash to the digest Crow last
-        //    wrote? The record stores only a SHA-256 of the canonical entry, not
-        //    the entry itself — so the token isn't copied to a third file.
+        // 3. Provenance: is the on-disk entry the exact one Crow last wrote?
+        //    The record stores the entry itself (in Crow's own `0600` state dir);
+        //    it can't be a hash without a crypto dependency that breaks the Linux
+        //    CI link (swift-crypto's BoringSSL interop), and all three files are
+        //    `0600`, so this is a duplicated-secret note, not a leak.
         let recordPath = mirrorRecordPath ?? Self.defaultMirrorRecordPath()
         var record = readMirrorRecord(path: recordPath)
-        let recordedDigest = record[serverName] as? String
-        let existingDigest = existing.flatMap(canonicalDigest)
-        let entryIsOurs = existing != nil && recordedDigest != nil && existingDigest == recordedDigest
+        let recorded = record[serverName] as? [String: Any]
+        let entryIsOurs = existing != nil && recorded != nil && jsonEqual(existing!, recorded!)
 
         // 4a. Source absent → un-mirror, but only an entry we actually wrote.
         if sourceServer == nil {
@@ -153,7 +154,7 @@ public enum OpenCodeMCPConfigWriter {
         // 4c. Durable opt-out: the user deleted a mirror Crow wrote (entry gone,
         //     record still present). Treat the deletion as intent and don't
         //     re-add it — deleting behaves the same as editing.
-        if existing == nil, recordedDigest != nil {
+        if existing == nil, recorded != nil {
             NSLog("[OpenCodeMCPConfigWriter] mcp.%@ removed after Crow wrote it; honoring the opt-out", serverName)
             return .skippedUserOwned
         }
@@ -166,9 +167,10 @@ public enum OpenCodeMCPConfigWriter {
 
         // 4e. Register/update. Reaching here means either no existing entry (and
         //     no record — 4c caught deleted-with-record) or an entry that is
-        //     exactly ours; either way it's safe to (re)write.
-        let desiredDigest = canonicalDigest(translated)
-        if let existingDigest, existingDigest == desiredDigest {
+        //     exactly ours (so `recorded == existing`); either way it's safe to
+        //     (re)write, and when it already equals the desired entry the record
+        //     is already in sync — so there's nothing to re-sync.
+        if let existing, jsonEqual(existing, translated) {
             return .unchanged
         }
         mcp[serverName] = translated
@@ -176,10 +178,8 @@ public enum OpenCodeMCPConfigWriter {
         if let failure = write(root, to: targetPath, configHome: configHome, fm: fm) {
             return failure
         }
-        if let desiredDigest {
-            record[serverName] = desiredDigest
-            writeMirrorRecord(record, path: recordPath, fm: fm)
-        }
+        record[serverName] = translated
+        writeMirrorRecord(record, path: recordPath, fm: fm)
         return .registered
     }
 
@@ -213,18 +213,17 @@ public enum OpenCodeMCPConfigWriter {
     // MARK: - Provenance record
 
     /// `~/.local/share/crow/opencode-mcp-mirror.json` — Crow's own state dir
-    /// (alongside `crow.sock`), never the user's config. Maps each server name
-    /// to the SHA-256 digest of the entry Crow last wrote, so the register/remove
-    /// paths can tell "ours" from "user-authored" without storing the entry (and
-    /// its token) a third time.
+    /// (alongside `crow.sock`), never the user's config. Holds the exact entry
+    /// Crow last wrote per server name, so the register/remove paths can tell
+    /// "ours" from "user-authored".
     static func defaultMirrorRecordPath() -> String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/crow/opencode-mcp-mirror.json").path
     }
 
-    /// Read the provenance sidecar (`{ "<server>": "<sha256-hex>" }`). Missing or
-    /// unparseable → empty (fail open: with no record every entry reads as "not
-    /// ours", so we never delete or overwrite — the safe direction).
+    /// Read the provenance sidecar. Missing or unparseable → empty (fail open:
+    /// with no record every entry reads as "not ours", so we never delete or
+    /// overwrite — the safe direction).
     static func readMirrorRecord(path: String) -> [String: Any] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: path),
@@ -234,11 +233,10 @@ public enum OpenCodeMCPConfigWriter {
         return root
     }
 
-    /// Persist the provenance sidecar `0600`. It holds only digests now (no
-    /// secret), but `0600` still keeps the "which servers does Crow manage" list
-    /// owner-only. Best effort — a failure only means the next run re-evaluates
-    /// provenance and, lacking a record, treats the entry as user-owned (safe:
-    /// leaves it alone).
+    /// Persist the provenance sidecar `0600` (it holds the same
+    /// `environment`/`headers` the mirror does, in Crow's own state dir). Best
+    /// effort — a failure only means the next run re-evaluates provenance and,
+    /// lacking a record, treats the entry as user-owned (safe: leaves it alone).
     static func writeMirrorRecord(_ record: [String: Any], path: String, fm: FileManager) {
         do {
             let dir = (path as NSString).deletingLastPathComponent
@@ -315,16 +313,18 @@ public enum OpenCodeMCPConfigWriter {
         return nil
     }
 
-    /// SHA-256 hex digest of an entry's canonical JSON, used as the provenance
-    /// fingerprint. `.sortedKeys` normalizes every value type identically on
-    /// macOS and Linux (a freshly-built `[String]`/`Bool` and the same value
-    /// round-tripped through JSON as `NSArray`/`NSNumber` serialize to identical
-    /// bytes) — the reason `NSDictionary.isEqual`, which does *not* deep-equate
-    /// those across swift-corelibs-foundation, can't be used. Storing the digest
-    /// rather than the entry keeps the Jira token out of the sidecar entirely.
-    static func canonicalDigest(_ dict: [String: Any]) -> String? {
-        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
-        else { return nil }
-        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    /// Structural equality via canonical JSON bytes. `NSDictionary.isEqual`
+    /// can't be used here: on swift-corelibs-foundation (Linux CI) it does not
+    /// deep-equate a Swift `[String]` against a JSON-decoded `NSArray`, nor a
+    /// `Bool` against an `NSNumber`, so a freshly-built server never compared
+    /// equal to the same server round-tripped through `opencode.json` — the
+    /// idempotency check always fired and rewrote the file. Serializing both
+    /// with `.sortedKeys` normalizes every value type identically on macOS and
+    /// Linux, so the comparison is stable cross-platform.
+    private static func jsonEqual(_ a: [String: Any], _ b: [String: Any]) -> Bool {
+        guard let da = try? JSONSerialization.data(withJSONObject: a, options: [.sortedKeys]),
+              let db = try? JSONSerialization.data(withJSONObject: b, options: [.sortedKeys])
+        else { return false }
+        return da == db
     }
 }

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -1,3 +1,4 @@
+import Crypto
 import Foundation
 
 /// Registers the Jira MCP server into OpenCode's config so OpenCode sessions
@@ -26,19 +27,21 @@ import Foundation
 /// **Provenance (CROW-831 review round 2).** `~/.config/opencode/opencode.json`
 /// is OpenCode's own documented global config path — exactly where an
 /// OpenCode-primary user's hand-configured `jira` server (or `opencode mcp add`)
-/// already lands. So Crow keeps a sidecar record of the exact entry it last
-/// wrote (`~/.local/share/crow/opencode-mcp-mirror.json`, `0600`) and only ever
-/// touches `mcp.jira` when the on-disk entry still matches that record. A
-/// user-authored `jira` (no record) or one the user has since edited (record
-/// mismatch) is left completely alone — never overwritten by the mirror, never
-/// deleted on un-mirror. That also *is* the opt-out: editing the entry (e.g.
-/// `enabled: false`) makes it "not ours", so it stops being managed.
+/// already lands. So Crow keeps a sidecar recording the SHA-256 digest of the
+/// entry it last wrote (`~/.local/share/crow/opencode-mcp-mirror.json`, `0600`)
+/// and only ever touches `mcp.jira` when the on-disk entry still hashes to that
+/// digest. A user-authored `jira` (no record) or one the user has since edited
+/// or deleted (digest mismatch / entry gone) is left completely alone — never
+/// overwritten by the mirror, never deleted on un-mirror, never re-added after a
+/// manual delete. That *is* the opt-out: editing or removing the entry makes it
+/// "not ours", so it stops being managed.
 ///
 /// It **un-mirrors**: when the source `jira` disappears from the Claude config,
 /// a mirror Crow wrote is dropped so a stale (possibly credential-bearing)
-/// server never lingers. The file is written `0600` — the mirrored
-/// `environment`/`headers` carry the same secrets `~/.claude.json` (itself
-/// `0600`) does; the sidecar record holds the same entry and is `0600` too.
+/// server never lingers. The `opencode.json` file is written `0600` — the
+/// mirrored `environment`/`headers` carry the same secrets `~/.claude.json`
+/// (itself `0600`) does. The sidecar stores only digests (no token) and is
+/// `0600` too.
 public enum OpenCodeMCPConfigWriter {
 
     /// The MCP server name. Matches Claude's `jira` key so the `jira_*` tool
@@ -103,11 +106,14 @@ public enum OpenCodeMCPConfigWriter {
         var mcp = root["mcp"] as? [String: Any] ?? [:]
         let existing = mcp[serverName] as? [String: Any]
 
-        // 3. Provenance: is the on-disk entry the exact one Crow last wrote?
+        // 3. Provenance: does the on-disk entry hash to the digest Crow last
+        //    wrote? The record stores only a SHA-256 of the canonical entry, not
+        //    the entry itself — so the token isn't copied to a third file.
         let recordPath = mirrorRecordPath ?? Self.defaultMirrorRecordPath()
         var record = readMirrorRecord(path: recordPath)
-        let recorded = record[serverName] as? [String: Any]
-        let entryIsOurs = existing != nil && recorded != nil && jsonEqual(existing!, recorded!)
+        let recordedDigest = record[serverName] as? String
+        let existingDigest = existing.flatMap(canonicalDigest)
+        let entryIsOurs = existing != nil && recordedDigest != nil && existingDigest == recordedDigest
 
         // 4a. Source absent → un-mirror, but only an entry we actually wrote.
         if sourceServer == nil {
@@ -144,18 +150,25 @@ public enum OpenCodeMCPConfigWriter {
             return .noSource
         }
 
-        // 4c. Source present + translatable → register/update, but never clobber
-        //     a user-authored entry (or the user's edits to ours).
+        // 4c. Durable opt-out: the user deleted a mirror Crow wrote (entry gone,
+        //     record still present). Treat the deletion as intent and don't
+        //     re-add it — deleting behaves the same as editing.
+        if existing == nil, recordedDigest != nil {
+            NSLog("[OpenCodeMCPConfigWriter] mcp.%@ removed after Crow wrote it; honoring the opt-out", serverName)
+            return .skippedUserOwned
+        }
+
+        // 4d. Never clobber a user-authored entry (or the user's edits to ours).
         if existing != nil, !entryIsOurs {
             NSLog("[OpenCodeMCPConfigWriter] mcp.%@ not written by Crow; not overwriting", serverName)
             return .skippedUserOwned
         }
-        if let existing, jsonEqual(existing, translated) {
-            // Already exactly our desired state; keep the record in sync.
-            if recorded == nil || !jsonEqual(recorded!, translated) {
-                record[serverName] = translated
-                writeMirrorRecord(record, path: recordPath, fm: fm)
-            }
+
+        // 4e. Register/update. Reaching here means either no existing entry (and
+        //     no record — 4c caught deleted-with-record) or an entry that is
+        //     exactly ours; either way it's safe to (re)write.
+        let desiredDigest = canonicalDigest(translated)
+        if let existingDigest, existingDigest == desiredDigest {
             return .unchanged
         }
         mcp[serverName] = translated
@@ -163,8 +176,10 @@ public enum OpenCodeMCPConfigWriter {
         if let failure = write(root, to: targetPath, configHome: configHome, fm: fm) {
             return failure
         }
-        record[serverName] = translated
-        writeMirrorRecord(record, path: recordPath, fm: fm)
+        if let desiredDigest {
+            record[serverName] = desiredDigest
+            writeMirrorRecord(record, path: recordPath, fm: fm)
+        }
         return .registered
     }
 
@@ -198,17 +213,18 @@ public enum OpenCodeMCPConfigWriter {
     // MARK: - Provenance record
 
     /// `~/.local/share/crow/opencode-mcp-mirror.json` — Crow's own state dir
-    /// (alongside `crow.sock`), never the user's config. Holds the exact entry
-    /// Crow last wrote per server name, so the register/remove paths can tell
-    /// "ours" from "user-authored".
+    /// (alongside `crow.sock`), never the user's config. Maps each server name
+    /// to the SHA-256 digest of the entry Crow last wrote, so the register/remove
+    /// paths can tell "ours" from "user-authored" without storing the entry (and
+    /// its token) a third time.
     static func defaultMirrorRecordPath() -> String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/crow/opencode-mcp-mirror.json").path
     }
 
-    /// Read the provenance sidecar. Missing or unparseable → empty (fail open:
-    /// with no record every entry reads as "not ours", so we never delete or
-    /// overwrite — the safe direction).
+    /// Read the provenance sidecar (`{ "<server>": "<sha256-hex>" }`). Missing or
+    /// unparseable → empty (fail open: with no record every entry reads as "not
+    /// ours", so we never delete or overwrite — the safe direction).
     static func readMirrorRecord(path: String) -> [String: Any] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: path),
@@ -218,10 +234,11 @@ public enum OpenCodeMCPConfigWriter {
         return root
     }
 
-    /// Persist the provenance sidecar `0600` (it carries the same
-    /// `environment`/`headers` secrets the mirror does). Best effort — a failure
-    /// only means the next run re-evaluates provenance and, lacking a record,
-    /// treats the entry as user-owned (safe: leaves it alone).
+    /// Persist the provenance sidecar `0600`. It holds only digests now (no
+    /// secret), but `0600` still keeps the "which servers does Crow manage" list
+    /// owner-only. Best effort — a failure only means the next run re-evaluates
+    /// provenance and, lacking a record, treats the entry as user-owned (safe:
+    /// leaves it alone).
     static func writeMirrorRecord(_ record: [String: Any], path: String, fm: FileManager) {
         do {
             let dir = (path as NSString).deletingLastPathComponent
@@ -298,18 +315,16 @@ public enum OpenCodeMCPConfigWriter {
         return nil
     }
 
-    /// Structural equality via canonical JSON bytes. `NSDictionary.isEqual`
-    /// can't be used here: on swift-corelibs-foundation (Linux CI) it does not
-    /// deep-equate a Swift `[String]` against a JSON-decoded `NSArray`, nor a
-    /// `Bool` against an `NSNumber`, so a freshly-built server never compared
-    /// equal to the same server round-tripped through `opencode.json` — the
-    /// idempotency check always fired and rewrote the file. Serializing both
-    /// with `.sortedKeys` normalizes every value type identically on macOS and
-    /// Linux, so the comparison is stable cross-platform.
-    private static func jsonEqual(_ a: [String: Any], _ b: [String: Any]) -> Bool {
-        guard let da = try? JSONSerialization.data(withJSONObject: a, options: [.sortedKeys]),
-              let db = try? JSONSerialization.data(withJSONObject: b, options: [.sortedKeys])
-        else { return false }
-        return da == db
+    /// SHA-256 hex digest of an entry's canonical JSON, used as the provenance
+    /// fingerprint. `.sortedKeys` normalizes every value type identically on
+    /// macOS and Linux (a freshly-built `[String]`/`Bool` and the same value
+    /// round-tripped through JSON as `NSArray`/`NSNumber` serialize to identical
+    /// bytes) — the reason `NSDictionary.isEqual`, which does *not* deep-equate
+    /// those across swift-corelibs-foundation, can't be used. Storing the digest
+    /// rather than the entry keeps the Jira token out of the sidecar entirely.
+    static func canonicalDigest(_ dict: [String: Any]) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        else { return nil }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -119,11 +119,11 @@ public enum OpenCodeMCPConfigWriter {
         // 4a. Source absent → un-mirror, but only an entry we actually wrote.
         if sourceServer == nil {
             guard existing != nil else {
-                // Nothing in config; drop any now-stale record.
-                if record[serverName] != nil {
-                    record.removeValue(forKey: serverName)
-                    writeMirrorRecord(record, path: recordPath, fm: fm)
-                }
+                // Entry already gone. Keep any record: it's the durable opt-out
+                // marker the register path (4c) honors, and it must survive the
+                // Claude source disappearing and later returning — otherwise a
+                // source round-trip would silently un-do the user's delete.
+                // Nothing on disk to remove.
                 return .noSource
             }
             guard entryIsOurs else {
@@ -161,7 +161,14 @@ public enum OpenCodeMCPConfigWriter {
 
         // 4d. Never clobber a user-authored entry (or the user's edits to ours).
         if existing != nil, !entryIsOurs {
-            NSLog("[OpenCodeMCPConfigWriter] mcp.%@ not written by Crow; not overwriting", serverName)
+            // Distinguish "we have no record for it" (user-authored, or our
+            // sidecar was lost) from "the record disagrees" (user edited ours) —
+            // otherwise a debugging user chasing a stale token is pointed at the
+            // wrong file.
+            let why = recorded == nil
+                ? "no Crow record for it (user-authored, or the mirror sidecar was lost)"
+                : "it differs from Crow's record (user-edited)"
+            NSLog("[OpenCodeMCPConfigWriter] mcp.%@ left as-is — %@; not overwriting", serverName, why)
             return .skippedUserOwned
         }
 

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
@@ -12,7 +12,7 @@ struct OpenCodeHookConfigWriterTests {
         #expect(js.contains("const CROW = \"/usr/local/bin/crow\""))
         // Exports a plugin function OpenCode auto-loads.
         #expect(js.contains("export const CrowHooks"))
-        // Forwards via `crow hook-event --agent opencode`.
+        // Forwards via `crow hook-event --agent opencode` (global/cwd-match form).
         #expect(js.contains("hook-event --agent opencode --event"))
         // Subscribes to the event bus + tool hooks.
         #expect(js.contains("event: async"))
@@ -38,6 +38,27 @@ struct OpenCodeHookConfigWriterTests {
         #expect(js.contains("worktree || directory"))
     }
 
+    @Test func globalPluginSourceSelfSuppressesWhenPerProjectExists() {
+        // Global variant (no session UUID): SESSION empty, cwd-match emit, and
+        // a guard that defers to a per-project plugin so events don't double-emit.
+        let js = OpenCodeHookConfigWriter.pluginSource(crowPath: "/bin/crow", sessionID: nil)
+        #expect(js.contains("const SESSION = \"\""))
+        #expect(js.contains("Bun.file(cwd + \"/.opencode/plugins/crow-hooks.js\").exists()"))
+        #expect(js.contains("return {};"))
+    }
+
+    @Test func perProjectPluginSourceBakesInSessionUUID() {
+        let sessionID = UUID()
+        let js = OpenCodeHookConfigWriter.pluginSource(crowPath: "/bin/crow", sessionID: sessionID)
+        // The exact session UUID is baked in and used for resolution.
+        #expect(js.contains("const SESSION = \"\(sessionID.uuidString)\""))
+        #expect(js.contains("hook-event --session ${SESSION} --agent opencode --event"))
+        // The self-suppress guard is a static template in both variants, but it
+        // only runs for the global fallback — gated behind `if (!SESSION)`, so a
+        // session-scoped plugin (non-empty SESSION) never suppresses itself.
+        #expect(js.contains("if (!SESSION)"))
+    }
+
     @Test func installGlobalConfigWritesPluginFile() throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("opencode-cfg-\(UUID().uuidString)")
@@ -50,6 +71,8 @@ struct OpenCodeHookConfigWriterTests {
         #expect(FileManager.default.fileExists(atPath: pluginPath.path))
         let content = try String(contentsOf: pluginPath, encoding: .utf8)
         #expect(content.contains("export const CrowHooks"))
+        // Global variant carries no session UUID.
+        #expect(content.contains("const SESSION = \"\""))
 
         // Idempotent: a second install overwrites cleanly.
         try OpenCodeHookConfigWriter.installGlobalConfig(
@@ -57,13 +80,65 @@ struct OpenCodeHookConfigWriterTests {
         #expect(FileManager.default.fileExists(atPath: pluginPath.path))
     }
 
-    @Test func perSessionMethodsAreNoOps() throws {
-        // Global model — per-session writes are no-ops and must not throw.
+    @Test func writeHookConfigInstallsPerProjectPluginWithSessionUUID() throws {
+        let worktree = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-wt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktree) }
+
+        let sessionID = UUID()
         let writer = OpenCodeHookConfigWriter()
         try writer.writeHookConfig(
-            worktreePath: "/tmp/does-not-matter",
-            sessionID: UUID(),
-            crowPath: "/bin/crow")
-        writer.removeHookConfig(worktreePath: "/tmp/does-not-matter")
+            worktreePath: worktree.path, sessionID: sessionID, crowPath: "/bin/crow")
+
+        // Lands in the worktree's `.opencode/plugins/`, not the global dir.
+        let pluginPath = worktree
+            .appendingPathComponent(".opencode/plugins/crow-hooks.js")
+        #expect(FileManager.default.fileExists(atPath: pluginPath.path))
+        let content = try String(contentsOf: pluginPath, encoding: .utf8)
+        #expect(content.contains("const SESSION = \"\(sessionID.uuidString)\""))
+        #expect(content.contains("hook-event --session ${SESSION} --agent opencode"))
+    }
+
+    @Test func removeHookConfigDeletesPluginAndPrunesEmptyDirs() throws {
+        let worktree = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-wt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktree) }
+
+        let writer = OpenCodeHookConfigWriter()
+        try writer.writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+
+        writer.removeHookConfig(worktreePath: worktree.path)
+        let pluginPath = worktree.appendingPathComponent(".opencode/plugins/crow-hooks.js")
+        #expect(!FileManager.default.fileExists(atPath: pluginPath.path))
+        // Crow-created empty dirs are pruned.
+        #expect(!FileManager.default.fileExists(
+            atPath: worktree.appendingPathComponent(".opencode").path))
+        // Removing again is a safe no-op.
+        writer.removeHookConfig(worktreePath: worktree.path)
+    }
+
+    @Test func removeHookConfigPreservesUserPluginsInDir() throws {
+        let worktree = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-wt-\(UUID().uuidString)")
+        let pluginsDir = worktree.appendingPathComponent(".opencode/plugins")
+        try FileManager.default.createDirectory(at: pluginsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktree) }
+
+        // A user's own plugin sits alongside ours.
+        let userPlugin = pluginsDir.appendingPathComponent("my-plugin.js")
+        try "export const Mine = () => ({})".write(to: userPlugin, atomically: true, encoding: .utf8)
+
+        let writer = OpenCodeHookConfigWriter()
+        try writer.writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        writer.removeHookConfig(worktreePath: worktree.path)
+
+        // Ours is gone; theirs (and the non-empty dir) survive.
+        #expect(!FileManager.default.fileExists(
+            atPath: pluginsDir.appendingPathComponent("crow-hooks.js").path))
+        #expect(FileManager.default.fileExists(atPath: userPlugin.path))
     }
 }

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
@@ -141,4 +141,44 @@ struct OpenCodeHookConfigWriterTests {
             atPath: pluginsDir.appendingPathComponent("crow-hooks.js").path))
         #expect(FileManager.default.fileExists(atPath: userPlugin.path))
     }
+
+    @Test func writeHookConfigPreservesUserGitignore() throws {
+        // `.opencode/plugins/` is the user's dir — a hand-written `.gitignore`
+        // there must never be clobbered by our self-scoped one.
+        let worktree = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-wt-\(UUID().uuidString)")
+        let pluginsDir = worktree.appendingPathComponent(".opencode/plugins")
+        try FileManager.default.createDirectory(at: pluginsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktree) }
+
+        let userGitignore = pluginsDir.appendingPathComponent(".gitignore")
+        try "my-local-only.js\n".write(to: userGitignore, atomically: true, encoding: .utf8)
+
+        let writer = OpenCodeHookConfigWriter()
+        try writer.writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+
+        // Our plugin is written, but the user's ignore rules are untouched.
+        #expect(FileManager.default.fileExists(
+            atPath: pluginsDir.appendingPathComponent("crow-hooks.js").path))
+        #expect(try String(contentsOf: userGitignore, encoding: .utf8) == "my-local-only.js\n")
+
+        // And removeHookConfig must not delete a `.gitignore` that isn't ours.
+        writer.removeHookConfig(worktreePath: worktree.path)
+        #expect(try String(contentsOf: userGitignore, encoding: .utf8) == "my-local-only.js\n")
+    }
+
+    @Test func writeHookConfigWritesOwnGitignoreIntoEmptyDir() throws {
+        let worktree = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-wt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktree) }
+
+        try OpenCodeHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        let gitignore = worktree.appendingPathComponent(".opencode/plugins/.gitignore")
+        let body = try String(contentsOf: gitignore, encoding: .utf8)
+        #expect(body == OpenCodeHookConfigWriter.gitignoreBody)
+        #expect(body.contains("crow-hooks.js"))
+    }
 }

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
@@ -181,4 +181,26 @@ struct OpenCodeHookConfigWriterTests {
         #expect(body == OpenCodeHookConfigWriter.gitignoreBody)
         #expect(body.contains("crow-hooks.js"))
     }
+
+    @Test func removeHookConfigCleansOrphanedGitignoreAfterManualPluginDelete() throws {
+        // A user who takes the "safe to delete" header at its word and removes
+        // `crow-hooks.js` by hand must not be left with an orphaned, self-ignoring
+        // `.gitignore` that `git status` can't surface — removeHookConfig no
+        // longer early-returns just because the plugin is already gone.
+        let worktree = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-wt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktree) }
+
+        let writer = OpenCodeHookConfigWriter()
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        let pluginsDir = worktree.appendingPathComponent(".opencode/plugins")
+        try FileManager.default.removeItem(at: pluginsDir.appendingPathComponent("crow-hooks.js"))
+        #expect(FileManager.default.fileExists(atPath: pluginsDir.appendingPathComponent(".gitignore").path))
+
+        writer.removeHookConfig(worktreePath: worktree.path)
+        #expect(!FileManager.default.fileExists(atPath: pluginsDir.appendingPathComponent(".gitignore").path))
+        #expect(!FileManager.default.fileExists(
+            atPath: worktree.appendingPathComponent(".opencode").path))
+    }
 }

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeLaunchArgsTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeLaunchArgsTests.swift
@@ -114,4 +114,32 @@ struct OpenCodeLaunchArgsTests {
         )
         #expect(cmd == "opencode --continue\n")
     }
+
+    // MARK: - Version-aware TUI `--auto` probe narrowing (CROW-831)
+
+    @Test func parseVersionExtractsSemVer() {
+        #expect(OpenCodeLaunchArgs.parseVersion("1.17.10") == OpenCodeLaunchArgs.SemVer(1, 17, 10))
+        // Tolerates a name prefix and trailing noise.
+        #expect(OpenCodeLaunchArgs.parseVersion("opencode 1.18.4\n") == OpenCodeLaunchArgs.SemVer(1, 18, 4))
+        #expect(OpenCodeLaunchArgs.parseVersion("v2.0.0-beta") == OpenCodeLaunchArgs.SemVer(2, 0, 0))
+        #expect(OpenCodeLaunchArgs.parseVersion("no version here") == nil)
+    }
+
+    @Test func semVerOrdersByField() {
+        #expect(OpenCodeLaunchArgs.SemVer(1, 17, 10) < OpenCodeLaunchArgs.SemVer(1, 18, 0))
+        #expect(OpenCodeLaunchArgs.SemVer(1, 18, 0) < OpenCodeLaunchArgs.SemVer(1, 18, 1))
+        #expect(!(OpenCodeLaunchArgs.SemVer(2, 0, 0) < OpenCodeLaunchArgs.SemVer(1, 99, 99)))
+    }
+
+    @Test func tuiAutoKnownAbsentOnlyForPre118() {
+        // < 1.18: the top-level `--auto` flag is known absent, skip the probe.
+        #expect(OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 17, 10)))
+        #expect(OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 0, 0)))
+        // >= 1.18: `--auto` was re-added — must still probe (not "known absent").
+        #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 18, 0)))
+        #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 18, 4)))
+        #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(2, 0, 0)))
+        // Unknown version → never assume absent; fall through to the probe.
+        #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: nil))
+    }
 }

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeLaunchArgsTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeLaunchArgsTests.swift
@@ -131,10 +131,13 @@ struct OpenCodeLaunchArgsTests {
         #expect(!(OpenCodeLaunchArgs.SemVer(2, 0, 0) < OpenCodeLaunchArgs.SemVer(1, 99, 99)))
     }
 
-    @Test func tuiAutoKnownAbsentOnlyForPre118() {
-        // < 1.18: the top-level `--auto` flag is known absent, skip the probe.
+    @Test func tuiAutoKnownAbsentOnlyForRemovedWindow() {
+        // [1.17.0, 1.18.0): the top-level `--auto` flag was dropped, skip the probe.
+        #expect(OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 17, 0)))
         #expect(OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 17, 10)))
-        #expect(OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 0, 0)))
+        // < 1.17: the flag was still present — must probe, not "known absent".
+        #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 16, 9)))
+        #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 0, 0)))
         // >= 1.18: `--auto` was re-added — must still probe (not "known absent").
         #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 18, 0)))
         #expect(!OpenCodeLaunchArgs.tuiAutoKnownAbsent(version: OpenCodeLaunchArgs.SemVer(1, 18, 4)))

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+@testable import CrowOpenCode
+
+@Suite("OpenCodeMCPConfigWriter")
+struct OpenCodeMCPConfigWriterTests {
+
+    // MARK: - Translation
+
+    @Test func translatesClaudeLocalServer() throws {
+        let claude: [String: Any] = [
+            "command": "uvx",
+            "args": ["mcp-atlassian", "--transport", "stdio"],
+            "env": ["JIRA_URL": "https://acme.example.net"],
+        ]
+        let out = try #require(OpenCodeMCPConfigWriter.translateClaudeServer(claude))
+        #expect(out["type"] as? String == "local")
+        #expect(out["command"] as? [String] == ["uvx", "mcp-atlassian", "--transport", "stdio"])
+        #expect(out["enabled"] as? Bool == true)
+        let env = try #require(out["environment"] as? [String: Any])
+        #expect(env["JIRA_URL"] as? String == "https://acme.example.net")
+    }
+
+    @Test func translatesClaudeRemoteServer() throws {
+        let claude: [String: Any] = [
+            "type": "http",
+            "url": "https://mcp.example.net/jira",
+            "headers": ["Authorization": "Bearer x"],
+        ]
+        let out = try #require(OpenCodeMCPConfigWriter.translateClaudeServer(claude))
+        #expect(out["type"] as? String == "remote")
+        #expect(out["url"] as? String == "https://mcp.example.net/jira")
+        #expect(out["enabled"] as? Bool == true)
+        let headers = try #require(out["headers"] as? [String: Any])
+        #expect(headers["Authorization"] as? String == "Bearer x")
+        // Never mislabels a remote server as local.
+        #expect(out["command"] == nil)
+    }
+
+    @Test func translateReturnsNilForUnusableServer() {
+        #expect(OpenCodeMCPConfigWriter.translateClaudeServer(["foo": "bar"]) == nil)
+    }
+
+    // MARK: - End-to-end registration
+
+    /// Write a Claude config carrying a `jira` MCP, run the mirror, and return
+    /// the parsed `<configHome>/opencode.json`.
+    private func runMirror(
+        claudeMCPServers: [String: Any]?,
+        existingOpenCode: [String: Any]? = nil
+    ) throws -> (outcome: OpenCodeMCPConfigWriter.Outcome, root: [String: Any]?) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let claudePath = tmp.appendingPathComponent(".claude.json")
+        if let servers = claudeMCPServers {
+            let data = try JSONSerialization.data(withJSONObject: ["mcpServers": servers])
+            try data.write(to: claudePath)
+        }
+
+        let configHome = tmp.appendingPathComponent("opencode")
+        try FileManager.default.createDirectory(at: configHome, withIntermediateDirectories: true)
+        if let existing = existingOpenCode {
+            let data = try JSONSerialization.data(withJSONObject: existing)
+            try data.write(to: configHome.appendingPathComponent("opencode.json"))
+        }
+
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claudePath.path)
+
+        let target = configHome.appendingPathComponent("opencode.json")
+        let root = FileManager.default.contents(atPath: target.path)
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] } ?? nil
+        return (outcome, root)
+    }
+
+    @Test func registersJiraMCPFromClaudeConfig() throws {
+        let (outcome, root) = try runMirror(claudeMCPServers: [
+            "jira": ["command": "uvx", "args": ["mcp-atlassian"]],
+        ])
+        #expect(outcome == .registered)
+        let mcp = try #require(root?["mcp"] as? [String: Any])
+        let jira = try #require(mcp["jira"] as? [String: Any])
+        #expect(jira["type"] as? String == "local")
+        #expect(jira["command"] as? [String] == ["uvx", "mcp-atlassian"])
+        // A fresh file gets the OpenCode schema.
+        #expect(root?["$schema"] as? String == "https://opencode.ai/config.json")
+    }
+
+    @Test func noOpWhenClaudeHasNoJiraMCP() throws {
+        let (outcome, _) = try runMirror(claudeMCPServers: ["other": ["command": "x"]])
+        #expect(outcome == .noSource)
+    }
+
+    @Test func noOpWhenClaudeConfigMissing() throws {
+        let (outcome, _) = try runMirror(claudeMCPServers: nil)
+        #expect(outcome == .noSource)
+    }
+
+    @Test func mergePreservesExistingOpenCodeKeys() throws {
+        let (outcome, root) = try runMirror(
+            claudeMCPServers: ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]],
+            existingOpenCode: [
+                "$schema": "https://opencode.ai/config.json",
+                "theme": "opencode",
+                "mcp": ["other": ["type": "local", "command": ["x"], "enabled": true]],
+            ])
+        #expect(outcome == .registered)
+        // User's unrelated keys survive.
+        #expect(root?["theme"] as? String == "opencode")
+        let mcp = try #require(root?["mcp"] as? [String: Any])
+        // Both the pre-existing server and the new jira entry are present.
+        #expect(mcp["other"] != nil)
+        #expect(mcp["jira"] != nil)
+    }
+
+    @Test func secondRunIsUnchanged() throws {
+        // Registering, then registering again against the same inputs, is idempotent.
+        let servers: [String: Any] = ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]]
+        let (first, root) = try runMirror(claudeMCPServers: servers)
+        #expect(first == .registered)
+        let (second, _) = try runMirror(
+            claudeMCPServers: servers, existingOpenCode: root)
+        #expect(second == .unchanged)
+    }
+
+    @Test func refusesToTouchUnparseableOpenCodeConfig() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let claudePath = tmp.appendingPathComponent(".claude.json")
+        try JSONSerialization.data(withJSONObject: [
+            "mcpServers": ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]],
+        ]).write(to: claudePath)
+
+        let configHome = tmp.appendingPathComponent("opencode")
+        try FileManager.default.createDirectory(at: configHome, withIntermediateDirectories: true)
+        try "not json {".write(
+            to: configHome.appendingPathComponent("opencode.json"),
+            atomically: true, encoding: .utf8)
+
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claudePath.path)
+        #expect(outcome == .skippedUnparseable)
+    }
+}

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
@@ -147,4 +147,101 @@ struct OpenCodeMCPConfigWriterTests {
             configHome: configHome.path, claudeJSONPath: claudePath.path)
         #expect(outcome == .skippedUnparseable)
     }
+
+    // MARK: - Credential handling + lifecycle (CROW-831 review)
+
+    /// Set up a persistent `.claude.json` + `opencode` config home under `tmp`,
+    /// with an optional initial Claude `jira` server. Returns the two paths so a
+    /// test can mutate the source between calls.
+    private func makeConfigDir(
+        _ tmp: URL, jira: [String: Any]?
+    ) throws -> (claude: URL, configHome: URL) {
+        let claude = tmp.appendingPathComponent(".claude.json")
+        if let jira {
+            try JSONSerialization.data(withJSONObject: ["mcpServers": ["jira": jira]])
+                .write(to: claude)
+        }
+        let configHome = tmp.appendingPathComponent("opencode")
+        try FileManager.default.createDirectory(at: configHome, withIntermediateDirectories: true)
+        return (claude, configHome)
+    }
+
+    @Test func writesTargetOwnerOnly() throws {
+        // Mirrored env/headers carry secrets; the file must not be world-readable.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (claude, configHome) = try makeConfigDir(tmp, jira: [
+            "command": "uvx", "args": ["mcp-atlassian"],
+            "env": ["JIRA_API_TOKEN": "secret"],
+        ])
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path)
+        #expect(outcome == .registered)
+
+        let target = configHome.appendingPathComponent("opencode.json")
+        let perms = try #require(
+            (try FileManager.default.attributesOfItem(atPath: target.path))[.posixPermissions] as? NSNumber)
+        #expect(perms.int16Value == 0o600)
+    }
+
+    @Test func unMirrorsWhenSourceRemoved() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (claude, configHome) = try makeConfigDir(tmp, jira: [
+            "command": "uvx", "args": ["mcp-atlassian"],
+        ])
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path) == .registered)
+
+        // User drops `jira` from the Claude config entirely.
+        try JSONSerialization.data(withJSONObject: ["mcpServers": [String: Any]()])
+            .write(to: claude)
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path)
+        #expect(outcome == .removed)
+
+        // The stale mirror is gone.
+        let target = configHome.appendingPathComponent("opencode.json")
+        let root = try #require(FileManager.default.contents(atPath: target.path)
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        let mcp = root["mcp"] as? [String: Any] ?? [:]
+        #expect(mcp["jira"] == nil)
+
+        // Running again with the source still gone is a clean no-op.
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path) == .noSource)
+    }
+
+    @Test func preservesUserDisabledEnabled() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (claude, configHome) = try makeConfigDir(tmp, jira: [
+            "command": "uvx", "args": ["mcp-atlassian"],
+        ])
+        // Seed a Crow-written entry the user has since disabled.
+        try JSONSerialization.data(withJSONObject: [
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": ["jira": ["type": "local", "command": ["uvx", "mcp-atlassian"], "enabled": false]],
+        ]).write(to: configHome.appendingPathComponent("opencode.json"))
+
+        // Next launch: source still present, but the user's opt-out must stick.
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path)
+        #expect(outcome == .unchanged)
+
+        let target = configHome.appendingPathComponent("opencode.json")
+        let root = try #require(FileManager.default.contents(atPath: target.path)
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        let jira = try #require((root["mcp"] as? [String: Any])?["jira"] as? [String: Any])
+        #expect(jira["enabled"] as? Bool == false)
+    }
 }

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
@@ -262,6 +262,37 @@ struct OpenCodeMCPConfigWriterTests {
         #expect(jira["enabled"] as? Bool == false)
     }
 
+    @Test func deletingEntryIsDurableOptOut() throws {
+        // Once Crow has written the mirror, a user who deletes `mcp.jira`
+        // outright (not just edits it) has opted out — the next launch must not
+        // silently re-add it.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (claude, configHome, record) = try makeConfigDir(tmp, jira: [
+            "command": "uvx", "args": ["mcp-atlassian"],
+        ])
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .registered)
+
+        // User deletes the mirrored entry (Claude source still present).
+        try JSONSerialization.data(withJSONObject: [
+            "$schema": "https://opencode.ai/config.json",
+        ]).write(to: configHome.appendingPathComponent("opencode.json"))
+
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record)
+        #expect(outcome == .skippedUserOwned)
+
+        // Still absent — the opt-out stuck.
+        let target = configHome.appendingPathComponent("opencode.json")
+        let root = try #require(FileManager.default.contents(atPath: target.path)
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect((root["mcp"] as? [String: Any])?["jira"] == nil)
+    }
+
     @Test func preservesUserAuthoredEntryOnSourceRemoval() throws {
         // The failure case the reviewer flagged: an OpenCode-primary user with
         // their own `mcp.jira` and no Claude source must NOT have it deleted.

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
@@ -153,7 +153,9 @@ struct OpenCodeMCPConfigWriterTests {
             atomically: true, encoding: .utf8)
 
         let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claudePath.path)
+            configHome: configHome.path,
+            claudeJSONPath: claudePath.path,
+            mirrorRecordPath: tmp.appendingPathComponent("mirror.json").path)
         #expect(outcome == .skippedUnparseable)
     }
 
@@ -288,9 +290,26 @@ struct OpenCodeMCPConfigWriterTests {
 
         // Still absent — the opt-out stuck.
         let target = configHome.appendingPathComponent("opencode.json")
-        let root = try #require(FileManager.default.contents(atPath: target.path)
-            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
-        #expect((root["mcp"] as? [String: Any])?["jira"] == nil)
+        func jiraEntry() throws -> [String: Any]? {
+            let root = try #require(FileManager.default.contents(atPath: target.path)
+                .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+            return (root["mcp"] as? [String: Any])?["jira"] as? [String: Any]
+        }
+        #expect(try jiraEntry() == nil)
+
+        // And the opt-out survives a Claude-source round-trip: the source
+        // vanishing (which must not clear the opt-out record) and returning must
+        // not silently re-add the mirror.
+        try JSONSerialization.data(withJSONObject: ["mcpServers": [String: Any]()]).write(to: claude)
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .noSource)
+
+        try JSONSerialization.data(withJSONObject: [
+            "mcpServers": ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]],
+        ]).write(to: claude)
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .skippedUserOwned)
+        #expect(try jiraEntry() == nil)
     }
 
     @Test func preservesUserAuthoredEntryOnSourceRemoval() throws {

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
@@ -44,7 +44,8 @@ struct OpenCodeMCPConfigWriterTests {
     // MARK: - End-to-end registration
 
     /// Write a Claude config carrying a `jira` MCP, run the mirror, and return
-    /// the parsed `<configHome>/opencode.json`.
+    /// the parsed `<configHome>/opencode.json`. The provenance record lives
+    /// inside the (deleted) temp dir so the run is hermetic.
     private func runMirror(
         claudeMCPServers: [String: Any]?,
         existingOpenCode: [String: Any]? = nil
@@ -68,7 +69,9 @@ struct OpenCodeMCPConfigWriterTests {
         }
 
         let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claudePath.path)
+            configHome: configHome.path,
+            claudeJSONPath: claudePath.path,
+            mirrorRecordPath: tmp.appendingPathComponent("mirror.json").path)
 
         let target = configHome.appendingPathComponent("opencode.json")
         let root = FileManager.default.contents(atPath: target.path)
@@ -117,13 +120,19 @@ struct OpenCodeMCPConfigWriterTests {
     }
 
     @Test func secondRunIsUnchanged() throws {
-        // Registering, then registering again against the same inputs, is idempotent.
-        let servers: [String: Any] = ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]]
-        let (first, root) = try runMirror(claudeMCPServers: servers)
-        #expect(first == .registered)
-        let (second, _) = try runMirror(
-            claudeMCPServers: servers, existingOpenCode: root)
-        #expect(second == .unchanged)
+        // Registering, then registering again against the same inputs (same
+        // config home + provenance record), is idempotent.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let (claude, configHome, record) = try makeConfigDir(tmp, jira: ["command": "uvx", "args": ["mcp-atlassian"]])
+
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .registered)
+        #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .unchanged)
     }
 
     @Test func refusesToTouchUnparseableOpenCodeConfig() throws {
@@ -150,12 +159,12 @@ struct OpenCodeMCPConfigWriterTests {
 
     // MARK: - Credential handling + lifecycle (CROW-831 review)
 
-    /// Set up a persistent `.claude.json` + `opencode` config home under `tmp`,
-    /// with an optional initial Claude `jira` server. Returns the two paths so a
-    /// test can mutate the source between calls.
+    /// Set up a persistent `.claude.json` + `opencode` config home + provenance
+    /// record path under `tmp`, with an optional initial Claude `jira` server.
+    /// Returns the paths so a test can mutate the source between calls.
     private func makeConfigDir(
         _ tmp: URL, jira: [String: Any]?
-    ) throws -> (claude: URL, configHome: URL) {
+    ) throws -> (claude: URL, configHome: URL, record: String) {
         let claude = tmp.appendingPathComponent(".claude.json")
         if let jira {
             try JSONSerialization.data(withJSONObject: ["mcpServers": ["jira": jira]])
@@ -163,7 +172,7 @@ struct OpenCodeMCPConfigWriterTests {
         }
         let configHome = tmp.appendingPathComponent("opencode")
         try FileManager.default.createDirectory(at: configHome, withIntermediateDirectories: true)
-        return (claude, configHome)
+        return (claude, configHome, tmp.appendingPathComponent("mirror.json").path)
     }
 
     @Test func writesTargetOwnerOnly() throws {
@@ -173,18 +182,19 @@ struct OpenCodeMCPConfigWriterTests {
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let (claude, configHome) = try makeConfigDir(tmp, jira: [
+        let (claude, configHome, record) = try makeConfigDir(tmp, jira: [
             "command": "uvx", "args": ["mcp-atlassian"],
             "env": ["JIRA_API_TOKEN": "secret"],
         ])
         let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claude.path)
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record)
         #expect(outcome == .registered)
 
-        let target = configHome.appendingPathComponent("opencode.json")
-        let perms = try #require(
-            (try FileManager.default.attributesOfItem(atPath: target.path))[.posixPermissions] as? NSNumber)
-        #expect(perms.int16Value == 0o600)
+        for path in [configHome.appendingPathComponent("opencode.json").path, record] {
+            let perms = try #require(
+                (try FileManager.default.attributesOfItem(atPath: path))[.posixPermissions] as? NSNumber)
+            #expect(perms.int16Value == 0o600)
+        }
     }
 
     @Test func unMirrorsWhenSourceRemoved() throws {
@@ -193,20 +203,20 @@ struct OpenCodeMCPConfigWriterTests {
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let (claude, configHome) = try makeConfigDir(tmp, jira: [
+        let (claude, configHome, record) = try makeConfigDir(tmp, jira: [
             "command": "uvx", "args": ["mcp-atlassian"],
         ])
         #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claude.path) == .registered)
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .registered)
 
         // User drops `jira` from the Claude config entirely.
         try JSONSerialization.data(withJSONObject: ["mcpServers": [String: Any]()])
             .write(to: claude)
         let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claude.path)
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record)
         #expect(outcome == .removed)
 
-        // The stale mirror is gone.
+        // The stale mirror (the one Crow wrote) is gone.
         let target = configHome.appendingPathComponent("opencode.json")
         let root = try #require(FileManager.default.contents(atPath: target.path)
             .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
@@ -215,33 +225,67 @@ struct OpenCodeMCPConfigWriterTests {
 
         // Running again with the source still gone is a clean no-op.
         #expect(OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claude.path) == .noSource)
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record) == .noSource)
     }
 
-    @Test func preservesUserDisabledEnabled() throws {
+    @Test func doesNotOverwriteUserAuthoredEntry() throws {
+        // A `mcp.jira` Crow never wrote (no provenance record) is left untouched
+        // even when a Claude source is present — the register path must not
+        // clobber a user's own OpenCode Jira server. Also the opt-out path: an
+        // `enabled: false` the user set survives.
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let (claude, configHome) = try makeConfigDir(tmp, jira: [
+        let (claude, configHome, record) = try makeConfigDir(tmp, jira: [
             "command": "uvx", "args": ["mcp-atlassian"],
         ])
-        // Seed a Crow-written entry the user has since disabled.
+        let userEntry: [String: Any] = [
+            "type": "local", "command": ["my-own-jira"], "enabled": false,
+        ]
         try JSONSerialization.data(withJSONObject: [
             "$schema": "https://opencode.ai/config.json",
-            "mcp": ["jira": ["type": "local", "command": ["uvx", "mcp-atlassian"], "enabled": false]],
+            "mcp": ["jira": userEntry],
         ]).write(to: configHome.appendingPathComponent("opencode.json"))
 
-        // Next launch: source still present, but the user's opt-out must stick.
         let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
-            configHome: configHome.path, claudeJSONPath: claude.path)
-        #expect(outcome == .unchanged)
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record)
+        #expect(outcome == .skippedUserOwned)
 
+        // The user's entry is byte-for-byte intact — not replaced by the mirror.
         let target = configHome.appendingPathComponent("opencode.json")
         let root = try #require(FileManager.default.contents(atPath: target.path)
             .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
         let jira = try #require((root["mcp"] as? [String: Any])?["jira"] as? [String: Any])
+        #expect(jira["command"] as? [String] == ["my-own-jira"])
         #expect(jira["enabled"] as? Bool == false)
+    }
+
+    @Test func preservesUserAuthoredEntryOnSourceRemoval() throws {
+        // The failure case the reviewer flagged: an OpenCode-primary user with
+        // their own `mcp.jira` and no Claude source must NOT have it deleted.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // No Claude jira at all.
+        let (claude, configHome, record) = try makeConfigDir(tmp, jira: nil)
+        try JSONSerialization.data(withJSONObject: [
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": ["jira": ["type": "remote", "url": "https://mine.example.net", "enabled": true]],
+        ]).write(to: configHome.appendingPathComponent("opencode.json"))
+
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path, claudeJSONPath: claude.path, mirrorRecordPath: record)
+        #expect(outcome == .skippedUserOwned)
+
+        // Their server (and its would-be credentials) survives.
+        let target = configHome.appendingPathComponent("opencode.json")
+        let root = try #require(FileManager.default.contents(atPath: target.path)
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        let jira = try #require((root["mcp"] as? [String: Any])?["jira"] as? [String: Any])
+        #expect(jira["url"] as? String == "https://mine.example.net")
     }
 }


### PR DESCRIPTION
Closes #831

Closes the CROW-545/547 OpenCode MVP caveats now that `opencode` 1.17.x is stable, per the #828 harness gap audit (§3c). Scope was trimmed by the ticket review — resume-with-history was **already shipped** (#547) — so this pass covers the three remaining closures.

## Per-project plugins (session UUID baked in)
`OpenCodeHookConfigWriter.writeHookConfig` (was a no-op) now installs `<worktree>/.opencode/plugins/crow-hooks.js` with the Crow **session UUID baked in**, so each worktree emits `crow hook-event --session <uuid> …` — exact resolution, no `cwd` matching. That **closes the shared-`cwd` collision** two sessions rooted at (or resolving to) the same path could otherwise hit.

The global `~/.config/opencode/plugins/` plugin stays as a fallback for hand-started sessions, but **self-suppresses** (returns no hooks) whenever a per-project plugin exists in the cwd — so the two never double-emit (OpenCode dedups plugins by file URL, `plugin.ts@v1.18.4`, so both files load). Verified under Bun: global defers when the per-project file is present, emits when not; per-project is always authoritative.

## Jira MCP registration (parity with Claude)
New `OpenCodeMCPConfigWriter` mirrors the user's global `jira` MCP from `~/.claude.json` (`mcpServers.jira` — the same server Claude Code sessions inherit post-CROW-528) into a Crow-owned `~/.config/opencode/opencode.json` under `mcp.jira`, translating Claude's local/remote shape into OpenCode's. Writing `opencode.json` (which OpenCode merges alongside the user's hand-edited `opencode.jsonc`, `config.ts@v1.18.4:258-260`) means we never strip the user's comments. Merge-safe, idempotent, and a **no-op when there's no Claude Jira MCP** to mirror. `OpenCodeLauncher`'s Jira prompt now prefers `jira_get_issue` via the MCP with an `acli` fallback.

## Version-aware auto-permission probe (narrow, don't delete)
Per the #832 round-1 correction: the TUI `--auto` flag was gone only in `v1.17.x` and re-added in `v1.18.0`, so `runAutoApproveSuffix`'s try-`--auto`/else-`--dangerously-skip-permissions` fallback **stays**. Only `tuiSupportsAuto`'s top-level `--auto --help` probe is dead weight — and only on `<1.18`. It's now version-gated: below 1.18 we answer "no auto" from the `opencode --version` string alone (skipping the subprocess); on `≥1.18` or an unparseable version we still run the `--help` probe, so a future upstream flip is caught without a code change.

## Not in scope (unchanged)
Native RC via `opencode serve`/`attach`/`acp`; `--session <id>` targeting and `.work` resume (both optional per the audit).

## Test plan
- `swift test --package-path Packages/CrowOpenCode` — 46 tests green (new coverage: per-project write/remove, self-suppress guard, MCP translation/merge/idempotency/unparseable-refusal, SemVer parse + `<1.18` narrowing).
- Bun-parsed both generated plugin variants and drove the self-suppress guard end-to-end (global defers with per-project present; emits without; per-project authoritative).
- Re-probed the installed `opencode` 1.17.10: top-level TUI has no `--auto`/`--yolo`/`--dangerously-skip-permissions`; `opencode run` has `--dangerously-skip-permissions`; `opencode mcp add` / config `mcp` block confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)