### PR TITLE
Settings/Jobs: don't discard job editor on backdrop click

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -193,8 +193,9 @@
     if (!backdrop) {
       backdrop = el('div', 'settings-backdrop');
       backdrop.onclick = (ev) => { if (ev.target === backdrop) closeSettings(); };
-      // Escape backs out of the topmost overlay first (sub-form), then Settings —
-      // matching backdrop-click behavior (review Yellow).
+      // Escape backs out of the topmost overlay first (sub-form), then Settings.
+      // The sub-form is intentionally *not* backdrop-dismissible (#851), so Esc
+      // is its only key-driven close path.
       escHandler = (ev) => {
         if (ev.key !== 'Escape') return;
         if (subForm) { subForm = null; render(); return; }
@@ -1053,7 +1054,9 @@
   // real `.settings-body` flex child so tall forms scroll instead of clipping.
   function renderSubFormOverlay() {
     const overlay = el('div', 'settings-backdrop settings-subform-overlay');
-    overlay.onclick = (ev) => { if (ev.target === overlay) { subForm = null; render(); } };
+    // Backdrop click is intentionally a no-op for the job/workspace editor: an
+    // accidental click off the modal must not silently discard in-progress edits
+    // (#851). Close via Cancel / Add-Done / ✕ / Esc only.
 
     const modal = el('div', 'settings-modal');
     const head = el('div', 'settings-head');


### PR DESCRIPTION
Closes #851

## Problem

In Settings → Jobs, clicking outside the add/edit **job** modal (on the backdrop) closed it and silently discarded whatever was being entered. An accidental off-modal click lost the in-progress job config.

## Root cause

The job/workspace add/edit editor opens as a stacked child modal via `renderSubFormOverlay()` (`settings.js`). Its overlay had a backdrop `onclick` that did `subForm = null; render()` on any click landing on the dimmed area — discarding the draft with no confirmation.

## Fix

Make the sub-form backdrop a **no-op**. Closing the editor now requires an explicit action — **Cancel**, **Add/Done**, **✕**, or **Esc** — per the acceptance criteria.

- The same overlay renders both the **job** and **workspace** editors, so the fix applies consistently to both (add *and* edit flows).
- Esc still backs out the sub-form (an explicit, key-driven close path that the ticket allows).
- The top-level **Settings** modal is unchanged — it already guards unsaved edits via `confirmModal` on backdrop-click, so it stays backdrop-dismissible.

## Test plan

1. Open Settings → Jobs.
2. Click **Add job** (or edit an existing job); start filling in the form.
3. Click anywhere on the backdrop outside the modal → **modal stays open, edits preserved** (previously: closed + discarded).
4. Confirm **Cancel**, **✕**, and **Esc** still close it, and **Add/Done** still saves.
5. Repeat for the **workspace** editor (same overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)