### PR TITLE
Cmd+V no longer pastes twice in the terminal

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -3600,25 +3600,7 @@ function ensureTerminal() {
     term.loadAddon(webglAddon);
   } catch (_) { /* WebGL unavailable → canvas/DOM renderer */ }
   term.onData(sendToPTY);
-  // Cmd/Ctrl+C copies the selection (falling through to SIGINT when nothing is
-  // selected so Ctrl+C still interrupts); Cmd+V pastes. Lets the browser own
-  // copy/paste instead of tmux's copy-mode.
-  term.attachCustomKeyEventHandler((e) => {
-    if (e.type !== 'keydown') return true;
-    const mod = e.metaKey || e.ctrlKey;
-    if (mod && (e.key === 'c' || e.key === 'C') && term.hasSelection()) {
-      copyToClipboard(term.getSelection());
-      return false;
-    }
-    if (e.metaKey && (e.key === 'v' || e.key === 'V')) { pasteIntoTerminal(); return false; }
-    if (e.metaKey && (e.key === 'f' || e.key === 'F')) {
-      textPrompt('Find in terminal', '', { okLabel: 'Find' }).then((q) => {
-        if (q && searchAddon) { try { searchAddon.findNext(q); } catch (_) {} }
-      });
-      return false;
-    }
-    return true;
-  });
+  term.attachCustomKeyEventHandler(handleTerminalKey);
   enableTouchScroll(document.getElementById('terminal'));
   enableWheelScroll(document.getElementById('terminal'));
   enableFileDrop(document.getElementById('terminal'));
@@ -3846,8 +3828,56 @@ async function uploadDroppedFiles(files) {
   }
 }
 
+// The terminal's custom key handler (attached in ensureTerminal). At module
+// scope so the jsdom suite can drive it directly — same reason swallowMouseMode
+// lives out here.
+//
+// Cmd/Ctrl+C copies the selection (falling through to SIGINT when nothing is
+// selected so Ctrl+C still interrupts), Cmd+F opens our find prompt. Lets the
+// browser own copy instead of tmux's copy-mode.
+//
+// A branch that shadows a browser default must preventDefault(): returning
+// false only makes xterm skip its OWN key handling (its _keyDown returns early,
+// before any cancel()), so the browser's default gesture still runs (#875).
+function handleTerminalKey(e) {
+  if (e.type !== 'keydown') return true;
+  const mod = e.metaKey || e.ctrlKey;
+  if (mod && (e.key === 'c' || e.key === 'C') && term.hasSelection()) {
+    copyToClipboard(term.getSelection());
+    // Safe to own the gesture: copyToClipboard always delivers — writeText, or
+    // fallbackCopy's execCommand in a non-secure context.
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  }
+  // #875: Cmd+V is deliberately NOT handled here. Pasting explicitly *and*
+  // returning false double-pasted, because the browser's native paste gesture
+  // still fired xterm's own `paste` listener (on the helper textarea) and wrote
+  // the clipboard a second time. Leaving the event alone gives exactly one
+  // paste — xterm's listener routes it through paste(), so bracketed-paste
+  // wrapping is applied once, then onData → sendToPTY. macOS Cmd+V produces no
+  // key data in xterm, so nothing leaks to the PTY either.
+  //
+  // The native gesture is also strictly more capable than reading the clipboard
+  // ourselves: it needs no clipboard-read permission and works over plain http
+  // (`--host 0.0.0.0`), where navigator.clipboard doesn't exist at all. The
+  // right-click menu still calls pasteIntoTerminal() — a click is not a paste
+  // gesture, so there it's the only path.
+  if (e.metaKey && (e.key === 'f' || e.key === 'F')) {
+    // Without this the browser's own find bar opens over our prompt.
+    e.preventDefault();
+    e.stopPropagation();
+    textPrompt('Find in terminal', '', { okLabel: 'Find' }).then((q) => {
+      if (q && searchAddon) { try { searchAddon.findNext(q); } catch (_) {} }
+    });
+    return false;
+  }
+  return true;
+}
+
 // Paste the browser clipboard into the terminal (writes to the PTY, same path
