### PR TITLE
Web Reviews board: multi-select + batch Start Review (N)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -793,6 +793,52 @@ func makeCommandRouter(
             }
             return ["session_id": .string(id.uuidString)]
         },
+        // Batch counterpart of start-review (CROW-865), backing the Reviews
+        // board's "Start Review (N)". Unlike batch-work-on-issues this types
+        // nothing at the Manager — it enqueues N kickoffs on the same
+        // serializer, so the dedupe stays race-free (the old desktop
+        // `onBatchStartReview` fanned out in parallel and did race, #212/#266).
+        //
+        // The enqueued tasks are deliberately NOT awaited: each one clones a PR
+        // and spawns a tmux window, far past the web client's 10s rpc timeout,
+        // and they run one at a time. So this acks as soon as the work is
+        // queued and the new sessions surface via the sidebar poll — the same
+        // "let it show up" contract `spawnAction` already relies on.
+        //
+        // Unsafe urls are dropped and reported in `rejected` rather than
+        // failing the whole batch, so one bad PR can't block the rest.
+        "batch-start-review": { params in
+            guard let sessionService else {
+                throw DaemonRPCError.applicationError(
+                    "Starting a review requires tmux on the daemon host")
+            }
+            guard let arr = params["urls"]?.arrayValue, !arr.isEmpty else {
+                throw DaemonRPCError.invalidParams("urls array required")
+            }
+            var valid: [String] = []
+            var rejected: [String] = []
+            for value in arr {
+                let url = value.stringValue ?? ""
+                if isSafeIssueURL(url) {
+                    if !valid.contains(url) { valid.append(url) }
+                } else {
+                    rejected.append(url)
+                }
+            }
+            guard !valid.isEmpty else {
+                throw DaemonRPCError.invalidParams("urls must be well-formed http(s) URLs with no control characters")
+            }
+            for url in valid {
+                _ = await reviewSerializer.enqueue {
+                    await sessionService.createReviewSession(prURL: url, selectAfterCreate: false)
+                }
+            }
+            return [
+                "ok": .bool(true),
+                "started": .int(valid.count),
+                "rejected": .array(rejected.map { .string($0) }),
+            ]
+        },
         // Allowlist writes/refreshes run locally when the daemon owns the
         // AllowListService (pure disk — no app needed); otherwise forward.
         "promote-allowlist": { params in

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -525,6 +525,9 @@ html, body {
 .board-card.selecting { position: relative; cursor: pointer; padding-right: 34px; }
 .board-card.selecting .row-check { position: absolute; top: 10px; right: 10px; margin: 0; }
 .board-card.selected { border-color: var(--gold); }
+/* A review that already has a session can't be started again — dim it while
+   selecting so the missing checkbox reads as intentional (CROW-865). */
+.board-card.not-selectable { opacity: 0.5; }
 /* Active Select toggle on a board button reads red, matching .nav-selecting. */
 .action-btn.nav-selecting { color: var(--red); border-color: var(--red); }
 .card-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -589,6 +589,11 @@ const selectedSessionIDs = new Set();
 // ticked for the batch "Start Working (N)" action.
 let ticketSelectionMode = false;
 const selectedIssueIDs = new Set();
+// Review-board multi-select (CROW-865): the same pattern, restoring the retired
+// ReviewBoardView's batch kickoff. Holds the urls of pending reviews ticked for
+// the batch "Start Review (N)" action.
+let reviewSelectionMode = false;
+const selectedReviewURLs = new Set();
 // CROW-751 board controls (session-only, like ticketFilter/ticketSearch above).
 let ticketRepoFilter = 'All';     // repo selector; 'All' or a repo slug ("org/repo")
 let ticketSort = 'updated_desc';  // one of TICKET_SORT_OPTIONS keys
@@ -2203,9 +2208,11 @@ async function recreateTerminal(t) {
 function selectBoard(key) {
   selectedBoard = key;
   selectedId = null;
-  // Leaving the ticket board (or re-entering) drops any stale ticket selection.
+  // Leaving a board (or re-entering) drops any stale selection on it.
   ticketSelectionMode = false;
   selectedIssueIDs.clear();
+  reviewSelectionMode = false;
+  selectedReviewURLs.clear();
   const app = document.getElementById('app');
   app.classList.add('has-selection', 'board-active');
   app.classList.remove('mobile-show-sidebar');
@@ -3129,6 +3136,20 @@ async function refreshReviews() {
 function renderReviewBoard(root) {
   const d = boardData.reviews;
   const busy = reviewsRefreshing();
+
+  // Filter/sort up front — before the head — so the Select button, the
+  // selection pruning, and the list all see the same visible set and no hidden
+  // review can be started (same ordering as renderTicketBoard).
+  let reviews = ((d && d.reviews) || []).slice()
+    .sort((a, b) => (b.requested_at || '').localeCompare(a.requested_at || ''));
+  const q = reviewSearch.trim().toLowerCase();
+  if (q) reviews = reviews.filter((r) => reviewHaystack(r).includes(q));
+  // Only reviews without a linked session can be started, so only those are
+  // selectable. Prune stale selections against the *visible* set (a refresh or
+  // the search may have removed/hidden/linked a review).
+  const selectableUrls = new Set(reviews.filter((r) => !r.review_session_id).map((r) => r.url));
+  for (const url of [...selectedReviewURLs]) if (!selectableUrls.has(url)) selectedReviewURLs.delete(url);
+
   const head = el('div', 'board-head');
   const title = el('div', 'board-title', 'Reviews');
   if (busy) title.appendChild(el('span', 'action-spinner'));
@@ -3137,19 +3158,74 @@ function renderReviewBoard(root) {
   refresh.disabled = busy;
   refresh.onclick = () => refreshReviews();
   head.appendChild(refresh);
+  // Select / Cancel toggle (CROW-865, mirroring the ticket board and the
+  // retired ReviewBoardView). Hidden when nothing is startable.
+  if (selectableUrls.size) {
+    const sel = el('button', 'action-btn' + (reviewSelectionMode ? ' nav-selecting' : ''),
+      reviewSelectionMode ? 'Cancel' : 'Select');
+    sel.onclick = () => {
+      reviewSelectionMode = !reviewSelectionMode;
+      if (!reviewSelectionMode) selectedReviewURLs.clear();
+      renderBoard();
+    };
+    head.appendChild(sel);
+  } else if (reviewSelectionMode) {
+    reviewSelectionMode = false;
+  }
   root.appendChild(head);
+
+  // Batch action bar: shown while selecting with at least one review ticked.
+  if (reviewSelectionMode && selectedReviewURLs.size) {
+    const bar = el('div', 'bulk-bar');
+    const n = selectedReviewURLs.size;
+    bar.appendChild(el('span', 'bulk-count', n + ' review' + (n === 1 ? '' : 's') + ' selected'));
+    bar.appendChild(el('div', 'bulk-spacer'));
+    const start = el('button', 'action-btn action-primary', 'Start Review (' + n + ')');
+    start.onclick = () => startReviewSelected(start);
+    bar.appendChild(start);
+    root.appendChild(bar);
+  }
 
   // #714: search bar; clearing restores the full list.
   root.appendChild(boardFilterInput('review-filter', reviewSearch, 'Filter reviews…', (v) => { reviewSearch = v; }));
 
-  let reviews = ((d && d.reviews) || []).slice()
-    .sort((a, b) => (b.requested_at || '').localeCompare(a.requested_at || ''));
-  const q = reviewSearch.trim().toLowerCase();
-  if (q) reviews = reviews.filter((r) => reviewHaystack(r).includes(q));
   if (!reviews.length) { root.appendChild(boardEmpty(q ? 'No matching reviews' : 'No review requests')); return; }
   const list = el('div', 'card-list');
   for (const r of reviews) list.appendChild(reviewCard(r));
   root.appendChild(list);
+}
+
+function toggleReviewSelect(url) {
+  if (selectedReviewURLs.has(url)) selectedReviewURLs.delete(url);
+  else selectedReviewURLs.add(url);
+  renderBoard();
+}
+
+// Batch "Start Review (N)": ONE batch-start-review call with every selected PR.
+// The daemon queues the kickoffs on its review serializer and acks immediately
+// — each one clones a PR and spawns tmux, well past our 10s rpc timeout — so
+// the new sessions surface via the sidebar poll rather than this response
+// (CROW-865). Then clear selection and exit selection mode.
+async function startReviewSelected(btn) {
+  const urls = ((boardData.reviews && boardData.reviews.reviews) || [])
+    .filter((r) => !r.review_session_id && selectedReviewURLs.has(r.url))
+    .map((r) => r.url);
+  if (!urls.length) return;
+  btn.disabled = true;
+  btn.textContent = 'Starting…';
+  let problem = '';
+  try {
+    const res = await rpc('batch-start-review', { urls });
+    const rejected = (res && res.rejected) || [];
+    if (rejected.length) problem = rejected.length + ' review(s) could not be started.';
+  } catch (e) {
+    problem = 'Start Review failed: ' + (e.message || e);
+  }
+  selectedReviewURLs.clear();
+  reviewSelectionMode = false;
+  refreshReviews();
+  renderBoard();
+  if (problem) alertModal(problem);
 }
 
 // #714: lowercased searchable text for a review — title, repo, @author, #pr_number.
@@ -3158,11 +3234,34 @@ function reviewHaystack(r) {
 }
 
 function reviewCard(r) {
-  const card = el('div', 'board-card');
+  // A review that already has a session can't be started again, so it isn't
+  // selectable — it renders dimmed and checkbox-less while selecting, as the
+  // retired ReviewBoardView did, but keeps its Go to Session button.
+  const selectable = !r.review_session_id;
+  const selecting = reviewSelectionMode && selectable;
+  const isSel = selectedReviewURLs.has(r.url);
+  const card = el('div', 'board-card'
+    + (selecting ? ' selecting' : '') + (isSel ? ' selected' : '')
+    + (reviewSelectionMode && !selectable ? ' not-selectable' : ''));
   card.oncontextmenu = (e) => showCardMenu(e, [{ label: 'Copy PR link', url: r.url }]);
+  // In selection mode a checkbox leads a selectable card and the whole card
+  // toggles selection (mirrors the ticket board).
+  if (selecting) {
+    const cb = el('input', 'row-check');
+    cb.type = 'checkbox';
+    cb.checked = isSel;
+    cb.onclick = (e) => { e.stopPropagation(); toggleReviewSelect(r.url); };
+    card.appendChild(cb);
+    card.onclick = () => toggleReviewSelect(r.url);
+  }
   const meta = el('div', 'card-meta');
   meta.appendChild(el('span', 'repo-tag', r.repo));
-  meta.appendChild(linkChip('#' + r.pr_number, r.url, 'pr'));
+  const chip = linkChip('#' + r.pr_number, r.url, 'pr');
+  // The chip is the only way to open the PR, and in select mode the card
+  // beneath it toggles selection — don't do both on one click. Kept local to
+  // reviewCard: linkChip is shared with ticketCard, whose behavior is unchanged.
+  if (selecting) chip.onclick = (e) => e.stopPropagation();
+  meta.appendChild(chip);
   if (r.is_draft) meta.appendChild(el('span', 'draft-badge', 'Draft'));
   const t = relTime(r.requested_at);
   if (t) meta.appendChild(el('span', 'card-time', t));
@@ -3178,12 +3277,15 @@ function reviewCard(r) {
     const go = el('button', 'action-btn', 'Go to Session');
     go.onclick = () => selectSession(r.review_session_id);
     foot.appendChild(go);
-  } else {
+  } else if (!selecting) {
+    // Suppressed while selecting — the batch bar owns the kickoff there.
     const rev = el('button', 'action-btn action-primary', 'Start Review');
     rev.onclick = () => spawnAction(rev, 'start-review', { url: r.url }, 'Start Review');
     foot.appendChild(rev);
   }
-  card.appendChild(foot);
+  // `.card-foot` carries a top margin, so a selectable card in select mode —
+  // which has no button at all — would otherwise end in 8px of dead space.
+  if (foot.childNodes.length) card.appendChild(foot);
   return card;
 }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BoardForwarderTests.swift
@@ -53,8 +53,8 @@ import CrowPersistence
         // mark-in-review / complete-session / set-session-active — now run
         // locally, so they're covered by LocalStatusTests instead.)
         let actions = [
-            "work-on-issue", "batch-work-on-issues", "start-review", "promote-allowlist",
-            "refresh-tickets", "refresh-allowlist",
+            "work-on-issue", "batch-work-on-issues", "start-review", "batch-start-review",
+            "promote-allowlist", "refresh-tickets", "refresh-allowlist",
             "create-manager", "mark-issue-done", "add-merge-label",
         ]
         for method in actions {
@@ -92,6 +92,21 @@ import CrowPersistence
         let resp = await router.handle(request: JSONRPCRequest(
             id: 1, method: "batch-work-on-issues", params: ["urls": .array([])]))
         #expect(resp.error?.code == RPCErrorCode.applicationError)
+    }
+
+    /// CROW-865: `batch-start-review` takes the same `urls` array. It shares
+    /// `isSafeIssueURL` and the same guard ordering, so with the app down the
+    /// applicationError fires before params validation here too.
+    @Test @MainActor func batchStartReviewSharesTheURLsContract() async {
+        let router = makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: NSTemporaryDirectory(), cockpit: nil)
+        let resp = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "batch-start-review", params: ["urls": .array([])]))
+        #expect(resp.error?.code == RPCErrorCode.applicationError)
+
+        #expect(isSafeIssueURL("https://github.com/corveil/crow/pull/865"))
+        #expect(!isSafeIssueURL("javascript:alert(1)"))
     }
 }
 

--- a/Packages/CrowDaemon/web-tests/board.test.js
+++ b/Packages/CrowDaemon/web-tests/board.test.js
@@ -14,6 +14,9 @@ const epilogue = `
   set ticketSearch(v){ticketSearch=v;},
   set ticketRefreshPending(v){ticketRefreshPending=v;},
   set reviewRefreshPending(v){reviewRefreshPending=v;},
+  set reviewSearch(v){reviewSearch=v;},
+  set reviewSelectionMode(v){reviewSelectionMode=v;},
+  get selectedReviewURLs(){return selectedReviewURLs;},
   renderBoard(){ return renderBoard(); },
   ticketsCard(){ return ticketsCard(); },
   ticketsRefreshing(){ return ticketsRefreshing(); },
@@ -189,6 +192,78 @@ T.reviewRefreshPending = false; T.renderBoard();
 check('Reviews idle: no spinner, button enabled',
   q('.board-title .action-spinner').length === 0
   && [...q('.action-btn')].find((b) => b.textContent === 'Refresh').disabled === false);
+
+// -- Reviews multi-select + batch Start Review (CROW-865) --
+// Restores the retired ReviewBoardView's batch kickoff on the web board, using
+// the ticket board's selection model. r3 already has a review session, so it is
+// the non-selectable/dimmed case.
+const review = (id, n, title, repo, author, url, hours, sessionID) => ({
+  id, pr_number: n, title, url, repo, author, head_branch: 'feat/' + id, base_branch: 'main',
+  is_draft: false, requested_at: iso(hours), labels: [], provider: 'github',
+  review_session_id: sessionID || null,
+});
+const reviewsPayload = { unseen: 0, reviews: [
+  review('r1', 900, 'Add batch review', 'corveil/crow', 'dhilgaertner', 'https://github.com/corveil/crow/pull/900', 1),
+  review('r2', 17, 'Fix flaky auth', 'acme/api', 'jordan', 'https://gitlab.example.com/acme/api/-/merge_requests/17', 3),
+  review('r3', 800, 'Redesign the board', 'corveil/crow', 'sam', 'https://github.com/corveil/crow/pull/800', 5, 'sess-r3'),
+]};
+const btn = (text) => [...q('.action-btn')].find((b) => b.textContent === text);
+const countBtn = (text) => [...q('.action-btn')].filter((b) => b.textContent === text).length;
+function renderReviews() { T.boardData.reviews = reviewsPayload; T.selectedBoard = 'reviews'; T.renderBoard(); }
+
+console.log('\nReviews board — idle (no select mode):');
+T.reviewSearch = ''; T.reviewSelectionMode = false; T.selectedReviewURLs.clear();
+renderReviews();
+check('3 review cards rendered', q('.board-card').length === 3);
+check('Select offered (2 startable)', !!btn('Select'));
+check('per-card Start Review on the 2 unlinked', countBtn('Start Review') === 2);
+check('linked review offers Go to Session', !!btn('Go to Session'));
+check('no checkboxes outside select mode', q('.row-check').length === 0);
+
+console.log('\nReviews board — select mode:');
+btn('Select').onclick();
+check('toggle now reads Cancel, styled red', !!btn('Cancel') && btn('Cancel').className.includes('nav-selecting'));
+check('checkbox only on the 2 selectable rows', q('.row-check').length === 2);
+check('linked row dimmed via .not-selectable', (() => {
+  const dim = [...q('.board-card.not-selectable')];
+  return dim.length === 1 && /Redesign the board/.test(dim[0].textContent) && !dim[0].querySelector('.row-check');
+})());
+check('per-card Start Review suppressed while selecting', countBtn('Start Review') === 0);
+check('Go to Session still rendered on the linked row', !!btn('Go to Session'));
+check('no bulk bar until something is ticked', q('.bulk-bar').length === 0);
+
+console.log('\nTicking rows:');
+q('.row-check')[0].onclick({ stopPropagation() {} });
+check('bulk bar appears', q('.bulk-bar').length === 1);
+check('count reads "1 review selected"', /1 review selected/.test(q('.bulk-count')[0].textContent));
+check('action reads Start Review (1)', !!btn('Start Review (1)'));
+check('ticked card carries .selected', q('.board-card.selected').length === 1);
+// The whole card toggles too, not just the checkbox.
+[...q('.board-card')].find((c) => c.className.includes('selecting') && !c.className.includes('selected')).onclick();
+check('card click toggles → "2 reviews selected"', /2 reviews selected/.test(q('.bulk-count')[0].textContent));
+check('action reads Start Review (2)', !!btn('Start Review (2)'));
+
+console.log('\nCancel:');
+btn('Cancel').onclick();
+check('selection cleared', T.selectedReviewURLs.size === 0);
+check('per-card Start Review restored', countBtn('Start Review') === 2);
+check('no checkboxes or bulk bar left', q('.row-check').length === 0 && q('.bulk-bar').length === 0);
+check('nothing dimmed outside select mode', q('.board-card.not-selectable').length === 0);
+
+console.log('\nSelection is pruned against the visible set:');
+btn('Select').onclick();
+q('.row-check')[0].onclick({ stopPropagation() {} });
+check('sanity: 1 selected', T.selectedReviewURLs.size === 1);
+T.reviewSearch = 'jordan'; T.renderBoard();   // hides r1, the selected one
+check('search-hidden review drops out of the selection', T.selectedReviewURLs.size === 0);
+T.reviewSearch = ''; T.reviewSelectionMode = false; T.renderBoard();
+
+console.log('\nEvery review already linked:');
+T.boardData.reviews = { unseen: 0,
+  reviews: reviewsPayload.reviews.map((r) => Object.assign({}, r, { review_session_id: 'sess-x' })) };
+T.renderBoard();
+check('no Select button when nothing is startable', !btn('Select'));
+check('all 3 rows offer Go to Session', countBtn('Go to Session') === 3);
 
 // The daemon half of the flag has no `finally` to fall back on — it clears only
 // when a later `list-tickets` says so. These cover the paths where that never


### PR DESCRIPTION
Closes #865

Restores the retired Review Board's multi-select + batch kickoff (#212 / #192) on the **web** Reviews board. That UI lived in `ReviewBoardView.swift` and went away with `d43fd56` (ADR 0007 — crowd + web UI are the sole client); the web board only ever had a per-card **Start Review**.

Mirrors the ticket board's selection model (`ticketSelectionMode` / `selectedIssueIDs` / `batch-work-on-issues`) rather than inventing a second one.

## Web UI

- Header **Select** / **Cancel** toggle, hidden when nothing is startable (and it flips the mode off in that case).
- Per-row checkbox on selectable rows; the whole card toggles too. The PR chip stops propagation in select mode so opening the PR doesn't also tick the row — done locally in `reviewCard`, not in the shared `linkChip`, so ticket behavior is untouched.
- Bulk bar with `N review(s) selected` + **Start Review (N)**.
- Rows with a `review_session_id` are non-selectable: dimmed via a new `.board-card.not-selectable`, no checkbox, but **Go to Session** still renders — matching how `ticketCard` treats a linked ticket.
- `renderReviewBoard` now filters/sorts **before** building the head, so the Select button, the selection pruning, and the list all see the same visible set. A search-hidden or newly-linked review drops out of the selection.
- Selection clears on Cancel, after a successful batch, and on board switch.

## Backend: `batch-start-review` rather than looping `start-review`

Unlike tickets, starting a review types nothing at the Manager — `start-review` clones the PR and spawns tmux **inline** (`RPCHandlers.swift`), and `ReviewKickoffSerializer` runs kickoffs one at a time. N sequential `start-review` calls from the browser would therefore have reviews 2..N reliably blow the web client's 10s `rpc()` timeout and report a false failure while the sessions were in fact being created.

So the new RPC enqueues all N on that same serializer and **acks immediately** — the sessions surface via the sidebar poll, the same contract `spawnAction` already relies on. This is the old desktop `onBatchStartReview`'s fire-and-forget shape, minus its dedupe race (it fanned out in parallel; CROW-581 / #266). Unsafe urls are dropped into `rejected` instead of failing the batch, as `batch-work-on-issues` does.

`AppState.onBatchStartReview` stays untouched — it has zero assignments and is vestigial from the retired UI.

## Tests

- `board.test.js`: 21 new assertions — Select toggle, checkbox only on selectable rows, the dimmed linked row keeping Go to Session, per-card Start Review suppressed while selecting, bulk-bar counts (singular/plural), card-click toggling, Cancel restoring the per-card buttons, selection pruning against a search, and an all-linked payload offering no Select. **75 passed, 0 failed** — the pre-existing ticket assertions are unchanged.
- `BoardForwarderTests.swift`: `batch-start-review` added to the app-down `applicationError` list, plus a test pinning the shared `isSafeIssueURL` contract. **16 tests, all pass.**
- `make build` clean.

> Note: `web-tests/row.test.js` fails 11 assertions on this branch — it also fails identically on `main`. `06590b2` swapped the sidebar text glyphs (`✔` / `◷` / `⚠` / `🏷`) for SVG without updating that test. Unrelated to this change; worth its own fix.

Not verified end-to-end against a live daemon — that needs ≥2 real pending review requests with no linked session. The jsdom suite drives the real `app.js` and asserts the resulting DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
