### PR TITLE
Drop redundant trailing "label" from crow:merge PR status chip

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1266,6 +1266,10 @@ function prBadgeColor(pr) {
 // inherit `currentColor`, so the checkmarks tint with their label instead of
 // staying black (Apple emoji ✔/✕/⚠ ignore CSS `color` — CROW-802). Geometric
 // glyphs (◷/○/?) and the 🏷 tag are already color-faithful, so they stay text.
+// `label` is the chip text in the detail header AND the sidebar pill's
+// aria-label/title; an optional `a11yLabel` overrides the latter when the
+// concise chip text would be ambiguous without its (unannounced) glyph
+// (CROW-846). Add it only where the two channels must diverge.
 const PR_CHECKS_GLYPH = {
   passing: { glyph: '✔', icon: 'check', color: 'var(--green)', label: 'Checks pass' },
   failing: { glyph: '✕', icon: 'close', color: 'var(--red)', label: 'Checks failing' },

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1280,7 +1280,7 @@ const PR_REVIEW_GLYPH = {
 };
 const PR_MERGED_GLYPH = { glyph: '✔', icon: 'check', color: 'var(--purple)', label: 'Merged' };
 const PR_CONFLICT_GLYPH = { glyph: '⚠', icon: 'warning', color: 'var(--red)', label: 'Conflicts' };
-const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge label' };
+const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge' };
 
 function prChecksGlyph(pr) {
   const base = PR_CHECKS_GLYPH[pr.checks] || PR_CHECKS_GLYPH.unknown;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1216,7 +1216,7 @@ function sessionRow(s) {
     }
     // Glyph + color must not be the only channel — mirrors native PRBadge's
     // `accessibilityDescription` ("#123, Checks pass, Approved").
-    const desc = [prLink.label || 'PR', ...parts.map((p) => p.label)].join(', ');
+    const desc = [prLink.label || 'PR', ...parts.map((p) => p.a11yLabel || p.label)].join(', ');
     prb.title = desc;
     prb.setAttribute('aria-label', desc);
     badges.appendChild(prb);
@@ -1280,7 +1280,10 @@ const PR_REVIEW_GLYPH = {
 };
 const PR_MERGED_GLYPH = { glyph: '✔', icon: 'check', color: 'var(--purple)', label: 'Merged' };
 const PR_CONFLICT_GLYPH = { glyph: '⚠', icon: 'warning', color: 'var(--red)', label: 'Conflicts' };
-const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge' };
+// Chip text drops the redundant "label" (the 🏷 glyph shows it beside the
+// text); the aria path keeps it via `a11yLabel` — there the glyph is never
+// announced, so the noun is the only signal it's a label (CROW-846).
+const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge', a11yLabel: 'crow:merge label' };
 
 function prChecksGlyph(pr) {
   const base = PR_CHECKS_GLYPH[pr.checks] || PR_CHECKS_GLYPH.unknown;

--- a/Packages/CrowDaemon/web-tests/row.test.js
+++ b/Packages/CrowDaemon/web-tests/row.test.js
@@ -56,6 +56,22 @@ function render(pr, overrides) {
 }
 const badge = (row) => row.querySelector('.pr-badge');
 
+// crow:merge a11y noun (CROW-846) — the sidebar pill is glyph-only, so its
+// aria-label/title is the sole screen-reader channel. The visible chip text
+// dropped the redundant trailing "label", but the aria path must keep the noun
+// via `PR_MERGE_LABEL_GLYPH.a11yLabel`; this pins that split so a later
+// `p.a11yLabel || p.label` → `p.label` "simplify" can't silently unwind it.
+// Placed ahead of the merged-PR section below, which trips a pre-existing
+// CROW-802 selector-drift crash (`.pr-ico` is null for the SVG ✔/✕/⚠ glyphs)
+// that would otherwise abort the run before this line executes.
+console.log('crow:merge announces the "label" noun to screen readers (CROW-846):');
+{
+  const rr = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergeable',
+    is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [], has_merge_label: true });
+  check('sidebar aria-label keeps the "crow:merge label" noun',
+    /crow:merge label/.test(badge(rr.row).getAttribute('aria-label')));
+}
+
 console.log('Failing checks + changes requested:');
 let r = render({ has_pr: true, checks: 'failing', review: 'changesRequested', merge: 'MERGEABLE',
   is_merged: false, has_blockers: true, ready_to_merge: false, failed_checks: ['build', 'lint'] });

--- a/Packages/CrowDaemon/web-tests/row.test.js
+++ b/Packages/CrowDaemon/web-tests/row.test.js
@@ -9,6 +9,7 @@ const { JSDOM } = require('jsdom');
 const epilogue = `
 ;globalThis.__t = {
   sessionRow(s){ return sessionRow(s); },
+  prStatusInline(pr){ return prStatusInline(pr); },
   set live(v){ liveById = v; },
   set hideDetails(v){ uiConfig.hideSessionDetails = v; },
 };
@@ -56,22 +57,6 @@ function render(pr, overrides) {
 }
 const badge = (row) => row.querySelector('.pr-badge');
 
-// crow:merge a11y noun (CROW-846) — the sidebar pill is glyph-only, so its
-// aria-label/title is the sole screen-reader channel. The visible chip text
-// dropped the redundant trailing "label", but the aria path must keep the noun
-// via `PR_MERGE_LABEL_GLYPH.a11yLabel`; this pins that split so a later
-// `p.a11yLabel || p.label` → `p.label` "simplify" can't silently unwind it.
-// Placed ahead of the merged-PR section below, which trips a pre-existing
-// CROW-802 selector-drift crash (`.pr-ico` is null for the SVG ✔/✕/⚠ glyphs)
-// that would otherwise abort the run before this line executes.
-console.log('crow:merge announces the "label" noun to screen readers (CROW-846):');
-{
-  const rr = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergeable',
-    is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [], has_merge_label: true });
-  check('sidebar aria-label keeps the "crow:merge label" noun',
-    /crow:merge label/.test(badge(rr.row).getAttribute('aria-label')));
-}
-
 console.log('Failing checks + changes requested:');
 let r = render({ has_pr: true, checks: 'failing', review: 'changesRequested', merge: 'MERGEABLE',
   is_merged: false, has_blockers: true, ready_to_merge: false, failed_checks: ['build', 'lint'] });
@@ -102,7 +87,13 @@ r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'merged
   is_merged: true, has_blockers: false, ready_to_merge: false, failed_checks: [] });
 check('exactly one glyph', r.glyphs.length === 1);
 check('glyph is ✔', r.glyphs[0] === '✔');
-check('glyph purple', r.row.querySelector('.pr-ico').style.color === 'var(--purple)');
+// `?.` guards a pre-existing CROW-802 selector drift: ✔/✕/⚠ now render as SVG
+// `.ico` spans, not `.pr-ico` text, so `.pr-ico` is null here. Without the
+// guard this line *throws* and aborts the whole file mid-run; with it the
+// suite runs to completion so later sections (incl. the crow:merge checks
+// below) execute and the exit code stops masking their pass/fail. Fixing the
+// drift itself (so this assertion passes again) is CROW-802's own ticket.
+check('glyph purple', r.row.querySelector('.pr-ico')?.style.color === 'var(--purple)');
 
 console.log('\nConflicting PR adds a ⚠:');
 r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'conflicting',
@@ -122,6 +113,18 @@ r = render({ has_pr: true, checks: 'passing', review: 'approved', merge: 'mergea
   is_merged: false, has_blockers: false, ready_to_merge: true, failed_checks: [], has_merge_label: true },
   { auto_merge: true });
 check('🏷 and ⛙ can both show', r.glyphs.includes('🏷') && !!r.row.querySelector('.automerge'));
+// CROW-846: the visible chip dropped the redundant trailing "label", but the
+// sidebar pill is glyph-only — its aria-label/title is the sole screen-reader
+// channel, so the noun must survive there via PR_MERGE_LABEL_GLYPH.a11yLabel.
+// Pin BOTH halves of that split so a later `p.a11yLabel || p.label` → `p.label`
+// (or reverting `label` to `'crow:merge label'`) can't silently unwind either.
+check('sidebar aria keeps the unambiguous "crow:merge label" noun',
+  /crow:merge label/.test(badge(r.row).getAttribute('aria-label')));
+const mergeChips = [...T.prStatusInline({ has_pr: true, checks: 'passing', review: 'approved',
+  merge: 'mergeable', is_merged: false, has_blockers: false, ready_to_merge: true,
+  failed_checks: [], has_merge_label: true }).querySelectorAll('.pr-stat-label')].map((n) => n.textContent);
+check('detail chip reads the concise "crow:merge"', mergeChips.includes('crow:merge'));
+check('detail chip drops the redundant "crow:merge label"', !mergeChips.includes('crow:merge label'));
 
 console.log('\nGraceful degradation (older daemon payload / no PR status):');
 r = render(undefined);


### PR DESCRIPTION
## Summary

The `crow:merge` PR-status marker rendered as **"🏷 crow:merge label"**. The trailing word **"label"** is redundant in the visible detail-header chip — the 🏷 glyph sits right beside the text — so it now reads **"🏷 crow:merge"**, matching the concise wording of its sibling chips ("Approved", "Conflicts", "Merged").

Closes #846.

## What changed (and why it's not purely "text-only")

The `.label` string has **two** consumers, so a naive one-line copy edit regressed accessibility — caught in review and fixed:

1. **Detail header** (`prStatusInline` → `prStatusPart`) — glyph is visible beside the text. Here `label: 'crow:merge'` is correct and unambiguous. ✅ the visible fix.
2. **Sidebar row pill** (`sessionRow`, `app.js:1219`) — glyph-only; the `.label` string becomes the pill's `aria-label`/`title`, which overrides the subtree, so the 🏷 glyph is **never announced** to a screen reader. Dropping "label" there would have made it announce a bare `crow:merge` token where every sibling is a full state phrase.

**Fix:** split the two channels.
```diff
-const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge label' };
+const PR_MERGE_LABEL_GLYPH = { glyph: '🏷', color: 'var(--gold)', label: 'crow:merge', a11yLabel: 'crow:merge label' };
```
```diff
-const desc = [prLink.label || 'PR', ...parts.map((p) => p.label)].join(', ');
+const desc = [prLink.label || 'PR', ...parts.map((p) => p.a11yLabel || p.label)].join(', ');
```
`label` stays concise for the visible chip; `a11yLabel` keeps the noun for the aria path; `|| p.label` leaves every other glyph entry untouched. The optional `a11yLabel` key is documented in the shared glyph-vocabulary header.

## Result
- **Detail chip:** `🏷 crow:merge` (redundant word dropped — the ticket's ask)
- **Sidebar screen-reader announcement:** `…, crow:merge label` (unchanged; noun preserved)

## Tests

Added to `Packages/CrowDaemon/web-tests/row.test.js`:
- `sidebar aria keeps the unambiguous "crow:merge label" noun`
- `detail chip reads the concise "crow:merge"`
- `detail chip drops the redundant "crow:merge label"`

Also applied a `?.` to a **pre-existing** CROW-802 crash (the merged-PR assertion deref'd a now-null `.pr-ico`) so the suite runs to completion instead of aborting mid-file. All three new guards pass.

⚠️ **Known gap:** `row.test.js` still exits non-zero on `main` — 8 assertions fail on the same pre-existing CROW-802 selector drift (✔/✕/⚠ moved to SVG `.ico`), and `web-tests` isn't wired into CI. So these guards can't yet *gate* via exit code; that needs the drift repair + a CI job, both a separate ticket (see PR discussion). Behavior is verified end-to-end in the meantime.

## Commits
`f1dfa5b` initial copy change → `1b1a847` a11y split → `202c28b` first regression guard → `8196cc1` run-to-completion + full split coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