-// as typing). readText() needs a user gesture — the menu click / Cmd+V is one.
+// as typing). readText() needs a user gesture — the right-click menu click is
+// one. Cmd+V never comes through here (#875); the browser pastes it natively.
 function pasteIntoTerminal() {
   if (!term || !(navigator.clipboard && navigator.clipboard.readText)) return;
   navigator.clipboard.readText().then((text) => {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -119,9 +119,33 @@
       // through) when there's no selection.
       function copySelection() {
         const sel = term.getSelection();
-        if (sel) { navigator.clipboard.writeText(sel).catch(function () {}); }
+        if (!sel) return;
+        // The key handler cancels the browser's own copy, so this must always
+        // deliver — mirrors app.js's copyToClipboard/fallbackCopy pair. Over
+        // plain http (a `--host 0.0.0.0` daemon) navigator.clipboard is absent
+        // entirely, and writeText can still reject where it exists; without the
+        // legacy fallback either case would be a silent no-op (review).
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(sel).catch(function () { fallbackCopy(sel); });
+        } else {
+          fallbackCopy(sel);
+        }
+      }
+      function fallbackCopy(text) {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); } catch (_) { /* best effort */ }
+        document.body.removeChild(ta);
       }
       function pasteClipboard() {
+        // Guarded like app.js's pasteIntoTerminal: navigator.clipboard is absent
+        // over plain http, where this would otherwise throw out of the menu
+        // click. Cmd+V is unaffected either way — the browser pastes it natively.
+        if (!(navigator.clipboard && navigator.clipboard.readText)) return;
         // Route through xterm so bracketed-paste wraps it — hidden newlines in the
         // clipboard would otherwise auto-execute in the shell (review).
         navigator.clipboard.readText().then(function (t) { if (t) term.paste(t); }).catch(function () {});

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -114,9 +114,9 @@
         }
       }
 
-      // Copy/paste. Cross-platform combos that never steal the shell's Ctrl+C
-      // (SIGINT): Cmd+C/V on macOS, Ctrl+Shift+C/V elsewhere. Copy is a no-op
-      // (passes through) when there's no selection.
+      // Copy. Cross-platform combos that never steal the shell's Ctrl+C
+      // (SIGINT): Cmd+C on macOS, Ctrl+Shift+C elsewhere. A no-op (passes
+      // through) when there's no selection.
       function copySelection() {
         const sel = term.getSelection();
         if (sel) { navigator.clipboard.writeText(sel).catch(function () {}); }
@@ -130,10 +130,22 @@
         if (e.type !== 'keydown') return true;
         const copyCombo = (e.metaKey && !e.ctrlKey) || (e.ctrlKey && e.shiftKey);
         if (copyCombo && (e.key === 'c' || e.key === 'C')) {
-          if (term.hasSelection()) { copySelection(); return false; }
+          if (term.hasSelection()) {
+            copySelection();
+            // Returning false only makes xterm skip its own key handling — the
+            // browser's default gesture keeps going unless we cancel it (#875).
+            e.preventDefault();
+            e.stopPropagation();
+            return false;
+          }
           return true; // no selection → let it through (e.g. Ctrl+C SIGINT)
         }
-        if (copyCombo && (e.key === 'v' || e.key === 'V')) { pasteClipboard(); return false; }
+        // #875: the paste combos are deliberately NOT handled here. Pasting
+        // explicitly *and* returning false double-pasted, because the browser's
+        // native paste still fired xterm's own `paste` listener. Left alone,
+        // that listener pastes exactly once (bracketed-paste wrapped), needs no
+        // clipboard-read permission, and works over plain http. The right-click
+        // menu still calls pasteClipboard() — a click is not a paste gesture.
         return true;
       });
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -42,13 +42,26 @@ import Testing
             "no `const MOUSE_MODES` declaration")
     }
 
