### PR TITLE
Gateways & web-password CLI (local-only, parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,21 @@ Events: `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `
 
 Notifications cascade — one fires only if `globalMute` is off, the global category toggle is on, **and** the per-event toggle is on. Omitted flags leave their stored value alone; every `--event-*` flag requires `--event`.
 
+### Gateways & Secrets
+
+Local-only (CROW-815) — these carry credentials, so the remote `/rpc` web path refuses them and only the local Unix socket works. Take exactly one target: `--manager` or `--workspace <name|uuid>`.
+
+```
+crow gateway get [--manager | --workspace <name|uuid>] [--reveal]        → {"gateway_set":true,"base_url":"...","headers":{...}}
+crow gateway set --manager --base-url URL --header "Name: Value" ...     → {"saved":true,"gateway_set":true}
+crow gateway clear --manager                                            → {"saved":true,"gateway_set":false}
+crow web-password status                                                → {"password_set":true,"iterations":210000}
+crow web-password set [--stdin]                                         → {"saved":true,"password_set":true}
+crow web-password clear                                                 → {"saved":true,"password_set":false}
+```
+
+`gateway get` blanks header values unless `--reveal`. A `--header` with a blank value (`--header "X-Api-Key:"`) keeps the stored secret — that's how to change a base URL without restating credentials. `web-password set` prompts twice with echo off; pipe with `--stdin` for scripts. There is no `--password` flag on purpose (shell history / `ps`).
+
 ## Important Notes
 
 - `--session` always expects a full UUID (e.g., `a1b2c3d4-e5f6-7890-abcd-ef1234567890`), not a session name

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SecretCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SecretCommands.swift
@@ -1,0 +1,231 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+// Local-only secret surfaces: the AI gateways and the web-access password
+// (CROW-815). These reach the daemon over the Unix socket, which is local by
+// construction; the same RPC methods are refused on the remote `/rpc` WebSocket
+// by `RPCWebSocketHandler.localOnlyDenial`. The web Settings UI drives the
+// equivalent HTTP routes in `SecretRoutes`.
+
+/// Which gateway a `crow gateway` subcommand addresses: the Manager's, or one
+/// workspace's. Shared by get/set/clear so the selector behaves identically.
+public struct GatewayTargetOptions: ParsableArguments {
+    @Flag(name: .long, help: "Target the Manager AI gateway")
+    public var manager: Bool = false
+
+    @Option(name: .long, help: "Target a workspace's AI gateway (workspace name or UUID)")
+    public var workspace: String?
+
+    public init() {}
+
+    /// Called explicitly from each subcommand's `validate()` rather than relying
+    /// on option-group validation, so the check runs at a predictable point.
+    public func validateTarget() throws {
+        switch (manager, workspace) {
+        case (true, .some):
+            throw ValidationError("--manager and --workspace are mutually exclusive.")
+        case (false, nil):
+            throw ValidationError("Exactly one of --manager or --workspace is required.")
+        case (false, .some(let workspace)):
+            guard !workspace.trimmingCharacters(in: .whitespaces).isEmpty else {
+                throw ValidationError("--workspace must not be blank.")
+            }
+        case (true, nil):
+            break
+        }
+    }
+
+    /// The target selector as RPC params.
+    public var params: [String: JSONValue] {
+        if let workspace { return ["workspace": .string(workspace)] }
+        return ["target": .string("manager")]
+    }
+}
+
+/// Parent command for AI gateway management: `crow gateway <subcommand>`.
+///
+/// A gateway is a base URL plus the auth headers sent with it; agents launched
+/// into the workspace (or the Manager) inherit them as `ANTHROPIC_BASE_URL` /
+/// `ANTHROPIC_CUSTOM_HEADERS`. Header values may be `op://…` 1Password
+/// references, resolved at launch so the secret never rests in `config.json`.
+///
+/// Local-only: these run over the Unix socket and are refused for remote web
+/// clients, because the headers are credentials.
+public struct Gateway: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "gateway",
+        abstract: "Manage AI gateways (local-only)",
+        subcommands: [GatewayGet.self, GatewaySet.self, GatewayClear.self]
+    )
+
+    public init() {}
+}
+
+public struct GatewayGet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "get",
+        abstract: "Show a gateway's base URL and header names",
+        discussion: """
+        Header values are blanked by default so the output is safe to share. \
+        Pass --reveal to print the stored values (which may be op:// references \
+        rather than the secrets themselves).
+        """
+    )
+
+    @OptionGroup public var target: GatewayTargetOptions
+
+    @Flag(name: .long, help: "Print header values instead of blanking them")
+    public var reveal: Bool = false
+
+    public init() {}
+
+    public func validate() throws {
+        try target.validateTarget()
+    }
+
+    public func run() throws {
+        var params = target.params
+        params["reveal"] = .bool(reveal)
+        printJSON(try rpc("gateway-get", params: params))
+    }
+}
+
+public struct GatewaySet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Set a gateway's base URL and headers",
+        discussion: """
+        Replaces the whole gateway: --base-url and at least one --header are \
+        both required (a gateway needs both, or neither). A --header with a \
+        blank value keeps the secret already stored under that name, so the base \
+        URL can be changed without restating credentials:
+
+          crow gateway set --manager --base-url https://gw.example.com --header "X-Api-Key:"
+
+        Header values may be op:// 1Password references, resolved at agent \
+        launch so the secret never rests in config.json.
+        """
+    )
+
+    @OptionGroup public var target: GatewayTargetOptions
+
+    @Option(name: .customLong("base-url"), help: "Gateway base URL")
+    public var baseURL: String
+
+    @Option(name: .long, parsing: .singleValue, help: "Header as 'Name: Value' (repeatable)")
+    public var header: [String] = []
+
+    public init() {}
+
+    public func validate() throws {
+        try target.validateTarget()
+        guard !baseURL.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw ValidationError("--base-url must not be blank. Use `crow gateway clear` to remove a gateway.")
+        }
+        guard !header.isEmpty else {
+            throw ValidationError("At least one --header is required (a gateway needs both a base URL and a header).")
+        }
+        try header.forEach(validateHeaderLine)
+    }
+
+    public func run() throws {
+        var params = target.params
+        params["base_url"] = .string(baseURL)
+        params["header_lines"] = .array(header.map { .string($0) })
+        printJSON(try rpc("gateway-set", params: params))
+    }
+}
+
+public struct GatewayClear: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "clear",
+        abstract: "Remove a gateway"
+    )
+
+    @OptionGroup public var target: GatewayTargetOptions
+
+    public init() {}
+
+    public func validate() throws {
+        try target.validateTarget()
+    }
+
+    public func run() throws {
+        var params = target.params
+        params["clear"] = .bool(true)
+        printJSON(try rpc("gateway-set", params: params))
+    }
+}
+
+/// Parent command for the web-access password: `crow web-password <subcommand>`.
+///
+/// The password gates the daemon's web UI for non-loopback clients. It is stored
+/// as a PBKDF2-HMAC-SHA256 hash; the plaintext is never persisted and never
+/// travels over anything but the local Unix socket.
+public struct WebPassword: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "web-password",
+        abstract: "Manage the web-access password (local-only)",
+        subcommands: [WebPasswordStatus.self, WebPasswordSet.self, WebPasswordClear.self]
+    )
+
+    public init() {}
+}
+
+public struct WebPasswordStatus: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Report whether a web-access password is set"
+    )
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("web-password-get"))
+    }
+}
+
+public struct WebPasswordSet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Set or change the web-access password",
+        discussion: """
+        Prompts twice with echo off. For scripts, pipe the password and pass \
+        --stdin:
+
+          printf '%s' "$PW" | crow web-password set --stdin
+
+        There is no --password flag on purpose — a plaintext password in argv is \
+        visible in shell history and to local `ps`. Changing the password does \
+        not require the old one; the local-only gate is the control.
+        """
+    )
+
+    @Flag(name: .long, help: "Read the password from stdin instead of prompting")
+    public var stdin: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        let password = try SecretArgs.readPassword(useStdin: stdin)
+        printJSON(try rpc("web-password-set", params: ["password": .string(password)]))
+    }
+}
+
+public struct WebPasswordClear: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "clear",
+        abstract: "Remove the web-access password",
+        discussion: """
+        With no password set, remote web clients are no longer challenged — \
+        check how the daemon is bound before clearing it.
+        """
+    )
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("web-password-set", params: ["clear": .bool(true)]))
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -42,6 +42,8 @@ public struct CrowCommand: ParsableCommand {
             Cleanup.self,
             UI.self,
             Notifications.self,
+            Gateway.self,
+            WebPassword.self,
             AddWorktree.self,
             ListWorktrees.self,
             NewTerminal.self,

--- a/Packages/CrowCLI/Sources/CrowCLILib/SecretArgs.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/SecretArgs.swift
@@ -1,0 +1,72 @@
+import ArgumentParser
+import Foundation
+
+/// Password input for `crow web-password set` (CROW-815).
+///
+/// There is deliberately no `--password` flag: a plaintext password on the
+/// command line lands in shell history and is visible to any local `ps` for the
+/// lifetime of the process. The password arrives either from an interactive TTY
+/// prompt (echo off, typed twice) or from stdin with `--stdin`.
+///
+/// The pure parts are split out from the I/O so they can be tested without a
+/// terminal — see `SecretArgsTests`.
+enum SecretArgs {
+    /// Reject a password that would be stored but never usable.
+    ///
+    /// Only emptiness is checked: the server applies no strength rule either, and
+    /// inventing one here would make the CLI reject passwords the web UI accepts.
+    static func validatePassword(_ value: String) throws -> String {
+        guard !value.isEmpty else {
+            throw ValidationError("Password must not be empty.")
+        }
+        return value
+    }
+
+    /// Interpret one line read from stdin as a password.
+    ///
+    /// The line is used verbatim apart from a trailing `\r` (so a CRLF pipe
+    /// doesn't silently append a carriage return to the password) — leading and
+    /// trailing spaces are meaningful and are kept.
+    static func passwordFromStdin(_ line: String?) throws -> String {
+        guard let line else {
+            throw ValidationError("No password on stdin.")
+        }
+        var password = line
+        if password.hasSuffix("\r") { password.removeLast() }
+        return try validatePassword(password)
+    }
+
+    /// Confirm a typed password against its repeat.
+    static func confirmPassword(_ first: String, _ second: String) throws -> String {
+        guard first == second else {
+            throw ValidationError("Passwords do not match.")
+        }
+        return try validatePassword(first)
+    }
+
+    /// Read the password from stdin (`--stdin`) or prompt for it twice on the TTY.
+    ///
+    /// - Throws: `ValidationError` when stdin is empty, the two entries differ,
+    ///   or no TTY is attached and `--stdin` was not passed.
+    static func readPassword(useStdin: Bool) throws -> String {
+        if useStdin {
+            return try passwordFromStdin(readLine(strippingNewline: true))
+        }
+        guard isatty(STDIN_FILENO) == 1 else {
+            throw ValidationError(
+                "No terminal attached — pipe the password and pass --stdin, e.g. "
+                    + "`printf '%s' \"$PW\" | crow web-password set --stdin`.")
+        }
+        let first = try promptSecret("New web password: ")
+        let second = try promptSecret("Confirm password: ")
+        return try confirmPassword(first, second)
+    }
+
+    /// Prompt on the terminal with echo disabled.
+    private static func promptSecret(_ prompt: String) throws -> String {
+        guard let raw = getpass(prompt) else {
+            throw ValidationError("Could not read the password from the terminal.")
+        }
+        return String(cString: raw)
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -179,6 +179,23 @@ func validateRetentionHours(_ value: Int) throws {
     }
 }
 
+/// Validate a `crow gateway set --header` value: `Name: Value`.
+///
+/// A blank *value* is legal and meaningful — `--header "X-Api-Key:"` means
+/// "keep the secret already stored for this header", which is how the base URL
+/// can be changed without restating the key. A missing colon or blank name is
+/// rejected so a typo'd flag fails loudly instead of being dropped server-side.
+///
+/// - Throws: `ValidationError` when the line has no colon or an empty name.
+func validateHeaderLine(_ value: String) throws {
+    let trimmed = value.trimmingCharacters(in: .whitespaces)
+    guard let colon = trimmed.firstIndex(of: ":"),
+          !String(trimmed[..<colon]).trimmingCharacters(in: .whitespaces).isEmpty else {
+        throw ValidationError(
+            "'\(value)' is not a valid header. Expected 'Name: Value' (e.g. \"X-Api-Key: sk-…\").")
+    }
+}
+
 /// Validate the set-goal argument shape: exactly one of `--goal`/`--clear`,
 /// and a provided goal must not be blank (a whitespace goal would silently
 /// fail to earn the on-goal alignment multiplier).

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -186,8 +186,19 @@ func validateRetentionHours(_ value: Int) throws {
 /// can be changed without restating the key. A missing colon or blank name is
 /// rejected so a typo'd flag fails loudly instead of being dropped server-side.
 ///
-/// - Throws: `ValidationError` when the line has no colon or an empty name.
+/// One `--header` must mean one header: the daemon parses these by splitting on
+/// newlines, so an embedded `\n` would smuggle in a second header. Reject it
+/// here so the typo fails loudly at the flag rather than silently expanding.
+///
+/// - Throws: `ValidationError` when the line has no colon, an empty name, or an
+///   embedded newline.
 func validateHeaderLine(_ value: String) throws {
+    // CharacterSet, not `contains("\n")`: Swift treats CRLF as a single Character,
+    // so a grapheme comparison misses "\r\n" entirely.
+    guard value.rangeOfCharacter(from: .newlines) == nil else {
+        throw ValidationError(
+            "A --header must be a single line — '\(value)' contains a newline. Pass one --header per header.")
+    }
     let trimmed = value.trimmingCharacters(in: .whitespaces)
     guard let colon = trimmed.firstIndex(of: ":"),
           !String(trimmed[..<colon]).trimmingCharacters(in: .whitespaces).isEmpty else {

--- a/Packages/CrowCLI/Tests/CrowCLITests/SecretArgsTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/SecretArgsTests.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import CrowCLILib
+
+@Test func passwordFromStdinUsesTheLineVerbatim() throws {
+    #expect(try SecretArgs.passwordFromStdin("hunter2") == "hunter2")
+    // Spaces are legal password characters — trimming would change the secret.
+    #expect(try SecretArgs.passwordFromStdin("  spaced  ") == "  spaced  ")
+}
+
+@Test func passwordFromStdinStripsTrailingCarriageReturn() throws {
+    // A CRLF pipe must not silently append \r to the stored password.
+    #expect(try SecretArgs.passwordFromStdin("hunter2\r") == "hunter2")
+}
+
+@Test func passwordFromStdinRejectsEmptyAndAbsentInput() {
+    #expect(throws: (any Error).self) { _ = try SecretArgs.passwordFromStdin("") }
+    #expect(throws: (any Error).self) { _ = try SecretArgs.passwordFromStdin("\r") }
+    // nil = EOF with nothing piped in.
+    #expect(throws: (any Error).self) { _ = try SecretArgs.passwordFromStdin(nil) }
+}
+
+@Test func confirmPasswordRequiresAMatch() throws {
+    #expect(try SecretArgs.confirmPassword("hunter2", "hunter2") == "hunter2")
+    #expect(throws: (any Error).self) {
+        _ = try SecretArgs.confirmPassword("hunter2", "hunter3")
+    }
+    #expect(throws: (any Error).self) { _ = try SecretArgs.confirmPassword("", "") }
+}
+
+@Test func validatePasswordRejectsOnlyEmptiness() throws {
+    // No strength rule on purpose: the server has none either, so inventing one
+    // here would reject passwords the web UI accepts.
+    #expect(try SecretArgs.validatePassword("a") == "a")
+    #expect(try SecretArgs.validatePassword(" ") == " ")
+    #expect(throws: (any Error).self) { _ = try SecretArgs.validatePassword("") }
+}

--- a/Packages/CrowCLI/Tests/CrowCLITests/SecretCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/SecretCommandParsingTests.swift
@@ -1,0 +1,136 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import CrowCLILib
+
+private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+// MARK: - Subcommand routing
+
+@Test func gatewayGroupRoutesToSubcommands() throws {
+    #expect(try Gateway.parseAsRoot(["get", "--manager"]) is GatewayGet)
+    #expect(try Gateway.parseAsRoot(
+        ["set", "--manager", "--base-url", "https://gw.example.com", "--header", "K: V"]
+    ) is GatewaySet)
+    #expect(try Gateway.parseAsRoot(["clear", "--manager"]) is GatewayClear)
+}
+
+@Test func webPasswordGroupRoutesToSubcommands() throws {
+    #expect(try WebPassword.parseAsRoot(["status"]) is WebPasswordStatus)
+    #expect(try WebPassword.parseAsRoot(["set"]) is WebPasswordSet)
+    #expect(try WebPassword.parseAsRoot(["clear"]) is WebPasswordClear)
+}
+
+// MARK: - Target selector
+
+@Test func gatewayGetParsesManagerTarget() throws {
+    let cmd = try GatewayGet.parse(["--manager"])
+    #expect(cmd.target.manager)
+    #expect(cmd.target.workspace == nil)
+    #expect(!cmd.reveal)
+    #expect(cmd.target.params["target"] == .string("manager"))
+}
+
+@Test func gatewayGetParsesWorkspaceTargetAndReveal() throws {
+    let byName = try GatewayGet.parse(["--workspace", "Corveil", "--reveal"])
+    #expect(byName.target.workspace == "Corveil")
+    #expect(byName.reveal)
+    #expect(byName.target.params["workspace"] == .string("Corveil"))
+    // A UUID is just as valid a reference as a name.
+    #expect(try GatewayGet.parse(["--workspace", validUUID]).target.workspace == validUUID)
+}
+
+@Test func gatewayTargetRejectsBothAndNeither() {
+    for args in [["--manager", "--workspace", "Corveil"], [], ["--workspace", "  "]] {
+        #expect(throws: (any Error).self, "expected \(args) to be rejected") {
+            _ = try GatewayGet.parse(args)
+        }
+    }
+}
+
+@Test func gatewayClearRequiresATarget() throws {
+    #expect(try GatewayClear.parse(["--manager"]).target.manager)
+    #expect(throws: (any Error).self) { _ = try GatewayClear.parse([]) }
+}
+
+// MARK: - gateway set
+
+@Test func gatewaySetParsesRepeatableHeaders() throws {
+    let cmd = try GatewaySet.parse([
+        "--manager",
+        "--base-url", "https://gw.example.com",
+        "--header", "X-Api-Key: sk-test-1",
+        "--header", "X-Tenant: acme",
+    ])
+    #expect(cmd.baseURL == "https://gw.example.com")
+    #expect(cmd.header == ["X-Api-Key: sk-test-1", "X-Tenant: acme"])
+}
+
+@Test func gatewaySetAcceptsBlankHeaderValue() throws {
+    // "keep the stored secret" — must survive client-side validation, since it's
+    // the documented way to change a base URL without restating credentials.
+    let cmd = try GatewaySet.parse([
+        "--manager", "--base-url", "https://gw.example.com", "--header", "X-Api-Key:",
+    ])
+    #expect(cmd.header == ["X-Api-Key:"])
+}
+
+@Test func gatewaySetRequiresBaseURLAndHeader() {
+    // Both-or-neither: a URL with no header (and vice versa) is refused locally
+    // before it reaches the daemon.
+    #expect(throws: (any Error).self) {
+        _ = try GatewaySet.parse(["--manager", "--base-url", "https://gw.example.com"])
+    }
+    #expect(throws: (any Error).self) {
+        _ = try GatewaySet.parse(["--manager", "--header", "X-Api-Key: sk-test-1"])
+    }
+    #expect(throws: (any Error).self) {
+        _ = try GatewaySet.parse([
+            "--manager", "--base-url", "  ", "--header", "X-Api-Key: sk-test-1",
+        ])
+    }
+}
+
+@Test func gatewaySetRejectsMalformedHeaders() {
+    for header in ["no-colon-here", ": orphan-value", "   "] {
+        #expect(throws: (any Error).self, "expected '\(header)' to be rejected") {
+            _ = try GatewaySet.parse([
+                "--manager", "--base-url", "https://gw.example.com", "--header", header,
+            ])
+        }
+    }
+}
+
+@Test func validateHeaderLineAcceptsValuesContainingColons() throws {
+    try validateHeaderLine("Authorization: Bearer a:b:c")
+    try validateHeaderLine("X-Api-Key: op://Vault/Item/field")
+}
+
+// MARK: - web-password
+
+@Test func webPasswordSetParsesStdinFlag() throws {
+    #expect(!(try WebPasswordSet.parse([])).stdin)
+    #expect((try WebPasswordSet.parse(["--stdin"])).stdin)
+}
+
+@Test func webPasswordSetHasNoPasswordFlag() {
+    // Plaintext in argv would land in shell history and local `ps` (CROW-815).
+    #expect(throws: (any Error).self) {
+        _ = try WebPasswordSet.parse(["--password", "hunter2"])
+    }
+}
+
+@Test func webPasswordStatusAndClearTakeNoArguments() throws {
+    _ = try WebPasswordStatus.parse([])
+    _ = try WebPasswordClear.parse([])
+    #expect(throws: (any Error).self) { _ = try WebPasswordClear.parse(["--manager"]) }
+}
+
+// MARK: - Registration
+
+@Test func rootCommandRegistersSecretGroups() {
+    let names = CrowCommand.configuration.subcommands.map { $0.configuration.commandName }
+    #expect(names.contains("gateway"))
+    #expect(names.contains("web-password"))
+}

