### PR TITLE
CrowAntigravity adapter (Tier-2): agy CLI, hooks-based state, resume (#860)

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           bash scripts/generate-build-info.sh
           LINUX_PACKAGES=(CrowCore CrowIPC CrowClaude CrowCodex CrowCursor \
-                          CrowGit CrowOpenCode CrowPersistence CrowProvider CrowCLI)
+                          CrowAntigravity CrowGit CrowOpenCode CrowPersistence CrowProvider CrowCLI)
           for pkg in "${LINUX_PACKAGES[@]}"; do
             echo "==> Building $pkg on Linux..."
             swift build --package-path "Packages/$pkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build & test Linux packages
         run: |
           LINUX_PACKAGES=(CrowCore CrowIPC CrowClaude CrowCodex CrowCursor \
-                          CrowGit CrowOpenCode CrowPersistence CrowProvider CrowCLI)
+                          CrowAntigravity CrowGit CrowOpenCode CrowPersistence CrowProvider CrowCLI)
           for pkg in "${LINUX_PACKAGES[@]}"; do
             echo "==> Building & testing $pkg on Linux..."
             swift build --package-path "Packages/$pkg"

--- a/Packages/CrowAntigravity/Package.swift
+++ b/Packages/CrowAntigravity/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CrowAntigravity",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "CrowAntigravity", targets: ["CrowAntigravity"]),
+    ],
+    dependencies: [
+        .package(path: "../CrowCore"),
+    ],
+    targets: [
+        .target(name: "CrowAntigravity", dependencies: ["CrowCore"]),
+        .testTarget(name: "CrowAntigravityTests", dependencies: ["CrowAntigravity"]),
+    ]
+)

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -106,10 +106,12 @@ public struct AntigravityAgent: CodingAgent {
             }
             return "\(agentPath)\(autoArgs) -c\n"
         case .review:
-            // Review-on-Antigravity is unsupported in Phase A — like Codex, the
-            // `/crow-review-pr` flow isn't wired for this harness. Returning nil
-            // makes Crow log the skip rather than dispatch a review it can't
-            // satisfy (no posted-verdict path). A documented Tier-2 gap.
+            // Review-on-Antigravity is unsupported in Phase A: the
+            // `/crow-review-pr` flow isn't wired for this harness yet. Returning
+            // nil makes Crow log the skip rather than dispatch a review it can't
+            // satisfy (no posted-verdict path). A documented Tier-2 gap — unlike
+            // Codex/Cursor/OpenCode, which inline the skill body, Antigravity has
+            // no review dispatch until a follow-up wires one.
             return nil
         case .manager:
             // Manager sessions never auto-launch an agent — Crow drives them

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -1,0 +1,170 @@
+import Foundation
+import CrowCore
+
+/// `CodingAgent` conformer for Google Antigravity's CLI (binary `agy`) — the
+/// terminal surface of Google's agent-first dev platform (Gemini 3). **Tier-2 /
+/// experimental** (ADR 0015): a real, driveable CLI, but it lands below the
+/// self-hostable harnesses and ships with honest, documented gaps (#860).
+///
+/// Structurally a near-clone of `CursorAgent`: hooks are Claude-Code-style, so
+/// the `HookConfigWriter` / `StateSignalSource` pair does real work (not a
+/// `cwd`-scoped fallback); remote control is faked via `crow send` typing into
+/// the interactive TUI (no native RC protocol); `.review` is unsupported in
+/// Phase A (like Codex). What Antigravity *can't* do is self-host — the CLI is
+/// closed-source and Google-Sign-In/GCP-authed, so it runs only against Google's
+/// cloud models (Gemini 3 Pro default, Claude Sonnet 4.5). That fails Corveil's
+/// self-host axis and is a **permanent** gap, not a phase.
+public struct AntigravityAgent: CodingAgent {
+    public let kind: AgentKind = .antigravity
+    public let displayName: String = "Antigravity"
+    /// Thematically "anti-gravity" (up), and visually distinct from Claude's
+    /// `"sparkles"`, Cursor's `"cursorarrow.rays"`, and Codex's `"terminal.fill"`.
+    public let iconSystemName: String = "arrow.up.circle"
+    /// `true`, but faked: Antigravity has no `--rc`/`--name` protocol, so remote
+    /// driving is `crow send` typing into the interactive TUI (the agent-agnostic
+    /// stdin path). The badge reflects that Crow *can* drive it, not a native RC
+    /// surface — same as Cursor/OpenCode.
+    public let supportsRemoteControl: Bool = true
+    /// Antigravity's CLI binary is `agy` (not `antigravity`) — low collision risk.
+    public let launchCommandToken: String = "agy"
+    public let hookConfigWriter: any HookConfigWriter
+    public let stateSignalSource: any StateSignalSource
+
+    private let launcher: AntigravityLauncher
+
+    /// Last-resort search paths for `agy`, checked only when a
+    /// `defaults.binaries.antigravity` override and a PATH walk both miss.
+    ///
+    /// ⚠️ **Supply-chain gate (#860).** These are conservative *standard-bin*
+    /// locations any well-behaved installer targets, pinned to the **official**
+    /// distribution (`antigravity.google`'s installer, which puts `agy` on PATH).
+    /// They are deliberately **NOT** wired to the community
+    /// `google-antigravity/*` GitHub org: that org is `is_verified: false`
+    /// (confirmed via `gh api orgs/google-antigravity`), is not one of Google's
+    /// canonical orgs (`google`, `google-gemini`), and its `antigravity-cli`
+    /// repo is README-only (no source, no license) — a mirror/tracker, not a
+    /// provenance you'd resolve a binary from. PATH resolution is the primary
+    /// mechanism (it picks up whatever the official installer placed); this list
+    /// only covers an unusually narrow PATH. The exact official install path
+    /// must be confirmed before Antigravity is promoted out of Tier-2 — until
+    /// then, off-PATH `agy` simply leaves the adapter unregistered (ADR 0014),
+    /// which is the safe default.
+    public let fallbackCandidates: [String] = [
+        "/opt/homebrew/bin/agy",
+        "/usr/local/bin/agy",
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin/agy").path,
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".antigravity/bin/agy").path,
+    ]
+
+    public init(
+        hookConfigWriter: any HookConfigWriter = AntigravityHookConfigWriter(),
+        stateSignalSource: any StateSignalSource = AntigravitySignalSource()
+    ) {
+        self.hookConfigWriter = hookConfigWriter
+        self.stateSignalSource = stateSignalSource
+        self.launcher = AntigravityLauncher()
+    }
+
+    public func autoLaunchCommand(
+        session: Session,
+        worktreePath: String,
+        remoteControlEnabled: Bool,
+        autoPermissionMode: Bool,
+        telemetryPort: UInt16?
+    ) -> String? {
+        let agentPath = AntigravityLaunchArgs.shellQuote(findBinary() ?? "agy")
+        // Bounded auto-permission — a no-op suffix on the pinned version (see
+        // `AntigravityLaunchArgs.autoPermissionSuffix`); kept for call-site
+        // uniformity so a future bounded flag lands once for every path.
+        let autoArgs = AntigravityLaunchArgs.autoPermissionSuffix(autoPermissionMode)
+
+        switch session.kind {
+        case .work:
+            // Interactive TUI — the user types their prompt. No prompt injection,
+            // no resume flag (a fresh work TUI launching bare is deliberate), no
+            // RC flag (remote control is `crow send` into the TUI).
+            return "\(agentPath)\(autoArgs)\n"
+        case .job:
+            // Unattended dispatch: feed the pre-written `.crow-job-prompt.md` as
+            // the initial prompt via `-p` on first launch. Crow runs `agy` inside
+            // a tmux window — a real PTY — so the non-TTY `-p` stdout-drop
+            // (headless *pipe* case, upstream FRs #119/#597) doesn't apply here;
+            // no PTY shim is needed on this path.
+            //
+            // On restart we resume with `-c` (continue most-recent conversation).
+            // Caveat (documented Tier-2 gap): `-c` is machine-global "most recent"
+            // and `--print` never surfaces the conversation id (upstream FR #7),
+            // so we can't capture a specific handle — in a per-worktree tmux
+            // window the most-recent conversation is almost always this session's,
+            // the same heuristic Cursor/OpenCode rely on.
+            if !session.reviewPromptDispatched {
+                let promptPath = (worktreePath as NSString)
+                    .appendingPathComponent(".crow-job-prompt.md")
+                // Quote the path so a devRoot containing spaces doesn't split
+                // `cat`'s argv and resolve the prompt to empty.
+                return "\(agentPath)\(autoArgs) -p \"$(cat \(AntigravityLaunchArgs.shellQuote(promptPath)))\"\n"
+            }
+            return "\(agentPath)\(autoArgs) -c\n"
+        case .review:
+            // Review-on-Antigravity is unsupported in Phase A — like Codex, the
+            // `/crow-review-pr` flow isn't wired for this harness. Returning nil
+            // makes Crow log the skip rather than dispatch a review it can't
+            // satisfy (no posted-verdict path). A documented Tier-2 gap.
+            return nil
+        case .manager:
+            // Manager sessions never auto-launch an agent — Crow drives them
+            // externally. Returning nil is the contract, not a gap.
+            return nil
+        }
+    }
+
+    public func generatePrompt(
+        session: Session,
+        worktrees: [SessionWorktree],
+        ticketURL: String?,
+        provider: Provider?,
+        codeProvider: Provider?
+    ) async -> String {
+        await launcher.generatePrompt(
+            session: session,
+            worktrees: worktrees,
+            ticketURL: ticketURL,
+            provider: provider,
+            codeProvider: codeProvider
+        )
+    }
+
+    public func launchCommand(
+        sessionID: UUID,
+        worktreePath: String,
+        prompt: String
+    ) async throws -> String {
+        try await launcher.launchCommand(
+            sessionID: sessionID,
+            worktreePath: worktreePath,
+            prompt: prompt,
+            binary: findBinary() ?? "agy"
+        )
+    }
+
+    public func managerLaunchCommand(
+        sessionName: String,
+        remoteControlEnabled: Bool,
+        autoPermissionMode: Bool,
+        telemetryPort: UInt16?
+    ) -> String {
+        // Antigravity's Manager is an orchestration TUI in the devRoot — no
+        // auto-prompt, no resume. No `--rc`/`--name` equivalent, so remote
+        // control doesn't apply. Terminal backend appends the submitting Enter,
+        // so return the command without a trailing newline (cross-agent
+        // convention).
+        let agentPath = AntigravityLaunchArgs.shellQuote(findBinary() ?? "agy")
+        return agentPath + AntigravityLaunchArgs.autoPermissionSuffix(autoPermissionMode)
+    }
+
+    // `sessionRenameSlashCommand` is intentionally NOT overridden: `agy` v1.1.7's
+    // rename surface is unverified, so it inherits the protocol's opt-out `nil`
+    // default rather than risk pasting a stray `/rename` prompt into the model
+    // (CROW-629). A documented Tier-2 gap; override once a rename command is
+    // confirmed.
+}

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
@@ -1,0 +1,338 @@
+import Foundation
+import CrowCore
+
+/// Writes Google Antigravity's per-worktree hook configuration into
+/// `<worktree>/.agents/hooks.json`, with the Crow session UUID baked into every
+/// command (`hook-event --session <uuid> --agent antigravity`). Structurally a
+/// near-clone of `CursorHookConfigWriter` — one config per session directory,
+/// no global config, per-session **UUID** resolution — because Antigravity's
+/// hooks are Claude-Code-style (JSON on stdin, reply on stdout, exit-code
+/// semantics, the `PreToolUse`/`PostToolUse` tool vocabulary), which is what
+/// lets the `HookConfigWriter` / `StateSignalSource` pair work rather than being
+/// a `cwd`-scoped fallback (#860).
+///
+/// **Why per-worktree with UUID, not global `~/.gemini/config/`.** Antigravity
+/// reads hooks from both the global `~/.gemini/config/hooks.json` and the
+/// workspace `.agents/hooks.json`; if it merges and runs both (as Cursor does),
+/// a surviving global config would double-fire every event. Per-worktree-only
+/// sidesteps that, bakes the session UUID into the command (so the server never
+/// guesses the session from `cwd` — which the Manager, running in the un-worktree
+/// devRoot, defeats), and `LaunchScaffold` calls `removeManagedGlobalConfig` to
+/// migrate users off any global config a prior Crow installed.
+///
+/// **`.agents/hooks.json` is a shared workspace file.** Like Cursor's
+/// `.cursor/hooks.json` (and unlike Claude's gitignored, local-only
+/// `.claude/settings.local.json`), a user may already track a committed
+/// `.agents/hooks.json`. So this writer inherits Cursor's guarantees verbatim:
+/// group-level Crow-marker preservation (a user's own hook for the same event is
+/// never clobbered), an untracked file is git-excluded so it isn't committed,
+/// and if the repo already **commits** `.agents/hooks.json` the write is skipped
+/// entirely (logged) rather than poison the shared repo with a machine-local
+/// crow path + dead session UUID.
+///
+/// The JSON shape is Claude-Code-style (PascalCase event keys, no top-level
+/// `version`): `{"hooks": {"PreToolUse": [{"hooks": [{type,command,…}]}], …}}`.
+public struct AntigravityHookConfigWriter: HookConfigWriter {
+
+    /// The lifecycle events documented for `agy` v1.1.7 that Crow observes,
+    /// mapped 1:1 to their Crow-canonical (= native, PascalCase) event name.
+    /// `PreInvocation`/`PostInvocation` are Antigravity's turn-boundary hooks
+    /// (Claude's `UserPromptSubmit`/`SessionStart` analogue); `Stop` carries
+    /// `fullyIdle` and is the authoritative done signal (see
+    /// `AntigravitySignalSource`).
+    static let events: [String] = [
+        "PreInvocation",
+        "PostInvocation",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+    ]
+
+    /// Post-execution events safe to run async (fire-and-forget). `Stop` stays
+    /// synchronous because its state-transition timing drives the UI;
+    /// `PreToolUse`/`PreInvocation` stay sync so they arrive in order.
+    private static let asyncEvents: Set<String> = ["PostToolUse", "PostInvocation"]
+
+    public init() {}
+
+    // MARK: - Hook generation
+
+    /// One Crow hook group (`{"hooks": [{command…}]}`) for `event`, with the
+    /// session UUID baked into the command.
+    static func crowGroup(sessionID: UUID, event: String, crowPath: String) -> [String: Any] {
+        // Antigravity runs this string through a shell, so quote the crow path —
+        // `findCrowBinary` prefers `{devRoot}/.claude/bin/crow` and devRoot is
+        // user-chosen (`/Users/x/My Projects/…` would otherwise split the command
+        // and silently stop every hook from firing).
+        let command = "\(AntigravityLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent antigravity --event \(event)"
+        var entry: [String: Any] = [
+            "type": "command",
+            "command": command,
+            "timeout": 5,
+        ]
+        if asyncEvents.contains(event) {
+            entry["async"] = true
+        }
+        return ["hooks": [entry]]
+    }
+
+    // MARK: - HookConfigWriter conformance
+
+    /// Write `<worktreePath>/.agents/hooks.json`. For each managed event we drop
+    /// any prior Crow group (keeps re-runs idempotent) and append a fresh one,
+    /// leaving the user's own groups — and every unmanaged event — untouched.
+    /// Git-excludes the file.
+    public func writeHookConfig(
+        worktreePath: String,
+        sessionID: UUID,
+        crowPath: String
+    ) throws {
+        let agentsDir = (worktreePath as NSString).appendingPathComponent(".agents")
+        let hooksPath = (agentsDir as NSString).appendingPathComponent("hooks.json")
+
+        // If the repo *tracks* `.agents/hooks.json`, refuse to write into it.
+        // `.git/info/exclude` has no effect on already-tracked files, so an
+        // unattended `.job` doing `git add -A` would commit Crow's absolute
+        // crow-path + dead session UUID into the shared repo, breaking every
+        // teammate's tool calls. Better to lose state detection for this one
+        // worktree than to poison the repo. Checked unconditionally (not gated on
+        // the file existing) so a tracked-but-`rm`'d file is still caught.
+        if Self.isGitTracked(worktreePath: worktreePath, relativePath: ".agents/hooks.json") {
+            NSLog("[AntigravityHookConfigWriter] %@/.agents/hooks.json is git-tracked; not writing Crow's session hooks into a committed file. Gitignore/untrack it to enable hook-based state detection for this worktree.", worktreePath)
+            return
+        }
+
+        try FileManager.default.createDirectory(atPath: agentsDir, withIntermediateDirectories: true)
+
+        // If the file EXISTS but doesn't parse (a torn concurrent write, a
+        // hand-edit with a syntax error), bail rather than start from `[:]` and
+        // overwrite the user's own hook groups.
+        var root: [String: Any] = [:]
+        if let data = FileManager.default.contents(atPath: hooksPath) {
+            guard let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                NSLog("[AntigravityHookConfigWriter] %@ exists but is unparseable; leaving it untouched (would otherwise drop the user's own hook groups)", hooksPath)
+                return
+            }
+            root = parsed
+        }
+
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+        for event in Self.events {
+            var groups = hooks[event] as? [[String: Any]] ?? []
+            groups.removeAll { Self.groupIsCrowManaged($0) }
+            groups.append(Self.crowGroup(sessionID: sessionID, event: event, crowPath: crowPath))
+            hooks[event] = groups
+        }
+        root["hooks"] = hooks
+
+        let data = try JSONSerialization.data(
+            withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        // Atomic (temp + rename): a crash mid-write would otherwise leave a
+        // truncated file that the unparseable-guard then refuses to touch,
+        // silently disabling this worktree's hook-based state detection forever.
+        try data.write(to: URL(fileURLWithPath: hooksPath), options: [.atomic])
+
+        // Keep the session-specific config out of commits (works for any repo,
+        // not just ones that gitignore `.agents/hooks.json`). One-way by design:
+        // the pattern is a repo-level ignore rule shared by every worktree, so
+        // `removeHookConfig` must NOT pull it back out — a sibling worktree's
+        // still-live session would otherwise lose the protection.
+        Self.ensureGitExcluded(worktreePath: worktreePath, pattern: ".agents/hooks.json")
+    }
+
+    /// Remove Crow's hook groups from a worktree's `.agents/hooks.json`,
+    /// preserving a user's own groups (and unmanaged events). Deletes the file
+    /// when nothing meaningful would remain.
+    public func removeHookConfig(worktreePath: String) {
+        let hooksPath = (worktreePath as NSString)
+            .appendingPathComponent(".agents/hooks.json")
+        Self.stripCrowGroups(at: hooksPath)
+    }
+
+    // MARK: - Global-config migration
+
+    /// Strip Crow's hook groups from the **global** `<geminiConfigHome>/hooks.json`
+    /// a prior Crow (or a future scope change) may have installed. Per-worktree
+    /// configs are the authority; because Antigravity may merge global + workspace
+    /// and run both, a surviving global config would double-fire every event.
+    /// Only Crow's groups are removed — a user's own hooks survive. `geminiConfigHome`
+    /// is typically `~/.gemini/config`.
+    public static func removeManagedGlobalConfig(geminiConfigHome: String) {
+        let hooksPath = (geminiConfigHome as NSString).appendingPathComponent("hooks.json")
+        stripCrowGroups(at: hooksPath)
+    }
+
+    // MARK: - Group-level helpers
+
+    /// Remove every Crow group from each managed event in `hooksPath`, preserving
+    /// user groups; drop an event key that ends up empty and the whole file when
+    /// only unmanaged scaffold remains. No-op when the file is absent,
+    /// unparseable, or already Crow-free.
+    private static func stripCrowGroups(at hooksPath: String) {
+        guard let data = FileManager.default.contents(atPath: hooksPath),
+              var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var hooks = root["hooks"] as? [String: Any] else {
+            return
+        }
+
+        var changed = false
+        for event in events {
+            guard var groups = hooks[event] as? [[String: Any]] else { continue }
+            let before = groups.count
+            groups.removeAll { groupIsCrowManaged($0) }
+            if groups.count == before { continue }
+            changed = true
+            if groups.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = groups
+            }
+        }
+        guard changed else { return }
+
+        if hooks.isEmpty {
+            root.removeValue(forKey: "hooks")
+        } else {
+            root["hooks"] = hooks
+        }
+
+        // Nothing meaningful left — remove the file rather than leave a husk.
+        if root.isEmpty {
+            try? FileManager.default.removeItem(atPath: hooksPath)
+            return
+        }
+        do {
+            let out = try JSONSerialization.data(
+                withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            try out.write(to: URL(fileURLWithPath: hooksPath), options: [.atomic])
+        } catch {
+            NSLog("[AntigravityHookConfigWriter] Failed to rewrite %@: %@",
+                  hooksPath, error.localizedDescription)
+        }
+    }
+
+    /// Whether a hook group (`{"hooks": [{command…}]}`) is one Crow installed —
+    /// its command shells `crow hook-event … --agent antigravity`. A user's own
+    /// command for the same event won't carry both tokens.
+    private static func groupIsCrowManaged(_ group: [String: Any]) -> Bool {
+        guard let inner = group["hooks"] as? [[String: Any]] else { return false }
+        for entry in inner {
+            guard let command = entry["command"] as? String else { continue }
+            if command.contains("hook-event") && command.contains("--agent antigravity") {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Git-tracked probe (mirrors CursorHookConfigWriter)
+
+    /// Cache of `(worktreePath, relativePath) → tracked?`, probed at most once per
+    /// process. Guarded by `trackedCacheLock`.
+    private nonisolated(unsafe) static var trackedCache: [String: Bool] = [:]
+    private static let trackedCacheLock = NSLock()
+
+    /// Best-effort: whether `relativePath` is tracked in the worktree's git index
+    /// (`git ls-files --error-unmatch`). Returns false on any error (no git, not a
+    /// repo, untracked) — the safe default is "untracked", so a normal worktree
+    /// still gets its hooks written. Bounded by a short timeout; cached per
+    /// (worktree, path).
+    private static func isGitTracked(worktreePath: String, relativePath: String) -> Bool {
+        let cacheKey = worktreePath + "\u{0}" + relativePath
+        trackedCacheLock.lock()
+        if let cached = trackedCache[cacheKey] {
+            trackedCacheLock.unlock()
+            return cached
+        }
+        trackedCacheLock.unlock()
+
+        let result = probeGitTracked(worktreePath: worktreePath, relativePath: relativePath)
+
+        trackedCacheLock.lock()
+        trackedCache[cacheKey] = result
+        trackedCacheLock.unlock()
+        return result
+    }
+
+    /// Reset the tracked-ness cache (tests only).
+    static func resetTrackedCacheForTesting() {
+        trackedCacheLock.lock()
+        trackedCache.removeAll()
+        trackedCacheLock.unlock()
+    }
+
+    private static func probeGitTracked(worktreePath: String, relativePath: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", worktreePath, "ls-files", "--error-unmatch", relativePath]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let done = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in done.signal() }
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        if done.wait(timeout: .now() + 3) == .timedOut {
+            process.terminate()
+            return false
+        }
+        return process.terminationStatus == 0
+    }
+
+    // MARK: - Git exclude (mirrors CursorHookConfigWriter)
+
+    /// Best-effort: ensure `pattern` is listed in the worktree's git
+    /// `info/exclude` so Crow's runtime config isn't committed. Handles both a
+    /// normal `.git` directory and a linked-worktree `.git` file. Silent on any
+    /// failure — the config still works, it just isn't excluded.
+    static func ensureGitExcluded(worktreePath: String, pattern: String) {
+        guard let excludePath = gitInfoExcludePath(worktreePath: worktreePath) else { return }
+        let existing = (try? String(contentsOfFile: excludePath, encoding: .utf8)) ?? ""
+        let alreadyListed = existing
+            .split(separator: "\n")
+            .contains { $0.trimmingCharacters(in: .whitespaces) == pattern }
+        if alreadyListed { return }
+
+        var updated = existing
+        if !updated.isEmpty && !updated.hasSuffix("\n") { updated += "\n" }
+        updated += pattern + "\n"
+        try? FileManager.default.createDirectory(
+            atPath: (excludePath as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true)
+        try? updated.write(toFile: excludePath, atomically: true, encoding: .utf8)
+    }
+
+    /// Resolve the git `info/exclude` path for a worktree, or `nil` when the
+    /// directory isn't a git checkout / can't be resolved.
+    private static func gitInfoExcludePath(worktreePath: String) -> String? {
+        let fm = FileManager.default
+        let dotGit = (worktreePath as NSString).appendingPathComponent(".git")
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: dotGit, isDirectory: &isDir) else { return nil }
+        if isDir.boolValue {
+            return (dotGit as NSString).appendingPathComponent("info/exclude")
+        }
+        // Linked worktree: `.git` is a file `gitdir: <path>`.
+        guard let raw = try? String(contentsOfFile: dotGit, encoding: .utf8) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("gitdir:") else { return nil }
+        var gitDir = String(trimmed.dropFirst("gitdir:".count)).trimmingCharacters(in: .whitespaces)
+        if !(gitDir as NSString).isAbsolutePath {
+            gitDir = (worktreePath as NSString).appendingPathComponent(gitDir)
+        }
+        gitDir = (gitDir as NSString).standardizingPath
+        // The `info/exclude` in the *common* dir applies to all worktrees.
+        let commonDirFile = (gitDir as NSString).appendingPathComponent("commondir")
+        if let common = try? String(contentsOfFile: commonDirFile, encoding: .utf8) {
+            var commonPath = common.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !(commonPath as NSString).isAbsolutePath {
+                commonPath = (gitDir as NSString).appendingPathComponent(commonPath)
+            }
+            return ((commonPath as NSString).standardizingPath as NSString)
+                .appendingPathComponent("info/exclude")
+        }
+        return (gitDir as NSString).appendingPathComponent("info/exclude")
+    }
+}

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
@@ -3,85 +3,115 @@ import CrowCore
 
 /// Writes Google Antigravity's per-worktree hook configuration into
 /// `<worktree>/.agents/hooks.json`, with the Crow session UUID baked into every
-/// command (`hook-event --session <uuid> --agent antigravity`). Structurally a
-/// near-clone of `CursorHookConfigWriter` — one config per session directory,
-/// no global config, per-session **UUID** resolution — because Antigravity's
-/// hooks are Claude-Code-style (JSON on stdin, reply on stdout, exit-code
-/// semantics, the `PreToolUse`/`PostToolUse` tool vocabulary), which is what
-/// lets the `HookConfigWriter` / `StateSignalSource` pair work rather than being
-/// a `cwd`-scoped fallback (#860).
+/// command (`hook-event --session <uuid> --agent antigravity`).
 ///
-/// **Why per-worktree with UUID, not global `~/.gemini/config/`.** Antigravity
-/// reads hooks from both the global `~/.gemini/config/hooks.json` and the
-/// workspace `.agents/hooks.json`; if it merges and runs both (as Cursor does),
-/// a surviving global config would double-fire every event. Per-worktree-only
-/// sidesteps that, bakes the session UUID into the command (so the server never
-/// guesses the session from `cwd` — which the Manager, running in the un-worktree
-/// devRoot, defeats), and `LaunchScaffold` calls `removeManagedGlobalConfig` to
-/// migrate users off any global config a prior Crow installed.
+/// **Schema — Antigravity's own, not Claude's.** Verified against
+/// [`antigravity.google/docs/hooks`](https://antigravity.google/docs/hooks): the
+/// file is a map of **named groups** → event configs, *not* Claude's
+/// `{"hooks": {Event: […]}}`. Crow owns exactly one named group (`"crow"`) and
+/// leaves every other group untouched:
 ///
-/// **`.agents/hooks.json` is a shared workspace file.** Like Cursor's
-/// `.cursor/hooks.json` (and unlike Claude's gitignored, local-only
-/// `.claude/settings.local.json`), a user may already track a committed
-/// `.agents/hooks.json`. So this writer inherits Cursor's guarantees verbatim:
-/// group-level Crow-marker preservation (a user's own hook for the same event is
-/// never clobbered), an untracked file is git-excluded so it isn't committed,
-/// and if the repo already **commits** `.agents/hooks.json` the write is skipped
-/// entirely (logged) rather than poison the shared repo with a machine-local
-/// crow path + dead session UUID.
+/// ```json
+/// {
+///   "crow": {
+///     "PreInvocation":  [ {"type":"command","command":"…","timeout":5} ],
+///     "PostInvocation": [ {"type":"command","command":"…","timeout":5} ],
+///     "PostToolUse":    [ {"matcher":"*","hooks":[{"type":"command","command":"…","timeout":5}]} ],
+///     "Stop":           [ {"type":"command","command":"…","timeout":5} ]
+///   }
+/// }
+/// ```
 ///
-/// The JSON shape is Claude-Code-style (PascalCase event keys, no top-level
-/// `version`): `{"hooks": {"PreToolUse": [{"hooks": [{type,command,…}]}], …}}`.
+/// Tool events (`PostToolUse`) wrap handlers in `{matcher, hooks:[…]}` with the
+/// catch-all `"*"` matcher; invocation/`Stop` events list handlers **directly**
+/// under the event key (matcher ignored). There is **no `async` field** in
+/// Antigravity's handler schema — declaring one risks a parse failure.
+///
+/// **`PreToolUse` is deliberately not registered.** Antigravity's own bundled
+/// plugin (vibe-island) registers `PreInvocation`/`PostInvocation`/`PostToolUse`/
+/// `Stop` and skips `PreToolUse`, because `PreToolUse` demands a strict stdout
+/// verdict (`{"decision":"allow"|"deny"|"ask"|"force_ask"}`) and a mis-shaped
+/// reply denies **every** tool call (see cmux #5358). Crow's hooks are
+/// observational, so we stay off that gate and detect tool activity from
+/// `PostToolUse` (whose reply is a harmless `{}`).
+///
+/// **Every command emits its own stdout verdict.** Antigravity reads the hook's
+/// stdout as JSON. `crow hook-event` is observational and may print a JSON-RPC
+/// error on failure, so each command **suppresses** hook-event's output and then
+/// `printf '{}'`s the empty-object verdict itself — the documented no-op reply
+/// for `PostToolUse`/`PreInvocation`/`PostInvocation`, and a non-`continue` reply
+/// for `Stop` (i.e. "allow the agent to stop"). Using `;` (not `&&`) plus the
+/// trailing `printf` guarantees the verdict is emitted and the hook exits 0 even
+/// when hook-event fails — so a Crow hook can never block a tool or loop the
+/// agent.
+///
+/// **`.agents/hooks.json` is a shared workspace file** (like Cursor's
+/// `.cursor/hooks.json`), so this writer keeps Cursor's protections: a
+/// git-tracked config is left untouched (never poison a committed file), an
+/// untracked one is git-excluded, and a torn/unparseable file is bailed on
+/// rather than clobbered. Crow only ever writes/removes its own `"crow"` group,
+/// so a user's other named groups survive verbatim.
 public struct AntigravityHookConfigWriter: HookConfigWriter {
 
-    /// The lifecycle events documented for `agy` v1.1.7 that Crow observes,
-    /// mapped 1:1 to their Crow-canonical (= native, PascalCase) event name.
-    /// `PreInvocation`/`PostInvocation` are Antigravity's turn-boundary hooks
-    /// (Claude's `UserPromptSubmit`/`SessionStart` analogue); `Stop` carries
-    /// `fullyIdle` and is the authoritative done signal (see
-    /// `AntigravitySignalSource`).
-    static let events: [String] = [
-        "PreInvocation",
-        "PostInvocation",
-        "PreToolUse",
-        "PostToolUse",
-        "Stop",
-    ]
+    /// Crow's named group key. Antigravity's config maps named groups → events;
+    /// Crow owns exactly this one group (a user naming their own group `"crow"`
+    /// is a documented collision — Crow's write wins for that key only).
+    static let groupKey = "crow"
 
-    /// Post-execution events safe to run async (fire-and-forget). `Stop` stays
-    /// synchronous because its state-transition timing drives the UI;
-    /// `PreToolUse`/`PreInvocation` stay sync so they arrive in order.
-    private static let asyncEvents: Set<String> = ["PostToolUse", "PostInvocation"]
+    /// Tool-scoped events — wrapped in `{matcher, hooks:[…]}`. Mirrors
+    /// vibe-island; `PreToolUse` is intentionally excluded (see type doc).
+    static let toolEvents = ["PostToolUse"]
+
+    /// Invocation / stop events — handlers listed directly under the event key
+    /// (no matcher, no `hooks` wrapper).
+    static let directEvents = ["PreInvocation", "PostInvocation", "Stop"]
+
+    /// All events Crow registers (for strip/round-trip helpers).
+    static var allEvents: [String] { toolEvents + directEvents }
 
     public init() {}
 
-    // MARK: - Hook generation
+    // MARK: - Command + group generation
 
-    /// One Crow hook group (`{"hooks": [{command…}]}`) for `event`, with the
-    /// session UUID baked into the command.
-    static func crowGroup(sessionID: UUID, event: String, crowPath: String) -> [String: Any] {
-        // Antigravity runs this string through a shell, so quote the crow path —
-        // `findCrowBinary` prefers `{devRoot}/.claude/bin/crow` and devRoot is
-        // user-chosen (`/Users/x/My Projects/…` would otherwise split the command
-        // and silently stop every hook from firing).
-        let command = "\(AntigravityLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent antigravity --event \(event)"
-        var entry: [String: Any] = [
+    /// The shell command for `event`: forward to `crow hook-event`, suppress its
+    /// output, then emit the `{}` stdout verdict and exit 0.
+    static func crowCommand(sessionID: UUID, event: String, crowPath: String) -> String {
+        // Quote the crow path — devRoot is user-chosen (`/Users/x/My Projects/…`
+        // would otherwise split the command).
+        "\(AntigravityLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent antigravity --event \(event) >/dev/null 2>&1; printf '{}'"
+    }
+
+    /// One `{type, command, timeout}` handler object.
+    private static func handler(sessionID: UUID, event: String, crowPath: String) -> [String: Any] {
+        [
             "type": "command",
-            "command": command,
+            "command": crowCommand(sessionID: sessionID, event: event, crowPath: crowPath),
             "timeout": 5,
         ]
-        if asyncEvents.contains(event) {
-            entry["async"] = true
+    }
+
+    /// Build Crow's `"crow"` group: direct handlers for invocation/Stop events,
+    /// `{matcher:"*", hooks:[…]}` for tool events.
+    static func crowGroup(sessionID: UUID, crowPath: String) -> [String: Any] {
+        var group: [String: Any] = [:]
+        for event in directEvents {
+            group[event] = [handler(sessionID: sessionID, event: event, crowPath: crowPath)]
         }
-        return ["hooks": [entry]]
+        for event in toolEvents {
+            group[event] = [
+                [
+                    "matcher": "*",
+                    "hooks": [handler(sessionID: sessionID, event: event, crowPath: crowPath)],
+                ] as [String: Any]
+            ]
+        }
+        return group
     }
 
     // MARK: - HookConfigWriter conformance
 
-    /// Write `<worktreePath>/.agents/hooks.json`. For each managed event we drop
-    /// any prior Crow group (keeps re-runs idempotent) and append a fresh one,
-    /// leaving the user's own groups — and every unmanaged event — untouched.
-    /// Git-excludes the file.
+    /// Write `<worktreePath>/.agents/hooks.json`, replacing only Crow's `"crow"`
+    /// group and preserving every other named group. Git-excludes the file.
     public func writeHookConfig(
         worktreePath: String,
         sessionID: UUID,
@@ -90,13 +120,12 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
         let agentsDir = (worktreePath as NSString).appendingPathComponent(".agents")
         let hooksPath = (agentsDir as NSString).appendingPathComponent("hooks.json")
 
-        // If the repo *tracks* `.agents/hooks.json`, refuse to write into it.
-        // `.git/info/exclude` has no effect on already-tracked files, so an
-        // unattended `.job` doing `git add -A` would commit Crow's absolute
-        // crow-path + dead session UUID into the shared repo, breaking every
-        // teammate's tool calls. Better to lose state detection for this one
-        // worktree than to poison the repo. Checked unconditionally (not gated on
-        // the file existing) so a tracked-but-`rm`'d file is still caught.
+        // If the repo *tracks* `.agents/hooks.json`, refuse to write into it —
+        // `.git/info/exclude` has no effect on tracked files, so an unattended
+        // `git add -A` would commit Crow's absolute crow-path + dead session UUID
+        // into the shared repo. Better to lose state detection for this one
+        // worktree than poison the repo. Checked unconditionally so a
+        // tracked-but-`rm`'d file is still caught.
         if Self.isGitTracked(worktreePath: worktreePath, relativePath: ".agents/hooks.json") {
             NSLog("[AntigravityHookConfigWriter] %@/.agents/hooks.json is git-tracked; not writing Crow's session hooks into a committed file. Gitignore/untrack it to enable hook-based state detection for this worktree.", worktreePath)
             return
@@ -104,9 +133,8 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
 
         try FileManager.default.createDirectory(atPath: agentsDir, withIntermediateDirectories: true)
 
-        // If the file EXISTS but doesn't parse (a torn concurrent write, a
-        // hand-edit with a syntax error), bail rather than start from `[:]` and
-        // overwrite the user's own hook groups.
+        // If the file EXISTS but doesn't parse (torn write, hand-edit), bail
+        // rather than start from `[:]` and drop the user's other groups.
         var root: [String: Any] = [:]
         if let data = FileManager.default.contents(atPath: hooksPath) {
             guard let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -116,87 +144,55 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
             root = parsed
         }
 
-        var hooks = root["hooks"] as? [String: Any] ?? [:]
-        for event in Self.events {
-            var groups = hooks[event] as? [[String: Any]] ?? []
-            groups.removeAll { Self.groupIsCrowManaged($0) }
-            groups.append(Self.crowGroup(sessionID: sessionID, event: event, crowPath: crowPath))
-            hooks[event] = groups
-        }
-        root["hooks"] = hooks
+        // Own only the `"crow"` group; every other named group is preserved.
+        root[Self.groupKey] = Self.crowGroup(sessionID: sessionID, crowPath: crowPath)
 
         let data = try JSONSerialization.data(
             withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
         // Atomic (temp + rename): a crash mid-write would otherwise leave a
-        // truncated file that the unparseable-guard then refuses to touch,
-        // silently disabling this worktree's hook-based state detection forever.
+        // truncated file the unparseable-guard then refuses to touch, silently
+        // disabling this worktree's hook-based state detection forever.
         try data.write(to: URL(fileURLWithPath: hooksPath), options: [.atomic])
 
-        // Keep the session-specific config out of commits (works for any repo,
-        // not just ones that gitignore `.agents/hooks.json`). One-way by design:
-        // the pattern is a repo-level ignore rule shared by every worktree, so
-        // `removeHookConfig` must NOT pull it back out — a sibling worktree's
-        // still-live session would otherwise lose the protection.
+        // Keep the session-specific config out of commits. One-way by design: the
+        // pattern is a repo-level ignore shared by every worktree, so
+        // `removeHookConfig` must NOT pull it back out.
         Self.ensureGitExcluded(worktreePath: worktreePath, pattern: ".agents/hooks.json")
     }
 
-    /// Remove Crow's hook groups from a worktree's `.agents/hooks.json`,
-    /// preserving a user's own groups (and unmanaged events). Deletes the file
-    /// when nothing meaningful would remain.
+    /// Remove Crow's `"crow"` group from a worktree's `.agents/hooks.json`,
+    /// preserving other groups. Deletes the file when nothing else remains.
     public func removeHookConfig(worktreePath: String) {
         let hooksPath = (worktreePath as NSString)
             .appendingPathComponent(".agents/hooks.json")
-        Self.stripCrowGroups(at: hooksPath)
+        Self.stripCrowGroup(at: hooksPath)
     }
 
     // MARK: - Global-config migration
 
-    /// Strip Crow's hook groups from the **global** `<geminiConfigHome>/hooks.json`
-    /// a prior Crow (or a future scope change) may have installed. Per-worktree
-    /// configs are the authority; because Antigravity may merge global + workspace
-    /// and run both, a surviving global config would double-fire every event.
-    /// Only Crow's groups are removed — a user's own hooks survive. `geminiConfigHome`
-    /// is typically `~/.gemini/config`.
+    /// Strip Crow's `"crow"` group from the **global** `<geminiConfigHome>/hooks.json`
+    /// (typically `~/.gemini/config`). Per-worktree configs are the authority;
+    /// because Antigravity may merge global + workspace and run both, a surviving
+    /// global Crow group would double-fire every event. Only Crow's group is
+    /// removed — a user's other groups survive.
     public static func removeManagedGlobalConfig(geminiConfigHome: String) {
         let hooksPath = (geminiConfigHome as NSString).appendingPathComponent("hooks.json")
-        stripCrowGroups(at: hooksPath)
+        stripCrowGroup(at: hooksPath)
     }
 
-    // MARK: - Group-level helpers
+    // MARK: - Group-level helper
 
-    /// Remove every Crow group from each managed event in `hooksPath`, preserving
-    /// user groups; drop an event key that ends up empty and the whole file when
-    /// only unmanaged scaffold remains. No-op when the file is absent,
+    /// Remove the `"crow"` group from `hooksPath`, preserving user groups; delete
+    /// the file when nothing else remains. No-op when the file is absent,
     /// unparseable, or already Crow-free.
-    private static func stripCrowGroups(at hooksPath: String) {
+    private static func stripCrowGroup(at hooksPath: String) {
         guard let data = FileManager.default.contents(atPath: hooksPath),
               var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              var hooks = root["hooks"] as? [String: Any] else {
+              root[groupKey] != nil else {
             return
         }
+        root.removeValue(forKey: groupKey)
 
-        var changed = false
-        for event in events {
-            guard var groups = hooks[event] as? [[String: Any]] else { continue }
-            let before = groups.count
-            groups.removeAll { groupIsCrowManaged($0) }
-            if groups.count == before { continue }
-            changed = true
-            if groups.isEmpty {
-                hooks.removeValue(forKey: event)
-            } else {
-                hooks[event] = groups
-            }
-        }
-        guard changed else { return }
-
-        if hooks.isEmpty {
-            root.removeValue(forKey: "hooks")
-        } else {
-            root["hooks"] = hooks
-        }
-
-        // Nothing meaningful left — remove the file rather than leave a husk.
         if root.isEmpty {
             try? FileManager.default.removeItem(atPath: hooksPath)
             return
@@ -211,32 +207,11 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
         }
     }
 
-    /// Whether a hook group (`{"hooks": [{command…}]}`) is one Crow installed —
-    /// its command shells `crow hook-event … --agent antigravity`. A user's own
-    /// command for the same event won't carry both tokens.
-    private static func groupIsCrowManaged(_ group: [String: Any]) -> Bool {
-        guard let inner = group["hooks"] as? [[String: Any]] else { return false }
-        for entry in inner {
-            guard let command = entry["command"] as? String else { continue }
-            if command.contains("hook-event") && command.contains("--agent antigravity") {
-                return true
-            }
-        }
-        return false
-    }
-
     // MARK: - Git-tracked probe (mirrors CursorHookConfigWriter)
 
-    /// Cache of `(worktreePath, relativePath) → tracked?`, probed at most once per
-    /// process. Guarded by `trackedCacheLock`.
     private nonisolated(unsafe) static var trackedCache: [String: Bool] = [:]
     private static let trackedCacheLock = NSLock()
 
-    /// Best-effort: whether `relativePath` is tracked in the worktree's git index
-    /// (`git ls-files --error-unmatch`). Returns false on any error (no git, not a
-    /// repo, untracked) — the safe default is "untracked", so a normal worktree
-    /// still gets its hooks written. Bounded by a short timeout; cached per
-    /// (worktree, path).
     private static func isGitTracked(worktreePath: String, relativePath: String) -> Bool {
         let cacheKey = worktreePath + "\u{0}" + relativePath
         trackedCacheLock.lock()
@@ -283,10 +258,6 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
 
     // MARK: - Git exclude (mirrors CursorHookConfigWriter)
 
-    /// Best-effort: ensure `pattern` is listed in the worktree's git
-    /// `info/exclude` so Crow's runtime config isn't committed. Handles both a
-    /// normal `.git` directory and a linked-worktree `.git` file. Silent on any
-    /// failure — the config still works, it just isn't excluded.
     static func ensureGitExcluded(worktreePath: String, pattern: String) {
         guard let excludePath = gitInfoExcludePath(worktreePath: worktreePath) else { return }
         let existing = (try? String(contentsOfFile: excludePath, encoding: .utf8)) ?? ""
@@ -304,8 +275,6 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
         try? updated.write(toFile: excludePath, atomically: true, encoding: .utf8)
     }
 
-    /// Resolve the git `info/exclude` path for a worktree, or `nil` when the
-    /// directory isn't a git checkout / can't be resolved.
     private static func gitInfoExcludePath(worktreePath: String) -> String? {
         let fm = FileManager.default
         let dotGit = (worktreePath as NSString).appendingPathComponent(".git")
@@ -323,7 +292,6 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
             gitDir = (worktreePath as NSString).appendingPathComponent(gitDir)
         }
         gitDir = (gitDir as NSString).standardizingPath
-        // The `info/exclude` in the *common* dir applies to all worktrees.
         let commonDirFile = (gitDir as NSString).appendingPathComponent("commondir")
         if let common = try? String(contentsOfFile: commonDirFile, encoding: .utf8) {
             var commonPath = common.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLaunchArgs.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLaunchArgs.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Helpers for building the argument string appended to an `agy` (Google
+/// Antigravity CLI) invocation. Centralized so `AntigravityAgent`, the
+/// launcher, and tests share one implementation of the flag choices — mirrors
+/// `CursorLaunchArgs` / `OpenCodeLaunchArgs` (#860).
+public enum AntigravityLaunchArgs {
+    /// POSIX single-quote escape for safe interpolation into a shell command line.
+    public static func shellQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Auto-permission flags for unattended `.job` launches. Returns a
+    /// leading-space suffix or `""`.
+    ///
+    /// **Deliberately empty on `agy` v1.1.7 — a documented Tier-2 gap, not an
+    /// oversight (#860).** Antigravity governs approval posture through
+    /// `settings.json` *modes* — `proceed-in-sandbox` (bounded auto-proceed),
+    /// `request-review` (the interactive default), and `strict` — plus the
+    /// full-danger escapes `always-proceed` / `--dangerously-skip-permissions`.
+    /// There is **no verified interactive launch flag** on this pinned version
+    /// that selects the bounded `proceed-in-sandbox` mode without escalating to
+    /// the full-danger bypass, and headless `-p` is separately known to ignore
+    /// `permissions.allow` (upstream issue #548). So rather than assert an
+    /// unverified flag or reach for `--dangerously-skip-permissions` (which we
+    /// **never** pass — it removes the sandbox entirely, the opposite of the
+    /// "bounded" posture the ticket asks for), an unattended `.job` runs under
+    /// whatever mode the user configured in `settings.json`. That means a job
+    /// can still stall at Antigravity's `request-review` gate — the same
+    /// honest, interactive-reliable-only property Codex's `.review` has.
+    ///
+    /// The parameter is kept so every call site (`autoLaunchCommand`,
+    /// `managerLaunchCommand`) has the uniform cross-agent shape; wiring a real
+    /// bounded flag (or seeding `proceed-in-sandbox` into a per-worktree
+    /// `settings.json`) is a version-pinned follow-up if `agy` grows a stable
+    /// interactive selector.
+    public static func autoPermissionSuffix(_ autoPermissionMode: Bool) -> String {
+        // Intentionally a no-op today — see the doc comment above. Kept as a
+        // function (not a dropped parameter) so a future bounded flag lands here
+        // and every caller inherits it at once.
+        _ = autoPermissionMode
+        return ""
+    }
+}

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLauncher.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLauncher.swift
@@ -1,0 +1,95 @@
+import Foundation
+import CrowCore
+
+/// Generates initial prompts for Antigravity (`agy`) sessions and materializes
+/// them for the agent-handoff path. Mirrors `CursorLauncher` / `CodexLauncher`
+/// — plan-first preamble, workspace table, ticket info — with **no** Claude
+/// slash commands and **no** `jira` MCP routing.
+///
+/// Phase A ships no MCP config writer for Antigravity (deferred — file-based
+/// `mcp_config.json` bridge, like `CursorMCPConfigWriter`, is a follow-up), so
+/// the Jira branch instructs `acli` directly, matching Codex/OpenCode. Every
+/// harness can still fetch the ticket; the gap is the MCP transport, not the
+/// fetch (#860).
+public actor AntigravityLauncher {
+    public init() {}
+
+    public func generatePrompt(
+        session: Session,
+        worktrees: [SessionWorktree],
+        ticketURL: String?,
+        provider: Provider?,
+        codeProvider: Provider? = nil
+    ) -> String {
+        var lines: [String] = []
+        lines.append("Before editing anything, sketch a brief plan covering:")
+        lines.append("- The files you'll touch and why")
+        lines.append("- Any migrations or cascading updates")
+        lines.append("- How you'll verify the change")
+        lines.append("Then proceed once the approach is clear.")
+        lines.append("")
+        lines.append("# Workspace Context")
+        lines.append("")
+        lines.append("| Repository | Path | Branch | Description |")
+        lines.append("|------------|------|--------|-------------|")
+
+        for wt in worktrees {
+            lines.append("| \(wt.repoName) | \(wt.worktreePath) | \(wt.branch) | |")
+        }
+
+        if let url = ticketURL {
+            lines.append("")
+            lines.append("## Ticket")
+            lines.append("")
+
+            switch provider {
+            case .github:
+                lines.append("```bash")
+                lines.append("gh issue view \(url) --comments")
+                lines.append("```")
+            case .gitlab:
+                lines.append("```bash")
+                lines.append("glab issue view \(url) --comments")
+                lines.append("```")
+            case .jira:
+                lines.append("")
+                if let key = Validation.jiraKey(from: url) {
+                    // No `jira` MCP bridge for Antigravity in Phase A — instruct
+                    // `acli` directly, like Codex/OpenCode.
+                    lines.append("Fetch this work item with `acli jira workitem view \(key) --fields summary,status,description,comment`.")
+                } else {
+                    lines.append("URL: \(url) — fetch it with `acli jira workitem view <KEY> --fields summary,status,description,comment`.")
+                }
+            case .corveil, nil:
+                lines.append("URL: \(url)")
+            }
+        }
+
+        lines.append("")
+        lines.append("## Instructions")
+        lines.append("1. Study the ticket thoroughly")
+        lines.append("2. Create an implementation plan")
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Write `prompt` to a temp file and return the launch command used by the
+    /// agent-handoff path (`crow handoff-agent --agent antigravity`) to start
+    /// `agy` on that prompt instead of a bare TUI.
+    ///
+    /// `binary` is the resolved `agy` path (`AntigravityAgent.findBinary()`), so
+    /// a `defaults.binaries.antigravity` override is honored and a narrow PATH
+    /// still launches.
+    ///
+    /// Like `CursorLauncher.launchCommand`, this one-shot handoff command feeds
+    /// the prompt only (`-p`); `AntigravityAgent.autoLaunchCommand` owns the
+    /// (re)launch/resume path that follows a handoff.
+    public func launchCommand(sessionID: UUID, worktreePath: String, prompt: String, binary: String = "agy") throws -> String {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let promptPath = tmpDir.appendingPathComponent("crow-antigravity-\(sessionID.uuidString)-prompt.md")
+        try prompt.write(to: promptPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
+        return "cd \(AntigravityLaunchArgs.shellQuote(worktreePath)) && \(AntigravityLaunchArgs.shellQuote(binary)) -p \"$(cat \(AntigravityLaunchArgs.shellQuote(promptPath.path)))\"\n"
+    }
+}

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravitySignalSource.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravitySignalSource.swift
@@ -16,14 +16,18 @@ import CrowCore
 /// (e.g. mapping `error` to a distinct state) is a version-pinned follow-up.
 ///
 /// **Events actually driven by the writer:** `PreInvocation` (turn start →
-/// working), `PostInvocation` (observational), `PostToolUse` (tool activity),
+/// working), `PostInvocation` (observational), `PostToolUse` (working-heartbeat),
 /// `Stop` (done). `PreToolUse` is **not registered** by
 /// `AntigravityHookConfigWriter` (its strict stdout decision gate is unsafe for
-/// an observational hook — see that type), so tool activity is detected on
-/// completion via `PostToolUse` rather than on start. The `PreToolUse` case
-/// below is kept for cross-agent parity / future-proofing, not because the
-/// current writer emits it — same posture as the defensive `PermissionRequest`
-/// case (Antigravity has no awaiting-input hook on v1.1.7).
+/// an observational hook — see that type). One consequence: **named tool
+/// activity is a Tier-2 gap.** Antigravity's `PostToolUse` stdin carries no tool
+/// name (only `stepIdx`/`error`); `toolCall.name` lives on `PreToolUse` alone,
+/// which we don't register — so `PostToolUse` can only signal "a tool ran, still
+/// working", not *which* tool. The `PreToolUse` case below is kept for
+/// cross-agent parity / future-proofing (if a later version is registered with a
+/// hard-coded `{"decision":"allow"}` verdict, tool naming lights up with no code
+/// change) — same posture as the defensive `PermissionRequest` case (Antigravity
+/// has no awaiting-input hook on v1.1.7).
 public struct AntigravitySignalSource: StateSignalSource {
     public init() {}
 
@@ -69,14 +73,16 @@ public struct AntigravitySignalSource: StateSignalSource {
             transition.newActivityState = .working
 
         case "PostToolUse":
-            // Where tool activity is actually detected (since PreToolUse is off).
-            // Records the tool that just ran; state stays whatever PreInvocation
-            // set (working) until Stop — mirrors Cursor's observational
-            // PostToolUse (no activity-state change here).
-            let toolName = event.toolName ?? "unknown"
-            transition.toolActivity = .set(ToolActivity(
-                toolName: toolName, isActive: false
-            ))
+            // A tool finished. Antigravity's PostToolUse stdin carries NO tool
+            // name (only `stepIdx`/`error`) — and PreToolUse (which does carry
+            // `toolCall.name`) is deliberately unregistered — so we can't name
+            // the tool here. Rather than surface a bogus "unknown", treat this as
+            // a working-heartbeat: a tool completed mid-turn, the agent is still
+            // working until `Stop`. Guarded so a stray PostToolUse after Stop
+            // doesn't re-elevate. Named tool activity is a documented Tier-2 gap.
+            if currentLastTopLevelStopAt == nil {
+                transition.newActivityState = .working
+            }
 
         case "Stop":
             transition.newActivityState = .done

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravitySignalSource.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravitySignalSource.swift
@@ -2,30 +2,28 @@ import Foundation
 import CrowCore
 
 /// Translates Google Antigravity (`agy`) hook events into
-/// `AgentStateTransition` values. Antigravity ships Claude-Code-style hooks —
-/// JSON on stdin, reply on stdout, the same `PreToolUse`/`PostToolUse` tool
-/// vocabulary — so this state machine is a near-clone of
-/// `ClaudeHookSignalSource` / `CursorSignalSource`, differing only in the
-/// invocation-level events Antigravity adds (`PreInvocation` / `PostInvocation`)
-/// in place of Claude's `UserPromptSubmit` / `SessionStart` pair (#860).
+/// `AgentStateTransition` values. Antigravity's hook *transport* is Claude-like
+/// (JSON on stdin, JSON verdict on stdout) but its config schema is its own
+/// (named groups — see `AntigravityHookConfigWriter`); this state machine only
+/// cares about the flattened event name + tool name, so it stays close to
+/// `ClaudeHookSignalSource` / `CursorSignalSource` (#860).
 ///
 /// **`Stop` is the canonical "done" signal.** Antigravity's `Stop` hook carries
 /// `fullyIdle` + `terminationReason` (`model_stop` / `max_steps_exceeded` /
-/// `error`) in its stdin payload — a real, reliable idle marker, which is what
-/// makes hooks Antigravity's single strongest integration point. The pinned
-/// `AgentHookEvent` schema doesn't surface those extra fields (they're not in
-/// the flattened struct), so here `Stop` firing at all ⇒ `.done`; the
-/// `fullyIdle`/`terminationReason` refinement (e.g. mapping `error` to a
-/// distinct state) is a version-pinned follow-up. Matching Claude/Cursor, the
-/// bare `Stop` → `.done` transition already satisfies Crow's active→done
-/// contract.
+/// `error`) in its stdin payload — a real idle marker, the strongest reason to
+/// integrate via hooks. The pinned `AgentHookEvent` schema doesn't surface those
+/// extra fields, so `Stop` firing ⇒ `.done`; refining on `terminationReason`
+/// (e.g. mapping `error` to a distinct state) is a version-pinned follow-up.
 ///
-/// **No awaiting-input event.** Antigravity has no dedicated "needs input" hook
-/// on this version, so — unlike Claude's `PermissionRequest`/`Notification`
-/// flow — this source never sets a `.waiting` notification. A `PermissionRequest`
-/// case is kept for cross-agent parity (and the follow-up that would map
-/// Antigravity's `request-review` mode / `statusLine` payload into it), but the
-/// writer doesn't currently emit it.
+/// **Events actually driven by the writer:** `PreInvocation` (turn start →
+/// working), `PostInvocation` (observational), `PostToolUse` (tool activity),
+/// `Stop` (done). `PreToolUse` is **not registered** by
+/// `AntigravityHookConfigWriter` (its strict stdout decision gate is unsafe for
+/// an observational hook — see that type), so tool activity is detected on
+/// completion via `PostToolUse` rather than on start. The `PreToolUse` case
+/// below is kept for cross-agent parity / future-proofing, not because the
+/// current writer emits it — same posture as the defensive `PermissionRequest`
+/// case (Antigravity has no awaiting-input hook on v1.1.7).
 public struct AntigravitySignalSource: StateSignalSource {
     public init() {}
 
@@ -60,6 +58,10 @@ public struct AntigravitySignalSource: StateSignalSource {
             break
 
         case "PreToolUse":
+            // NOT registered by the current writer (its stdout decision gate is
+            // unsafe for observational hooks — see AntigravityHookConfigWriter).
+            // Kept for cross-agent parity / future-proofing: if a later version
+            // registers it, tool-start detection works with no further change.
             let toolName = event.toolName ?? "unknown"
             transition.toolActivity = .set(ToolActivity(
                 toolName: toolName, isActive: true
@@ -67,6 +69,10 @@ public struct AntigravitySignalSource: StateSignalSource {
             transition.newActivityState = .working
 
         case "PostToolUse":
+            // Where tool activity is actually detected (since PreToolUse is off).
+            // Records the tool that just ran; state stays whatever PreInvocation
+            // set (working) until Stop — mirrors Cursor's observational
+            // PostToolUse (no activity-state change here).
             let toolName = event.toolName ?? "unknown"
             transition.toolActivity = .set(ToolActivity(
                 toolName: toolName, isActive: false

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravitySignalSource.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravitySignalSource.swift
@@ -1,0 +1,102 @@
+import Foundation
+import CrowCore
+
+/// Translates Google Antigravity (`agy`) hook events into
+/// `AgentStateTransition` values. Antigravity ships Claude-Code-style hooks —
+/// JSON on stdin, reply on stdout, the same `PreToolUse`/`PostToolUse` tool
+/// vocabulary — so this state machine is a near-clone of
+/// `ClaudeHookSignalSource` / `CursorSignalSource`, differing only in the
+/// invocation-level events Antigravity adds (`PreInvocation` / `PostInvocation`)
+/// in place of Claude's `UserPromptSubmit` / `SessionStart` pair (#860).
+///
+/// **`Stop` is the canonical "done" signal.** Antigravity's `Stop` hook carries
+/// `fullyIdle` + `terminationReason` (`model_stop` / `max_steps_exceeded` /
+/// `error`) in its stdin payload — a real, reliable idle marker, which is what
+/// makes hooks Antigravity's single strongest integration point. The pinned
+/// `AgentHookEvent` schema doesn't surface those extra fields (they're not in
+/// the flattened struct), so here `Stop` firing at all ⇒ `.done`; the
+/// `fullyIdle`/`terminationReason` refinement (e.g. mapping `error` to a
+/// distinct state) is a version-pinned follow-up. Matching Claude/Cursor, the
+/// bare `Stop` → `.done` transition already satisfies Crow's active→done
+/// contract.
+///
+/// **No awaiting-input event.** Antigravity has no dedicated "needs input" hook
+/// on this version, so — unlike Claude's `PermissionRequest`/`Notification`
+/// flow — this source never sets a `.waiting` notification. A `PermissionRequest`
+/// case is kept for cross-agent parity (and the follow-up that would map
+/// Antigravity's `request-review` mode / `statusLine` payload into it), but the
+/// writer doesn't currently emit it.
+public struct AntigravitySignalSource: StateSignalSource {
+    public init() {}
+
+    public func transition(
+        for event: AgentHookEvent,
+        currentActivityState: AgentActivityState,
+        currentNotificationType: String?,
+        currentLastTopLevelStopAt: Date?
+    ) -> AgentStateTransition {
+        // Same blanket-clear policy as Claude/Cursor/Codex: every event except
+        // `PermissionRequest` clears any pending notification. Kept defensive
+        // even though the current writer doesn't surface `PermissionRequest`.
+        let blanketClear = event.eventName != "PermissionRequest"
+        var transition = AgentStateTransition(
+            notification: blanketClear ? .clear : .leave
+        )
+
+        switch event.eventName {
+        case "PreInvocation":
+            // A new model invocation (turn) is starting — the analogue of
+            // Claude's `UserPromptSubmit`. Elevate to working and clear the
+            // post-Stop guard so this turn's tool activity can drive state.
+            transition.newActivityState = .working
+            transition.lastTopLevelStopAt = .clear
+
+        case "PostInvocation":
+            // The model invocation returned. Observational only: `Stop` is the
+            // authoritative "done" signal (it carries `fullyIdle`), and a
+            // multi-step turn can emit several invocations before genuinely
+            // idling, so flipping to `.done` here would report done too early.
+            // Blanket clear already applied; leave activity untouched.
+            break
+
+        case "PreToolUse":
+            let toolName = event.toolName ?? "unknown"
+            transition.toolActivity = .set(ToolActivity(
+                toolName: toolName, isActive: true
+            ))
+            transition.newActivityState = .working
+
+        case "PostToolUse":
+            let toolName = event.toolName ?? "unknown"
+            transition.toolActivity = .set(ToolActivity(
+                toolName: toolName, isActive: false
+            ))
+
+        case "Stop":
+            transition.newActivityState = .done
+            transition.toolActivity = .clear
+            transition.lastTopLevelStopAt = .set(Date())
+
+        case "PermissionRequest":
+            // Not emitted by the current writer (Antigravity has no dedicated
+            // awaiting-input hook on v1.1.7); kept for cross-agent parity and
+            // the follow-up that maps `request-review` / `statusLine` here.
+            if currentNotificationType != "question" {
+                transition.notification = .set(HookNotification(
+                    message: "Permission requested",
+                    notificationType: "permission_prompt"
+                ))
+            }
+            transition.newActivityState = .waiting
+            transition.toolActivity = .clear
+
+        default:
+            // Unknown / future events get the blanket notification clear and
+            // nothing else, so Antigravity's event vocabulary can grow without
+            // code changes for events that don't move Crow's state.
+            break
+        }
+
+        return transition
+    }
+}

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentTests.swift
@@ -55,6 +55,16 @@ struct AntigravityAgentTests {
         #expect(cmd?.hasSuffix("\n") == true)
     }
 
+    @Test func jobFirstLaunchQuotesPromptPathWithSpaces() {
+        // A worktree under `/Users/x/My Projects/…` must not split `cat`'s argv:
+        // the prompt path is single-quoted inside the `$(cat …)` substitution.
+        let session = Session(name: "job", kind: .job, agentKind: .antigravity)
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/Users/x/My Projects/wt",
+            remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
+        #expect(cmd?.contains("-p \"$(cat '/Users/x/My Projects/wt/.crow-job-prompt.md')\"") == true)
+    }
+
     @Test func jobSubsequentLaunchResumesWithDashC() {
         var session = Session(name: "job", kind: .job, agentKind: .antigravity)
         session.reviewPromptDispatched = true

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import CrowAntigravity
+@testable import CrowCore
+
+@Suite("AntigravityAgent")
+struct AntigravityAgentTests {
+    private let agent = AntigravityAgent()
+
+    @Test func protocolMembers() {
+        #expect(agent.kind == .antigravity)
+        #expect(agent.kind.rawValue == "antigravity")
+        #expect(agent.displayName == "Antigravity")
+        #expect(agent.iconSystemName == "arrow.up.circle")
+        #expect(agent.supportsRemoteControl == true)
+        #expect(agent.launchCommandToken == "agy")
+        // Rename surface is unverified on v1.1.7 → opt-out nil (no stray paste).
+        #expect(agent.sessionRenameSlashCommand(newName: "my-session") == nil)
+    }
+
+    // MARK: - Supply-chain gate
+
+    @Test func fallbackCandidatesNeverReferenceCommunityGitHubOrg() {
+        // The gate: fallbacks must be standard-bin / official-installer paths,
+        // never the unverified `google-antigravity/*` GitHub release binary.
+        for path in agent.fallbackCandidates {
+            #expect(path.hasSuffix("/agy"), "fallback should resolve the `agy` binary: \(path)")
+            #expect(!path.contains("google-antigravity"), "must not reference the community org: \(path)")
+            #expect(!path.lowercased().contains("github"), "must not reference GitHub releases: \(path)")
+        }
+    }
+
+    // MARK: - autoLaunchCommand
+
+    @Test func workSessionLaunchesBareTUI() {
+        let session = Session(name: "test", agentKind: .antigravity)
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/tmp/wt",
+            remoteControlEnabled: true, autoPermissionMode: true, telemetryPort: 4318)
+        // Bare interactive TUI: no prompt, no resume flag, no OTEL prefix, no RC.
+        #expect(cmd?.hasSuffix("agy'\n") == true)  // binary is shell-quoted
+        #expect(cmd?.contains(".crow-job-prompt.md") == false)
+        #expect(cmd?.contains("OTEL_") == false)
+        #expect(cmd?.contains("-p ") == false)
+    }
+
+    @Test func jobFirstLaunchInjectsPromptViaDashP() {
+        let session = Session(name: "job", kind: .job, agentKind: .antigravity)
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/tmp/wt",
+            remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
+        #expect(cmd != nil)
+        #expect(cmd?.contains(" -p \"$(cat ") == true)
+        #expect(cmd?.contains(".crow-job-prompt.md") == true)
+        #expect(cmd?.hasSuffix("\n") == true)
+    }
+
+    @Test func jobSubsequentLaunchResumesWithDashC() {
+        var session = Session(name: "job", kind: .job, agentKind: .antigravity)
+        session.reviewPromptDispatched = true
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/tmp/wt",
+            remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
+        #expect(cmd?.contains(".crow-job-prompt.md") == false)
+        #expect(cmd?.hasSuffix(" -c\n") == true)
+    }
+
+    @Test func reviewSessionUnsupportedPhaseA() {
+        let session = Session(name: "review", kind: .review, agentKind: .antigravity)
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/tmp/wt",
+            remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
+        #expect(cmd == nil)
+    }
+
+    @Test func managerSessionUnsupported() {
+        let session = Session(name: "manager", kind: .manager, agentKind: .antigravity)
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/tmp/wt",
+            remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
+        #expect(cmd == nil)
+    }
+
+    @Test func autoPermissionIsNoOpOnPinnedVersion() {
+        // Bounded auto-permission is a documented Tier-2 gap: no verified launch
+        // flag, and we never pass --dangerously-skip-permissions.
+        let session = Session(name: "job", kind: .job, agentKind: .antigravity)
+        let cmd = agent.autoLaunchCommand(
+            session: session, worktreePath: "/tmp/wt",
+            remoteControlEnabled: false, autoPermissionMode: true, telemetryPort: nil)
+        #expect(cmd?.contains("--dangerously-skip-permissions") == false)
+        #expect(cmd?.contains("always-proceed") == false)
+    }
+
+    @Test func managerLaunchCommandBareNoRC() {
+        let cmd = agent.managerLaunchCommand(
+            sessionName: "Manager", remoteControlEnabled: true,
+            autoPermissionMode: true, telemetryPort: 4318)
+        #expect(cmd.hasSuffix("agy'"))  // binary is shell-quoted, no trailing newline
+        #expect(cmd.contains("--dangerously-skip-permissions") == false)
+    }
+
+    @Test func findBinaryDoesNotCrash() {
+        _ = agent.findBinary()  // smoke test
+    }
+}

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityHookConfigWriterTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityHookConfigWriterTests.swift
@@ -12,129 +12,183 @@ struct AntigravityHookConfigWriterTests {
         return url
     }
 
-    private func readHooks(_ path: URL) throws -> [String: Any] {
-        let data = try Data(contentsOf: path)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-        return json["hooks"] as! [String: Any]
+    /// The whole hooks.json as a named-group map (root is the groups, NOT a
+    /// top-level `hooks` wrapper).
+    private func readRoot(_ path: URL) throws -> [String: Any] {
+        try JSONSerialization.jsonObject(with: Data(contentsOf: path)) as! [String: Any]
     }
 
-    private func entry(_ hooks: [String: Any], _ event: String) -> [String: Any] {
-        let groups = hooks[event] as! [[String: Any]]
-        let inner = groups.first!["hooks"] as! [[String: Any]]
-        return inner.first!
+    /// Crow's `"crow"` group (event → config array).
+    private func crowGroup(_ path: URL) throws -> [String: Any] {
+        try readRoot(path)["crow"] as! [String: Any]
     }
 
-    private func command(_ hooks: [String: Any], _ event: String) -> String {
-        entry(hooks, event)["command"] as! String
+    /// The handler object for a *direct* event (invocation/Stop) — no matcher.
+    private func directHandler(_ group: [String: Any], _ event: String) -> [String: Any] {
+        (group[event] as! [[String: Any]]).first!
     }
 
-    // MARK: - Per-worktree write, Claude-style schema, UUID baked in
+    /// The handler object for a *tool* event (matcher + hooks[]).
+    private func toolHandler(_ group: [String: Any], _ event: String) -> [String: Any] {
+        let wrap = (group[event] as! [[String: Any]]).first!
+        return (wrap["hooks"] as! [[String: Any]]).first!
+    }
 
-    @Test func writesPerWorktreeWithSessionAndPascalCaseEvents() throws {
+    // MARK: - Named-group schema (Antigravity's, not Claude's)
+
+    @Test func writesNamedCrowGroupNotClaudeHooksWrapper() throws {
         let worktree = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: worktree) }
         AntigravityHookConfigWriter.resetTrackedCacheForTesting()
         let sid = UUID()
         try AntigravityHookConfigWriter().writeHookConfig(
-            worktreePath: worktree.path,
-            sessionID: sid,
-            crowPath: "/opt/homebrew/bin/crow"
-        )
+            worktreePath: worktree.path, sessionID: sid, crowPath: "/opt/homebrew/bin/crow")
 
-        let hooksPath = worktree.appendingPathComponent(".agents/hooks.json")
-        let hooks = try readHooks(hooksPath)
-        // Exactly the documented v1.1.7 lifecycle events.
-        #expect(hooks.count == 5)
-        for event in ["PreInvocation", "PostInvocation", "PreToolUse", "PostToolUse", "Stop"] {
-            #expect(hooks[event] != nil, "missing hook entry for \(event)")
-        }
-
-        // Claude-style schema has NO top-level version field.
-        let root = try JSONSerialization.jsonObject(
-            with: Data(contentsOf: hooksPath)) as! [String: Any]
+        let root = try readRoot(worktree.appendingPathComponent(".agents/hooks.json"))
+        // Top-level is the named group `crow` — NOT a Claude-style `hooks` key,
+        // and no `version` scaffold.
+        #expect(root["crow"] != nil)
+        #expect(root["hooks"] == nil)
         #expect(root["version"] == nil)
 
-        // Command bakes the session UUID + --agent antigravity + PascalCase event.
-        #expect(command(hooks, "PreToolUse")
-            == "'/opt/homebrew/bin/crow' hook-event --session \(sid.uuidString) --agent antigravity --event PreToolUse")
+        let group = root["crow"] as! [String: Any]
+        // Mirrors Antigravity's vibe-island plugin: no PreToolUse.
+        #expect(Set(group.keys) == ["PreInvocation", "PostInvocation", "PostToolUse", "Stop"])
+        #expect(group["PreToolUse"] == nil)
     }
 
-    @Test func stopSyncPostToolUseAndPostInvocationAsync() throws {
+    @Test func toolEventUsesMatcherAndHooksWrapper() throws {
         let worktree = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: worktree) }
         AntigravityHookConfigWriter.resetTrackedCacheForTesting()
         try AntigravityHookConfigWriter().writeHookConfig(
-            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/usr/local/bin/crow")
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        let group = try crowGroup(worktree.appendingPathComponent(".agents/hooks.json"))
 
-        let hooks = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))
-        #expect(entry(hooks, "PostToolUse")["async"] as? Bool == true)
-        #expect(entry(hooks, "PostInvocation")["async"] as? Bool == true)
-        // Stop / PreToolUse / PreInvocation stay synchronous (ordering + timing).
-        #expect(entry(hooks, "Stop")["async"] == nil)
-        #expect(entry(hooks, "PreToolUse")["async"] == nil)
-        #expect(entry(hooks, "PreInvocation")["async"] == nil)
+        // PostToolUse: `[{matcher:"*", hooks:[handler]}]`.
+        let wrap = (group["PostToolUse"] as! [[String: Any]]).first!
+        #expect(wrap["matcher"] as? String == "*")
+        #expect(wrap["hooks"] != nil)
     }
 
-    // MARK: - Idempotency + user-group preservation
-
-    @Test func rewriteIsIdempotentAndPreservesUserGroups() throws {
+    @Test func directEventsListHandlersUnderEventKey() throws {
         let worktree = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: worktree) }
         AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        let group = try crowGroup(worktree.appendingPathComponent(".agents/hooks.json"))
 
-        // Seed a user-authored group for a managed event.
+        // Invocation/Stop handlers sit directly under the event key — no matcher,
+        // no `hooks` wrapper.
+        for event in ["PreInvocation", "PostInvocation", "Stop"] {
+            let h = directHandler(group, event)
+            #expect(h["type"] as? String == "command")
+            #expect(h["command"] != nil)
+            #expect(h["matcher"] == nil)
+            #expect(h["hooks"] == nil)
+        }
+    }
+
+    @Test func noAsyncFieldAnywhere() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        // `async` is not part of Antigravity's handler schema — a stray field
+        // risks a parse failure.
+        let raw = try String(
+            contentsOf: worktree.appendingPathComponent(".agents/hooks.json"), encoding: .utf8)
+        #expect(raw.contains("async") == false)
+    }
+
+    // MARK: - Command wrapper (session UUID + stdout verdict + always-exit-0)
+
+    @Test func commandForwardsThenEmitsStdoutVerdict() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let sid = UUID()
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: sid, crowPath: "/opt/homebrew/bin/crow")
+        let group = try crowGroup(worktree.appendingPathComponent(".agents/hooks.json"))
+
+        // Stop command: session UUID + --agent antigravity, hook-event output
+        // suppressed, then an empty-object verdict emitted so the hook never
+        // blocks / loops the agent.
+        let stopCmd = directHandler(group, "Stop")["command"] as! String
+        #expect(stopCmd.contains("hook-event --session \(sid.uuidString) --agent antigravity --event Stop"))
+        #expect(stopCmd.contains(">/dev/null 2>&1; printf '{}'"))
+
+        // PostToolUse command carries the same wrapper shape.
+        let toolCmd = toolHandler(group, "PostToolUse")["command"] as! String
+        #expect(toolCmd.contains("--event PostToolUse >/dev/null 2>&1; printf '{}'"))
+    }
+
+    @Test func crowPathWithSpacesIsShellQuoted() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let spaced = "/Users/x/My Projects/.claude/bin/crow"
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: spaced)
+        let group = try crowGroup(worktree.appendingPathComponent(".agents/hooks.json"))
+        #expect((directHandler(group, "Stop")["command"] as! String).hasPrefix("'\(spaced)' hook-event "))
+    }
+
+    // MARK: - User-group preservation + idempotency
+
+    @Test func preservesOtherNamedGroupsAndIsIdempotent() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        // Seed a user's own named group alongside where Crow's will go.
         let agentsDir = worktree.appendingPathComponent(".agents")
         try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
-        let userSeed: [String: Any] = [
-            "hooks": [
-                "Stop": [["hooks": [["type": "command", "command": "my-own-hook"]]]],
-            ],
+        let seed: [String: Any] = [
+            "my-linter": ["PostToolUse": [["matcher": "run_command", "hooks": [["command": "lint.sh"]]]]],
         ]
-        try JSONSerialization.data(withJSONObject: userSeed)
+        try JSONSerialization.data(withJSONObject: seed)
             .write(to: agentsDir.appendingPathComponent("hooks.json"))
 
         let writer = AntigravityHookConfigWriter()
-        let sid = UUID()
-        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: sid, crowPath: "/bin/crow")
-        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: sid, crowPath: "/bin/crow")
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
 
-        let stopGroups = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))["Stop"] as! [[String: Any]]
-        // Exactly two groups survive: the user's + one (not two) Crow group.
-        #expect(stopGroups.count == 2)
-        let commands = stopGroups.compactMap { ($0["hooks"] as? [[String: Any]])?.first?["command"] as? String }
-        #expect(commands.contains("my-own-hook"))
-        #expect(commands.contains { $0.contains("--agent antigravity") })
+        let root = try readRoot(worktree.appendingPathComponent(".agents/hooks.json"))
+        // The user's group survives untouched; Crow's group is present exactly once.
+        #expect(root["my-linter"] != nil)
+        #expect(root["crow"] != nil)
+        let linter = root["my-linter"] as! [String: Any]
+        let wrap = (linter["PostToolUse"] as! [[String: Any]]).first!
+        #expect(wrap["matcher"] as? String == "run_command")
     }
 
     // MARK: - remove
 
-    @Test func removeStripsCrowGroupsButKeepsUserGroups() throws {
+    @Test func removeStripsCrowGroupButKeepsUserGroups() throws {
         let worktree = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: worktree) }
         AntigravityHookConfigWriter.resetTrackedCacheForTesting()
         let agentsDir = worktree.appendingPathComponent(".agents")
         try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
-        let userSeed: [String: Any] = [
-            "hooks": [
-                "PreToolUse": [["hooks": [["type": "command", "command": "user-pretool"]]]],
-            ],
+        let seed: [String: Any] = [
+            "my-linter": ["PreInvocation": [["command": "lint.sh"]]],
         ]
-        try JSONSerialization.data(withJSONObject: userSeed)
+        try JSONSerialization.data(withJSONObject: seed)
             .write(to: agentsDir.appendingPathComponent("hooks.json"))
 
         let writer = AntigravityHookConfigWriter()
         try writer.writeHookConfig(worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
         writer.removeHookConfig(worktreePath: worktree.path)
 
-        let hooks = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))
-        // The user's PreToolUse group survives; every Crow group is gone.
-        let pre = hooks["PreToolUse"] as! [[String: Any]]
-        #expect(pre.count == 1)
-        #expect((pre.first!["hooks"] as! [[String: Any]]).first!["command"] as? String == "user-pretool")
-        #expect(hooks["Stop"] == nil)
+        let root = try readRoot(worktree.appendingPathComponent(".agents/hooks.json"))
+        #expect(root["crow"] == nil)
+        #expect(root["my-linter"] != nil)
     }
 
-    @Test func removeDeletesFileWhenOnlyCrowGroupsExisted() throws {
+    @Test func removeDeletesFileWhenOnlyCrowGroupExisted() throws {
         let worktree = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: worktree) }
         AntigravityHookConfigWriter.resetTrackedCacheForTesting()
@@ -145,7 +199,26 @@ struct AntigravityHookConfigWriterTests {
             atPath: worktree.appendingPathComponent(".agents/hooks.json").path))
     }
 
-    // MARK: - Unparseable / torn-file guard (regression, mirrors Cursor #829)
+    // MARK: - Global-config migration (double-fire guard)
+
+    @Test func removeManagedGlobalConfigStripsOnlyCrowGroup() throws {
+        let home = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let seed: [String: Any] = [
+            "crow": ["Stop": [["type": "command", "command": "old-crow"]]],
+            "user-group": ["Stop": [["type": "command", "command": "user-hook"]]],
+        ]
+        let path = home.appendingPathComponent("hooks.json")
+        try JSONSerialization.data(withJSONObject: seed).write(to: path)
+
+        AntigravityHookConfigWriter.removeManagedGlobalConfig(geminiConfigHome: home.path)
+
+        let root = try readRoot(path)
+        #expect(root["crow"] == nil)
+        #expect(root["user-group"] != nil)
+    }
+
+    // MARK: - Unparseable / torn-file guard (regression)
 
     @Test func writeHookConfigLeavesUnparseableFileUntouched() throws {
         let worktree = try makeTempDir()
@@ -153,58 +226,14 @@ struct AntigravityHookConfigWriterTests {
         AntigravityHookConfigWriter.resetTrackedCacheForTesting()
         let agentsDir = worktree.appendingPathComponent(".agents")
         try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
-        // A torn/hand-edited config that doesn't parse. The writer must bail
-        // rather than start from `[:]` and clobber whatever the user had — a
-        // future refactor that drops the parse guard would silently destroy it.
-        let garbage = "{ \"hooks\": { \"Stop\": [  <-- oops not json"
+        let garbage = "{ \"crow\": {  <-- oops not json"
         let hooksPath = agentsDir.appendingPathComponent("hooks.json")
         try garbage.write(to: hooksPath, atomically: true, encoding: .utf8)
 
         try AntigravityHookConfigWriter().writeHookConfig(
             worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
 
-        // Byte-for-byte unchanged: no Crow group injected, nothing overwritten.
         #expect(try String(contentsOf: hooksPath, encoding: .utf8) == garbage)
-    }
-
-    // MARK: - Path-with-spaces (shell-quoting regression)
-
-    @Test func crowPathWithSpacesIsShellQuoted() throws {
-        let worktree = try makeTempDir()
-        defer { try? FileManager.default.removeItem(at: worktree) }
-        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
-        // A devRoot with a space (`/Users/x/My Projects/.claude/bin/crow`) must
-        // not split the hook command — the crow path is single-quoted, so the
-        // shell sees one argument.
-        let spaced = "/Users/x/My Projects/.claude/bin/crow"
-        try AntigravityHookConfigWriter().writeHookConfig(
-            worktreePath: worktree.path, sessionID: UUID(), crowPath: spaced)
-
-        let hooks = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))
-        #expect(command(hooks, "Stop").hasPrefix("'\(spaced)' hook-event "))
-    }
-
-    // MARK: - Global-config migration (double-fire guard)
-
-    @Test func removeManagedGlobalConfigStripsOnlyCrowGroups() throws {
-        let home = try makeTempDir()
-        defer { try? FileManager.default.removeItem(at: home) }
-        let seed: [String: Any] = [
-            "hooks": [
-                "Stop": [
-                    ["hooks": [["type": "command", "command": "user-global-hook"]]],
-                    ["hooks": [["type": "command", "command": "/x/crow hook-event --session X --agent antigravity --event Stop"]]],
-                ],
-            ],
-        ]
-        let path = home.appendingPathComponent("hooks.json")
-        try JSONSerialization.data(withJSONObject: seed).write(to: path)
-
-        AntigravityHookConfigWriter.removeManagedGlobalConfig(geminiConfigHome: home.path)
-
-        let stop = try readHooks(path)["Stop"] as! [[String: Any]]
-        #expect(stop.count == 1)
-        #expect((stop.first!["hooks"] as! [[String: Any]]).first!["command"] as? String == "user-global-hook")
     }
 
     // MARK: - Git-tracked guard + exclude
@@ -228,7 +257,7 @@ struct AntigravityHookConfigWriterTests {
         git(["init"])
         let agentsDir = repo.appendingPathComponent(".agents")
         try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
-        let committed: [String: Any] = ["hooks": ["Stop": [["hooks": [["type": "command", "command": "committed"]]]]]]
+        let committed: [String: Any] = ["user-group": ["Stop": [["command": "committed"]]]]
         try JSONSerialization.data(withJSONObject: committed)
             .write(to: agentsDir.appendingPathComponent("hooks.json"))
         git(["add", ".agents/hooks.json"])
@@ -237,11 +266,10 @@ struct AntigravityHookConfigWriterTests {
         try AntigravityHookConfigWriter().writeHookConfig(
             worktreePath: repo.path, sessionID: UUID(), crowPath: "/bin/crow")
 
-        // The committed file is left untouched — no Crow group injected.
-        let hooks = try readHooks(repo.appendingPathComponent(".agents/hooks.json"))
-        let stop = hooks["Stop"] as! [[String: Any]]
-        #expect(stop.count == 1)
-        #expect((stop.first!["hooks"] as! [[String: Any]]).first!["command"] as? String == "committed")
+        // The committed file is untouched — no `crow` group injected.
+        let root = try readRoot(repo.appendingPathComponent(".agents/hooks.json"))
+        #expect(root["crow"] == nil)
+        #expect(root["user-group"] != nil)
     }
 
     @Test func gitExcludesUntrackedConfig() throws {
@@ -258,7 +286,8 @@ struct AntigravityHookConfigWriterTests {
         try AntigravityHookConfigWriter().writeHookConfig(
             worktreePath: repo.path, sessionID: UUID(), crowPath: "/bin/crow")
 
-        let exclude = try String(contentsOfFile: repo.appendingPathComponent(".git/info/exclude").path, encoding: .utf8)
+        let exclude = try String(
+            contentsOfFile: repo.appendingPathComponent(".git/info/exclude").path, encoding: .utf8)
         #expect(exclude.contains(".agents/hooks.json"))
     }
 }

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityHookConfigWriterTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityHookConfigWriterTests.swift
@@ -145,6 +145,45 @@ struct AntigravityHookConfigWriterTests {
             atPath: worktree.appendingPathComponent(".agents/hooks.json").path))
     }
 
+    // MARK: - Unparseable / torn-file guard (regression, mirrors Cursor #829)
+
+    @Test func writeHookConfigLeavesUnparseableFileUntouched() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let agentsDir = worktree.appendingPathComponent(".agents")
+        try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
+        // A torn/hand-edited config that doesn't parse. The writer must bail
+        // rather than start from `[:]` and clobber whatever the user had — a
+        // future refactor that drops the parse guard would silently destroy it.
+        let garbage = "{ \"hooks\": { \"Stop\": [  <-- oops not json"
+        let hooksPath = agentsDir.appendingPathComponent("hooks.json")
+        try garbage.write(to: hooksPath, atomically: true, encoding: .utf8)
+
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+
+        // Byte-for-byte unchanged: no Crow group injected, nothing overwritten.
+        #expect(try String(contentsOf: hooksPath, encoding: .utf8) == garbage)
+    }
+
+    // MARK: - Path-with-spaces (shell-quoting regression)
+
+    @Test func crowPathWithSpacesIsShellQuoted() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        // A devRoot with a space (`/Users/x/My Projects/.claude/bin/crow`) must
+        // not split the hook command — the crow path is single-quoted, so the
+        // shell sees one argument.
+        let spaced = "/Users/x/My Projects/.claude/bin/crow"
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: spaced)
+
+        let hooks = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))
+        #expect(command(hooks, "Stop").hasPrefix("'\(spaced)' hook-event "))
+    }
+
     // MARK: - Global-config migration (double-fire guard)
 
     @Test func removeManagedGlobalConfigStripsOnlyCrowGroups() throws {

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityHookConfigWriterTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityHookConfigWriterTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+@testable import CrowAntigravity
+@testable import CrowCore
+
+@Suite("AntigravityHookConfigWriter")
+struct AntigravityHookConfigWriterTests {
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func readHooks(_ path: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: path)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        return json["hooks"] as! [String: Any]
+    }
+
+    private func entry(_ hooks: [String: Any], _ event: String) -> [String: Any] {
+        let groups = hooks[event] as! [[String: Any]]
+        let inner = groups.first!["hooks"] as! [[String: Any]]
+        return inner.first!
+    }
+
+    private func command(_ hooks: [String: Any], _ event: String) -> String {
+        entry(hooks, event)["command"] as! String
+    }
+
+    // MARK: - Per-worktree write, Claude-style schema, UUID baked in
+
+    @Test func writesPerWorktreeWithSessionAndPascalCaseEvents() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let sid = UUID()
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path,
+            sessionID: sid,
+            crowPath: "/opt/homebrew/bin/crow"
+        )
+
+        let hooksPath = worktree.appendingPathComponent(".agents/hooks.json")
+        let hooks = try readHooks(hooksPath)
+        // Exactly the documented v1.1.7 lifecycle events.
+        #expect(hooks.count == 5)
+        for event in ["PreInvocation", "PostInvocation", "PreToolUse", "PostToolUse", "Stop"] {
+            #expect(hooks[event] != nil, "missing hook entry for \(event)")
+        }
+
+        // Claude-style schema has NO top-level version field.
+        let root = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: hooksPath)) as! [String: Any]
+        #expect(root["version"] == nil)
+
+        // Command bakes the session UUID + --agent antigravity + PascalCase event.
+        #expect(command(hooks, "PreToolUse")
+            == "'/opt/homebrew/bin/crow' hook-event --session \(sid.uuidString) --agent antigravity --event PreToolUse")
+    }
+
+    @Test func stopSyncPostToolUseAndPostInvocationAsync() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: worktree.path, sessionID: UUID(), crowPath: "/usr/local/bin/crow")
+
+        let hooks = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))
+        #expect(entry(hooks, "PostToolUse")["async"] as? Bool == true)
+        #expect(entry(hooks, "PostInvocation")["async"] as? Bool == true)
+        // Stop / PreToolUse / PreInvocation stay synchronous (ordering + timing).
+        #expect(entry(hooks, "Stop")["async"] == nil)
+        #expect(entry(hooks, "PreToolUse")["async"] == nil)
+        #expect(entry(hooks, "PreInvocation")["async"] == nil)
+    }
+
+    // MARK: - Idempotency + user-group preservation
+
+    @Test func rewriteIsIdempotentAndPreservesUserGroups() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+
+        // Seed a user-authored group for a managed event.
+        let agentsDir = worktree.appendingPathComponent(".agents")
+        try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
+        let userSeed: [String: Any] = [
+            "hooks": [
+                "Stop": [["hooks": [["type": "command", "command": "my-own-hook"]]]],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: userSeed)
+            .write(to: agentsDir.appendingPathComponent("hooks.json"))
+
+        let writer = AntigravityHookConfigWriter()
+        let sid = UUID()
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: sid, crowPath: "/bin/crow")
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: sid, crowPath: "/bin/crow")
+
+        let stopGroups = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))["Stop"] as! [[String: Any]]
+        // Exactly two groups survive: the user's + one (not two) Crow group.
+        #expect(stopGroups.count == 2)
+        let commands = stopGroups.compactMap { ($0["hooks"] as? [[String: Any]])?.first?["command"] as? String }
+        #expect(commands.contains("my-own-hook"))
+        #expect(commands.contains { $0.contains("--agent antigravity") })
+    }
+
+    // MARK: - remove
+
+    @Test func removeStripsCrowGroupsButKeepsUserGroups() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let agentsDir = worktree.appendingPathComponent(".agents")
+        try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
+        let userSeed: [String: Any] = [
+            "hooks": [
+                "PreToolUse": [["hooks": [["type": "command", "command": "user-pretool"]]]],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: userSeed)
+            .write(to: agentsDir.appendingPathComponent("hooks.json"))
+
+        let writer = AntigravityHookConfigWriter()
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        writer.removeHookConfig(worktreePath: worktree.path)
+
+        let hooks = try readHooks(worktree.appendingPathComponent(".agents/hooks.json"))
+        // The user's PreToolUse group survives; every Crow group is gone.
+        let pre = hooks["PreToolUse"] as! [[String: Any]]
+        #expect(pre.count == 1)
+        #expect((pre.first!["hooks"] as! [[String: Any]]).first!["command"] as? String == "user-pretool")
+        #expect(hooks["Stop"] == nil)
+    }
+
+    @Test func removeDeletesFileWhenOnlyCrowGroupsExisted() throws {
+        let worktree = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: worktree) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let writer = AntigravityHookConfigWriter()
+        try writer.writeHookConfig(worktreePath: worktree.path, sessionID: UUID(), crowPath: "/bin/crow")
+        writer.removeHookConfig(worktreePath: worktree.path)
+        #expect(!FileManager.default.fileExists(
+            atPath: worktree.appendingPathComponent(".agents/hooks.json").path))
+    }
+
+    // MARK: - Global-config migration (double-fire guard)
+
+    @Test func removeManagedGlobalConfigStripsOnlyCrowGroups() throws {
+        let home = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let seed: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "user-global-hook"]]],
+                    ["hooks": [["type": "command", "command": "/x/crow hook-event --session X --agent antigravity --event Stop"]]],
+                ],
+            ],
+        ]
+        let path = home.appendingPathComponent("hooks.json")
+        try JSONSerialization.data(withJSONObject: seed).write(to: path)
+
+        AntigravityHookConfigWriter.removeManagedGlobalConfig(geminiConfigHome: home.path)
+
+        let stop = try readHooks(path)["Stop"] as! [[String: Any]]
+        #expect(stop.count == 1)
+        #expect((stop.first!["hooks"] as! [[String: Any]]).first!["command"] as? String == "user-global-hook")
+    }
+
+    // MARK: - Git-tracked guard + exclude
+
+    @Test func skipsWriteWhenFileIsGitTracked() throws {
+        let repo = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        func git(_ args: [String]) {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            p.arguments = ["git", "-C", repo.path] + args
+            p.standardOutput = FileHandle.nullDevice
+            p.standardError = FileHandle.nullDevice
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            ]) { _, new in new }
+            try? p.run(); p.waitUntilExit()
+        }
+        git(["init"])
+        let agentsDir = repo.appendingPathComponent(".agents")
+        try FileManager.default.createDirectory(at: agentsDir, withIntermediateDirectories: true)
+        let committed: [String: Any] = ["hooks": ["Stop": [["hooks": [["type": "command", "command": "committed"]]]]]]
+        try JSONSerialization.data(withJSONObject: committed)
+            .write(to: agentsDir.appendingPathComponent("hooks.json"))
+        git(["add", ".agents/hooks.json"])
+        git(["commit", "-m", "seed"])
+
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: repo.path, sessionID: UUID(), crowPath: "/bin/crow")
+
+        // The committed file is left untouched — no Crow group injected.
+        let hooks = try readHooks(repo.appendingPathComponent(".agents/hooks.json"))
+        let stop = hooks["Stop"] as! [[String: Any]]
+        #expect(stop.count == 1)
+        #expect((stop.first!["hooks"] as! [[String: Any]]).first!["command"] as? String == "committed")
+    }
+
+    @Test func gitExcludesUntrackedConfig() throws {
+        let repo = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        AntigravityHookConfigWriter.resetTrackedCacheForTesting()
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        p.arguments = ["git", "-C", repo.path, "init"]
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        try? p.run(); p.waitUntilExit()
+
+        try AntigravityHookConfigWriter().writeHookConfig(
+            worktreePath: repo.path, sessionID: UUID(), crowPath: "/bin/crow")
+
+        let exclude = try String(contentsOfFile: repo.appendingPathComponent(".git/info/exclude").path, encoding: .utf8)
+        #expect(exclude.contains(".agents/hooks.json"))
+    }
+}

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityLauncherTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityLauncherTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import CrowAntigravity
+@testable import CrowCore
+
+@Suite("AntigravityLauncher")
+struct AntigravityLauncherTests {
+    private let launcher = AntigravityLauncher()
+
+    private func worktree(_ repo: String = "crow", branch: String = "feature/x") -> SessionWorktree {
+        SessionWorktree(
+            sessionID: UUID(),
+            repoName: repo,
+            repoPath: "/repos/\(repo)",
+            worktreePath: "/wt/\(repo)",
+            branch: branch)
+    }
+
+    // MARK: - generatePrompt
+
+    @Test func promptIncludesPlanPreambleAndWorkspaceTable() async {
+        let session = Session(name: "s", agentKind: .antigravity)
+        let prompt = await launcher.generatePrompt(
+            session: session, worktrees: [worktree()],
+            ticketURL: nil, provider: nil, codeProvider: nil)
+        #expect(prompt.contains("sketch a brief plan"))
+        #expect(prompt.contains("# Workspace Context"))
+        #expect(prompt.contains("| crow | /wt/crow | feature/x | |"))
+    }
+
+    @Test func githubTicketUsesGhIssueView() async {
+        let session = Session(name: "s", agentKind: .antigravity)
+        let prompt = await launcher.generatePrompt(
+            session: session, worktrees: [worktree()],
+            ticketURL: "https://github.com/o/r/issues/7", provider: .github, codeProvider: nil)
+        #expect(prompt.contains("gh issue view https://github.com/o/r/issues/7 --comments"))
+    }
+
+    @Test func jiraTicketFallsBackToAcliNotMCP() async {
+        // Phase A has no MCP bridge for Antigravity — the Jira branch must
+        // instruct `acli`, never a `jira_*` MCP tool.
+        let session = Session(name: "s", agentKind: .antigravity)
+        let prompt = await launcher.generatePrompt(
+            session: session, worktrees: [worktree()],
+            ticketURL: "https://x.atlassian.net/browse/ABC-123", provider: .jira, codeProvider: nil)
+        #expect(prompt.contains("acli jira workitem view ABC-123"))
+        #expect(prompt.contains("jira_get_issue") == false)
+        #expect(prompt.lowercased().contains("mcp") == false)
+    }
+
+    // MARK: - launchCommand (handoff)
+
+    @Test func launchCommandMaterializesPromptWith0600AndDashP() async throws {
+        let sid = UUID()
+        let cmd = try await launcher.launchCommand(
+            sessionID: sid, worktreePath: "/wt/crow", prompt: "hello world", binary: "/bin/agy")
+
+        // Shape: cd '<wt>' && '<binary>' -p "$(cat '<tmp>')" — all paths quoted.
+        #expect(cmd.hasPrefix("cd '/wt/crow' && '/bin/agy' -p \"$(cat '"))
+        #expect(cmd.hasSuffix("')\"\n"))
+
+        // The temp prompt file exists, holds the prompt, and is owner-only 0600.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-antigravity-\(sid.uuidString)-prompt.md")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        #expect(try String(contentsOf: tmp, encoding: .utf8) == "hello world")
+        let perms = try FileManager.default.attributesOfItem(atPath: tmp.path)[.posixPermissions] as? Int
+        #expect(perms == 0o600)
+    }
+
+    @Test func launchCommandQuotesWorktreeWithSpaces() async throws {
+        let cmd = try await launcher.launchCommand(
+            sessionID: UUID(), worktreePath: "/Users/x/My Projects/wt",
+            prompt: "p", binary: "/bin/agy")
+        #expect(cmd.hasPrefix("cd '/Users/x/My Projects/wt' && "))
+    }
+}

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravitySignalSourceTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravitySignalSourceTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import CrowAntigravity
+@testable import CrowCore
+
+@Suite("AntigravitySignalSource")
+struct AntigravitySignalSourceTests {
+    private let source = AntigravitySignalSource()
+
+    private func event(
+        _ name: String,
+        toolName: String? = nil,
+        source: String? = nil
+    ) -> AgentHookEvent {
+        AgentHookEvent(
+            sessionID: UUID(),
+            eventName: name,
+            toolName: toolName,
+            source: source,
+            summary: name
+        )
+    }
+
+    // MARK: - Invocation boundaries
+
+    @Test func preInvocationSetsWorkingAndClearsStop() {
+        let t = source.transition(
+            for: event("PreInvocation"),
+            currentActivityState: .done,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: Date()
+        )
+        #expect(t.newActivityState == .working)
+        if case .clear = t.lastTopLevelStopAt {} else {
+            Issue.record("PreInvocation should clear lastTopLevelStopAt (new turn)")
+        }
+    }
+
+    @Test func postInvocationIsObservationalOnly() {
+        // PostInvocation must NOT flip to done — Stop (fullyIdle) is the
+        // authoritative done signal; a multi-step turn emits several invocations.
+        let t = source.transition(
+            for: event("PostInvocation"),
+            currentActivityState: .working,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: nil
+        )
+        #expect(t.newActivityState == nil)
+    }
+
+    // MARK: - Tool activity
+
+    @Test func preToolUseSetsWorking() {
+        let t = source.transition(
+            for: event("PreToolUse", toolName: "Bash"),
+            currentActivityState: .idle,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: nil
+        )
+        #expect(t.newActivityState == .working)
+        if case .set(let activity) = t.toolActivity {
+            #expect(activity.toolName == "Bash")
+            #expect(activity.isActive == true)
+        } else {
+            Issue.record("expected tool activity set active")
+        }
+    }
+
+    @Test func postToolUseMarksInactive() {
+        let t = source.transition(
+            for: event("PostToolUse", toolName: "Bash"),
+            currentActivityState: .working,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: nil
+        )
+        #expect(t.newActivityState == nil)
+        if case .set(let activity) = t.toolActivity {
+            #expect(activity.isActive == false)
+        } else {
+            Issue.record("expected inactive tool activity")
+        }
+    }
+
+    // MARK: - Stop (fullyIdle → done)
+
+    @Test func stopMarksDoneAndSetsStopAt() {
+        let t = source.transition(
+            for: event("Stop"),
+            currentActivityState: .working,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: nil
+        )
+        #expect(t.newActivityState == .done)
+        if case .clear = t.toolActivity {} else {
+            Issue.record("Stop should clear tool activity")
+        }
+        if case .set = t.lastTopLevelStopAt {} else {
+            Issue.record("Stop should set lastTopLevelStopAt")
+        }
+    }
+
+    // MARK: - PermissionRequest (defensive parity — not emitted by the writer)
+
+    @Test func permissionRequestWaits() {
+        let t = source.transition(
+            for: event("PermissionRequest"),
+            currentActivityState: .working,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: nil
+        )
+        #expect(t.newActivityState == .waiting)
+        if case .set(let n) = t.notification {
+            #expect(n.notificationType == "permission_prompt")
+        } else {
+            Issue.record("expected permission_prompt notification")
+        }
+    }
+
+    @Test func permissionRequestPreservesQuestionNotification() {
+        let t = source.transition(
+            for: event("PermissionRequest"),
+            currentActivityState: .waiting,
+            currentNotificationType: "question",
+            currentLastTopLevelStopAt: nil
+        )
+        if case .leave = t.notification {} else {
+            Issue.record("question notification should not be overridden")
+        }
+    }
+
+    // MARK: - Blanket clear
+
+    @Test func nonPermissionRequestClearsPendingNotification() {
+        let t = source.transition(
+            for: event("PreToolUse", toolName: "Bash"),
+            currentActivityState: .waiting,
+            currentNotificationType: "permission_prompt",
+            currentLastTopLevelStopAt: nil
+        )
+        if case .clear = t.notification {} else {
+            Issue.record("non-PermissionRequest events should clear pending notification")
+        }
+    }
+
+    @Test func unknownEventAppliesBlanketClearOnly() {
+        let t = source.transition(
+            for: event("SomeFutureEvent"),
+            currentActivityState: .working,
+            currentNotificationType: "permission_prompt",
+            currentLastTopLevelStopAt: nil
+        )
+        #expect(t.newActivityState == nil)
+        if case .clear = t.notification {} else {
+            Issue.record("unknown events should still clear pending notification")
+        }
+    }
+}

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravitySignalSourceTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravitySignalSourceTests.swift
@@ -66,19 +66,30 @@ struct AntigravitySignalSourceTests {
         }
     }
 
