### PR TITLE
Anti-drift CLI↔RPC↔config parity gate (CROW-807)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,28 @@ jobs:
             swift test --no-parallel --package-path "Packages/$pkg"
           done
 
+  # Source-level drift gates: cheap text checks that need no Swift build, so they
+  # cover packages the Linux lane above cannot compile. `check-cli-parity.sh` is
+  # the PR-lane stand-in for CrowDaemonTests/RPCLedgerParityTests — CrowDaemon
+  # depends on the Darwin-only CrowTelemetry and so is absent from LINUX_PACKAGES,
+  # which would otherwise leave the RPC half of the parity gate running only on
+  # release tags (CROW-807, docs/adr/0016-cli-control-plane-parity.md).
+  #
+  # Plain ubuntu-latest rather than the swift container: check-notification-events
+  # needs node, which the container does not ship.
+  parity:
+    name: Catalog & Parity Gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: CLI/RPC control-plane parity (CROW-807)
+        run: bash scripts/check-cli-parity.sh
+
+      # Was previously reachable only via `make test`, which CI never runs.
+      - name: Notification-event catalogs (CROW-768)
+        run: bash scripts/check-notification-events.sh
+
   desktop:
     name: Desktop (Tauri) Build
     runs-on: macos-15

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build daemon app run setup install uninstall clean check test help daemon-run docs
+.PHONY: build daemon app run setup install uninstall clean check test parity help daemon-run docs
 
 # Install destination and build config (override on the command line, e.g.
 # `make install BINDIR=/usr/local/bin` or `make build CONFIG=release`).
@@ -52,7 +52,8 @@ help:
 	@echo "  daemon-run Run crowd serving the frozen bundle-baked web UI (add --watch to rebuild on Swift/web change)"
 	@echo "  setup      Check build prerequisites"
 	@echo "  check      Verify all build and runtime prerequisites"
-	@echo "  test       Run all package tests"
+	@echo "  test       Run all package tests, then the parity gates"
+	@echo "  parity     Run just the source-level drift gates (catalogs + CLI/RPC parity)"
 	@echo "  docs       Regenerate docs/cli.md from the CLI's ArgumentParser metadata"
 	@echo "  install    Symlink crow + crowd into ~/.local/bin (override BINDIR=, CONFIG=release)"
 	@echo "  uninstall  Remove installed crow + crowd symlinks"
@@ -96,8 +97,15 @@ test:
 			swift test --package-path "$$pkg"; \
 		fi; \
 	done
+	@$(MAKE) --no-print-directory parity
+
+# Source-level drift gates. Cheap, no build required, and both also run in CI —
+# see the `parity` job in .github/workflows/ci.yml.
+parity:
 	@echo "==> Checking notification-event catalogs (CROW-768)..."
 	@./scripts/check-notification-events.sh
+	@echo "==> Checking CLI/RPC control-plane parity (CROW-807)..."
+	@./scripts/check-cli-parity.sh
 
 # Regenerate the CLI reference from the commands themselves (CROW-808). Run
 # after adding or changing a subcommand — a stale docs/cli.md fails CrowCLI's

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -238,6 +238,90 @@ struct ParityGateTests {
         }
     }
 
