### PR TITLE
Gate agent_kind against the registry on every session-creation surface

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift
@@ -27,6 +27,22 @@ public final class AgentRegistry: @unchecked Sendable {
         return agents[kind]
     }
 
+    /// The single registry gate for a caller-supplied `AgentKind` (CROW-593; #834).
+    ///
+    /// Returns `requested` only when an agent is actually registered for it;
+    /// otherwise `nil`, so the caller falls back to its own configured default.
+    /// Every session-creation surface (new-session and web/daemon
+    /// `create-manager`) funnels a requested kind through here so none can
+    /// persist a session with an unregistered/unknown kind — a persisted-but-
+    /// unlaunchable session (`launchAgent` no-ops on the registry miss) or one
+    /// that silently launches the default instead of the requested harness.
+    /// Composed with each surface's `?? <configured default>` fallback rather
+    /// than falling back itself, so the default choice stays with the caller.
+    public func registeredKind(_ requested: AgentKind?) -> AgentKind? {
+        guard let requested, agent(for: requested) != nil else { return nil }
+        return requested
+    }
+
     /// The agent to use when the caller doesn't specify one. Falls back to
     /// the first-registered agent.
     public var defaultAgent: (any CodingAgent)? {

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentRegistryResolverTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentRegistryResolverTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// #834: `registeredKind` is the single registry gate every session-creation
+// surface (new-session + web/daemon create-manager) funnels a caller-supplied
+// `AgentKind` through, replacing the per-surface asymmetry where only the web
+// `create-manager` (CROW-593) validated. An unregistered/unknown kind or `nil`
+// returns `nil` so the caller falls back to its own configured default.
+//
+// The registered-kind passthrough is asserted at the surface level in
+// CrowEngineTests / CrowDaemonTests, where a real `ClaudeCodeAgent` is
+// registered — CrowCore has no concrete `CodingAgent` to register here.
+
+@Suite("AgentRegistry.registeredKind gate")
+struct AgentRegistryResolverTests {
+
+    @Test func rejectsAnUnregisteredKind() {
+        // A kind value no shipped agent claims — misses even if the process-wide
+        // registry has been populated by another test.
+        let unknown = AgentKind(rawValue: "crow-834-unregistered-resolver")
+        #expect(AgentRegistry.shared.agent(for: unknown) == nil)
+        #expect(AgentRegistry.shared.registeredKind(unknown) == nil)
+    }
+
+    @Test func passesThroughNil() {
+        // No request → no gate decision to make; the caller supplies the default.
+        #expect(AgentRegistry.shared.registeredKind(nil) == nil)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -163,7 +163,11 @@ func makeCommandRouter(
             let requestedAgentKind = params["agent_kind"]?.stringValue
                 .flatMap { $0.isEmpty ? nil : AgentKind(rawValue: $0) }
             return await MainActor.run {
-                let agentKind = requestedAgentKind ?? appState.agentKind(for: .work)
+                // Registry gate (CROW-593; #834), matching the app's new-session
+                // surface: honor the requested kind only if registered, else the
+                // configured default — no unregistered kind persists here either.
+                let agentKind = AgentRegistry.shared.registeredKind(requestedAgentKind)
+                    ?? appState.agentKind(for: .work)
                 let session = Session(name: name, kind: .work, agentKind: agentKind)
                 appState.sessions.append(session)
                 store.mutate { $0.sessions.append(session) }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonAgentKindGateTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonAgentKindGateTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowClaude
+import CrowGit
+import CrowIPC
+import CrowPersistence
+@testable import CrowDaemon
+
+/// #834: the daemon's `new-session` surface must run a requested `agent_kind`
+/// through the same shared registry gate the app's surfaces use — closing the
+/// asymmetry where only the web `create-manager` (CROW-593) validated. An
+/// unregistered kind falls back to the configured default (so the session isn't
+/// persisted with a kind that would leave it unlaunchable); a registered kind
+/// passes through.
+@Suite("daemon new-session agent_kind gate")
+struct DaemonAgentKindGateTests {
+
+    @MainActor
+    private func makeRouter(appState: AppState, store: JSONStore) -> CommandRouter {
+        makeCommandRouter(
+            appState: appState, store: store, git: GitManager(),
+            devRoot: NSTemporaryDirectory(), cockpit: nil)
+    }
+
+    @Test @MainActor func gatesAgentKindAgainstRegistry() async {
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+
+        let appState = AppState()
+        // Configured default is a kind NOT registered here (only Claude is), so
+        // the fallback is distinguishable from the registered passthrough — and
+        // it mirrors the web gate: only the *requested* kind is validated, the
+        // configured default is trusted as-is (CROW-593).
+        appState.defaultAgentKind = .codex
+        let store = JSONStore.temporary()
+        let router = makeRouter(appState: appState, store: store)
+
+        func createSession(agentKind: String) async -> JSONRPCResponse {
+            await router.handle(request: JSONRPCRequest(id: 1, method: "new-session", params: [
+                "name": .string("s"), "agent_kind": .string(agentKind),
+            ]))
+        }
+
+        // Registered kind (non-default) → honored, proving the gate isn't just
+        // always returning the default.
+        let claude = await createSession(agentKind: AgentKind.claudeCode.rawValue)
+        #expect(claude.error == nil)
+        #expect(claude.result?["agent_kind"]?.stringValue == AgentKind.claudeCode.rawValue)
+
+        // Unregistered kind → falls back to the configured default.
+        let unknown = await createSession(agentKind: "crow-834-unregistered-daemon")
+        #expect(unknown.error == nil)
+        #expect(unknown.result?["agent_kind"]?.stringValue == AgentKind.codex.rawValue)
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -125,7 +125,13 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         let createdName = capturedAppState.sessions.first(where: { $0.id == id })?.name ?? name
                         return ["session_id": .string(id.uuidString), "name": .string(createdName)]
                     }
-                    let agentKind = requestedAgentKind ?? capturedAppState.agentKind(for: .work)
+                    // Registry gate (CROW-593; #834): honor the requested kind
+                    // only if an agent is registered for it, else fall back to
+                    // the configured default — so this surface can't persist a
+                    // session with an unregistered kind that `launchAgent` would
+                    // then silently no-op on.
+                    let agentKind = AgentRegistry.shared.registeredKind(requestedAgentKind)
+                        ?? capturedAppState.agentKind(for: .work)
                     let session = Session(name: name, kind: .work, agentKind: agentKind)
                     capturedAppState.sessions.append(session)
                     capturedStore.mutate { $0.sessions.append(session) }
@@ -435,9 +441,10 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // registered in AgentRegistry, so a web/daemon caller can't
                 // request an arbitrary agent. An unknown/unavailable kind falls
                 // back to the configured default (launch is additionally gated
-                // in managerCommand's AgentRegistry fallback).
+                // in managerCommand's AgentRegistry fallback). Shared with the
+                // other creation surfaces via `registeredKind` (#834).
                 let requested = params["agent_kind"]?.stringValue.flatMap { AgentKind(rawValue: $0) }
-                let agent = requested.flatMap { AgentRegistry.shared.agent(for: $0) != nil ? $0 : nil }
+                let agent = AgentRegistry.shared.registeredKind(requested)
                 await MainActor.run { capturedAppState.onCreateManager?(agent) }
                 return ["ok": .bool(true)]
             },

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1681,10 +1681,18 @@ public final class SessionService {
     }
 
     /// Resolve the agent for a new Manager session: an explicit per-session
-    /// choice wins, otherwise the configured default
-    /// (`agentsByKind["manager"] ?? defaultAgentKind`). Never mutates config.
+    /// choice wins **when an agent is registered for it**, otherwise the
+    /// configured default (`agentsByKind["manager"] ?? defaultAgentKind`).
+    /// Never mutates config.
+    ///
+    /// The single choke point both `create-manager` surfaces funnel through —
+    /// the web RPC (forwarded to `onCreateManager` → `createManagerSession`) and
+    /// the daemon RPC (`createManagerSession` directly). Routing the registry
+    /// gate here (CROW-593; #834, via `AgentRegistry.registeredKind`) keeps the
+    /// two symmetric — neither can persist a Manager with an unregistered kind
+    /// that `managerCommand` would then silently launch as the default.
     func resolvedManagerAgentKind(_ explicit: AgentKind?) -> AgentKind {
-        explicit ?? appState.agentKind(for: .manager)
+        AgentRegistry.shared.registeredKind(explicit) ?? appState.agentKind(for: .manager)
     }
 
     // MARK: - Delete Session

--- a/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/EngineRouterSmokeTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowClaude
+import CrowCursor
 import CrowPersistence
 import CrowIPC
 @testable import CrowEngine
@@ -190,5 +192,54 @@ struct EngineRouterSmokeTests {
         let mgr = await handle(["session_id": .string(manager.id.uuidString), "goal": .string("x")])
         #expect(mgr.error != nil)
         #expect(appState.sessions.first(where: { $0.id == manager.id })?.orgGoal == nil)
+    }
+
+    /// #834: the app's `new-session` surface must run a requested `agent_kind`
+    /// through the shared registry gate — an unregistered kind falls back to the
+    /// configured default (not persisted verbatim, which would leave the session
+    /// unlaunchable), while a registered non-default kind passes through.
+    @Test("new-session gates agent_kind against the registry")
+    func newSessionGatesAgentKindAgainstRegistry() async throws {
+        // Two agents registered; the app default is Claude Code (AppState default).
+        AgentRegistry.shared.register(ClaudeCodeAgent())
+        AgentRegistry.shared.register(CursorAgent())
+        #expect(AgentRegistry.shared.registeredKind(.cursor) == .cursor)
+
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-engine-smoke-\(UUID().uuidString)")
+        let appState = AppState()
+        appState.defaultAgentKind = .claudeCode
+        let store = JSONStore(directory: tmp)
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+
+        let ctx = EngineContext(
+            appState: appState,
+            store: store,
+            sessionService: service,
+            issueTracker: nil,
+            telemetryPort: nil,
+            devRoot: tmp.path,
+            hostBridge: NoopHostBridge(),
+            loadConfig: { nil },
+            applyConfig: { _ in nil }
+        )
+        let router = makeEngineRouter(ctx)
+
+        func createSession(agentKind: String) async -> JSONRPCResponse {
+            await router.handle(request: JSONRPCRequest(id: 1, method: "new-session", params: [
+                "name": .string("s"), "agent_kind": .string(agentKind),
+            ]))
+        }
+
+        // Unregistered kind → falls back to the configured default, not persisted.
+        let unknown = await createSession(agentKind: "crow-834-unregistered-work")
+        #expect(unknown.error == nil)
+        #expect(unknown.result?["agent_kind"]?.stringValue == AgentKind.claudeCode.rawValue)
+
+        // Registered non-default kind → honored (proves the gate isn't just
+        // always returning the default).
+        let cursor = await createSession(agentKind: AgentKind.cursor.rawValue)
+        #expect(cursor.error == nil)
+        #expect(cursor.result?["agent_kind"]?.stringValue == AgentKind.cursor.rawValue)
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/ManagerMigrationTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/ManagerMigrationTests.swift
@@ -100,9 +100,12 @@ struct ManagerMigrationTests {
         #expect(!cursorCmd.contains("claude"))
     }
 
-    /// #582: the "+" agent picker passes a one-shot `AgentKind` into
+    /// #582 / #834: the "+" agent picker passes a one-shot `AgentKind` into
     /// `createManagerSession`. `resolvedManagerAgentKind` must prefer that
-    /// explicit choice over the configured Manager default.
+    /// explicit choice over the configured Manager default — but only when an
+    /// agent is registered for it (the CROW-593 gate, now shared across every
+    /// creation surface). This is the single choke point both `create-manager`
+    /// RPC surfaces (web + daemon) funnel through.
     @MainActor
     @Test
     func resolvedManagerAgentKindPrefersExplicitOverride() {
@@ -113,11 +116,24 @@ struct ManagerMigrationTests {
         appState.agentsByKind = ["manager": .claudeCode]
         let service = SessionService(store: JSONStore(directory: tmp), appState: appState)
 
-        // Explicit pick wins over both agentsByKind["manager"] and the default.
+        // Register Cursor so the explicit pick is honored (idempotent under the
+        // process-wide singleton). registeredKind passthrough proven directly.
+        AgentRegistry.shared.register(CursorAgent())
+        #expect(AgentRegistry.shared.registeredKind(.cursor) == .cursor)
+
+        // Explicit *registered* pick wins over both agentsByKind["manager"] and
+        // the default.
         #expect(service.resolvedManagerAgentKind(.cursor) == .cursor)
         // The configured default is left untouched (no config mutation).
         #expect(appState.agentsByKind["manager"] == .claudeCode)
         #expect(appState.defaultAgentKind == .claudeCode)
+
+        // #834: an explicit but *unregistered* kind is rejected by the gate and
+        // falls back to the configured Manager default — a Manager can't be
+        // persisted with a kind that would silently launch as the default.
+        let unregistered = AgentKind(rawValue: "crow-834-unregistered-manager")
+        #expect(AgentRegistry.shared.agent(for: unregistered) == nil)
+        #expect(service.resolvedManagerAgentKind(unregistered) == .claudeCode)
     }
 
     /// #582: with no explicit pick (the RPC / single-agent path passes `nil`),


### PR DESCRIPTION
Closes #834

## Problem

Three session-creation surfaces validated the requested `AgentKind` against `AgentRegistry` inconsistently — only the web `create-manager` ran the CROW-593 security gate:

| Surface | Validated before? |
|---|---|
| New-session (app, `EngineRouter`) | ❌ no check |
| Web `create-manager` (`EngineRouter`) | ✅ CROW-593 gate |
| Daemon `create-manager` (`RPCHandlers`) | ❌ passed straight through |
| Daemon `new-session` (`RPCHandlers`) | ❌ no check *(same bug, not in the ticket table)* |

A session persisted with an unregistered kind isn't code execution, but it either won't launch its agent (`launchAgent` no-ops on the registry miss) or silently launches the default instead of the requested harness.

## Fix

Converge every surface on a single registry-validated resolver:

- **`AgentRegistry.registeredKind(_:)`** — returns the requested kind only when an agent is registered for it, else `nil`, so each caller applies its own `?? <configured default>` fallback. The CROW-593 gate as a reusable primitive.
- Routed through it:
  - App `new-session` — was ungated.
  - Web `create-manager` — inline gate refactored to the primitive (behavior unchanged).
  - Daemon `new-session` — was ungated (fourth instance of the same asymmetry; fixed for symmetry so the two `new-session` surfaces don't diverge).
  - `SessionService.resolvedManagerAgentKind` — the single choke point **both** `create-manager` RPCs (web-forwarded + daemon-local) funnel through, so the daemon `create-manager` is covered without a call-site change.

Fallback semantics match the CROW-593 gate: only the *requested* kind is validated; the configured default is trusted as-is.

## Tests (one per surface)

- `AgentRegistryResolverTests` — the gate rejects an unknown kind and `nil`.
- `EngineRouterSmokeTests.newSessionGatesAgentKindAgainstRegistry` — app `new-session`: unregistered → configured default; registered non-default → honored.
- `DaemonAgentKindGateTests` — daemon `new-session`: same contract.
- `ManagerMigrationTests.resolvedManagerAgentKindPrefersExplicitOverride` — updated to the gated contract (registered explicit wins; unregistered falls back to the configured Manager default). Covers both `create-manager` surfaces via the shared choke point.

All three affected packages green: CrowCore (471), CrowEngine (343), CrowDaemon (151).

## Notes

- ADR 0015 §8 names this as the code follow-up (#834), scoped as code-only — no doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
