### PR TITLE
Generate the CLI reference from ArgumentParser (CROW-808)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ crow select-session --session <uuid>            → {"session_id":"..."}
 crow list-sessions                              → {"sessions":[...]}
 crow get-session --session <uuid>               → {id, name, status, ticket_url, ...}
 crow set-status --session <uuid> active|paused|inReview|completed|archived
+crow set-locked --session <uuid> true|false     → exempt a session from (or return it to) the retention reaper
 crow handoff-agent --session <uuid> --agent cursor [--note "..."] → {"session_id":"...","agent_kind":"...","terminal_id":"..."}
 crow delete-session --session <uuid>            → {"deleted":true}
 ```
@@ -105,6 +106,26 @@ Everything is live except `--binary` (agent discovery + `.claude/bin` symlinks a
 
 The review board filters on defaults ∪ every workspace's own `excludeReviewRepos`, so `--clear-exclude-review-repos` won't unhide a repo a workspace excludes.
 
+### Job Commands
+
+Scheduled prompt-sets scoped to one repo in a workspace (CROW-604) — the Jobs sidebar, as CLI verbs. Jobs are addressed by UUID; `crow job list` prints them. Mutations hit the app's live config, so the scheduler and Settings UI see them immediately.
+
+```
+crow job list                                   → {"jobs":[...]}
+crow job get --id <job-uuid>                    → {"job":{...}}
+crow job add --name "..." --workspace "..." --repo owner/repo --prompt "..." (--interval-seconds N | --daily-at HH:MM [--weekdays mon,tue])
+crow job edit --id <job-uuid> [--name ...] [--prompt ...] [--daily-at HH:MM] [--weekdays ...]
+crow job enable --id <job-uuid>                 → {"job":{...}}
+crow job disable --id <job-uuid>                → {"job":{...}}
+crow job run --id <job-uuid>                    → {"job_id":"...","session_id":"...","terminal_id":"..."}   needs tmux; ignores schedule + enabled
+crow job delete --id <job-uuid>                 → {"deleted":true,"job_id":"..."}
+crow job duplicate --id <job-uuid>              → {"job":{...}}   the copy starts disabled with a uniquified name
+```
+
+- `add` needs exactly one schedule (`--interval-seconds` **or** `--daily-at`) and at least one `--prompt`/`--prompt-file`. `--prompt` and `--prompt-file` are repeatable and sent in that order; `--prompt-file -` reads stdin (at most once).
+- On `edit`, any `--prompt` replaces the **whole** prompt list and any schedule flag replaces the **whole** schedule — so changing `--weekdays` means restating `--daily-at`. Use `enable`/`disable` instead of `edit` to toggle enabled.
+- `job run` can take a while on first run (it may clone the repo); the run continues in the app even if the CLI stops waiting.
+
 ### Worktree Commands
 ```
 crow add-worktree --session <uuid> --repo "name" --repo-path "/main/repo" --path "/worktree/path" --branch "feature/..." [--primary]
@@ -116,6 +137,8 @@ crow list-worktrees --session <uuid>
 crow new-terminal --session <uuid> --cwd "/path" [--name "Claude Code"] [--command "claude ..."] [--managed]
 crow list-terminals --session <uuid>
 crow close-terminal --session <uuid> --terminal <uuid>
+crow rename-terminal --session <uuid> --terminal <uuid> "new name"
+crow recreate-terminal --session <uuid> --terminal <uuid>   → DESTRUCTIVE: rebuilds the pane to restore scrollback; relaunches the agent with --continue
 crow send --session <uuid> --terminal <uuid> "text to send"
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build daemon app run setup install uninstall clean check test help daemon-run
+.PHONY: build daemon app run setup install uninstall clean check test help daemon-run docs
 
 # Install destination and build config (override on the command line, e.g.
 # `make install BINDIR=/usr/local/bin` or `make build CONFIG=release`).
@@ -53,6 +53,7 @@ help:
 	@echo "  setup      Check build prerequisites"
 	@echo "  check      Verify all build and runtime prerequisites"
 	@echo "  test       Run all package tests"
+	@echo "  docs       Regenerate docs/cli.md from the CLI's ArgumentParser metadata"
 	@echo "  install    Symlink crow + crowd into ~/.local/bin (override BINDIR=, CONFIG=release)"
 	@echo "  uninstall  Remove installed crow + crowd symlinks"
 	@echo "  clean      Remove .build/ and the desktop app's target/"
@@ -97,6 +98,14 @@ test:
 	done
 	@echo "==> Checking notification-event catalogs (CROW-768)..."
 	@./scripts/check-notification-events.sh
+
+# Regenerate the CLI reference from the commands themselves (CROW-808). Run
+# after adding or changing a subcommand — a stale docs/cli.md fails CrowCLI's
+# test suite, which is what keeps the docs honest.
+docs:
+	@bash scripts/generate-build-info.sh
+	@swift build $(if $(filter release,$(CONFIG)),-c release,) --product crow
+	@$(BUILD_OUT)/crow generate-docs
 
 clean:
 	rm -rf .build

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/DocsCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/DocsCommand.swift
@@ -1,0 +1,57 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+/// Regenerate `docs/cli.md` from the command tree's own ArgumentParser metadata
+/// (CROW-808).
+///
+/// Purely local — it never touches the socket, so it works with `crowd` down.
+/// Hidden from `crow --help` because it is a repo-maintenance verb, not part of
+/// the control plane; `make docs` is the front door.
+public struct GenerateDocs: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "generate-docs",
+        abstract: "Regenerate the generated CLI reference from ArgumentParser metadata",
+        discussion: """
+        Writes every subcommand and flag the binary accepts to docs/cli.md. \
+        Run it after adding or changing a command; `make docs` does exactly this. \
+        Use --check in a script to assert the committed file is current without \
+        writing anything — it exits non-zero when the file is stale or missing.
+        """,
+        shouldDisplay: false
+    )
+
+    @Option(name: .long, help: "Path to write (default: docs/cli.md, relative to the current directory)")
+    var output: String?
+
+    @Flag(name: .long, help: "Verify the file on disk instead of writing it; exits non-zero when stale")
+    var check: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        let path = output ?? CLIDocs.outputPath
+        let generated = try CLIDocs.markdown()
+        let url = URL(fileURLWithPath: path)
+
+        if check {
+            let onDisk = try? String(contentsOf: url, encoding: .utf8)
+            guard onDisk == generated else {
+                let reason = onDisk == nil ? "is missing" : "is out of date"
+                FileHandle.standardError.write(Data(
+                    "crow: \(path) \(reason) — run `make docs`\n".utf8
+                ))
+                throw ExitCode.failure
+            }
+            printJSON(["path": .string(path), "up_to_date": .bool(true)])
+            return
+        }
+
+        try generated.write(to: url, atomically: true, encoding: .utf8)
+        printJSON([
+            "path": .string(path),
+            "commands": .int(CLIDocs.documentedCommandCount),
+            "written": .bool(true),
+        ])
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -75,6 +75,7 @@ public struct CrowCommand: ParsableCommand {
             ListArtifacts.self,
             HookEventCmd.self,
             CodexNotify.self,
+            GenerateDocs.self,
         ]
     )
 