-    /// `source` with `//` line comments removed, for assertions about what the
-    /// code *does*. The prose around a handler legitimately names the thing the
+    /// `source` with its comments removed, for assertions about what the code
+    /// *does*. The prose around a handler legitimately names the thing the
     /// handler must not call (e.g. #875's "the right-click menu still calls
     /// pasteIntoTerminal()"), and that explanation is the part most worth
     /// keeping — so it must not trip the guard.
-    private static func stripLineComments(_ source: String) -> String {
-        source.split(separator: "\n", omittingEmptySubsequences: false)
+    ///
+    /// Both `/* … */` and `//` forms, so a block comment can't smuggle a
+    /// mention past a negative assertion (review). Only *closed* block comments
+    /// are dropped: an unterminated `/*` is left in place, which can make a
+    /// guard fail loudly but never pass silently.
+    private static func stripComments(_ source: String) -> String {
+        var withoutBlocks = ""
+        var rest = Substring(source)
+        while let open = rest.range(of: "/*"),
+              let close = rest.range(of: "*/", range: open.upperBound..<rest.endIndex) {
+            withoutBlocks += rest[..<open.lowerBound]
+            rest = rest[close.upperBound...]
+        }
+        withoutBlocks += rest
+        return withoutBlocks.split(separator: "\n", omittingEmptySubsequences: false)
             .map { line -> Substring in
                 guard let marker = line.range(of: "//") else { return line }
                 return line[..<marker.lowerBound]
@@ -208,7 +221,7 @@ import Testing
     /// the same handler (the drift this suite exists to prevent).
     @Test func keyHandlersLeavePasteToTheBrowserAndCancelWhatTheyDoHandle() throws {
         let appJS = try Self.webAsset("app.js")
-        let body = Self.stripLineComments(String(try Self.functionBody("handleTerminalKey", in: appJS)))
+        let body = Self.stripComments(String(try Self.functionBody("handleTerminalKey", in: appJS)))
         #expect(
             !body.contains("pasteIntoTerminal"),
             "app.js's key handler must not paste on Cmd+V — the native paste already does (#875)")
@@ -226,7 +239,7 @@ import Testing
 
         let debugPage = try Self.webAsset("terminal.html")
         #expect(
-            !Self.stripLineComments(debugPage).lowercased().contains("e.key === 'v'"),
+            !Self.stripComments(debugPage).lowercased().contains("e.key === 'v'"),
             "terminal.html's key handler must not claim the paste chord either (#875)")
         #expect(
             debugPage.contains("addItem('Paste', true, pasteClipboard)"),
@@ -234,5 +247,31 @@ import Testing
         #expect(
             debugPage.contains("e.preventDefault();") && debugPage.contains("e.stopPropagation();"),
             "terminal.html's copy branch must cancel the browser default")
+    }
+
+    /// Cancelling a gesture and being able to perform it are one decision: a
+    /// surface may only `preventDefault()` the copy chord if its copy always
+    /// delivers. `navigator.clipboard` is absent over plain http (a
+    /// `--host 0.0.0.0` daemon) and `writeText` can reject where it exists, so
+    /// without the legacy `execCommand` path cancelling turns Cmd+C into a
+    /// silent no-op — the same non-secure-context trap that decided #875's paste
+    /// direction, which is why the debug page's copy was left cancelling with no
+    /// fallback in the first cut (review).
+    ///
+    /// Reading the clipboard is guarded rather than fallback'd: there is no
+    /// `execCommand('paste')` for a web page, so the menu simply does nothing
+    /// where the API is missing — and Cmd+V still pastes, natively.
+    @Test(arguments: ["app.js", "terminal.html"])
+    func clipboardWritesAlwaysDeliverAndReadsAreGuarded(asset: String) throws {
+        let source = try Self.webAsset(asset)
+        #expect(
+            source.contains("navigator.clipboard && navigator.clipboard.writeText"),
+            "\(asset) must feature-detect writeText before using it")
+        #expect(
+            source.contains("execCommand('copy')"),
+            "\(asset) must keep the non-secure-context copy fallback")
+        #expect(
+            source.contains("navigator.clipboard && navigator.clipboard.readText"),
+            "\(asset) must guard readText — it has no fallback to reach for")
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -42,6 +42,20 @@ import Testing
             "no `const MOUSE_MODES` declaration")
     }
 
