### PR TITLE
Sidebar: stop duplicate review rows piling up (CROW-877)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -795,13 +795,31 @@ public enum CrowDaemon {
                 // completed/archived) yet still renders, so each re-review round
                 // left another identical row piling up in Completed (CROW-877).
                 // Deleting also drops its `.pr` link, so the create below can't
-                // reuse the stale session via that same guard. Await the delete
-                // first so it's gone before `createReviewSession` runs its check.
+                // reuse the stale session via that same guard.
+                //
+                // This always tears down a *live* round-1 review clone (kickoff
+                // only returns `.reReview` while that session is still open):
+                // `rm -rf` on its PR clone, `TerminalRouter.destroy` on its
+                // terminal, and its raw telemetry rows are dropped. That's
+                // intended — round 1 is reviewing a now-dead SHA — but it's a
+                // harder teardown than the old status flip.
                 let url = request.url
                 let staleReviewID: UUID?
                 if case let .reReview(id) = action { staleReviewID = id } else { staleReviewID = nil }
                 Task {
-                    if let staleReviewID { await sessionService.deleteSession(id: staleReviewID) }
+                    if let staleReviewID {
+                        await sessionService.deleteSession(id: staleReviewID)
+                        // `deleteSession` no-ops on a concurrent delete (its
+                        // `isDeletingSession` guard) and bails on a disk-cleanup
+                        // failure — both leave the stale session AND its `.pr`
+                        // link intact, which would make `createReviewSession`'s
+                        // dedup guard return the stale session and swallow the new
+                        // round. Fall back to completing it (the old path's effect)
+                        // so it's at least invisible to that guard (CROW-877 review).
+                        if appState.sessions.contains(where: { $0.id == staleReviewID }) {
+                            sessionService.completeSession(id: staleReviewID)
+                        }
+                    }
                     _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) }
                 }
             }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -787,41 +787,27 @@ public enum CrowDaemon {
                 // the session's link/reviewSessionID land).
                 let fingerprint = "\(request.id)\n\(request.headRefOid ?? "")"
                 guard autoReviewed.insert(fingerprint).inserted else { continue }
-                // B-fallback: tear down the stale round's review session before
+                // B-fallback: retire the stale round's review session before
                 // enqueuing so `reviewSessions` doesn't double up for this PR.
-                // DELETE it — not `onCompleteSession`, which only flips it to
-                // `.completed`. A completed `review-<repo>-<pr>` row is invisible
-                // to `existingReviewSession(forPRURL:)` (that dedup guard excludes
-                // completed/archived) yet still renders, so each re-review round
-                // left another identical row piling up in Completed (CROW-877).
-                // Deleting also drops its `.pr` link, so the create below can't
-                // reuse the stale session via that same guard.
-                //
-                // This always tears down a *live* round-1 review clone (kickoff
-                // only returns `.reReview` while that session is still open):
-                // `rm -rf` on its PR clone, `TerminalRouter.destroy` on its
-                // terminal, and its raw telemetry rows are dropped. That's
-                // intended — round 1 is reviewing a now-dead SHA — but it's a
-                // harder teardown than the old status flip.
-                let url = request.url
-                let staleReviewID: UUID?
-                if case let .reReview(id) = action { staleReviewID = id } else { staleReviewID = nil }
-                Task {
-                    if let staleReviewID {
-                        await sessionService.deleteSession(id: staleReviewID)
-                        // `deleteSession` no-ops on a concurrent delete (its
-                        // `isDeletingSession` guard) and bails on a disk-cleanup
-                        // failure — both leave the stale session AND its `.pr`
-                        // link intact, which would make `createReviewSession`'s
-                        // dedup guard return the stale session and swallow the new
-                        // round. Fall back to completing it (the old path's effect)
-                        // so it's at least invisible to that guard (CROW-877 review).
-                        if appState.sessions.contains(where: { $0.id == staleReviewID }) {
-                            sessionService.completeSession(id: staleReviewID)
-                        }
-                    }
-                    _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) }
+                // Complete it (not delete): completing writes its end-of-round
+                // `SessionAnalyticsSnapshot` and keeps its telemetry, whereas
+                // `deleteSession` transitions no status — so no snapshot is
+                // written — and then drops the raw rows, silently erasing round
+                // 1's tokens/cost from the scorecard on Crow's own auto-review
+                // flow (CROW-877 review). Completing also makes it invisible to
+                // `existingReviewSession(forPRURL:)` (that dedup guard excludes
+                // completed/archived), so the create below starts the new round
+                // instead of reusing the stale session. The identical completed
+                // `review-<repo>-<pr>` rows that used to pile up in Completed are
+                // now folded into one by the sidebar's within-section collapse
+                // (`groupSessions` in app.js), which also cleans up pre-existing
+                // pile-ups — so the visible-duplicate half no longer needs a
+                // destructive teardown here.
+                if case let .reReview(staleID) = action {
+                    appState.onCompleteSession?(staleID)
                 }