--- a/Packages/CrowCLI/Tests/CrowCLITests/SecretCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/SecretCommandParsingTests.swift
@@ -107,6 +107,18 @@ private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     try validateHeaderLine("X-Api-Key: op://Vault/Item/field")
 }
 
+@Test func gatewaySetRejectsHeadersWithEmbeddedNewlines() {
+    // One --header must mean one header: the daemon splits on newlines, so an
+    // embedded \n would smuggle in a second one.
+    for header in ["X-Api-Key: sk-1\nX-Smuggled: evil", "X-Api-Key: sk-1\r\nX-Smuggled: evil"] {
+        #expect(throws: (any Error).self, "expected an embedded newline to be rejected") {
+            _ = try GatewaySet.parse([
+                "--manager", "--base-url", "https://gw.example.com", "--header", header,
+            ])
+        }
+    }
+}
+
 // MARK: - web-password
 
 @Test func webPasswordSetParsesStdinFlag() throws {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -1159,6 +1159,11 @@ func makeCommandRouter(
         // plus at least one `header_lines` entry is required (both-or-neither).
         // A blank header value keeps the currently-stored secret, so the CLI can
         // change a base URL without restating the key.
+        //
+        // Writes go through `mutateConfig`, which refuses to overwrite a
+        // `config.json` that exists but won't decode (CROW-814) — otherwise a
+        // corrupt file plus one `crow gateway set` would silently replace every
+        // workspace, job and credential with defaults.
         "gateway-set": { params in
             let target = try SecretsRPC.decodeTarget(params)
             let clear = params["clear"]?.boolValue ?? false
@@ -1171,7 +1176,7 @@ func makeCommandRouter(
             case .success(let gateway): incoming = gateway
             }
             return try mapGatewayError {
-                try mutateSecrets(devRoot: devRoot) { config -> [String: JSONValue] in
+                try mutateConfig(devRoot: devRoot) { config -> [String: JSONValue] in
                     switch target {
                     case .manager:
                         let merged = try SecretRoutes.mergingPreservedHeaders(
@@ -1209,7 +1214,7 @@ func makeCommandRouter(
             if !clear, password.isEmpty {
                 throw DaemonRPCError.invalidParams("password must be a non-empty string (or clear: true)")
             }
-            return try mutateSecrets(devRoot: devRoot) { config -> [String: JSONValue] in
+            return try mutateConfig(devRoot: devRoot) { config -> [String: JSONValue] in
                 config.webAuth = clear ? nil : PasswordHash.make(password: password)
                 return ["saved": .bool(true), "password_set": .bool(config.webAuth != nil)]
             }
@@ -1710,23 +1715,6 @@ private func mutateConfig<T>(devRoot: String, _ transform: (inout AppConfig) thr
             try ConfigStore.saveConfig(config, devRoot: devRoot)
         } catch {
             throw RPCError.applicationError("Failed to persist config change: \(error.localizedDescription)")
-        }
-        return result
-    }
-}
-
-/// Persist a secret-config mutation (gateways / `webAuth`) under the shared
-/// lock, mirroring ``mutateJobs(devRoot:_:)``. Kept separate so the failure
-/// message names the surface the caller was actually changing.
-private func mutateSecrets<T>(devRoot: String, _ transform: (inout AppConfig) throws -> T) throws -> T {
-    try ConfigStore.withConfigLock {
-        var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-        let result = try transform(&config)
-        do {
-            try ConfigStore.saveConfig(config, devRoot: devRoot)
-        } catch {
-            throw DaemonRPCError.applicationError(
-                "Failed to persist secret change: \(error.localizedDescription)")
         }
         return result
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -1057,7 +1057,8 @@ func makeCommandRouter(
             // The browser can't see or change credentials, so keep whatever is
             // already on disk (nil-current drops any credential shell — see
             // SettingsSecrets). Load+save under the shared lock so a concurrent
-            // set-web-password / onJobRan can't clobber this write (review #10).
+            // web-password-set / gateway-set / onJobRan can't clobber this
+            // write (review #10).
             let merged: AppConfig
             do {
                 merged = try ConfigStore.withConfigLock {
@@ -1118,16 +1119,101 @@ func makeCommandRouter(
             return ["ok": .bool(true), "dev_root": .string(chosen)]
         },
 
-        // NOTE: the web-access password and AI gateways are secret writes and
-        // are managed via local-only, Origin-checked HTTP POSTs in
-        // `SecretRoutes`, never here. A JSON-RPC method on this shared router is
-        // reachable over the possibly-remote `/rpc` WebSocket and can't tell a
-        // local caller from a logged-in remote one, so it must not carry secret
-        // writes — that would let a remote client change the password that gates
-        // remote access (CROW-593). The same local-direct bar applies to
-        // `set-config` changes of `defaults.binaries` (gated in
-        // `RPCWebSocketHandler`) — those absolute binary paths execute at the next
-        // launch. Scheduled `jobs` are no longer gated (CROW-665).
+        // Secret surfaces: the web-access password and the AI gateways. The
+        // browser reaches these through the local-only, Origin-checked HTTP POSTs
+        // in `SecretRoutes`; the methods below are the CLI's equivalent over the
+        // Unix socket (CROW-815).
+        //
+        // A JSON-RPC method on this shared router is *also* reachable over the
+        // possibly-remote `/rpc` WebSocket, which can't tell a local caller from
+        // a logged-in remote one — so each of these is listed in
+        // `RPCWebSocketHandler.localOnlyDenial` and refused for non-local peers.
+        // Without that gate a remote client could change the very password that
+        // gates remote access (CROW-593). Reads are gated too: `gateway-get`
+        // with `reveal` returns header secrets. Any new method here that touches
+        // `webAuth` or a gateway MUST be added to that switch.
+        //
+        // The same local-direct bar applies to `set-config` changes of
+        // `defaults.binaries` — those absolute binary paths execute at the next
+        // launch. Scheduled `jobs` are not gated (CROW-665).
+        "gateway-get": { params in
+            let target = try SecretsRPC.decodeTarget(params)
+            // Fail safe: a caller that omits `reveal` gets redacted values.
+            let reveal = params["reveal"]?.boolValue ?? false
+            let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            switch target {
+            case .manager:
+                var result = SecretsRPC.gatewayJSON(config.managerGateway, reveal: reveal)
+                result["target"] = .string("manager")
+                return result
+            case .workspace(let ref):
+                let index = try SecretsRPC.resolveWorkspace(ref, in: config)
+                let workspace = config.workspaces[index]
+                var result = SecretsRPC.gatewayJSON(workspace.gateway, reveal: reveal)
+                result["workspace_id"] = .string(workspace.id.uuidString)
+                result["workspace_name"] = .string(workspace.name)
+                return result
+            }
+        },
+        // Set or clear a gateway. `clear: true` removes it; otherwise `base_url`
+        // plus at least one `header_lines` entry is required (both-or-neither).
+        // A blank header value keeps the currently-stored secret, so the CLI can
+        // change a base URL without restating the key.
+        "gateway-set": { params in
+            let target = try SecretsRPC.decodeTarget(params)
+            let clear = params["clear"]?.boolValue ?? false
+            let headers = clear ? nil : try SecretsRPC.decodeHeaderLines(params["header_lines"])
+            let body = SecretRoutes.GatewayBody(
+                baseURL: params["base_url"]?.stringValue, headers: headers, clear: clear)
+            let incoming: WorkspaceGateway?
+            switch SecretRoutes.buildGateway(body) {
+            case .failure(let error): throw DaemonRPCError.invalidParams(error.message)
+            case .success(let gateway): incoming = gateway
+            }
+            return try mapGatewayError {
+                try mutateSecrets(devRoot: devRoot) { config -> [String: JSONValue] in
+                    switch target {
+                    case .manager:
+                        let merged = try SecretRoutes.mergingPreservedHeaders(
+                            incoming: incoming, stored: config.managerGateway).get()
+                        config.managerGateway = merged
+                        return ["saved": .bool(true), "gateway_set": .bool(merged != nil),
+                                "target": .string("manager")]
+                    case .workspace(let ref):
+                        let index = try SecretsRPC.resolveWorkspace(ref, in: config)
+                        let merged = try SecretRoutes.mergingPreservedHeaders(
+                            incoming: incoming, stored: config.workspaces[index].gateway).get()
+                        config.workspaces[index].gateway = merged
+                        return ["saved": .bool(true), "gateway_set": .bool(merged != nil),
+                                "workspace_id": .string(config.workspaces[index].id.uuidString),
+                                "workspace_name": .string(config.workspaces[index].name)]
+                    }
+                }
+            }
+        },
+        // Whether a web-access password is set, and at what PBKDF2 cost. The
+        // hash and salt are never returned.
+        "web-password-get": { _ in
+            let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            return [
+                "password_set": .bool(config.webAuth != nil),
+                "iterations": .int(config.webAuth?.iterations ?? 0),
+            ]
+        },
+        // Set, change, or clear the web-access password. Changing does not
+        // require the old password — matching the web UI, where the local-direct
+        // gate is the control. The plaintext is hashed here and never persisted.
+        "web-password-set": { params in
+            let clear = params["clear"]?.boolValue ?? false
+            let password = params["password"]?.stringValue ?? ""
+            if !clear, password.isEmpty {
+                throw DaemonRPCError.invalidParams("password must be a non-empty string (or clear: true)")
+            }
+            return try mutateSecrets(devRoot: devRoot) { config -> [String: JSONValue] in
+                config.webAuth = clear ? nil : PasswordHash.make(password: password)
+                return ["saved": .bool(true), "password_set": .bool(config.webAuth != nil)]
+            }
+        },
 
         // Session/board actions — forward-only (need the app's coordinators).
         // Spawning a Manager forwards to the app when it's running (its
@@ -1626,6 +1712,33 @@ private func mutateConfig<T>(devRoot: String, _ transform: (inout AppConfig) thr
             throw RPCError.applicationError("Failed to persist config change: \(error.localizedDescription)")
         }
         return result
+    }
+}
+
+/// Persist a secret-config mutation (gateways / `webAuth`) under the shared
+/// lock, mirroring ``mutateJobs(devRoot:_:)``. Kept separate so the failure
+/// message names the surface the caller was actually changing.
+private func mutateSecrets<T>(devRoot: String, _ transform: (inout AppConfig) throws -> T) throws -> T {
+    try ConfigStore.withConfigLock {
+        var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+        let result = try transform(&config)
+        do {
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+        } catch {
+            throw DaemonRPCError.applicationError(
+                "Failed to persist secret change: \(error.localizedDescription)")
+        }
+        return result
+    }
+}
+
+/// `SecretRoutes` reports a bad gateway shape as `GatewayValidationError`
+/// (the HTTP routes turn it into a 400); surface it as `invalidParams` here.
+private func mapGatewayError<T>(_ body: () throws -> T) throws -> T {
+    do {
+        return try body()
+    } catch let error as SecretRoutes.GatewayValidationError {
+        throw DaemonRPCError.invalidParams(error.message)
     }
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -114,6 +114,13 @@ enum RPCWebSocketHandler {
     ///   unauthenticated non-loopback bind). Other `set-config` fields flow through.
     /// - `open-in-vscode` / `open-terminal`: launch a GUI app on the daemon host
     ///   at the worktree path — a remote peer must not spawn host processes (CROW-749).
+    /// - `gateway-*` / `web-password-*`: the CLI's route to the same secret
+    ///   surfaces `SecretRoutes` serves the browser (CROW-815). Writes must stay
+    ///   local so a remote client can't change the password gating remote access;
+    ///   **reads are gated too**, because `gateway-get` with `reveal` returns the
+    ///   gateway auth headers verbatim. The web Settings UI is unaffected — it
+    ///   reads gateway state through `get-config` (stripped) and writes through
+    ///   `SecretRoutes`.
     ///
     /// Scheduled `jobs` are intentionally NOT gated here (CROW-665): the Jobs
     /// editor is a core web-Settings surface, so an authenticated remote session
@@ -156,6 +163,9 @@ enum RPCWebSocketHandler {
             // the worktree path). Restrict to loopback callers — a remote web
             // session must not spawn host processes (CROW-749).
             return "opening host apps is local-only"
+        case "gateway-get", "gateway-set", "web-password-get", "web-password-set":
+            // Secret reads *and* writes (CROW-815) — see the doc comment above.
+            return "gateway and web-password management is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
             return "set-config binaries is local-only"

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
@@ -16,13 +16,23 @@ import NIOCore
 ///   - gateway auth-header secrets never travel to or from a remote browser
 ///     (they stay stripped / read-only there, per `SettingsSecrets`).
 ///
-/// These are dedicated HTTP POSTs rather than JSON-RPC methods precisely so the
-/// handler has the peer address + `X-Forwarded-For` in hand for the locality
-/// check — the shared `/rpc` WebSocket router is transport-agnostic and can't
-/// tell a local caller from a logged-in remote one. Each write is also
-/// Origin-checked, so a malicious page in the *local* browser can't drive it via
-/// CSRF. Mirrors the `WebAuthRoutes` POST pattern; both sit behind
-/// `WebAuthMiddleware`.
+/// These are dedicated HTTP POSTs because the handler then has the peer address
+/// + `X-Forwarded-For` in hand for the locality check, and can Origin-check each
+/// write so a malicious page in the *local* browser can't drive it via CSRF.
+/// Mirrors the `WebAuthRoutes` POST pattern; both sit behind `WebAuthMiddleware`.
+/// This is the path the **browser** uses.
+///
+/// The **CLI** reaches the same surfaces over the Unix socket through the
+/// `gateway-*` / `web-password-*` JSON-RPC methods (CROW-815). Those are safe
+/// despite the shared `/rpc` router being transport-agnostic *only* because
+/// every one of them is listed in
+/// ``RPCWebSocketHandler/localOnlyDenial(for:devRoot:)``, which refuses them for
+/// non-local peers — reads included, since `gateway-get` with `reveal` returns
+/// the auth headers. Validation is not duplicated: those handlers call
+/// ``buildGateway(_:)`` and ``mergingPreservedHeaders(incoming:stored:)`` below.
+///
+/// So there are two doors to one room. Removing either the RPC gate or these
+/// routes' `gateOK` check re-opens the hole this type exists to close.
 enum SecretRoutes {
     static func mount(on router: Router<CrowHTTPContext>, boundHost: String, devRoot: String) {
         // Locality probe: tells the web UI whether THIS connection may manage

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretsRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretsRPCSupport.swift
@@ -1,0 +1,110 @@
+import CrowCore
+import CrowIPC
+import Foundation
+
+/// Param decoding and response encoding for the `gateway-*` / `web-password-*`
+/// RPC methods (CROW-815) — the CLI-facing analog of the `SecretRoutes` HTTP
+/// bodies. The validation itself is *not* duplicated here: the handlers feed
+/// what this decodes straight into ``SecretRoutes/buildGateway(_:)`` and
+/// ``SecretRoutes/mergingPreservedHeaders(incoming:stored:)``, which own the
+/// both-or-neither invariant and the "blank value keeps the stored secret"
+/// contract.
+///
+/// These methods are reachable over the local Unix socket only — the `/rpc`
+/// WebSocket path refuses them in ``RPCWebSocketHandler/localOnlyDenial(for:devRoot:)``.
+enum SecretsRPC {
+    /// Which gateway a `gateway-*` call addresses.
+    enum GatewayTarget: Equatable {
+        case manager
+        /// A workspace, referenced by UUID or by name (see ``resolveWorkspace(_:in:)``).
+        case workspace(String)
+    }
+
+    /// Decode the target selector: exactly one of `target: "manager"` or
+    /// `workspace: "<name|uuid>"`.
+    static func decodeTarget(_ params: [String: JSONValue]) throws -> GatewayTarget {
+        let target = params["target"]?.stringValue?.trimmingCharacters(in: .whitespaces)
+        let workspace = params["workspace"]?.stringValue?.trimmingCharacters(in: .whitespaces)
+
+        switch (target, workspace) {
+        case let (.some(target), nil) where !target.isEmpty:
+            guard target == "manager" else {
+                throw DaemonRPCError.invalidParams("target must be \"manager\" (got \"\(target)\")")
+            }
+            return .manager
+        case let (nil, .some(workspace)) where !workspace.isEmpty:
+            return .workspace(workspace)
+        case (.some, .some):
+            throw DaemonRPCError.invalidParams("target and workspace are mutually exclusive")
+        default:
+            throw DaemonRPCError.invalidParams("one of target=\"manager\" or workspace=<name|uuid> is required")
+        }
+    }
+
+    /// Find a workspace by UUID, falling back to a case-insensitive name match.
+    ///
+    /// `WorkspaceInfo.validateName` enforces case-insensitive uniqueness, so a
+    /// name matches at most one workspace — but a config hand-edited before that
+    /// rule existed could hold duplicates, so ambiguity is an error rather than
+    /// a coin flip.
+    static func resolveWorkspace(_ ref: String, in config: AppConfig) throws -> Int {
+        if let uid = UUID(uuidString: ref),
+           let index = config.workspaces.firstIndex(where: { $0.id == uid }) {
+            return index
+        }
+        let lowered = ref.lowercased()
+        let matches = config.workspaces.indices.filter {
+            config.workspaces[$0].name.lowercased() == lowered
+        }
+        switch matches.count {
+        case 1: return matches[0]
+        case 0: throw DaemonRPCError.invalidParams("Unknown workspace '\(ref)'")
+        default:
+            throw DaemonRPCError.invalidParams(
+                "'\(ref)' matches \(matches.count) workspaces — use the workspace UUID")
+        }
+    }
+
+    /// Decode `header_lines: ["Name: Value", …]` into a header map.
+    ///
+    /// Parsing goes through ``WorkspaceGateway/parseHeaderLines(_:)`` so the CLI,
+    /// the Settings UI, and the gateway model all split headers the same way. A
+    /// blank *value* is preserved (it means "keep the stored secret"); a line
+    /// with no colon or a blank name is rejected here rather than silently
+    /// dropped, since a typo'd flag should not quietly produce an empty gateway.
+    static func decodeHeaderLines(_ value: JSONValue?) throws -> [String: String] {
+        guard let lines = value?.arrayValue else { return [:] }
+        let texts = try lines.map { line -> String in
+            guard let text = line.stringValue else {
+                throw DaemonRPCError.invalidParams("header_lines must be an array of strings")
+            }
+            return text
+        }
+        for text in texts {
+            let trimmed = text.trimmingCharacters(in: .whitespaces)
+            guard let colon = trimmed.firstIndex(of: ":"),
+                  !String(trimmed[..<colon]).trimmingCharacters(in: .whitespaces).isEmpty else {
+                throw DaemonRPCError.invalidParams(
+                    "'\(text)' is not a valid header. Expected 'Name: Value'.")
+            }
+        }
+        return WorkspaceGateway.parseHeaderLines(texts.joined(separator: "\n"))
+    }
+
+    /// Encode a gateway for a `gateway-get` response.
+    ///
+    /// Header *values* are blanked unless `reveal` — mirroring
+    /// `SettingsSecrets.strippedForTransport`, so the default output is safe to
+    /// paste into a ticket. Keys and the base URL always pass through.
+    static func gatewayJSON(_ gateway: WorkspaceGateway?, reveal: Bool) -> [String: JSONValue] {
+        guard let gateway else {
+            return ["gateway_set": .bool(false), "base_url": .string(""), "headers": .object([:])]
+        }
+        let headers = gateway.customHeaders.mapValues { JSONValue.string(reveal ? $0 : "") }
+        return [
+            "gateway_set": .bool(true),
+            "base_url": .string(gateway.baseURL),
+            "headers": .object(headers),
+        ]
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretsRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretsRPCSupport.swift
@@ -72,6 +72,10 @@ enum SecretsRPC {
     /// blank *value* is preserved (it means "keep the stored secret"); a line
     /// with no colon or a blank name is rejected here rather than silently
     /// dropped, since a typo'd flag should not quietly produce an empty gateway.
+    ///
+    /// One entry must mean one header. `parseHeaderLines` splits on newlines, so
+    /// an entry containing `\n` would smuggle in extra headers past the per-entry
+    /// check below — reject embedded newlines instead of silently expanding them.
     static func decodeHeaderLines(_ value: JSONValue?) throws -> [String: String] {
         guard let lines = value?.arrayValue else { return [:] }
         let texts = try lines.map { line -> String in
@@ -81,6 +85,12 @@ enum SecretsRPC {
             return text
         }
         for text in texts {
+            // CharacterSet, not `contains("\n")`: Swift treats CRLF as a single
+            // Character, so a grapheme comparison misses "\r\n" entirely.
+            guard text.rangeOfCharacter(from: .newlines) == nil else {
+                throw DaemonRPCError.invalidParams(
+                    "A header must be a single line — '\(text)' contains a newline.")
+            }
             let trimmed = text.trimmingCharacters(in: .whitespaces)
             guard let colon = trimmed.firstIndex(of: ":"),
                   !String(trimmed[..<colon]).trimmingCharacters(in: .whitespaces).isEmpty else {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -846,6 +846,29 @@ import CrowPersistence
         }
     }
 
+    @Test func secretMethodsAreLocalOnly() {
+        // Gateways and the web password are the CLI's route to the same secrets
+        // `SecretRoutes` guards for the browser (CROW-815). Reads are gated too:
+        // `gateway-get` with reveal returns the gateway auth headers, and
+        // `web-password-set` from a remote peer would let it change the password
+        // gating remote access.
+        for method in ["gateway-get", "gateway-set", "web-password-get", "web-password-set"] {
+            let req = JSONRPCRequest(id: 1, method: method, params: [
+                "target": .string("manager"),
+            ])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
+                == "gateway and web-password management is local-only")
+        }
+    }
+
+    @Test func unrelatedMethodsStayUngated() {
+        // Guards against a too-broad match swallowing neighbouring methods.
+        for method in ["get-config", "job-list", "list-sessions"] {
+            let req = JSONRPCRequest(id: 1, method: method, params: [:])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot()) == nil)
+        }
+    }
+
     @Test func setConfigBinariesChangeIsLocalOnly() throws {
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretsRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretsRPCTests.swift
@@ -1,0 +1,393 @@
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+import Foundation
+import Testing
+
+@testable import CrowDaemon
+
+/// The `gateway-*` / `web-password-*` RPC methods the CLI drives (CROW-815).
+///
+/// These go through the real router and read back from disk, so they cover the
+/// handler, the `SecretRoutes` validators it reuses, and `AppConfig`'s
+/// both-or-neither decode invariant in one pass.
+@Suite struct SecretsRPCTests {
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crowd-secrets-rpc-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @MainActor private func router(devRoot: String) -> CommandRouter {
+        makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: devRoot, cockpit: nil)
+    }
+
+    private func call(
+        _ router: CommandRouter, _ method: String, _ params: [String: JSONValue] = [:]
+    ) async -> JSONRPCResponse {
+        await router.handle(request: JSONRPCRequest(id: 1, method: method, params: params))
+    }
+
+    // MARK: - Manager gateway
+
+    @Test @MainActor func managerGatewaySetGetClearRoundTrip() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        // Nothing set yet.
+        let empty = await call(router, "gateway-get", ["target": .string("manager")])
+        #expect(empty.result?["gateway_set"] == .bool(false))
+
+        let set = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-test-1")]),
+        ])
+        #expect(set.error == nil)
+        #expect(set.result?["gateway_set"] == .bool(true))
+
+        // It reached disk, not just memory.
+        let stored = ConfigStore.loadConfig(devRoot: devRoot)
+        #expect(stored?.managerGateway?.baseURL == "https://gw.example.com")
+        #expect(stored?.managerGateway?.customHeaders["X-Api-Key"] == "sk-test-1")
+
+        // Default read redacts the value but keeps the key.
+        let redacted = await call(router, "gateway-get", ["target": .string("manager")])
+        #expect(redacted.result?["base_url"] == .string("https://gw.example.com"))
+        #expect(redacted.result?["headers"] == .object(["X-Api-Key": .string("")]))
+
+        let revealed = await call(router, "gateway-get", [
+            "target": .string("manager"), "reveal": .bool(true),
+        ])
+        #expect(revealed.result?["headers"] == .object(["X-Api-Key": .string("sk-test-1")]))
+
+        let cleared = await call(router, "gateway-set", [
+            "target": .string("manager"), "clear": .bool(true),
+        ])
+        #expect(cleared.result?["gateway_set"] == .bool(false))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.managerGateway == nil)
+    }
+
+    @Test @MainActor func omittedRevealRedacts() async throws {
+        // Fail safe: a caller that never sends `reveal` must not get secrets.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        _ = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-secret")]),
+        ])
+        let response = await call(router, "gateway-get", ["target": .string("manager")])
+        #expect(response.result?["headers"] == .object(["X-Api-Key": .string("")]))
+    }
+
+    @Test @MainActor func blankHeaderValueKeepsStoredSecret() async throws {
+        // The documented way to change a base URL without restating credentials.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        _ = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-test-1")]),
+        ])
+        let updated = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw2.example.com"),
+            "header_lines": .array([.string("X-Api-Key:")]),
+        ])
+        #expect(updated.error == nil)
+
+        let stored = ConfigStore.loadConfig(devRoot: devRoot)
+        #expect(stored?.managerGateway?.baseURL == "https://gw2.example.com")
+        #expect(stored?.managerGateway?.customHeaders["X-Api-Key"] == "sk-test-1")
+    }
+
+    @Test @MainActor func blankHeaderWithNoStoredSecretIsRejected() async throws {
+        // Persisting {baseURL, no headers} would make the next loadConfig return
+        // nil and wipe the file on the following write — SecretRoutes guards it.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let response = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key:")]),
+        ])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.managerGateway == nil)
+    }
+
+    @Test @MainActor func baseURLWithoutHeadersIsRejected() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let response = await call(router(devRoot: devRoot), "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([]),
+        ])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    @Test @MainActor func malformedHeaderLineIsRejected() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let response = await call(router(devRoot: devRoot), "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("no-colon-here")]),
+        ])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    // MARK: - Workspace gateway
+
+    @Test @MainActor func workspaceGatewayResolvesByNameAndUUID() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let workspace = WorkspaceInfo(name: "Corveil")
+        try ConfigStore.saveConfig(AppConfig(workspaces: [workspace]), devRoot: devRoot)
+        let router = router(devRoot: devRoot)
+
+        // By name, case-insensitively.
+        let set = await call(router, "gateway-set", [
+            "workspace": .string("corveil"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-ws")]),
+        ])
+        #expect(set.error == nil)
+        #expect(set.result?["workspace_id"] == .string(workspace.id.uuidString))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?
+            .workspaces[0].gateway?.customHeaders["X-Api-Key"] == "sk-ws")
+
+        // By UUID.
+        let get = await call(router, "gateway-get", [
+            "workspace": .string(workspace.id.uuidString), "reveal": .bool(true),
+        ])
+        #expect(get.result?["workspace_name"] == .string("Corveil"))
+        #expect(get.result?["headers"] == .object(["X-Api-Key": .string("sk-ws")]))
+    }
+
+    @Test @MainActor func unknownWorkspaceIsRejected() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let response = await call(router(devRoot: devRoot), "gateway-get", [
+            "workspace": .string("nope"),
+        ])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    @Test @MainActor func managerGatewayAndWorkspaceGatewayAreIndependent() async throws {
+        // Clearing the Manager gateway must not disturb a workspace's.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(
+            AppConfig(workspaces: [WorkspaceInfo(name: "Corveil")]), devRoot: devRoot)
+        let router = router(devRoot: devRoot)
+
+        _ = await call(router, "gateway-set", [
+            "workspace": .string("Corveil"),
+            "base_url": .string("https://ws.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-ws")]),
+        ])
+        _ = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://mgr.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-mgr")]),
+        ])
+        _ = await call(router, "gateway-set", ["target": .string("manager"), "clear": .bool(true)])
+
+        let stored = ConfigStore.loadConfig(devRoot: devRoot)
+        #expect(stored?.managerGateway == nil)
+        #expect(stored?.workspaces[0].gateway?.customHeaders["X-Api-Key"] == "sk-ws")
+    }
+
+    // MARK: - Target selector
+
+    @Test @MainActor func targetSelectorRejectsBothAndNeither() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let both = await call(router, "gateway-get", [
+            "target": .string("manager"), "workspace": .string("Corveil"),
+        ])
+        #expect(both.error?.code == RPCErrorCode.invalidParams)
+
+        let neither = await call(router, "gateway-get")
+        #expect(neither.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    // MARK: - Web password
+
+    /// Set → status → change → clear in one test on purpose: each
+    /// `web-password-set` runs real 210k-iteration PBKDF2, which is seconds per
+    /// call in a debug build, so the stages share one setup rather than paying
+    /// it again per test. The cheap crypto properties (verify rejects a wrong
+    /// password, salts differ between records) are already pinned at
+    /// `iterations: 2000` in `DaemonSecurityTests` — only the integration
+    /// properties are asserted here.
+    @Test @MainActor func webPasswordSetStatusChangeClearRoundTrip() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let before = await call(router, "web-password-get")
+        #expect(before.result?["password_set"] == .bool(false))
+
+        let set = await call(router, "web-password-set", ["password": .string("hunter2")])
+        #expect(set.result?["password_set"] == .bool(true))
+
+        // Hashed, not stored in plaintext — and it hashed the password we sent.
+        let stored = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.webAuth)
+        #expect(stored.hashB64 != "hunter2")
+        #expect(!stored.saltB64.isEmpty)
+        #expect(PasswordHash.verify(password: "hunter2", record: stored))
+
+        let status = await call(router, "web-password-get")
+        #expect(status.result?["password_set"] == .bool(true))
+        #expect(status.result?["iterations"] == .int(PasswordHash.defaultIterations))
+        // The status read must never hand back the hash or salt.
+        #expect(status.result?["hash_b64"] == nil)
+        #expect(status.result?["salt_b64"] == nil)
+
+        // Changing needs no old password, and re-salts rather than reusing.
+        _ = await call(router, "web-password-set", ["password": .string("hunter3")])
+        let changed = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.webAuth)
+        #expect(changed.saltB64 != stored.saltB64)
+        #expect(changed.hashB64 != stored.hashB64)
+
+        let cleared = await call(router, "web-password-set", ["clear": .bool(true)])
+        #expect(cleared.result?["password_set"] == .bool(false))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.webAuth == nil)
+    }
+
+    @Test @MainActor func emptyPasswordIsRejected() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let response = await call(router, "web-password-set", ["password": .string("")])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.webAuth == nil)
+    }
+
+    @Test @MainActor func settingAPasswordLeavesGatewaysIntact() async throws {
+        // Both surfaces read-modify-write the whole AppConfig; neither may drop
+        // the other's field.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        _ = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-test-1")]),
+        ])
+        _ = await call(router, "web-password-set", ["password": .string("hunter2")])
+
+        let stored = ConfigStore.loadConfig(devRoot: devRoot)
+        #expect(stored?.managerGateway?.customHeaders["X-Api-Key"] == "sk-test-1")
+        #expect(stored?.webAuth != nil)
+    }
+}
+
+/// Unit coverage for the param decode/encode helpers behind those handlers.
+@Suite struct SecretsRPCSupportTests {
+    @Test func decodeTargetAcceptsManagerAndWorkspace() throws {
+        #expect(try SecretsRPC.decodeTarget(["target": .string("manager")]) == .manager)
+        #expect(try SecretsRPC.decodeTarget(["workspace": .string("Corveil")])
+            == .workspace("Corveil"))
+    }
+
+    @Test func decodeTargetRejectsUnknownTargetBothAndNeither() {
+        #expect(throws: (any Error).self) {
+            _ = try SecretsRPC.decodeTarget(["target": .string("workspace")])
+        }
+        #expect(throws: (any Error).self) {
+            _ = try SecretsRPC.decodeTarget([
+                "target": .string("manager"), "workspace": .string("Corveil"),
+            ])
+        }
+        #expect(throws: (any Error).self) { _ = try SecretsRPC.decodeTarget([:]) }
+    }
+
+    @Test func decodeHeaderLinesSplitsOnFirstColon() throws {
+        let headers = try SecretsRPC.decodeHeaderLines(.array([
+            .string("X-Api-Key: sk-test-1"),
+            .string("Authorization: Bearer a:b:c"),
+        ]))
+        #expect(headers == ["X-Api-Key": "sk-test-1", "Authorization": "Bearer a:b:c"])
+    }
+
+    @Test func decodeHeaderLinesKeepsBlankValues() throws {
+        // A blank value is the "keep the stored secret" signal — it must survive
+        // decoding rather than being dropped as noise.
+        #expect(try SecretsRPC.decodeHeaderLines(.array([.string("X-Api-Key:")]))
+            == ["X-Api-Key": ""])
+    }
+
+    @Test func decodeHeaderLinesRejectsMalformedLines() {
+        for line in ["no-colon", "  ", ": orphan-value"] {
+            #expect(throws: (any Error).self, "expected '\(line)' to be rejected") {
+                _ = try SecretsRPC.decodeHeaderLines(.array([.string(line)]))
+            }
+        }
+    }
+
+    @Test func decodeHeaderLinesDefaultsToEmpty() throws {
+        #expect(try SecretsRPC.decodeHeaderLines(nil).isEmpty)
+    }
+
+    @Test func gatewayJSONBlanksValuesUnlessRevealing() {
+        let gateway = WorkspaceGateway(
+            baseURL: "https://gw.example.com", customHeaders: ["X-Api-Key": "sk-test-1"])
+
+        let redacted = SecretsRPC.gatewayJSON(gateway, reveal: false)
+        #expect(redacted["gateway_set"] == .bool(true))
+        #expect(redacted["base_url"] == .string("https://gw.example.com"))
+        #expect(redacted["headers"] == .object(["X-Api-Key": .string("")]))
+
+        let revealed = SecretsRPC.gatewayJSON(gateway, reveal: true)
+        #expect(revealed["headers"] == .object(["X-Api-Key": .string("sk-test-1")]))
+    }
+
+    @Test func gatewayJSONReportsAbsentGateway() {
+        let json = SecretsRPC.gatewayJSON(nil, reveal: true)
+        #expect(json["gateway_set"] == .bool(false))
+        #expect(json["base_url"] == .string(""))
+        #expect(json["headers"] == .object([:]))
+    }
+
+    @Test func resolveWorkspacePrefersUUIDThenName() throws {
+        let first = WorkspaceInfo(name: "Corveil")
+        let second = WorkspaceInfo(name: "Personal")
+        let config = AppConfig(workspaces: [first, second])
+
+        #expect(try SecretsRPC.resolveWorkspace(second.id.uuidString, in: config) == 1)
+        #expect(try SecretsRPC.resolveWorkspace("PERSONAL", in: config) == 1)
+        #expect(throws: (any Error).self) {
+            _ = try SecretsRPC.resolveWorkspace("missing", in: config)
+        }
+    }
+
+    @Test func resolveWorkspaceRejectsAmbiguousNames() {
+        // Impossible through the UI (names are unique) but reachable in a
+        // hand-edited config — better an error than a coin flip.
+        let config = AppConfig(workspaces: [
+            WorkspaceInfo(name: "Corveil"), WorkspaceInfo(name: "corveil"),
+        ])
+        #expect(throws: (any Error).self) {
+            _ = try SecretsRPC.resolveWorkspace("Corveil", in: config)
+        }
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretsRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretsRPCTests.swift
@@ -344,6 +344,16 @@ import Testing
         }
     }
 