+    /// `source` with `//` line comments removed, for assertions about what the
+    /// code *does*. The prose around a handler legitimately names the thing the
+    /// handler must not call (e.g. #875's "the right-click menu still calls
+    /// pasteIntoTerminal()"), and that explanation is the part most worth
+    /// keeping — so it must not trip the guard.
+    private static func stripLineComments(_ source: String) -> String {
+        source.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                guard let marker = line.range(of: "//") else { return line }
+                return line[..<marker.lowerBound]
+            }
+            .joined(separator: "\n")
+    }
+
     /// The body of a top-level `function <name>(` … `\n}` block, for asserting on
     /// one handler rather than the whole file.
     private static func functionBody(_ name: String, in source: String) throws -> Substring {
@@ -173,5 +187,52 @@ import Testing
         #expect(
             source.contains("macOptionClickForcesSelection: true"),
             "⌥-drag selection must be enabled explicitly (xterm.js defaults it to false)")
+    }
+
+    /// #875: neither surface may handle the paste chord in its key handler, and
+    /// any branch that DOES shadow a browser default must cancel the event.
+    ///
+    /// `attachCustomKeyEventHandler` returning `false` only makes xterm skip its
+    /// own key handling — xterm's `_keyDown` returns early, before any
+    /// `cancel()` — so the browser's default gesture still runs. Handling Cmd+V
+    /// there pasted once explicitly and once more when the native paste fired
+    /// xterm's own `paste` listener (registered on the helper textarea), with
+    /// bracketed-paste wrapping applied twice. Leaving the chord alone is what
+    /// makes it exactly one paste: xterm's listener already wraps and forwards
+    /// it, needs no clipboard-read permission, and works over plain http
+    /// (`--host 0.0.0.0`), where `navigator.clipboard` doesn't exist and the
+    /// explicit path was a no-op anyway. The right-click menu keeps the explicit
+    /// path — a click is not a paste gesture, so nothing native fires there.
+    ///
+    /// Asserted on both surfaces because they carry separate implementations of
+    /// the same handler (the drift this suite exists to prevent).
+    @Test func keyHandlersLeavePasteToTheBrowserAndCancelWhatTheyDoHandle() throws {
+        let appJS = try Self.webAsset("app.js")
+        let body = Self.stripLineComments(String(try Self.functionBody("handleTerminalKey", in: appJS)))
+        #expect(
+            !body.contains("pasteIntoTerminal"),
+            "app.js's key handler must not paste on Cmd+V — the native paste already does (#875)")
+        #expect(
+            !body.lowercased().contains("e.key === 'v'"),
+            "app.js's key handler must not claim the paste chord at all (#875)")
+        for cancel in ["e.preventDefault();", "e.stopPropagation();"] {
+            #expect(
+                body.contains(cancel),
+                "a branch that shadows a browser default must cancel the event: \(cancel)")
+        }
+        #expect(
+            appJS.contains("action: pasteIntoTerminal"),
+            "the right-click menu keeps the explicit paste path — it has no native gesture")
+
+        let debugPage = try Self.webAsset("terminal.html")
+        #expect(
+            !Self.stripLineComments(debugPage).lowercased().contains("e.key === 'v'"),
+            "terminal.html's key handler must not claim the paste chord either (#875)")
+        #expect(
+            debugPage.contains("addItem('Paste', true, pasteClipboard)"),
+            "terminal.html's right-click menu keeps the explicit paste path")
+        #expect(
+            debugPage.contains("e.preventDefault();") && debugPage.contains("e.stopPropagation();"),
+            "terminal.html's copy branch must cancel the browser default")
     }
 }

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -37,6 +37,18 @@ swallowing a non-mouse mode like `?25`), including xterm's params-object and
 sub-parameter shapes; and graceful degradation when `activeTerminal` is null or
 an older daemon omits `agent_surface`.
 
