### PR TITLE
Relabel "Open Issue"/"Open PR" ticket links to "View Issue"/"View PR"

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2939,11 +2939,11 @@ function ticketCard(i) {
   if (i.pr_state) foot.appendChild(prStateBadge(i.pr_state));
   if (i.checks && i.checks.state) foot.appendChild(checksBadge(i.checks));
 
-  // #751: right-aligned action cluster — Open Issue / Open PR always, plus the
+  // #751: right-aligned action cluster — View Issue / View PR always, plus the
   // existing Go to Session / Start Working affordance.
   const actions = el('div', 'card-actions');
-  actions.appendChild(openLinkButton('Open Issue', i.url));
-  if (i.pr_url) actions.appendChild(openLinkButton('Open PR', i.pr_url));
+  actions.appendChild(openLinkButton('View Issue', i.url));
+  if (i.pr_url) actions.appendChild(openLinkButton('View PR', i.pr_url));
   if (i.linked_session_id) {
     const go = el('button', 'action-btn', 'Go to Session');
     go.onclick = () => selectSession(i.linked_session_id);

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -10,7 +10,7 @@ Drives `renderTicketBoard` / `ticketCard` against mock board payloads and
 asserts the resulting DOM. Coverage: repo filter, every sort mode,
 status-pipeline + text-search composition, the label-name search fix, richer
 card detail (author / created / comments / description excerpt + expand
-toggle), Open Issue / Open PR buttons (hrefs + `target=_blank`), inline PR
+toggle), View Issue / View PR buttons (hrefs + `target=_blank`), inline PR
 state + CI badges (incl. failing-check tooltip), and graceful degradation of an
 older payload with the new fields absent.
 

--- a/Packages/CrowDaemon/web-tests/board.test.js
+++ b/Packages/CrowDaemon/web-tests/board.test.js
@@ -95,10 +95,10 @@ check('comment count 4 shown', q('.byline-comments').length >= 1 && /4/.test(q('
 check('description excerpt rendered', q('.card-desc').length >= 1);
 check('long body has Show more toggle', [...q('.card-desc-toggle')].some((b) => b.textContent === 'Show more'));
 check('short body (#42) still renders a desc', q('.card-desc').length >= 2);
-check('Open Issue buttons on all 3', [...q('.open-link-btn')].filter((b) => b.textContent === 'Open Issue').length === 3);
-check('Open PR buttons on the 2 with a PR', [...q('.open-link-btn')].filter((b) => b.textContent === 'Open PR').length === 2);
-check('Open Issue href correct', [...q('.open-link-btn')].find((b) => b.textContent === 'Open Issue').getAttribute('href') === 'https://github.com/corveil/crow/issues/751');
-check('Open Issue opens new tab', [...q('.open-link-btn')].find((b) => b.textContent === 'Open Issue').getAttribute('target') === '_blank');
+check('View Issue buttons on all 3', [...q('.open-link-btn')].filter((b) => b.textContent === 'View Issue').length === 3);
+check('View PR buttons on the 2 with a PR', [...q('.open-link-btn')].filter((b) => b.textContent === 'View PR').length === 2);
+check('View Issue href correct', [...q('.open-link-btn')].find((b) => b.textContent === 'View Issue').getAttribute('href') === 'https://github.com/corveil/crow/issues/751');
+check('View Issue opens new tab', [...q('.open-link-btn')].find((b) => b.textContent === 'View Issue').getAttribute('target') === '_blank');
 check('pr-state badges = 2', q('.pr-state-badge').length === 2);
 check('draft badge text present', /Draft PR/.test(board.textContent));
 check('checks badges = 2', q('.checks-badge').length === 2);


### PR DESCRIPTION
Closes #844

## What
The session tickets action cluster labeled its two link buttons **"Open Issue"** and **"Open PR"**. "Open" reads like *create/open a new* issue or PR, when the buttons only navigate to the existing item. Relabel them to **"View Issue"** and **"View PR"**.

## Changes
- `web/app.js` — the two `openLinkButton(...)` label strings (+ the `#751` comment). No behavior change; `openLinkButton` still just opens the URL in a new tab.
- `web-tests/board.test.js` — updated the four button-text assertions to match the new labels.
- `web-tests/README.md` — updated the descriptive reference.

## Verification
`node board.test.js` → **50 passed, 0 failed** (includes the View Issue/View PR button assertions).

## Acceptance
- ✅ The tickets section shows "View Issue" and "View PR" instead of "Open Issue"/"Open PR".

🤖 Generated with [Claude Code](https://claude.com/claude-code)