+    @Test func decodeHeaderLinesRejectsEmbeddedNewlines() {
+        // One entry must mean one header. Parsing splits on newlines, so an
+        // embedded \n would smuggle a second header past the per-entry check.
+        for line in ["X-Api-Key: sk-1\nX-Smuggled: evil", "X-Api-Key: sk-1\r\nX-Smuggled: evil"] {
+            #expect(throws: (any Error).self, "expected an embedded newline to be rejected") {
+                _ = try SecretsRPC.decodeHeaderLines(.array([.string(line)]))
+            }
+        }
+    }
+
     @Test func decodeHeaderLinesDefaultsToEmpty() throws {
         #expect(try SecretsRPC.decodeHeaderLines(nil).isEmpty)
     }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretsRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretsRPCTests.swift
@@ -211,6 +211,39 @@ import Testing
         #expect(stored?.workspaces[0].gateway?.customHeaders["X-Api-Key"] == "sk-ws")
     }
 
+    // MARK: - Corrupt config
+
+    @Test @MainActor func secretWritesRefuseToOverwriteAnUndecodableConfig() async throws {
+        // `ConfigStore.loadConfig` returns nil for both "missing" and "malformed",
+        // so a `?? AppConfig()` fallback here would let one `crow gateway set` on a
+        // corrupt file silently replace every workspace, job and credential with
+        // defaults. Both writers share `mutateConfig`'s refusal (CROW-814); this is
+        // the secrets-side parallel to
+        // `SettingsHandlerTests.writeRefusesToOverwriteAnUndecodableConfig`.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let claudeDir = (devRoot as NSString).appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(
+            atPath: claudeDir, withIntermediateDirectories: true)
+        let configPath = (claudeDir as NSString).appendingPathComponent("config.json")
+        let corrupt = #"{"workspaces": "not-an-array"}"#
+        try corrupt.write(toFile: configPath, atomically: true, encoding: .utf8)
+        let router = router(devRoot: devRoot)
+
+        let gateway = await call(router, "gateway-set", [
+            "target": .string("manager"),
+            "base_url": .string("https://gw.example.com"),
+            "header_lines": .array([.string("X-Api-Key: sk-test-1")]),
+        ])
+        #expect(gateway.error?.code == RPCErrorCode.applicationError)
+
+        let password = await call(router, "web-password-set", ["password": .string("hunter2")])
+        #expect(password.error?.code == RPCErrorCode.applicationError)
+
+        // The bad file is left exactly as it was, not replaced with defaults.
+        #expect(try String(contentsOfFile: configPath, encoding: .utf8) == corrupt)
+    }
+
     // MARK: - Target selector
 
     @Test @MainActor func targetSelectorRejectsBothAndNeither() async throws {

--- a/Packages/CrowPersistence/Sources/CrowPersistence/ConfigStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/ConfigStore.swift
@@ -107,9 +107,13 @@ public final class ConfigStore: Sendable {
     }
 
     /// Serializes `config.json` read-modify-write across concurrent writers
-    /// (set-config / set-web-password / onJobRan) so one save can't clobber
-    /// another writer's just-loaded copy (review #10). Callers wrap their whole
-    /// load → mutate → save in this.
+    /// (`set-config`, the `SecretRoutes` POSTs, `gateway-set` / `web-password-set`,
+    /// `onJobRan`) so one save can't clobber another writer's just-loaded copy
+    /// (review #10). Callers wrap their whole load → mutate → save in this.
+    ///
+    /// Process-local: this serializes writers *inside* one process, not against a
+    /// separate one. That is why the CLI goes through the daemon over RPC rather
+    /// than writing `config.json` itself.
     private static let configLock = NSLock()
 
     /// Run `body` while holding the shared config.json write lock.

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
@@ -168,6 +168,29 @@ import Testing
     #expect(loaded?.managerGateway?.customHeaders["x-citadel-api-key"] == "Bearer sk-citadel-456")
 }
 