--- a/Packages/CrowCLI/Sources/CrowCLILib/Docs/CLIDocs.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Docs/CLIDocs.swift
@@ -1,0 +1,402 @@
+import ArgumentParser
+import Foundation
+
+/// Renders `docs/cli.md` from the `CrowCommand` tree's own ArgumentParser
+/// metadata, so the reference cannot drift from the commands it describes
+/// (CROW-808).
+///
+/// Two sources are stitched together, deliberately:
+///
+/// - The **command layer** (name, abstract, discussion, hidden-ness, nesting)
+///   comes from `CommandConfiguration`, which has been stable public API for
+///   years.
+/// - The **argument layer** comes from the JSON that
+///   `ParsableCommand._dumpHelp()` emits — the same payload behind
+///   `--experimental-dump-help`. There is no public API for walking a command's
+///   `@Option`/`@Flag` declarations, so this is the only way to get flag help
+///   text without a macro or reflection hack.
+///
+/// The JSON is decoded into local types rather than by importing
+/// `ArgumentParserToolInfo`, because that module is not a library product of
+/// swift-argument-parser and therefore cannot be depended on. Every field is
+/// optional and only fields present in 1.5.0 (the manifest's floor) are read —
+/// `Package.resolved` is not committed, so any 1.x may be resolved and the
+/// generated file has to stay byte-identical across them.
+public enum CLIDocs {
+    /// Where the generated reference lives, relative to the repo root.
+    public static let outputPath = "docs/cli.md"
+
+    /// How many commands the reference documents — everything but the bare `crow` root.
+    public static var documentedCommandCount: Int { tree().count - 1 }
+
+    // MARK: - Model
+
+    /// One node of the command tree, with its full invocation path.
+    struct Command {
+        /// e.g. `["crow", "job", "add"]`.
+        let path: [String]
+        let abstract: String
+        let discussion: String
+        let isHidden: Bool
+        let aliases: [String]
+        let defaultSubcommand: String?
+        let subcommandPaths: [[String]]
+
+        /// e.g. `crow job add`.
+        var invocation: String { path.joined(separator: " ") }
+        /// GitHub-style heading anchor for `## \`crow job add\``.
+        var anchor: String { path.joined(separator: "-") }
+        var isRoot: Bool { path.count == 1 }
+    }
+
+    /// One `@Option` / `@Flag` / `@Argument` on a command.
+    struct Argument {
+        enum Kind: String {
+            case positional, option, flag
+        }
+
+        let kind: Kind
+        /// Rendered with their dashes, e.g. `["--session"]`. Empty for positionals.
+        /// A merged inversion pair carries both spellings.
+        var names: [String]
+        let valueName: String?
+        let isOptional: Bool
+        let isRepeating: Bool
+        let defaultValue: String?
+        let abstract: String
+        let allValues: [String]
+
+        /// How the argument appears in a usage line. Positionals fall back to
+        /// their value name; merged inversion pairs show both spellings.
+        var displayName: String {
+            names.isEmpty ? "<\(valueName ?? "value")>" : names.joined(separator: "|")
+        }
+    }
+
+    // MARK: - Command tree
+
+    /// Every command reachable from `crow`, root first, then depth-first in
+    /// declaration order.
+    static func tree() -> [Command] {
+        var commands: [Command] = []
+        walk(CrowCommand.self, path: ["crow"], into: &commands)
+        return commands
+    }
+
+    private static func walk(
+        _ type: ParsableCommand.Type,
+        path: [String],
+        into commands: inout [Command]
+    ) {
+        let configuration = type.configuration
+        let subcommandPaths = configuration.subcommands.map { path + [$0._commandName] }
+
+        commands.append(Command(
+            path: path,
+            abstract: configuration.abstract.trimmed,
+            discussion: configuration.discussion.trimmed,
+            isHidden: !configuration.shouldDisplay,
+            aliases: configuration.aliases,
+            defaultSubcommand: configuration.defaultSubcommand?._commandName,
+            subcommandPaths: subcommandPaths
+        ))
+
+        for subcommand in configuration.subcommands {
+            walk(subcommand, path: path + [subcommand._commandName], into: &commands)
+        }
+    }
+
+    // MARK: - Arguments
+
+    /// Arguments for every command, keyed by invocation path (`"crow job add"`).
+    ///
+    /// One dump of the whole tree rather than one per command: the per-command
+    /// dump loses the super-command chain, and the root dump already carries
+    /// every nested command.
+    static func argumentsByPath() throws -> [String: [Argument]] {
+        let dumped = try JSONDecoder().decode(
+            DumpedTool.self, from: Data(CrowCommand._dumpHelp().utf8)
+        )
+        var result: [String: [Argument]] = [:]
+        index(dumped.command, path: ["crow"], into: &result)
+        return result
+    }
+
+    private static func index(
+        _ dumped: DumpedCommand,
+        path: [String],
+        into result: inout [String: [Argument]]
+    ) {
+        let arguments = (dumped.arguments ?? []).compactMap(Argument.init)
+        result[path.joined(separator: " ")] = mergingInversions(arguments)
+        for subcommand in dumped.subcommands ?? [] {
+            index(subcommand, path: path + [subcommand.commandName], into: &result)
+        }
+    }
+
+    /// Collapse `@Flag(inversion: .prefixedNo)` pairs into one row.
+    ///
+    /// The dump reports `--global-mute` and `--no-global-mute` as two arguments
+    /// carrying the same help text, which doubles the size of the table and the
+    /// usage line for something the reader thinks of as a single toggle.
+    private static func mergingInversions(_ arguments: [Argument]) -> [Argument] {
+        var merged: [Argument] = []
+        for argument in arguments {
+            guard argument.kind == .flag,
+                  argument.names.count == 1,
+                  let negated = argument.names.first,
+                  negated.hasPrefix("--no-"),
+                  let positive = merged.lastIndex(where: {
+                      $0.names == ["--" + negated.dropFirst("--no-".count)]
+                          && $0.abstract == argument.abstract
+                  })
+            else {
+                merged.append(argument)
+                continue
+            }
+            merged[positive].names.append(negated)
+        }
+        return merged
+    }
+
+    // MARK: - Rendering
+
+    /// The full contents of `docs/cli.md`.
+    public static func markdown() throws -> String {
+        let arguments = try argumentsByPath()
+        let all = tree()
+        // Keep-first rather than uniqueKeysWithValues: two commands sharing an
+        // invocation path is a CLI bug, and the docs tool should report it as a
+        // duplicated section rather than trap while generating.
+        let byPath = Dictionary(all.map { ($0.invocation, $0) }, uniquingKeysWith: { first, _ in first })
+        // Alphabetical so a reordered `subcommands:` array never rewrites the file.
+        let documented = all.filter { !$0.isRoot }.sorted { $0.invocation < $1.invocation }
+
+        var out = header(root: all[0])
+        out += "\n## Command index\n\n"
+        out += "| Command | Summary |\n| --- | --- |\n"
+        for command in documented {
+            let summary = command.abstract.isEmpty ? "—" : command.abstract
+            out += "| [`\(command.invocation)`](#\(command.anchor)) | \(escapeCell(summary)) |\n"
+        }
+        out += "\n---\n\n"
+
+        for command in documented {
+            out += section(command, arguments: arguments[command.invocation] ?? [], byPath: byPath)
+        }
+        return out
+    }
+
+    private static func header(root: Command) -> String {
+        """
+        <!-- Generated from ArgumentParser metadata by `crow generate-docs`. Do not edit by hand. -->
+        <!-- Regenerate with `make docs` after changing anything in Packages/CrowCLI/Sources/CrowCLILib/Commands/. -->
+
+        # `crow` CLI — generated reference
+
+        \(root.abstract).
+
+        Every subcommand and flag the `crow` binary accepts, generated from the commands themselves \
+        so it cannot drift. For prose, worked examples, JSON response shapes and the gotchas that \
+        matter in practice, read [`cli-reference.md`](cli-reference.md) instead — this file is the \
+        exhaustive surface, that one is the guide.
+
+        `--help` is accepted everywhere and `crow --version` prints the build version; neither is \
+        repeated per command below. Commands marked **hidden** are omitted from `crow --help` but \
+        still work.
+
+        ---
+
+        """
+    }
+
+    private static func section(
+        _ command: Command,
+        arguments: [Argument],
+        byPath: [String: Command]
+    ) -> String {
+        var out = "## `\(command.invocation)`\n\n"
+
+        if !command.abstract.isEmpty {
+            out += "\(command.abstract).\n\n"
+        }
+        if command.isHidden {
+            out += "**Hidden** — not listed in `crow --help`.\n\n"
+        }
+        if !command.aliases.isEmpty {
+            out += "Aliases: \(command.aliases.map { "`\($0)`" }.joined(separator: ", ")).\n\n"
+        }
+
+        out += "```\n\(usage(command, arguments: arguments))\n```\n\n"
+
+        if !command.discussion.isEmpty {
+            out += "\(renderDiscussion(command.discussion))\n\n"
+        }
+
+        if !command.subcommandPaths.isEmpty {
+            let links = command.subcommandPaths.compactMap { path -> String? in
+                guard let sub = byPath[path.joined(separator: " ")] else { return nil }
+                return "[`\(sub.path.last ?? "")`](#\(sub.anchor))"
+            }
+            out += "Subcommands: \(links.joined(separator: ", ")).\n\n"
+            if let fallback = command.defaultSubcommand {
+                out += "Bare `\(command.invocation)` runs `\(fallback)`.\n\n"
+            }
+        }
+
+        if !arguments.isEmpty {
+            out += "| Flag | Value | Required | Description |\n| --- | --- | --- | --- |\n"
+            for argument in arguments {
+                out += row(argument)
+            }
+            out += "\n"
+        }
+
+        return out + "---\n\n"
+    }
+
+    private static func row(_ argument: Argument) -> String {
+        let name = argument.kind == .positional
+            ? "_(positional)_"
+            : argument.names.map { "`\($0)`" }.joined(separator: ", ")
+
+        var value = argument.valueName.map { "`<\($0)>`" } ?? "—"
+        if argument.kind == .flag { value = "—" }
+        if argument.isRepeating { value += " _(repeatable)_" }
+
+        // Help strings rarely end in a period, so terminate before appending.
+        var description = argument.abstract.isEmpty ? "—" : argument.abstract
+        if !argument.allValues.isEmpty {
+            description = description.sentenceTerminated
+                + " Values: \(argument.allValues.map { "`\($0)`" }.joined(separator: ", "))."
+        }
+        if let fallback = argument.defaultValue, !fallback.isEmpty {
+            description = description.sentenceTerminated + " Default: `\(fallback)`."
+        }
+
+        return "| \(escapeCell(name)) | \(escapeCell(value)) | \(argument.isOptional ? "no" : "yes") "
+            + "| \(escapeCell(description)) |\n"
+    }
+
+    /// A synthesised usage line — optional parts bracketed, repeatables suffixed.
+    private static func usage(_ command: Command, arguments: [Argument]) -> String {
+        var parts = [command.invocation]
+        if !command.subcommandPaths.isEmpty {
+            let names = command.subcommandPaths.compactMap(\.last).joined(separator: "|")
+            parts.append(command.defaultSubcommand == nil ? "<\(names)>" : "[\(names)]")
+        }
+        for argument in arguments {
+            var part: String
+            switch argument.kind {
+            case .flag:
+                part = argument.displayName
+            case .option:
+                part = "\(argument.displayName) <\(argument.valueName ?? "value")>"
+            case .positional:
+                part = "<\(argument.valueName ?? "value")>"
+            }
+            if argument.isRepeating { part += " ..." }
+            parts.append(argument.isOptional ? "[\(part)]" : part)
+        }
+        return parts.joined(separator: " ")
+    }
+
+    /// A `discussion:` is plain text written for a terminal, where an indented
+    /// line means "this is a command to type". Markdown needs that spelled out,
+    /// so indented runs become fenced blocks; everything else passes through.
+    private static func renderDiscussion(_ discussion: String) -> String {
+        var out: [String] = []
+        var fenced = false
+        for line in discussion.components(separatedBy: "\n") {
+            let indented = line.hasPrefix("  ") && !line.trimmed.isEmpty
+            if indented != fenced {
+                out.append("```")
+                fenced = indented
+            }
+            out.append(fenced ? line.trimmed : line)
+        }
+        if fenced { out.append("```") }
+        return out.joined(separator: "\n")
+    }
+
+    /// `|` terminates a Markdown table cell, so it has to be escaped — several
+    /// help strings enumerate choices as `active|paused|…`.
+    private static func escapeCell(_ text: String) -> String {
+        text.replacingOccurrences(of: "|", with: "\\|")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+}
+
+// MARK: - `_dumpHelp()` JSON
+
+/// Mirrors `ToolInfoV0` closely enough to read, and no further. Every field is
+/// optional so a newer swift-argument-parser adding or dropping keys degrades
+/// instead of throwing.
+private struct DumpedTool: Decodable {
+    let command: DumpedCommand
+}
+
+private struct DumpedCommand: Decodable {
+    let commandName: String
+    let subcommands: [DumpedCommand]?
+    let arguments: [DumpedArgument]?
+}
+
+private struct DumpedArgument: Decodable {
+    struct Name: Decodable {
+        let kind: String
+        let name: String
+
+        /// `long` → `--flag`, `short` → `-f`, `longWithSingleDash` → `-flag`.
+        var rendered: String {
+            switch kind {
+            case "long": return "--\(name)"
+            case "longWithSingleDash": return "-\(name)"
+            default: return "-\(name)"
+            }
+        }
+    }
+
+    let kind: String
+    let isOptional: Bool?
+    let isRepeating: Bool?
+    let names: [Name]?
+    let valueName: String?
+    let defaultValue: String?
+    let abstract: String?
+    /// The stored key in 1.5.0; later versions also expose `allValueStrings`.
+    let allValues: [String]?
+    let allValueStrings: [String]?
+}
+
+extension CLIDocs.Argument {
+    /// `nil` for `--help` / `--version`, which every command inherits and no
+    /// per-command table should repeat.
+    fileprivate init?(_ dumped: DumpedArgument) {
+        guard let kind = Kind(rawValue: dumped.kind) else { return nil }
+        let names = (dumped.names ?? []).map(\.rendered)
+        guard !names.contains("--help"), !names.contains("--version") else { return nil }
+
+        self.kind = kind
+        self.names = names
+        self.valueName = dumped.valueName?.nonBlank
+        self.isOptional = dumped.isOptional ?? true
+        self.isRepeating = dumped.isRepeating ?? false
+        self.defaultValue = dumped.defaultValue?.nonBlank
+        self.abstract = (dumped.abstract ?? "").trimmed
+        self.allValues = dumped.allValues ?? dumped.allValueStrings ?? []
+    }
+}
+
+// MARK: - Small helpers
+
+extension String {
+    fileprivate var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+    fileprivate var nonBlank: String? { trimmed.isEmpty ? nil : self }
+
+    /// The string with a trailing `.` added unless it already closes a sentence.
+    fileprivate var sentenceTerminated: String {
+        guard let last, !".!?:".contains(last) else { return self }
+        return self + "."
+    }
+}

--- a/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift
@@ -69,6 +69,36 @@ private func codeBlocks(of markdown: String) -> String {
     return blocks.joined(separator: "\n")
 }
 
+/// Whether `invocation` appears in `examples` as a complete command token.
+///
+/// A plain `contains` would let one verb be covered by a longer one that merely
+/// starts the same way — a future `crow set-status-bulk` example would satisfy
+/// `crow set-status`. So the match must begin a token and must not be followed
+/// by a character that continues the verb (letter, digit, or hyphen).
+///
+/// Parent groups still pass on a child's example: `crow job` is followed by a
+/// space in `crow job list`. That is intended — a bare `crow job` only prints
+/// help, so demanding a standalone example for it would add a line nobody would
+/// ever run. A group is documented when its subcommands are.
+private func mentionsCommand(_ invocation: String, in examples: String) -> Bool {
+    for line in examples.components(separatedBy: "\n") {
+        var searchStart = line.startIndex
+        while let found = line.range(of: invocation, range: searchStart..<line.endIndex) {
+            let startsToken = found.lowerBound == line.startIndex
+                || " \t|(`$".contains(line[line.index(before: found.lowerBound)])
+            let endsToken = found.upperBound == line.endIndex
+                || !isVerbCharacter(line[found.upperBound])
+            if startsToken, endsToken { return true }
+            searchStart = found.upperBound
+        }
+    }
+    return false
+}
+
+private func isVerbCharacter(_ character: Character) -> Bool {
+    character.isLetter || character.isNumber || character == "-"
+}
+
 /// The body of one `## \`crow …\`` section of the generated reference.
 private func section(_ invocation: String, in markdown: String) -> String? {
     guard let start = markdown.range(of: "## `\(invocation)`\n") else { return nil }
@@ -101,15 +131,29 @@ private func section(_ invocation: String, in markdown: String) -> String? {
         )
     }
 
+    var asserted = 0
     for (invocation, type) in commandTypesByInvocation() {
         guard let body = section(invocation, in: markdown) else { continue }
-        for flag in longFlagNames(of: type) {
+        for flag in try longFlagNames(of: type) {
             #expect(
                 body.contains("`\(flag)`"),
                 "`\(invocation)` accepts \(flag) but the generated reference omits it"
             )
+            asserted += 1
         }
     }
+
+    // Positive control. Failing closed on a decode error is not enough on its
+    // own: a dump that decodes cleanly but yields no flags would make every
+    // assertion above vacuous and still pass. Pin one flag-rich command exactly,
+    // and floor the total, so "the independent pass looked at nothing" is itself
+    // a failure. The real figure is 147 — the floor leaves room to delete verbs.
+    let jobAdd = try longFlagNames(of: JobAdd.self).sorted()
+    #expect(jobAdd == [
+        "--daily-at", "--disabled", "--interval-seconds", "--name", "--prompt",
+        "--prompt-file", "--repo", "--weekdays", "--workspace",
+    ])
+    #expect(asserted > 100, "only \(asserted) flags were checked — the independent dump is failing open")
 }
 
 /// Flag rendering the tables are easy to get quietly wrong: `@OptionGroup`