+    // MARK: - Write classification
+
+    /// Names that read as queries: `get-…`, `list-…`, `…-get`, `…-list`.
+    static func namePresumesRead(_ method: String) -> Bool {
+        method.hasPrefix("get-") || method.hasPrefix("list-")
+            || method.hasSuffix("-get") || method.hasSuffix("-list")
+    }
+
+    /// Rows whose deliberate `isWrite` classification disagrees with the name.
+    ///
+    /// Empty today. The hand classification always wins — a method named
+    /// `get-something` that mutates state is a write, full stop. This set only
+    /// forces the disagreement to be *stated* rather than sitting unnoticed in a
+    /// row nobody re-reads.
+    static let namingExceptions: Set<String> = []
+
+    /// `isWrite` is hand-set per row, deliberately, because a `get-`/`list-`
+    /// heuristic would wave through a future write named `get-something`. But
+    /// nothing checked the hand classification itself — so a write mislabelled
+    /// `.read` would silently skip the write bar below. This cross-checks the two
+    /// against each other without letting the heuristic overrule the decision.
+    @Test("isWrite agrees with the method name, or the disagreement is declared")
+    func writeClassificationMatchesNaming() {
+        let disagreements = ParityLedger.rpcMethods
+            .filter { Self.namePresumesRead($0.method) == $0.isWrite }
+            .map(\.method)
+            .filter { !Self.namingExceptions.contains($0) }
+            .sorted()
+
+        #expect(
+            disagreements.isEmpty,
+            """
+            These rows classify against what their name suggests:
+            \(disagreements.map { "  \($0)" }.joined(separator: "\n"))
+            A `get-`/`list-` name marked .write, or any other name marked .read.
+            If the classification is right, add the method to `namingExceptions`
+            with a comment; if it's wrong, fix the row.
+            """)
+    }
+
+    /// The un-CLI-able writes, pinned.
+    ///
+    /// This is the milestone's burn-down list: each per-area parity ticket
+    /// deletes entries. Pinning the *set* — not just requiring a reason per row
+    /// — is what makes adding one a deliberate, visible act instead of a single
+    /// `.noCLI(…)` row lost among 85.
+    static let knownWriteExemptions: Set<String> = [
+        "batch-start-review",
+        "run-job",
+        "run-setup",
+        "set-config",
+        "set-pinned",
+    ]
+
+    @Test("The set of writes with no CLI path is exactly the pinned list")
+    func writeExemptionsArePinned() {
+        let actual = Set(
+            ParityLedger.rpcMethods
+                .filter { $0.isWrite && $0.coverage.exemptionReason != nil }
+                .map(\.method))
+
+        let added = actual.subtracting(Self.knownWriteExemptions)
+        let closed = Self.knownWriteExemptions.subtracting(actual)
+
+        #expect(
+            added.isEmpty,
+            """
+            New write methods with no CLI path (\(added.count)):
+            \(added.sorted().map { "  \($0)" }.joined(separator: "\n"))
+            This is the drift CROW-807 exists to stop. Give the method a `crow`
+            verb, or — if it genuinely cannot have one — add it to
+            `knownWriteExemptions` so the widening is explicit in review.
+            """)
+        #expect(
+            closed.isEmpty,
+            """
+            These writes now have a CLI path — remove them from
+            `knownWriteExemptions` so the burn-down stays accurate (\(closed.count)):
+            \(closed.sorted().map { "  \($0)" }.joined(separator: "\n"))
+            """)
+    }
+
+    // MARK: - Ledger hygiene
+
     @Test("Every declared CLI path is a real verb")
     func declaredCLIPathsResolve() {
         let verbs = Self.verbPaths()

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -1,0 +1,303 @@
+import ArgumentParser
+import CrowCore
+import Foundation
+import Testing
+
+@testable import CrowCLILib
+
+/// CLI control-plane parity gate (CROW-807, ADR 0016).
+///
+/// Holds `ParityLedger` to the two surfaces this target can actually see: the
+/// `crow` verb tree and `AppConfig`. The third surface — the registered RPC
+/// methods — is checked by `CrowDaemonTests/RPCLedgerParityTests` and by
+/// `scripts/check-cli-parity.sh`, because CrowCLI cannot depend on CrowDaemon.
+///
+/// A failure here means someone shipped a config field or changed a verb without
+/// deciding how the CLI reaches it. The fix is a ledger row, not a weakened test.
+@Suite("CLI control-plane parity")
+struct ParityGateTests {
+
+    // MARK: - Verb tree
+
+    /// Every `crow` verb as a full space-separated path — `"job add"`,
+    /// `"web-password status"`. Group parents (`"job"`) are included too, so a
+    /// ledger row may point at a group when that is genuinely the entry point.
+    ///
+    /// Keyed on the full path on purpose: six different leaf commands are named
+    /// `set` and six are named `get`, so leaf names alone are ambiguous.
+    static func verbPaths(
+        of command: ParsableCommand.Type = CrowCommand.self,
+        prefix: [String] = []
+    ) -> Set<String> {
+        var paths: Set<String> = []
+        for sub in command.configuration.subcommands {
+            let name = sub.configuration.commandName ?? String(describing: sub).lowercased()
+            let path = prefix + [name]
+            paths.insert(path.joined(separator: " "))
+            paths.formUnion(verbPaths(of: sub, prefix: path))
+        }
+        return paths
+    }
+
+    // MARK: - AppConfig reflection
+
+    /// Types that are structs underneath but are values to a user — recursing
+    /// into them would yield noise like `jobs[].id.uuid`.
+    static let opaqueLeafTypes: [Any.Type] = [
+        UUID.self, Date.self, URL.self, Data.self,
+    ]
+
+    /// Containers the probe left empty, so the walk could not see through them.
+    /// Collected rather than ignored: an unpopulated optional or collection is
+    /// exactly how a subtree of new config fields would slip past this gate.
+    struct WalkResult {
+        var leaves: Set<String> = []
+        var unpopulated: Set<String> = []
+    }
+
+    /// Recursively enumerate the leaf fields of a value as dotted paths.
+    ///
+    /// Collection and dictionary *elements* get a `[]` segment
+    /// (`workspaces[].jiraJQL`); a collection or dictionary of scalars collapses
+    /// to a single leaf at its own path (`defaults.excludeDirs`, `agentsByKind`),
+    /// because there is nothing underneath worth addressing separately.
+    static func walk(_ value: Any, prefix: String, into result: inout WalkResult) {
+        let mirror = Mirror(reflecting: value)
+
+        if opaqueLeafTypes.contains(where: { $0 == type(of: value) }) {
+            result.leaves.insert(prefix)
+            return
+        }
+
+        // `AgentKind` is a RawRepresentable *struct*, not an enum, so Mirror
+        // reports it as a shape with a `rawValue` child. It is a value to the
+        // user; recursing would yield `defaultAgentKind.rawValue`.
+        if value is any RawRepresentable {
+            result.leaves.insert(prefix)
+            return
+        }
+
+        switch mirror.displayStyle {
+        case .optional:
+            guard let wrapped = mirror.children.first?.value else {
+                result.unpopulated.insert(prefix)
+                result.leaves.insert(prefix)
+                return
+            }
+            walk(wrapped, prefix: prefix, into: &result)
+
+        case .collection:
+            guard let element = mirror.children.first?.value else {
+                result.unpopulated.insert(prefix)
+                result.leaves.insert(prefix)
+                return
+            }
+            collapseOrKeep(element, prefix: prefix, into: &result)
+
+        case .dictionary:
+            // Each child of a dictionary mirror is a (key, value) pair.
+            guard let pair = mirror.children.first?.value,
+                  let element = Mirror(reflecting: pair).children.dropFirst().first?.value
+            else {
+                result.unpopulated.insert(prefix)
+                result.leaves.insert(prefix)
+                return
+            }
+            collapseOrKeep(element, prefix: prefix, into: &result)
+
+        case .struct, .class:
+            guard !mirror.children.isEmpty else {
+                result.leaves.insert(prefix)
+                return
+            }
+            for child in mirror.children {
+                guard let label = child.label else { continue }
+                let next = prefix.isEmpty ? label : "\(prefix).\(label)"
+                walk(child.value, prefix: next, into: &result)
+            }
+
+        default:
+            // Enums (JobSchedule) and primitives are values, not shapes.
+            result.leaves.insert(prefix)
+        }
+    }
+
+    /// Walk a container's element. If the element is itself a leaf, the whole
+    /// container collapses to one path; if it has structure, keep the `[]` segment.
+    private static func collapseOrKeep(_ element: Any, prefix: String, into result: inout WalkResult) {
+        var inner = WalkResult()
+        walk(element, prefix: "\(prefix)[]", into: &inner)
+        if inner.leaves == ["\(prefix)[]"] {
+            result.leaves.insert(prefix)
+        } else {
+            result.leaves.formUnion(inner.leaves)
+            result.unpopulated.formUnion(inner.unpopulated)
+        }
+    }
+
+    /// An `AppConfig` with **every** optional inhabited and every collection
+    /// non-empty, so `Mirror` can see the whole tree — a default `AppConfig()`
+    /// leaves `managerGateway`/`jiraCredential`/`webAuth` nil and the arrays
+    /// empty, which would hide ~25 fields from the gate.
+    ///
+    /// `probeIsFullyPopulated` fails if this drifts, so a new nested field cannot
+    /// hide behind an unpopulated container.
+    static func parityProbeConfig() -> AppConfig {
+        let gateway = WorkspaceGateway(baseURL: "https://gw.example", customHeaders: ["X-Probe": "1"])
+        return AppConfig(
+            workspaces: [
+                WorkspaceInfo(
+                    name: "probe",
+                    host: "git.example",
+                    alwaysInclude: ["owner/repo"],
+                    autoReviewRepos: ["owner/repo"],
+                    excludeReviewRepos: ["owner/repo"],
+                    customInstructions: "probe",
+                    taskProvider: "jira",
+                    jiraProjectKey: "PROBE",
+                    jiraJQL: "project = PROBE",
+                    jiraSite: "probe.atlassian.net",
+                    jiraStatusMap: ["inProgress": "In Progress"],
+                    corveilHost: "corveil.example",
+                    gateway: gateway
+                )
+            ],
+            defaults: ConfigDefaults(
+                excludeReviewRepos: ["owner/repo"],
+                excludeTicketRepos: ["owner/repo"],
+                ignoreReviewLabels: ["wip"],
+                binaries: ["claude": "/usr/local/bin/claude"]
+            ),
+            notifications: NotificationSettings(eventSettings: [.taskComplete: EventNotificationConfig()]),
+            telemetry: TelemetryConfig(),
+            terminal: TerminalSettings(),
+            autoRespond: AutoRespondSettings(),
+            cleanup: CleanupConfig(),
+            jobs: [
+                JobConfig(
+                    name: "probe",
+                    workspace: "probe",
+                    repo: "owner/repo",
+                    prompts: ["probe"],
+                    schedule: .interval(seconds: 3600),
+                    lastRunAt: Date()
+                )
+            ],
+            agentsByKind: ["work": .claudeCode],
+            managerGateway: gateway,
+            jiraCredential: JiraCredential(username: "probe", tokenRef: "op://probe/token"),
+            webAuth: WebAuthConfig(hashB64: "aGFzaA==", saltB64: "c2FsdA==", iterations: 210_000)
+        )
+    }
+
+    static func walkProbe() -> WalkResult {
+        var result = WalkResult()
+        walk(parityProbeConfig(), prefix: "", into: &result)
+        return result
+    }
+
+    static func report(_ title: String, _ items: some Collection<String>) -> String {
+        "\(title) (\(items.count)):\n" + items.sorted().map { "  \($0)" }.joined(separator: "\n")
+    }
+
+    // MARK: - Ledger hygiene
+
+    @Test("Ledger rows are unique")
+    func ledgerRowsAreUnique() {
+        let methods = ParityLedger.rpcMethods.map(\.method)
+        let dupeMethods = Set(methods.filter { m in methods.filter { $0 == m }.count > 1 })
+        #expect(dupeMethods.isEmpty, "Duplicate rpcMethods rows: \(dupeMethods.sorted())")
+
+        let paths = ParityLedger.configFields.map(\.path)
+        let dupePaths = Set(paths.filter { p in paths.filter { $0 == p }.count > 1 })
+        #expect(dupePaths.isEmpty, "Duplicate configFields rows: \(dupePaths.sorted())")
+    }
+
+    /// An exemption is only a decision if it says something. A bare `""` or
+    /// `"n/a"` would turn the ledger back into a rubber stamp.
+    @Test("Every exemption carries a substantive reason")
+    func exemptionsAreJustified() {
+        let minimumReasonLength = 40
+        var reasons: [(String, String)] = []
+        for entry in ParityLedger.rpcMethods {
+            if let reason = entry.coverage.exemptionReason { reasons.append((entry.method, reason)) }
+        }
+        for entry in ParityLedger.configFields {
+            if let reason = entry.read.exemptionReason { reasons.append(("\(entry.path) (read)", reason)) }
+            if let reason = entry.write.exemptionReason { reasons.append(("\(entry.path) (write)", reason)) }
+        }
+
+        for (subject, reason) in reasons {
+            let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(
+                trimmed.count >= minimumReasonLength,
+                """
+                Exemption for \(subject) needs a real justification \
+                (>= \(minimumReasonLength) chars, got \(trimmed.count)): "\(trimmed)"
+                """)
+        }
+    }
+
+    @Test("Every declared CLI path is a real verb")
+    func declaredCLIPathsResolve() {
+        let verbs = Self.verbPaths()
+        var declared: [(String, String)] = []
+        for entry in ParityLedger.rpcMethods {
+            if let path = entry.coverage.cliPath { declared.append((entry.method, path)) }
+        }
+        for entry in ParityLedger.configFields {
+            if let path = entry.read.cliPath { declared.append(("\(entry.path) (read)", path)) }
+            if let path = entry.write.cliPath { declared.append(("\(entry.path) (write)", path)) }
+        }
+
+        let dangling = declared.filter { !verbs.contains($0.1) }
+        #expect(
+            dangling.isEmpty,
+            """
+            Ledger rows point at verbs that CrowCommand does not register:
+            \(dangling.sorted { $0.0 < $1.0 }.map { "  \($0.0) -> \"\($0.1)\"" }.joined(separator: "\n"))
+            Paths are full and space-separated, e.g. "job add", not "add".
+            """)
+    }
+
+    // MARK: - AppConfig parity
+
+    @Test("The reflection probe reaches every subtree")
+    func probeIsFullyPopulated() {
+        let result = Self.walkProbe()
+        #expect(
+            result.unpopulated.isEmpty,
+            """
+            parityProbeConfig() left these nil/empty, so Mirror could not walk into them
+            and any fields underneath are invisible to this gate. Populate them:
+            \(Self.report("unpopulated", result.unpopulated))
+            """)
+    }
+
+    /// The gate proper: the ledger must name exactly the fields `AppConfig` has.
+    /// Checked in both directions, so a removed field leaves a stale row that
+    /// also fails — the ledger cannot rot in either direction.
+    @Test("Ledger covers exactly AppConfig's fields")
+    func configFieldsMatchAppConfig() {
+        let actual = Self.walkProbe().leaves
+        let ledgered = Set(ParityLedger.configFields.map(\.path))
+
+        let missing = actual.subtracting(ledgered)
+        let stale = ledgered.subtracting(actual)
+
+        #expect(
+            missing.isEmpty,
+            """
+            AppConfig fields with no ParityLedger.configFields row. Add one for each,
+            stating how the CLI reads and writes it — or why it cannot:
+            \(Self.report("missing from ledger", missing))
+            """)
+        #expect(
+            stale.isEmpty,
+            """
+            ParityLedger.configFields rows for fields AppConfig no longer has.
+            Delete them:
+            \(Self.report("stale ledger rows", stale))
+            """)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -167,9 +167,10 @@ public enum ParityLedger {
         .read(
             "list-agents",
             noCLI: """
-                Populates the agent picker in the web session-create sheet. The CLI \
-                takes an agent kind directly on `crow create-manager --agent` and \
-                `crow handoff-agent --agent`, so it never needs to enumerate them.
+                Populates the agent picker in the web session-create sheet. `crow \
+                agents list` covers the CLI's need to enumerate agents via \
+                `agents-get`, whose `known` array is a superset of this payload \
+                (CROW-811) — this method is the older, picker-shaped read.
                 """),
         .write(
             "batch-start-review",
@@ -195,6 +196,8 @@ public enum ParityLedger {
         // local-only when the request carries `binaries` (CROW-810).
         .read("defaults-get", cli: "defaults get"),
         .write("defaults-set", cli: "defaults set"),
+        .read("agents-get", cli: "agents list"),
+        .write("agents-set", cli: "agents set"),
         .read("telemetry-get", cli: "telemetry get"),
         .write("telemetry-set", cli: "telemetry set"),
         .read("cleanup-get", cli: "cleanup get"),
@@ -294,9 +297,10 @@ public enum ParityLedger {
     ///
     /// The exempt rows below are the honest state of the milestone as of CROW-807:
     /// the settings blocks that already have verbs (`telemetry`, `cleanup`,
-    /// `sidebar`, `notifications`, gateways, jobs, and `defaults` since CROW-810)
-    /// are covered, and everything the web Settings tab owns exclusively —
-    /// `workspaces[].*`, the automation toggles, `terminal.*` — is not.
+    /// `sidebar`, `notifications`, gateways, jobs, `defaults` since CROW-810 and
+    /// agent selection since CROW-811) are covered, and everything the web
+    /// Settings tab owns exclusively — `workspaces[].*`, the automation toggles,
+    /// `terminal.*` — is not.
     public static let configFields: [ConfigEntry] = [
         // MARK: Covered — settings blocks with dedicated verbs
 
@@ -407,6 +411,11 @@ public enum ParityLedger {
                 sessions inherit Claude's MCP servers; web Settings tab only.
                 """),
 
+        // MARK: Covered — agent selection (CROW-811)
+
+        .field("defaultAgentKind", read: "agents list", write: "agents set"),
+        .field("agentsByKind", read: "agents list", write: "agents set"),
+
         // MARK: Exempt — workspaces (no CLI surface at all)
 
         .field(
@@ -502,7 +511,7 @@ public enum ParityLedger {
                 verb — see `workspaces[].id`.
                 """),
 
-        // MARK: Exempt — automation toggles and agent defaults (web Settings tab)
+        // MARK: Exempt — automation toggles (web Settings tab)
 
         .field(
             "remoteControlEnabled",
@@ -574,20 +583,6 @@ public enum ParityLedger {
                 toggle; the manual equivalent is `crow quick-action --action \
                 fixConflicts`.
                 """),
-        .field(
-            "defaultAgentKind",
-            noCLI: """
-                Coding agent used for new sessions when none is given. Web Settings \
-                picker; `crow create-manager --agent` and `crow handoff-agent --agent` \
-                choose per session but cannot change the default (CROW-421).
-                """),
-        .field(
-            "agentsByKind",
-            noCLI: """
-                Per-session-kind agent overrides, keyed by `SessionKind.rawValue` \
-                (CROW-433). Web Settings pickers; no verb reads or writes the map.
-                """),
-
         // MARK: Exempt — terminal tuning and Jira credential
 
         .field(

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -1,0 +1,622 @@
+import Foundation
+
+/// The checked-in CLI control-plane parity ledger (CROW-807, ADR 0016).
+///
+/// Crow's control plane exists three times over: the JSON-RPC methods `crowd`
+/// registers, the `crow` verbs that call them, and the ``AppConfig`` fields both
+/// mutate. Nothing in the compiler ties those together, so a capability can ship
+/// as an RPC method plus a web control and quietly never grow a CLI path. This
+/// ledger is the one place that states, per method and per config field, whether
+/// a CLI path exists — and when it doesn't, *why*.
+///
+/// **It is not documentation; it is a gate.** Three checks keep it honest:
+///
+/// - `CrowCLITests/ParityGateTests` — every ``Coverage/cli(_:)`` path resolves
+///   against `CrowCommand`'s subcommand tree, and ``configFields`` matches the
+///   `Mirror` walk of `AppConfig` exactly, in both directions.
+/// - `CrowDaemonTests/RPCLedgerParityTests` — ``rpcMethods`` matches
+///   `CommandRouter.methodNames` for the live daemon+engine router pair.
+/// - `scripts/check-cli-parity.sh` — the same RPC assertion by text, because
+///   CrowDaemon is Darwin-only and cannot run in the Linux PR lane.
+///
+/// Adding a ``Coverage/noCLI(reason:)`` row is the review gate: the reason is a
+/// required associated value, so an exemption cannot be added silently. Each
+/// per-area parity ticket closes its gap by *deleting* rows from the exempt set.
+///
+/// ``Coverage/noCLI(reason:)`` is CROW-807's `KNOWN_UI_ONLY` allowlist, named for
+/// what it asserts rather than what usually causes it — most exemptions are indeed
+/// web-UI-only, but a few surfaces (the web-password hash) are readable nowhere.
+public enum ParityLedger {
+
+    // MARK: - Coverage
+
+    /// Whether a surface is reachable from the `crow` CLI, or deliberately isn't.
+    public enum Coverage: Sendable, Equatable {
+        /// Reachable, via this full verb path — e.g. `"job add"`, `"web-password status"`.
+        /// Leaf command names collide across groups (six commands are named `set`),
+        /// so this is always the *full* path, never the leaf.
+        case cli(String)
+
+        /// Deliberately not reachable from the CLI. The reason is required and is
+        /// checked for substance by `ParityGateTests`; state what drives the surface
+        /// instead and, where one exists, the ticket that will close the gap.
+        case noCLI(reason: String)
+
+        public var cliPath: String? {
+            if case .cli(let path) = self { return path }
+            return nil
+        }
+
+        public var exemptionReason: String? {
+            if case .noCLI(let reason) = self { return reason }
+            return nil
+        }
+    }
+
+    // MARK: - RPC methods
+
+    /// One registered JSON-RPC method.
+    public struct RPCEntry: Sendable, Equatable {
+        public let method: String
+        /// `false` for pure queries; `true` for anything that mutates state or
+        /// performs an action. Stated per row rather than inferred from a `get-`/
+        /// `list-` prefix — a heuristic would wave through a future write named
+        /// `get-something`.
+        public let isWrite: Bool
+        public let coverage: Coverage
+
+        public static func read(_ method: String, cli path: String) -> RPCEntry {
+            RPCEntry(method: method, isWrite: false, coverage: .cli(path))
+        }
+
+        public static func read(_ method: String, noCLI reason: String) -> RPCEntry {
+            RPCEntry(method: method, isWrite: false, coverage: .noCLI(reason: reason))
+        }
+
+        public static func write(_ method: String, cli path: String) -> RPCEntry {
+            RPCEntry(method: method, isWrite: true, coverage: .cli(path))
+        }
+
+        public static func write(_ method: String, noCLI reason: String) -> RPCEntry {
+            RPCEntry(method: method, isWrite: true, coverage: .noCLI(reason: reason))
+        }
+    }
+
+    /// Every method reachable through the live router pair — the daemon's
+    /// `makeCommandRouter` unioned with the `makeEngineRouter` it falls back to.
+    public static let rpcMethods: [RPCEntry] = [
+        // Sessions
+        .write("new-session", cli: "new-session"),
+        .write("rename-session", cli: "rename-session"),
+        .write("select-session", cli: "select-session"),
+        .read("list-sessions", cli: "list-sessions"),
+        .read("get-session", cli: "get-session"),
+        .write("set-status", cli: "set-status"),
+        .write("set-locked", cli: "set-locked"),
+        .write("delete-session", cli: "delete-session"),
+        .write("handoff-agent", cli: "handoff-agent"),
+        .read(
+            "list-sessions-live",
+            noCLI: """
+                Web-board streaming read: the same rows as `list-sessions` plus live \
+                terminal/agent state, shaped for the browser's poll loop. `crow \
+                list-sessions` and `crow get-session` cover the CLI's needs.
+                """),
+        .write(
+            "set-pinned",
+            noCLI: """
+                Engine method with no caller: `crow set-pinned` in fact sends the \
+                `set-locked` RPC (SessionCommands.swift). Either the verb is \
+                misrouted or this method is dead — resolve before removing this row.
+                """),
+
+        // Session lifecycle
+        .write("mark-in-review", cli: "mark-in-review"),
+        .write("complete-session", cli: "complete-session"),
+        .write("set-session-active", cli: "set-session-active"),
+        .write("mark-issue-done", cli: "mark-issue-done"),
+        .write("add-merge-label", cli: "add-merge-label"),
+
+        // Metadata & links
+        .write("set-ticket", cli: "set-ticket"),
+        .write("set-goal", cli: "set-goal"),
+        .write("add-link", cli: "add-link"),
+        .read("list-links", cli: "list-links"),
+        .write("remove-link", cli: "remove-link"),
+        .write("edit-link", cli: "edit-link"),
+        .write("transition-ticket", cli: "transition-ticket"),
+        .write("resync-jira", cli: "resync-jira"),
+
+        // Worktrees
+        .write("add-worktree", cli: "add-worktree"),
+        .read("list-worktrees", cli: "list-worktrees"),
+
+        // Terminals
+        .write("new-terminal", cli: "new-terminal"),
+        .read("list-terminals", cli: "list-terminals"),
+        .write("close-terminal", cli: "close-terminal"),
+        .write("recreate-terminal", cli: "recreate-terminal"),
+        .write("rename-terminal", cli: "rename-terminal"),
+        .write("send", cli: "send"),
+
+        // Maintenance
+        .write("launch-agent", cli: "launch-agent"),
+        .write("retry-readiness", cli: "retry-readiness"),
+        .write("restart-manager", cli: "restart-manager"),
+        .write("restart-tmux-server", cli: "restart-tmux-server"),
+        .write("reload-tmux-config", cli: "reload-tmux-config"),
+        .write("open-in-vscode", cli: "open-in-vscode"),
+        .write("open-terminal", cli: "open-terminal"),
+
+        // Board & workflow
+        .read("list-tickets", cli: "list-tickets"),
+        .read("list-reviews", cli: "list-reviews"),
+        .write("refresh-tickets", cli: "refresh-tickets"),
+        .write("work-on-issue", cli: "work-on-issue"),
+        .write("batch-work-on-issues", cli: "batch-work-on-issues"),
+        .write("start-review", cli: "start-review"),
+        .write("create-manager", cli: "create-manager"),
+        .write("quick-action", cli: "quick-action"),
+        .read(
+            "get-pr-status",
+            noCLI: """
+                Per-row PR badge fetch for the web Reviews board, called once per \
+                visible card. `crow list-reviews` already returns the same PR state \
+                for every review in one payload, which is the shape a script wants.
+                """),
+        .read(
+            "list-agents",
+            noCLI: """
+                Populates the agent picker in the web session-create sheet. The CLI \
+                takes an agent kind directly on `crow create-manager --agent` and \
+                `crow handoff-agent --agent`, so it never needs to enumerate them.
+                """),
+        .write(
+            "batch-start-review",
+            noCLI: """
+                Backs the Reviews board's multi-select "Start Review (N)" button \
+                (#869). The CLI equivalent is looping `crow start-review --url`, \
+                which reports per-URL failures instead of one batch result.
+                """),
+
+        // Allowlist
+        .read("list-allowlist", cli: "list-allowlist"),
+        .write("promote-allowlist", cli: "promote-allowlist"),
+        .write("refresh-allowlist", cli: "refresh-allowlist"),
+
+        // Analytics
+        .read("get-scorecard", cli: "get-scorecard"),
+        .write("rebuild-scorecard", cli: "rebuild-scorecard"),
+        .read("get-state", cli: "get-state"),
+        .read("list-artifacts", cli: "list-artifacts"),
+
+        // Settings
+        // `defaults-get` is deliberately un-gated on `/rpc`; `defaults-set` is
+        // local-only when the request carries `binaries` (CROW-810).
+        .read("defaults-get", cli: "defaults get"),
+        .write("defaults-set", cli: "defaults set"),
+        .read("telemetry-get", cli: "telemetry get"),
+        .write("telemetry-set", cli: "telemetry set"),
+        .read("cleanup-get", cli: "cleanup get"),
+        .write("cleanup-set", cli: "cleanup set"),
+        .read("ui-get", cli: "ui get"),
+        .write("ui-set", cli: "ui set"),
+        .read("notifications-get", cli: "notifications get"),
+        .write("notifications-set", cli: "notifications set"),
+        .read(
+            "get-config",
+            noCLI: """
+                Ships the whole AppConfig as one opaque JSON blob to the web Settings \
+                modal. The CLI reads config per area instead (`telemetry get`, \
+                `cleanup get`, `ui get`, `notifications get`, `gateway get`), which is \
+                what `configFields` below tracks field by field.
+                """),
+        .write(
+            "set-config",
+            noCLI: """
+                Whole-config write behind the web Settings modal — it replaces every \
+                field at once, so exposing it as a verb would hand scripts a \
+                read-modify-write race against the daemon. The CLI writes per area; \
+                `configFields` below is the ledger of which fields still lack a verb.
+                """),
+        .write(
+            "run-setup",
+            noCLI: """
+                Runs the workspace `setup.sh` on the daemon host with the caller's \
+                environment; local-only on `/rpc` for that reason \
+                (RPCWebSocketHandler.localOnlyDenial). `crow setup` is the CLI path \
+                and runs the wizard in-process rather than over the socket.
+                """),
+
+        // Secrets — local-socket only (CROW-815); see RPCWebSocketHandler.localOnlyDenial.
+        .read("gateway-get", cli: "gateway get"),
+        // `gateway clear` and `web-password clear` reuse the same write RPC with a
+        // clearing payload, so only the `set` verb is named here.
+        .write("gateway-set", cli: "gateway set"),
+        .read("web-password-get", cli: "web-password status"),
+        .write("web-password-set", cli: "web-password set"),
+
+        // Jobs
+        .read("job-list", cli: "job list"),
+        .read("job-get", cli: "job get"),
+        .write("job-add", cli: "job add"),
+        .write("job-edit", cli: "job edit"),
+        .write("job-enable", cli: "job enable"),
+        .write("job-disable", cli: "job disable"),
+        .write("job-delete", cli: "job delete"),
+        .write("job-duplicate", cli: "job duplicate"),
+        .write("job-run", cli: "job run"),
+        .write(
+            "run-job",
+            noCLI: """
+                Internal scheduler entry point: fires a job on the daemon's own \
+                timer path, bypassing the enabled/schedule checks a user-initiated \
+                run must honour. `crow job run` is the user-facing verb.
+                """),
+
+        // Agent hooks
+        .write("hook-event", cli: "hook-event"),
+    ]
+
+    // MARK: - Config fields
+
+    /// One leaf field of ``AppConfig``, addressed by dotted path. Collection and
+    /// dictionary elements are addressed with a `[]` segment — e.g.
+    /// `workspaces[].jiraJQL`, `notifications.eventSettings[].soundName`.
+    public struct ConfigEntry: Sendable, Equatable {
+        public let path: String
+        /// How a user reads this field back without opening the web UI.
+        public let read: Coverage
+        /// How a user changes it.
+        public let write: Coverage
+
+        public static func field(_ path: String, read: String, write: String) -> ConfigEntry {
+            ConfigEntry(path: path, read: .cli(read), write: .cli(write))
+        }
+
+        /// Neither readable nor writable from the CLI — one reason covers both.
+        public static func field(_ path: String, noCLI reason: String) -> ConfigEntry {
+            ConfigEntry(path: path, read: .noCLI(reason: reason), write: .noCLI(reason: reason))
+        }
+
+        public static func field(_ path: String, read: String, writeNoCLI: String) -> ConfigEntry {
+            ConfigEntry(path: path, read: .cli(read), write: .noCLI(reason: writeNoCLI))
+        }
+
+        public static func field(_ path: String, readNoCLI: String, write: String) -> ConfigEntry {
+            ConfigEntry(path: path, read: .noCLI(reason: readNoCLI), write: .cli(write))
+        }
+    }
+
+    /// Every leaf field of ``AppConfig``, as produced by the `Mirror` walk in
+    /// `ParityGateTests`. The two sets must match exactly, so a new config field
+    /// fails the build until someone decides whether it gets a verb.
+    ///
+    /// The exempt rows below are the honest state of the milestone as of CROW-807:
+    /// the settings blocks that already have verbs (`telemetry`, `cleanup`,
+    /// `sidebar`, `notifications`, gateways, jobs, and `defaults` since CROW-810)
+    /// are covered, and everything the web Settings tab owns exclusively —
+    /// `workspaces[].*`, the automation toggles, `terminal.*` — is not.
+    public static let configFields: [ConfigEntry] = [
+        // MARK: Covered — settings blocks with dedicated verbs
+
+        .field("telemetry.enabled", read: "telemetry get", write: "telemetry set"),
+        .field("telemetry.port", read: "telemetry get", write: "telemetry set"),
+        .field("telemetry.retentionDays", read: "telemetry get", write: "telemetry set"),
+
+        .field("cleanup.enabled", read: "cleanup get", write: "cleanup set"),
+        .field("cleanup.retentionHours", read: "cleanup get", write: "cleanup set"),
+
+        .field("sidebar.hideSessionDetails", read: "ui get", write: "ui set"),
+
+        .field("notifications.globalMute", read: "notifications get", write: "notifications set"),
+        .field("notifications.soundEnabled", read: "notifications get", write: "notifications set"),
+        .field(
+            "notifications.systemNotificationsEnabled",
+            read: "notifications get", write: "notifications set"),
+        .field(
+            "notifications.eventSettings[].enabled",
+            read: "notifications get", write: "notifications set"),
+        .field(
+            "notifications.eventSettings[].soundEnabled",
+            read: "notifications get", write: "notifications set"),
+        .field(
+            "notifications.eventSettings[].systemNotificationEnabled",
+            read: "notifications get", write: "notifications set"),
+        .field(
+            "notifications.eventSettings[].soundName",
+            read: "notifications get", write: "notifications set"),
+
+        // Gateways and the web password are local-socket only (CROW-815).
+        .field("managerGateway.baseURL", read: "gateway get", write: "gateway set"),
+        .field("managerGateway.customHeaders", read: "gateway get", write: "gateway set"),
+        .field("workspaces[].gateway.baseURL", read: "gateway get", write: "gateway set"),
+        .field("workspaces[].gateway.customHeaders", read: "gateway get", write: "gateway set"),
+
+        .field("webAuth.iterations", read: "web-password status", write: "web-password set"),
+        .field(
+            "webAuth.hashB64",
+            readNoCLI: """
+                The PBKDF2 hash is never read back by anything — not the CLI, not the \
+                web UI. `crow web-password status` reports only that a password is \
+                set. Exposing it would defeat storing a hash rather than the password.
+                """,
+            write: "web-password set"),
+        .field(
+            "webAuth.saltB64",
+            readNoCLI: """
+                Salt for the password hash above; never read back by any surface, for \
+                the same reason. Written as a unit with the hash by `web-password set`.
+                """,
+            write: "web-password set"),
+
+        // MARK: Covered — jobs
+
+        .field("jobs[].name", read: "job get", write: "job add"),
+        .field("jobs[].workspace", read: "job get", write: "job add"),
+        .field("jobs[].repo", read: "job get", write: "job add"),
+        .field("jobs[].prompts", read: "job get", write: "job add"),
+        .field("jobs[].schedule", read: "job get", write: "job add"),
+        .field("jobs[].enabled", read: "job get", write: "job enable"),
+        .field(
+            "jobs[].id",
+            read: "job get",
+            writeNoCLI: """
+                Server-assigned UUID, minted by `job add` and thereafter the handle \
+                every other job verb takes. Not user-settable by design.
+                """),
+        .field(
+            "jobs[].createdAt",
+            read: "job get",
+            writeNoCLI: """
+                Stamped by the daemon when `job add` succeeds. Runtime provenance, \
+                not a setting — there is nothing for a user to write here.
+                """),
+        .field(
+            "jobs[].lastRunAt",
+            read: "job get",
+            writeNoCLI: """
+                Scheduler bookkeeping, written when a job fires so a daemon restart \
+                does not replay it. Not a setting; `job run` is how a user forces one.
+                """),
+
+        // MARK: Covered — global defaults (CROW-810)
+
+        .field("defaults.provider", read: "defaults get", write: "defaults set"),
+        .field("defaults.cli", read: "defaults get", write: "defaults set"),
+        .field("defaults.branchPrefix", read: "defaults get", write: "defaults set"),
+        .field("defaults.excludeReviewRepos", read: "defaults get", write: "defaults set"),
+        .field("defaults.excludeTicketRepos", read: "defaults get", write: "defaults set"),
+        .field("defaults.ignoreReviewLabels", read: "defaults get", write: "defaults set"),
+        .field("defaults.binaries", read: "defaults get", write: "defaults set"),
+        .field(
+            "defaults.excludeDirs",
+            read: "defaults get",
+            writeNoCLI: """
+                Returned by `defaults get` but `defaults set` has no flag for it \
+                (CROW-810 shipped seven of the nine fields writable). Directory-scan \
+                exclusions for repo discovery; web Settings tab is still the only \
+                way to change them.
+                """),
+        .field(
+            "defaults.mirrorClaudeMCPToCodex",
+            read: "defaults get",
+            writeNoCLI: """
+                Returned by `defaults get` but `defaults set` has no flag for it \
+                (CROW-810 shipped seven of the nine fields writable). Whether Codex \
+                sessions inherit Claude's MCP servers; web Settings tab only.
+                """),
+
+        // MARK: Exempt — workspaces (no CLI surface at all)
+
+        .field(
+            "workspaces[].id",
+            noCLI: """
+                Workspaces have no CLI surface whatsoever: they are created by the \
+                `crow setup` wizard and edited in the web Settings tab. This UUID is \
+                the identity the rest of the block hangs off.
+                """),
+        .field(
+            "workspaces[].name",
+            noCLI: """
+                Workspace folder name under the dev root. Setup wizard / web Settings \
+                only — see `workspaces[].id`. `WorkspaceInfo.validateName` guards it.
+                """),
+        .field(
+            "workspaces[].provider",
+            noCLI: """
+                Forge provider (`github`/`gitlab`) for the workspace. No verb reads or \
+                writes any workspace field — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].cli",
+            noCLI: """
+                Provider CLI for this workspace, kept for config-file compatibility. \
+                No workspace field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].host",
+            noCLI: """
+                Self-hosted GitLab host for the workspace. No workspace field has a \
+                verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].alwaysInclude",
+            noCLI: """
+                Repos always listed in the Manager's prompt table. No workspace field \
+                has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].autoReviewRepos",
+            noCLI: """
+                Repos whose review requests auto-create a review session. No workspace \
+                field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].excludeReviewRepos",
+            noCLI: """
+                Per-workspace review-board exclusions, unioned with the global \
+                defaults. No workspace field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].customInstructions",
+            noCLI: """
+                Free-text instructions appended to session prompts for this \
+                workspace. No workspace field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].taskProvider",
+            noCLI: """
+                Which ticket backend this workspace uses (github/gitlab/jira). No \
+                workspace field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].jiraProjectKey",
+            noCLI: """
+                Jira project key for ticket-board queries. No workspace field has a \
+                verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].jiraJQL",
+            noCLI: """
+                Custom JQL overriding the default ticket-board query. No workspace \
+                field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].jiraSite",
+            noCLI: """
+                Jira site hostname for issue links. No workspace field has a verb — \
+                see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].jiraStatusMap",
+            noCLI: """
+                Maps Crow pipeline states to this project's Jira workflow names; \
+                honoured by `crow transition-ticket`, but only editable in the web \
+                Settings tab. No workspace field has a verb — see `workspaces[].id`.
+                """),
+        .field(
+            "workspaces[].corveilHost",
+            noCLI: """
+                Corveil task-backend host for this workspace. No workspace field has a \
+                verb — see `workspaces[].id`.
+                """),
+
+        // MARK: Exempt — automation toggles and agent defaults (web Settings tab)
+
+        .field(
+            "remoteControlEnabled",
+            noCLI: """
+                Master switch for the daemon's remote HTTP/WS surface. Web Settings \
+                toggle; a verb would let a remote caller widen its own access, so any \
+                future one must be local-socket only like the gateway verbs.
+                """),
+        .field(
+            "managerAutoPermissionMode",
+            noCLI: """
+                Whether Manager sessions launch with `--permission-mode auto`. Web \
+                Settings toggle (ADR 0004); no verb reads or writes it.
+                """),
+        .field(
+            "jobsAutoPermissionMode",
+            noCLI: """
+                Whether scheduler-launched sessions get `--permission-mode auto`. Web \
+                Settings toggle; no verb reads or writes it.
+                """),
+        .field(
+            "reviewAutoPermissionMode",
+            noCLI: """
+                Whether code-review sessions get `--permission-mode auto`. Web \
+                Settings toggle; no verb reads or writes it.
+                """),
+        .field(
+            "coderViewAutoPermissionMode",
+            noCLI: """
+                Whether new work coder views start in auto-accept rather than plan \
+                mode (#586). Web Settings toggle; no verb reads or writes it.
+                """),
+        .field(
+            "attributionTrailers",
+            noCLI: """
+                Whether `setup.sh` writes the per-worktree Claude attribution \
+                override. Web Settings toggle; no verb reads or writes it.
+                """),
+        .field(
+            "autoMergeWatcherEnabled",
+            noCLI: """
+                Opt-in watcher that enables GitHub auto-merge on Crow-authored PRs \
+                labeled `crow:merge` (CROW-299). Web Settings toggle; `crow \
+                add-merge-label` applies the label but cannot arm the watcher.
+                """),
+        .field(
+            "autoCreateWatcherEnabled",
+            noCLI: """
+                Opt-in watcher that dispatches `/crow-workspace` for issues labeled \
+                `crow:auto` (CROW-312). Web Settings toggle; `crow work-on-issue` \
+                dispatches one by hand but cannot arm the watcher.
+                """),
+        .field(
+            "autoRespond.respondToChangesRequested",
+            noCLI: """
+                Whether Crow auto-answers review feedback. Web Settings toggle; the \
+                manual equivalent is `crow quick-action --action addressChanges`.
+                """),
+        .field(
+            "autoRespond.respondToFailedChecks",
+            noCLI: """
+                Whether Crow auto-answers failing CI. Web Settings toggle; the manual \
+                equivalent is `crow quick-action --action fixChecks`.
+                """),
+        .field(
+            "autoRespond.autoRebaseAndResolveConflicts",
+            noCLI: """
+                Whether Crow auto-rebases conflicted PRs (CROW-551). Web Settings \
+                toggle; the manual equivalent is `crow quick-action --action \
+                fixConflicts`.
+                """),
+        .field(
+            "defaultAgentKind",
+            noCLI: """
+                Coding agent used for new sessions when none is given. Web Settings \
+                picker; `crow create-manager --agent` and `crow handoff-agent --agent` \
+                choose per session but cannot change the default (CROW-421).
+                """),
+        .field(
+            "agentsByKind",
+            noCLI: """
+                Per-session-kind agent overrides, keyed by `SessionKind.rawValue` \
+                (CROW-433). Web Settings pickers; no verb reads or writes the map.
+                """),
+
+        // MARK: Exempt — terminal tuning and Jira credential
+
+        .field(
+            "terminal.wheelScrollLines",
+            noCLI: """
+                Scrollback lines per wheel notch on plain-shell surfaces (CROW-835, \
+                ADR 0013). Web Settings only — the `ui` verb covers the sidebar block, \
+                not this one.
+                """),
+        .field(
+            "terminal.agentWheelNotches",
+            noCLI: """
+                Wheel notches forwarded per physical notch on agent surfaces \
+                (CROW-835, ADR 0013). Web Settings only — see \
+                `terminal.wheelScrollLines`.
+                """),
+        .field(
+            "jiraCredential.username",
+            noCLI: """
+                Jira REST account for the in-app status fetch (CROW-528). Carries a \
+                credential, so any verb must be local-socket only like `crow gateway`; \
+                today it is written in the web Settings tab only.
+                """),
+        .field(
+            "jiraCredential.tokenRef",
+            noCLI: """
+                `op://` reference to the Jira API token — resolved on demand so the \
+                secret never lands in config.json. Same local-only constraint as \
+                `jiraCredential.username`; no verb exists yet.
+                """),
+    ]
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLedgerParityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLedgerParityTests.swift
@@ -1,0 +1,116 @@
+import CrowCore
+import CrowEngine
+import CrowGit
+import CrowIPC
+import CrowPersistence
+import Foundation
+import Testing
+
+@testable import CrowDaemon
+
+/// CLI control-plane parity gate, RPC half (CROW-807, ADR 0016).
+///
+/// `ParityLedger.rpcMethods` must name exactly the methods the live router pair
+/// answers. A new RPC method that nobody ledgered — and so nobody decided
+/// whether to give a `crow` verb — fails here.
+///
+/// This is the authoritative form of the check: it asks the real
+/// `CommandRouter`, composed exactly as `CrowDaemon` composes it (daemon
+/// handlers with the engine router as fallback), rather than pattern-matching
+/// source. `scripts/check-cli-parity.sh` makes the same assertion by text
+/// because CrowDaemon depends on the Darwin-only CrowTelemetry and therefore
+/// cannot run in the Linux PR lane (see `ci.yml`'s `LINUX_PACKAGES`) — the two
+/// exist together so the gate runs on every PR *and* cannot be fooled by a
+/// router refactor the regex would under-report.
+///
+/// Router construction is side-effect free: `makeCommandRouter` only allocates
+/// before its dictionary literal, and every handler's I/O lives inside a closure
+/// that is never invoked here.
+@Suite("RPC ledger parity")
+@MainActor
+struct RPCLedgerParityTests {
+
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crowd-parity-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// The daemon router wired to the engine fallback, mirroring `CrowDaemon.swift`.
+    private func liveRouter() -> CommandRouter {
+        let devRoot = tempDevRoot()
+        let appState = AppState()
+        let store = JSONStore.temporary()
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+
+        let engine = makeEngineRouter(
+            EngineContext(
+                appState: appState,
+                store: store,
+                sessionService: service,
+                issueTracker: nil,
+                telemetryPort: nil,
+                devRoot: devRoot,
+                hostBridge: NoopHostBridge(),
+                loadConfig: { nil },
+                applyConfig: { _ in nil }
+            ))
+
+        return makeCommandRouter(
+            appState: appState, store: store, git: GitManager(),
+            devRoot: devRoot, cockpit: nil, fallback: engine)
+    }
+
+    @Test("Ledger names exactly the registered RPC methods")
+    func ledgerMatchesRegisteredMethods() {
+        let registered = liveRouter().methodNames
+        let ledgered = Set(ParityLedger.rpcMethods.map(\.method))
+
+        let missing = registered.subtracting(ledgered)
+        let stale = ledgered.subtracting(registered)
+
+        #expect(
+            missing.isEmpty,
+            """
+            RPC methods with no ParityLedger.rpcMethods row (\(missing.count)):
+            \(missing.sorted().map { "  \($0)" }.joined(separator: "\n"))
+            Add a row for each, either
+              .write("your-method", cli: "your verb")   — it has a crow verb, or
+              .write("your-method", noCLI: "why not, and the ticket that closes it")
+            """)
+        #expect(
+            stale.isEmpty,
+            """
+            ParityLedger.rpcMethods rows for methods no router registers (\(stale.count)):
+            \(stale.sorted().map { "  \($0)" }.joined(separator: "\n"))
+            Delete them.
+            """)
+    }
+
+    /// The whole point of classifying rows: a write without a CLI path is a
+    /// capability a script cannot reach. Reads are ledgered too, but a read-only
+    /// gap is a convenience issue, not a control-plane one.
+    @Test("Every write method is reachable or explicitly exempt")
+    func writesAreCoveredOrExempt() {
+        let uncovered = ParityLedger.rpcMethods.filter {
+            $0.isWrite && $0.coverage.cliPath == nil && $0.coverage.exemptionReason == nil
+        }
+        #expect(
+            uncovered.isEmpty,
+            "Write methods with neither a CLI verb nor an exemption: \(uncovered.map(\.method).sorted())")
+    }
+
+    /// Guards the text-based stand-in: if `methodNames` ever stopped walking the
+    /// fallback chain, both this suite and the script would compare a truncated
+    /// surface against a truncated ledger and agree.
+    @Test("Router surface is the daemon/engine union, not just the daemon")
+    func fallbackChainIsIncluded() {
+        let names = liveRouter().methodNames
+        // Registered only by the daemon router...
+        #expect(names.contains("telemetry-set"))
+        // ...and only by the engine router it falls back to.
+        #expect(names.contains("set-goal"))
+        #expect(names.count > 70, "Expected the union of both routers, got \(names.count) methods")
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLedgerParityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLedgerParityTests.swift
@@ -23,6 +23,11 @@ import Testing
 /// exist together so the gate runs on every PR *and* cannot be fooled by a
 /// router refactor the regex would under-report.
 ///
+/// Only assertions that need a live router live here. The ledger's internal
+/// invariants — CLI paths resolving, `isWrite` classification, the write
+/// exemption set — are in `CrowCLITests/ParityGateTests` so they run on PRs
+/// too; this suite does not.
+///
 /// Router construction is side-effect free: `makeCommandRouter` only allocates
 /// before its dictionary literal, and every handler's I/O lives inside a closure
 /// that is never invoked here.
@@ -30,16 +35,18 @@ import Testing
 @MainActor
 struct RPCLedgerParityTests {
 
-    private func tempDevRoot() -> String {
-        let dir = (NSTemporaryDirectory() as NSString)
+    /// Build the daemon router wired to the engine fallback, mirroring
+    /// `CrowDaemon.swift`, and hand it to `body`.
+    ///
+    /// Scoped rather than returned so the temp dev root is removed afterwards —
+    /// `makeCommandRouter` never touches it, but leaving a directory per test
+    /// run behind is the kind of litter that compounds once a pattern spreads.
+    private func withLiveRouter<T>(_ body: (CommandRouter) throws -> T) rethrows -> T {
+        let devRoot = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("crowd-parity-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        return dir
-    }
+        try? FileManager.default.createDirectory(atPath: devRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
 
-    /// The daemon router wired to the engine fallback, mirroring `CrowDaemon.swift`.
-    private func liveRouter() -> CommandRouter {
-        let devRoot = tempDevRoot()
         let appState = AppState()
         let store = JSONStore.temporary()
         let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
@@ -57,14 +64,16 @@ struct RPCLedgerParityTests {
                 applyConfig: { _ in nil }
             ))
 
-        return makeCommandRouter(
+        let router = makeCommandRouter(
             appState: appState, store: store, git: GitManager(),
             devRoot: devRoot, cockpit: nil, fallback: engine)
+
+        return try body(router)
     }
 
     @Test("Ledger names exactly the registered RPC methods")
     func ledgerMatchesRegisteredMethods() {
-        let registered = liveRouter().methodNames
+        let registered = withLiveRouter { $0.methodNames }
         let ledgered = Set(ParityLedger.rpcMethods.map(\.method))
 
         let missing = registered.subtracting(ledgered)
@@ -88,25 +97,12 @@ struct RPCLedgerParityTests {
             """)
     }
 
-    /// The whole point of classifying rows: a write without a CLI path is a
-    /// capability a script cannot reach. Reads are ledgered too, but a read-only
-    /// gap is a convenience issue, not a control-plane one.
-    @Test("Every write method is reachable or explicitly exempt")
-    func writesAreCoveredOrExempt() {
-        let uncovered = ParityLedger.rpcMethods.filter {
-            $0.isWrite && $0.coverage.cliPath == nil && $0.coverage.exemptionReason == nil
-        }
-        #expect(
-            uncovered.isEmpty,
-            "Write methods with neither a CLI verb nor an exemption: \(uncovered.map(\.method).sorted())")
-    }
-
     /// Guards the text-based stand-in: if `methodNames` ever stopped walking the
     /// fallback chain, both this suite and the script would compare a truncated
     /// surface against a truncated ledger and agree.
     @Test("Router surface is the daemon/engine union, not just the daemon")
     func fallbackChainIsIncluded() {
-        let names = liveRouter().methodNames
+        let names = withLiveRouter { $0.methodNames }
         // Registered only by the daemon router...
         #expect(names.contains("telemetry-set"))
         // ...and only by the engine router it falls back to.

--- a/Packages/CrowIPC/Sources/CrowIPC/CommandRouter.swift
+++ b/Packages/CrowIPC/Sources/CrowIPC/CommandRouter.swift
@@ -23,6 +23,17 @@ public final class CommandRouter: Sendable {
         self.fallback = fallback
     }
 
+    /// Every method name this router answers, including everything reachable
+    /// through its ``fallback`` chain — i.e. exactly the set for which
+    /// ``handle(request:)`` will not return `methodNotFound`.
+    ///
+    /// Exists so the CLI-parity gate can enumerate the live RPC surface instead
+    /// of trusting a hand-maintained list (CROW-807). `handlers` stays private:
+    /// callers get the names, never the closures.
+    public var methodNames: Set<String> {
+        Set(handlers.keys).union(fallback?.methodNames ?? [])
+    }
+
     public func handle(request: JSONRPCRequest) async -> JSONRPCResponse {
         guard let handler = handlers[request.method] else {
             if let fallback {

--- a/docs/adr/0016-cli-control-plane-parity.md
+++ b/docs/adr/0016-cli-control-plane-parity.md
@@ -1,0 +1,128 @@
+# 0016 — Every user-mutable capability has a CLI path
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+- **Deciders:** @dhilgaertner
+
+## Context
+
+Crow's control plane exists three times over:
+
+1. the JSON-RPC methods `crowd` registers (`makeCommandRouter` + the `makeEngineRouter` it falls back to),
+2. the `crow` verbs that call them (`CrowCommand.configuration.subcommands`),
+3. the `AppConfig` fields both of them mutate.
+
+Nothing in the compiler ties those together. [ADR 0009](./0009-crowd-sole-authority-clients-only.md)
+established that all mutation flows through `crowd` RPCs and that new client
+features are "RPC + render, never local engine" — but it said nothing about
+*which* clients must be able to reach a given capability. In practice that meant
+a feature could ship as an RPC method plus a web Settings control and quietly
+never grow a CLI verb.
+
+That asymmetry matters more for Crow than for a typical app, because the primary
+operator of Crow is an agent. The Manager session drives Crow through the `crow`
+CLI ([ADR 0002](./0002-unix-socket-cli-architecture.md)); a capability reachable
+only from a browser is a capability no agent can use and no script can automate.
+Drift here doesn't degrade convenience, it removes the product's main interface.
+
+The drift was also invisible. Nobody could answer "what can the web UI do that
+the CLI can't?" without reading three files and holding the result in their head,
+so the gap grew without anyone deciding it should.
+
+All three surfaces are enumerable at build time, so the question can be settled
+mechanically rather than by review vigilance.
+
+## Decision
+
+**Every user-mutable capability in Crow has a CLI path, or a checked-in written
+reason why it doesn't.**
+
+The rule is enforced by `ParityLedger` (`Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift`),
+a checked-in ledger naming every RPC method and every `AppConfig` leaf field and,
+for each, either the `crow` verb that reaches it or a `Coverage.noCLI(reason:)`
+exemption. The reason is a required associated value, so an exemption cannot be
+added without writing one — **the ledger diff is the review surface**, and adding
+a row is the moment a human decides the gap is acceptable.
+
+Three checks keep the ledger honest, each placed where it can see the truth:
+
+| Check | Where | Runs on PRs |
+|---|---|---|
+| Ledger ⇄ `crow` verb tree; ledger ⇄ `AppConfig` `Mirror` walk | `CrowCLITests/ParityGateTests` | yes (Linux lane) |
+| Ledger ⇄ `CommandRouter.methodNames` (authoritative) | `CrowDaemonTests/RPCLedgerParityTests` | no — macOS only |
+| Ledger ⇄ router source (text) | `scripts/check-cli-parity.sh` | yes (`parity` job) |
+
+The split is forced: no single test target can see both sides. `CrowCLI` does not
+depend on `CrowDaemon`, and `CrowDaemon` depends on the Darwin-only `CrowTelemetry`,
+so it is absent from `ci.yml`'s `LINUX_PACKAGES` per [ADR 0007](./0007-linux-ci-swift.md).
+The shell script is the PR-lane stand-in for the daemon test; the daemon test is
+what catches a router refactor the script's regex would under-report.
+
+Reads are ledgered too, but only **writes** are held to the parity bar. A missing
+read verb is an inconvenience; a missing write verb is a capability an agent
+cannot exercise.
+
+## Consequences
+
+**Easier.** "What can the UI do that the CLI can't?" is now a grep of the ledger's
+exempt rows rather than an audit. Each per-area parity ticket has an unambiguous
+definition of done: delete its rows from the exempt set. A new RPC method or
+config field cannot ship without someone consciously deciding its CLI story,
+because the build goes red until a row exists.
+
+**Harder.** Adding a config field now costs a ledger row and a sentence of
+justification. That friction is the point, but it is real, and it lands on
+changes that may feel unrelated to the CLI. Nested `AppConfig` fields are
+enumerated by `Mirror` over a hand-maintained fully-populated probe instance
+(`parityProbeConfig()`); a new optional struct or collection must be populated
+there too, or the walk cannot see through it. A dedicated test fails loudly when
+it isn't, so this is a caught error rather than a silent gap.
+
+**Lived with.** The ledger is production code in `CrowCore` — the only package
+both the CLI and the daemon already depend on — so a few KB of governance data is
+compiled into shipped binaries. Encoding it as Swift rather than JSON buys the
+type-enforced exemption reason and removes a hand-written decoder that could
+itself drift, which is worth more than the bytes.
+
+The gate records today's honest state, and it is not flattering: all of
+`workspaces[].*`, the automation toggles and `terminal.*` have no CLI path at
+all, and `set-config`/`run-setup`/`batch-start-review`/`run-job` are writes with
+no verb. Freezing that inventory in a file is what makes it shrinkable — and it
+already works in both directions: rebasing onto CROW-810 turned the gate red
+until the nine `defaults.*` rows were moved from exempt to covered, which is also
+how the two fields that ticket left readable-but-not-writable
+(`defaults.excludeDirs`, `defaults.mirrorClaudeMCPToCodex`) came to light.
+
+## Alternatives considered
+
+**A JSON or YAML ledger at the repo root.** Closer to the literal ticket wording
+and trivial for the shell script to read with `jq`, but the Swift tests would need
+`#filePath` walk-ups to locate it and a hand-written `Codable` schema that is
+itself a drift risk — a decoder that can rot inside the drift detector.
+
+**Naming/prefix heuristics instead of a ledger** (`get-`/`list-` is a read, everything
+else needs a verb). No file to maintain, but it silently waves through a future
+write named `get-something`, and it cannot express *why* a gap is acceptable —
+which is the part that makes the gate a decision rather than a nag.
+
+**One test target depending on both sides.** Cleanest assertion, but `CrowCLI`
+would have to depend on `CrowDaemon` and thus on Darwin-only `CrowTelemetry`,
+dropping the entire CLI package out of the Linux PR lane — trading a broad, fast
+gate for a narrow one that only runs on release tags.
+
+**Documentation and review discipline.** This is the status quo that produced the
+drift; `docs/agent-harness-matrix.md` shows the pattern works when a table is
+maintained, but only because something else forces the update.
+
+## References
+
+- Ticket: [corveil/crow#807](https://github.com/corveil/crow/issues/807) — anti-drift parity test + CI gate
+- Related ADRs: [0002](./0002-unix-socket-cli-architecture.md) (the CLI surface),
+  [0007](./0007-linux-ci-swift.md) (why the RPC check is split),
+  [0009](./0009-crowd-sole-authority-clients-only.md) (mutation flows through crowd),
+  [0015](./0015-harness-capability-tiers.md) (*harness* parity — a different axis)
+- Code: `Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift`,
+  `Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift`,
+  `Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLedgerParityTests.swift`,
+  `Packages/CrowIPC/Sources/CrowIPC/CommandRouter.swift` (`methodNames`),
+  `scripts/check-cli-parity.sh`, `.github/workflows/ci.yml` (`parity` job)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0013 | [Terminal scroll model: per-surface hybrid](./0013-terminal-scroll-model.md) | Accepted | 2026-07-23 |
 | 0014 | [Pluggable `CodingAgent` adapter](./0014-pluggable-coding-agent-adapter.md) | Accepted | 2026-07-23 |
 | 0015 | [Harness capability tiers & phased parity](./0015-harness-capability-tiers.md) | Accepted | 2026-07-23 |
+| 0016 | [Every user-mutable capability has a CLI path](./0016-cli-control-plane-parity.md) | Accepted | 2026-07-27 |

--- a/scripts/check-cli-parity.sh
+++ b/scripts/check-cli-parity.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# CLI control-plane parity gate, RPC half (CROW-807 / ADR 0016).
+#
+# Asserts that the set of registered JSON-RPC methods equals the set enumerated
+# in the checked-in parity ledger. A new RPC method that nobody ledgered — and
+# therefore nobody decided whether to give a `crow` verb — fails this check.
+#
+#   - daemon handlers → Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+#   - engine handlers → Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+#     (the daemon router is built with `fallback: makeEngineRouter(ctx)`, so the
+#      live surface is the union of the two dictionaries)
+#   - the ledger      → Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+#
+# `CrowDaemonTests/RPCLedgerParityTests` makes the same assertion against the
+# real `CommandRouter.methodNames`, which is authoritative. This script exists
+# because CrowDaemon depends on the Darwin-only CrowTelemetry and so cannot run
+# in the Linux PR lane (see ci.yml's LINUX_PACKAGES) — text is the only way to
+# get this check onto every pull request.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DAEMON="$ROOT/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift"
+ENGINE="$ROOT/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift"
+LEDGER="$ROOT/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift"
+
+for f in "$DAEMON" "$ENGINE" "$LEDGER"; do
+  if [ ! -f "$f" ]; then
+    echo "check-cli-parity: missing $f" >&2
+    exit 1
+  fi
+done
+
+# A handler registration is a dictionary key whose value opens a closure:
+#     "job-add": { params in            (daemon)
+#     "set-goal": { @Sendable _ in      (engine)
+#     "job-list": { _ in [:] },         (hypothetical one-liner)
+# Requiring the `{ … in` opener is what keeps plain data dictionaries inside
+# handler bodies (`"checks": .string(…)`) out of the result. Deliberately not
+# anchored at end-of-line: a handler whose body starts on the same line is still
+# a handler, and anchoring here silently hid one from the gate.
+HANDLER_RE='^[[:space:]]+"[a-z0-9-]+": \{ (@Sendable )?[A-Za-z_][A-Za-z0-9_]* in([[:space:]]|$)'
+
+registered_methods() {
+  grep -hoE "$HANDLER_RE" "$DAEMON" "$ENGINE" \
+    | sed -E 's/^[[:space:]]*"([a-z0-9-]+)".*/\1/' \
+    | sort -u
+}
+
+# Ledger rows are `.read("method", …)` / `.write("method", …)`. A row with a long
+# exemption reason wraps, putting the method literal on its own line, so the
+# array body is flattened to one line before matching — otherwise a reformatted
+# row would silently drop out of the comparison and weaken the gate. Scoped to
+# the `rpcMethods` array so `configFields` below it can never contribute.
+ledger_methods() {
+  awk '/^    public static let rpcMethods/ { inside = 1 }
+       inside                             { print }
+       inside && /^    \]$/               { exit }' "$LEDGER" \
+    | tr '\n' ' ' \
+    | grep -oE '\.(read|write)\([[:space:]]*"[a-z0-9-]+"' \
+    | sed -E 's/.*"([a-z0-9-]+)".*/\1/' \
+    | sort -u
+}
+
+# Vacuity guard: if a router refactor stops matching HANDLER_RE the diff would
+# silently agree with an equally-empty ledger. The surface only ever grows, so a
+# floor well under today's count still catches a regex that has gone blind.
+MIN_METHODS=60
+count="$(registered_methods | wc -l | tr -d ' ')"
+if [ "$count" -lt "$MIN_METHODS" ]; then
+  echo "check-cli-parity: only $count RPC methods extracted (expected >= $MIN_METHODS)." >&2
+  echo "The handler-registration regex has probably gone stale — check that" >&2
+  echo "RPCHandlers.swift / EngineRouter.swift still register handlers as" >&2
+  echo '    "method-name": { params in' >&2
+  exit 1
+fi
+
+if ! diff -u <(registered_methods) <(ledger_methods) > "${TMPDIR:-/tmp}/cli-parity.diff" 2>&1; then
+  echo "MISMATCH: registered RPC methods vs ParityLedger.rpcMethods" >&2
+  echo "  (- registered but not ledgered, + ledgered but not registered)" >&2
+  tail -n +3 "${TMPDIR:-/tmp}/cli-parity.diff" >&2
+  echo "" >&2
+  echo "Add a row to ParityLedger.rpcMethods for each new method: either" >&2
+  echo '  .write("your-method", cli: "your verb")   — it has a crow verb, or' >&2
+  echo '  .write("your-method", noCLI: "why not, and the ticket that closes it")' >&2
+  exit 1
+fi
+
+echo "CLI/RPC parity: registered methods match the ledger ($count methods)"

--- a/scripts/check-cli-parity.sh
+++ b/scripts/check-cli-parity.sh
@@ -74,10 +74,15 @@ if [ "$count" -lt "$MIN_METHODS" ]; then
   exit 1
 fi
 
-if ! diff -u <(registered_methods) <(ledger_methods) > "${TMPDIR:-/tmp}/cli-parity.diff" 2>&1; then
+# mktemp, not a fixed path: a predictable name in a shared /tmp is a symlink
+# footgun on a multi-user box, and this script is meant to be run locally too.
+DIFF_OUT="$(mktemp "${TMPDIR:-/tmp}/cli-parity.XXXXXX")"
+trap 'rm -f "$DIFF_OUT"' EXIT
+
+if ! diff -u <(registered_methods) <(ledger_methods) > "$DIFF_OUT" 2>&1; then
   echo "MISMATCH: registered RPC methods vs ParityLedger.rpcMethods" >&2
   echo "  (- registered but not ledgered, + ledgered but not registered)" >&2
-  tail -n +3 "${TMPDIR:-/tmp}/cli-parity.diff" >&2
+  tail -n +3 "$DIFF_OUT" >&2
   echo "" >&2
   echo "Add a row to ParityLedger.rpcMethods for each new method: either" >&2
   echo '  .write("your-method", cli: "your verb")   — it has a crow verb, or' >&2


### PR DESCRIPTION
Closes #807

Crow's control plane exists three times over — the JSON-RPC methods `crowd` registers, the `crow` verbs that call them, and the `AppConfig` fields both mutate. Nothing tied them together, so a capability could ship as an RPC method plus a web control and quietly never grow a CLI path. Since the primary operator of Crow is an agent driving the `crow` CLI, that drift doesn't cost convenience — it removes the main interface.

## The ledger

`ParityLedger` (`Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift`) names **all 87 RPC methods** and **all 70 `AppConfig` leaf fields**, each mapped to the verb that reaches it or carrying a `Coverage.noCLI(reason:)` exemption. The reason is a *required associated value*, so an exemption cannot be added without writing one — **the ledger diff is the review gate**, and each per-area ticket closes its gap by deleting rows.

| | Covered | Exempt |
|---|---|---|
| RPC methods (87) | 78 | 9 (5 writes, 4 reads) |
| Config fields (70) | 33 read+write, 7 partial | 30 |

## Three checks, because no test target can see both sides

`CrowCLI` doesn't depend on `CrowDaemon`, and `CrowDaemon` depends on Darwin-only `CrowTelemetry` so it's absent from `ci.yml`'s `LINUX_PACKAGES` ([ADR 0007](docs/adr/0007-linux-ci-swift.md)). Each check therefore lives where it can see the truth:

| Check | Where | On PRs |
|---|---|---|
| Ledger ⇄ `CrowCommand` verb tree; ledger ⇄ `Mirror` walk of `AppConfig` | `CrowCLITests/ParityGateTests` | ✅ Linux lane |
| Ledger ⇄ real `CommandRouter.methodNames` (authoritative) | `CrowDaemonTests/RPCLedgerParityTests` | ❌ macOS only |
| Ledger ⇄ router source, by text | `scripts/check-cli-parity.sh` | ✅ new `parity` job |

The script is the PR-lane stand-in for the daemon test; the daemon test is what catches a router refactor the regex would under-report.

`CommandRouter` gains `methodNames`, walking the fallback chain, so the surface is enumerable without exposing handler closures.

The `Mirror` walk runs over a **fully-populated probe** `AppConfig` — a default one leaves optionals nil and arrays empty, hiding ~25 fields — and a dedicated test fails if the probe ever stops reaching a subtree.

## Day-one drift, recorded rather than hidden

The exempt set is not flattering, and that's the point:

- `set-config`, `run-setup`, `batch-start-review`, `run-job` — writes with no verb.
- **Engine RPC `set-pinned` has no caller**: `crow set-pinned` actually sends the `set-locked` RPC (`SessionCommands.swift:156`). Either the verb is misrouted or the method is dead. Ledgered with that note; deliberately not fixed here.
- `terminal.*` and all 15 `workspaces[].*` fields have no CLI path at all.
- `defaults.excludeDirs` and `defaults.mirrorClaudeMCPToCodex` are returned by `defaults get` but have no `defaults set` flag — surfaced by the rebase below.

## Verification

All four planned drift canaries were run, confirmed to fail with a precise message, and reverted. **Canary 1 found a real bug**: the script's first regex anchored on end-of-line, so a one-line handler registration (`"foo": { _ in [:] },`) slipped past silently — fixed, then re-verified against both the script and the daemon test.

| | |
|---|---|
| `scripts/check-cli-parity.sh` | ✅ 87 methods agree |
| `ParityGateTests` (7 tests) | ✅ |
| `RPCLedgerParityTests` (2 tests) | ✅ |
| CrowCLI / CrowCore / CrowIPC suites | ✅ 296 / 484 / 37 |
| `shellcheck scripts/*.sh` | ✅ clean |

## The gate proved itself on the rebase

The gate has now caught real drift three times on this branch, each time before a human looked:

- **#887 (defaults CLI)** — rebase turned it red on `defaults-get`/`defaults-set`; stayed red until the nine `defaults.*` rows moved to covered. Working through them surfaced that #887 left two fields readable but not writable.
- **#886 (agents CLI)**, via the `main` merge into this branch — red on `agents-get`/`agents-set`; `defaultAgentKind` and `agentsByKind` moved to covered, and the stale `list-agents` exemption reason ("the CLI never needs to enumerate agents" — it does now) got corrected.
- **Its own regex bug** — a canary caught that the handler pattern was anchored at end-of-line, so a one-line handler registration would have slipped past silently.

Exempt config fields are down 41 → 30 as a result.

## Scope note

The new `parity` job also runs `check-notification-events.sh`, which existed but was reachable only from `make test` — which CI never runs. One line to stop an existing gate being decorative; say the word and I'll drop it.

[ADR 0016](docs/adr/0016-cli-control-plane-parity.md) states the principle the gate mechanizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