+@Test func configStoreWebAuthRoundTrip() throws {
+    // The web-password hash survives a save/load, and its presence is what marks
+    // "a password is set" — the CLI's `web-password status` reads exactly this
+    // (CROW-815). Clearing it removes the block rather than blanking the fields.
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let claudeDir = tmpDir.appendingPathComponent(".claude", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    let configURL = claudeDir.appendingPathComponent("config.json")
+
+    var config = AppConfig()
+    config.webAuth = WebAuthConfig(hashB64: "aGFzaA==", saltB64: "c2FsdA==", iterations: 210_000)
+    try ConfigStore.saveConfig(config, to: claudeDir)
+
+    let loaded = ConfigStore.loadConfig(from: configURL)
+    #expect(loaded?.webAuth?.hashB64 == "aGFzaA==")
+    #expect(loaded?.webAuth?.saltB64 == "c2FsdA==")
+    #expect(loaded?.webAuth?.iterations == 210_000)
+
+    config.webAuth = nil
+    try ConfigStore.saveConfig(config, to: claudeDir)
+    #expect(ConfigStore.loadConfig(from: configURL)?.webAuth == nil)
+}
+
 @Test func configStoreLoadReturnsNilOnMalformedGateway() throws {
     // A half-filled gateway (baseURL but no headers) is rejected at decode time;
     // loadConfig logs and returns nil rather than dropping just the bad field.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ Use a different directory with `BINDIR`, e.g. `make install BINDIR=/usr/local/bi
 
 ### Remote access
 
-`crowd` binds `127.0.0.1:8787` by default, so it's reachable only from the machine it runs on. To reach it from another device, front it with an HTTPS reverse proxy (e.g. [`tailscale serve`](https://tailscale.com/kb/1242/tailscale-serve)) and set a **web password** under **Settings → Web Access**. Non-loopback requests are blocked until a password is set and the connection is HTTPS (CROW-593).
+`crowd` binds `127.0.0.1:8787` by default, so it's reachable only from the machine it runs on. To reach it from another device, front it with an HTTPS reverse proxy (e.g. [`tailscale serve`](https://tailscale.com/kb/1242/tailscale-serve)) and set a **web password** under **Settings → Web Access** or with `crow web-password set`. Non-loopback requests are blocked until a password is set and the connection is HTTPS (CROW-593).
+
+The password and the AI gateways are **local-only** surfaces: they're settable from a local browser or the `crow` CLI (which talks over the Unix socket), and refused for remote web clients — a remote session must not be able to change the password gating remote access, or read gateway credentials. See [CLI Reference → Gateway Commands](docs/cli-reference.md#gateway-commands).
 
 ## Desktop app (native window over crowd)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -920,6 +920,100 @@ Returns `{"dispatched": true, "action": "..."}` on success. A **skipped** dispat
 
 ---
 
+## Gateway Commands
+
+An AI gateway is a base URL plus the auth headers sent with it. Agents launched into a workspace inherit them as `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS`; the Manager session has its own gateway (`AppConfig.managerGateway`) rather than following a workspace's. Header values may be `op://…` 1Password references, resolved at launch so the secret never rests in `config.json` — see [Configuration](configuration.md#ai-gateway).
+
+**Local-only.** These run over the Unix socket, which is local by construction. The same RPC methods are refused for remote `/rpc` web clients (`RPCWebSocketHandler.localOnlyDenial`), because gateway headers are credentials — reads included. A local browser can drive the equivalent controls at Settings → the workspace / Manager gateway editor.
+
+Every subcommand takes exactly one target: `--manager`, or `--workspace` with a workspace name or UUID.
+
+### `crow gateway get`
+
+Show a gateway's base URL and header names. Header **values are blanked** unless `--reveal`, so the default output is safe to paste into a ticket.
+
+```bash
+crow gateway get --manager
+crow gateway get --workspace Corveil --reveal
+```
+
+| Flag          | Required | Description                                          |
+| ------------- | -------- | ---------------------------------------------------- |
+| `--manager`   | one of   | Target the Manager AI gateway                        |
+| `--workspace` | one of   | Target a workspace's gateway (name or UUID)          |
+| `--reveal`    | no       | Print header values instead of blanking them         |
+
+Returns `{"gateway_set": true, "base_url": "...", "headers": {...}}`, plus `workspace_id` / `workspace_name` for a workspace target.
+
+### `crow gateway set`
+
+Set a gateway. `--base-url` and at least one `--header` are both required — a gateway needs both or neither, so a half-filled one is rejected rather than persisted.
+
+A `--header` with a **blank value keeps the secret already stored** under that name. That is how to change a base URL without restating credentials:
+
+```bash
+crow gateway set --manager --base-url https://gw.example.com --header "X-Api-Key: sk-…"
+crow gateway set --manager --base-url https://gw2.example.com --header "X-Api-Key:"
+crow gateway set --workspace Corveil \
+  --base-url https://gw.example.com \
+  --header "X-Api-Key: op://Prod/Gateway/api_key" \
+  --header "X-Tenant: acme"
+```
+
+| Flag          | Required | Description                                          |
+| ------------- | -------- | ---------------------------------------------------- |
+| `--manager`   | one of   | Target the Manager AI gateway                        |
+| `--workspace` | one of   | Target a workspace's gateway (name or UUID)          |
+| `--base-url`  | yes      | Gateway base URL                                     |
+| `--header`    | yes      | Header as `Name: Value` (repeatable)                 |
+
+Returns `{"saved": true, "gateway_set": true}`.
+
+### `crow gateway clear`
+
+Remove a gateway. Agents launched afterwards fall back to vanilla Anthropic (the env vars are explicitly unset, so a global `~/.zshrc` export cannot leak in).
+
+```bash
+crow gateway clear --manager
+crow gateway clear --workspace Corveil
+```
+
+| Flag          | Required | Description                                 |
+| ------------- | -------- | ------------------------------------------- |
+| `--manager`   | one of   | Target the Manager AI gateway               |
+| `--workspace` | one of   | Target a workspace's gateway (name or UUID) |
+
+Returns `{"saved": true, "gateway_set": false}`.
+
+---
+
+## Secrets Commands
+
+### `crow web-password status | set | clear`
+
+Manage the password that gates the `crowd` web UI for non-loopback clients. It is stored as a PBKDF2-HMAC-SHA256 hash (210,000 iterations, random per-password salt); the plaintext is never persisted and never leaves the local socket. **Local-only**, like the gateway commands.
+
+```bash
+crow web-password status
+crow web-password set                              # prompts twice, echo off
+printf '%s' "$PW" | crow web-password set --stdin  # for scripts
+crow web-password clear
+```
+
+| Flag       | Applies to | Description                                  |
+| ---------- | ---------- | -------------------------------------------- |
+| `--stdin`  | set        | Read the password from stdin instead of prompting |
+
+There is deliberately **no `--password` flag** — a plaintext password in `argv` lands in shell history and is visible to any local `ps`. Changing the password does not require the old one; the local-only gate is the control, matching the web UI. Clearing it means remote web clients are no longer challenged, so check how `crowd` is bound first.
+
+`status` returns `{"password_set": true, "iterations": 210000}` — never the hash or salt. `set` / `clear` return `{"saved": true, "password_set": <bool>}`.
+
+---
+
+## Not Exposed on the CLI
+
+The **Jira credential** (`AppConfig.jiraCredential`) is intentionally UI-only. It is a `op://` 1Password reference managed outside Crow, and the app resolves it at call time rather than storing a secret — so there is nothing for a CLI verb to write that editing the reference in Settings (or 1Password) does not already cover.
+
 ---
 
 ## Hooks (Internal)


### PR DESCRIPTION
Closes #815

Adds `crow gateway` and `crow web-password` for the three local-only secret surfaces that were previously writable only from the web Settings UI.

## Why new RPC methods

These fields live in `AppConfig`, but `set-config` **cannot** write them — `SettingsSecrets.preservingSecrets` always overwrites `managerGateway`, `workspaces[].gateway`, and `webAuth` from disk. The only writer was the three HTTP POSTs in `SecretRoutes`, which the CLI can't reach (Unix-socket JSON-RPC only, no HTTP client in `CrowCLILib`).

The two alternatives were worse: writing `config.json` from the CLI process is unsafe because `ConfigStore.withConfigLock` is a process-local `NSLock` and wouldn't serialize against the daemon; teaching the CLI to POST would mean a new HTTP client plus host/port discovery. So: granular RPC methods gated in `localOnlyDenial`, which is what the ticket specifies and what `run-setup` (an equally privileged write+re-exec) already does.

## Commands

```
crow gateway get   [--manager | --workspace <name|uuid>] [--reveal]
crow gateway set   [--manager | --workspace <name|uuid>] --base-url URL --header "K: V" ...
crow gateway clear [--manager | --workspace <name|uuid>]
crow web-password  status | set [--stdin] | clear
```

Workspace gateways resolve by **name or UUID** — a UX win over the web UI, which requires a saved `id`. An ambiguous name in a hand-edited config errors rather than guessing.

## Security posture

- **All four methods gated** in `RPCWebSocketHandler.localOnlyDenial`. Reads included: `gateway-get --reveal` returns the gateway auth headers, and `web-password-set` from a remote peer would let it change the password gating remote access.
- The stale NOTE in `RPCHandlers.swift` asserting secret writes live in `SecretRoutes` and "never here" is **rewritten** to explain the gate — leaving it would have misled the next reader into thinking no gate existed.
- `gateway get` **redacts header values by default** (mirroring `SettingsSecrets.strippedForTransport`); `--reveal` opts in. A caller that omits `reveal` gets redacted values, so the default fails safe.
- `web-password set` has **no `--password` flag** on purpose — plaintext in argv lands in shell history and local `ps`. It prompts twice with echo off, or reads stdin with `--stdin`.
- The web Settings UI is unaffected: it reads gateway state via `get-config` (stripped) and writes via `SecretRoutes`.

## Reuse over reimplementation

Handlers feed `SecretRoutes.buildGateway` / `mergingPreservedHeaders` rather than duplicating validation, so the both-or-neither invariant and the "blank header value keeps the stored secret" contract hold on the CLI path — including the guard against persisting a shape that would make the next `loadConfig` return `nil` and wipe the config. Header parsing goes through `WorkspaceGateway.parseHeaderLines`, so no third parser appears next to the Swift and `settings.js` ones.

## Tests

All 1721 tests pass (`make test`). New coverage:

| Target | Covers |
|---|---|
| `CrowCLITests` | arg parsing, target mutual exclusion, malformed vs blank-valued headers, password input |
| `CrowDaemonTests` | param decode/encode, plus end-to-end handler round-trips through the real router against temp dev roots (set → redacted get → `--reveal` → blank-value preserve → clear) |
| `DaemonSecurityTests` | the local-only gate, and that neighbouring methods stay ungated |
| `CrowPersistenceTests` | `webAuth` persistence round-trip |

Note the password tests consolidate into one case: each `web-password-set` runs real 210k-iteration PBKDF2, which is seconds per call in a debug build. The cheap crypto properties are already pinned at `iterations: 2000` in `DaemonSecurityTests`, so only the integration properties are asserted here.

## Deferred / out of scope

- **The #807 parity harness does not exist yet** — `KNOWN_UI_ONLY`, `ParityTest`, and `coveredSet` all return zero hits repo-wide. The "add to covered set / remove from `KNOWN_UI_ONLY`" checklist item is therefore **deferred, not done**; this PR does not build the harness.
- The **Jira credential** is documented in `docs/cli-reference.md` under "Not Exposed on the CLI" as a deliberate exception (an `op://` reference managed externally), ready for #807 to lift into `KNOWN_UI_ONLY`.

## Verification note

Handler behavior is covered end-to-end by the daemon tests against temp dev roots, and the CLI→socket wire was confirmed live. A full CLI-against-daemon smoke test was **not** run: `crowd` holds a global store-writer lock on App Support regardless of `--socket`, so an isolated second instance can't start, and I wasn't going to stop the running daemon or write to a real config's gateway/password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RtWKbWW9GC6n7FPsJXvhM