@@ -147,6 +191,26 @@ private func section(_ invocation: String, in markdown: String) -> String? {
     #expect(!markdown.contains("| `--help` |"))
 }
 
+/// `mentionsCommand` decides whether every hand-written doc check passes, so pin
+/// its boundary behaviour instead of trusting it by inspection.
+@Test func mentionsCommandRequiresAWholeCommandToken() {
+    // Ordinary examples, including one behind a pipe.
+    #expect(mentionsCommand("crow set-status", in: "crow set-status --session <uuid> active"))
+    #expect(mentionsCommand("crow resync-jira", in: "crow resync-jira"))
+    #expect(mentionsCommand("crow web-password set", in: #"printf '%s' "$PW" | crow web-password set --stdin"#))
+
+    // A longer verb must not satisfy a shorter one — the reason plain
+    // `contains` was not enough.
+    #expect(!mentionsCommand("crow set-status", in: "crow set-status-bulk --session <uuid>"))
+    #expect(!mentionsCommand("crow job get", in: "crow job getx --id <uuid>"))
+
+    // Nor may a match that does not start its own token.
+    #expect(!mentionsCommand("crow send", in: "xcrow send hello"))
+
+    // A parent group is satisfied by a child's example, deliberately.
+    #expect(mentionsCommand("crow job", in: "crow job list"))
+}
+
 // MARK: - The committed reference is current
 
 @Test func committedGeneratedDocIsUpToDate() throws {
@@ -175,9 +239,9 @@ private func section(_ invocation: String, in markdown: String) -> String? {
     ]
 
     for invocation in invocations where exempt[invocation] == nil {
-        // Bound to a Bool first: expanding `examples.contains(…)` inside the
-        // macro puts the whole 1000-line document in the failure output.
-        let documented = examples.contains(invocation)
+        // Bound to a Bool first: expanding the match inside the macro puts the
+        // whole 1000-line document in the failure output.
+        let documented = mentionsCommand(invocation, in: examples)
         #expect(
             documented,
             "`\(invocation)` has no worked example in docs/cli-reference.md — write it up, or exempt it with a reason"
@@ -208,7 +272,7 @@ private func section(_ invocation: String, in markdown: String) -> String? {
     ]
 
     for invocation in invocations where exempt[invocation] == nil {
-        let documented = examples.contains(invocation)
+        let documented = mentionsCommand(invocation, in: examples)
         #expect(
             documented,
             "`\(invocation)` is missing from CLAUDE.md's CLI Reference — the Manager agent reads it to learn what it can run"
@@ -237,7 +301,18 @@ private func commandTypesByInvocation() -> [(String, ParsableCommand.Type)] {
 /// The long flag names one command accepts, read straight out of its own
 /// `--experimental-dump-help` payload. `--help` / `--version` are inherited by
 /// every command and documented once in the reference's preamble.
-private func longFlagNames(of type: ParsableCommand.Type) -> [String] {
+///
+/// Deliberately fails closed. This is the independent check on the generator, so
+/// swallowing a decode error and returning `[]` would let a `_dumpHelp()` shape
+/// change silently skip every flag assertion while the test still reported
+/// green.
+///
+/// `arguments` is therefore decoded as **required** — ArgumentParser appends a
+/// help flag to every command, so the key is always present, and treating it as
+/// optional would turn a renamed key into the same quiet no-op `try?` was.
+/// `names` stays optional because positional arguments genuinely have none; the
+/// positive control in the caller is what guards *that* key against renaming.
+private func longFlagNames(of type: ParsableCommand.Type) throws -> [String] {
     struct Dump: Decodable {
         struct Command: Decodable {
             struct Argument: Decodable {
@@ -245,19 +320,18 @@ private func longFlagNames(of type: ParsableCommand.Type) -> [String] {
                     let kind: String
                     let name: String
                 }
+                /// Absent for positionals.
                 let names: [Name]?
             }
-            let arguments: [Argument]?
+            let arguments: [Argument]
         }
         let command: Command
     }
 
-    guard let dump = try? JSONDecoder().decode(
-        Dump.self, from: Data(type._dumpHelp().utf8)
-    ) else { return [] }
+    let dump = try JSONDecoder().decode(Dump.self, from: Data(type._dumpHelp().utf8))
 
     var flags: [String] = []
-    for argument in dump.command.arguments ?? [] {
+    for argument in dump.command.arguments {
         for name in argument.names ?? [] where name.kind == "long" {
             let flag = "--" + name.name
             if flag != "--help", flag != "--version" { flags.append(flag) }

--- a/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift
@@ -1,0 +1,267 @@
+import ArgumentParser
+import Foundation
+import Testing
+@testable import CrowCLILib
+
+/// The doc-drift guard (CROW-808).
+///
+/// The parity tests prove a verb *exists*; these prove it is *documented*. A new
+/// subcommand that nobody writes up fails the build here rather than shipping
+/// invisible — which is how `crow job`, `set-locked`, `recreate-terminal`,
+/// `resync-jira` and `codex-notify` all went missing from the reference before
+/// this existed.
+///
+/// These run in CI's Linux lane, which builds only `Packages/CrowCLI` and never
+/// links the `crow` executable — so everything here works in-process, off the
+/// command tree itself, with no binary to invoke.
+
+// MARK: - Repo layout
+
+/// The repo root, derived from this file's compile-time path
+/// (`<root>/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift`).
+private let repoRoot: URL = {
+    var url = URL(fileURLWithPath: #filePath)
+    for _ in 0..<5 { url = url.deletingLastPathComponent() }
+    return url
+}()
+
+private func repoFile(_ path: String) throws -> String {
+    let url = repoRoot.appendingPathComponent(path)
+    guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+        throw DocsTestError.unreadable(url.path)
+    }
+    return contents
+}
+
+private enum DocsTestError: Error, CustomStringConvertible {
+    case unreadable(String)
+
+    var description: String {
+        switch self {
+        case .unreadable(let path):
+            return "Could not read \(path) — is the repo root still 5 levels above this test file?"
+        }
+    }
+}
+
+/// Every command below the `crow` root, as invocation strings.
+private var invocations: [String] {
+    CLIDocs.tree().filter { !$0.isRoot }.map(\.invocation)
+}
+
+/// Just the fenced code blocks of a Markdown document, concatenated.
+///
+/// The hand-written docs are checked against this rather than the whole file so
+/// that "documented" means "there is a command here you can copy and run". A
+/// passing mention in prose is not enough: `crow transition-ticket` had nothing
+/// but a cross-reference link — pointing at an anchor that did not exist — and
+/// a whole-file substring match called that documented.
+private func codeBlocks(of markdown: String) -> String {
+    var blocks: [String] = []
+    var insideFence = false
+    for line in markdown.components(separatedBy: "\n") {
+        if line.hasPrefix("```") {
+            insideFence.toggle()
+        } else if insideFence {
+            blocks.append(line)
+        }
+    }
+    return blocks.joined(separator: "\n")
+}
+
+/// The body of one `## \`crow …\`` section of the generated reference.
+private func section(_ invocation: String, in markdown: String) -> String? {
+    guard let start = markdown.range(of: "## `\(invocation)`\n") else { return nil }
+    let rest = markdown[start.upperBound...]
+    let end = rest.range(of: "\n## `")?.lowerBound ?? rest.endIndex
+    return String(rest[..<end])
+}
+
+// MARK: - The generated reference is complete
+
+/// The ticket's core assertion: no verb and no flag is missing from the
+/// generated reference.
+///
+/// Flags are re-derived by dumping each command type *on its own*, rather than
+/// reusing the whole-tree dump the generator indexes by path. That second,
+/// independent pass is the point — a generator that mis-joins a nested path
+/// (`crow job add` vs `crow add`) would still look self-consistent against its
+/// own index.
+@Test func generatedDocCoversEveryCommandAndFlag() throws {
+    let markdown = try CLIDocs.markdown()
+
+    for command in CLIDocs.tree() where !command.isRoot {
+        #expect(
+            section(command.invocation, in: markdown) != nil,
+            "`\(command.invocation)` has no section in the generated reference"
+        )
+        #expect(
+            markdown.contains("[`\(command.invocation)`](#\(command.anchor))"),
+            "`\(command.invocation)` is missing from the command index"
+        )
+    }
+
+    for (invocation, type) in commandTypesByInvocation() {
+        guard let body = section(invocation, in: markdown) else { continue }
+        for flag in longFlagNames(of: type) {
+            #expect(
+                body.contains("`\(flag)`"),
+                "`\(invocation)` accepts \(flag) but the generated reference omits it"
+            )
+        }
+    }
+}
+
+/// Flag rendering the tables are easy to get quietly wrong: `@OptionGroup`
+/// members that must be flattened in, `.customLong` names that differ from the
+/// property, repeatable options, positionals, and `.prefixedNo` inversions.
+@Test func generatedDocRendersAwkwardArgumentShapes() throws {
+    let markdown = try CLIDocs.markdown()
+
+    // @OptionGroup members belong to the command that includes the group.
+    let install = try #require(section("crow autostart install", in: markdown))
+    for flag in ["--binary", "--host", "--port", "--dev-root", "--socket", "--json"] {
+        #expect(install.contains("`\(flag)`"), "crow autostart install is missing \(flag)")
+    }
+
+    // .customLong names and repeatable options.
+    let jobAdd = try #require(section("crow job add", in: markdown))
+    #expect(jobAdd.contains("`--interval-seconds`"))
+    #expect(jobAdd.contains("`--prompt-file`"))
+    #expect(jobAdd.contains("_(repeatable)_"), "crow job add's --prompt is repeatable")
+
+    // Positional arguments have no flag name to print.
+    let setStatus = try #require(section("crow set-status", in: markdown))
+    #expect(setStatus.contains("_(positional)_"))
+    #expect(setStatus.contains("`<status>`"))
+
+    // .prefixedNo pairs collapse into one row carrying both spellings.
+    let notifications = try #require(section("crow notifications set", in: markdown))
+    #expect(notifications.contains("`--global-mute`, `--no-global-mute`"))
+
+    // Hidden commands are documented, and labelled as hidden.
+    let setPinned = try #require(section("crow set-pinned", in: markdown))
+    #expect(setPinned.contains("**Hidden**"))
+
+    // Inherited help/version flags are noted once, not repeated per command.
+    #expect(!markdown.contains("| `--help` |"))
+}
+
+// MARK: - The committed reference is current
+
+@Test func committedGeneratedDocIsUpToDate() throws {
+    let committed = try repoFile(CLIDocs.outputPath)
+    let generated = try CLIDocs.markdown()
+    // Compared as a Bool so a stale file reports one line, not both copies of a
+    // 1500-line document.
+    let current = committed == generated
+    #expect(
+        current,
+        "\(CLIDocs.outputPath) is stale — run `make docs` and commit the result"
+    )
+}
+
+// MARK: - The hand-written docs mention every command
+
+/// `docs/cli-reference.md` is the prose guide — written by hand, so it is the
+/// one that actually drifts. Requiring the full invocation path means a new verb
+/// cannot slip in behind a section that merely looks related.
+@Test func handWrittenReferenceDocumentsEveryCommand() throws {
+    let examples = codeBlocks(of: try repoFile("docs/cli-reference.md"))
+
+    /// Path → why it is deliberately absent.
+    let exempt = [
+        "crow generate-docs": "repo maintenance, not part of the control plane",
+    ]
+
+    for invocation in invocations where exempt[invocation] == nil {
+        // Bound to a Bool first: expanding `examples.contains(…)` inside the
+        // macro puts the whole 1000-line document in the failure output.
+        let documented = examples.contains(invocation)
+        #expect(
+            documented,
+            "`\(invocation)` has no worked example in docs/cli-reference.md — write it up, or exempt it with a reason"
+        )
+    }
+}
+
+/// `CLAUDE.md` doubles as the Manager tab's context, so a verb missing here is a
+/// verb the Manager agent does not know it can call. It is a curated cheat
+/// sheet rather than a full reference, so genuinely internal verbs are exempt —
+/// each with its reason, because an unexplained exemption is how drift returns.
+@Test func claudeMdDocumentsEveryUserFacingVerb() throws {
+    let claudeMD = try repoFile("CLAUDE.md")
+    let heading = "## crow CLI Reference"
+    let start = try #require(
+        claudeMD.range(of: heading), "CLAUDE.md no longer has a '\(heading)' section"
+    )
+    let rest = claudeMD[start.upperBound...]
+    let end = rest.range(of: "\n## ")?.lowerBound ?? rest.endIndex
+    let examples = codeBlocks(of: String(rest[..<end]))
+
+    let exempt = [
+        "crow setup": "first-run installer, not a control-plane verb",
+        "crow hook-event": "invoked by agent hook configs, never by hand",
+        "crow codex-notify": "invoked by Codex's notify config, never by hand",
+        "crow set-pinned": "hidden deprecated alias for set-locked",
+        "crow generate-docs": "repo maintenance, not part of the control plane",
+    ]
+
+    for invocation in invocations where exempt[invocation] == nil {
+        let documented = examples.contains(invocation)
+        #expect(
+            documented,
+            "`\(invocation)` is missing from CLAUDE.md's CLI Reference — the Manager agent reads it to learn what it can run"
+        )
+    }
+}
+
+// MARK: - Independent view of the command tree
+
+/// Walks `CommandConfiguration` a second time, keeping the concrete types so
+/// each can be dumped on its own.
+private func commandTypesByInvocation() -> [(String, ParsableCommand.Type)] {
+    var found: [(String, ParsableCommand.Type)] = []
+
+    func walk(_ type: ParsableCommand.Type, path: [String]) {
+        if path.count > 1 { found.append((path.joined(separator: " "), type)) }
+        for subcommand in type.configuration.subcommands {
+            walk(subcommand, path: path + [subcommand._commandName])
+        }
+    }
+
+    walk(CrowCommand.self, path: ["crow"])
+    return found
+}
+
+/// The long flag names one command accepts, read straight out of its own
+/// `--experimental-dump-help` payload. `--help` / `--version` are inherited by
+/// every command and documented once in the reference's preamble.
+private func longFlagNames(of type: ParsableCommand.Type) -> [String] {
+    struct Dump: Decodable {
+        struct Command: Decodable {
+            struct Argument: Decodable {
+                struct Name: Decodable {
+                    let kind: String
+                    let name: String
+                }
+                let names: [Name]?
+            }
+            let arguments: [Argument]?
+        }
+        let command: Command
+    }
+
+    guard let dump = try? JSONDecoder().decode(
+        Dump.self, from: Data(type._dumpHelp().utf8)
+    ) else { return [] }
+
+    var flags: [String] = []
+    for argument in dump.command.arguments ?? [] {
+        for name in argument.names ?? [] where name.kind == "long" {
+            let flag = "--" + name.name
+            if flag != "--help", flag != "--version" { flags.append(flag) }
+        }
+    }
+    return flags
+}

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Handy for Rust/window work, but each relaunch re-runs the launch logic and tears
 ## Documentation
 
 - [**Getting Started**](docs/getting-started.md) — Clone, build, authenticate, and run
-- [**CLI Reference**](docs/cli-reference.md) — Every `crow` subcommand and its flags
+- [**CLI Reference**](docs/cli-reference.md) — Every `crow` subcommand and its flags, with examples and gotchas
+- [**CLI (generated)**](docs/cli.md) — The same surface generated from the commands themselves; regenerate with `make docs`
 - [**Architecture**](docs/architecture.md) — Packages, key components, data flow
 - [**Configuration**](docs/configuration.md) — File locations, workspace config, directory layout, session lifecycle
 - [**Automation**](docs/automation.md) — Auto-create, auto-respond, auto-complete, and the Settings → Automation tab

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,6 +6,8 @@ All commands print JSON to stdout on success. Session and terminal identifiers a
 
 Every subcommand source lives in `Packages/CrowCLI/Sources/CrowCLILib/Commands/`.
 
+This page is the guide: what each verb is for, what it returns, and where it bites. For the exhaustive machine-generated surface — every subcommand and every flag, straight from the commands themselves — see [`cli.md`](cli.md). A test fails the build if a verb documented there is missing here (CROW-808).
+
 ---
 
 ## Setup
@@ -120,6 +122,23 @@ crow set-status --session <uuid> archived
 | ------------------------- | -------- | ------------------------------------------------------- |
 | `--session`               | yes      | Session UUID                                            |
 | *(positional)* `STATUS`   | yes      | `active`, `paused`, `inReview`, `completed`, `archived` |
+
+### `crow set-locked`
+
+Lock a session so the retention reaper leaves it alone. Cleanup deletes completed/archived sessions once they age past the `retention_hours` set under [Settings Commands](#settings-commands) — locking exempts a session from that, and unlocking returns it to the pool. Independent of status: a locked session still moves through `active` → `completed` normally, it just never gets swept.
+
+```bash
+crow set-locked --session <uuid> true
+crow set-locked --session <uuid> false
+crow set-pinned --session <uuid> true   # deprecated alias, still accepted
+```
+
+| Arg / Flag              | Required | Description                |
+| ----------------------- | -------- | -------------------------- |
+| `--session`             | yes      | Session UUID               |
+| *(positional)* `LOCKED` | yes      | `true` or `false`          |
+
+`crow set-pinned` is a deprecated alias kept working for existing scripts (the field was renamed in CROW-573). It is hidden from `crow --help` and takes the same arguments — prefer `set-locked`.
 
 ### Session lifecycle verbs
 
@@ -279,6 +298,33 @@ crow edit-link --session <uuid> --url "https://old..." --new-url "https://new...
 | `--type`    | no       | New type: `ticket`, `pr`, `repo`, or `custom`      |
 
 Provide at least one selector (`--id` / `--url`) and at least one field to change (`--label` / `--new-url` / `--type`). Returns `{"updated": N}`.
+
+### `crow transition-ticket`
+
+Move the session's linked ticket to a pipeline status on the *provider's* board. This is the provider-side counterpart to the [session lifecycle verbs](#session-lifecycle-verbs), which only write Crow's own status — moving a Jira issue or a GitHub Projects card needs this.
+
+```bash
+crow transition-ticket --session <uuid> --to inProgress
+crow transition-ticket --session <uuid> --to inReview
+crow transition-ticket --session <uuid> --to done
+```
+
+| Flag        | Required | Description                              |
+| ----------- | -------- | ---------------------------------------- |
+| `--session` | yes      | Session UUID                             |
+| `--to`      | yes      | `inProgress`, `inReview`, or `done` (matched case-insensitively) |
+
+Jira maps the pipeline status onto a real workflow transition through `jiraStatusMap` (see [Configuration](configuration.md)). Requires a linked ticket and a provider that supports transitions.
+
+### `crow resync-jira`
+
+Re-sync every Jira-backed session's ticket to the status implied by its Crow session state — one-shot remediation for tickets left in Backlog because earlier sessions never transitioned them (CROW-529).
+
+```bash
+crow resync-jira
+```
+
+Takes no arguments and walks every session, so it is safe but not cheap. Nothing happens for sessions whose ticket is not Jira-backed.
 
 ---
 
@@ -466,6 +512,123 @@ A path that isn't executable right now is **saved with a warning**, not rejected
 
 ---
 
+## Job Commands
+
+Scheduled jobs (CROW-604) are timed prompt-sets scoped to one repo in one workspace — the Jobs sidebar feature, as CLI verbs. When a job fires, Crow creates a session, clones the repo if needed, launches the configured agent, and sends the job's prompts in order.
+
+Every subcommand goes through the running app's RPC socket, so mutations land on the live in-memory config: the scheduler and the web Settings UI pick them up immediately, with no restart. Jobs are addressed by UUID (`--id`), which `crow job list` prints.
+
+### `crow job list`
+
+```bash
+crow job list
+```
+
+Returns `{"jobs": [...]}` — every job with its schedule, prompts, and `enabled` flag.
+
+### `crow job get`
+
+```bash
+crow job get --id <job-uuid>
+```
+
+| Flag   | Required | Description |
+| ------ | -------- | ----------- |
+| `--id` | yes      | Job UUID    |
+
+### `crow job add`
+
+Create a job. Prompts are sent in the order given: every `--prompt` first, then the contents of every `--prompt-file`.
+
+Exactly one schedule is required — either `--interval-seconds` or `--daily-at HH:MM`, the latter optionally narrowed with `--weekdays`.
+
+```bash
+crow job add --name "nightly-audit" --workspace Corveil --repo corveil/crow \
+  --prompt "Run the test suite and summarise failures" --daily-at 02:00
+
+crow job add --name "hourly-triage" --workspace Corveil --repo corveil/crow \
+  --prompt-file ./prompts/triage.md --interval-seconds 3600 --disabled
+```
+
+| Flag                 | Required | Description                                                            |
+| -------------------- | -------- | ---------------------------------------------------------------------- |
+| `--name`             | yes      | Job name; must be unique                                               |
+| `--workspace`        | yes      | Workspace name (a folder under the dev root)                           |
+| `--repo`             | yes      | Repository slug, `owner/repo`                                          |
+| `--prompt`           | one of   | Prompt text; repeatable, sent in order                                  |
+| `--prompt-file`      | one of   | Read a prompt from a file; repeatable. `-` reads stdin (at most once)  |
+| `--interval-seconds` | one of   | Run every N seconds                                                    |
+| `--daily-at`         | one of   | Run daily at `HH:MM`, 24-hour local time                               |
+| `--weekdays`         | no       | Comma-separated days for `--daily-at` (`sun,mon,…` or `1-7`); omit for every day |
+| `--disabled`         | no       | Create the job disabled                                                |
+
+Returns `{"job": {...}}`.
+
+### `crow job edit`
+
+Update fields on an existing job. Only the flags you pass change — with two sharp edges:
+
+- Any `--prompt` / `--prompt-file` replaces the **whole** prompt list, not appends to it.
+- Any schedule flag replaces the **whole** schedule, so changing `--weekdays` means restating `--daily-at` alongside it.
+
+```bash
+crow job edit --id <job-uuid> --name "nightly-audit-v2"
+crow job edit --id <job-uuid> --daily-at 03:30 --weekdays mon,tue,wed,thu,fri
+```
+
+| Flag                 | Required | Description                                       |
+| -------------------- | -------- | ------------------------------------------------- |
+| `--id`               | yes      | Job UUID                                          |
+| `--name`             | no       | New name; must still be unique                    |
+| `--workspace`        | no       | New workspace name                                |
+| `--repo`             | no       | New repository slug                               |
+| `--prompt`           | no       | Replacement prompt text (repeatable)              |
+| `--prompt-file`      | no       | Replacement prompt read from a file (repeatable)  |
+| `--interval-seconds` | no       | Replacement interval schedule                     |
+| `--daily-at`         | no       | Replacement daily schedule                        |
+| `--weekdays`         | no       | Weekday filter for `--daily-at`                   |
+
+At least one field flag is required. Use `enable` / `disable` rather than `edit` to toggle the enabled flag.
+
+### `crow job enable | disable`
+
+```bash
+crow job enable --id <job-uuid>
+crow job disable --id <job-uuid>
+```
+
+| Flag   | Required | Description |
+| ------ | -------- | ----------- |
+| `--id` | yes      | Job UUID    |
+
+### `crow job run`
+
+Run a job right now, whatever its schedule says and even if it is disabled.
+
+```bash
+crow job run --id <job-uuid>
+```
+
+Returns `{"job_id": "…", "session_id": "…", "terminal_id": "…"}`. Needs tmux on the daemon host. The CLI waits up to 120s because a first run may clone the repo — and the run continues inside the app even if the CLI gives up waiting.
+
+### `crow job delete`
+
+```bash
+crow job delete --id <job-uuid>
+```
+
+Returns `{"deleted": true, "job_id": "…"}`.
+
+### `crow job duplicate`
+
+Copy a job. The copy is created **disabled**, with a uniquified name, so it can be edited before it fires.
+
+```bash
+crow job duplicate --id <job-uuid>
+```
+
+---
+
 ## Worktree Commands
 
 ### `crow add-worktree`
@@ -532,6 +695,21 @@ Close a terminal tab in a session.
 ```bash
 crow close-terminal --session <uuid> --terminal <uuid>
 ```
+
+### `crow recreate-terminal`
+
+Rebuild a terminal whose tmux window has degraded scrollback (CROW-804). Kills the stale window, creates a fresh correctly-configured one at the same worktree, and relaunches the session's agent with `--continue` so the conversation carries over.
+
+```bash
+crow recreate-terminal --session <uuid> --terminal <uuid>
+```
+
+| Flag         | Required | Description   |
+| ------------ | -------- | ------------- |
+| `--session`  | yes      | Session UUID  |
+| `--terminal` | yes      | Terminal UUID |
+
+**Destructive to whatever is running in that pane** — anything mid-flight dies with the window. The web UI asks for confirmation first; from the CLI that judgement is yours.
 
 ### `crow rename-terminal`
 
@@ -1075,6 +1253,16 @@ echo '{"tool":"Bash"}' | crow hook-event --session <uuid> --event PreToolUse
 ```
 
 On success it is silent; on error it prints JSON to stdout.
+
+### `crow codex-notify`
+
+The same bridge for Codex, whose `notify` config is global rather than per-session and passes its JSON payload as the final positional argument instead of on stdin. Crow resolves the session from the payload's `cwd`, matching it against registered worktree paths — which is why no `--session` is needed (and why Codex could not supply one anyway).
+
+```bash
+crow codex-notify '{"type":"agent-turn-complete","cwd":"/path/to/worktree"}'
+```
+
+Wired up automatically when a session is handed off to Codex; you do not invoke it by hand.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,1553 @@
+<!-- Generated from ArgumentParser metadata by `crow generate-docs`. Do not edit by hand. -->
+<!-- Regenerate with `make docs` after changing anything in Packages/CrowCLI/Sources/CrowCLILib/Commands/. -->
+
+# `crow` CLI — generated reference
+
+CLI for Crow — manage sessions, terminals, and metadata.
+
+Every subcommand and flag the `crow` binary accepts, generated from the commands themselves so it cannot drift. For prose, worked examples, JSON response shapes and the gotchas that matter in practice, read [`cli-reference.md`](cli-reference.md) instead — this file is the exhaustive surface, that one is the guide.
+
+`--help` is accepted everywhere and `crow --version` prints the build version; neither is repeated per command below. Commands marked **hidden** are omitted from `crow --help` but still work.
+
+---
+
+## Command index
+
+| Command | Summary |
+| --- | --- |
+| [`crow add-link`](#crow-add-link) | Add a link to a session |
+| [`crow add-merge-label`](#crow-add-merge-label) | Add the crow:merge label to the session's PR |
+| [`crow add-worktree`](#crow-add-worktree) | Register a worktree for a session |
+| [`crow autostart`](#crow-autostart) | Start crowd at login (install/uninstall/status) |
+| [`crow autostart install`](#crow-autostart-install) | Register crowd to start at login (idempotent; re-points after an upgrade) |
+| [`crow autostart status`](#crow-autostart-status) | Report whether crowd is set to start at login, and whether it's running |
+| [`crow autostart uninstall`](#crow-autostart-uninstall) | Remove the login item (leaves a running crowd alone) |
+| [`crow batch-work-on-issues`](#crow-batch-work-on-issues) | Start working on several tickets in one batch |
+| [`crow cleanup`](#crow-cleanup) | View or change automatic session cleanup |
+| [`crow cleanup get`](#crow-cleanup-get) | Show the current cleanup settings |
+| [`crow cleanup set`](#crow-cleanup-set) | Change automatic session cleanup |
+| [`crow close-terminal`](#crow-close-terminal) | Close a terminal tab in a session |
+| [`crow codex-notify`](#crow-codex-notify) | Bridge Codex's notify command into Crow's hook-event pipeline |
+| [`crow complete-session`](#crow-complete-session) | Mark a session completed |
+| [`crow create-manager`](#crow-create-manager) | Create an additional Manager session |
+| [`crow defaults`](#crow-defaults) | View or change workspace and automation defaults |
+| [`crow defaults get`](#crow-defaults-get) | Show the current workspace and automation defaults |
+| [`crow defaults set`](#crow-defaults-set) | Change workspace and automation defaults |
+| [`crow delete-session`](#crow-delete-session) | Delete a session |
+| [`crow edit-link`](#crow-edit-link) | Edit a link's label, URL, or type in place |
+| [`crow gateway`](#crow-gateway) | Manage AI gateways (local-only) |
+| [`crow gateway clear`](#crow-gateway-clear) | Remove a gateway |
+| [`crow gateway get`](#crow-gateway-get) | Show a gateway's base URL and header names |
+| [`crow gateway set`](#crow-gateway-set) | Set a gateway's base URL and headers |
+| [`crow generate-docs`](#crow-generate-docs) | Regenerate the generated CLI reference from ArgumentParser metadata |
+| [`crow get-scorecard`](#crow-get-scorecard) | Print the efficiency scorecard as JSON |
+| [`crow get-session`](#crow-get-session) | Get session details |
+| [`crow get-state`](#crow-get-state) | Print the daemon's full render-state snapshot as JSON |
+| [`crow handoff-agent`](#crow-handoff-agent) | Switch a session to a different coding agent (e.g. when credits run out) |
+| [`crow hook-event`](#crow-hook-event) | Forward an agent hook event to the app (reads JSON from stdin) |
+| [`crow job`](#crow-job) | Manage scheduled jobs |
+| [`crow job add`](#crow-job-add) | Create a job |
+| [`crow job delete`](#crow-job-delete) | Delete a job |
+| [`crow job disable`](#crow-job-disable) | Disable a job |
+| [`crow job duplicate`](#crow-job-duplicate) | Duplicate a job (the copy starts disabled with a unique name) |
+| [`crow job edit`](#crow-job-edit) | Update fields on an existing job |
+| [`crow job enable`](#crow-job-enable) | Enable a job |
+| [`crow job get`](#crow-job-get) | Show one job's full details |
+| [`crow job list`](#crow-job-list) | List all jobs |
+| [`crow job run`](#crow-job-run) | Run a job now, regardless of its schedule or enabled flag |
+| [`crow launch-agent`](#crow-launch-agent) | Launch the session's coding agent in a ready terminal |
+| [`crow list-allowlist`](#crow-list-allowlist) | List allowlist patterns and where each one is defined |
+| [`crow list-artifacts`](#crow-list-artifacts) | List images an agent dropped in a session's artifacts directory |
+| [`crow list-links`](#crow-list-links) | List links for a session |
+| [`crow list-reviews`](#crow-list-reviews) | List requested PR reviews (with unseen count and loading state) |
+| [`crow list-sessions`](#crow-list-sessions) | List all sessions |
+| [`crow list-terminals`](#crow-list-terminals) | List terminals for a session |
+| [`crow list-tickets`](#crow-list-tickets) | List the ticket board (issues, per-status counts, loading state) |
+| [`crow list-worktrees`](#crow-list-worktrees) | List worktrees for a session |
+| [`crow mark-in-review`](#crow-mark-in-review) | Move a session to In Review |
+| [`crow mark-issue-done`](#crow-mark-issue-done) | Close the session's linked issue and complete the session |
+| [`crow new-session`](#crow-new-session) | Create a new session |
+| [`crow new-terminal`](#crow-new-terminal) | Create a terminal tab inside Crow (tmux) |
+| [`crow notifications`](#crow-notifications) | Read and write notification settings |
+| [`crow notifications get`](#crow-notifications-get) | Show notification settings |
+| [`crow notifications set`](#crow-notifications-set) | Change notification settings |
+| [`crow open-in-vscode`](#crow-open-in-vscode) | Open the session's worktree in VS Code on the host |
+| [`crow open-terminal`](#crow-open-terminal) | Open a macOS Terminal.app window at the session's worktree (host GUI) |
+| [`crow promote-allowlist`](#crow-promote-allowlist) | Copy worktree-local allowlist patterns into ~/.claude/settings.json |
+| [`crow quick-action`](#crow-quick-action) | Dispatch a PR quick action into a session's agent terminal |
+| [`crow rebuild-scorecard`](#crow-rebuild-scorecard) | Backfill analytics snapshots and recompute the scorecard |
+| [`crow recreate-terminal`](#crow-recreate-terminal) | Recreate a terminal to restore full scrollback (CROW-804) |
+| [`crow refresh-allowlist`](#crow-refresh-allowlist) | Re-scan global and worktree settings files for allowlist patterns |
+| [`crow refresh-tickets`](#crow-refresh-tickets) | Re-poll the ticket provider now |
+| [`crow reload-tmux-config`](#crow-reload-tmux-config) | Reload the bundled tmux config into the running server |
+| [`crow remove-link`](#crow-remove-link) | Remove a link from a session |
+| [`crow rename-session`](#crow-rename-session) | Rename a session |
+| [`crow rename-terminal`](#crow-rename-terminal) | Rename a terminal tab |
+| [`crow restart-manager`](#crow-restart-manager) | Relaunch the Manager's agent process in place |
+| [`crow restart-tmux-server`](#crow-restart-tmux-server) | Restart the tmux server, rebuilding every terminal (destructive) |
+| [`crow resync-jira`](#crow-resync-jira) | Re-sync Jira ticket statuses from Crow session state |
+| [`crow retry-readiness`](#crow-retry-readiness) | Re-arm the readiness watch for a stuck terminal |
+| [`crow select-session`](#crow-select-session) | Switch to a session |
+| [`crow send`](#crow-send) | Send text to a terminal |
+| [`crow set-goal`](#crow-set-goal) | Set or clear the org-goal tag on a session |
+| [`crow set-locked`](#crow-set-locked) | Lock/unlock a session to protect it from auto-cleanup |
+| [`crow set-pinned`](#crow-set-pinned) | Deprecated alias for set-locked |
+| [`crow set-session-active`](#crow-set-session-active) | Return a session to active |
+| [`crow set-status`](#crow-set-status) | Set session status |
+| [`crow set-ticket`](#crow-set-ticket) | Set ticket metadata |
+| [`crow setup`](#crow-setup) | First-time setup for Crow |
+| [`crow start-review`](#crow-start-review) | Start a review session for a pull request |
+| [`crow telemetry`](#crow-telemetry) | View or change session-analytics collection |
+| [`crow telemetry get`](#crow-telemetry-get) | Show the current telemetry settings |
+| [`crow telemetry set`](#crow-telemetry-set) | Change telemetry settings |
+| [`crow transition-ticket`](#crow-transition-ticket) | Transition a session's ticket to a pipeline status |
+| [`crow ui`](#crow-ui) | View or change UI display preferences |
+| [`crow ui get`](#crow-ui-get) | Show the current UI display preferences |
+| [`crow ui set`](#crow-ui-set) | Change UI display preferences |
+| [`crow web-password`](#crow-web-password) | Manage the web-access password (local-only) |
+| [`crow web-password clear`](#crow-web-password-clear) | Remove the web-access password |
+| [`crow web-password set`](#crow-web-password-set) | Set or change the web-access password |
+| [`crow web-password status`](#crow-web-password-status) | Report whether a web-access password is set |
+| [`crow work-on-issue`](#crow-work-on-issue) | Start working on a ticket (types /crow-workspace into the Manager) |
+
+---
+
+## `crow add-link`
+
+Add a link to a session.
+
+```
+crow add-link --session <session> --label <label> --url <url> [--type <type>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--label` | `<label>` | yes | Link label |
+| `--url` | `<url>` | yes | Link URL |
+| `--type` | `<type>` | no | Link type: ticket, pr, repo, custom. Default: `custom`. |
+
+---
+
+## `crow add-merge-label`
+
+Add the crow:merge label to the session's PR.
+
+```
+crow add-merge-label --session <session>
+```
+
+Requires a linked PR (attach one with `crow add-link --type pr --url …`) and a provider whose backend supports auto-merge labels.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow add-worktree`
+
+Register a worktree for a session.
+
+```
+crow add-worktree --session <session> --repo <repo> --path <path> --branch <branch> [--repo-path <repo-path>] [--primary]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--repo` | `<repo>` | yes | Repo name |
+| `--path` | `<path>` | yes | Worktree path |
+| `--branch` | `<branch>` | yes | Branch name |
+| `--repo-path` | `<repo-path>` | no | Main repo path (for git commands) |
+| `--primary` | — | no | Mark as primary worktree |
+
+---
+
+## `crow autostart`
+
+Start crowd at login (install/uninstall/status).
+
+```
+crow autostart [install|uninstall|status]
+```
+
+Subcommands: [`install`](#crow-autostart-install), [`uninstall`](#crow-autostart-uninstall), [`status`](#crow-autostart-status).
+
+Bare `crow autostart` runs `status`.
+
+---
+
+## `crow autostart install`
+
+Register crowd to start at login (idempotent; re-points after an upgrade).
+
+```
+crow autostart install [--binary <binary>] [--host <host>] [--port <port>] [--dev-root <dev-root>] [--socket <socket>] [--json]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--binary` | `<binary>` | no | Path to the crowd binary, launched at login as-is (default: next to this crow, then PATH) |
+| `--host` | `<host>` | no | Bind host to pass to crowd (default: crowd's own default) |
+| `--port` | `<port>` | no | HTTP port to pass to crowd |
+| `--dev-root` | `<dev-root>` | no | Development root to pass to crowd |
+| `--socket` | `<socket>` | no | Unix socket path to pass to crowd |
+| `--json` | — | no | Print the status as JSON |
+
+---
+
+## `crow autostart status`
+
+Report whether crowd is set to start at login, and whether it's running.
+
+```
+crow autostart status [--binary <binary>] [--socket <socket>] [--json]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--binary` | `<binary>` | no | Path to the crowd binary to compare against (stale-plist detection) |
+| `--socket` | `<socket>` | no | Unix socket to probe for a running crowd (default: the login item's, else the well-known socket) |
+| `--json` | — | no | Print the status as JSON |
+
+---
+
+## `crow autostart uninstall`
+
+Remove the login item (leaves a running crowd alone).
+
+```
+crow autostart uninstall [--json]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--json` | — | no | Print the status as JSON |
+
+---
+
+## `crow batch-work-on-issues`
+
+Start working on several tickets in one batch.
+
+```
+crow batch-work-on-issues [--url <url> ...] [--urls-file <urls-file>]
+```
+
+URLs are sent in order: every --url first, then the lines of --urls-file. Malformed URLs are not rejected locally — the daemon drops them into the `rejected` array and starts the rest, so one bad ticket can't block the batch.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--url` | `<url>` _(repeatable)_ | no | Ticket / issue URL (repeatable) |
+| `--urls-file` | `<urls-file>` | no | Read newline-delimited URLs from a file; '-' reads stdin |
+
+---
+
+## `crow cleanup`
+
+View or change automatic session cleanup.
+
+```
+crow cleanup <get|set>
+```
+
+Subcommands: [`get`](#crow-cleanup-get), [`set`](#crow-cleanup-set).
+
+---
+
+## `crow cleanup get`
+
+Show the current cleanup settings.
+
+```
+crow cleanup get
+```
+
+---
+
+## `crow cleanup set`
+
+Change automatic session cleanup.
+
+```
+crow cleanup set [--enabled <enabled>] [--retention-hours <retention-hours>]
+```
+
+Only the flags you pass change; at least one is required.
+
+Auto-cleanup deletes completed and archived sessions after the retention period, including their worktree and branch. Manager, virtual, and locked sessions are never deleted.
+
+This setting is live: the board poll re-reads it from disk each cycle, so enabling it starts deleting eligible sessions within about a minute. No restart, and no confirmation prompt.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--enabled` | `<enabled>` | no | Enable auto-cleanup (true or false) |
+| `--retention-hours` | `<retention-hours>` | no | Hours to keep completed/archived sessions (minimum 1, default 24) |
+
+---
+
+## `crow close-terminal`
+
+Close a terminal tab in a session.
+
+```
+crow close-terminal --session <session> --terminal <terminal>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--terminal` | `<terminal>` | yes | Terminal UUID |
+
+---
+
+## `crow codex-notify`
+
+Bridge Codex's notify command into Crow's hook-event pipeline.
+
+```
+crow codex-notify [<payload-arg> ...]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| _(positional)_ | `<payload-arg>` _(repeatable)_ | no | Codex notify JSON payload (final positional arg) |
+
+---
+
+## `crow complete-session`
+
+Mark a session completed.
+
+```
+crow complete-session --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow create-manager`
+
+Create an additional Manager session.
+
+```
+crow create-manager [--agent <agent>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--agent` | `<agent>` | no | Coding agent kind (claude-code, cursor, codex, opencode); default agent when omitted |
+
+---
+
+## `crow defaults`
+
+View or change workspace and automation defaults.
+
+```
+crow defaults <get|set>
+```
+
+These are the `defaults` block of config.json: the forge provider and CLI used for new workspaces, the branch prefix for new session branches, the repo/label lists that filter the review and ticket boards, and the binary path overrides.
+
+Subcommands: [`get`](#crow-defaults-get), [`set`](#crow-defaults-set).
+
+---
+
+## `crow defaults get`
+
+Show the current workspace and automation defaults.
+
+```
+crow defaults get
+```
+
+Echoes the whole defaults block, including `exclude_dirs` and `mirror_claude_mcp_to_codex`, which `set` does not write — neither has a Settings UI either, and omitting them would make this a worse answer to "what is my config?".
+
+`config_readable` is false when config.json exists but could not be decoded: the values shown are then the built-in defaults rather than yours, which matters when you are working out why a filter isn't firing.
+
+---
+
+## `crow defaults set`
+
+Change workspace and automation defaults.
+
+```
+crow defaults set [--provider <provider>] [--cli <cli>] [--branch-prefix <branch-prefix>] [--binary <binary> ...] [--add-exclude-review-repo <add-exclude-review-repo> ...] [--remove-exclude-review-repo <remove-exclude-review-repo> ...] [--clear-exclude-review-repos] [--add-exclude-ticket-repo <add-exclude-ticket-repo> ...] [--remove-exclude-ticket-repo <remove-exclude-ticket-repo> ...] [--clear-exclude-ticket-repos] [--add-ignore-review-label <add-ignore-review-label> ...] [--remove-ignore-review-label <remove-ignore-review-label> ...] [--clear-ignore-review-labels]
+```
+
+Only the flags you pass change; at least one is required.
+
+Most of these are live. The provider and CLI are re-read on each repo scan, the board lists are re-read on each board poll (about a minute), and the branch prefix is read when a workspace is created. --binary is the exception: agent binary discovery and the .claude/bin symlinks are both set up at startup, so a change there returns "restart_required" and needs a crowd restart — including when you remove one, since the stale symlink keeps shadowing PATH until then.
+
+--provider and --cli are stored independently and neither implies the other, matching how GitManager reads them; setting only one warns if the resulting pair is crossed.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--provider` | `<provider>` | no | Forge for new workspaces (github or gitlab) |
+| `--cli` | `<cli>` | no | Forge CLI for new workspaces (gh or glab) |
+| `--branch-prefix` | `<branch-prefix>` | no | Prefix for new session branches, e.g. 'feature/' (empty for none) |
+| `--binary` | `<binary>` _(repeatable)_ | no | Binary path override as NAME=PATH, e.g. corveil=/opt/corveil/bin/corveil; NAME= removes it (repeatable) |
+| `--add-exclude-review-repo` | `<add-exclude-review-repo>` _(repeatable)_ | no | Repo to hide from the review board; supports one wildcard, e.g. 'owner/*' (repeatable) |
+| `--remove-exclude-review-repo` | `<remove-exclude-review-repo>` _(repeatable)_ | no | Repo to stop hiding from the review board (repeatable) |
+| `--clear-exclude-review-repos` | — | no | Empty the review-board repo exclusions |
+| `--add-exclude-ticket-repo` | `<add-exclude-ticket-repo>` _(repeatable)_ | no | Repo to hide from the ticket board; supports one wildcard (repeatable) |
+| `--remove-exclude-ticket-repo` | `<remove-exclude-ticket-repo>` _(repeatable)_ | no | Repo to stop hiding from the ticket board (repeatable) |
+| `--clear-exclude-ticket-repos` | — | no | Empty the ticket-board repo exclusions |
+| `--add-ignore-review-label` | `<add-ignore-review-label>` _(repeatable)_ | no | PR label that hides a review from the board; exact match, no wildcards (repeatable) |
+| `--remove-ignore-review-label` | `<remove-ignore-review-label>` _(repeatable)_ | no | PR label to stop ignoring (repeatable) |
+| `--clear-ignore-review-labels` | — | no | Empty the ignored review labels |
+
+---
+
+## `crow delete-session`
+
+Delete a session.
+
+```
+crow delete-session --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow edit-link`
+
+Edit a link's label, URL, or type in place.
+
+```
+crow edit-link --session <session> [--id <id>] [--url <url>] [--label <label>] [--new-url <new-url>] [--type <type>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--id` | `<id>` | no | Link ID (from list-links) |
+| `--url` | `<url>` | no | Current link URL to match (alternative to --id) |
+| `--label` | `<label>` | no | New label |
+| `--new-url` | `<new-url>` | no | New URL |
+| `--type` | `<type>` | no | New link type: ticket, pr, repo, custom |
+
+---
+
+## `crow gateway`
+
+Manage AI gateways (local-only).
+
+```
+crow gateway <get|set|clear>
+```
+
+Subcommands: [`get`](#crow-gateway-get), [`set`](#crow-gateway-set), [`clear`](#crow-gateway-clear).
+
+---
+
+## `crow gateway clear`
+
+Remove a gateway.
+
+```
+crow gateway clear [--manager] [--workspace <workspace>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--manager` | — | no | Target the Manager AI gateway |
+| `--workspace` | `<workspace>` | no | Target a workspace's AI gateway (workspace name or UUID) |
+
+---
+
+## `crow gateway get`
+
+Show a gateway's base URL and header names.
+
+```
+crow gateway get [--manager] [--workspace <workspace>] [--reveal]
+```
+
+Header values are blanked by default so the output is safe to share. Pass --reveal to print the stored values (which may be op:// references rather than the secrets themselves).
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--manager` | — | no | Target the Manager AI gateway |
+| `--workspace` | `<workspace>` | no | Target a workspace's AI gateway (workspace name or UUID) |
+| `--reveal` | — | no | Print header values instead of blanking them |
+
+---
+
+## `crow gateway set`
+
+Set a gateway's base URL and headers.
+
+```
+crow gateway set [--manager] [--workspace <workspace>] --base-url <base-url> [--header <header> ...]
+```
+
+Replaces the whole gateway: --base-url and at least one --header are both required (a gateway needs both, or neither). A --header with a blank value keeps the secret already stored under that name, so the base URL can be changed without restating credentials:
+
+```
+crow gateway set --manager --base-url https://gw.example.com --header "X-Api-Key:"
+```
+
+Header values may be op:// 1Password references, resolved at agent launch so the secret never rests in config.json.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--manager` | — | no | Target the Manager AI gateway |
+| `--workspace` | `<workspace>` | no | Target a workspace's AI gateway (workspace name or UUID) |
+| `--base-url` | `<base-url>` | yes | Gateway base URL |
+| `--header` | `<header>` _(repeatable)_ | no | Header as 'Name: Value' (repeatable) |
+
+---
+
+## `crow generate-docs`
+
+Regenerate the generated CLI reference from ArgumentParser metadata.
+
+**Hidden** — not listed in `crow --help`.
+
+```
+crow generate-docs [--output <output>] [--check]
+```
+
+Writes every subcommand and flag the binary accepts to docs/cli.md. Run it after adding or changing a command; `make docs` does exactly this. Use --check in a script to assert the committed file is current without writing anything — it exits non-zero when the file is stale or missing.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--output` | `<output>` | no | Path to write (default: docs/cli.md, relative to the current directory) |
+| `--check` | — | no | Verify the file on disk instead of writing it; exits non-zero when stale |
+
+---
+
+## `crow get-scorecard`
+
+Print the efficiency scorecard as JSON.
+
+```
+crow get-scorecard
+```
+
+Grade, weekly rollups, baseline medians, and per-session rows. Grading runs daemon-side so the CLI, web, and desktop can never drift. With telemetry off the result is an empty shell — check telemetryEnabled and snapshotCount. All timestamps are epoch milliseconds.
+
+---
+
+## `crow get-session`
+
+Get session details.
+
+```
+crow get-session --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow get-state`
+
+Print the daemon's full render-state snapshot as JSON.
+
+```
+crow get-state
+```
+
+Sessions, terminals, worktrees, links, PR status, review requests, assigned issues, allowlist entries, and config (credentials stripped). This is the whole snapshot in one call and it is large — prefer list-sessions / get-session / list-links when you want one slice.
+
+---
+
+## `crow handoff-agent`
+
+Switch a session to a different coding agent (e.g. when credits run out).
+
+```
+crow handoff-agent --session <session> --agent <agent> [--note <note>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--agent` | `<agent>` | yes | Target agent kind (claude-code, cursor, codex, opencode, antigravity) |
+| `--note` | `<note>` | no | Optional note for the incoming agent about where to resume |
+
+---
+
+## `crow hook-event`
+
+Forward an agent hook event to the app (reads JSON from stdin).
+
+```
+crow hook-event [--session <session>] --event <event> [--agent <agent>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | no | Session UUID (omit to resolve from payload cwd) |
+| `--event` | `<event>` | yes | Event name (e.g., Stop, Notification, PreToolUse) |
+| `--agent` | `<agent>` | no | Agent kind (e.g., claude-code, codex). Defaults to the session's stored agent. |
+
+---
+
+## `crow job`
+
+Manage scheduled jobs.
+
+```
+crow job <list|get|add|edit|enable|disable|run|delete|duplicate>
+```
+
+Subcommands: [`list`](#crow-job-list), [`get`](#crow-job-get), [`add`](#crow-job-add), [`edit`](#crow-job-edit), [`enable`](#crow-job-enable), [`disable`](#crow-job-disable), [`run`](#crow-job-run), [`delete`](#crow-job-delete), [`duplicate`](#crow-job-duplicate).
+
+---
+
+## `crow job add`
+
+Create a job.
+
+```
+crow job add --name <name> --workspace <workspace> --repo <repo> [--prompt <prompt> ...] [--prompt-file <prompt-file> ...] [--interval-seconds <interval-seconds>] [--daily-at <daily-at>] [--weekdays <weekdays>] [--disabled]
+```
+
+Prompts are sent in order: every --prompt first, then the contents of every --prompt-file. Exactly one schedule is required: --interval-seconds or --daily-at HH:MM (optionally restricted with --weekdays).
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--name` | `<name>` | yes | Job name (must be unique) |
+| `--workspace` | `<workspace>` | yes | Workspace name (folder under the dev root) |
+| `--repo` | `<repo>` | yes | Repository slug (owner/repo) |
+| `--prompt` | `<prompt>` _(repeatable)_ | no | Prompt text (repeatable; sent in order) |
+| `--prompt-file` | `<prompt-file>` _(repeatable)_ | no | Read a prompt from a file; '-' reads stdin (repeatable) |
+| `--interval-seconds` | `<interval-seconds>` | no | Run every N seconds |
+| `--daily-at` | `<daily-at>` | no | Run daily at HH:MM (24-hour, local time) |
+| `--weekdays` | `<weekdays>` | no | Comma-separated weekdays for --daily-at (sun,mon,… or 1-7); omit for every day |
+| `--disabled` | — | no | Create the job disabled |
+
+---
+
+## `crow job delete`
+
+Delete a job.
+
+```
+crow job delete --id <id>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+
+---
+
+## `crow job disable`
+
+Disable a job.
+
+```
+crow job disable --id <id>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+
+---
+
+## `crow job duplicate`
+
+Duplicate a job (the copy starts disabled with a unique name).
+
+```
+crow job duplicate --id <id>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+
+---
+
+## `crow job edit`
+
+Update fields on an existing job.
+
+```
+crow job edit --id <id> [--name <name>] [--workspace <workspace>] [--repo <repo>] [--prompt <prompt> ...] [--prompt-file <prompt-file> ...] [--interval-seconds <interval-seconds>] [--daily-at <daily-at>] [--weekdays <weekdays>]
+```
+
+Only the provided flags change; everything else keeps its value. Any --prompt/--prompt-file replaces the job's whole prompt list, and any schedule flag replaces the whole schedule — so changing --weekdays requires restating --daily-at. Use enable/disable to toggle the enabled flag.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+| `--name` | `<name>` | no | New job name (must be unique) |
+| `--workspace` | `<workspace>` | no | New workspace name |
+| `--repo` | `<repo>` | no | New repository slug (owner/repo) |
+| `--prompt` | `<prompt>` _(repeatable)_ | no | Replacement prompt text (repeatable; replaces all prompts) |
+| `--prompt-file` | `<prompt-file>` _(repeatable)_ | no | Read a replacement prompt from a file; '-' reads stdin (repeatable) |
+| `--interval-seconds` | `<interval-seconds>` | no | Run every N seconds |
+| `--daily-at` | `<daily-at>` | no | Run daily at HH:MM (24-hour, local time) |
+| `--weekdays` | `<weekdays>` | no | Comma-separated weekdays for --daily-at (sun,mon,… or 1-7); omit for every day |
+
+---
+
+## `crow job enable`
+
+Enable a job.
+
+```
+crow job enable --id <id>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+
+---
+
+## `crow job get`
+
+Show one job's full details.
+
+```
+crow job get --id <id>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+
+---
+
+## `crow job list`
+
+List all jobs.
+
+```
+crow job list
+```
+
+---
+
+## `crow job run`
+
+Run a job now, regardless of its schedule or enabled flag.
+
+```
+crow job run --id <id>
+```
+
+Returns the launched session and terminal ids. The run continues in the app even if the CLI times out waiting (e.g. while a repo is cloned on demand).
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--id` | `<id>` | yes | Job UUID |
+
+---
+
+## `crow launch-agent`
+
+Launch the session's coding agent in a ready terminal.
+
+```
+crow launch-agent --terminal <terminal>
+```
+
+Takes only `--terminal` — the terminal id alone identifies the surface, so unlike `new-terminal` / `send` there is no `--session` flag.
+
+The daemon applies this only to a terminal that is shell-ready and still pending auto-launch; in any other state it is a no-op. `{"ok": true}` means the request was accepted, not that an agent was started.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--terminal` | `<terminal>` | yes | Terminal UUID |
+
+---
+
+## `crow list-allowlist`
+
+List allowlist patterns and where each one is defined.
+
+```
+crow list-allowlist
+```
+
+Reads the daemon's last scan rather than re-reading disk — run refresh-allowlist first if a settings file changed underneath it.
+
+---
+
+## `crow list-artifacts`
+
+List images an agent dropped in a session's artifacts directory.
+
+```
+crow list-artifacts --session <session>
+```
+
+Each image reports an absolute on-disk path plus a url that only resolves against the daemon's own web server. The directory is the one agents see as $CROW_ARTIFACTS_DIR; it lives under $TMPDIR and does not survive a reboot.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow list-links`
+
+List links for a session.
+
+```
+crow list-links --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow list-reviews`
+
+List requested PR reviews (with unseen count and loading state).
+
+```
+crow list-reviews
+```
+
+---
+
+## `crow list-sessions`
+
+List all sessions.
+
+```
+crow list-sessions
+```
+
+---
+
+## `crow list-terminals`
+
+List terminals for a session.
+
+```
+crow list-terminals --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow list-tickets`
+
+List the ticket board (issues, per-status counts, loading state).
+
+```
+crow list-tickets
+```
+
+---
+
+## `crow list-worktrees`
+
+List worktrees for a session.
+
+```
+crow list-worktrees --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow mark-in-review`
+
+Move a session to In Review.
+
+```
+crow mark-in-review --session <session>
+```
+
+Requires a linked ticket (attach one with `crow set-ticket --url …`). Writes session status only — use `crow transition-ticket --to inReview` to move the provider's board.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow mark-issue-done`
+
+Close the session's linked issue and complete the session.
+
+```
+crow mark-issue-done --session <session>
+```
+
+GitHub/GitLab close the issue; Jira and Corveil transition it to the mapped done status. On success the session flips to completed. Requires a linked ticket and a provider-configured daemon.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow new-session`
+
+Create a new session.
+
+```
+crow new-session --name <name> [--kind <kind>] [--agent <agent>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--name` | `<name>` | yes | Session name |
+| `--kind` | `<kind>` | no | Session kind: work (default) or manager |
+| `--agent` | `<agent>` | no | Agent kind (e.g. claude-code). Defaults to the configured default agent. |
+
+---
+
+## `crow new-terminal`
+
+Create a terminal tab inside Crow (tmux).
+
+```
+crow new-terminal --session <session> --cwd <cwd> [--name <name>] [--command <command>] [--managed]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--cwd` | `<cwd>` | yes | Working directory |
+| `--name` | `<name>` | no | Terminal name |
+| `--command` | `<command>` | no | Command to run |
+| `--managed` | — | no | Mark as managed Claude Code terminal |
+
+---
+
+## `crow notifications`
+
+Read and write notification settings.
+
+```
+crow notifications <get|set>
+```
+
+Notifications cascade: a notification fires only if globalMute is off, the matching global category toggle is on, AND the per-event toggle is on. Global flags apply to every event; the --event-* flags apply to the single event named by --event.
+
+Subcommands: [`get`](#crow-notifications-get), [`set`](#crow-notifications-set).
+
+---
+
+## `crow notifications get`
+
+Show notification settings.
+
+```
+crow notifications get [--event <event>]
+```
+
+Lists the global toggles, every event's effective settings, and the built-in sound names. Events absent from config.json are reported with the defaults they will actually fire with. --event narrows the event list to one entry; the global toggles are always included, since they can be the reason an event never fires.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--event` | `<event>` | no | Restrict the event list to one event. Values: `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoRebasePushed`, `autoRebaseConflicts`, `configReloaded`. |
+
+---
+
+## `crow notifications set`
+
+Change notification settings.
+
+```
+crow notifications set [--global-mute|--no-global-mute] [--sound-enabled|--no-sound-enabled] [--system-notifications-enabled|--no-system-notifications-enabled] [--event <event>] [--event-enabled|--no-event-enabled] [--event-sound-enabled|--no-event-sound-enabled] [--event-system-notification-enabled|--no-event-system-notification-enabled] [--event-sound-name <event-sound-name>]
+```
+
+Only the provided flags change; everything else keeps its value. Each toggle takes a --flag / --no-flag pair. The --event-* flags require --event and apply to that event alone. --event-sound-name accepts the built-in sounds listed by `crow notifications get` (case-insensitive).
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--global-mute`, `--no-global-mute` | — | no | Master mute — suppresses every sound and system notification |
+| `--sound-enabled`, `--no-sound-enabled` | — | no | Global sound-playback toggle |
+| `--system-notifications-enabled`, `--no-system-notifications-enabled` | — | no | Global system-notification toggle |
+| `--event` | `<event>` | no | Event to change (required by every --event-* flag). Values: `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoRebasePushed`, `autoRebaseConflicts`, `configReloaded`. |
+| `--event-enabled`, `--no-event-enabled` | — | no | Whether this event notifies at all |
+| `--event-sound-enabled`, `--no-event-sound-enabled` | — | no | Whether this event plays a sound |
+| `--event-system-notification-enabled`, `--no-event-system-notification-enabled` | — | no | Whether this event posts a system notification |
+| `--event-sound-name` | `<event-sound-name>` | no | Sound for this event (a built-in sound name) |
+
+---
+
+## `crow open-in-vscode`
+
+Open the session's worktree in VS Code on the host.
+
+```
+crow open-in-vscode --session <session>
+```
+
+Launches the `code` CLI at the session's primary worktree. Requires that CLI on PATH (or in a standard VS Code install location) and a worktree attached to the session.
+
+Host-app launches are restricted to local callers; the CLI qualifies, since it talks to the daemon over its Unix socket.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow open-terminal`
+
+Open a macOS Terminal.app window at the session's worktree (host GUI).
+
+```
+crow open-terminal --session <session>
+```
+
+This is NOT a Crow terminal tab — it opens Terminal.app on the daemon host, cd'd to the session's primary worktree. Use `new-terminal` to create a tab inside Crow.
+
+macOS only. Host-app launches are restricted to local callers; the CLI qualifies, since it talks to the daemon over its Unix socket.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow promote-allowlist`
+
+Copy worktree-local allowlist patterns into ~/.claude/settings.json.
+
+```
+crow promote-allowlist [--pattern <pattern> ...]
+```
+
+Patterns already in the global file are reported under already_global and left alone. Quote patterns — parentheses and '*' are shell metacharacters: --pattern 'Bash(npm test:*)'.
+
+Promote everything not yet global:
+```
+crow list-allowlist | jq -r '.entries[] | select(.is_global | not) | "--pattern", .pattern' | xargs crow promote-allowlist
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--pattern` | `<pattern>` _(repeatable)_ | no | Allowlist pattern to promote, e.g. 'Bash(npm test:*)' (repeatable) |
+
+---
+
+## `crow quick-action`
+
+Dispatch a PR quick action into a session's agent terminal.
+
+```
+crow quick-action --session <session> --action <action>
+```
+
+A skipped dispatch is reported as {"dispatched": false, "reason": "…"} with a zero exit code — the RPC succeeded, the session just had no terminal to send to (or no linked PR). Check `dispatched` rather than the exit code.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--action` | `<action>` | yes | Action: fixConflicts, addressChanges, fixChecks, mergePR, reReview |
+
+---
+
+## `crow rebuild-scorecard`
+
+Backfill analytics snapshots and recompute the scorecard.
+
+```
+crow rebuild-scorecard
+```
+
+Idempotent, and overlapping callers coalesce into one rebuild. Errors when telemetry is disabled — there is no database to rebuild from.
+
+---
+
+## `crow recreate-terminal`
+
+Recreate a terminal to restore full scrollback (CROW-804).
+
+```
+crow recreate-terminal --session <session> --terminal <terminal>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--terminal` | `<terminal>` | yes | Terminal UUID |
+
+---
+
+## `crow refresh-allowlist`
+
+Re-scan global and worktree settings files for allowlist patterns.
+
+```
+crow refresh-allowlist
+```
+
+---
+
+## `crow refresh-tickets`
+
+Re-poll the ticket provider now.
+
+```
+crow refresh-tickets
+```
+
+---
+
+## `crow reload-tmux-config`
+
+Reload the bundled tmux config into the running server.
+
+```
+crow reload-tmux-config
+```
+
+Runs `tmux source-file` against the bundled crow-tmux.conf. Non-destructive: windows, sessions, and running agents are unaffected. Errors if the tmux server isn't running or the bundled config is missing.
+
+---
+
+## `crow remove-link`
+
+Remove a link from a session.
+
+```
+crow remove-link --session <session> [--id <id>] [--url <url>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--id` | `<id>` | no | Link ID (from list-links) |
+| `--url` | `<url>` | no | Link URL (alternative to --id) |
+
+---
+
+## `crow rename-session`
+
+Rename a session.
+
+```
+crow rename-session --session <session> <name>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| _(positional)_ | `<name>` | yes | New name |
+
+---
+
+## `crow rename-terminal`
+
+Rename a terminal tab.
+
+```
+crow rename-terminal --session <session> --terminal <terminal> <name>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--terminal` | `<terminal>` | yes | Terminal UUID |
+| _(positional)_ | `<name>` | yes | New name |
+
+---
+
+## `crow restart-manager`
+
+Relaunch the Manager's agent process in place.
+
+```
+crow restart-manager
+```
+
+Tears down the Manager's dead terminal surface and recreates a fresh one (new terminal UUID) with the current remote-control / auto-permission args. The Manager session row and its id are preserved.
+
+Only the primary Manager session is restarted — secondary Managers are untouched.
+
+---
+
+## `crow restart-tmux-server`
+
+Restart the tmux server, rebuilding every terminal (destructive).
+
+```
+crow restart-tmux-server
+```
+
+Kills the shared tmux server — every agent in every session dies — then relaunches each persisted terminal (the Manager via its stored command, work sessions via `claude --continue`).
+
+The web UI confirms first; from the CLI the caller owns that choice, the same stance as `recreate-terminal`.
+
+Returns as soon as the teardown is done — the per-terminal rebuild continues in the background, so don't chain a `crow send` straight after this or you'll race a half-rebuilt surface.
+
+---
+
+## `crow resync-jira`
+
+Re-sync Jira ticket statuses from Crow session state.
+
+```
+crow resync-jira
+```
+
+---
+
+## `crow retry-readiness`
+
+Re-arm the readiness watch for a stuck terminal.
+
+```
+crow retry-readiness --terminal <terminal>
+```
+
+Starts a longer-budget readiness watch on a terminal whose first attempt timed out, clearing the Retry overlay in the UI.
+
+Takes only `--terminal` — no `--session` flag.
+
+The daemon applies this only to a terminal that timed out or never reached shell-ready; in any other state it is a no-op. `{"ok": true}` means the request was accepted, not that a watch was re-armed.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--terminal` | `<terminal>` | yes | Terminal UUID |
+
+---
+
+## `crow select-session`
+
+Switch to a session.
+
+```
+crow select-session --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow send`
+
+Send text to a terminal.
+
+```
+crow send --session <session> --terminal <terminal> <text>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--terminal` | `<terminal>` | yes | Terminal UUID |
+| _(positional)_ | `<text>` | yes | Text to send |
+
+---
+
+## `crow set-goal`
+
+Set or clear the org-goal tag on a session.
+
+```
+crow set-goal --session <session> [--goal <goal>] [--clear]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--goal` | `<goal>` | no | Org goal/KPI this session's work ladders up to |
+| `--clear` | — | no | Clear the org-goal tag |
+
+---
+
+## `crow set-locked`
+
+Lock/unlock a session to protect it from auto-cleanup.
+
+```
+crow set-locked --session <session> <locked>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| _(positional)_ | `<locked>` | yes | Locked state: true or false |
+
+---
+
+## `crow set-pinned`
+
+Deprecated alias for set-locked.
+
+**Hidden** — not listed in `crow --help`.
+
+```
+crow set-pinned --session <session> <pinned>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| _(positional)_ | `<pinned>` | yes | Locked state: true or false |
+
+---
+
+## `crow set-session-active`
+
+Return a session to active.
+
+```
+crow set-session-active --session <session>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow set-status`
+
+Set session status.
+
+```
+crow set-status --session <session> <status>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| _(positional)_ | `<status>` | yes | Status: active, paused, inReview, completed, archived |
+
+---
+
+## `crow set-ticket`
+
+Set ticket metadata.
+
+```
+crow set-ticket --session <session> [--url <url>] [--title <title>] [--number <number>] [--priority <priority>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--url` | `<url>` | no | Ticket URL |
+| `--title` | `<title>` | no | Ticket title |
+| `--number` | `<number>` | no | Ticket number |
+| `--priority` | `<priority>` | no | Ticket priority: highest, high, medium, low, or lowest |
+
+---
+
+## `crow setup`
+
+First-time setup for Crow.
+
+```
+crow setup [--dev-root <dev-root>]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--dev-root` | `<dev-root>` | no | Development root path |
+
+---
+
+## `crow start-review`
+
+Start a review session for a pull request.
+
+```
+crow start-review --url <url>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--url` | `<url>` | yes | Pull request URL |
+
+---
+
+## `crow telemetry`
+
+View or change session-analytics collection.
+
+```
+crow telemetry <get|set>
+```
+
+Subcommands: [`get`](#crow-telemetry-get), [`set`](#crow-telemetry-set).
+
+---
+
+## `crow telemetry get`
+
+Show the current telemetry settings.
+
+```
+crow telemetry get
+```
+
+---
+
+## `crow telemetry set`
+
+Change telemetry settings.
+
+```
+crow telemetry set [--enabled <enabled>] [--port <port>] [--retention-days <retention-days>]
+```
+
+Only the flags you pass change; at least one is required.
+
+--enabled and --port are read once when crowd starts, and the port is baked into every agent launch's OTEL_EXPORTER_OTLP_ENDPOINT, so changing either returns "restart_required": true — restart crowd to apply it. --retention-days drives the prune that runs at startup, so it likewise applies at the next daemon start.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--enabled` | `<enabled>` | no | Enable the OTLP receiver (true or false) |
+| `--port` | `<port>` | no | OTLP HTTP receiver port (1024-65535, default 4318) |
+| `--retention-days` | `<retention-days>` | no | Days of telemetry to keep; 0 keeps forever (default 180) |
+
+---
+
+## `crow transition-ticket`
+
+Transition a session's ticket to a pipeline status.
+
+```
+crow transition-ticket --session <session> --to <to>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--session` | `<session>` | yes | Session UUID |
+| `--to` | `<to>` | yes | Target status: inProgress, inReview, or done |
+
+---
+
+## `crow ui`
+
+View or change UI display preferences.
+
+```
+crow ui <get|set>
+```
+
+Display preferences only — this does not start, stop, or open the web UI.
+
+Settings are grouped by the config block they belong to, so `get` returns {"ui": {"sidebar": {...}}} and gains further blocks as more view options become configurable.
+
+Subcommands: [`get`](#crow-ui-get), [`set`](#crow-ui-set).
+
+---
+
+## `crow ui get`
+
+Show the current UI display preferences.
+
+```
+crow ui get
+```
+
+---
+
+## `crow ui set`
+
+Change UI display preferences.
+
+```
+crow ui set [--hide-session-details <hide-session-details>]
+```
+
+Only the flags you pass change; at least one is required. Connected browsers pick the change up within a couple of seconds — no reload.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--hide-session-details` | `<hide-session-details>` | no | Hide ticket title and repo/branch lines in sidebar rows (true or false) |
+
+---
+
+## `crow web-password`
+
+Manage the web-access password (local-only).
+
+```
+crow web-password <status|set|clear>
+```
+
+Subcommands: [`status`](#crow-web-password-status), [`set`](#crow-web-password-set), [`clear`](#crow-web-password-clear).
+
+---
+
+## `crow web-password clear`
+
+Remove the web-access password.
+
+```
+crow web-password clear
+```
+
+With no password set, remote web clients are no longer challenged — check how the daemon is bound before clearing it.
+
+---
+
+## `crow web-password set`
+
+Set or change the web-access password.
+
+```
+crow web-password set [--stdin]
+```
+
+Prompts twice with echo off. For scripts, pipe the password and pass --stdin:
+
+```
+printf '%s' "$PW" | crow web-password set --stdin
+```
+
+There is no --password flag on purpose — a plaintext password in argv is visible in shell history and to local `ps`. Changing the password does not require the old one; the local-only gate is the control.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--stdin` | — | no | Read the password from stdin instead of prompting |
+
+---
+
+## `crow web-password status`
+
+Report whether a web-access password is set.
+
+```
+crow web-password status
+```
+
+---
+
+## `crow work-on-issue`
+
+Start working on a ticket (types /crow-workspace into the Manager).
+
+```
+crow work-on-issue --url <url>
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--url` | `<url>` | yes | Ticket / issue URL |
+
+---
+


### PR DESCRIPTION
Closes #808

The `crow` CLI surface was hand-documented in several places with nothing tying those docs to `CrowCommand`, so verbs shipped undocumented and nobody noticed.

## The drift was already real

Measured against the 82 real invocation paths, `docs/cli-reference.md` was missing 14 — the entire `crow job` group (9 subcommands), `set-locked`, `set-pinned`, `recreate-terminal`, `resync-jira`, `codex-notify`. `CLAUDE.md` was missing 16. And `crow transition-ticket` had nothing but a cross-reference link pointing at an anchor that did not exist.

## How it works

`CLIDocs` renders `docs/cli.md` from the command tree itself, stitching two sources deliberately:

- The **command layer** (name, abstract, discussion, hidden-ness, nesting) comes from `CommandConfiguration` — stable public API.
- The **argument layer** is decoded from the JSON `ParsableCommand._dumpHelp()` emits. There is no public API for walking a command's `@Option`/`@Flag` declarations, so this is the only way to get flag help text without a macro or reflection hack.

The JSON is decoded into local types rather than by importing `ArgumentParserToolInfo`, because that module is not a library product of swift-argument-parser. Only fields present in 1.5.0 (the manifest's floor) are read — `Package.resolved` is not committed, so any 1.x may be resolved and the generated file has to stay byte-identical across them.

`crow generate-docs` (hidden, local-only) writes the file, `make docs` is the front door, `--check` verifies without writing.

## The guard is a test, not a binary invocation

CI's Linux lane builds only `Packages/CrowCLI` and never links the `crow` executable, so everything runs in-process off the command tree. `CrowCLI` is already in `LINUX_PACKAGES` — **no CI changes needed**.

Four tests in `CrowCLITests`:

1. **Every command and flag appears in the generated reference.** Flags are re-derived by dumping each command type *on its own* rather than reusing the whole-tree dump the generator indexes by path — that independent second pass is the point, since a generator that mis-joins a nested path (`crow job add` vs `crow add`) would still look self-consistent against its own index.
2. **The committed `docs/cli.md` matches what the generator produces** — fails with "run `make docs`".
3. **Every verb has a worked example in `docs/cli-reference.md`.**
4. **Every user-facing verb appears in `CLAUDE.md`'s CLI Reference** — the Manager agent reads it to learn what it can run.

Tests 3 and 4 match against **fenced code blocks, not the whole file**: "documented" should mean "there is a command here you can copy and run". A whole-file substring match is exactly what let `transition-ticket`'s dead link pass as documented. Each carries an exemption list where every entry states its reason.

## Docs

`docs/cli-reference.md` stays hand-written and keeps its anchors — `#gateway-commands`, `#maintenance-commands`, `#settings-commands` and `#notification-commands` are linked from `README.md` (x4), `docs/getting-started.md`, `docs/configuration.md` (x2) and a comment in `EngineRouter.swift`. `docs/cli.md` is the exhaustive generated surface; the two cross-link.

All of today's drift is backfilled so the exemption lists ship near-empty: a Job Commands section in both docs, plus `set-locked`/`set-pinned`, `transition-ticket` (repairing the dead anchor), `resync-jira`, `recreate-terminal`, `rename-terminal` and `codex-notify`.

## Verification

- `swift test --package-path Packages/CrowCLI` — 241/241 pass
- `make docs && git diff --exit-code docs/cli.md` — generator is idempotent
- `crow generate-docs --check` — exits 0
- Negative checks, each confirmed to fail and then reverted: a new undocumented verb fails tests 2-4; a hand-edited `docs/cli.md` fails test 2 with the "run `make docs`" message; deleting the `crow job add` section fails test 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