-    @Test func postToolUseMarksInactive() {
+    @Test func postToolUseIsWorkingHeartbeatWithoutBogusToolName() {
+        // Antigravity's PostToolUse stdin has no tool name, so we must NOT surface
+        // a bogus "unknown" tool — just keep the working heartbeat.
         let t = source.transition(
-            for: event("PostToolUse", toolName: "Bash"),
+            for: event("PostToolUse"),
             currentActivityState: .working,
             currentNotificationType: nil,
             currentLastTopLevelStopAt: nil
         )
-        #expect(t.newActivityState == nil)
-        if case .set(let activity) = t.toolActivity {
-            #expect(activity.isActive == false)
-        } else {
-            Issue.record("expected inactive tool activity")
+        #expect(t.newActivityState == .working)
+        if case .leave = t.toolActivity {} else {
+            Issue.record("PostToolUse should not set a (bogus) tool activity")
         }
+    }
+
+    @Test func postToolUseAfterStopDoesNotReElevate() {
+        // A stray PostToolUse after Stop must not flip back to working.
+        let t = source.transition(
+            for: event("PostToolUse"),
+            currentActivityState: .done,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: Date()
+        )
+        #expect(t.newActivityState == nil)
     }
 
     // MARK: - Stop (fullyIdle → done)

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
@@ -186,7 +186,7 @@ public struct HandoffAgent: ParsableCommand {
         abstract: "Switch a session to a different coding agent (e.g. when credits run out)"
     )
     @Option(name: .long, help: "Session UUID") var session: String
-    @Option(name: .long, help: "Target agent kind (claude-code, cursor, codex, opencode)")
+    @Option(name: .long, help: "Target agent kind (claude-code, cursor, codex, opencode, antigravity)")
     var agent: String
     @Option(name: .long, help: "Optional note for the incoming agent about where to resume")
     var note: String?
@@ -196,7 +196,7 @@ public struct HandoffAgent: ParsableCommand {
     public func validate() throws {
         try validateUUID(session, label: "session UUID")
         guard !agent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw ValidationError("agent must be non-empty (claude-code, cursor, codex, or opencode)")
+            throw ValidationError("agent must be non-empty (claude-code, cursor, codex, opencode, or antigravity)")
         }
     }
 

--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift
@@ -22,6 +22,10 @@ public struct AgentKind: Hashable, Sendable, Codable, RawRepresentable {
 
     /// The OpenCode agent (sst/opencode).
     public static let openCode = AgentKind(rawValue: "opencode")
+
+    /// The Google Antigravity agent (CLI binary `agy`). Tier-2 / experimental —
+    /// closed-source, Google-auth-locked, hooks-only state detection (#860).
+    public static let antigravity = AgentKind(rawValue: "antigravity")
 }
 
 public extension AgentKind {

--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -27,6 +27,7 @@ public enum CrowAttribution {
         AgentKind.cursor.rawValue: "Cursor",
         AgentKind.codex.rawValue: "OpenAI Codex",
         AgentKind.openCode.rawValue: "OpenCode",
+        AgentKind.antigravity.rawValue: "Antigravity",
     ]
 
     /// Resolve the display name for `agentKind`, falling back to `defaultAgentDisplayName`.

--- a/Packages/CrowDaemon/Package.swift
+++ b/Packages/CrowDaemon/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         .package(path: "../CrowCodex"),
         .package(path: "../CrowCursor"),
         .package(path: "../CrowOpenCode"),
+        .package(path: "../CrowAntigravity"),
         // OTLP receiver + telemetry.db, so the daemon produces the per-session
         // analytics the web strip and the scorecard read (#772). Darwin-only
         // (Network.framework) — CrowDaemon already is, via CrowTerminal, and
@@ -52,6 +53,7 @@ let package = Package(
                 .product(name: "CrowCodex", package: "CrowCodex"),
                 .product(name: "CrowCursor", package: "CrowCursor"),
                 .product(name: "CrowOpenCode", package: "CrowOpenCode"),
+                .product(name: "CrowAntigravity", package: "CrowAntigravity"),
                 .product(name: "CrowTelemetry", package: "CrowTelemetry"),
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -9,6 +9,7 @@ import CrowClaude
 import CrowCodex
 import CrowCursor
 import CrowOpenCode
+import CrowAntigravity
 import CrowEngine
 import CrowProvider
 import CrowGit
@@ -912,6 +913,18 @@ public enum CrowDaemon {
         if let path = openCode.findBinary() {
             AgentRegistry.shared.register(openCode)
             log("OpenCode agent registered at \(path)")
+        }
+
+        // Google Antigravity (`agy`) — Tier-2 / experimental (#860). Registered
+        // only when its binary resolves on PATH (or a `defaults.binaries.antigravity`
+        // override); off-PATH ⇒ silently absent from the picker and handoff
+        // (ADR 0014). This is also the safe default while the supply-chain
+        // provenance is confirmed — Crow never installs `agy` itself, it only
+        // resolves whatever the official `antigravity.google` installer placed.
+        let antigravity = AntigravityAgent()
+        if let path = antigravity.findBinary() {
+            AgentRegistry.shared.register(antigravity)
+            log("Antigravity agent registered at \(path)")
         }
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -4,6 +4,7 @@ import CrowCore
 import CrowCursor
 import CrowEngine
 import CrowOpenCode
+import CrowAntigravity
 import CrowPersistence
 import Foundation
 
@@ -159,6 +160,26 @@ enum LaunchScaffold {
                 CrowDaemon.log("OpenCode Jira MCP registration: \(mcpOutcome)")
             case .skippedUnparseable, .failed:
                 CrowDaemon.log("WARNING: OpenCode Jira MCP registration: \(mcpOutcome)")
+            }
+        }
+
+        if AgentRegistry.shared.agent(for: .antigravity) != nil {
+            // Per-worktree `.agents/hooks.json` (with `--session` baked in) is the
+            // authority (#860), written by the engine per session via the generic
+            // `agent.hookConfigWriter` path. Antigravity may merge global +
+            // workspace hooks and run both, so any global config a prior Crow
+            // installed under `~/.gemini/config/` would double-fire every event —
+            // strip our managed entries there (user entries survive). Doesn't need
+            // `crowPath`. No dev-root scaffold and no MCP bridge in Phase A: the
+            // launcher prompt uses `acli` for Jira (no MCP writer yet — deferred),
+            // and Antigravity reads no shared `AGENTS.md` we own.
+            //
+            // Empty `GEMINI_CONFIG_HOME=` treated as unset, same reason as
+            // `CODEX_HOME`/`CURSOR_CONFIG_DIR` above.
+            let geminiConfigHome = nonEmptyEnv("GEMINI_CONFIG_HOME")
+                ?? NSString(string: "~/.gemini/config").expandingTildeInPath
+            attempt("Antigravity global hook cleanup") {
+                AntigravityHookConfigWriter.removeManagedGlobalConfig(geminiConfigHome: geminiConfigHome)
             }
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -630,7 +630,7 @@ const STATUS_COLOR = {
   active: 'var(--green)', paused: 'var(--yellow)',
   inReview: 'var(--gold)', completed: 'var(--gold)', archived: 'var(--text-muted)',
 };
-const AGENT_GLYPH = { 'claude-code': '✦', cursor: '▲', codex: '◆', 'open-code': '◇', opencode: '◇' };
+const AGENT_GLYPH = { 'claude-code': '✦', cursor: '▲', codex: '◆', 'open-code': '◇', opencode: '◇', antigravity: '↑' };
 
 // Sidebar session groups (Managers now live in the nav pill row, not a group).
 const GROUPS = [

--- a/Packages/CrowEngine/Sources/CrowEngine/AgentHandoff.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AgentHandoff.swift
@@ -10,6 +10,7 @@ public enum AgentHandoffError: Error, LocalizedError, Equatable {
     case agentBinaryMissing(String)
     case noWorktree
     case launchFailed(String)
+    case reviewNotSupported(String)
 
     public var errorDescription: String? {
         switch self {
@@ -27,6 +28,8 @@ public enum AgentHandoffError: Error, LocalizedError, Equatable {
             return "Session has no worktree to hand off"
         case .launchFailed(let message):
             return "Failed to build handoff launch command: \(message)"
+        case .reviewNotSupported(let kind):
+            return "Agent \"\(kind)\" does not support review sessions; hand the review to a review-capable agent instead"
         }
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -48,10 +48,15 @@ public struct EngineContext {
 }
 
 /// Extract the tool name from a hook payload, tolerating each harness's shape.
-/// Claude/Cursor/Codex send a flat `tool_name`; Antigravity's stdin nests it as
-/// `toolCall.name` (camelCase). Falling back keeps Antigravity's `PostToolUse`
-/// tool activity from always reading `"unknown"` (#862 review). Harmless for the
-/// other harnesses — they have no `toolCall` object.
+/// Claude/Cursor/Codex send a flat `tool_name`; Antigravity nests it as
+/// `toolCall.name` (camelCase) — but **only on `PreToolUse`**. Antigravity's
+/// `PostToolUse` stdin carries no tool name at all (only `stepIdx`/`error`/common
+/// fields), and Crow deliberately doesn't register `PreToolUse` (its strict
+/// decision gate), so for Antigravity this fallback is future-proofing for a
+/// possible `PreToolUse` re-enable, not a live path — Antigravity's registered
+/// `PostToolUse` tool activity is unnamed by design (a documented Tier-2 gap;
+/// see `AntigravitySignalSource`). Harmless for the other harnesses (they have
+/// no `toolCall` object).
 func hookToolName(from payload: [String: JSONValue]) -> String? {
     if let flat = payload["tool_name"]?.stringValue { return flat }
     return payload["toolCall"]?.objectValue?["name"]?.stringValue

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -47,6 +47,16 @@ public struct EngineContext {
     }
 }
 
+/// Extract the tool name from a hook payload, tolerating each harness's shape.
+/// Claude/Cursor/Codex send a flat `tool_name`; Antigravity's stdin nests it as
+/// `toolCall.name` (camelCase). Falling back keeps Antigravity's `PostToolUse`
+/// tool activity from always reading `"unknown"` (#862 review). Harmless for the
+/// other harnesses — they have no `toolCall` object.
+func hookToolName(from payload: [String: JSONValue]) -> String? {
+    if let flat = payload["tool_name"]?.stringValue { return flat }
+    return payload["toolCall"]?.objectValue?["name"]?.stringValue
+}
+
 @MainActor
 public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
     let capturedAppState = ctx.appState
@@ -1191,7 +1201,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 let summary: String = {
                     switch eventName {
                     case "PreToolUse", "PostToolUse", "PostToolUseFailure":
-                        let tool = payload["tool_name"]?.stringValue ?? "unknown"
+                        let tool = hookToolName(from: payload) ?? "unknown"
                         return "\(eventName): \(tool)"
                     case "Notification":
                         let msg = payload["message"]?.stringValue ?? ""
@@ -1260,7 +1270,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                     let agentEvent = AgentHookEvent(
                         sessionID: sessionID,
                         eventName: eventName,
-                        toolName: payload["tool_name"]?.stringValue,
+                        toolName: hookToolName(from: payload),
                         source: payload["source"]?.stringValue,
                         message: payload["message"]?.stringValue,
                         notificationType: payload["notification_type"]?.stringValue,

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -869,7 +869,7 @@ public final class SessionService {
         // `new-terminal` pins on managed agent windows, so orphaned agents are
         // identified positively and the anchor/infra is never touched.
         let keep = Set(appState.terminals.values.flatMap { $0 }.compactMap { $0.tmuxBinding?.windowIndex })
-        let agentNames = Set([AgentKind.claudeCode, .cursor, .codex, .openCode]
+        let agentNames = Set([AgentKind.claudeCode, .cursor, .codex, .openCode, .antigravity]
             .map { CrowAttribution.agentDisplayName(for: $0) })
         TmuxBackend.shared.reconcileOrphanWindows(keepWindowIndices: keep, agentWindowNames: agentNames)
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1193,6 +1193,22 @@ public final class SessionService {
         guard target.findBinary() != nil else {
             throw AgentHandoffError.agentBinaryMissing(targetKind.rawValue)
         }
+        // Refuse handing a *review* session off to Antigravity. Review is
+        // unsupported on this Tier-2 harness (`autoLaunchCommand(.review)` → nil),
+        // and the handoff path launches via `AntigravityLauncher.launchCommand`
+        // (`agy -p …`) regardless — which would start `agy` inside the review
+        // clone. A hostile PR head can commit `.agents/hooks.json` with arbitrary
+        // command hooks that Antigravity runs with **no approval gate**, and
+        // Crow's git-tracked guard then declines to overwrite that committed file
+        // (leaving the attacker's hooks live) — i.e. RCE on the reviewer's
+        // machine. Unlike Cursor/Codex (which support review and strip
+        // `.cursor/`/`.codex/` + trust-gate), Antigravity has no legitimate
+        // review launch, so refusing the handoff outright closes the vector at
+        // its source rather than relying on a strip. `prepareReviewClone` also
+        // strips `.agents/` for Antigravity review clones as defense-in-depth.
+        guard !Self.shouldRefuseReviewHandoff(targetKind: targetKind, sessionKind: session.kind) else {
+            throw AgentHandoffError.reviewNotSupported(targetKind.rawValue)
+        }
         guard let worktree = appState.primaryWorktree(for: sessionID) else {
             throw AgentHandoffError.noWorktree
         }
@@ -2563,6 +2579,20 @@ public final class SessionService {
         targetKind == .cursor && sessionKind == .review
     }
 
+    /// Gate for refusing a review-session handoff to an agent that can't perform
+    /// reviews. Today only Antigravity: its `.review` is unsupported in Phase A
+    /// (`autoLaunchCommand(.review)` → nil) AND it has no `.agents/` strip / trust
+    /// gate, so a review handoff would launch `agy` in an attacker-controlled
+    /// clone and run committed `.agents/hooks.json` unsandboxed. Extracted as a
+    /// pure predicate so the security gate is unit-testable without the full
+    /// `handoffAgent` machinery (mirrors `shouldStripCursorReviewCloneOnHandoff`).
+    /// Codex/Cursor/OpenCode are deliberately excluded — they support review
+    /// handoff with their own strip + trust protections.
+    nonisolated static func shouldRefuseReviewHandoff(
+        targetKind: AgentKind, sessionKind: SessionKind) -> Bool {
+        targetKind == .antigravity && sessionKind == .review
+    }
+
     /// Neutralize a review clone's committed Cursor config layer by removing the
     /// working-tree `.cursor/` directory. A hostile PR head can commit
     /// `.cursor/hooks.json` (arbitrary `beforeShellExecution` commands, with no
@@ -2716,6 +2746,20 @@ public final class SessionService {
         // on `.codex/`.
         if reviewAgentKind == .codex {
             try? fm.removeItem(atPath: (clonePath as NSString).appendingPathComponent(".codex"))
+        }
+        // Defense-in-depth for Antigravity review clones (#862 review): a hostile
+        // PR head can commit `.agents/hooks.json` with arbitrary command hooks
+        // that `agy` runs with no approval gate. Antigravity review handoff is
+        // refused outright (`shouldRefuseReviewHandoff`), so this normally guards
+        // a path that can't be reached today — but if any future code launches
+        // `agy` in a review clone (e.g. Antigravity becoming a valid review
+        // agent), the committed `.agents/` is already neutralized. Gated to
+        // Antigravity reviews for the same reason as `.codex`/`.cursor`: only
+        // Antigravity loads `.agents/`, so stripping it for another agent's
+        // review would just hide the files a hostile PR ships. Re-run on every
+        // prep so a `git pull` can't reintroduce it.
+        if reviewAgentKind == .antigravity {
+            try? fm.removeItem(atPath: (clonePath as NSString).appendingPathComponent(".agents"))
         }
         // Same defense-in-depth for Cursor reviews (#829 review round 9). This
         // PR makes project `.cursor/hooks.json` Crow's load-bearing hook

--- a/Packages/CrowEngine/Tests/CrowEngineTests/HookToolNameTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/HookToolNameTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+import CrowIPC
+@testable import CrowEngine
+
+/// Unit tests for the `hookToolName` payload-shape normalizer used by the
+/// `hook-event` router (#862 review). Locks the two shapes: a flat `tool_name`
+/// (Claude/Cursor/Codex) and Antigravity's nested `toolCall.name`.
+@Suite("hookToolName")
+struct HookToolNameTests {
+    @Test func readsFlatToolName() {
+        let payload: [String: JSONValue] = ["tool_name": .string("Bash")]
+        #expect(hookToolName(from: payload) == "Bash")
+    }
+
+    @Test func readsNestedToolCallName() {
+        // Antigravity's PreToolUse shape: { "toolCall": { "name": "run_command" } }
+        let payload: [String: JSONValue] = [
+            "toolCall": .object(["name": .string("run_command")]),
+        ]
+        #expect(hookToolName(from: payload) == "run_command")
+    }
+
+    @Test func flatWinsOverNested() {
+        let payload: [String: JSONValue] = [
+            "tool_name": .string("Bash"),
+            "toolCall": .object(["name": .string("run_command")]),
+        ]
+        #expect(hookToolName(from: payload) == "Bash")
+    }
+
+    @Test func nilWhenNeitherPresent() {
+        // Antigravity's PostToolUse shape carries no tool name — helper returns nil
+        // (the documented Tier-2 gap), never a bogus value.
+        let payload: [String: JSONValue] = ["stepIdx": .int(5), "error": .string("")]
+        #expect(hookToolName(from: payload) == nil)
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
@@ -107,4 +107,32 @@ struct SessionServiceReviewCloneStripTests {
                 targetKind: k, sessionKind: .review))
         }
     }
+
+    // MARK: - Antigravity review-handoff refusal (#862 review — RCE vector)
+
+    /// A `.review` handoff to Antigravity is refused: review is unsupported on
+    /// this Tier-2 harness and it has no `.agents/` strip / trust gate, so a
+    /// handoff would launch `agy` in an attacker-controlled clone and run
+    /// committed `.agents/hooks.json` unsandboxed.
+    @Test func refuseGateFiresForAntigravityReview() {
+        #expect(SessionService.shouldRefuseReviewHandoff(
+            targetKind: .antigravity, sessionKind: .review))
+    }
+
+    /// A `.work`/`.job` handoff to Antigravity is a normal working clone — allowed.
+    @Test func refuseGateAllowsNonReviewAntigravity() {
+        #expect(!SessionService.shouldRefuseReviewHandoff(
+            targetKind: .antigravity, sessionKind: .work))
+        #expect(!SessionService.shouldRefuseReviewHandoff(
+            targetKind: .antigravity, sessionKind: .job))
+    }
+
+    /// A `.review` handoff to a review-capable agent is NOT refused — they have
+    /// their own strip + trust protections.
+    @Test func refuseGateAllowsReviewForOtherAgents() {
+        for k: AgentKind in [.claudeCode, .cursor, .codex, .openCode] {
+            #expect(!SessionService.shouldRefuseReviewHandoff(
+                targetKind: k, sessionKind: .review))
+        }
+    }
 }

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -13,6 +13,16 @@ implementation with every capability wired; the other three ship with
 deliberate, documented gaps (full grid in the
 [capability matrix](../agent-harness-matrix.md)).
 
+> **Amendment (2026-07-26, #860):** a fifth harness — **Antigravity** (Google's
+> `agy` CLI) — joined as an explicit **Tier-2 / experimental** target: a real,
+> driveable CLI that lands below the self-hostable harnesses and ships with
+> honest, documented gaps (closed-source + Google-auth-locked ⇒ a *permanent*
+> self-host ❌, hooks-only state detection, no review, no MCP bridge, a
+> supply-chain gate on its binary provenance). It is the first harness added
+> under the tiering this ADR defines; its gaps live in the same
+> [capability matrix](../agent-harness-matrix.md) column and are governed by the
+> Tier-2 rationale below.
+
 Until now, the *why* behind each gap lived only in scattered code comments —
 several of them **pinned to a specific upstream version** ("sync-only as of
 v0.139.0"). That makes the reasons easy to lose and, worse, easy to leave stale:

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -1,10 +1,12 @@
 # Coding-agent harness capability matrix
 
-Crow can drive four coding agents ("harnesses") through one adapter protocol,
+Crow can drive several coding agents ("harnesses") through one adapter protocol,
 [`CodingAgent`](../Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift):
-**Claude Code**, **Cursor**, **OpenAI Codex**, and **OpenCode** (sst/opencode).
-Claude Code is the reference implementation and the default; the other three
-ship with deliberate gaps.
+**Claude Code**, **Cursor**, **OpenAI Codex**, **OpenCode** (sst/opencode), and
+the Tier-2 **Antigravity** (Google's `agy` CLI). Claude Code is the reference
+implementation and the default; the others ship with deliberate gaps, and
+Antigravity ships as **Tier-2 / experimental** (closed-source, Google-auth-
+locked — see its section below).
 
 This page is the living reference for **what each harness can do and why the
 gaps exist**. The *architecture* of the adapter is
@@ -21,21 +23,22 @@ capabilities, update this table in the same PR.
 
 ## The matrix
 
-| Dimension | Claude Code | Cursor | Codex | OpenCode |
-|---|---|---|---|---|
-| Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` |
-| Registered at boot | **always** (default out of the box) | only if binary found | only if binary found | only if binary found |
-| Resume / continue | ✅ `--continue` | ✅ `--continue` (job/review restart, #829) | ✅ `resume --last` | ⚠️ `--continue` re-enters TUI, no history |
-| Remote control | ✅ native `--rc --name` | ⚠️ faked via `crow send` stdin | ❌ `supportsRemoteControl=false` (experimental `--remote` unwired) | ⚠️ faked via `crow send` stdin |
-| Auto-permission | ✅ `--permission-mode auto` | ✅ `--force --approve-mcps` (parity with Claude auto, #829) | ✅ `-a never -s workspace-write` (`.job`, interactive) | ⚠️ runtime-probed `--auto`, `.job` only |
-| Hooks transport | per-worktree `.claude/settings.local.json` | per-worktree `.cursor/hooks.json` (#829) | global `~/.codex/hooks.json` + `config.toml` `notify` bridge (per-worktree deferred — see below) | global JS plugin `~/.config/opencode/plugins/crow-hooks.js` |
-| Hook → session scope | ✅ per-session UUID | ✅ per-session UUID (#829) | ❌ `cwd` match (per-worktree UUID deferred) | ❌ `cwd` match |
-| Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.141.0) | ⚠️ names verified, timing unverified |
-| MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ✅ `jira` bridged into `~/.cursor/mcp.json` (#829) | ✅ mirrored from `~/.claude.json` into `config.toml` | ❌ falls back to `acli` |
-| Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body |
-| Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `$(cat …)` job/review; handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (`$(cat …-prompt.md)`) | ✅ run-then-`--continue` |
-| Gateway env / trust seed / telemetry | ✅ Claude special-case | ❌ | ⚠️ trust seed only (`[projects."…"]` in `config.toml`) | ❌ |
-| Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ |
+| Dimension | Claude Code | Cursor | Codex | OpenCode | Antigravity (Tier-2) |
+|---|---|---|---|---|---|
+| Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` | `agy` ✅ low collision |
+| Registered at boot | **always** (default out of the box) | only if binary found | only if binary found | only if binary found | only if binary found |
+| Resume / continue | ✅ `--continue` | ✅ `--continue` (job/review restart, #829) | ✅ `resume --last` | ⚠️ `--continue` re-enters TUI, no history | ⚠️ `-c` (machine-global most-recent; no per-run id, FR #7) |
+| Remote control | ✅ native `--rc --name` | ⚠️ faked via `crow send` stdin | ❌ `supportsRemoteControl=false` (experimental `--remote` unwired) | ⚠️ faked via `crow send` stdin | ⚠️ faked via `crow send` stdin (no native RC) |
+| Auto-permission | ✅ `--permission-mode auto` | ✅ `--force --approve-mcps` (parity with Claude auto, #829) | ✅ `-a never -s workspace-write` (`.job`, interactive) | ⚠️ runtime-probed `--auto`, `.job` only | ⚠️ `settings.json` modes only (no verified launch flag; never `--dangerously-skip-permissions`) |
+| Hooks transport | per-worktree `.claude/settings.local.json` | per-worktree `.cursor/hooks.json` (#829) | global `~/.codex/hooks.json` + `config.toml` `notify` bridge (per-worktree deferred — see below) | global JS plugin `~/.config/opencode/plugins/crow-hooks.js` | per-worktree `.agents/hooks.json` (#860) |
+| Hook → session scope | ✅ per-session UUID | ✅ per-session UUID (#829) | ❌ `cwd` match (per-worktree UUID deferred) | ❌ `cwd` match | ✅ per-session UUID |
+| Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.141.0) | ⚠️ names verified, timing unverified | ⚠️ `PostToolUse`/`PostInvocation` declared, timing unverified |
+| MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ✅ `jira` bridged into `~/.cursor/mcp.json` (#829) | ✅ mirrored from `~/.claude.json` into `config.toml` | ❌ falls back to `acli` | ❌ falls back to `acli` (file bridge deferred) |
+| Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body | ❌ unsupported in Phase A (`autoLaunchCommand(.review)` → nil, like Codex) |
+| Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `$(cat …)` job/review; handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (`$(cat …-prompt.md)`) | ✅ run-then-`--continue` | ✅ `-p "$(cat …-job-prompt.md)"` (`.job`); `.work` bare |
+| Gateway env / trust seed / telemetry | ✅ Claude special-case | ❌ | ⚠️ trust seed only (`[projects."…"]` in `config.toml`) | ❌ | ❌ |
+| Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ | ❌ unverified on v1.1.7 (opt-out `nil`) |
+| Self-host / local models | provider-dependent | provider-dependent | provider-dependent | provider-dependent | ❌ **permanent** — closed-source, Google-Sign-In/GCP-locked (Gemini 3 Pro / Claude Sonnet 4.5 only) |
 
 Legend: ✅ full · ⚠️ partial / faked / unverified · ❌ not supported.
 
@@ -348,9 +351,51 @@ sent after a Crow rename so the agent's own session title stays in sync
 (CROW-629). The protocol default is `nil` so a *future* harness can't inherit a
 spurious `/rename` paste.
 
+## Antigravity (Tier-2 / experimental)
+
+Google Antigravity's CLI (binary **`agy`**) is the terminal surface of Google's
+agent-first dev platform (IDE + CLI + SDK, launched with Gemini 3). Crow drives
+it through the same `CodingAgent` protocol as the others — its adapter
+(`CrowAntigravity`) is structurally a **near-clone of `CrowCursor`**: Claude-
+Code-style hooks (JSON on stdin, reply on stdout), so the
+`HookConfigWriter`/`StateSignalSource` pair does real work; per-worktree
+`.agents/hooks.json` with the session UUID baked in (per-session scope, not
+`cwd`); remote control faked via `crow send`; `.review` unsupported in Phase A
+(like Codex). It ships **Tier-2** ([ADR 0015](adr/0015-harness-capability-tiers.md))
+with honest, documented gaps (#860).
+
+**Hooks are its single strongest point.** Antigravity's `Stop` hook carries
+`fullyIdle` + `terminationReason` (`model_stop` / `max_steps_exceeded` /
+`error`) — a real "done" signal that `AntigravitySignalSource` maps to `.done`.
+`PreInvocation`/`PostInvocation` are the turn-boundary hooks (Claude's
+`UserPromptSubmit`/`SessionStart` analogue); `PreToolUse`/`PostToolUse` share the
+tool vocabulary. Gaps: no `--output-format json`/`stream-json` (upstream FRs
+#119/#597), no ACP/JSON-RPC (FR #31), no dedicated "awaiting-input" event, and
+headless `-p` historically drops stdout on a **non-TTY** — which doesn't bite
+Crow because it launches `agy` inside a tmux PTY, so no shim is needed on the
+`.job` `-p` path.
+
+**Permanent gap — self-host.** The `agy` binary is **closed-source** and auth is
+**Google Sign-In / GCP**, so it runs only against Google's cloud models (Gemini
+3 Pro default, Claude Sonnet 4.5) — never an arbitrary self-hosted/local model.
+That fails Corveil's self-host axis and is a **fixed** gap, not a phase.
+
+**⚠️ Supply-chain note (the gate this adapter was built behind).** The
+`google-antigravity` GitHub org is `is_verified: false` (confirmed via
+`gh api orgs/google-antigravity`), was created 2025-11-04, and is **not** one of
+Google's canonical orgs (`google`, `google-gemini`); its `antigravity-cli` repo
+is README-only (no source, no license) — a community mirror/tracker. Crow's
+`findBinary()`/`fallbackCandidates` are therefore **never** wired to that org's
+release binaries: resolution is PATH-first (picking up whatever the **official**
+`antigravity.google` installer placed), with only conservative standard-bin
+fallbacks (`/opt/homebrew/bin/agy`, `/usr/local/bin/agy`, `~/.local/bin/agy`,
+`~/.antigravity/bin/agy`). Off-`PATH` `agy` ⇒ silently unregistered (ADR 0014),
+the safe default. **The exact official install path must be confirmed before
+Antigravity is promoted out of Tier-2.**
+
 ## Handoff between harnesses
 
-`crow handoff-agent --session <UUID> --agent <claude-code|cursor|codex|opencode>
+`crow handoff-agent --session <UUID> --agent <claude-code|cursor|codex|opencode|antigravity>
 [--note "…"]` switches a running session to a different harness. It preserves the
 Crow session identity, worktree, branch, ticket, and links; it does **not**
 transfer chat history ([ADR 0011](adr/0011-agent-handoff-preserves-session-not-chat.md)).
@@ -379,3 +424,7 @@ against current upstream CLIs.
 | Claude background-recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` | 2026-07-24 |
 | Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` | 2026-07-24 |
 | OpenCode `session.idle` "done" semantics unconfirmed for TUI | — (CROW-545) | `OpenCodeHookConfigWriter` | 2026-07-24 |
+| Antigravity flags (`agy` hooks events, `-p` non-TTY stdout, `-c`/`--conversation` resume) | `agy` **v1.1.7 (2026-07-26)** | `AntigravityAgent` / `AntigravityHookConfigWriter` | 2026-07-26 — re-probe on upgrade |
+| Antigravity structured-stdout (would promote toward first-class parity) | upstream FRs **#119/#597** (`--output-format stream-json`), **#31** (ACP) | `AntigravitySignalSource` | 2026-07-26 — hooks are the only transport until either lands |
+| Antigravity bounded auto-permission has no verified interactive launch flag | `agy` **v1.1.7**; headless `-p` ignores `permissions.allow` (issue #548) | `AntigravityLaunchArgs.autoPermissionSuffix` | 2026-07-26 |
+| Antigravity official-installer provenance (supply-chain gate) unconfirmed | `google-antigravity` org `is_verified: false`; pin `antigravity.google` | `AntigravityAgent.fallbackCandidates` | 2026-07-26 — confirm before promoting out of Tier-2 |

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -32,7 +32,7 @@ capabilities, update this table in the same PR.
 | Auto-permission | ✅ `--permission-mode auto` | ✅ `--force --approve-mcps` (parity with Claude auto, #829) | ✅ `-a never -s workspace-write` (`.job`, interactive) | ⚠️ runtime-probed `--auto`, `.job` only | ⚠️ `settings.json` modes only (no verified launch flag; never `--dangerously-skip-permissions`) |
 | Hooks transport | per-worktree `.claude/settings.local.json` | per-worktree `.cursor/hooks.json` (#829) | global `~/.codex/hooks.json` + `config.toml` `notify` bridge (per-worktree deferred — see below) | global JS plugin `~/.config/opencode/plugins/crow-hooks.js` | per-worktree `.agents/hooks.json` (#860) |
 | Hook → session scope | ✅ per-session UUID | ✅ per-session UUID (#829) | ❌ `cwd` match (per-worktree UUID deferred) | ❌ `cwd` match | ✅ per-session UUID |
-| Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.141.0) | ⚠️ names verified, timing unverified | ⚠️ `PostToolUse`/`PostInvocation` declared, timing unverified |
+| Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.141.0) | ⚠️ names verified, timing unverified | ❌ no `async` in Antigravity's schema — all sync |
 | MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ✅ `jira` bridged into `~/.cursor/mcp.json` (#829) | ✅ mirrored from `~/.claude.json` into `config.toml` | ❌ falls back to `acli` | ❌ falls back to `acli` (file bridge deferred) |
 | Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body | ❌ unsupported in Phase A (`autoLaunchCommand(.review)` → nil) |
 | Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `$(cat …)` job/review; handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (`$(cat …-prompt.md)`) | ✅ run-then-`--continue` | ✅ `-p "$(cat …-job-prompt.md)"` (`.job`); `.work` bare |
@@ -356,8 +356,8 @@ spurious `/rename` paste.
 Google Antigravity's CLI (binary **`agy`**) is the terminal surface of Google's
 agent-first dev platform (IDE + CLI + SDK, launched with Gemini 3). Crow drives
 it through the same `CodingAgent` protocol as the others — its adapter
-(`CrowAntigravity`) is structurally a **near-clone of `CrowCursor`**: Claude-
-Code-style hooks (JSON on stdin, reply on stdout), so the
+(`CrowAntigravity`) is structurally a **near-clone of `CrowCursor`**: hooks feed
+lifecycle events (JSON on stdin, JSON verdict on stdout) so the
 `HookConfigWriter`/`StateSignalSource` pair does real work; per-worktree
 `.agents/hooks.json` with the session UUID baked in (per-session scope, not
 `cwd`); remote control faked via `crow send`; `.review` unsupported in Phase A
@@ -365,12 +365,23 @@ Code-style hooks (JSON on stdin, reply on stdout), so the
 It ships **Tier-2** ([ADR 0015](adr/0015-harness-capability-tiers.md))
 with honest, documented gaps (#860).
 
-**Hooks are its single strongest point.** Antigravity's `Stop` hook carries
-`fullyIdle` + `terminationReason` (`model_stop` / `max_steps_exceeded` /
-`error`) — a real "done" signal that `AntigravitySignalSource` maps to `.done`.
-`PreInvocation`/`PostInvocation` are the turn-boundary hooks (Claude's
-`UserPromptSubmit`/`SessionStart` analogue); `PreToolUse`/`PostToolUse` share the
-tool vocabulary. Gaps: no `--output-format json`/`stream-json` (upstream FRs
+**Hooks are its single strongest point — but the schema is Antigravity's own,
+not Claude's.** Verified against [`antigravity.google/docs/hooks`](https://antigravity.google/docs/hooks):
+`hooks.json` is a map of **named groups** → event configs (`{"crow": {…}}`), not
+Claude's `{"hooks": {Event: […]}}`. Tool events (`PostToolUse`) wrap handlers in
+`{matcher:"*", hooks:[…]}`; invocation/`Stop` events list handlers directly under
+the event key; there is **no `async` field**. Each hook command reads its stdin
+event, forwards it to `crow hook-event`, then `printf '{}'`s the stdout verdict
+itself (`crow hook-event` is observational) and exits 0 — so a Crow hook can
+never block a tool or loop the agent. `Stop` carries `fullyIdle` +
+`terminationReason` (`model_stop`/`max_steps_exceeded`/`error`) →
+`AntigravitySignalSource` maps it to `.done`; `PreInvocation` → working;
+`PostToolUse` → tool activity. **`PreToolUse` is deliberately not registered** —
+it demands a strict `{"decision":…}` stdout verdict and a mis-shaped reply denies
+every tool call (cmux #5358), so — like Antigravity's own bundled vibe-island
+plugin — Crow stays off it and reads tool activity from `PostToolUse`. The stdin
+tool name is `toolCall.name` (camelCase), normalized in `EngineRouter`
+(`hookToolName`). Gaps: no `--output-format json`/`stream-json` (upstream FRs
 #119/#597), no ACP/JSON-RPC (FR #31), no dedicated "awaiting-input" event, and
 headless `-p` historically drops stdout on a **non-TTY** — which doesn't bite
 Crow because it launches `agy` inside a tmux PTY, so no shim is needed on the

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -92,8 +92,9 @@ Each harness declares a `launchCommandToken` — the binary name Crow resolves o
 `PATH` and the token the `send` RPC watches for to decide whether a
 managed-terminal command needs hook/env prep.
 
-- Tokens: `claude`, `agent`, `codex`, `opencode`
-  (`ClaudeCodeAgent`, `CursorAgent`, `OpenAICodexAgent`, `OpenCodeAgent`).
+- Tokens: `claude`, `agent`, `codex`, `opencode`, `agy`
+  (`ClaudeCodeAgent`, `CursorAgent`, `OpenAICodexAgent`, `OpenCodeAgent`,
+  `AntigravityAgent`).
 - **Cursor's token is `agent`, a generic name.** CI runners (Azure DevOps,
   TeamCity) also ship a binary called `agent`; Crow accepts the false-positive
   risk and lets users pin the real path via `defaults.binaries.cursor`
@@ -102,11 +103,13 @@ managed-terminal command needs hook/env prep.
   the *first* kind registered
   ([`AgentRegistry.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)).
   `CrowDaemon.registerAgents` registers **Claude unconditionally first**, then
-  Codex / Cursor / OpenCode **only if `findBinary()` resolves**
+  Codex / Cursor / OpenCode / Antigravity **only if `findBinary()` resolves**
   ([`CrowDaemon.swift`](../Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift),
   `registerAgents`). So a harness whose binary is off `PATH` is silently absent
   from the picker and from `handoff-agent` — see
-  [ADR 0015](adr/0015-harness-capability-tiers.md).
+  [ADR 0015](adr/0015-harness-capability-tiers.md). Antigravity's `agy` gate is
+  also the safe default while its supply-chain provenance is confirmed (Crow
+  never installs `agy`; it only resolves what the official installer placed).
 - `findBinary()` resolves in three tiers: explicit `defaults.binaries.<kind>`
   override → `PATH` walk → hardcoded `fallbackCandidates`
   (`CodingAgent` default impl; `BinaryOverrides`, CROW-484).
@@ -375,13 +378,19 @@ event, forwards it to `crow hook-event`, then `printf '{}'`s the stdout verdict
 itself (`crow hook-event` is observational) and exits 0 — so a Crow hook can
 never block a tool or loop the agent. `Stop` carries `fullyIdle` +
 `terminationReason` (`model_stop`/`max_steps_exceeded`/`error`) →
-`AntigravitySignalSource` maps it to `.done`; `PreInvocation` → working;
-`PostToolUse` → tool activity. **`PreToolUse` is deliberately not registered** —
-it demands a strict `{"decision":…}` stdout verdict and a mis-shaped reply denies
-every tool call (cmux #5358), so — like Antigravity's own bundled vibe-island
-plugin — Crow stays off it and reads tool activity from `PostToolUse`. The stdin
-tool name is `toolCall.name` (camelCase), normalized in `EngineRouter`
-(`hookToolName`). Gaps: no `--output-format json`/`stream-json` (upstream FRs
+`AntigravitySignalSource` maps **any `Stop`** to `.done` (it does *not* gate on
+`fullyIdle`/`terminationReason` — the pinned `AgentHookEvent` doesn't surface
+those; refining on them is a version-pinned follow-up); `PreInvocation` →
+working; `PostToolUse` → working-heartbeat. **`PreToolUse` is deliberately not
+registered** — it demands a strict `{"decision":…}` stdout verdict and a
+mis-shaped reply denies every tool call (cmux #5358), so — like Antigravity's own
+bundled vibe-island plugin — Crow stays off it. **Consequence — named tool
+activity is a Tier-2 gap:** `PostToolUse` stdin carries no tool name (only
+`stepIdx`/`error`), and `toolCall.name` lives on `PreToolUse` alone, so Crow can
+signal "a tool ran, still working" but not *which* tool. `EngineRouter`'s
+`hookToolName` reads `tool_name` or the nested `toolCall.name` (future-proofing a
+`PreToolUse` re-enable; a no-op for the currently-registered events). Gaps: no
+`--output-format json`/`stream-json` (upstream FRs
 #119/#597), no ACP/JSON-RPC (FR #31), no dedicated "awaiting-input" event, and
 headless `-p` historically drops stdout on a **non-TTY** — which doesn't bite
 Crow because it launches `agy` inside a tmux PTY, so no shim is needed on the

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -34,7 +34,7 @@ capabilities, update this table in the same PR.
 | Hook → session scope | ✅ per-session UUID | ✅ per-session UUID (#829) | ❌ `cwd` match (per-worktree UUID deferred) | ❌ `cwd` match | ✅ per-session UUID |
 | Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.141.0) | ⚠️ names verified, timing unverified | ⚠️ `PostToolUse`/`PostInvocation` declared, timing unverified |
 | MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ✅ `jira` bridged into `~/.cursor/mcp.json` (#829) | ✅ mirrored from `~/.claude.json` into `config.toml` | ❌ falls back to `acli` | ❌ falls back to `acli` (file bridge deferred) |
-| Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body | ❌ unsupported in Phase A (`autoLaunchCommand(.review)` → nil, like Codex) |
+| Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body | ❌ unsupported in Phase A (`autoLaunchCommand(.review)` → nil) |
 | Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `$(cat …)` job/review; handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (`$(cat …-prompt.md)`) | ✅ run-then-`--continue` | ✅ `-p "$(cat …-job-prompt.md)"` (`.job`); `.work` bare |
 | Gateway env / trust seed / telemetry | ✅ Claude special-case | ❌ | ⚠️ trust seed only (`[projects."…"]` in `config.toml`) | ❌ | ❌ |
 | Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ | ❌ unverified on v1.1.7 (opt-out `nil`) |
@@ -361,7 +361,8 @@ Code-style hooks (JSON on stdin, reply on stdout), so the
 `HookConfigWriter`/`StateSignalSource` pair does real work; per-worktree
 `.agents/hooks.json` with the session UUID baked in (per-session scope, not
 `cwd`); remote control faked via `crow send`; `.review` unsupported in Phase A
-(like Codex). It ships **Tier-2** ([ADR 0015](adr/0015-harness-capability-tiers.md))
+(no review dispatch — unlike Codex/Cursor/OpenCode, which inline the skill body).
+It ships **Tier-2** ([ADR 0015](adr/0015-harness-capability-tiers.md))
 with honest, documented gaps (#860).
 
 **Hooks are its single strongest point.** Antigravity's `Stop` hook carries


### PR DESCRIPTION
Closes #860

Adds a **Tier-2 / experimental** `CrowAntigravity` adapter for Google Antigravity's CLI (binary **`agy`**), per [ADR 0014](https://github.com/corveil/crow/blob/main/docs/adr/0014-pluggable-coding-agent-adapter.md) / [0015](https://github.com/corveil/crow/blob/main/docs/adr/0015-harness-capability-tiers.md). New package `Packages/CrowAntigravity/`, structurally a near-clone of `CrowCursor`.

## What's here (Phase A core loop)

- **`AntigravityAgent`** — `launchCommandToken = "agy"`, remote control faked via `crow send`, `-p` prompt injection (`.job`), `-c` resume, `.review`/`.manager` → `nil`. `sessionRenameSlashCommand` left at the opt-out `nil` default (unverified on v1.1.7).
- **`AntigravityHookConfigWriter`** — per-worktree `.agents/hooks.json` in Antigravity's **own named-group schema** (verified against [`antigravity.google/docs/hooks`](https://antigravity.google/docs/hooks)), *not* Claude's `{"hooks": {…}}`: Crow owns one group `{"crow": {…}}`; `PostToolUse` wraps handlers in `{matcher:"*", hooks:[…]}`; `PreInvocation`/`PostInvocation`/`Stop` list handlers directly under the event key; **no `async` field**. Session UUID baked into each `crow hook-event … --agent antigravity` command. Inherits Cursor's shared-file protections (git-tracked skip, unparseable-guard, atomic write, git-exclude); Crow only ever writes/removes its own `"crow"` group. `removeManagedGlobalConfig` strips a stale `~/.gemini/config/hooks.json` Crow group (double-fire guard).
- **stdout verdict contract** — each hook command suppresses `crow hook-event`'s output and `printf '{}'`s the verdict itself, exiting 0 via `;`, so a Crow hook can never block a tool or loop the agent on `Stop`. **`PreToolUse` is deliberately not registered** (its strict `{"decision":…}` gate denies every tool call when mis-shaped — cmux #5358 — so, like Antigravity's own vibe-island plugin, Crow stays off it).
- **`AntigravitySignalSource`** — `Stop`→`.done` (maps *any* Stop; doesn't yet gate on `fullyIdle`/`terminationReason`), `PreInvocation`→working, `PostToolUse`→working-heartbeat. **Named tool activity is a documented Tier-2 gap**: `PostToolUse` stdin carries no tool name and `PreToolUse` (which does) is unregistered. `EngineRouter.hookToolName` normalizes `tool_name`/`toolCall.name` (future-proofs a `PreToolUse` re-enable).
- **`AntigravityLauncher` / `AntigravityLaunchArgs`** — `acli` Jira fallback (no MCP bridge in Phase A). Bounded auto-permission is a documented no-op (never `--dangerously-skip-permissions`).
- **Wiring** — `AgentKind.antigravity` + `CrowAttribution`; registered in `CrowDaemon.registerAgents` **gated on `findBinary()`**; `LaunchScaffold` global-hook cleanup; `SessionService` tmux reconcile; CLI help/error strings; `ci.yml` + `cache-warm.yml` Linux package lists.
- **Tests** — CrowAntigravity signal-source + hook-writer (real named-group schema) + agent; `HookToolNameTests` in CrowEngine. Matrix gains a Tier-2 Antigravity column + subsection + version-pin rows.

## ⚠️ Supply-chain gate — how it's honored

The `google-antigravity` GitHub org is **`is_verified: false`** (created 2025-11-04, README-only `antigravity-cli` mirror) and not one of Google's canonical orgs. `findBinary()` / `fallbackCandidates` are **never** wired to that org's release binaries — resolution is **PATH-first** (official `antigravity.google` installer), with conservative standard-bin fallbacks. Off-`PATH` `agy` ⇒ silently unregistered (ADR 0014).

> **Release checklist (human):** confirm the exact official `agy` install path before Antigravity is promoted out of Tier-2.

## Permanent gap

`agy` is closed-source and Google-Sign-In/GCP-authed, so it runs only against Google's cloud models — it cannot self-host. Fails Corveil's self-host axis; a fixed gap, not a phase.

## Test plan

- `swift test --package-path Packages/CrowAntigravity` — 39/39 pass (named-group schema, matcher/hooks vs direct handlers, stdout-verdict wrapper, no `async`, no `PreToolUse`, user-group preservation, tracked-guard, git-exclude, unparseable-guard, launcher, agent).
- `swift test --package-path Packages/CrowEngine` — 346/346 pass (incl. `HookToolNameTests`).
- `swift build` (root `crow` + `crowd`) — clean.
- Acceptance: off-`PATH` `agy` ⇒ unregistered; `crow handoff-agent --agent antigravity` routes through the registry once `agy` resolves, active→done observed via `.agents/hooks.json` (`Stop`). *Driving the live binary is blocked behind the supply-chain gate above; the hook schema is verified against the official docs rather than an end-to-end run.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)