### PR TITLE
Terminal wheel/touch scrolls the viewport at an agent prompt, not history (#850)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -3387,34 +3387,46 @@ function forceSelectModifierLabel() {
   return /Mac|iPhone|iPad|iPod/.test(ua) ? '⌥' : 'Shift';
 }
 
-// True when the app on the other end should receive the scroll instead of us
-// scrolling xterm's local buffer. Shared by the wheel and touch shims so both
-// agree on who owns the surface.
+// True when the wheel/touch scroll should be FORWARDED to the app on the other
+// end instead of scrolling xterm's local buffer. Shared by the wheel and touch
+// shims so both agree on who owns the surface.
 //
-// The daemon-supplied `agent_surface` is AUTHORITATIVE whenever we have it: an
-// agent surface forwards, and a known plain shell scrolls its unified 50k
-// scrollback — full stop. The alt-buffer / mouse-tracking checks are consulted
-// ONLY when we have no surface metadata at all (before the first
-// `list-terminals` lands).
+// Forwarding is right in exactly one case: the app is actively MOUSE-TRACKING,
+// so the tick becomes an SGR wheel button (`\x1b[<64/65`) it scrolls its own
+// transcript with (an agent TUI showing a scrollable view, vim, htop, …).
+// Everything else — a plain shell AND an agent TUI idling at its prompt —
+// scrolls the local xterm viewport. Forwarding a NON-mouse wheel would fall to
+// sendScrollToPTY's arrow-key branch, which Claude Code / Cursor read as
+// input-HISTORY navigation rather than scrollback — the #850 bug. Scrolling the
+// local viewport instead matches the desktop terminal and web/terminal.html,
+// neither of which forwards a non-mouse wheel.
 //