+## `key-handler.test.js` — terminal copy/paste keys (#875)
+
+Drives `handleTerminalKey` and `pasteIntoTerminal` against a fake xterm +
+clipboard. Coverage: the #875 regression — Cmd+V is left entirely to the
+browser, so the native paste (which xterm already bracketed-paste-wraps) is the
+only one that fires, instead of that plus an explicit `term.paste` for a double
+paste; the right-click menu still pasting exactly once, and degrading without
+throwing where `navigator.clipboard` is absent (plain http); Cmd/Ctrl+C copying
+the selection and cancelling the browser default, while Ctrl+C with no
+selection still falls through as SIGINT; Cmd+F cancelling the browser find bar
+and opening ours; and non-keydown / unmodified keys passing through untouched.
+
 ## `row.test.js` — sidebar session rows (CROW-773)
 
 Drives `sessionRow`. Coverage: the PR pill's status glyphs for every

--- a/Packages/CrowDaemon/web-tests/key-handler.test.js
+++ b/Packages/CrowDaemon/web-tests/key-handler.test.js
@@ -1,0 +1,256 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// #875 regression: the terminal's custom key handler. Drives the real
+// handleTerminalKey + pasteIntoTerminal from Resources/web/app.js against a fake
+// xterm + clipboard. Same harness shape as wheel-scroll.test.js — an epilogue
+// evaluated in app.js's own top-level lexical scope exposes the module-scope
+// bindings (which is why handleTerminalKey lives at module scope rather than
+// nested inside ensureTerminal).
+//
+// The handler is invoked the way xterm invokes it: called directly with the
+// keydown, its return value deciding only whether xterm runs its OWN key
+// handling. Returning false does NOT cancel the event — that's the bug this
+// file pins.
+const epilogue = `
+;globalThis.__t = {
+  handleTerminalKey(e){ return handleTerminalKey(e); },
+  pasteIntoTerminal(){ return pasteIntoTerminal(); },
+  set term(v){ term = v; },
+  set searchAddon(v){ searchAddon = v; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body><div id="terminal"></div></body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.WebSocket.OPEN = 1;
+window.TextEncoder = TextEncoder; // jsdom omits it; real browsers have it
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+// ---- Fakes -----------------------------------------------------------------
+
+// A fake xterm plus recorders for everything the handler can reach: what got
+// pasted into the terminal and what got written to the system clipboard.
+const pasted = [];
+const copied = [];
+let clipboardText = '';
+
+function setup({ selection = '' } = {}) {
+  pasted.length = 0;
+  copied.length = 0;
+  window.document.querySelectorAll('.text-prompt-backdrop').forEach((n) => n.remove());
+  T.term = {
+    hasSelection: () => selection.length > 0,
+    getSelection: () => selection,
+    paste: (t) => pasted.push(t),
+    focus() {},
+  };
+  T.searchAddon = { findNext() {} };
+}
+
+// navigator.clipboard is absent in jsdom (and in a real browser over plain
+// http, which is the case `withoutClipboard` models).
+function withClipboard() {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      readText: () => Promise.resolve(clipboardText),
+      writeText: (t) => { copied.push(t); return Promise.resolve(); },
+    },
+  });
+}
+function withoutClipboard() {
+  Object.defineProperty(window.navigator, 'clipboard', { configurable: true, value: undefined });
+}
+
+// xterm hands the handler the raw KeyboardEvent; we count the cancellation calls
+// the handler makes on it.
+function key(k, { meta = false, ctrl = false, type = 'keydown' } = {}) {
+  const e = {
+    type, key: k, metaKey: meta, ctrlKey: ctrl,
+    prevented: 0, stopped: 0,
+    preventDefault() { e.prevented++; },
+    stopPropagation() { e.stopped++; },
+  };
+  return e;
+}
+
+const settle = () => new Promise((r) => process.nextTick(r));
+
+async function main() {
+  // ---- Cmd+V: the browser's native paste owns it (#875) --------------------
+
+  // The whole bug: the handler pasted explicitly AND returned false, but false
+  // doesn't cancel the event, so the browser's native paste fired xterm's own
+  // `paste` listener too and the clipboard landed twice (double-wrapped for
+  // bracketed paste, at that). The handler must now leave Cmd+V entirely alone.
+  console.log('Cmd+V is left to the browser so it pastes exactly once (#875):');
+  {
+    withClipboard();
+    clipboardText = 'hello';
+    setup();
+    const e = key('v', { meta: true });
+    const result = T.handleTerminalKey(e);
+    await settle();
+    check('returns true (the event is not intercepted)', result === true);
+    check('does not paste explicitly — that was the second paste', pasted.length === 0);
+    check('does not cancel the native paste gesture', e.prevented === 0 && e.stopped === 0);
+  }
+  {
+    // Shift/caps-lock variant of the same chord.
+    withClipboard();
+    setup();
+    const e = key('V', { meta: true });
+    check('Cmd+Shift+V is left alone too', T.handleTerminalKey(e) === true);
+    await settle();
+    check('...and still pastes nothing explicitly', pasted.length === 0);
+  }
+  {
+    // Ctrl+V was never handled here (it's literal-next in readline/tmux) and
+    // must stay that way.
+    withClipboard();
+    setup();
+    const e = key('v', { ctrl: true });
+    check('Ctrl+V is untouched', T.handleTerminalKey(e) === true && e.prevented === 0);
+    await settle();
+    check('...and pastes nothing explicitly', pasted.length === 0);
+  }
+
+  // ---- The right-click menu keeps the explicit path -------------------------
+
+  // A menu click is not a paste gesture, so nothing native fires — reading the
+  // clipboard ourselves is the only way, and it must still land exactly once.
+  console.log('\nThe right-click Paste item still pastes, exactly once:');
+  {
+    withClipboard();
+    clipboardText = 'from the menu';
+    setup();
+    T.pasteIntoTerminal();
+    await settle();
+    check('pastes once', pasted.length === 1);
+    check('pastes the clipboard text', pasted[0] === 'from the menu');
+    check('routes through term.paste so xterm wraps it for bracketed paste',
+      pasted.join() === 'from the menu');
+  }
+  {
+    // Over plain http (`--host 0.0.0.0`) there is no navigator.clipboard at
+    // all. The menu can't paste there — but nothing may throw, and Cmd+V still
+    // works because the native gesture never depended on this path.
+    withoutClipboard();
+    clipboardText = 'unreachable';
+    setup();
+    let threw = false;
+    try { T.pasteIntoTerminal(); } catch (_) { threw = true; }
+    await settle();
+    check('no clipboard API → no throw', !threw);
+    check('no clipboard API → nothing pasted', pasted.length === 0);
+  }
+  {
+    withClipboard();
+    clipboardText = '';
+    setup();
+    T.pasteIntoTerminal();
+    await settle();
+    check('an empty clipboard pastes nothing', pasted.length === 0);
+  }
+
+  // ---- Copy: we own the gesture because we can always deliver ---------------
+
+  // Unlike paste, copy has a working fallback in every context (writeText, else
+  // fallbackCopy's execCommand), so cancelling the browser default is safe.
+  console.log('\nCmd/Ctrl+C copies the selection and consumes the event:');
+  {
+    withClipboard();
+    setup({ selection: 'selected text' });
+    const e = key('c', { meta: true });
+    const result = T.handleTerminalKey(e);
+    await settle();
+    check('returns false so xterm skips its own handling', result === false);
+    check('copies the selection once', copied.join() === 'selected text');
+    check('cancels the browser default', e.prevented === 1 && e.stopped === 1);
+  }
+  {
+    withClipboard();
+    setup({ selection: 'selected text' });
+    const e = key('c', { ctrl: true });
+    T.handleTerminalKey(e);
+    await settle();
+    check('Ctrl+C with a selection copies too', copied.join() === 'selected text');
+  }
+  {
+    // The acceptance criterion that keeps the shell usable: with nothing
+    // selected, Ctrl+C must reach the PTY as SIGINT.
+    withClipboard();
+    setup({ selection: '' });
+    const e = key('c', { ctrl: true });
+    const result = T.handleTerminalKey(e);
+    await settle();
+    check('Ctrl+C with no selection falls through to SIGINT', result === true);
+    check('...copies nothing', copied.length === 0);
+    check('...and is not cancelled', e.prevented === 0 && e.stopped === 0);
+  }
+
+  // ---- Find -----------------------------------------------------------------
+
+  console.log('\nCmd+F opens our find prompt instead of the browser find bar:');
+  {
+    withClipboard();
+    setup();
+    const e = key('f', { meta: true });
+    const result = T.handleTerminalKey(e);
+    check('returns false', result === false);
+    check('cancels the browser default (its find bar would open over ours)',
+      e.prevented === 1 && e.stopped === 1);
+    check('opens the find prompt', !!window.document.querySelector('.text-prompt-backdrop'));
+  }
+
+  // ---- Everything else passes through ---------------------------------------
+
+  console.log('\nEverything else reaches the terminal untouched:');
+  {
+    withClipboard();
+    setup({ selection: 'selected text' });
+    for (const type of ['keyup', 'keypress']) {
+      const e = key('c', { meta: true, type });
+      check(`${type} is ignored (keydown only)`,
+        T.handleTerminalKey(e) === true && e.prevented === 0);
+    }
+    await settle();
+    check('...so a non-keydown never copies', copied.length === 0);
+  }
+  {
+    withClipboard();
+    setup();
+    const e = key('v');
+    check('an unmodified keystroke passes through',
+      T.handleTerminalKey(e) === true && e.prevented === 0);
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main();

--- a/Packages/CrowDaemon/web-tests/key-handler.test.js
+++ b/Packages/CrowDaemon/web-tests/key-handler.test.js
@@ -88,9 +88,9 @@ function withoutClipboard() {
 
 // xterm hands the handler the raw KeyboardEvent; we count the cancellation calls
 // the handler makes on it.
-function key(k, { meta = false, ctrl = false, type = 'keydown' } = {}) {
+function key(k, { meta = false, ctrl = false, shift = false, type = 'keydown' } = {}) {
   const e = {
-    type, key: k, metaKey: meta, ctrlKey: ctrl,
+    type, key: k, metaKey: meta, ctrlKey: ctrl, shiftKey: shift,
     prevented: 0, stopped: 0,
     preventDefault() { e.prevented++; },
     stopPropagation() { e.stopped++; },
@@ -120,13 +120,19 @@ async function main() {
     check('does not cancel the native paste gesture', e.prevented === 0 && e.stopped === 0);
   }
   {
-    // Shift/caps-lock variant of the same chord.
+    // The chord arrives with an uppercase `key` under Shift, and under caps
+    // lock with no Shift at all — the old handler matched both, so both must
+    // stay unhandled.
     withClipboard();
     setup();
-    const e = key('V', { meta: true });
-    check('Cmd+Shift+V is left alone too', T.handleTerminalKey(e) === true);
+    const shifted = key('V', { meta: true, shift: true });
+    check('Cmd+Shift+V is left alone too', T.handleTerminalKey(shifted) === true);
+    const capsLocked = key('V', { meta: true });
+    check('caps-locked Cmd+V is left alone too', T.handleTerminalKey(capsLocked) === true);
     await settle();
-    check('...and still pastes nothing explicitly', pasted.length === 0);
+    check('...and neither pastes explicitly', pasted.length === 0);
+    check('...nor cancels the native paste',
+      shifted.prevented === 0 && capsLocked.prevented === 0);
   }
   {
     // Ctrl+V was never handled here (it's literal-next in readline/tmux) and

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,9 +2,9 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node row.test.js"
+    "test": "node board.test.js && node touch-scroll.test.js && node wheel-scroll.test.js && node key-handler.test.js && node row.test.js"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"


### PR DESCRIPTION
Closes #875

## The bug

Cmd+V in a web-UI terminal inserted the clipboard **twice**; right-click "Paste" was fine.

Two paths ran on one keydown: the custom key handler called `pasteIntoTerminal()`, *and* the browser's native paste gesture fired xterm's own `paste` listener (registered on the helper textarea and the element), which pasted again — bracketed-paste wrapping applied twice with it. Returning `false` from `attachCustomKeyEventHandler` does not cancel the event: xterm's `_keyDown` returns early, before any `cancel()`. Right-click Paste never doubled because a click is not a paste gesture.

## The fix — leave Cmd+V to the browser

The ticket proposed `preventDefault()`. That would have **deleted paste entirely** for anyone on a plain-http daemon (`--host 0.0.0.0`, documented in `docs/getting-started.md`): there is no `navigator.clipboard` in a non-secure context, so `pasteIntoTerminal()` already returns at its guard and the native paste is the only working path. `copyToClipboard` carries an `execCommand` fallback for exactly that context.

So the Cmd+V branch is dropped instead. xterm's listener already routes the clipboard through `paste()` — wrapped once, then `onData` → `sendToPTY` — and it needs no clipboard-read permission and works in every browser and security context. Verified in the vendored xterm.js 6.0.0 that macOS Cmd+V (`isMac` + meta, no ctrl/alt/shift) matches only keyCode 65 and leaves `result.key`/`result.cancel` unset, so nothing leaks to the PTY and nothing is cancelled. `pasteIntoTerminal()` stays for the right-click menu, now its only caller.

Sibling branches keep their explicit paths and now cancel properly:

- **Cmd+C** — safe to own: `copyToClipboard` always delivers. Ctrl+C with no selection still falls through as SIGINT.
- **Cmd+F** — the browser's find bar no longer opens over ours.

`Resources/web/terminal.html` (standalone debug page) carried the same shape and gets the same treatment.

## Tests

- `web-tests/key-handler.test.js` (new, jsdom) drives the real handler — hoisted to module scope as `handleTerminalKey` for that, the same precedent as `swallowMouseMode`. 27 assertions: Cmd+V untouched and unprevented, menu paste exactly once, degrading without throwing where `navigator.clipboard` is absent, Cmd/Ctrl+C copy, Ctrl+C SIGINT, Cmd+F, pass-through.
- `WebTerminalAssetTests` gains a drift guard over both surfaces.

Both were checked to **fail** against the old shape before being accepted.

```
226 tests in 47 suites passed   # swift test --package-path Packages/CrowDaemon
27 passed, 0 failed             # node key-handler.test.js
```

Pre-existing and unrelated: `web-tests/row.test.js` has 11 failures on a clean tree (confirmed by stashing).

## Manual verification checklist

- [ ] Cmd+V pastes exactly once
- [ ] Multi-line clipboard arrives as one bracketed paste (no auto-execute, not double-wrapped)
- [ ] Right-click Paste still pastes once
- [ ] Cmd+C copies; Ctrl+C with no selection still interrupts
- [ ] Cmd+F opens Crow's Find prompt with no browser find bar behind it
- [ ] Cmd+V still pastes over `http://<LAN-IP>:8787` (the case that ruled out `preventDefault`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)