+                let url = request.url
+                Task { _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) } }
             }
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -787,13 +787,23 @@ public enum CrowDaemon {
                 // the session's link/reviewSessionID land).
                 let fingerprint = "\(request.id)\n\(request.headRefOid ?? "")"
                 guard autoReviewed.insert(fingerprint).inserted else { continue }
-                // B-fallback: tear down the stale round-1 session before enqueuing
-                // so `reviewSessions` doesn't double up for this PR.
-                if case let .reReview(staleID) = action {
-                    appState.onCompleteSession?(staleID)
-                }
+                // B-fallback: tear down the stale round's review session before
+                // enqueuing so `reviewSessions` doesn't double up for this PR.
+                // DELETE it — not `onCompleteSession`, which only flips it to
+                // `.completed`. A completed `review-<repo>-<pr>` row is invisible
+                // to `existingReviewSession(forPRURL:)` (that dedup guard excludes
+                // completed/archived) yet still renders, so each re-review round
+                // left another identical row piling up in Completed (CROW-877).
+                // Deleting also drops its `.pr` link, so the create below can't
+                // reuse the stale session via that same guard. Await the delete
+                // first so it's gone before `createReviewSession` runs its check.
                 let url = request.url
-                Task { _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) } }
+                let staleReviewID: UUID?
+                if case let .reReview(id) = action { staleReviewID = id } else { staleReviewID = nil }
+                Task {
+                    if let staleReviewID { await sessionService.deleteSession(id: staleReviewID) }
+                    _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) }
+                }
             }
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -667,29 +667,42 @@ const GROUPS = [
 //   2. first-match grouping — each session lands in the FIRST group it matches,
 //      not every one, so a `kind:'review'` + `status:'inReview'` session can't
 //      appear in both "Reviews" and "In Review";
-//   3. collapse same-PR duplicates WITHIN a section — a merged PR (its completed
-//      work row + completed review clone both land in "Completed") and any
-//      pile-up of identical completed `review-<repo>-<pr>` clones become one row.
+//   3. collapse same-PR duplicates WITHIN a section, and only among
+//      completed/archived rows — a merged PR (its completed work row + completed
+//      review clone both land in "Completed") and any pile-up of identical
+//      completed `review-<repo>-<pr>` clones become one row.
 // Collapsing AFTER assignment, never across sections, is deliberate: a live work
 // row in "Active"/"In Review" is never hidden by an open review clone in
 // "Reviews", and a collapse survivor can never be a row that matches no group —
-// the two failure modes of a pre-assignment collapse (CROW-877 review).
+// the two failure modes of a pre-assignment collapse. Restricting collapse to
+// TERMINAL rows is equally deliberate: two live sessions can legitimately share
+// a PR within one section (e.g. a manual "Start Review" racing the auto-review
+// clone lands two open reviews in "Reviews"), and hiding either would strand a
+// running agent with no way to select or delete it (CROW-877 review).
 // Managers carry no PR link and match no GROUP, so they drop out here and are
 // rendered by renderSidebar's dedicated managers pass.
 function prURLOf(s) {
+  // The persisted `links` array is authoritative for the terminal rows this
+  // collapse touches — a completed review clone always carries its `.pr` link
+  // there. (Live sessions can hold a PR link only in the app's in-memory
+  // `liveFor(id).pr_link`, but those are non-terminal and never collapsed.)
   const link = (s.links || []).find((l) => l.type === 'pr');
   return link ? link.url : null;
 }
-// Collapse rows that describe the same PR, keeping one. A non-review (work) row
-// represents the PR over a review clone (a merged PR shows its work row, not the
-// leftover completed clone); otherwise the first seen stays. Rows without a PR
-// link are never collapsed. Only ever called on rows already in the same section.
+function isTerminal(s) {
+  return s.status === 'completed' || s.status === 'archived';
+}
+// Collapse rows that describe the same PR, keeping one. Only completed/archived
+// rows are ever collapsed, so a live session is never hidden. A non-review (work)
+// row represents the PR over a review clone (a merged PR shows its work row, not
+// the leftover completed clone); otherwise the first seen stays. Only ever called
+// on rows already in the same section.
 function collapsePRDuplicates(rows) {
   const byPR = new Map();     // PR URL -> index into `out`
   const out = [];
   for (const s of rows) {
     const url = prURLOf(s);
-    if (!url) { out.push(s); continue; }
+    if (!url || !isTerminal(s)) { out.push(s); continue; }
     const idx = byPR.get(url);
     if (idx === undefined) { byPR.set(url, out.length); out.push(s); continue; }
     if (out[idx].kind === 'review' && s.kind !== 'review') out[idx] = s;   // work wins

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -681,45 +681,58 @@ const GROUPS = [
 // running agent with no way to select or delete it (CROW-877 review).
 // Managers carry no PR link and match no GROUP, so they drop out here and are
 // rendered by renderSidebar's dedicated managers pass.
-function prURLOf(s) {
-  // The persisted `links` array is authoritative for the terminal rows this
-  // collapse touches — a completed review clone always carries its `.pr` link
-  // there. (Live sessions can hold a PR link only in the app's in-memory
-  // `liveFor(id).pr_link`, but those are non-terminal and never collapsed.)
-  const link = (s.links || []).find((l) => l.type === 'pr');
-  return link ? link.url : null;
-}
 function isTerminal(s) {
   return s.status === 'completed' || s.status === 'archived';
 }
-// Collapse rows that describe the same PR, keeping one. Only completed/archived
-// rows are ever collapsed, so a live session is never hidden. A non-review (work)
-// row represents the PR over a review clone (a merged PR shows its work row, not
-// the leftover completed clone); otherwise the first seen stays. Only ever called
-// on rows already in the same section.
+// Collapse a PR's duplicate rows within one section, keeping one survivor.
+// Returns { rows, collapsedIds }: the rows to render, plus the ids folded away
+// so the section's select-all can still reach them (they'd otherwise be
+// undeletable from the sidebar — CROW-877 review). Only terminal rows collapse,
+// so a live session is never hidden. A pair collapses only when at least one
+// side is a review CLONE — a merged PR's work row + its completed review clone,
+// or a pile-up of completed clones. Two independent work/job sessions that
+// happen to share a PR (a follow-up session, or a manual `add-link`) are NEVER
+// folded; both render. A work row represents the PR over a review clone.
+// Uses the shared `prUrlForSession` (hoisted; defined below) so "does this row
+// have a PR" means one thing across the file.
 function collapsePRDuplicates(rows) {
-  const byPR = new Map();     // PR URL -> index into `out`
+  const byPR = new Map();       // PR URL -> index into `out`
   const out = [];
+  const collapsedIds = [];
   for (const s of rows) {
-    const url = prURLOf(s);
+    const url = prUrlForSession(s);
     if (!url || !isTerminal(s)) { out.push(s); continue; }
     const idx = byPR.get(url);
     if (idx === undefined) { byPR.set(url, out.length); out.push(s); continue; }
-    if (out[idx].kind === 'review' && s.kind !== 'review') out[idx] = s;   // work wins
+    const prior = out[idx];
+    if (prior.kind !== 'review' && s.kind !== 'review') { out.push(s); continue; }  // two non-clones: keep both
+    if (prior.kind === 'review' && s.kind !== 'review') {                            // work supersedes a clone
+      collapsedIds.push(prior.id);
+      out[idx] = s;
+    } else {                                                                          // clone folds into the survivor
+      collapsedIds.push(s.id);
+    }
   }
-  return out;
+  return { rows: out, collapsedIds };
 }
 function groupSessions(list) {
   const seenIds = new Set();
-  const out = GROUPS.map((g) => ({ title: g.title, rows: [] }));
+  const buckets = GROUPS.map((g) => ({ title: g.title, assigned: [] }));
   for (const s of list) {
     if (seenIds.has(s.id)) continue;
     seenIds.add(s.id);
     const gi = GROUPS.findIndex((g) => g.match(s));
-    if (gi >= 0) out[gi].rows.push(s);
+    if (gi >= 0) buckets[gi].assigned.push(s);
   }
-  for (const g of out) g.rows = collapsePRDuplicates(g.rows);
-  return out.filter((g) => g.rows.length);
+  const out = [];
+  for (const b of buckets) {
+    if (!b.assigned.length) continue;
+    const { rows, collapsedIds } = collapsePRDuplicates(b.assigned);
+    // `allIds` = rendered survivors + folded-away ids, so a section's "select
+    // all" (and thus bulk-delete) still reaches the hidden collapsed rows.
+    out.push({ title: b.title, rows, allIds: rows.map((r) => r.id).concat(collapsedIds) });
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -813,8 +826,8 @@ function renderSidebar() {
   for (const m of managers.slice(1)) root.appendChild(sessionRow(m));
 
   let shown = 0;
-  for (const { title, rows } of groupSessions(sessions)) {
-    root.appendChild(selectionMode ? sectionHeader(title, rows) : el('div', 'divider', title));
+  for (const { title, rows, allIds } of groupSessions(sessions)) {
+    root.appendChild(selectionMode ? sectionHeader(title, allIds) : el('div', 'divider', title));
     for (const s of rows) { root.appendChild(sessionRow(s)); shown++; }
   }
   if ((sessionsLoaded || sidebarCacheHit) && !shown && !managers.length) {
@@ -850,11 +863,11 @@ function toggleSelect(id) {
 }
 
 // Section divider with a per-section select-all/clear toggle (mirrors the
-// desktop section header checklist button).
-function sectionHeader(title, rows) {
+// desktop section header checklist button). `ids` is the section's full id set
+// (survivors + PR-collapsed rows), so "select all" reaches the hidden rows too.
+function sectionHeader(title, ids) {
   const head = el('div', 'divider divider-sel');
   head.appendChild(el('span', 'divider-label', title));
-  const ids = rows.map((r) => r.id);
   const allSel = ids.length && ids.every((id) => selectedSessionIDs.has(id));
   const btn = el('button', 'divider-selall', allSel ? 'Clear' : 'All');
   btn.title = allSel ? 'Deselect all in section' : 'Select all in section';

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -661,55 +661,51 @@ const GROUPS = [
   { title: 'Completed', match: (s) => (s.status === 'completed' || s.status === 'archived') && s.kind !== 'manager' },
 ];
 
-// Assign sessions to sidebar sections, collapsing the duplicates that used to
-// render as separate rows for the same PR (CROW-877):
+// Assign sessions to sidebar sections without the duplicate rows that used to
+// render for one PR (CROW-877):
 //   1. dedup by session id — a payload that repeats an id renders once;
-//   2. collapse by PR URL — a PR's work row + auto-review clone become ONE
-//      entry (the open review row wins while the review is in progress; once
-//      the review session closes, the work row represents the PR). This kills
-//      both the same-PR-in-Reviews-and-Completed cross-section duplicate and
-//      any pile-up of identical completed `review-<repo>-<pr>` clones;
-//   3. first-match grouping — each surviving session lands in the FIRST group
-//      it matches, not every one, so a `kind:'review'` + `status:'inReview'`
-//      session can't appear in both "Reviews" and "In Review".
+//   2. first-match grouping — each session lands in the FIRST group it matches,
+//      not every one, so a `kind:'review'` + `status:'inReview'` session can't
+//      appear in both "Reviews" and "In Review";
+//   3. collapse same-PR duplicates WITHIN a section — a merged PR (its completed
+//      work row + completed review clone both land in "Completed") and any
+//      pile-up of identical completed `review-<repo>-<pr>` clones become one row.
+// Collapsing AFTER assignment, never across sections, is deliberate: a live work
+// row in "Active"/"In Review" is never hidden by an open review clone in
+// "Reviews", and a collapse survivor can never be a row that matches no group —
+// the two failure modes of a pre-assignment collapse (CROW-877 review).
 // Managers carry no PR link and match no GROUP, so they drop out here and are
 // rendered by renderSidebar's dedicated managers pass.
 function prURLOf(s) {
   const link = (s.links || []).find((l) => l.type === 'pr');
   return link ? link.url : null;
 }
-function isOpenReview(s) {
-  return s.kind === 'review' && s.status !== 'completed' && s.status !== 'archived';
-}
-// Between two sessions describing the same PR, pick the one to keep.
-function pickPRRow(a, b) {
-  const ao = isOpenReview(a), bo = isOpenReview(b);
-  if (ao !== bo) return ao ? a : b;           // an open review wins outright
-  // Neither is an open review (both closed, or both non-review work rows):
-  // prefer the non-review (work) row so a merged PR shows its work session
-  // rather than a leftover completed review clone.
-  const aWork = a.kind !== 'review', bWork = b.kind !== 'review';
-  if (aWork !== bWork) return aWork ? a : b;
-  return a;                                    // stable: keep the first seen
+// Collapse rows that describe the same PR, keeping one. A non-review (work) row
+// represents the PR over a review clone (a merged PR shows its work row, not the
+// leftover completed clone); otherwise the first seen stays. Rows without a PR
+// link are never collapsed. Only ever called on rows already in the same section.
+function collapsePRDuplicates(rows) {
+  const byPR = new Map();     // PR URL -> index into `out`
+  const out = [];
+  for (const s of rows) {
+    const url = prURLOf(s);
+    if (!url) { out.push(s); continue; }
+    const idx = byPR.get(url);
+    if (idx === undefined) { byPR.set(url, out.length); out.push(s); continue; }
+    if (out[idx].kind === 'review' && s.kind !== 'review') out[idx] = s;   // work wins
+  }
+  return out;
 }
 function groupSessions(list) {
   const seenIds = new Set();
-  const byPR = new Map();     // PR URL -> index into `collapsed`
-  const collapsed = [];
+  const out = GROUPS.map((g) => ({ title: g.title, rows: [] }));
   for (const s of list) {
     if (seenIds.has(s.id)) continue;
     seenIds.add(s.id);
-    const url = prURLOf(s);
-    if (!url) { collapsed.push(s); continue; }
-    const idx = byPR.get(url);
-    if (idx === undefined) { byPR.set(url, collapsed.length); collapsed.push(s); }
-    else collapsed[idx] = pickPRRow(collapsed[idx], s);
-  }
-  const out = GROUPS.map((g) => ({ title: g.title, rows: [] }));
-  for (const s of collapsed) {
     const gi = GROUPS.findIndex((g) => g.match(s));
     if (gi >= 0) out[gi].rows.push(s);
   }
+  for (const g of out) g.rows = collapsePRDuplicates(g.rows);
   return out.filter((g) => g.rows.length);
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -661,6 +661,58 @@ const GROUPS = [
   { title: 'Completed', match: (s) => (s.status === 'completed' || s.status === 'archived') && s.kind !== 'manager' },
 ];
 
+// Assign sessions to sidebar sections, collapsing the duplicates that used to
+// render as separate rows for the same PR (CROW-877):
+//   1. dedup by session id — a payload that repeats an id renders once;
+//   2. collapse by PR URL — a PR's work row + auto-review clone become ONE
+//      entry (the open review row wins while the review is in progress; once
+//      the review session closes, the work row represents the PR). This kills
+//      both the same-PR-in-Reviews-and-Completed cross-section duplicate and
+//      any pile-up of identical completed `review-<repo>-<pr>` clones;
+//   3. first-match grouping — each surviving session lands in the FIRST group
+//      it matches, not every one, so a `kind:'review'` + `status:'inReview'`
+//      session can't appear in both "Reviews" and "In Review".
+// Managers carry no PR link and match no GROUP, so they drop out here and are
+// rendered by renderSidebar's dedicated managers pass.
+function prURLOf(s) {
+  const link = (s.links || []).find((l) => l.type === 'pr');
+  return link ? link.url : null;
+}
+function isOpenReview(s) {
+  return s.kind === 'review' && s.status !== 'completed' && s.status !== 'archived';
+}
+// Between two sessions describing the same PR, pick the one to keep.
+function pickPRRow(a, b) {
+  const ao = isOpenReview(a), bo = isOpenReview(b);
+  if (ao !== bo) return ao ? a : b;           // an open review wins outright
+  // Neither is an open review (both closed, or both non-review work rows):
+  // prefer the non-review (work) row so a merged PR shows its work session
+  // rather than a leftover completed review clone.
+  const aWork = a.kind !== 'review', bWork = b.kind !== 'review';
+  if (aWork !== bWork) return aWork ? a : b;
+  return a;                                    // stable: keep the first seen
+}
+function groupSessions(list) {
+  const seenIds = new Set();
+  const byPR = new Map();     // PR URL -> index into `collapsed`
+  const collapsed = [];
+  for (const s of list) {
+    if (seenIds.has(s.id)) continue;
+    seenIds.add(s.id);
+    const url = prURLOf(s);
+    if (!url) { collapsed.push(s); continue; }
+    const idx = byPR.get(url);
+    if (idx === undefined) { byPR.set(url, collapsed.length); collapsed.push(s); }
+    else collapsed[idx] = pickPRRow(collapsed[idx], s);
+  }
+  const out = GROUPS.map((g) => ({ title: g.title, rows: [] }));
+  for (const s of collapsed) {
+    const gi = GROUPS.findIndex((g) => g.match(s));
+    if (gi >= 0) out[gi].rows.push(s);
+  }
+  return out.filter((g) => g.rows.length);
+}
+
 // ---------------------------------------------------------------------------
 // Sidebar
 // ---------------------------------------------------------------------------
@@ -752,10 +804,8 @@ function renderSidebar() {
   for (const m of managers.slice(1)) root.appendChild(sessionRow(m));
 
   let shown = 0;
-  for (const group of GROUPS) {
-    const rows = sessions.filter(group.match);
-    if (!rows.length) continue;
-    root.appendChild(selectionMode ? sectionHeader(group.title, rows) : el('div', 'divider', group.title));
+  for (const { title, rows } of groupSessions(sessions)) {
+    root.appendChild(selectionMode ? sectionHeader(title, rows) : el('div', 'divider', title));
     for (const s of rows) { root.appendChild(sessionRow(s)); shown++; }
   }
   if ((sessionsLoaded || sidebarCacheHit) && !shown && !managers.length) {

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node key-handler.test.js && node row.test.js"
+    "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node key-handler.test.js && node row.test.js && node sidebar-groups.test.js"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,7 +2,7 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows; sidebar grouping/collapse). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
     "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node key-handler.test.js && node row.test.js && node sidebar-groups.test.js"
   },

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows; sidebar grouping/collapse). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node key-handler.test.js && node row.test.js && node sidebar-groups.test.js"
+    "test": "fail=0; for f in board touch-scroll wheel-scroll key-handler row sidebar-groups; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
+++ b/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
@@ -1,0 +1,125 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// Sidebar grouping/dedup regression tests (CROW-877). Runs the REAL app.js in a
+// jsdom VM and drives `groupSessions` directly — the pure section-assignment
+// helper behind renderSidebar. Same loader shape as row.test.js / board.test.js.
+const epilogue = `
+;globalThis.__t = {
+  groupSessions(list){ return groupSessions(list); },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body>
+     <div id="sidebar"></div><div id="board"></div><div id="header"></div>
+   </body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+// Map the grouped output to { title -> [ids] } for concise assertions.
+function groupsOf(list) {
+  const out = {};
+  for (const g of T.groupSessions(list)) out[g.title] = g.rows.map((s) => s.id);
+  return out;
+}
+// Flat count of every rendered row across all sections.
+function rowCount(list) {
+  return T.groupSessions(list).reduce((n, g) => n + g.rows.length, 0);
+}
+
+const PR = (n) => `https://github.com/corveil/crow/pull/${n}`;
+const prLink = (n) => [{ label: `PR #${n}`, url: PR(n), type: 'pr' }];
+
+console.log('CROW-877 sidebar grouping:');
+
+// 1. First-match: a review session that is also inReview lands only in Reviews.
+{
+  const s = { id: 'r1', kind: 'review', status: 'inReview', links: prLink(1) };
+  const g = groupsOf([s]);
+  check('review+inReview appears only in Reviews (first-match)',
+    (g['Reviews'] || []).includes('r1') && !(g['In Review'] || []).includes('r1'));
+  check('review+inReview renders exactly one row total', rowCount([s]) === 1);
+}
+
+// 2. Cross-section collapse: a PR's work row + open review clone → one Reviews row.
+{
+  const work = { id: 'w2', kind: 'work', status: 'completed', links: prLink(2) };
+  const rev = { id: 'v2', kind: 'review', status: 'active', links: prLink(2) };
+  const g = groupsOf([work, rev]);
+  check('open review wins while review is in progress',
+    (g['Reviews'] || []).includes('v2') && !(g['Completed'] || []).includes('w2'));
+  check('same PR collapses to a single row', rowCount([work, rev]) === 1);
+}
+
+// 3. Once the review closes, the work row represents the PR.
+{
+  const work = { id: 'w3', kind: 'work', status: 'completed', links: prLink(3) };
+  const rev = { id: 'v3', kind: 'review', status: 'completed', links: prLink(3) };
+  const g = groupsOf([work, rev]);
+  check('closed review yields to the work row in Completed',
+    (g['Completed'] || []).includes('w3') && !(g['Completed'] || []).includes('v3'));
+  check('merged PR renders one Completed row', rowCount([work, rev]) === 1);
+}
+
+// 4. Pile-up of identical completed review clones collapses to one row.
+{
+  const clones = [1, 2, 3].map((i) => ({ id: `c${i}`, kind: 'review', status: 'completed', links: prLink(4) }));
+  check('N completed review clones for one PR collapse to a single row', rowCount(clones) === 1);
+}
+
+// 5. Duplicate session ids render once.
+{
+  const dup = [
+    { id: 'd5', kind: 'work', status: 'active' },
+    { id: 'd5', kind: 'work', status: 'active' },
+  ];
+  check('duplicate ids dedup to one row', rowCount(dup) === 1);
+}
+
+// 6. Distinct PRs are never collapsed together.
+{
+  const a = { id: 'a6', kind: 'review', status: 'active', links: prLink(6) };
+  const b = { id: 'b6', kind: 'review', status: 'active', links: prLink(7) };
+  check('different PRs stay as separate rows', rowCount([a, b]) === 2);
+}
+
+// 7. Sessions without a PR link are never collapsed and keep their section.
+{
+  const a = { id: 'n7', kind: 'work', status: 'active' };
+  const b = { id: 'm7', kind: 'work', status: 'active' };
+  const g = groupsOf([a, b]);
+  check('PR-less work rows both render in Active',
+    (g['Active'] || []).length === 2);
+}
+
+// 8. Managers drop out of the grouped output (rendered separately by renderSidebar).
+{
+  const mgr = { id: 'mg8', kind: 'manager', status: 'inReview' };
+  check('manager sessions are excluded from all groups', rowCount([mgr]) === 0);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
+++ b/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
@@ -137,5 +137,18 @@ console.log('CROW-877 sidebar grouping:');
   check('manager sessions are excluded from all groups', rowCount([mgr]) === 0);
 }
 
+// 9. Two LIVE sessions for one PR in the same section are never collapsed — a
+//    manual "Start Review" racing the auto-review clone lands two open reviews
+//    in "Reviews", and hiding either would strand a running agent (CROW-877
+//    review, Yellow 1). Collapse is gated to terminal rows only.
+{
+  const r1 = { id: 'live1', kind: 'review', status: 'active', links: prLink(9) };
+  const r2 = { id: 'live2', kind: 'review', status: 'inReview', links: prLink(9) };
+  const g = groupsOf([r1, r2]);
+  check('two open reviews for one PR both stay in Reviews',
+    (g['Reviews'] || []).includes('live1') && (g['Reviews'] || []).includes('live2'));
+  check('a live session is never collapsed away', rowCount([r1, r2]) === 2);
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
+++ b/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
@@ -64,14 +64,30 @@ console.log('CROW-877 sidebar grouping:');
   check('review+inReview renders exactly one row total', rowCount([s]) === 1);
 }
 
-// 2. Cross-section collapse: a PR's work row + open review clone → one Reviews row.
+// 2. A live work session is NEVER hidden by an open review clone for the same
+//    PR. Collapse runs within a section, not across, so an active work row in
+//    "Active" and its open review clone in "Reviews" both survive (CROW-877
+//    review, Red 1 — a pre-assignment collapse dropped the developer's live row).
 {
-  const work = { id: 'w2', kind: 'work', status: 'completed', links: prLink(2) };
+  const work = { id: 'w2', kind: 'work', status: 'active', links: prLink(2) };
   const rev = { id: 'v2', kind: 'review', status: 'active', links: prLink(2) };
   const g = groupsOf([work, rev]);
-  check('open review wins while review is in progress',
-    (g['Reviews'] || []).includes('v2') && !(g['Completed'] || []).includes('w2'));
-  check('same PR collapses to a single row', rowCount([work, rev]) === 1);
+  check('active work row stays in Active', (g['Active'] || []).includes('w2'));
+  check('open review clone stays in Reviews', (g['Reviews'] || []).includes('v2'));
+  check('a live work session is never hidden by its open review', rowCount([work, rev]) === 2);
+}
+
+// 2b. A survivor is never a row that matches no group. A `paused` work row
+//     matches no GROUP; collapsing it in would drop the completed review that
+//     WOULD render, printing "No sessions" while sessions exist (CROW-877
+//     review, Red 2). Within-section collapse can't do this.
+{
+  const work = { id: 'w2b', kind: 'work', status: 'paused', links: prLink(12) };
+  const rev = { id: 'v2b', kind: 'review', status: 'completed', links: prLink(12) };
+  const g = groupsOf([work, rev]);
+  check('completed review still renders when the other row matches no group',
+    (g['Completed'] || []).includes('v2b'));
+  check('no-group work row does not suppress a renderable review', rowCount([work, rev]) === 1);
 }
 
 // 3. Once the review closes, the work row represents the PR.

--- a/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
+++ b/Packages/CrowDaemon/web-tests/sidebar-groups.test.js
@@ -49,6 +49,11 @@ function groupsOf(list) {
 function rowCount(list) {
   return T.groupSessions(list).reduce((n, g) => n + g.rows.length, 0);
 }
+// The select-all id set for a section (survivors + PR-collapsed rows).
+function allIdsFor(list, title) {
+  const g = T.groupSessions(list).find((x) => x.title === title);
+  return g ? g.allIds : [];
+}
 
 const PR = (n) => `https://github.com/corveil/crow/pull/${n}`;
 const prLink = (n) => [{ label: `PR #${n}`, url: PR(n), type: 'pr' }];
@@ -148,6 +153,31 @@ console.log('CROW-877 sidebar grouping:');
   check('two open reviews for one PR both stay in Reviews',
     (g['Reviews'] || []).includes('live1') && (g['Reviews'] || []).includes('live2'));
   check('a live session is never collapsed away', rowCount([r1, r2]) === 2);
+}
+
+// 10. Two independent WORK/JOB sessions sharing a PR are never collapsed — only
+//     a review-clone pair folds. Two completed work sessions on one PR (a
+//     follow-up session, or a manual `add-link`) would otherwise silently lose
+//     one, worktree and branch stranded on disk (CROW-877 review, Yellow 2).
+{
+  const w1 = { id: 'ww1', kind: 'work', status: 'completed', links: prLink(10) };
+  const w2 = { id: 'ww2', kind: 'work', status: 'archived', links: prLink(10) };
+  const g = groupsOf([w1, w2]);
+  check('two work rows for one PR both render (not a clone pair)',
+    (g['Completed'] || []).includes('ww1') && (g['Completed'] || []).includes('ww2'));
+  check('work+work sharing a PR is never collapsed', rowCount([w1, w2]) === 2);
+}
+
+// 11. A collapsed review clone stays reachable for bulk-delete: the section's
+//     select-all id set (`allIds`) includes the folded-away clone even though it
+//     renders no row (CROW-877 review, Yellow 3).
+{
+  const work = { id: 'w11', kind: 'work', status: 'completed', links: prLink(11) };
+  const clone = { id: 'c11', kind: 'review', status: 'completed', links: prLink(11) };
+  check('merged PR renders only the work row', rowCount([work, clone]) === 1);
+  const ids = allIdsFor([work, clone], 'Completed');
+  check('select-all still reaches the collapsed review clone',
+    ids.includes('w11') && ids.includes('c11'));
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #877

## Problem
The sidebar showed duplicate session rows for one PR: (a) the same PR in **both** a review section and **Completed**, and (b) repeated identical rows **within Completed**. Both trace to auto-review completing a separate review session per re-review round, which the sidebar then rendered without any dedup.

## What this PR does
The fix is **entirely in the web sidebar** (`app.js` `groupSessions`); the daemon behavior is **unchanged** from `main`.

### 1. First-match grouping
`renderSidebar` assigned each session to **every** matching `GROUP` via independent `sessions.filter()` calls, so a `kind:'review'` + `status:'inReview'` session showed in both **Reviews** and **In Review**. Each session now lands in the **first** group it matches only. This fixes the genuine one-session-in-two-sections half of symptom (a).

### 2. Within-section, clone-only collapse
After grouping, `collapsePRDuplicates` folds duplicate rows for one PR **within a single section**:
- **Terminal-only** — only `completed`/`archived` rows collapse, so a live session is never hidden.
- **Clone pairs only** — a pair folds only when at least one side is a review **clone** (a merged PR's work row + its completed review clone, or a pile-up of completed clones). Two independent work/job sessions that share a PR are never folded.
- **Never across sections** — collapsing across sections is what hid live work rows in earlier review rounds; a live review in *Reviews* and a completed work row in *Completed* deliberately stay as two rows.

This collapses report (b)'s completed-clone pile-up into one row, and merges a merged PR's work+review rows into one — including pre-existing data.

### 3. Collapsed rows stay deletable
`groupSessions` returns `allIds` per section (survivors **+** folded-away ids), and a section's **select-all** uses it, so bulk-delete still reaches a hidden collapsed clone in one pass.

## Daemon: unchanged (deliberate)
The re-review kickoff still **completes** the stale round (`onCompleteSession`), exactly as on `main`. An earlier revision *deleted* it instead, but deletion writes no analytics snapshot and then drops the raw telemetry rows — silently erasing that round's tokens/cost from the scorecard. Completion preserves the snapshot and still makes the stale row invisible to `createReviewSession`'s dedup guard; the sidebar collapse (above) owns the visible-duplicate half. So the daemon diff here is comment-only.

## Not changed
`cleanup.enabled` still defaults to `false` — the ticket flags it as *aggravating, not core*. Completed review sessions (and their clones) persist until cleanup is enabled or they're deleted; they're now collapsed in the sidebar but remain bulk-deletable via a section's select-all.

## Testing
- New jsdom regression test `sidebar-groups.test.js` — **20 checks, all green**: first-match, dedup-by-id, terminal-only + clone-only collapse, live-session-never-hidden (incl. two open reviews on one PR, and work+work sharing a PR), no-group survivor, merged-PR collapse, clone pile-up, and select-all reaching a collapsed clone.
- `package.json` `test` now runs every suite and aggregates the exit code (previously `&&`-chained, so it short-circuited at `row.test.js`). All suites execute; `row.test.js`'s failures are **pre-existing** (identical on `main` — currently 10) and unrelated to this change; no CI workflow runs `npm test` yet.
- `swift build` (CrowDaemon) ✅ · `swift test --filter BoardForwarderTests` ✅ · CLI/RPC parity gate ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)