-// That gating is load-bearing, not defensive coding. There is ONE shared xterm
-// instance across every tab, and agent surfaces now let DECSET 1000–1016
-// through, so `term.modes.mouseTrackingMode` can outlive the tab that set it:
-// `attachWindow` only clears it via `reloadTerminal()`/`term.reset()` when the
-// socket is already OPEN, and skips that during a reconnect. Ungated, a shell
-// tab visited right after an agent tab would inherit its modes and forward the
-// wheel to the PTY as arrow keys — regressing the exact shell path this model
-// exists to preserve. Nothing is lost by gating: under the smcup strip plus the
-// conditional swallow, a real shell surface can never legitimately be in the
-// alternate buffer or be mouse-tracking.
+// `agent_surface` (daemon-supplied) is AUTHORITATIVE whenever we have it and is
+// consulted BEFORE the mouse-mode check — that ordering is load-bearing, not
+// defensive coding. There is ONE shared xterm instance across every tab, and
+// agent surfaces now let DECSET 1000–1016 through, so
+// `term.modes.mouseTrackingMode` can outlive the tab that set it: `attachWindow`
+// only clears it via `reloadTerminal()`/`term.reset()` when the socket is
+// already OPEN, and skips that during a reconnect. If we tested the mode first,
+// a shell tab visited right after an agent tab would inherit that stale mode and
+// forward the wheel to the PTY — regressing the exact shell path this model
+// exists to preserve. So a KNOWN surface reads its own kind and only an agent
+// that is genuinely mouse-tracking forwards. The alt-buffer / mouse-tracking
+// fallbacks apply ONLY before the first `list-terminals` lands (no metadata).
 function appOwnsScroll() {
-  if (activeTerminal && typeof activeTerminal.agent_surface === 'boolean') {
-    return activeTerminal.agent_surface;
-  }
-  const buf = term && term.buffer && term.buffer.active;
-  if (buf && buf.type === 'alternate') return true;
   const modes = (term && term.modes) || {};
-  return !!(modes.mouseTrackingMode && modes.mouseTrackingMode !== 'none');
+  const mouseTracking = !!(modes.mouseTrackingMode && modes.mouseTrackingMode !== 'none');
+  if (activeTerminal && typeof activeTerminal.agent_surface === 'boolean') {
+    // Agent TUI → forward only while it's mouse-tracking (SGR wheel scrolls the
+    // agent's transcript); at a plain prompt fall through to a LOCAL viewport
+    // scroll instead of the arrow keys it reads as history nav (#850). A plain
+    // shell always scrolls locally, even if a prior agent tab left the shared
+    // xterm mouse-tracking.
+    return activeTerminal.agent_surface && mouseTracking;
+  }
+  if (mouseTracking) return true;
+  const buf = term && term.buffer && term.buffer.active;
+  return !!(buf && buf.type === 'alternate');
 }
 
 function ensureTerminal() {
@@ -3541,8 +3553,11 @@ function sendScrollToPTY(lines) {
   const up = lines < 0;
   const modes = (term && term.modes) || {};
   // Mouse-reporting apps (and tmux, whose `mouse on` relays to them) want SGR
-  // wheel buttons 64/65; everything else takes the cursor-key fallback xterm
-  // itself uses for an alt-buffer wheel.
+  // wheel buttons 64/65. The cursor-key branch is now only the UNCLASSIFIED
+  // alt-buffer fallback (a genuine fullscreen app like less/vim before
+  // list-terminals lands): appOwnsScroll no longer forwards a non-mouse agent
+  // wheel here, so this branch never turns an agent's wheel into history nav
+  // (#850).
   let seq;
   if (modes.mouseTrackingMode && modes.mouseTrackingMode !== 'none') {
     seq = up ? '\x1b[<64;1;1M' : '\x1b[<65;1;1M';
@@ -3601,26 +3616,30 @@ function wheelNotches(e) {
   return Math.abs(px) >= WHEEL_NOTCH_MIN_PX ? Math.sign(px) : px / WHEEL_NOTCH_MIN_PX;
 }
 
-// Route the wheel by surface (ADR-0013) — the mirror of what enableTouchScroll
-// does for touch:
+// Route the wheel by surface (ADR-0013, refined by #850) — the mirror of what
+// enableTouchScroll does for touch:
 //
-//   * PLAIN SHELL → scroll xterm's local 50k scrollback. Forwarding to tmux
-//     instead would drop into copy-mode, which is janky in a browser.
-//   * AGENT SURFACE → forward the tick to the app so it scrolls its own
-//     transcript, like a naked terminal.
+//   * PLAIN SHELL, or an AGENT SURFACE idling at its prompt → scroll xterm's
+//     local viewport. On a shell that's the 50k scrollback; on an agent (whose
+//     transcript lives in tmux's scrollback-less alt buffer) it's a harmless
+//     no-op — but critically NOT the arrow-key history nav forwarding used to
+//     produce (#850). Matches the desktop terminal and web/terminal.html.
+//   * MOUSE-TRACKING app (an agent showing a scrollable view, vim, htop) →
+//     forward the tick so it becomes an SGR wheel button the app scrolls its
+//     own transcript with, like a naked terminal.
 //
 // This handler always CONSUMES the event (capture + preventDefault +
 // stopPropagation) so xterm's own alternate-scroll fallback never runs. That
 // fallback emits ARROW KEYS, which Claude Code reads as input-history
-// navigation — the #776 bug. Forwarding goes through sendScrollToPTY, which
-// picks SGR wheel buttons when the app is mouse-tracking and cursor keys
-// otherwise, and caps a fling so it can't flood the PTY.
+// navigation — the #776/#850 bug. `appOwnsScroll` (mouse-tracking, per above)
+// decides forward-vs-local; forwarding goes through sendScrollToPTY, which caps
+// a fling so it can't flood the PTY.
 //
 // Magnitude is device-normalized to whole notches (wheelNotches) with a
 // sub-notch accumulator (mirroring enableTouchScroll's `accum`), then scaled by
-// the user's per-path sensitivity (CROW-835): agent surfaces forward
+// the user's per-path sensitivity (CROW-835): a forwarded wheel sends
 // `agentWheelNotches` reports per notch (default 1 — one detent in, one out),
-// plain shells scroll `wheelScrollLines` local lines per notch (default 3 — the
+// a local scroll moves `wheelScrollLines` lines per notch (default 3 — the
 // historical feel). The `if (!term)` guard is the only early exit; a partial
 // notch simply consumes the event and waits for more.
 function enableWheelScroll(node) {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -79,9 +79,10 @@ import Testing
     ///
     /// Consuming is the #776 invariant: any early return hands the wheel to
     /// xterm's alternate-scroll fallback, which emits arrow keys that the agent
-    /// TUI reads as input-history navigation. Routing is the #824 invariant: a
-    /// plain shell scrolls the local 50k scrollback, while an agent surface
-    /// forwards the tick to the app so it scrolls its own transcript.
+    /// TUI reads as input-history navigation. Routing is the #824/#850 invariant:
+    /// a plain shell — and an agent idling at its prompt — scrolls the local
+    /// viewport, while a mouse-tracking app forwards the tick so it scrolls its
+    /// own transcript (never arrow keys, which would be history nav).
     ///
     /// Asserted as the positive shape rather than the absence of a string, so
     /// reintroducing a bail with different wording still fails (review).
@@ -93,7 +94,7 @@ import Testing
         #expect(body.contains("term.scrollLines("), "must scroll the local scrollback")
         #expect(
             body.contains("sendScrollToPTY("),
-            "must forward the wheel to the app on an agent surface")
+            "must forward the wheel to the app when it is mouse-tracking")
         for consume in ["e.preventDefault();", "e.stopPropagation();"] {
             #expect(body.contains(consume), "must always consume the wheel event: \(consume)")
         }
@@ -121,8 +122,8 @@ import Testing
             body.contains("typeof activeTerminal.agent_surface === 'boolean'"),
             "must treat a known surface kind as authoritative in BOTH directions")
         #expect(
-            body.contains("return activeTerminal.agent_surface;"),
-            "a known plain shell must scroll locally, not fall through to the legacy signals")
+            body.contains("return activeTerminal.agent_surface && mouseTracking;"),
+            "a known surface is authoritative: a plain shell always scrolls locally, and an agent forwards only while mouse-tracking — at a plain prompt it scrolls the local viewport rather than the history-nav arrow keys (#850)")
         #expect(
             body.contains("'alternate'") && body.contains("mouseTrackingMode"),
             "must keep the alt-buffer / mouse-tracking signals as the unclassified fallback")

--- a/Packages/CrowDaemon/web-tests/touch-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/touch-scroll.test.js
@@ -11,6 +11,7 @@ const epilogue = `
   enableTouchScroll(node){ return enableTouchScroll(node); },
   set term(v){ term = v; },
   set termWs(v){ termWs = v; },
+  set activeTerminal(v){ activeTerminal = v; },
 };
 `;
 const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
@@ -49,7 +50,8 @@ const CELL = 20; // px per row in the fakes below
 // A fresh #terminal node with the listeners attached, plus recorders for what
 // the shim did. Returns a small driver for synthesising a one-finger drag.
 function setup({ rows = 24, screenHeight = rows * CELL, altScreen = false,
-                 mouseTrackingMode = 'none', applicationCursorKeysMode = false } = {}) {
+                 mouseTrackingMode = 'none', applicationCursorKeysMode = false,
+                 agentSurface = undefined } = {}) {
   const node = window.document.createElement('div');
   window.document.body.appendChild(node);
   Object.defineProperty(node, 'clientHeight', { value: rows * CELL, configurable: true });
@@ -72,6 +74,12 @@ function setup({ rows = 24, screenHeight = rows * CELL, altScreen = false,
     readyState: 1,
     send: (bytes) => sent.push(new TextDecoder().decode(bytes)),
   };
+  // Models the daemon-supplied `agent_surface` flag. Set deterministically every
+  // call (it's shared global state): a boolean → classified surface; undefined →
+  // unclassified, so appOwnsScroll falls to its legacy alt-buffer/mouse signals.
+  T.activeTerminal = typeof agentSurface === 'boolean'
+    ? { id: 't1', window: 1, agent_surface: agentSurface }
+    : null;
 
   // Record listener registration so we can assert passive-ness directly.
   const opts = {};
@@ -135,7 +143,9 @@ console.log('\nSub-cell drags accumulate instead of being truncated away:');
   check('...but is still preventDefault\'ed', t2.prevented() === 1);
 }
 
-console.log('\nAlternate screen (TUI) forwards to the PTY — scrollLines is a no-op there:');
+// Unclassified surface (no agent_surface metadata yet): a real alt buffer or a
+// mouse-tracking app forwards to the PTY — scrollLines is a no-op there.
+console.log('\nUnclassified alt screen / TUI forwards to the PTY:');
 {
   const t = setup({ altScreen: true, mouseTrackingMode: 'vt200' });
   t.start(500);
@@ -162,6 +172,36 @@ console.log('\nAlternate screen (TUI) forwards to the PTY — scrollLines is a n
   t.start(500);
   t.move(500 + 100 * CELL); // a fling
   check('a fling is capped at 24 lines', t.sent.join() === '\x1b[A'.repeat(24));
+}
+
+// #850: a classified AGENT surface at its plain prompt (no mouse tracking) must
+// scroll the LOCAL viewport, not forward the arrow keys Claude Code / Cursor
+// read as input-history navigation. Parity with the wheel and the desktop.
+console.log('\nAgent surface: a plain prompt scrolls locally, not into history (#850):');
+{
+  const t = setup({ agentSurface: true, mouseTrackingMode: 'none' });
+  t.start(500);
+  t.move(500 + 2 * CELL); // drag down 2 rows
+  check('no mouse tracking → local viewport scroll, not arrow keys', t.scrolled.join() === '-2');
+  check('nothing forwarded to the PTY (no history nav)', t.sent.length === 0);
+}
+{
+  // A mouse-tracking agent (a scrollable view) still forwards SGR wheel buttons
+  // so it scrolls its own transcript.
+  const t = setup({ agentSurface: true, mouseTrackingMode: 'any' });
+  t.start(500);
+  t.move(500 + 2 * CELL);
+  check('mouse tracking → SGR wheel reports', t.sent.join() === '\x1b[<64;1;1M'.repeat(2));
+  check('no local scrollLines while mouse-tracking', t.scrolled.length === 0);
+}
+{
+  // A KNOWN plain shell scrolls its local scrollback even if a prior agent tab
+  // left the shared xterm mouse-tracking (anti-stale ordering, ADR-0013).
+  const t = setup({ agentSurface: false, mouseTrackingMode: 'any' });
+  t.start(500);
+  t.move(500 + 2 * CELL);
+  check('sticky mouse mode does not hijack the shell', t.scrolled.join() === '-2');
+  check('nothing forwarded to the PTY', t.sent.length === 0);
 }
 
 console.log('\nMulti-touch is left to the browser:');

--- a/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
+++ b/Packages/CrowDaemon/web-tests/wheel-scroll.test.js
@@ -124,7 +124,7 @@ console.log('\nPlain shell scrolls the unified local scrollback:');
   check('nothing written to the PTY', t.sent.length === 0);
 }
 
-console.log('\nAgent surface forwards the wheel to the app:');
+console.log('\nAgent surface: mouse-tracking forwards, a plain prompt scrolls locally:');
 {
   // The agent turned mouse tracking on and — because the swallow is now
   // conditional — xterm actually recorded it, so we speak SGR wheel buttons.
@@ -135,15 +135,18 @@ console.log('\nAgent surface forwards the wheel to the app:');
   check('one SGR wheel-up report per notch', t.sent.join() === '\x1b[<64;1;1M');
   t.down();
   check('one SGR wheel-down report on the way back', t.sent[1] === '\x1b[<65;1;1M');
-  check('no local scrollLines on an agent surface', t.scrolled.length === 0);
+  check('no local scrollLines while mouse-tracking', t.scrolled.length === 0);
 }
 {
-  // An agent surface whose app has NOT enabled mouse tracking still must not
-  // scroll the (empty) local buffer — that was the "same frame forever" bug.
+  // An agent TUI idling at its prompt (no mouse tracking) must scroll the LOCAL
+  // viewport, NOT forward arrow keys — Claude Code / Cursor read those as
+  // input-history navigation (#850). On the scrollback-less alt buffer that is a
+  // no-op, but it is never history nav, and it matches the desktop terminal and
+  // web/terminal.html, which never forward a non-mouse wheel.
   const t = setup({ agentSurface: true, mouseTrackingMode: 'none' });
   t.up();
-  check('no mouse tracking → cursor keys, still not scrollLines', t.sent.join() === '\x1b[A');
-  check('still nothing scrolled locally', t.scrolled.length === 0);
+  check('no mouse tracking → local viewport scroll, not arrow keys', t.scrolled.join() === '-3');
+  check('nothing forwarded to the PTY (no history nav)', t.sent.length === 0);
 }
 
 // There is ONE shared xterm across every tab, and agent surfaces now let the

--- a/docs/adr/0013-terminal-scroll-model.md
+++ b/docs/adr/0013-terminal-scroll-model.md
@@ -58,6 +58,12 @@ Boundary accepted: an extra Manager-session terminal created with an explicit `-
 
 The predicate lives in `CrowCore` because the daemon needs it twice — to set the window option at creation/adopt, and as the `list-terminals` fallback before a window exists — and those two must not drift apart.
 
+### Amendment — #850: forward an agent's wheel ONLY while it is mouse-tracking
+
+The original decision forwarded an agent surface's wheel to the app unconditionally, expecting the app to scroll its own transcript "like a naked terminal." In practice Claude Code and Cursor do **not** enable mouse tracking at their idle prompt, so the forward fell to `sendScrollToPTY`'s cursor-key branch — and the agent read those arrow keys as **input-history navigation**, not scrollback (#850). Every wheel notch stepped through past prompts.
+
+`appOwnsScroll` is refined so a **known agent surface forwards only while it is actively mouse-tracking** (the wheel becomes an SGR wheel button it scrolls its transcript with). At a plain prompt (no tracking) the wheel scrolls xterm's local viewport instead — on the scrollback-less alt buffer a harmless no-op, but never history nav. This is the behavior the desktop terminal and `web/terminal.html` already had (neither forwards a non-mouse wheel), so the amendment brings `app.js` to parity across surfaces. `enableTouchScroll` shares the predicate, so touch-drag matches. The alt-screen model itself is unchanged; only the wheel/touch *routing* on an agent surface is tightened. The cursor-key branch of `sendScrollToPTY` survives solely as the pre-classification alt-buffer fallback for genuine full-screen apps (less/vim).
+
 ## Consequences
 
 **Easier / better**


### PR DESCRIPTION
Closes #850

## Problem
In the web SPA terminal, scrolling the mouse wheel over an agent (Claude Code / Cursor) prompt stepped through **prompt/command history** instead of scrolling the viewport. Touch-drag did the same on mobile.

## Root cause
Per ADR-0013, an agent surface forwards its wheel/touch to the PTY. But Claude Code and Cursor **don't enable mouse tracking at their idle prompt**, so the forward fell to `sendScrollToPTY`'s cursor-key branch — and the agent reads those `↑`/`↓` arrow keys as **input-history navigation**, not scrollback. Every notch walked the prompt history.

This lives **only** in `web/app.js`:
- Desktop `terminal.html` — no custom wheel handler; xterm's default scrolls the local viewport and never emits arrow keys. ✓ already correct
- Web `web/terminal.html` (standalone debug page) — unconditional mouse-mode swallow, no wheel handler → xterm scrolls local. ✓ already correct

## Fix
Refine `appOwnsScroll` so a **known agent surface forwards only while it is actively mouse-tracking** (wheel → SGR wheel button, which scrolls the agent's own transcript). At a plain prompt the wheel/touch scrolls xterm's **local viewport** instead — on the scrollback-less alt buffer a harmless no-op, but **never history nav**. This brings `app.js` to parity with the other two surfaces.

Preserved:
- **Mouse-tracking apps** (fullscreen interactive: an agent scrollable view, vim, htop) still forward SGR wheel buttons — AC "keep viewport scroll as the default in the normal prompt without breaking that case."
- **Anti-stale ordering**: a plain shell visited right after an agent tab never inherits stale `mouseTrackingMode` and forwards (ADR-0013).
- The cursor-key branch of `sendScrollToPTY` survives only as the pre-classification alt-buffer fallback for genuine fullscreen apps (less/vim).

`enableTouchScroll` shares the predicate, so touch-drag matches the wheel.

## Acceptance criteria
- [x] Mouse wheel over an agent terminal scrolls the viewport, not history (both directions).
- [x] Touch-drag scrolls the viewport, not history.
- [x] Consistent across Claude/Cursor and desktop + web front-ends (app.js now matches the other two surfaces).
- [x] Wheel-as-arrow-key kept for genuine full-screen apps (mouse-tracking / pre-classification alt buffer); viewport scroll is the default at the normal prompt.

## Docs
ADR-0013 amended with a "#850" note (alt-screen model unchanged; only the wheel/touch routing on an agent surface is tightened).

## Test plan
- `web-tests` (jsdom, drives the real `app.js`): `wheel-scroll` 50/50, `touch-scroll` 26/26 — updated/extended so a non-mouse-tracking agent surface asserts **local viewport scroll (no arrow keys)**, and the mouse-tracking + anti-stale-shell cases still hold.
- `swift test --filter WebTerminalAssetTests` — 5/5 pass (routing-shape assertions updated).
- `row.test.js`'s 8 failures are pre-existing (jsdom glyph rendering, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)