### PR TITLE
Stop blocking I/O on the MainActor from wedging the daemon's RPC surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Notification-event catalogs (CROW-768)
         run: bash scripts/check-notification-events.sh
 
+      - name: NSLog ban (CROW-874)
+        run: bash scripts/check-no-nslog.sh
+
   desktop:
     name: Desktop (Tauri) Build
     runs-on: macos-15
@@ -97,6 +100,9 @@ jobs:
       - name: Build crow-desktop (Rust/Tauri)
         run: cargo build --manifest-path crow-desktop/src-tauri/Cargo.toml
 
+  # Cheap cross-cutting invariants that no compiler enforces. These live in
+  # `make test` too, but that only runs locally — before this job, nothing ran
+  # them in CI at all.
   shellcheck:
     name: Shell Lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ parity:
 	@./scripts/check-notification-events.sh
 	@echo "==> Checking CLI/RPC control-plane parity (CROW-807)..."
 	@./scripts/check-cli-parity.sh
+	@echo "==> Checking for banned NSLog (CROW-874)..."
+	@./scripts/check-no-nslog.sh
 
 # Regenerate the CLI reference from the commands themselves (CROW-808). Run
 # after adding or changing a subcommand — a stale docs/cli.md fails CrowCLI's

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
@@ -127,7 +127,7 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
         // worktree than poison the repo. Checked unconditionally so a
         // tracked-but-`rm`'d file is still caught.
         if Self.isGitTracked(worktreePath: worktreePath, relativePath: ".agents/hooks.json") {
-            NSLog("[AntigravityHookConfigWriter] %@/.agents/hooks.json is git-tracked; not writing Crow's session hooks into a committed file. Gitignore/untrack it to enable hook-based state detection for this worktree.", worktreePath)
+            CrowLog.info("[AntigravityHookConfigWriter] \(worktreePath)/.agents/hooks.json is git-tracked; not writing Crow's session hooks into a committed file. Gitignore/untrack it to enable hook-based state detection for this worktree.")
             return
         }
 
@@ -138,7 +138,7 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
         var root: [String: Any] = [:]
         if let data = FileManager.default.contents(atPath: hooksPath) {
             guard let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                NSLog("[AntigravityHookConfigWriter] %@ exists but is unparseable; leaving it untouched (would otherwise drop the user's own hook groups)", hooksPath)
+                CrowLog.info("[AntigravityHookConfigWriter] \(hooksPath) exists but is unparseable; leaving it untouched (would otherwise drop the user's own hook groups)")
                 return
             }
             root = parsed
@@ -202,8 +202,7 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
                 withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
             try out.write(to: URL(fileURLWithPath: hooksPath), options: [.atomic])
         } catch {
-            NSLog("[AntigravityHookConfigWriter] Failed to rewrite %@: %@",
-                  hooksPath, error.localizedDescription)
+            CrowLog.info("[AntigravityHookConfigWriter] Failed to rewrite \(hooksPath): \(error.localizedDescription)")
         }
     }
 

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -147,8 +147,7 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
             try? FileManager.default.setAttributes(
                 [.posixPermissions: 0o600], ofItemAtPath: settingsPath)
         } catch {
-            NSLog("[ClaudeHookConfigWriter] Failed to write gateway env to %@: %@",
-                  settingsPath, error.localizedDescription)
+            CrowLog.info("[ClaudeHookConfigWriter] Failed to write gateway env to \(settingsPath): \(error.localizedDescription)")
         }
     }
 
@@ -179,8 +178,7 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
             do {
                 try FileManager.default.removeItem(atPath: settingsPath)
             } catch {
-                NSLog("[ClaudeHookConfigWriter] Failed to remove empty settings file at %@: %@",
-                      settingsPath, error.localizedDescription)
+                CrowLog.info("[ClaudeHookConfigWriter] Failed to remove empty settings file at \(settingsPath): \(error.localizedDescription)")
             }
         } else {
             do {
@@ -188,8 +186,7 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
                     withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
                 try updatedData.write(to: URL(fileURLWithPath: settingsPath))
             } catch {
-                NSLog("[ClaudeHookConfigWriter] Failed to write updated settings to %@: %@",
-                      settingsPath, error.localizedDescription)
+                CrowLog.info("[ClaudeHookConfigWriter] Failed to write updated settings to \(settingsPath): \(error.localizedDescription)")
             }
         }
     }

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeTrustSeeder.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeTrustSeeder.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Seeds per-project trust into `~/.claude.json` so Claude Code skips the
@@ -60,7 +61,7 @@ public enum ClaudeTrustSeeder {
             guard let data = fm.contents(atPath: jsonPath),
                   let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
             else {
-                NSLog("[ClaudeTrustSeeder] %@ exists but is not a JSON object; refusing to modify it", jsonPath)
+                CrowLog.info("[ClaudeTrustSeeder] \(jsonPath) exists but is not a JSON object; refusing to modify it")
                 return .skippedUnparseable
             }
             root = parsed
@@ -94,7 +95,7 @@ public enum ClaudeTrustSeeder {
             let perms = existingPerms ?? NSNumber(value: 0o600)
             try? fm.setAttributes([.posixPermissions: perms], ofItemAtPath: jsonPath)
         } catch {
-            NSLog("[ClaudeTrustSeeder] Failed to write %@: %@", jsonPath, error.localizedDescription)
+            CrowLog.info("[ClaudeTrustSeeder] Failed to write \(jsonPath): \(error.localizedDescription)")
             return .failed(error.localizedDescription)
         }
         return .seeded

--- a/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
@@ -1,93 +1,301 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+import os
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
-/// Durable, greppable log file for background-automation decisions (CROW-782).
+/// Process-wide log sink. **Never blocks the caller** (CROW-874).
 ///
-/// The daemon's own `log()` writes to stderr, and `IssueTracker` `NSLog`s only
-/// when it *acts* — so when auto-merge silently skipped every PR there was
-/// nothing left to read afterwards. This sink gives each poll's automation
-/// decisions (including the skips and their reasons) a stable file that
-/// survives daemon restarts and stderr redirection:
+/// The rule this type exists to enforce: `crowd` serves every CLI and web client
+/// through RPC handlers that hop to the MainActor, so anything that blocks the
+/// MainActor stalls the whole daemon rather than one request. `NSLog` does
+/// exactly that — it funnels into CoreFoundation's `_logToStderr`, which calls
+/// `writev(2)` on the controlling tty. When that tty's output queue is full and
+/// nobody is draining it (Ctrl-S, a stopped terminal, an unread pane), `writev`
+/// blocks in the kernel with no timeout. A `sample` of a wedged daemon caught
+/// exactly this: one `NSLog` inside `MainActor.run` holding up every other
+/// MainActor-bound RPC until the tty drained. `NSLog` is therefore banned
+/// repo-wide outside this file — see `scripts/check-no-nslog.sh`.
+///
+/// How this stays non-blocking:
+///
+/// - **os_log mirror runs on the calling thread, before enqueue.** `Logger.log`
+///   is a bounded `memcpy` into this process's trace buffer, which cannot block.
+///   Doing it here rather than on the drain thread is the whole point: it is the
+///   copy that survives a wedged stderr, a dropped line, and `execv`.
+/// - **The backlog is bounded** (`backlogCapacity`). Past the cap lines are
+///   dropped and counted, and the drain reports the gap when it next runs. A
+///   wedged sink costs bounded memory and a hole in the log, never a hang.
+/// - **A dedicated thread does the blocking write.** Not a serial
+///   `DispatchQueue`: `DispatchQueue.async` already never blocks the caller, so
+///   the actual job here is *bounding* the queue — and a dispatch queue's queue
+///   cannot be bounded.
+///
+/// It also remains the durable automation-decision log from CROW-782:
+/// `automation(_:)` additionally appends to
 ///
 ///     ~/Library/Logs/crow/crowd-automation.log
 ///
-/// Lines are `<ISO8601> [automation] <message>` and are also mirrored to
-/// `NSLog`, so existing Console-based debugging keeps working unchanged.
+/// as `<ISO8601> [automation] <message>`, size-capped at `maxBytes` with exactly
+/// one rotated generation (`…log.1`) and owner-only permissions. `info(_:)` and
+/// `error(_:)` deliberately do **not** touch that file — it is a decision log,
+/// and general traffic would evict the auto-merge trail it exists to preserve.
 ///
-/// Writes are serialized with an `NSLock` (same approach as `JSONStore`) and
-/// the file is size-capped: past `maxBytes` it rotates to `…log.1`, keeping
-/// exactly one previous generation, so a long-lived daemon can't fill the disk.
-///
-/// Per ADR 0012, a test process never writes to the live log directory — the
-/// default directory resolves to a per-process temp dir under a test runner.
+/// Per ADR 0012 a test process never writes to the live log directory: the
+/// destination is resolved on the *caller's* thread at enqueue (see `emit`), so
+/// `configure(directory:)` is a strict happens-before for every later line.
 public enum CrowLog {
-    /// Rotate once the active file exceeds this size (bytes).
+    /// Rotate the automation file once it exceeds this size (bytes).
     static let maxBytes: Int = 5 * 1024 * 1024
 
-    private static let lock = NSLock()
-    /// `nonisolated(unsafe)`: only ever touched while holding `lock`.
+    /// Maximum lines held while the sink is blocked. Past this, lines are
+    /// dropped and counted. `var` only so tests can shrink it; production
+    /// never assigns it.
+    nonisolated(unsafe) static var backlogCapacity: Int = 4096
+
+    // MARK: - State
+    //
+    // Two locks, and they are NEVER nested. `cond` guards the queue and is held
+    // only for a handful of array operations — never across a write. `dirLock`
+    // guards `overrideDirectory` alone, and `automation(_:)` takes and releases
+    // it *before* it touches `cond`. That ordering is the safety argument: the
+    // drain thread cannot be holding a lock that a logging caller needs, so a
+    // blocked write can never back-pressure into the caller.
+
+    private static let cond = NSCondition()
+    /// `nonisolated(unsafe)`: only ever touched while holding `cond`.
+    private nonisolated(unsafe) static var pending: [Record] = []
+    private nonisolated(unsafe) static var dropped: Int = 0
+    /// Monotonic drop total, never reset. Exists so tests can assert the
+    /// overflow path was taken; `dropped` above is cleared by each drain.
+    private nonisolated(unsafe) static var droppedTotal: Int = 0
+    /// Highest sequence actually appended to `pending`. Dropped lines never get
+    /// one — that is what keeps `flush` from waiting on a line that will never
+    /// be written.
+    private nonisolated(unsafe) static var enqueuedSeq: UInt64 = 0
+    /// Highest sequence the drain has finished writing.
+    private nonisolated(unsafe) static var retiredSeq: UInt64 = 0
+    private nonisolated(unsafe) static var workerStarted = false
+
+    private static let dirLock = NSLock()
+    /// `nonisolated(unsafe)`: only ever touched while holding `dirLock`.
     private nonisolated(unsafe) static var overrideDirectory: URL?
 
-    /// `nonisolated(unsafe)`: only ever used while holding `lock`.
-    private nonisolated(unsafe) static let timestampFormatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
+    #if canImport(Darwin)
+    /// `com.corveil.crowd` matches the launchd label, so `log stream
+    /// --predicate 'subsystem == "com.corveil.crowd"'` picks up the daemon.
+    private static let osLogger = Logger(subsystem: "com.corveil.crowd", category: "crow")
+    #endif
 
-    /// Point the sink at a different directory. Tests use this to write into a
-    /// temp dir; production leaves it alone.
+    private struct Record {
+        let seq: UInt64
+        /// Captured at enqueue, formatted on the drain. Formatting at drain time
+        /// would stamp every line buffered during a wedge with the *resume*
+        /// time — destroying the one thing you need to reconstruct the hang.
+        let date: Date
+        let message: String
+        /// Resolved on the caller's thread at enqueue (ADR 0012). `nil` means
+        /// stderr + os_log only.
+        let fileDirectory: URL?
+    }
+
+    private enum Level { case info, error }
+
+    // MARK: - Public API
+
+    /// Log one line to stderr and the unified log. Never blocks.
+    public static func info(_ message: String) {
+        emit(message, level: .info, fileDirectory: nil)
+    }
+
+    /// As `info(_:)`, but recorded at error level in the unified log so
+    /// `log show --predicate 'messageType == error'` can isolate it.
+    public static func error(_ message: String) {
+        emit(message, level: .error, fileDirectory: nil)
+    }
+
+    /// Record a background-automation decision (CROW-782). Same non-blocking
+    /// path as `info(_:)`, plus an append to `crowd-automation.log`.
+    public static func automation(_ message: String) {
+        // Resolve the destination HERE, on the caller, so a later
+        // `configure(directory:)` cannot retarget a line that is already queued.
+        dirLock.lock()
+        let dir = resolvedDirectoryLocked()
+        dirLock.unlock()
+        emit("[automation] \(message)", level: .info, fileDirectory: dir)
+    }
+
+    /// Block until every line queued at the time of the call has been written,
+    /// or `timeout` elapses. Returns `false` on timeout.
+    ///
+    /// This is a barrier, **not** a delivery guarantee: a sink that is wedged
+    /// stays wedged, and this returns `false` with those lines still unwritten.
+    /// They are not lost — the os_log copy was made on the calling thread before
+    /// the line was ever queued, which is precisely why that mirror is on the
+    /// producer side.
+    ///
+    /// Call before `exit()` / `execv()`, and from tests that assert on file
+    /// contents. Must not be called from the drain thread.
+    @discardableResult
+    public static func flush(timeout: TimeInterval = 2.0) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        cond.lock()
+        defer { cond.unlock() }
+        // Waits on `enqueuedSeq`, not `pending` — a batch the drain has already
+        // taken is no longer in `pending` but is not yet written.
+        while retiredSeq < enqueuedSeq {
+            if !cond.wait(until: deadline) { return false }
+        }
+        return true
+    }
+
+    /// Point the automation file at a different directory. Tests use this to
+    /// write into a temp dir; production leaves it alone.
     public static func configure(directory: URL?) {
-        lock.lock()
+        dirLock.lock()
         overrideDirectory = directory
-        lock.unlock()
+        dirLock.unlock()
     }
 
     /// Directory holding the automation log. `~/Library/Logs/crow` in
     /// production; a temp directory under a test runner (ADR 0012).
     public static var directory: URL {
-        lock.lock()
-        defer { lock.unlock() }
+        dirLock.lock()
+        defer { dirLock.unlock() }
         return resolvedDirectoryLocked()
     }
 
     /// Full path of the active automation log file.
     public static var fileURL: URL { directory.appendingPathComponent("crowd-automation.log") }
 
-    /// Append one automation line, and mirror it to `NSLog`.
-    public static func automation(_ message: String) {
-        NSLog("[Crow][automation] %@", message as NSString)
-        let now = Date()
-        lock.lock()
-        defer { lock.unlock() }
-        appendLocked("\(timestampFormatter.string(from: now)) [automation] \(message)\n")
-    }
+    // MARK: - Producer
 
-    // MARK: - Internals (all callers hold `lock`)
-
-    private static func resolvedDirectoryLocked() -> URL {
-        if let overrideDirectory { return overrideDirectory }
-        if isRunningUnderTests() {
-            // Never write into the developer's real log directory from a test
-            // process (ADR 0012). Appending is not destructive the way a
-            // full-store `mutate` is, but test noise in a diagnostic log is
-            // exactly what makes the log untrustworthy later.
-            return URL(fileURLWithPath: NSTemporaryDirectory())
-                .appendingPathComponent("crow-test-logs-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+    private static func emit(_ message: String, level: Level, fileDirectory: URL?) {
+        #if canImport(Darwin)
+        // On the CALLER, before enqueue — see the type doc. `privacy: .public`
+        // is mandatory, not decorative: `Logger` renders dynamic (non-literal)
+        // interpolations as `<private>` to other processes, and every message
+        // here is a runtime String. Without it every line reads `<private>`.
+        switch level {
+        case .info: osLogger.log("\(message, privacy: .public)")
+        case .error: osLogger.error("\(message, privacy: .public)")
         }
-        return FileManager.default
-            .homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Logs/crow", isDirectory: true)
+        #endif
+
+        let now = Date()
+        cond.lock()
+        startWorkerIfNeededLocked()
+        if pending.count < backlogCapacity {
+            enqueuedSeq &+= 1
+            pending.append(Record(seq: enqueuedSeq, date: now, message: message,
+                                  fileDirectory: fileDirectory))
+            cond.signal()
+        } else {
+            dropped &+= 1
+            droppedTotal &+= 1
+        }
+        cond.unlock()
     }
 
-    private static func appendLocked(_ line: String) {
-        let dir = resolvedDirectoryLocked()
+    /// Total lines dropped to backlog overflow since process start. Test seam.
+    static var droppedLineCount: Int {
+        cond.lock()
+        defer { cond.unlock() }
+        return droppedTotal
+    }
+
+    private static func startWorkerIfNeededLocked() {
+        guard !workerStarted else { return }
+        workerStarted = true
+        let thread = Thread { drainLoop() }
+        thread.name = "com.corveil.crow.log"
+        thread.qualityOfService = .utility
+        thread.stackSize = 512 * 1024
+        thread.start()
+    }
+
+    // MARK: - Drain (one dedicated thread; holds no lock during I/O)
+
+    private static func drainLoop() {
+        // Thread-confined: ISO8601DateFormatter is not thread-safe, and this is
+        // now its only user.
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let tag = "\(ProcessInfo.processInfo.processName)[\(getpid())]"
+
+        while true {
+            cond.lock()
+            while pending.isEmpty { cond.wait() }
+            let batch = pending
+            pending.removeAll(keepingCapacity: true)
+            let drops = dropped
+            dropped = 0
+            cond.unlock()
+
+            var out = ""
+            if drops > 0 {
+                out += "\(iso.string(from: Date())) \(tag) [CrowLog] dropped \(drops) line(s) — sink was blocked\n"
+            }
+            for record in batch {
+                let stamp = iso.string(from: record.date)
+                out += "\(stamp) \(tag) \(record.message)\n"
+                if let dir = record.fileDirectory {
+                    appendToAutomationFile(directory: dir, line: "\(stamp) \(record.message)\n")
+                }
+            }
+            // The only blocking call in this loop, and no lock is held across it.
+            writeAll(out, to: STDERR_FILENO)
+
+            cond.lock()
+            if let last = batch.last { retiredSeq = last.seq }
+            cond.broadcast()
+            cond.unlock()
+        }
+    }
+
+    /// `write(2)` loop handling short writes, `EINTR`, and a non-blocking fd.
+    ///
+    /// Deliberately not `FileHandle.standardError.write(_:)`: that raises an
+    /// uncatchable Objective-C exception on `EPIPE`/`EBADF`, so a closed stderr
+    /// would take the daemon down instead of dropping a log line.
+    private static func writeAll(_ text: String, to fd: Int32) {
+        let bytes = Array(text.utf8)
+        bytes.withUnsafeBufferPointer { buf in
+            guard let base = buf.baseAddress else { return }
+            var offset = 0
+            while offset < buf.count {
+                let written = write(fd, base + offset, buf.count - offset)
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    if errno == EAGAIN || errno == EWOULDBLOCK {
+                        // Someone set O_NONBLOCK on our stderr. Park rather than
+                        // spin; this thread blocking is the design.
+                        var poller = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+                        _ = poll(&poller, 1, 100)
+                        continue
+                    }
+                }
+                return  // EPIPE / EBADF / closed — drop the rest rather than spin.
+            }
+        }
+    }
+
+    // MARK: - Automation file (drain thread is the sole writer)
+
+    private static func appendToAutomationFile(directory dir: URL, line: String) {
         let url = dir.appendingPathComponent("crowd-automation.log")
         let fm = FileManager.default
         try? fm.createDirectory(
             at: dir, withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700])
 
-        rotateIfNeededLocked(url: url)
+        rotateIfNeeded(url: url)
 
         guard let data = line.data(using: .utf8) else { return }
         if let handle = try? FileHandle(forWritingTo: url) {
@@ -107,7 +315,7 @@ public enum CrowLog {
         try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
     }
 
-    private static func rotateIfNeededLocked(url: URL) {
+    private static func rotateIfNeeded(url: URL) {
         let fm = FileManager.default
         guard let attrs = try? fm.attributesOfItem(atPath: url.path),
               let size = attrs[.size] as? Int, size > maxBytes else { return }
@@ -118,6 +326,23 @@ public enum CrowLog {
         // keeps the same owner-only permissions (a move preserves them, but the
         // active file may predate this hardening).
         try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: rotated.path)
+    }
+
+    // MARK: - Directory resolution (callers hold `dirLock`)
+
+    private static func resolvedDirectoryLocked() -> URL {
+        if let overrideDirectory { return overrideDirectory }
+        if isRunningUnderTests() {
+            // Never write into the developer's real log directory from a test
+            // process (ADR 0012). Appending is not destructive the way a
+            // full-store `mutate` is, but test noise in a diagnostic log is
+            // exactly what makes the log untrustworthy later.
+            return URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("crow-test-logs-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+        }
+        return FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/crow", isDirectory: true)
     }
 
     /// Mirrors `JSONStore.isRunningUnderTests()` — see ADR 0012 for why each

--- a/Packages/CrowCore/Sources/CrowCore/GatewayResolver.swift
+++ b/Packages/CrowCore/Sources/CrowCore/GatewayResolver.swift
@@ -55,7 +55,7 @@ public enum GatewayResolver {
                 if let secret = resolveSecret(value) {
                     resolvedHeaders[name] = secret
                 } else {
-                    NSLog("[GatewayResolver] Failed to resolve secret reference for header '%@' (op read failed or op not signed in); dropping this header — the gateway will reject the request", name)
+                    CrowLog.info("[GatewayResolver] Failed to resolve secret reference for header '\(name)' (op read failed or op not signed in); dropping this header — the gateway will reject the request")
                 }
             } else {
                 resolvedHeaders[name] = value
@@ -85,7 +85,7 @@ public enum GatewayResolver {
         do {
             try process.run()
         } catch {
-            NSLog("[GatewayResolver] Failed to launch `op` for secret resolution: %@", error.localizedDescription)
+            CrowLog.info("[GatewayResolver] Failed to launch `op` for secret resolution: \(error.localizedDescription)")
             return nil
         }
 
@@ -99,12 +99,12 @@ public enum GatewayResolver {
         }
         if done.wait(timeout: deadline) == .timedOut {
             process.terminate()
-            NSLog("[GatewayResolver] `op read` timed out resolving a secret reference")
+            CrowLog.info("[GatewayResolver] `op read` timed out resolving a secret reference")
             return nil
         }
 
         guard process.terminationStatus == 0 else {
-            NSLog("[GatewayResolver] `op read` exited with status %d", process.terminationStatus)
+            CrowLog.info("[GatewayResolver] `op read` exited with status \(process.terminationStatus)")
             return nil
         }
 

--- a/Packages/CrowCore/Sources/CrowCore/JiraCredentialResolver.swift
+++ b/Packages/CrowCore/Sources/CrowCore/JiraCredentialResolver.swift
@@ -25,20 +25,20 @@ public enum JiraCredentialResolver {
 
         let username = credential.username.trimmingCharacters(in: .whitespaces)
         guard !username.isEmpty else {
-            NSLog("[JiraCredentialResolver] No username set; cannot build Jira auth header")
+            CrowLog.info("[JiraCredentialResolver] No username set; cannot build Jira auth header")
             return nil
         }
 
         let tokenRef = credential.tokenRef.trimmingCharacters(in: .whitespaces)
         guard !tokenRef.isEmpty else {
-            NSLog("[JiraCredentialResolver] No API token set; cannot build Jira auth header")
+            CrowLog.info("[JiraCredentialResolver] No API token set; cannot build Jira auth header")
             return nil
         }
 
         let token: String
         if tokenRef.hasPrefix("op://") {
             guard let secret = resolveSecret(tokenRef) else {
-                NSLog("[JiraCredentialResolver] Failed to resolve API token reference (op read failed or op not signed in)")
+                CrowLog.info("[JiraCredentialResolver] Failed to resolve API token reference (op read failed or op not signed in)")
                 return nil
             }
             token = secret

--- a/Packages/CrowCore/Sources/CrowCore/ShellEnvironment.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ShellEnvironment.swift
@@ -76,7 +76,7 @@ public final class ShellEnvironment: Sendable {
         do {
             try process.run()
         } catch {
-            NSLog("[Crow] Failed to launch login shell for PATH resolution: %@", error.localizedDescription)
+            CrowLog.info("[Crow] Failed to launch login shell for PATH resolution: \(error.localizedDescription)")
             return nil
         }
 
@@ -89,12 +89,12 @@ public final class ShellEnvironment: Sendable {
         }
         if done.wait(timeout: deadline) == .timedOut {
             process.terminate()
-            NSLog("[Crow] Login shell PATH resolution timed out")
+            CrowLog.info("[Crow] Login shell PATH resolution timed out")
             return nil
         }
 
         guard process.terminationStatus == 0 else {
-            NSLog("[Crow] Login shell exited with status %d", process.terminationStatus)
+            CrowLog.info("[Crow] Login shell exited with status \(process.terminationStatus)")
             return nil
         }
 
@@ -109,13 +109,13 @@ public final class ShellEnvironment: Sendable {
             .trimmingCharacters(in: .whitespaces)
 
         guard let path, !path.isEmpty else { return nil }
-        NSLog("[Crow] Resolved PATH from login shell (%d components)", path.split(separator: ":").count)
+        CrowLog.info("[Crow] Resolved PATH from login shell (\(path.split(separator: ":").count) components)")
         return path
     }
 
     /// Appends well-known tool directories to the inherited PATH.
     private static func fallbackPATH(inherited: [String: String]) -> String {
-        NSLog("[Crow] Using fallback PATH resolution")
+        CrowLog.info("[Crow] Using fallback PATH resolution")
         let current = inherited["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         let existing = Set(current.split(separator: ":").map(String.init))
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
@@ -2,9 +2,14 @@ import Foundation
 import Testing
 @testable import CrowCore
 
-/// `CrowLog` is the durable automation log added for CROW-782. Every test here
-/// points the sink at a fresh temp directory (ADR 0012 — tests never write to
-/// the live `~/Library/Logs/crow`) and restores the default afterwards.
+/// `CrowLog` is the durable automation log added for CROW-782, and since
+/// CROW-874 the process-wide non-blocking sink. Every test here points the sink
+/// at a fresh temp directory (ADR 0012 — tests never write to the live
+/// `~/Library/Logs/crow`) and restores the default afterwards.
+///
+/// Delivery is asynchronous, so any test that asserts on file contents must
+/// `flush()` first. `flush` is a real barrier on the drain thread's progress —
+/// never sleep to wait for a line.
 @Suite(.serialized)
 struct CrowLogTests {
     private func withTempLogDirectory(_ body: (URL) throws -> Void) rethrows {
@@ -12,6 +17,10 @@ struct CrowLogTests {
             .appendingPathComponent("crow-test-crowlog-\(UUID().uuidString)", isDirectory: true)
         CrowLog.configure(directory: dir)
         defer {
+            // Drain into `dir` BEFORE retargeting and deleting it — otherwise an
+            // in-flight line lands after the removal and the drain recreates the
+            // directory, littering NSTemporaryDirectory().
+            CrowLog.flush(timeout: 5)
             CrowLog.configure(directory: nil)
             try? FileManager.default.removeItem(at: dir)
         }
@@ -22,6 +31,7 @@ struct CrowLogTests {
         try withTempLogDirectory { dir in
             CrowLog.automation("auto-merge: enabled=1 skipped=0")
             CrowLog.automation("auto-rebase: candidates=0")
+            #expect(CrowLog.flush(timeout: 5))
 
             let contents = try String(contentsOf: CrowLog.fileURL, encoding: .utf8)
             let lines = contents.split(separator: "\n").map(String.init)
@@ -34,8 +44,8 @@ struct CrowLogTests {
         }
     }
 
-    @Test func fileURLLivesUnderTheConfiguredDirectory() throws {
-        try withTempLogDirectory { dir in
+    @Test func fileURLLivesUnderTheConfiguredDirectory() {
+        withTempLogDirectory { dir in
             #expect(CrowLog.fileURL == dir.appendingPathComponent("crowd-automation.log"))
         }
     }
@@ -50,6 +60,7 @@ struct CrowLogTests {
             try filler.write(to: url, atomically: true, encoding: .utf8)
 
             CrowLog.automation("after rotation")
+            #expect(CrowLog.flush(timeout: 5))
 
             let rotated = url.appendingPathExtension("1")
             #expect(FileManager.default.fileExists(atPath: rotated.path))
@@ -66,6 +77,7 @@ struct CrowLogTests {
         // 0o700 dir / 0o600 file treatment as JSONStore/ConfigStore (review #787).
         try withTempLogDirectory { dir in
             CrowLog.automation("first line creates the file")
+            #expect(CrowLog.flush(timeout: 5))
             let fm = FileManager.default
             let filePerms = try #require(
                 (try fm.attributesOfItem(atPath: CrowLog.fileURL.path))[.posixPermissions] as? NSNumber)
@@ -76,6 +88,7 @@ struct CrowLogTests {
 
             // Still owner-only after an append to the existing file...
             CrowLog.automation("second line appends")
+            #expect(CrowLog.flush(timeout: 5))
             let afterAppend = try #require(
                 (try fm.attributesOfItem(atPath: CrowLog.fileURL.path))[.posixPermissions] as? NSNumber)
             #expect(afterAppend.int16Value == 0o600)
@@ -86,10 +99,15 @@ struct CrowLogTests {
         try withTempLogDirectory { _ in
             let url = CrowLog.fileURL
             CrowLog.automation("seed")
+            // Interior flush, not just a trailing one: the filler below is an
+            // atomic write that replaces the inode, so if "seed" landed after it
+            // the filler would be clobbered and rotation would never fire.
+            #expect(CrowLog.flush(timeout: 5))
             let filler = String(repeating: "x", count: CrowLog.maxBytes + 1)
             try filler.write(to: url, atomically: true, encoding: .utf8)
 
             CrowLog.automation("triggers rotation")
+            #expect(CrowLog.flush(timeout: 5))
 
             let fm = FileManager.default
             // Both the fresh active file and the rotated generation stay 0o600 —
@@ -109,5 +127,75 @@ struct CrowLogTests {
         let live = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/crow", isDirectory: true)
         #expect(CrowLog.directory != live)
+    }
+
+    // MARK: - CROW-874
+
+    @Test func infoDoesNotTouchTheAutomationFile() {
+        // `crowd-automation.log` is a *decision* log, capped at 5 MiB with one
+        // rotated generation. General traffic (SessionService alone has 65 call
+        // sites) would evict the auto-merge trail CROW-782 exists to preserve.
+        withTempLogDirectory { _ in
+            CrowLog.info("[TmuxBackend] created cockpit surface")
+            CrowLog.error("[crowd] socket bind failed")
+            #expect(CrowLog.flush(timeout: 5))
+            #expect(!FileManager.default.fileExists(atPath: CrowLog.fileURL.path))
+        }
+    }
+
+    @Test func flushReturnsImmediatelyOnAnIdleSink() {
+        // Nothing queued: the barrier must not burn its timeout. Deliberately
+        // asks for a long deadline so a regression shows up as a slow test.
+        let started = Date()
+        #expect(CrowLog.flush(timeout: 30))
+        #expect(Date().timeIntervalSince(started) < 1.0)
+    }
+
+    @Test func backlogOverflowDropsInsteadOfBlocking() throws {
+        // A wedged sink must cost bounded memory and a gap in the log — never a
+        // blocked caller. Capacity 0 forces every line down the drop path
+        // deterministically, with no reliance on out-running the drain thread.
+        try withTempLogDirectory { _ in
+            let realCapacity = CrowLog.backlogCapacity
+            defer { CrowLog.backlogCapacity = realCapacity }
+
+            let before = CrowLog.droppedLineCount
+            CrowLog.backlogCapacity = 0
+            for i in 0..<50 { CrowLog.automation("dropped line \(i)") }
+
+            // Dropped lines never take a sequence, so `flush` must not wait on
+            // them — this returning false would mean flush can hang under load.
+            #expect(CrowLog.flush(timeout: 5))
+            #expect(CrowLog.droppedLineCount == before + 50)
+            #expect(!FileManager.default.fileExists(atPath: CrowLog.fileURL.path))
+
+            // ...and the sink recovers once there is room again.
+            CrowLog.backlogCapacity = realCapacity
+            CrowLog.automation("after recovery")
+            #expect(CrowLog.flush(timeout: 5))
+            let contents = try String(contentsOf: CrowLog.fileURL, encoding: .utf8)
+            #expect(contents.hasSuffix("[automation] after recovery\n"))
+        }
+    }
+
+    @Test func automationFileFormatIsPinned() throws {
+        // The file format is `<ISO8601> [automation] <message>`, independent of
+        // the stderr line format (which also carries `processName[pid]`). Pinned
+        // so a future change to one cannot silently drift the other.
+        try withTempLogDirectory { _ in
+            CrowLog.automation("auto-merge: pr=42 skipped reason=checks-pending")
+            #expect(CrowLog.flush(timeout: 5))
+
+            let line = try String(contentsOf: CrowLog.fileURL, encoding: .utf8)
+                .trimmingCharacters(in: .newlines)
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            #expect(parts.count == 2)
+            // Fractional seconds are part of the format — a bare
+            // ISO8601DateFormatter would not parse these back.
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            #expect(iso.date(from: parts[0]) != nil)
+            #expect(parts[1] == "[automation] auto-merge: pr=42 skipped reason=checks-pending")
+        }
     }
 }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorHookConfigWriter.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorHookConfigWriter.swift
@@ -107,7 +107,7 @@ public struct CursorHookConfigWriter: HookConfigWriter {
         // Checked unconditionally (not gated on the file existing) so a
         // tracked-but-deleted file — `rm` without `git rm` — is still caught.
         if Self.isGitTracked(worktreePath: worktreePath, relativePath: ".cursor/hooks.json") {
-            NSLog("[CursorHookConfigWriter] %@/.cursor/hooks.json is git-tracked; not writing Crow's session hooks into a committed file. Gitignore/untrack it to enable hook-based state detection for this worktree.", worktreePath)
+            CrowLog.info("[CursorHookConfigWriter] \(worktreePath)/.cursor/hooks.json is git-tracked; not writing Crow's session hooks into a committed file. Gitignore/untrack it to enable hook-based state detection for this worktree.")
             return
         }
 
@@ -119,7 +119,7 @@ public struct CursorHookConfigWriter: HookConfigWriter {
         var root: [String: Any] = [:]
         if let data = FileManager.default.contents(atPath: hooksPath) {
             guard let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                NSLog("[CursorHookConfigWriter] %@ exists but is unparseable; leaving it untouched (would otherwise drop the user's own hook groups)", hooksPath)
+                CrowLog.info("[CursorHookConfigWriter] \(hooksPath) exists but is unparseable; leaving it untouched (would otherwise drop the user's own hook groups)")
                 return
             }
             root = parsed
@@ -223,8 +223,7 @@ public struct CursorHookConfigWriter: HookConfigWriter {
                 withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
             try out.write(to: URL(fileURLWithPath: hooksPath), options: [.atomic])
         } catch {
-            NSLog("[CursorHookConfigWriter] Failed to rewrite %@: %@",
-                  hooksPath, error.localizedDescription)
+            CrowLog.info("[CursorHookConfigWriter] Failed to rewrite \(hooksPath): \(error.localizedDescription)")
         }
     }
 

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorMCPConfigWriter.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorMCPConfigWriter.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 #if canImport(Glibc)
 import Glibc  // POSIX `rename`/`errno` on Linux (Darwin re-exports them via Foundation on macOS)
@@ -81,15 +82,15 @@ public enum CursorMCPConfigWriter {
             let tmp = (dir as NSString).appendingPathComponent(".crow-mcp-\(UUID().uuidString).tmp")
             guard FileManager.default.createFile(
                 atPath: tmp, contents: out, attributes: [.posixPermissions: 0o600]) else {
-                NSLog("[CursorMCPConfigWriter] Failed to create temp for %@", path)
+                CrowLog.info("[CursorMCPConfigWriter] Failed to create temp for \(path)")
                 return
             }
             if rename(tmp, path) != 0 {
-                NSLog("[CursorMCPConfigWriter] atomic rename to %@ failed (errno %d)", path, errno)
+                CrowLog.info("[CursorMCPConfigWriter] atomic rename to \(path) failed (errno \(errno))")
                 try? FileManager.default.removeItem(atPath: tmp)
             }
         } catch {
-            NSLog("[CursorMCPConfigWriter] Failed to write %@: %@", path, error.localizedDescription)
+            CrowLog.info("[CursorMCPConfigWriter] Failed to write \(path): \(error.localizedDescription)")
         }
     }
 
@@ -132,7 +133,7 @@ public enum CursorMCPConfigWriter {
             reapManagedJira(cursorMCPPath: cursorPath)
             return
         case .sourceUnavailable:
-            NSLog("[CursorMCPConfigWriter] %@ missing/unreadable; leaving ~/.cursor/mcp.json untouched", claudePath)
+            CrowLog.info("[CursorMCPConfigWriter] \(claudePath) missing/unreadable; leaving ~/.cursor/mcp.json untouched")
             return
         }
 
@@ -144,7 +145,7 @@ public enum CursorMCPConfigWriter {
         var root: [String: Any] = [:]
         if let existing = FileManager.default.contents(atPath: cursorPath) {
             guard let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] else {
-                NSLog("[CursorMCPConfigWriter] %@ exists but is unparseable; leaving it untouched (would otherwise drop the user's other MCP servers)", cursorPath)
+                CrowLog.info("[CursorMCPConfigWriter] \(cursorPath) exists but is unparseable; leaving it untouched (would otherwise drop the user's other MCP servers)")
                 return
             }
             root = parsed
@@ -154,7 +155,7 @@ public enum CursorMCPConfigWriter {
 
         if let current = servers[serverKey] as? [String: Any] {
             if !managed.contains(serverKey) {
-                NSLog("[CursorMCPConfigWriter] %@ already has a user-authored `jira` MCP server; leaving it untouched", cursorPath)
+                CrowLog.info("[CursorMCPConfigWriter] \(cursorPath) already has a user-authored `jira` MCP server; leaving it untouched")
                 return
             }
             if NSDictionary(dictionary: current).isEqual(to: jiraEntry) {
@@ -197,7 +198,7 @@ public enum CursorMCPConfigWriter {
         } else {
             atomicWriteJSON(root, to: cursorMCPPath)
         }
-        NSLog("[CursorMCPConfigWriter] Reaped bridged `jira` MCP from %@ — no longer in Claude's config", cursorMCPPath)
+        CrowLog.info("[CursorMCPConfigWriter] Reaped bridged `jira` MCP from \(cursorMCPPath) — no longer in Claude's config")
     }
 
     /// Outcome of looking for a `jira` server in Claude's config.
@@ -237,7 +238,7 @@ public enum CursorMCPConfigWriter {
                    let jira = servers[serverKey] as? [String: Any] {
                     // Visibility: a project-scoped Claude MCP token is about to
                     // be promoted into Cursor's *global* config (every session).
-                    NSLog("[CursorMCPConfigWriter] Promoting project-scoped `jira` MCP from %@ into global ~/.cursor/mcp.json", key)
+                    CrowLog.info("[CursorMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global ~/.cursor/mcp.json")
                     return .found(jira)
                 }
             }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/AutostartRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/AutostartRoutes.swift
@@ -1,4 +1,5 @@
 import CrowAutostart
+import CrowCore
 import Foundation
 import HTTPTypes
 import Hummingbird
@@ -72,10 +73,10 @@ enum AutostartRoutes {
 
     // MARK: - HTTP helpers
 
-    /// Same `[crowd]`-prefixed stderr line the daemon's own logging uses, so an
+    /// Same `[crowd]`-prefixed line the daemon's own logging uses, so an
     /// install/uninstall (and any failure) shows up in the daemon log.
     private static func logLine(_ message: String) {
-        FileHandle.standardError.write(Data("[crowd] \(message)\n".utf8))
+        CrowLog.info("[crowd] \(message)")
     }
 
     /// `AutostartStatus` → a JSON object, so the web UI reads the same field

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -55,9 +55,8 @@ public enum CrowDaemon {
         // exits (the multi-`daemon-run` footgun). Distinct --socket → own lock, so
         // isolated daemons still run (CROW-581).
         guard acquireSingleInstanceLock(socketPath: options.socketPath) else {
-            log("Another crowd is already running on \(options.socketPath) — exiting. "
+            logAndExit("Another crowd is already running on \(options.socketPath) — exiting. "
                 + "Only one daemon per socket is allowed (use a distinct --socket for an isolated instance).")
-            exit(1)
         }
 
         // Store-writer guard: the socket lock above is keyed to the socket, but
@@ -68,11 +67,10 @@ public enum CrowDaemon {
         // crowd may write it, whatever --socket each was launched with (#759).
         let storeDirectory = JSONStore.defaultDirectory
         guard acquireStoreWriterLock(storeDirectory: storeDirectory) else {
-            log("FATAL: another process already holds the store writer lock for "
+            logAndExit("FATAL: another process already holds the store writer lock for "
                 + "\(storeDirectory.path) — refusing to start. Only ONE crowd may write store.json, "
                 + "regardless of --socket. Stop the other daemon first (a second writer silently "
                 + "clobbers every session the first one knew about).")
-            exit(1)
         }
 
         log("started: pid \(getpid()); socket \(options.socketPath); store \(storeDirectory.appendingPathComponent("store.json").path)")
@@ -524,11 +522,15 @@ public enum CrowDaemon {
             storeWriterLockFD = -1
         }
         guard let argv0 = argv.first, !argv0.isEmpty else {
-            log("re-exec failed: empty argv")
-            exit(1)
+            logAndExit("re-exec failed: empty argv")
         }
         let cArgv: [UnsafeMutablePointer<CChar>?] = argv.map { strdup($0) } + [nil]
         defer { for p in cArgv where p != nil { free(p) } }
+
+        // `execv` replaces this image, taking the log drain thread with it, so
+        // anything still queued would never be written (CROW-874). The os_log
+        // copy survives regardless; this is for stderr / crowd.log.
+        CrowLog.flush(timeout: 1.0)
 
         // Prefer the kernel's view of this process's executable (absolute path),
         // then a path-shaped argv[0], then `execvp` so a bare `crowd` on PATH still
@@ -543,6 +545,7 @@ public enum CrowDaemon {
             execvp(argv0, cArgv)
             log("re-exec failed (execvp \(argv0)): \(String(cString: strerror(errno)))")
         }
+        CrowLog.flush(timeout: 1.0)
         exit(1)
     }
 
@@ -1049,8 +1052,25 @@ public enum CrowDaemon {
     }
 
     // Internal (not private): `LaunchScaffold` logs through the same prefix.
+    //
+    // Routed through `CrowLog` so it cannot block: this used to be a synchronous
+    // `FileHandle.standardError.write`, which stalls the caller when stderr is a
+    // tty nobody is draining — and `CrowDaemon` is `@MainActor` (CROW-874). The
+    // `[crowd]` prefix stays inside the message so these lines read as they
+    // always have, now with a leading timestamp.
     static func log(_ message: String) {
-        FileHandle.standardError.write(Data("[crowd] \(message)\n".utf8))
+        CrowLog.info("[crowd] \(message)")
+    }
+
+    /// Log a final line, drain the sink, then exit. `CrowLog` delivery is
+    /// asynchronous (CROW-874), so a bare `exit()` right after `log()` would
+    /// race the drain and lose the message explaining why the daemon stopped.
+    /// The flush is bounded — a wedged stderr delays shutdown by at most a
+    /// second, and the os_log copy was already made on this thread regardless.
+    private static func logAndExit(_ message: String, code: Int32 = 1) -> Never {
+        log(message)
+        CrowLog.flush(timeout: 1.0)
+        exit(code)
     }
 
     /// Whether a live server is already accepting on the Unix socket at `path` —
@@ -1208,8 +1228,8 @@ struct DaemonOptions {
                     if let port = Int(value) {
                         options.httpPort = port
                     } else {
-                        FileHandle.standardError.write(Data(
-                            "[crowd] WARNING: ignoring malformed --http-port '\(value)'; using \(options.httpPort)\n".utf8))
+                        CrowLog.info(
+                            "[crowd] WARNING: ignoring malformed --http-port '\(value)'; using \(options.httpPort)")
                     }
                 }
                 index += 1
@@ -1230,7 +1250,7 @@ struct DaemonOptions {
             case "--web-dir": if let value = next { options.webDir = value }; index += 1
             default:
                 if flag.hasPrefix("-") {
-                    FileHandle.standardError.write(Data("[crowd] WARNING: ignoring unknown flag '\(flag)'\n".utf8))
+                    CrowLog.info("[crowd] WARNING: ignoring unknown flag '\(flag)'")
                 }
             }
             index += 1

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -364,7 +364,7 @@ func makeCommandRouter(
             guard sessionService != nil else {
                 throw DaemonRPCError.applicationError("Reloading tmux config requires tmux on the daemon host")
             }
-            if let err = await MainActor.run(body: { TmuxBackend.shared.reloadBundledConfig() }) {
+            if let err = await TmuxBackend.shared.reloadBundledConfig() {
                 throw DaemonRPCError.applicationError(err)
             }
             return ["ok": .bool(true)]

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import CrowTerminal
 import Foundation
 
@@ -49,7 +50,7 @@ struct TerminalCockpit: Sendable {
             historyLimit: w.historyLimit,
             alternateOn: w.alternateOn,
             alternateScreenEnabled: w.alternateScreenEnabled) {
-            NSLog("[CrowTelemetry tmux:scrollback_degraded index=\(w.index) history_limit=\(w.historyLimit) alternate_on=\(w.alternateOn ? 1 : 0)]")
+            CrowLog.info("[CrowTelemetry tmux:scrollback_degraded index=\(w.index) history_limit=\(w.historyLimit) alternate_on=\(w.alternateOn ? 1 : 0)]")
         }
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/AgentLaunch.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AgentLaunch.swift
@@ -30,8 +30,7 @@ public enum AgentLaunch {
                     crowPath: crowPath
                 )
             } catch {
-                NSLog("[AgentLaunch] Failed to write hook config for session %@: %@",
-                      sessionID.uuidString, error.localizedDescription)
+                CrowLog.info("[AgentLaunch] Failed to write hook config for session \(sessionID.uuidString): \(error.localizedDescription)")
             }
         }
         // Cursor launching via a brand-new terminal (#408 deferred paste) or

--- a/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
@@ -33,8 +33,7 @@ public final class AutoRespondCoordinator {
         let cfg = settingsProvider()
         for t in transitions {
             if shouldSkipReviewSession(t) {
-                NSLog("[AutoRespond] Skipping %@ for session %@: review session",
-                      t.kind.rawValue, t.sessionID.uuidString)
+                CrowLog.info("[AutoRespond] Skipping \(t.kind.rawValue) for session \(t.sessionID.uuidString): review session")
                 continue
             }
             switch t.kind {
@@ -59,19 +58,16 @@ public final class AutoRespondCoordinator {
     private func dispatch(_ transition: PRStatusTransition) {
         let terminals = appState.terminals(for: transition.sessionID)
         guard let terminal = terminals.first(where: { $0.isManaged }) else {
-            NSLog("[AutoRespond] Skipping %@ for session %@: no managed terminal",
-                  transition.kind.rawValue, transition.sessionID.uuidString)
+            CrowLog.info("[AutoRespond] Skipping \(transition.kind.rawValue) for session \(transition.sessionID.uuidString): no managed terminal")
             return
         }
         guard TerminalRouter.canSend(terminal) else {
-            NSLog("[AutoRespond] Skipping %@ for session %@: terminal surface not initialized",
-                  transition.kind.rawValue, transition.sessionID.uuidString)
+            CrowLog.info("[AutoRespond] Skipping \(transition.kind.rawValue) for session \(transition.sessionID.uuidString): terminal surface not initialized")
             return
         }
 
         let prompt = AutoRespondPrompts.build(for: transition, codeBackend: resolveCodeBackend(forSessionID: transition.sessionID))
-        NSLog("[AutoRespond] Sending %@ prompt to terminal %@ (%d chars)",
-              transition.kind.rawValue, terminal.id.uuidString, prompt.count)
+        CrowLog.info("[AutoRespond] Sending \(transition.kind.rawValue) prompt to terminal \(terminal.id.uuidString) (\(prompt.count) chars)")
         TerminalRouter.send(terminal, text: prompt)
     }
 
@@ -92,25 +88,21 @@ public final class AutoRespondCoordinator {
         // code-modifying actions on review sessions; `reReview` is the correct
         // reviewer affordance and stays allowed.
         if session?.kind == .review, action.modifiesCodeUnderReview {
-            NSLog("[QuickAction] Refusing %@ for session %@: review session must not modify the branch under review",
-                  action.rawValue, sessionID.uuidString)
+            CrowLog.info("[QuickAction] Refusing \(action.rawValue) for session \(sessionID.uuidString): review session must not modify the branch under review")
             return .forbiddenOnReviewSession
         }
 
         let terminals = appState.terminals(for: sessionID)
         guard let terminal = terminals.first(where: { $0.isManaged }) else {
-            NSLog("[QuickAction] Skipping %@ for session %@: no managed terminal",
-                  action.rawValue, sessionID.uuidString)
+            CrowLog.info("[QuickAction] Skipping \(action.rawValue) for session \(sessionID.uuidString): no managed terminal")
             return .noManagedTerminal
         }
         guard TerminalRouter.canSend(terminal) else {
-            NSLog("[QuickAction] Skipping %@ for session %@: terminal surface not initialized",
-                  action.rawValue, sessionID.uuidString)
+            CrowLog.info("[QuickAction] Skipping \(action.rawValue) for session \(sessionID.uuidString): terminal surface not initialized")
             return .surfaceNotReady
         }
         guard let prLink = appState.links(for: sessionID).first(where: { $0.linkType == .pr }) else {
-            NSLog("[QuickAction] Skipping %@ for session %@: no PR link",
-                  action.rawValue, sessionID.uuidString)
+            CrowLog.info("[QuickAction] Skipping \(action.rawValue) for session \(sessionID.uuidString): no PR link")
             return .noPRLink
         }
 
@@ -122,8 +114,7 @@ public final class AutoRespondCoordinator {
             prNumber: prNumber,
             lastReviewedHeadSha: session?.lastReviewedHeadSha
         )
-        NSLog("[QuickAction] Sending %@ prompt to terminal %@ (%d chars)",
-              action.rawValue, terminal.id.uuidString, prompt.count)
+        CrowLog.info("[QuickAction] Sending \(action.rawValue) prompt to terminal \(terminal.id.uuidString) (\(prompt.count) chars)")
         TerminalRouter.send(terminal, text: prompt)
         return .sent
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -883,7 +883,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // launch succeeded (#408): surface it so the UI shows a
                         // Retry affordance and the CLI caller reports honestly
                         // instead of leaving a silent window-less terminal.
-                        NSLog("[Crow] tmux registerTerminal failed after retries (\(error)); surfacing launch failure")
+                        CrowLog.info("[Crow] tmux registerTerminal failed after retries (\(error)); surfacing launch failure")
                         launchFailed = true
                         if trackReadiness {
                             capturedAppState.terminalReadiness[terminal.id] = .failed
@@ -1051,7 +1051,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // Process escape sequences: literal \n in the text becomes a real newline
                 text = text.replacingOccurrences(of: "\\n", with: "\n")
                 text = text.replacingOccurrences(of: "\\t", with: "\t")
-                NSLog("crow send: text length=\(text.count), ends_with_newline=\(text.hasSuffix("\n")), ends_with_cr=\(text.hasSuffix("\r"))")
+                CrowLog.info("crow send: text length=\(text.count), ends_with_newline=\(text.hasSuffix("\n")), ends_with_cr=\(text.hasSuffix("\r"))")
                 await MainActor.run {
                     let routedTerminal = capturedAppState.terminals[sessionID]?.first(where: { $0.id == terminalID })
                     // tmux-backed terminals already have their window from
@@ -1086,7 +1086,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         TerminalRouter.send(routedTerminal, text: text)
                     } else {
                         // No SessionTerminal row known — nothing to route to.
-                        NSLog("[Crow] crow send for unknown terminal \(terminalID); ignoring")
+                        CrowLog.info("[Crow] crow send for unknown terminal \(terminalID); ignoring")
                     }
                 }
                 return ["sent": .bool(true)]
@@ -1267,7 +1267,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                     if hookDebug {
                         let shortID = String(sessionIDStr.prefix(8))
                         let keys = payload.keys.sorted().joined(separator: ",")
-                        NSLog("[hook-event] session=\(shortID) event=\(eventName) payload-keys=[\(keys)]")
+                        CrowLog.info("[hook-event] session=\(shortID) event=\(eventName) payload-keys=[\(keys)]")
                     }
 
                     let event = HookEvent(
@@ -1358,7 +1358,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
 
                     if hookDebug && state.activityState != stateBefore {
                         let shortID = String(sessionIDStr.prefix(8))
-                        NSLog("[hook-event] session=\(shortID) event=\(eventName) state=\(stateBefore.rawValue)→\(state.activityState.rawValue)")
+                        CrowLog.info("[hook-event] session=\(shortID) event=\(eventName) state=\(stateBefore.rawValue)→\(state.activityState.rawValue)")
                     }
 
                     // Persist the color-driving state only when it actually changed,

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -2423,8 +2423,7 @@ public final class IssueTracker {
                     prNumber: attribution.prNumber
                 )
             } catch {
-                NSLog("[Crow] fetchPRChangedFiles failed for %@: %@",
-                      attribution.prURL as NSString, error.localizedDescription as NSString)
+                CrowLog.info("[Crow] fetchPRChangedFiles failed for \(attribution.prURL): \(error.localizedDescription)")
                 continue
             }
             guard !files.isEmpty else { continue }
@@ -2466,8 +2465,7 @@ public final class IssueTracker {
             do {
                 commits = try await backend.fetchRecentDefaultBranchCommits(repoSlug: repo, since: since)
             } catch {
-                NSLog("[Crow] fetchRecentDefaultBranchCommits failed for %@: %@",
-                      repo as NSString, error.localizedDescription as NSString)
+                CrowLog.info("[Crow] fetchRecentDefaultBranchCommits failed for \(repo): \(error.localizedDescription)")
                 continue
             }
             // Re-read inside the loop so a prior repo's writes are visible.
@@ -2716,8 +2714,7 @@ public final class IssueTracker {
                 prNumber: pr.number
             )
         } catch {
-            NSLog("[Crow] fetchCrowAuthoredCommits failed for %@: %@",
-                  pr.url as NSString, error.localizedDescription as NSString)
+            CrowLog.info("[Crow] fetchCrowAuthoredCommits failed for \(pr.url): \(error.localizedDescription)")
             return false
         }
         recordPRAttribution(pr: pr, commits: commits)
@@ -3714,7 +3711,7 @@ public final class IssueTracker {
         do {
             try await backend.ensureMergeLabel(repo: repo)
             try await backend.addMergeLabel(prURL: prLink.url)
-            NSLog("[Crow] Added crow:merge to %@", prLink.url as NSString)
+            CrowLog.info("[Crow] Added crow:merge to \(prLink.url)")
             // Optimistically flip the merge icon so the user sees the label
             // land immediately, rather than waiting for — and getting stuck
             // behind — the next full poll's snapshot (#838). The sticky marker

--- a/Packages/CrowEngine/Sources/CrowEngine/JobScheduler.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/JobScheduler.swift
@@ -235,7 +235,7 @@ public final class JobScheduler {
             return
         }
         guard polls < maxLaunchWaitPolls else {
-            NSLog("[JobScheduler] gave up waiting for agent launch on \(terminalID)")
+            CrowLog.info("[JobScheduler] gave up waiting for agent launch on \(terminalID)")
             return
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
@@ -257,7 +257,7 @@ public final class JobScheduler {
             guard let terminal = self.appState.terminals.values
                 .flatMap({ $0 })
                 .first(where: { $0.id == terminalID }) else {
-                NSLog("[JobScheduler] terminal \(terminalID) gone; stopping prompt delivery")
+                CrowLog.info("[JobScheduler] terminal \(terminalID) gone; stopping prompt delivery")
                 // Delivery aborted — stop watching this run for completion too.
                 self.watchedRuns[sessionID] = nil
                 return

--- a/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
@@ -230,7 +230,7 @@ public struct Scaffolder {
         do {
             try fm.createDirectory(atPath: binDir, withIntermediateDirectories: true)
         } catch {
-            NSLog("[Scaffolder] could not create bin dir %@: %@", binDir, error.localizedDescription)
+            CrowLog.info("[Scaffolder] could not create bin dir \(binDir): \(error.localizedDescription)")
             return
         }
 
@@ -254,8 +254,7 @@ public struct Scaffolder {
                 // broken pointer doesn't shadow a working PATH install.
                 try? fm.removeItem(atPath: link)
                 if !trimmed.isEmpty {
-                    NSLog("[Scaffolder] defaults.binaries.%@ not executable at %@ — skipping symlink",
-                          name, trimmed)
+                    CrowLog.info("[Scaffolder] defaults.binaries.\(name) not executable at \(trimmed) — skipping symlink")
                 }
                 continue
             }
@@ -263,8 +262,7 @@ public struct Scaffolder {
             do {
                 try fm.createSymbolicLink(atPath: link, withDestinationPath: trimmed)
             } catch {
-                NSLog("[Scaffolder] failed to symlink %@ -> %@: %@",
-                      link, trimmed, error.localizedDescription)
+                CrowLog.info("[Scaffolder] failed to symlink \(link) -> \(trimmed): \(error.localizedDescription)")
             }
         }
     }
@@ -288,7 +286,7 @@ public struct Scaffolder {
                 try? fm.removeItem(atPath: link)
             }
             if let resolved {
-                NSLog("[Scaffolder] app crow binary not executable at %@ — skipping symlink", resolved)
+                CrowLog.info("[Scaffolder] app crow binary not executable at \(resolved) — skipping symlink")
             }
             return
         }
@@ -298,7 +296,7 @@ public struct Scaffolder {
         // absent and we'd skip removal, then createSymbolicLink hits EEXIST.
         if let attrs = try? fm.attributesOfItem(atPath: link) {
             guard (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else {
-                NSLog("[Scaffolder] crow exists at %@ but is not a symlink — leaving alone", link)
+                CrowLog.info("[Scaffolder] crow exists at \(link) but is not a symlink — leaving alone")
                 return
             }
             try? fm.removeItem(atPath: link)
@@ -307,8 +305,7 @@ public struct Scaffolder {
         do {
             try fm.createSymbolicLink(atPath: link, withDestinationPath: target)
         } catch {
-            NSLog("[Scaffolder] failed to symlink %@ -> %@: %@",
-                  link, target, error.localizedDescription)
+            CrowLog.info("[Scaffolder] failed to symlink \(link) -> \(target): \(error.localizedDescription)")
         }
     }
 
@@ -337,7 +334,7 @@ public struct Scaffolder {
         }
         let fm = FileManager.default
         guard fm.isExecutableFile(atPath: path) else {
-            NSLog("[Scaffolder] corveil binary not executable: %@", path)
+            CrowLog.info("[Scaffolder] corveil binary not executable: \(path)")
             return "Corveil skill install skipped — binary at \(path) is missing or not executable. Check Settings → General → Corveil CLI."
         }
 
@@ -345,7 +342,7 @@ public struct Scaffolder {
         do {
             try fm.createDirectory(atPath: commandsDir, withIntermediateDirectories: true)
         } catch {
-            NSLog("[Scaffolder] could not create commands dir: %@", error.localizedDescription)
+            CrowLog.info("[Scaffolder] could not create commands dir: \(error.localizedDescription)")
             return "Corveil skill install failed — could not create .claude/commands directory."
         }
         let target = (commandsDir as NSString).appendingPathComponent("query-corveil.md")
@@ -363,7 +360,7 @@ public struct Scaffolder {
         do {
             try proc.run()
         } catch {
-            NSLog("[Scaffolder] corveil launch failed: %@", error.localizedDescription)
+            CrowLog.info("[Scaffolder] corveil launch failed: \(error.localizedDescription)")
             return "Corveil skill install failed — \(error.localizedDescription). Check path in Settings."
         }
 
@@ -379,19 +376,18 @@ public struct Scaffolder {
         let timedOut = watchdog.cancel()
 
         if timedOut {
-            NSLog("[Scaffolder] corveil skill install timed out after %.1fs", Self.corveilInstallTimeout)
+            CrowLog.info("[Scaffolder] corveil skill install timed out after \(String(format: "%.1f", Self.corveilInstallTimeout))s")
             return "Corveil skill install timed out after \(Int(Self.corveilInstallTimeout))s — binary may be hung. Check path in Settings."
         }
         if proc.terminationStatus != 0 {
             let stderr = (try? stderrPipe.fileHandleForReading.readToEnd())
                 .flatMap { String(data: $0, encoding: .utf8) }?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            NSLog("[Scaffolder] corveil skill install exit=%d stderr=%@",
-                  proc.terminationStatus, stderr)
+            CrowLog.info("[Scaffolder] corveil skill install exit=\(proc.terminationStatus) stderr=\(stderr)")
             let detail = stderr.isEmpty ? "exit code \(proc.terminationStatus)" : stderr
             return "Corveil skill install failed — \(detail). Check path in Settings."
         }
-        NSLog("[Scaffolder] corveil skill installed at %@", target)
+        CrowLog.info("[Scaffolder] corveil skill installed at \(target)")
         return nil
     }
 
@@ -770,7 +766,7 @@ public struct Scaffolder {
                 if let content = try? String(contentsOf: filePath) {
                     return content
                 }
-                NSLog("[Scaffolder] File not found at repo path: %@", filePath.path)
+                CrowLog.info("[Scaffolder] File not found at repo path: \(filePath.path)")
                 return nil
             }
             dir = dir.deletingLastPathComponent()

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -337,7 +337,7 @@ public final class SessionService {
                 do {
                     try TmuxBackend.shared.adoptTerminal(id: terminal.id, binding: binding, trackReadiness: false)
                 } catch {
-                    NSLog("[SessionService] client-mode adopt failed for \(terminal.id): \(error.localizedDescription)")
+                    CrowLog.info("[SessionService] client-mode adopt failed for \(terminal.id): \(error.localizedDescription)")
                 }
             }
         }
@@ -431,7 +431,7 @@ public final class SessionService {
     public func takeOverTerminalSurfaces() -> Bool {
         let recreate = Self.shouldRecreateSurfacesOnTakeover(
             cockpitSessionIsLive: TmuxBackend.shared.cockpitSessionIsLive())
-        NSLog(recreate
+        CrowLog.info(recreate
             ? "[CrowTelemetry takeover:recreate] tmux cockpit gone (reboot/kill-server) — recreating windows + relaunching agents (CROW-747)"
             : "[CrowTelemetry takeover:adopt] tmux cockpit alive — adopting surviving surfaces in place")
         rebuildAllSurfaces(forceRegister: recreate)
@@ -490,7 +490,7 @@ public final class SessionService {
     public func recreateTerminalSurface(sessionID: UUID, terminalID: UUID, devRoot: String) -> Bool {
         guard appState.sessions.contains(where: { $0.id == sessionID }),
               let terminal = appState.terminals(for: sessionID).first(where: { $0.id == terminalID }) else {
-            NSLog("[SessionService] recreateTerminalSurface: terminal \(terminalID) not found in session \(sessionID)")
+            CrowLog.info("[SessionService] recreateTerminalSurface: terminal \(terminalID) not found in session \(sessionID)")
             return false
         }
 
@@ -530,7 +530,7 @@ public final class SessionService {
             }
         }
 
-        NSLog("[CrowTelemetry tmux:scrollback_recreate terminal=\(terminalID) session=\(sessionID)]")
+        CrowLog.info("[CrowTelemetry tmux:scrollback_recreate terminal=\(terminalID) session=\(sessionID)]")
         let updated = rehydrateTerminalSurface(seed, trackReadiness: trackReadiness)
 
         guard updated.tmuxBinding != nil else {
@@ -538,7 +538,7 @@ public final class SessionService {
             // window is untouched (still live/degraded), so restore the readiness
             // we re-armed and report failure. The RPC surfaces it and the ⚠ /
             // Recreate affordance persists for a retry (review).
-            NSLog("[SessionService] recreateTerminalSurface: re-register failed for \(terminalID); keeping the existing degraded window")
+            CrowLog.info("[SessionService] recreateTerminalSurface: re-register failed for \(terminalID); keeping the existing degraded window")
             if trackReadiness {
                 appState.terminalReadiness[terminalID] = priorReadiness
                 if !priorAutoLaunch { appState.autoLaunchTerminals.remove(terminalID) }
@@ -570,7 +570,7 @@ public final class SessionService {
     @MainActor
     private func rehydrateTerminalSurface(_ terminal: SessionTerminal, trackReadiness: Bool) -> SessionTerminal {
         guard !TmuxBackend.shared.tmuxBinary.isEmpty else {
-            NSLog("[SessionService] tmux not configured this run — terminal \(terminal.id) will not render")
+            CrowLog.info("[SessionService] tmux not configured this run — terminal \(terminal.id) will not render")
             return terminal
         }
 
@@ -626,7 +626,7 @@ public final class SessionService {
                                 crowPath: crowPath
                             )
                         } catch {
-                            NSLog("[SessionService] adopt: hook config rewrite failed for \(terminal.sessionID): \(error.localizedDescription)")
+                            CrowLog.info("[SessionService] adopt: hook config rewrite failed for \(terminal.sessionID): \(error.localizedDescription)")
                         }
                     }
                     // Re-seed the RemoteControl badge for adopted --rc terminals.
@@ -647,7 +647,7 @@ public final class SessionService {
                 }
                 return terminal  // binding unchanged → no redundant persist
             } catch {
-                NSLog("[SessionService] tmux adopt failed (\(error)) for \(terminal.id); creating a fresh window")
+                CrowLog.info("[SessionService] tmux adopt failed (\(error)) for \(terminal.id); creating a fresh window")
             }
         }
 
@@ -670,7 +670,7 @@ public final class SessionService {
             updated.tmuxBinding = binding
             return updated
         } catch {
-            NSLog("[SessionService] tmux re-register failed on hydrate (\(error)) for \(terminal.id); terminal will not render this run")
+            CrowLog.info("[SessionService] tmux re-register failed on hydrate (\(error)) for \(terminal.id); terminal will not render this run")
             return terminal
         }
     }
@@ -694,11 +694,11 @@ public final class SessionService {
     }
 
     public func wireTerminalReadiness() {
-        NSLog("[SessionService] wireTerminalReadiness — setting tmux readiness callback")
+        CrowLog.info("[SessionService] wireTerminalReadiness — setting tmux readiness callback")
         TmuxBackend.shared.onReadinessChanged = { [weak self] terminalID, readiness in
             guard let self else { return }
             guard let currentState = self.appState.terminalReadiness[terminalID] else { return }
-            NSLog("[SessionService] tmux readiness: terminal=\(terminalID), state=\(readiness), current=\(currentState)")
+            CrowLog.info("[SessionService] tmux readiness: terminal=\(terminalID), state=\(readiness), current=\(currentState)")
             if readiness == .shellReady, currentState < .shellReady {
                 self.appState.terminalReadiness[terminalID] = .shellReady
                 // Brand-new managed terminals created via `new-terminal --command`
@@ -771,7 +771,7 @@ public final class SessionService {
             terminals.contains(where: { $0.id == terminalID })
         })?.key,
               let routedTerminal = appState.terminals[sessionID]?.first(where: { $0.id == terminalID }) else {
-            NSLog("[SessionService] pasteDeferredLaunch: no terminal record for \(terminalID); cannot send")
+            CrowLog.info("[SessionService] pasteDeferredLaunch: no terminal record for \(terminalID); cannot send")
             return
         }
 
@@ -815,7 +815,7 @@ public final class SessionService {
     public func copyDiagnostics(terminalID: UUID) {
         let bundle = TmuxBackend.shared.captureDiagnostics(id: terminalID)
         hostBridge.copyToClipboard(bundle)
-        NSLog("[SessionService] copied tmux diagnostics for terminal=\(terminalID) bytes=\(bundle.utf8.count)")
+        CrowLog.info("[SessionService] copied tmux diagnostics for terminal=\(terminalID) bytes=\(bundle.utf8.count)")
     }
 
     /// Reap leaked orphan cockpit windows once at launch — bare-shell windows
@@ -828,7 +828,7 @@ public final class SessionService {
     public func reapOrphanedCockpitWindows() {
         let keep = Set(appState.terminals.values.flatMap { $0 }.compactMap { $0.tmuxBinding?.windowIndex })
         let n = TmuxBackend.shared.reapUnboundCockpitWindows(keepWindowIndices: keep)
-        if n > 0 { NSLog("[SessionService] reaped \(n) orphaned cockpit window(s) at launch (#408)") }
+        if n > 0 { CrowLog.info("[SessionService] reaped \(n) orphaned cockpit window(s) at launch (#408)") }
     }
 
     /// Reconcile persisted terminals ↔ live cockpit tmux windows (CROW-581).
@@ -862,7 +862,7 @@ public final class SessionService {
         if !deadIDs.isEmpty {
             let dead = Set(deadIDs)
             store.mutate { $0.terminals.removeAll { dead.contains($0.id) } }
-            NSLog("[SessionService] pruned \(deadIDs.count) dead terminal record(s) (CROW-581)")
+            CrowLog.info("[SessionService] pruned \(deadIDs.count) dead terminal record(s) (CROW-581)")
         }
 
         // (2) Reap orphaned cockpit windows. Agent window names are exactly what
@@ -882,7 +882,7 @@ public final class SessionService {
         for (terminalID, state) in appState.terminalReadiness {
             guard appState.autoLaunchTerminals.contains(terminalID) else { continue }
             guard state == .timedOut else { continue }
-            NSLog("[SessionService] re-arming stuck tmux readiness watch for terminal=\(terminalID)")
+            CrowLog.info("[SessionService] re-arming stuck tmux readiness watch for terminal=\(terminalID)")
             retryReadiness(terminalID: terminalID)
         }
     }
@@ -913,8 +913,7 @@ public final class SessionService {
                     crowPath: crowPath
                 )
             } catch {
-                NSLog("[SessionService] Failed to write hook config for session %@: %@",
-                      sessionID.uuidString, error.localizedDescription)
+                CrowLog.info("[SessionService] Failed to write hook config for session \(sessionID.uuidString): \(error.localizedDescription)")
             }
         }
 
@@ -937,7 +936,7 @@ public final class SessionService {
             // (acceptable — review is the human-gated path anyway).
             if session.kind != .review {
                 if case let .failed(msg) = CodexTrustSeeder.seedTrust(projectPath: worktree.worktreePath) {
-                    NSLog("[SessionService] Codex trust seed failed for %@: %@", worktree.worktreePath, msg)
+                    CrowLog.info("[SessionService] Codex trust seed failed for \(worktree.worktreePath): \(msg)")
                 }
             }
         default:
@@ -989,8 +988,7 @@ public final class SessionService {
             autoPermissionMode: autoPermissionMode,
             telemetryPort: telemetryPort
         ) else {
-            NSLog("[SessionService] Agent %@ could not build a launch command for session %@ (kind=%@)",
-                  agent.kind.rawValue, sessionID.uuidString, String(describing: session.kind))
+            CrowLog.info("[SessionService] Agent \(agent.kind.rawValue) could not build a launch command for session \(sessionID.uuidString) (kind=\(String(describing: session.kind)))")
             // Surface the failure where the user is already looking — paste a
             // shell-comment + echo line into the terminal so they aren't stuck
             // staring at an idle prompt wondering why nothing happened (#424).
@@ -1015,7 +1013,7 @@ public final class SessionService {
             let promptPath = (worktree.worktreePath as NSString)
                 .appendingPathComponent(initialPromptFile)
             if !FileManager.default.fileExists(atPath: promptPath) {
-                NSLog("[SessionService] launchAgent: initial prompt missing at \(promptPath) for session \(sessionID.uuidString); refusing to dispatch")
+                CrowLog.info("[SessionService] launchAgent: initial prompt missing at \(promptPath) for session \(sessionID.uuidString); refusing to dispatch")
                 if let routedTerminal = appState.terminals[sessionID]?.first(where: { $0.id == terminalID }) {
                     let msg = "echo '⚠️  Crow: \(session.kind.rawValue) prompt missing at \(promptPath); not launching \(agent.displayName).'\n"
                     TerminalRouter.send(routedTerminal, text: msg)
@@ -1032,7 +1030,7 @@ public final class SessionService {
         if let routedTerminal = appState.terminals[sessionID]?.first(where: { $0.id == terminalID }) {
             TerminalRouter.send(routedTerminal, text: gatewayPrefix + command)
         } else {
-            NSLog("[SessionService] launchAgent: no terminal record for \(terminalID); cannot send")
+            CrowLog.info("[SessionService] launchAgent: no terminal record for \(terminalID); cannot send")
         }
 
         appState.terminalReadiness[terminalID] = .agentLaunched
@@ -1157,7 +1155,7 @@ public final class SessionService {
         }
 
         appState.managerProcessExited = false
-        NSLog("[CrowTelemetry manager:restart]")
+        CrowLog.info("[CrowTelemetry manager:restart]")
 
         // Session row still exists, so this only recreates the terminal.
         ensureManagerSession(devRoot: resolvedDevRoot)
@@ -1252,7 +1250,7 @@ public final class SessionService {
             // seeding never fires for it. Skip `.review` for the same
             // attacker-controlled-clone reason as `launchAgent`.
             if case let .failed(msg) = CodexTrustSeeder.seedTrust(projectPath: worktree.worktreePath) {
-                NSLog("[SessionService] Codex trust seed failed for %@: %@", worktree.worktreePath, msg)
+                CrowLog.info("[SessionService] Codex trust seed failed for \(worktree.worktreePath): \(msg)")
             }
         }
         // Handing off to Cursor → sync its global Jira MCP (this path selects
@@ -1322,13 +1320,7 @@ public final class SessionService {
             data.terminals.append(prepared)
         }
 
-        NSLog(
-            "[CrowTelemetry agent:handoff] session=%@ from=%@ to=%@ terminal=%@",
-            sessionID.uuidString,
-            priorKind.rawValue,
-            targetKind.rawValue,
-            prepared.id.uuidString
-        )
+        CrowLog.info("[CrowTelemetry agent:handoff] session=\(sessionID.uuidString) from=\(priorKind.rawValue) to=\(targetKind.rawValue) terminal=\(prepared.id.uuidString)")
         return prepared.id
     }
 
@@ -1341,7 +1333,7 @@ public final class SessionService {
     /// confirmation alert in `AppDelegate.restartTmuxServer`.
     @MainActor
     public func restartTmuxServer() {
-        NSLog("[CrowTelemetry tmux:server_restart_by_user]")
+        CrowLog.info("[CrowTelemetry tmux:server_restart_by_user]")
         // A manual restart supersedes any in-flight crash recovery — clear the
         // flag so the crash overlay doesn't linger over the user-driven rebuild.
         appState.tmuxCrashRecovering = false
@@ -1398,7 +1390,7 @@ public final class SessionService {
     public func handleCockpitClientExit() {
         guard !appState.tmuxCrashRecovering else { return }
         if TmuxBackend.shared.isRunning {
-            NSLog("[CrowTelemetry tmux:cockpit_client_reattach]")
+            CrowLog.info("[CrowTelemetry tmux:cockpit_client_reattach]")
             TmuxBackend.shared.recycleCockpitSurface()
             // Same SwiftUI re-render trick as recycleTmuxServerAndRebuild: a
             // same-value reassignment makes TerminalSurfaceView re-create the
@@ -1422,11 +1414,11 @@ public final class SessionService {
     public func handleTmuxServerCrash() {
         guard !appState.tmuxCrashRecovering else { return }
         if let last = lastCrashRecoveryAt, Date().timeIntervalSince(last) < 10 {
-            NSLog("[CrowTelemetry tmux:server_crash_recovery_debounced]")
+            CrowLog.info("[CrowTelemetry tmux:server_crash_recovery_debounced]")
             return
         }
         lastCrashRecoveryAt = Date()
-        NSLog("[CrowTelemetry tmux:server_crash_autorecovery]")
+        CrowLog.info("[CrowTelemetry tmux:server_crash_autorecovery]")
         // Set the flag BEFORE shutdown: the subprocess waits inside the rebuild
         // pump the main run loop, so a re-entrant crash signal during recovery
         // must find the guard already up.
@@ -1440,7 +1432,7 @@ public final class SessionService {
             try? await Task.sleep(nanoseconds: 120 * 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
             if self.appState.tmuxCrashRecovering {
-                NSLog("[CrowTelemetry tmux:server_crash_recovery_timeout]")
+                CrowLog.info("[CrowTelemetry tmux:server_crash_recovery_timeout]")
                 self.appState.tmuxCrashRecovering = false
             }
         }
@@ -1539,8 +1531,7 @@ public final class SessionService {
                 crowPath: crowPath
             )
         } catch {
-            NSLog("[SessionService] Failed to write Manager hook config for session %@: %@",
-                  session.id.uuidString, error.localizedDescription)
+            CrowLog.info("[SessionService] Failed to write Manager hook config for session \(session.id.uuidString): \(error.localizedDescription)")
         }
     }
 
@@ -1646,7 +1637,7 @@ public final class SessionService {
             ClaudeTrustSeeder.seedTrust(projectPath: cwd)
         case .codex:
             if case let .failed(msg) = CodexTrustSeeder.seedTrust(projectPath: cwd) {
-                NSLog("[SessionService] Codex trust seed failed for %@: %@", cwd, msg)
+                CrowLog.info("[SessionService] Codex trust seed failed for \(cwd): \(msg)")
             }
         default:
             break
@@ -1844,17 +1835,17 @@ public final class SessionService {
                 guard FileManager.default.fileExists(atPath: item.worktreePath) else { continue }
                 do {
                     try FileManager.default.removeItem(atPath: item.worktreePath)
-                    NSLog("[SessionService] Cleaned up review clone: \(item.worktreePath)")
+                    CrowLog.info("[SessionService] Cleaned up review clone: \(item.worktreePath)")
                 } catch {
                     let msg = "Failed to remove review clone: \(error.localizedDescription)"
-                    NSLog("[SessionService] \(msg) (\(item.worktreePath))")
+                    CrowLog.info("[SessionService] \(msg) (\(item.worktreePath))")
                     if firstFatalError == nil { firstFatalError = msg }
                 }
                 continue
             }
 
             if item.isMainCheckout {
-                NSLog("Skipping worktree cleanup for main checkout: \(item.worktreePath) (branch: \(item.branch))")
+                CrowLog.info("Skipping worktree cleanup for main checkout: \(item.worktreePath) (branch: \(item.branch))")
                 continue
             }
 
@@ -1869,24 +1860,24 @@ public final class SessionService {
             var gitRemoveFailed = false
             do {
                 let removeResult = try runShellSync(["git", "-C", item.repoPath, "worktree", "remove", "--force", item.worktreePath])
-                NSLog("Removed worktree: \(item.worktreePath) \(removeResult)")
+                CrowLog.info("Removed worktree: \(item.worktreePath) \(removeResult)")
 
                 if !SessionWorktree.isProtectedBranch(item.branch) {
                     do {
                         _ = try runShellSync(["git", "-C", item.repoPath, "branch", "-D", item.branch])
                     } catch {
-                        NSLog("[SessionService] Failed to delete branch \(item.branch): \(error)")
+                        CrowLog.info("[SessionService] Failed to delete branch \(item.branch): \(error)")
                     }
                 }
 
                 do {
                     _ = try runShellSync(["git", "-C", item.repoPath, "worktree", "prune"])
                 } catch {
-                    NSLog("[SessionService] Failed to prune worktree metadata: \(error)")
+                    CrowLog.info("[SessionService] Failed to prune worktree metadata: \(error)")
                 }
             } catch {
                 gitRemoveFailed = true
-                NSLog("[SessionService] Failed to remove worktree \(item.worktreePath): \(error)")
+                CrowLog.info("[SessionService] Failed to remove worktree \(item.worktreePath): \(error)")
             }
 
             // Either way, ensure the directory is gone.
@@ -1894,7 +1885,7 @@ public final class SessionService {
                 do {
                     try FileManager.default.removeItem(atPath: item.worktreePath)
                 } catch {
-                    NSLog("[SessionService] Failed to remove directory \(item.worktreePath): \(error)")
+                    CrowLog.info("[SessionService] Failed to remove directory \(item.worktreePath): \(error)")
                     if gitRemoveFailed && firstFatalError == nil {
                         firstFatalError = "Could not remove worktree at \(item.worktreePath): \(error.localizedDescription)"
                     }
@@ -2072,7 +2063,7 @@ public final class SessionService {
                     if SessionWorktree.isProtectedBranch(wt.branch) { continue }
 
                     // This is an orphan — recover it
-                    NSLog("[SessionService] Recovered orphan worktree: \(wt.path) branch=\(wt.branch)")
+                    CrowLog.info("[SessionService] Recovered orphan worktree: \(wt.path) branch=\(wt.branch)")
                     await recoverOrphan(worktreePath: wt.path, branch: wt.branch, repoName: repoDir, repoPath: repoPath)
                 }
             }
@@ -2176,7 +2167,7 @@ public final class SessionService {
               let pr = try? await backend.linkedPR(repo: repoSlug, branch: branch) else {
             return nil
         }
-        NSLog("[SessionService] Found PR #\(pr.number) for branch '\(branch)'")
+        CrowLog.info("[SessionService] Found PR #\(pr.number) for branch '\(branch)'")
         return SessionLink(sessionID: sessionID, label: "PR #\(pr.number)", url: pr.url, linkType: .pr)
     }
 
@@ -2263,7 +2254,7 @@ public final class SessionService {
             data.links.append(contentsOf: links)
         }
 
-        NSLog("[SessionService] Recovered session '\(dirName)' — ticket=#\(ticket.number.map(String.init) ?? "none") title=\(ticket.title ?? "unknown")")
+        CrowLog.info("[SessionService] Recovered session '\(dirName)' — ticket=#\(ticket.number.map(String.init) ?? "none") title=\(ticket.title ?? "unknown")")
     }
 
     // MARK: - Terminal Tab Management
@@ -2424,14 +2415,14 @@ public final class SessionService {
         // not racy. Belt-and-suspenders for the auto-review watcher race
         // (CROW-406) and any future caller that re-enters during a kickoff.
         if let existing = appState.existingReviewSession(forPRURL: prURL) {
-            NSLog("[SessionService] Skipping duplicate review session for \(prURL); reusing \(existing.id)")
+            CrowLog.info("[SessionService] Skipping duplicate review session for \(prURL); reusing \(existing.id)")
             if selectAfterCreate { appState.selectedSessionID = existing.id }
             return existing.id
         }
 
         // Parse org/repo and PR number from URL like "https://github.com/org/repo/pull/123"
         guard let parsed = Session.parseReviewPR(url: prURL) else {
-            NSLog("[SessionService] Could not parse PR URL: \(prURL)")
+            CrowLog.info("[SessionService] Could not parse PR URL: \(prURL)")
             return nil
         }
         let owner = parsed.owner
@@ -2441,7 +2432,7 @@ public final class SessionService {
 
         // Determine clone path
         guard let devRoot = ConfigStore.loadDevRoot() else {
-            NSLog("[SessionService] No devRoot configured")
+            CrowLog.info("[SessionService] No devRoot configured")
             return nil
         }
 
@@ -2464,13 +2455,13 @@ public final class SessionService {
         let prMetadata: PRMetadata
         do {
             guard let manager = providerManager else {
-                NSLog("[SessionService] No providerManager wired; cannot prepare review for \(prURL)")
+                CrowLog.info("[SessionService] No providerManager wired; cannot prepare review for \(prURL)")
                 return nil
             }
             let backend = manager.codeBackend(for: .github)!
             prMetadata = try await backend.fetchPRMetadata(prURL: prURL)
         } catch {
-            NSLog("[SessionService] Failed to fetch PR metadata for \(prURL): \(error.localizedDescription)")
+            CrowLog.info("[SessionService] Failed to fetch PR metadata for \(prURL): \(error.localizedDescription)")
             return nil
         }
 
@@ -2489,7 +2480,7 @@ public final class SessionService {
                 )
             }.value
         } catch {
-            NSLog("[SessionService] Failed to prepare review clone for \(prURL): \(error.localizedDescription)")
+            CrowLog.info("[SessionService] Failed to prepare review clone for \(prURL): \(error.localizedDescription)")
             return nil
         }
 
@@ -2562,7 +2553,7 @@ public final class SessionService {
             appState.selectedSessionID = session.id
         }
 
-        NSLog("[SessionService] Created review session '\(session.name)' for \(prURL)")
+        CrowLog.info("[SessionService] Created review session '\(session.name)' for \(prURL)")
         return session.id
     }
 
@@ -2636,8 +2627,7 @@ public final class SessionService {
             // mount, etc.) leaves the attacker's config layer in place, so this
             // security control must be audible rather than swallowed (#829
             // review round 11, Green 1).
-            NSLog("[SessionService] Failed to strip .cursor/ from review clone %@: %@",
-                  clonePath, error.localizedDescription)
+            CrowLog.info("[SessionService] Failed to strip .cursor/ from review clone \(clonePath): \(error.localizedDescription)")
         }
     }
 
@@ -2687,7 +2677,7 @@ public final class SessionService {
         // path that doesn't exist, and the agent would launch with an empty
         // prompt. Throwing here aborts session creation cleanly.
         if !fm.fileExists(atPath: (clonePath as NSString).appendingPathComponent(".git")) {
-            NSLog("[SessionService] Cloning \(repoSlug) into \(clonePath)")
+            CrowLog.info("[SessionService] Cloning \(repoSlug) into \(clonePath)")
             do {
                 _ = try await runShellAsync(env: env, args: ["gh", "repo", "clone", repoSlug, clonePath])
             } catch {
@@ -2844,7 +2834,7 @@ public final class SessionService {
     /// the worktree can't be created.
     func runJob(_ job: JobConfig, devRoot: String) async -> (sessionID: UUID, terminalID: UUID)? {
         guard let firstPrompt = job.prompts.first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
-            NSLog("[SessionService] Job '\(job.name)' has no prompts; skipping")
+            CrowLog.info("[SessionService] Job '\(job.name)' has no prompts; skipping")
             return nil
         }
 
@@ -2868,7 +2858,7 @@ public final class SessionService {
             repoPath = layout.repoPath
             if !FileManager.default.fileExists(atPath: (repoPath as NSString).appendingPathComponent(".git")) {
                 guard await cloneJobRepo(job: job, devRoot: devRoot, into: repoPath) else {
-                    NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not cloned and clone-on-demand failed")
+                    CrowLog.info("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not cloned and clone-on-demand failed")
                     return nil
                 }
             }
@@ -2879,7 +2869,7 @@ public final class SessionService {
             let repos = ((try? await gitManager.discoverRepos()) ?? [])
                 .sorted { $0.path < $1.path }
             guard let repoInfo = repos.first(where: { $0.name == job.repo }) else {
-                NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' not found under devRoot")
+                CrowLog.info("[SessionService] Job '\(job.name)': repo '\(job.repo)' not found under devRoot")
                 return nil
             }
             repoPath = repoInfo.path
@@ -2898,7 +2888,7 @@ public final class SessionService {
                 repoPath: repoPath, worktreePath: worktreePath, branch: branch
             )
         } catch {
-            NSLog("[SessionService] Job '\(job.name)': createWorktree failed: \(error.localizedDescription)")
+            CrowLog.info("[SessionService] Job '\(job.name)': createWorktree failed: \(error.localizedDescription)")
             return nil
         }
 
@@ -2910,11 +2900,11 @@ public final class SessionService {
         do {
             try firstPrompt.write(toFile: promptPath, atomically: true, encoding: .utf8)
         } catch {
-            NSLog("[SessionService] Job '\(job.name)': failed to write \(promptPath): \(error.localizedDescription)")
+            CrowLog.info("[SessionService] Job '\(job.name)': failed to write \(promptPath): \(error.localizedDescription)")
             return nil
         }
         guard FileManager.default.fileExists(atPath: promptPath) else {
-            NSLog("[SessionService] Job '\(job.name)': prompt file missing at \(promptPath) after write")
+            CrowLog.info("[SessionService] Job '\(job.name)': prompt file missing at \(promptPath) after write")
             return nil
         }
 
@@ -2953,7 +2943,7 @@ public final class SessionService {
             data.terminals.append(preparedTerminal)
         }
 
-        NSLog("[SessionService] Job '\(job.name)': created session '\(session.name)' at \(worktreePath)")
+        CrowLog.info("[SessionService] Job '\(job.name)': created session '\(session.name)' at \(worktreePath)")
         return (session.id, preparedTerminal.id)
     }
 
@@ -2982,7 +2972,7 @@ public final class SessionService {
     /// whether a `.git` checkout exists at `destination` afterward.
     private func cloneJobRepo(job: JobConfig, devRoot: String, into destination: String) async -> Bool {
         guard job.repo.contains("/") else {
-            NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not an owner/repo slug; cannot clone")
+            CrowLog.info("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not an owner/repo slug; cannot clone")
             return false
         }
         let workspace = ConfigStore.loadConfig(devRoot: devRoot)?
@@ -2996,7 +2986,7 @@ public final class SessionService {
             withIntermediateDirectories: true
         )
 
-        NSLog("[SessionService] Job '\(job.name)': cloning \(job.repo) into \(destination)")
+        CrowLog.info("[SessionService] Job '\(job.name)': cloning \(job.repo) into \(destination)")
         do {
             if provider == "gitlab" {
                 var env: [String: String] = [:]
@@ -3006,7 +2996,7 @@ public final class SessionService {
                 _ = try await shell("gh", "repo", "clone", job.repo, destination)
             }
         } catch {
-            NSLog("[SessionService] Job '\(job.name)': clone failed: \(error.localizedDescription)")
+            CrowLog.info("[SessionService] Job '\(job.name)': clone failed: \(error.localizedDescription)")
         }
         return FileManager.default.fileExists(atPath: (destination as NSString).appendingPathComponent(".git"))
     }
@@ -3196,9 +3186,10 @@ public final class SessionService {
             ? fresh
             : appState.existingHookState(for: id)?.analytics
         guard let analytics, !analytics.isEmpty else {
-            NSLog(
-                "[SessionService] Skipped analytics snapshot for %@ (%@): no telemetry data — telemetry disabled, not restarted since enabling, or the session produced none",
-                id.uuidString, status.rawValue)
+            CrowLog.info(
+                "[SessionService] Skipped analytics snapshot for \(id.uuidString) (\(status.rawValue)): "
+                    + "no telemetry data — telemetry disabled, not restarted since enabling, "
+                    + "or the session produced none")
             appState.analyticsSnapshotSkipCount += 1
             appState.lastAnalyticsSnapshotSkipAt = Date()
             return
@@ -3249,7 +3240,7 @@ public final class SessionService {
             if store.data.analyticsSnapshots?[key] != nil { written += 1 }
         }
         if written > 0 {
-            NSLog("[SessionService] Backfilled %d analytics snapshot(s) from telemetry.db", written)
+            CrowLog.info("[SessionService] Backfilled \(written) analytics snapshot(s) from telemetry.db")
         }
         return written
     }
@@ -3457,7 +3448,7 @@ public final class SessionService {
     private func prepareTerminal(_ terminal: SessionTerminal, trackReadiness: Bool) -> SessionTerminal {
         var t = terminal
         guard !TmuxBackend.shared.tmuxBinary.isEmpty else {
-            NSLog("[SessionService] tmux not configured; terminal \(t.id) will not render")
+            CrowLog.info("[SessionService] tmux not configured; terminal \(t.id) will not render")
             return t
         }
         let session = appState.sessions.first(where: { $0.id == t.sessionID })
@@ -3476,7 +3467,7 @@ public final class SessionService {
             )
             t.tmuxBinding = binding
         } catch {
-            NSLog("[SessionService] tmux registerTerminal failed (\(error)); terminal \(t.id) will not render")
+            CrowLog.info("[SessionService] tmux registerTerminal failed (\(error)); terminal \(t.id) will not render")
         }
         return t
     }

--- a/Packages/CrowEngine/Sources/CrowEngine/TerminalRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/TerminalRouter.swift
@@ -17,7 +17,7 @@ public enum TerminalRouter {
         do {
             try TmuxBackend.shared.sendText(id: terminal.id, text: text)
         } catch {
-            NSLog("[TerminalRouter] tmux sendText failed for \(terminal.id): \(error)")
+            CrowLog.info("[TerminalRouter] tmux sendText failed for \(terminal.id): \(error)")
         }
     }
 

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Registers the Jira MCP server into OpenCode's config so OpenCode sessions
@@ -98,7 +99,7 @@ public enum OpenCodeMCPConfigWriter {
             guard let data = fm.contents(atPath: targetPath),
                   let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
             else {
-                NSLog("[OpenCodeMCPConfigWriter] %@ exists but is not a JSON object; refusing to modify it", targetPath)
+                CrowLog.info("[OpenCodeMCPConfigWriter] \(targetPath) exists but is not a JSON object; refusing to modify it")
                 return .skippedUnparseable
             }
             root = parsed
@@ -127,7 +128,7 @@ public enum OpenCodeMCPConfigWriter {
                 return .noSource
             }
             guard entryIsOurs else {
-                NSLog("[OpenCodeMCPConfigWriter] mcp.%@ not written by Crow; leaving it alone", serverName)
+                CrowLog.info("[OpenCodeMCPConfigWriter] mcp.\(serverName) not written by Crow; leaving it alone")
                 return .skippedUserOwned
             }
             mcp.removeValue(forKey: serverName)
@@ -147,7 +148,7 @@ public enum OpenCodeMCPConfigWriter {
         // 4b. Source present but untranslatable (e.g. a half-edited entry) →
         //     leave the mirror alone rather than deleting it.
         guard let translated = translateClaudeServer(sourceServer!) else {
-            NSLog("[OpenCodeMCPConfigWriter] Claude mcpServers.%@ present but not translatable; leaving OpenCode config unchanged", serverName)
+            CrowLog.info("[OpenCodeMCPConfigWriter] Claude mcpServers.\(serverName) present but not translatable; leaving OpenCode config unchanged")
             return .noSource
         }
 
@@ -155,7 +156,7 @@ public enum OpenCodeMCPConfigWriter {
         //     record still present). Treat the deletion as intent and don't
         //     re-add it — deleting behaves the same as editing.
         if existing == nil, recorded != nil {
-            NSLog("[OpenCodeMCPConfigWriter] mcp.%@ removed after Crow wrote it; honoring the opt-out", serverName)
+            CrowLog.info("[OpenCodeMCPConfigWriter] mcp.\(serverName) removed after Crow wrote it; honoring the opt-out")
             return .skippedUserOwned
         }
 
@@ -168,7 +169,7 @@ public enum OpenCodeMCPConfigWriter {
             let why = recorded == nil
                 ? "no Crow record for it (user-authored, or the mirror sidecar was lost)"
                 : "it differs from Crow's record (user-edited)"
-            NSLog("[OpenCodeMCPConfigWriter] mcp.%@ left as-is — %@; not overwriting", serverName, why)
+            CrowLog.info("[OpenCodeMCPConfigWriter] mcp.\(serverName) left as-is — \(why); not overwriting")
             return .skippedUserOwned
         }
 
@@ -212,7 +213,7 @@ public enum OpenCodeMCPConfigWriter {
             try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
             return nil
         } catch {
-            NSLog("[OpenCodeMCPConfigWriter] Failed to write %@: %@", path, error.localizedDescription)
+            CrowLog.info("[OpenCodeMCPConfigWriter] Failed to write \(path): \(error.localizedDescription)")
             return .failed(error.localizedDescription)
         }
     }
@@ -253,7 +254,7 @@ public enum OpenCodeMCPConfigWriter {
             try data.write(to: URL(fileURLWithPath: path), options: .atomic)
             try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
         } catch {
-            NSLog("[OpenCodeMCPConfigWriter] Failed to write mirror record %@: %@", path, error.localizedDescription)
+            CrowLog.info("[OpenCodeMCPConfigWriter] Failed to write mirror record \(path): \(error.localizedDescription)")
         }
     }
 
@@ -273,7 +274,7 @@ public enum OpenCodeMCPConfigWriter {
         guard let data = fm.contents(atPath: claudeJSONPath),
               let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
         else {
-            NSLog("[OpenCodeMCPConfigWriter] %@ exists but is not a JSON object; ignoring", claudeJSONPath)
+            CrowLog.info("[OpenCodeMCPConfigWriter] \(claudeJSONPath) exists but is not a JSON object; ignoring")
             return .unparseable
         }
         let servers = root["mcpServers"] as? [String: Any]

--- a/Packages/CrowPersistence/Sources/CrowPersistence/AppSupportDirectory.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/AppSupportDirectory.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Provides the canonical Application Support directory for Crow, performing
@@ -15,9 +16,9 @@ enum AppSupportDirectory {
            FileManager.default.fileExists(atPath: oldDir.path) {
             do {
                 try FileManager.default.copyItem(at: oldDir, to: crowDir)
-                NSLog("[AppSupportDirectory] Migrated data from rm-ai-ide to crow")
+                CrowLog.info("[AppSupportDirectory] Migrated data from rm-ai-ide to crow")
             } catch {
-                NSLog("[AppSupportDirectory] Failed to migrate rm-ai-ide data: %@", error.localizedDescription)
+                CrowLog.info("[AppSupportDirectory] Failed to migrate rm-ai-ide data: \(error.localizedDescription)")
             }
         }
         return crowDir

--- a/Packages/CrowPersistence/Sources/CrowPersistence/ConfigStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/ConfigStore.swift
@@ -24,7 +24,7 @@ public final class ConfigStore: Sendable {
             return nil
         }
         if !FileManager.default.fileExists(atPath: path) {
-            NSLog("[ConfigStore] devRoot path does not exist on disk: %@", path)
+            CrowLog.info("[ConfigStore] devRoot path does not exist on disk: \(path)")
         }
         return path
     }
@@ -77,7 +77,7 @@ public final class ConfigStore: Sendable {
         do {
             return try JSONDecoder().decode(AppConfig.self, from: data)
         } catch {
-            NSLog("[ConfigStore] Failed to decode config at %@: %@", configURL.path, error.localizedDescription)
+            CrowLog.info("[ConfigStore] Failed to decode config at \(configURL.path): \(error.localizedDescription)")
             return nil
         }
     }

--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -168,8 +168,8 @@ public final class JSONStore: Sendable {
                 self._data = try decoder.decode(StoreData.self, from: data)
             } catch {
                 // Log the error so we know WHY decoding failed — this was silently wiping the store
-                NSLog("[JSONStore] ERROR: Failed to decode store.json: \(error.localizedDescription)")
-                NSLog("[JSONStore] Backing up corrupt store to store.json.bak")
+                CrowLog.info("[JSONStore] ERROR: Failed to decode store.json: \(error.localizedDescription)")
+                CrowLog.info("[JSONStore] Backing up corrupt store to store.json.bak")
                 let backupURL = dir.appendingPathComponent("store.json.bak")
                 try? FileManager.default.removeItem(at: backupURL)
                 try? FileManager.default.copyItem(at: fileURL, to: backupURL)
@@ -261,13 +261,12 @@ public final class JSONStore: Sendable {
     private func detectExternalWrite(context: String) {
         guard let expected = lastWrittenSignature, let actual = currentSignature(),
               actual != expected else { return }
-        NSLog(
-            "[JSONStore] EXTERNAL WRITE DETECTED (%@): store.json at %@ changed under pid %d "
-                + "— a second writer is touching store.json (expected mtime=%@ size=%d, "
-                + "found mtime=%@ size=%d). Whole-file writes mean the losing writer's sessions "
-                + "vanish; only ONE crowd may write this store.",
-            context, fileURL.path, getpid(),
-            "\(expected.modified)", expected.size, "\(actual.modified)", actual.size)
+        CrowLog.info(
+            "[JSONStore] EXTERNAL WRITE DETECTED (\(context)): store.json at \(fileURL.path) "
+                + "changed under pid \(getpid()) — a second writer is touching store.json "
+                + "(expected mtime=\(expected.modified) size=\(expected.size), "
+                + "found mtime=\(actual.modified) size=\(actual.size)). Whole-file writes mean "
+                + "the losing writer's sessions vanish; only ONE crowd may write this store.")
     }
 
     private static func save(_ data: StoreData, to url: URL) {
@@ -275,7 +274,7 @@ public final class JSONStore: Sendable {
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         guard let jsonData = try? encoder.encode(data) else {
-            NSLog("[JSONStore] ERROR: Failed to encode store data")
+            CrowLog.info("[JSONStore] ERROR: Failed to encode store data")
             return
         }
         do {
@@ -284,7 +283,7 @@ public final class JSONStore: Sendable {
             try FileManager.default.setAttributes(
                 [.posixPermissions: 0o600], ofItemAtPath: url.path)
         } catch {
-            NSLog("[JSONStore] ERROR: Failed to write store.json: \(error.localizedDescription)")
+            CrowLog.info("[JSONStore] ERROR: Failed to write store.json: \(error.localizedDescription)")
         }
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
@@ -122,7 +122,7 @@ public struct JiraTaskBackend: TaskBackend {
             case .success(let items):
                 open = Self.parseAssigned(items: items, site: config.site, statusOverride: nil, statusMap: config.statusMap)
             case .failure(let error):
-                NSLog("[JiraTaskBackend] REST listAssigned failed for %@: %@", site, String(describing: error))
+                CrowLog.info("[JiraTaskBackend] REST listAssigned failed for \(site): \(String(describing: error))")
                 return AssignedListing(open: [], closed: [])
             }
 
@@ -221,8 +221,7 @@ public struct JiraTaskBackend: TaskBackend {
             case .success(.transitioned):
                 return
             case .success(.noMatchingTransition(let available)):
-                NSLog("[JiraTaskBackend] No transition to \"%@\" available for %@ (reachable: %@); skipping",
-                      targetName, parsed.key, available.isEmpty ? "none" : available.joined(separator: ", "))
+                CrowLog.info("[JiraTaskBackend] No transition to \"\(targetName)\" available for \(parsed.key) (reachable: \(available.isEmpty ? "none" : available.joined(separator: ", "))); skipping")
                 return
             case .failure(let error):
                 throw ProviderError.commandFailed("Jira REST transition failed for \(parsed.key): \(error)")

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -290,7 +290,7 @@ public actor ProviderManager {
                 return []
             }
         } catch {
-            NSLog("[ProviderManager] listRepos failed for owner '\(owner)': \(error.localizedDescription)")
+            CrowLog.info("[ProviderManager] listRepos failed for owner '\(owner)': \(error.localizedDescription)")
             return []
         }
     }

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/Receiver/OTLPReceiver.swift
@@ -40,11 +40,11 @@ public final class OTLPReceiver: Sendable {
         listener.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
-                NSLog("[OTLPReceiver] Listening on localhost:%d", self?.port ?? 0)
+                CrowLog.info("[OTLPReceiver] Listening on localhost:\(self?.port ?? 0)")
             case .failed(let error):
-                NSLog("[OTLPReceiver] Listener failed: %@", error.localizedDescription)
+                CrowLog.info("[OTLPReceiver] Listener failed: \(error.localizedDescription)")
             case .cancelled:
-                NSLog("[OTLPReceiver] Listener cancelled")
+                CrowLog.info("[OTLPReceiver] Listener cancelled")
             default:
                 break
             }
@@ -83,7 +83,7 @@ public final class OTLPReceiver: Sendable {
             }
 
             if let error {
-                NSLog("[OTLPReceiver] Receive error: %@", error.localizedDescription)
+                CrowLog.info("[OTLPReceiver] Receive error: \(error.localizedDescription)")
                 connection.cancel()
                 return
             }
@@ -100,14 +100,13 @@ public final class OTLPReceiver: Sendable {
                     // Backstop: the parser can only reject what it can frame,
                     // so never let one connection buffer without bound while it
                     // keeps asking for more.
-                    NSLog("[OTLPReceiver] Buffered %d bytes without a complete request; closing",
-                          accumulated.count)
+                    CrowLog.info("[OTLPReceiver] Buffered \(accumulated.count) bytes without a complete request; closing")
                     self.sendResponse(HTTPResponse.badRequest(message: "Request too large"), on: connection)
                 } else {
                     self.receiveData(on: connection, buffer: accumulated)
                 }
             case .error(let message):
-                NSLog("[OTLPReceiver] Parse error: %@", message)
+                CrowLog.info("[OTLPReceiver] Parse error: \(message)")
                 self.sendResponse(HTTPResponse.badRequest(message: message), on: connection)
             }
         }
@@ -167,7 +166,7 @@ public final class OTLPReceiver: Sendable {
         decoder.userInfo[.otlpDiagnostics] = diagnostics
         let payload = try decoder.decode(T.self, from: request.body)
         if let summary = diagnostics.summary {
-            NSLog("[OTLPReceiver] %@: skipped malformed %@", request.path, summary)
+            CrowLog.info("[OTLPReceiver] \(request.path): skipped malformed \(summary)")
         }
         return payload
     }
@@ -198,7 +197,7 @@ public final class OTLPReceiver: Sendable {
                 .replacingOccurrences(of: "\n", with: " ")
             message += "\n  body[0..<\(prefix.count)]: \(text)"
         }
-        NSLog("%@", message)
+        CrowLog.info("\(message)")
     }
 
     private static var logRawBodies: Bool {

--- a/Packages/CrowTelemetry/Sources/CrowTelemetry/TelemetryService.swift
+++ b/Packages/CrowTelemetry/Sources/CrowTelemetry/TelemetryService.swift
@@ -37,14 +37,14 @@ public final class TelemetryService: Sendable {
     public func start() async throws {
         try await database.open()
         receiver.start()
-        NSLog("[TelemetryService] Started on port %d", port)
+        CrowLog.info("[TelemetryService] Started on port \(port)")
     }
 
     /// Stop receiving telemetry. Stops the listener and closes the database.
     public func stop() async {
         receiver.stop()
         await database.close()
-        NSLog("[TelemetryService] Stopped")
+        CrowLog.info("[TelemetryService] Stopped")
     }
 
     /// Get analytics for a Crow session.

--- a/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift
@@ -91,7 +91,21 @@ public final class PTYProcess: @unchecked Sendable {
             throw PTYProcessError.spawnFailed(errno)
         }
         defer { posix_spawnattr_destroy(&attrs) }
+        // CLOEXEC_DEFAULT closes every descriptor NOT named in `actions` above.
+        // Without it, posix_spawn hands the child a copy of the entire fd table
+        // as it stood at spawn time — and this child is a cockpit attach client
+        // that lives for the whole browser session or app run. A
+        // `TmuxController.run()` pipe write end captured that way keeps its pipe
+        // from ever reaching EOF, so the reader blocks and the caller wedges for
+        // as long as the attach client survives (CROW-874). The explicit dup2s
+        // above are exempt from the flag, so the PTY wiring is unaffected.
+        #if canImport(Darwin)
+        posix_spawnattr_setflags(&attrs, Int16(POSIX_SPAWN_SETSID | POSIX_SPAWN_CLOEXEC_DEFAULT))
+        #else
+        // Linux has no CLOEXEC_DEFAULT. The daemon's own pipes are opened
+        // O_CLOEXEC by Foundation there, so this is a narrower gap, not none.
         posix_spawnattr_setflags(&attrs, Int16(POSIX_SPAWN_SETSID))
+        #endif
 
         var envStrings = ProcessInfo.processInfo.environment.map { "\($0.key)=\($0.value)" }
         if !envStrings.contains(where: { $0.hasPrefix("TERM=") }) {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
@@ -2,6 +2,7 @@
 // Not part of the Linux headless build; compiles away there.
 #if canImport(AppKit)
 import AppKit
+import CrowCore
 import Foundation
 
 /// Floating search affordance pinned to the top of a terminal container
@@ -135,7 +136,7 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
             )
             hasActiveSearch = true
         } catch {
-            NSLog("[TerminalSearchBar] search failed: \(error)")
+            CrowLog.info("[TerminalSearchBar] search failed: \(error)")
         }
     }
 
@@ -148,7 +149,7 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
         do {
             try TmuxBackend.shared.searchAgain(id: id, reverse: false)
         } catch {
-            NSLog("[TerminalSearchBar] search-again failed: \(error)")
+            CrowLog.info("[TerminalSearchBar] search-again failed: \(error)")
         }
     }
 
@@ -160,7 +161,7 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
         do {
             try TmuxBackend.shared.searchAgain(id: id, reverse: true)
         } catch {
-            NSLog("[TerminalSearchBar] search-reverse failed: \(error)")
+            CrowLog.info("[TerminalSearchBar] search-reverse failed: \(error)")
         }
     }
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -135,7 +135,7 @@ public struct TerminalSurfaceView: NSViewRepresentable {
         do {
             return try TmuxBackend.shared.cockpitSurface()
         } catch {
-            NSLog("[TerminalSurfaceView] tmux cockpitSurface failed: \(error). Rendering blank — tmux is required.")
+            CrowLog.info("[TerminalSurfaceView] tmux cockpitSurface failed: \(error). Rendering blank — tmux is required.")
             return nil
         }
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -192,11 +192,14 @@ public final class TmuxBackend {
             CrowLog.info("[CrowTelemetry tmux:\(killServer ? "server_killed" : "server_detach") bindings=\(bindings.count)]")
         }
         // Destroy the surface BEFORE kill-server: destroy() nils the surface's
-        // onProcessExit synchronously, and killServer's waitUntilExit pumps the
-        // main run loop — without this order the attach client's death would be
-        // delivered mid-shutdown and a deliberate restart would masquerade as
-        // a server crash (#588). Guarded for the Linux daemon build, where the
-        // AppKit surface doesn't exist (b982621).
+        // onProcessExit synchronously, so the attach client's death can no
+        // longer be delivered mid-shutdown and a deliberate restart can't
+        // masquerade as a server crash (#588). (The original reason given here
+        // was that killServer's waitUntilExit pumps the main run loop; that has
+        // not been true since #653 replaced the wait with a semaphore. The
+        // ordering still matters, for the synchronous-nil reason above.)
+        // Guarded for the Linux daemon build, where the AppKit surface doesn't
+        // exist (b982621).
         #if canImport(AppKit)
         sharedSurface?.destroy()
         sharedSurface = nil
@@ -974,7 +977,8 @@ public final class TmuxBackend {
                 guard let self else { return }
                 // Capture the tmux handle + window index on the main actor, then
                 // read `#{pane_current_command}` off it: `TmuxController.run`
-                // blocks on `waitUntilExit()`, so keep that subprocess off the UI
+                // blocks the calling thread (on a semaphore since #653, without
+                // pumping the run loop), so keep that subprocess off the UI
                 // thread. A missing binding/controller yields a `nil` sample (skip).
                 let ctrl = self.controller
                 let windowIndex = self.bindings[id]
@@ -1157,22 +1161,37 @@ public final class TmuxBackend {
     /// can surface in a banner. Idempotent: `source-file` against a live
     /// server updates server-scoped options in place; existing windows and
     /// sessions are unaffected.
-    @MainActor
-    public func reloadBundledConfig() -> String? {
-        guard let ctrl = controller, ctrl.hasSession() else {
+    ///
+    /// `async` and off the main actor: both `hasSession()` and `run()` block the
+    /// calling thread, and the RPC handler invokes this from `MainActor.run`, so
+    /// on the main actor they stall every other MainActor-bound RPC behind them
+    /// (CROW-874). `TmuxController` is a `Sendable` struct of three strings, so
+    /// it crosses cleanly — the same shape `startManagerExitMonitor` uses.
+    ///
+    /// This is one of ~24 `@MainActor` entry points on this type that call
+    /// `TmuxController` synchronously; bounding `run()` itself is what fixes the
+    /// class. Moving the rest needs `sendText`/`makeActive` and friends to stop
+    /// being sync `throws` APIs, which touches every caller.
+    public func reloadBundledConfig() async -> String? {
+        guard let ctrl = controller else {
             return "tmux server is not running"
         }
         guard let confURL = BundledResources.tmuxConfURL else {
             return "bundled crow-tmux.conf not found"
         }
-        do {
-            try ctrl.run(["source-file", confURL.path])
-            CrowLog.info("[CrowTelemetry tmux:config_reloaded_by_user path=\(confURL.path)]")
-            return nil
-        } catch {
-            CrowLog.info("[CrowTelemetry tmux:config_reload_failed error=\"\(error)\"]")
-            return "\(error)"
-        }
+        return await Task.detached {
+            guard ctrl.hasSession() else {
+                return "tmux server is not running"
+            }
+            do {
+                try ctrl.run(["source-file", confURL.path])
+                CrowLog.info("[CrowTelemetry tmux:config_reloaded_by_user path=\(confURL.path)]")
+                return nil
+            } catch {
+                CrowLog.info("[CrowTelemetry tmux:config_reload_failed error=\"\(error)\"]")
+                return "\(error)"
+            }
+        }.value
     }
 
     /// Pure policy: reconcile when either timestamp is missing (conservative
@@ -1196,20 +1215,25 @@ public final class TmuxBackend {
     /// Ensure the cockpit session is live, adopting an existing one if a
     /// concurrent caller won the `new-session` race.
     ///
-    /// The cockpit session may already be live even though `controller` is
-    /// nil. `TmuxController.run` blocks on `Process.waitUntilExit()`, which
-    /// pumps the main run loop — so the `new-session` we're about to issue can
-    /// be re-entered by another `ensureRunningServer()` caller before we cache
-    /// `controller`. On launch this is the norm: every persisted terminal
-    /// hydrates as its own `Task { @MainActor }` (#293) and, with multiple
-    /// Manager sessions (#326), six-plus of them race here at once. Whoever
-    /// wins creates `crow-cockpit`; the rest must ADOPT it, not re-create it
-    /// (`new-session` errors with "duplicate session", and because that throws
-    /// the loser never cached `controller` — so every subsequent call kept
-    /// failing and every terminal rendered blank).
+    /// **The adopt branch below is load-bearing — do not delete it.** Its
+    /// original justification was in-process: `TmuxController.run` blocked on
+    /// `Process.waitUntilExit()`, which pumps the main run loop, so a
+    /// `new-session` could be re-entered by another `ensureRunningServer()`
+    /// caller before `controller` was cached. That mechanism is gone — since
+    /// #653 the wait is a semaphore that does not pump — but the race is not.
+    ///
+    /// It is now a **cross-process** TOCTOU, which no in-process argument can
+    /// close: `TerminalCockpit.ensureSession` in `crowd` performs the identical
+    /// `hasSession()` → `newSessionDetached` against the *same* socket
+    /// (`appTmuxSocketPath()`, #330), and runs it on every daemon startup.
+    /// Whoever wins creates `crow-cockpit`; the rest must ADOPT it, not
+    /// re-create it — `new-session` errors with "duplicate session", and
+    /// because that throws, the loser never cached `controller`, so every
+    /// subsequent call kept failing and every terminal rendered blank (#326).
     ///
     /// `nonisolated static` so the adopt branch is testable without a real
-    /// tmux server or the main actor — it touches no instance/actor state.
+    /// tmux server or the main actor — it touches no instance/actor state, and
+    /// nothing pins it to the main actor.
     nonisolated static func ensureCockpitSession(
         _ ctrl: CockpitSessionStarter,
         configPath: String?,

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -189,7 +189,7 @@ public final class TmuxBackend {
     ///     `kill-server` and unlink the per-terminal scratch files.
     public func shutdown(killServer: Bool = true) {
         if controller != nil {
-            NSLog("[CrowTelemetry tmux:\(killServer ? "server_killed" : "server_detach") bindings=\(bindings.count)]")
+            CrowLog.info("[CrowTelemetry tmux:\(killServer ? "server_killed" : "server_detach") bindings=\(bindings.count)]")
         }
         // Destroy the surface BEFORE kill-server: destroy() nils the surface's
         // onProcessExit synchronously, and killServer's waitUntilExit pumps the
@@ -410,7 +410,7 @@ public final class TmuxBackend {
         // Operator-greppable: `[CrowTelemetry tmux:tab_switch_ms=…]`. Easy
         // to graph from logs today; trivially re-routed to a real metrics
         // pipeline once one exists.
-        NSLog("[CrowTelemetry tmux:tab_switch_ms=\(elapsedMS) terminal=\(id)]")
+        CrowLog.info("[CrowTelemetry tmux:tab_switch_ms=\(elapsedMS) terminal=\(id)]")
     }
 
     /// Settle time between `paste-buffer` and the submitting `Enter`.
@@ -825,7 +825,7 @@ public final class TmuxBackend {
             return true
         } catch {
             reportIfTimeout(error)
-            NSLog("[Crow] could not set alternate-screen on window \(index): \(error)")
+            CrowLog.info("[Crow] could not set alternate-screen on window \(index): \(error)")
             return false
         }
     }
@@ -863,12 +863,12 @@ public final class TmuxBackend {
                 agentWindowNames: agentWindowNames,
                 seenOrphanedLastPass: previouslyOrphaned.contains(w.index)) {
                 ctrl.killWindow(index: w.index)
-                NSLog("[CrowTelemetry tmux:orphan_window_reaped index=\(w.index) name=\(w.name) command=\(w.command)]")
+                CrowLog.info("[CrowTelemetry tmux:orphan_window_reaped index=\(w.index) name=\(w.name) command=\(w.command)]")
                 reaped += 1
             }
         }
         orphanGraceWindows = stillOrphanedAgents
-        if reaped > 0 { NSLog("[Crow] Reaped \(reaped) orphaned cockpit window(s) (CROW-581)") }
+        if reaped > 0 { CrowLog.info("[Crow] Reaped \(reaped) orphaned cockpit window(s) (CROW-581)") }
         return reaped
     }
 
@@ -924,11 +924,11 @@ public final class TmuxBackend {
         var reaped = 0
         for window in windows where Self.shouldReapWindow(index: window.index, command: window.command, keep: keep) {
             ctrl.killWindow(index: window.index)
-            NSLog("[CrowTelemetry tmux:orphan_window_reaped index=\(window.index) command=\(window.command)]")
+            CrowLog.info("[CrowTelemetry tmux:orphan_window_reaped index=\(window.index) command=\(window.command)]")
             reaped += 1
         }
         if reaped > 0 {
-            NSLog("[Crow] Reaped \(reaped) orphaned bare-shell cockpit window(s) (#408)")
+            CrowLog.info("[Crow] Reaped \(reaped) orphaned bare-shell cockpit window(s) (#408)")
         }
         return reaped
     }
@@ -990,7 +990,7 @@ public final class TmuxBackend {
                 let (nextSaw, fired) = Self.advanceExitMonitor(sawAgentRunning: sawAgentRunning, sample: sample)
                 sawAgentRunning = nextSaw
                 if fired {
-                    NSLog("[CrowTelemetry manager:exit_detected terminal=\(id) command=\(sample ?? "")]")
+                    CrowLog.info("[CrowTelemetry manager:exit_detected terminal=\(id) command=\(sample ?? "")]")
                     onExit()
                     return
                 }
@@ -1025,10 +1025,10 @@ public final class TmuxBackend {
         // (#588). Wired here (not by the caller) so every recreated surface is
         // automatically re-armed after recovery.
         view.onProcessExit = { [weak self] code in
-            NSLog("[CrowTelemetry tmux:cockpit_client_exited code=\(code)]")
+            CrowLog.info("[CrowTelemetry tmux:cockpit_client_exited code=\(code)]")
             self?.onCockpitExit?(code)
         }
-        NSLog("[TmuxBackend] created cockpit surface attach=%@", attachCommand)
+        CrowLog.info("[TmuxBackend] created cockpit surface attach=\(attachCommand)")
         // Cache before SwiftUI re-parents into the visible tab container.
         // WKWebView must load in a visible window — do not park offscreen or
         // xterm.js never initializes.
@@ -1086,7 +1086,7 @@ public final class TmuxBackend {
             // identically). Fire BEFORE resurrecting so the handler can
             // observe the dead state; it's reentrancy-guarded and hops to a
             // later main-actor turn, so recovery never races this call.
-            NSLog("[CrowTelemetry tmux:server_died_midrun bindings=\(bindings.count)]")
+            CrowLog.info("[CrowTelemetry tmux:server_died_midrun bindings=\(bindings.count)]")
             onServerLost?()
         }
         guard !tmuxBinary.isEmpty, !socketPath.isEmpty else {
@@ -1136,15 +1136,15 @@ public final class TmuxBackend {
         let serverStart = serverStartTime(controller: controller)
 
         guard shouldReconcile(configMTime: confMTime, serverStartTime: serverStart) else {
-            NSLog("[CrowTelemetry tmux:config_reconcile_skipped reason=fresh]")
+            CrowLog.info("[CrowTelemetry tmux:config_reconcile_skipped reason=fresh]")
             return
         }
 
         do {
             try controller.run(["source-file", confPath])
-            NSLog("[CrowTelemetry tmux:config_reconciled path=\(confPath)]")
+            CrowLog.info("[CrowTelemetry tmux:config_reconciled path=\(confPath)]")
         } catch {
-            NSLog("[CrowTelemetry tmux:config_reconcile_failed error=\"\(error)\"]")
+            CrowLog.info("[CrowTelemetry tmux:config_reconcile_failed error=\"\(error)\"]")
         }
     }
 
@@ -1167,10 +1167,10 @@ public final class TmuxBackend {
         }
         do {
             try ctrl.run(["source-file", confURL.path])
-            NSLog("[CrowTelemetry tmux:config_reloaded_by_user path=\(confURL.path)]")
+            CrowLog.info("[CrowTelemetry tmux:config_reloaded_by_user path=\(confURL.path)]")
             return nil
         } catch {
-            NSLog("[CrowTelemetry tmux:config_reload_failed error=\"\(error)\"]")
+            CrowLog.info("[CrowTelemetry tmux:config_reload_failed error=\"\(error)\"]")
             return "\(error)"
         }
     }
@@ -1263,7 +1263,7 @@ public final class TmuxBackend {
                 let elapsed = Int(Date().timeIntervalSince(startedAt) * 1000)
                 let exists = FileManager.default.fileExists(atPath: sentinelPath)
                 _ = self  // keep the capture; method-level NSLog is fine
-                NSLog("[CrowTelemetry tmux:first_prompt_progress terminal=\(id) elapsed_ms=\(elapsed) sentinel_exists=\(exists)]")
+                CrowLog.info("[CrowTelemetry tmux:first_prompt_progress terminal=\(id) elapsed_ms=\(elapsed) sentinel_exists=\(exists)]")
             }
         }
         let waiterTask = Task { [weak self] in
@@ -1284,7 +1284,7 @@ public final class TmuxBackend {
                 guard let self, self.bindings[id] != nil else { return }
                 if let elapsed {
                     let ms = Int(elapsed * 1000)
-                    NSLog("[CrowTelemetry tmux:first_prompt_ms=\(ms) terminal=\(id)]")
+                    CrowLog.info("[CrowTelemetry tmux:first_prompt_ms=\(ms) terminal=\(id)]")
                     self.onReadinessChanged?(id, .shellReady)
                 } else {
                     // Genuine timeout. Most likely the shell is alive but its
@@ -1302,12 +1302,12 @@ public final class TmuxBackend {
                     // `didBecomeActive` observer also re-arms automatically
                     // when the app returns to the foreground.
                     let ms = Int(timeoutBudget * 1000)
-                    NSLog("[CrowTelemetry tmux:first_prompt_timeout terminal=\(id) budget_ms=\(ms)]")
+                    CrowLog.info("[CrowTelemetry tmux:first_prompt_timeout terminal=\(id) budget_ms=\(ms)]")
                     // Capture stage-by-stage diagnostics and dump them to the
                     // system log alongside the timeout marker. The UI surfaces
                     // the same bundle via "Copy diagnostics" (issue #256).
                     let bundle = self.captureDiagnostics(id: id)
-                    NSLog("[CrowTelemetry tmux:first_prompt_diagnostics terminal=\(id)]\n\(bundle)")
+                    CrowLog.info("[CrowTelemetry tmux:first_prompt_diagnostics terminal=\(id)]\n\(bundle)")
                     self.onReadinessChanged?(id, .timedOut)
                 }
             }
@@ -1517,7 +1517,7 @@ public final class TmuxBackend {
     /// already handles.
     private func reportIfTimeout(_ error: Error) {
         if let tmuxError = error as? TmuxError, case .timedOut = tmuxError {
-            NSLog("[CrowTelemetry tmux:server_unresponsive error=\"\(tmuxError)\"]")
+            CrowLog.info("[CrowTelemetry tmux:server_unresponsive error=\"\(tmuxError)\"]")
             onUnresponsive?(tmuxError)
         }
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -16,7 +16,8 @@ import Foundation
 /// child and throws `.timedOut`; callers wire that into a watchdog flow
 /// that offers the user "Restart tmux server" (spec §10.1).
 ///
-/// All methods are blocking until the spawned tmux process exits.
+/// All methods block the calling thread until the spawned tmux process exits
+/// and its output is drained (both bounded — see `run`).
 public struct TmuxController: Sendable {
     public let tmuxBinary: String
     public let socketPath: String

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Thin wrapper around the `tmux` CLI.
@@ -25,6 +26,16 @@ public struct TmuxController: Sendable {
     /// spike) and matches the watchdog threshold in spec §10.1.
     public static let defaultTimeout: TimeInterval = 2.0
 
+    /// Grace for the post-exit pipe drain.
+    ///
+    /// Deliberately **not** derived from `timeout`: that bounds the *child*,
+    /// this bounds a drain whose child has already exited, so every remaining
+    /// byte is already sitting in a ≤64 KB kernel pipe buffer. The only thing
+    /// this budget must absorb is GCD worker bring-up under contention. Tying it
+    /// to `timeout` would hand `capturePane` a pointless 10s stall — on the
+    /// MainActor — for microseconds of actual work.
+    public static let drainGrace: TimeInterval = 0.25
+
     public init(tmuxBinary: String, socketPath: String, sessionName: String) {
         self.tmuxBinary = tmuxBinary
         self.socketPath = socketPath
@@ -38,10 +49,15 @@ public struct TmuxController: Sendable {
     /// `TmuxError.timedOut` if the child doesn't exit within `timeout`.
     ///
     /// Stdout/stderr are drained on background threads **while** waiting for
-    /// the child. Reading only after `waitUntilExit` deadlocks once output
+    /// the child. Reading only after the child exits deadlocks once output
     /// exceeds the ~64 KB pipe buffer — `capture-pane -pe -S -N` for a rich
     /// TUI pane routinely does, which made CROW-606 web-terminal replay
     /// silently no-op (`try?` swallowed the timeout).
+    ///
+    /// Both waits are bounded. The drain in particular gets `drainGrace` rather
+    /// than running unbounded: EOF needs *every* copy of the pipe's write end to
+    /// close, and a process that inherited one at spawn time can hold it open
+    /// long after the tmux child is reaped (CROW-874).
     @discardableResult
     public func run(_ args: [String], timeout: TimeInterval = TmuxController.defaultTimeout) throws -> String {
         let p = Process()
@@ -56,34 +72,34 @@ public struct TmuxController: Sendable {
         try p.run()
 
         // Drain both pipes concurrently so a large capture can't fill the OS
-        // pipe buffer and stall tmux before it exits. Boxes keep the mutable
-        // Data off the caller's stack so the concurrent readers don't race a
-        // local `var`.
-        final class PipeBox: @unchecked Sendable { var data = Data() }
+        // pipe buffer and stall tmux before it exits.
         let stdoutBox = PipeBox()
         let stderrBox = PipeBox()
         let group = DispatchGroup()
-        group.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
-            stdoutBox.data = stdout.fileHandleForReading.readDataToEndOfFile()
-            group.leave()
-        }
-        group.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
-            stderrBox.data = stderr.fileHandleForReading.readDataToEndOfFile()
-            group.leave()
-        }
-
+        drain(stdout.fileHandleForReading, into: stdoutBox, group: group)
+        drain(stderr.fileHandleForReading, into: stderrBox, group: group)
         let watchdog = ProcessWatchdog(p, timeout: timeout)
         done.wait()
         watchdog.cancel()
-        group.wait()
+        let drainIncomplete = group.wait(timeout: .now() + Self.drainGrace) == .timedOut
 
-        let outString = String(data: stdoutBox.data, encoding: .utf8) ?? ""
-        let errString = String(data: stderrBox.data, encoding: .utf8) ?? ""
+        let outString = String(data: stdoutBox.snapshot(), encoding: .utf8) ?? ""
+        let errString = String(data: stderrBox.snapshot(), encoding: .utf8) ?? ""
 
         if watchdog.didFire {
             throw TmuxError.timedOut(args: args, after: timeout)
+        }
+        if drainIncomplete {
+            // NOT an error: `done.wait()` returned, so the child exited and
+            // wrote everything it will ever write — and because the readers are
+            // incremental, we already hold those bytes. Only the EOF notice is
+            // missing. Throwing here would be actively harmful: `.timedOut`
+            // drives TmuxBackend.onUnresponsive, which offers the user "Restart
+            // tmux server" — destroying their terminals over our own fd hygiene.
+            CrowLog.info(
+                "[TmuxController] pipe drain hit \(Self.drainGrace)s without EOF for "
+                    + "`tmux \(args.joined(separator: " "))` (status \(p.terminationStatus)); "
+                    + "another process inherited the pipe. Continuing with the captured output.")
         }
         guard p.terminationStatus == 0 else {
             throw TmuxError.cliFailed(
@@ -285,6 +301,14 @@ public struct TmuxController: Sendable {
         let done = makeTerminationSignal(for: p)
         try p.run()
 
+        // Drain stderr concurrently rather than lazily on the failure path: a
+        // read that only happens after the child exits deadlocks once the output
+        // exceeds the pipe buffer. `load-buffer` error text is short, so that
+        // was latent rather than live — but it is the same bug as CROW-606.
+        let stderrBox = PipeBox()
+        let group = DispatchGroup()
+        drain(stderr.fileHandleForReading, into: stderrBox, group: group)
+
         let watchdog = ProcessWatchdog(p, timeout: timeout)
         do {
             try stdin.fileHandleForWriting.write(contentsOf: data)
@@ -292,6 +316,7 @@ public struct TmuxController: Sendable {
         } catch {
             done.wait()
             watchdog.cancel()
+            _ = group.wait(timeout: .now() + Self.drainGrace)
             if watchdog.didFire {
                 throw TmuxError.timedOut(args: args, after: timeout)
             }
@@ -300,20 +325,17 @@ public struct TmuxController: Sendable {
 
         done.wait()
         watchdog.cancel()
+        _ = group.wait(timeout: .now() + Self.drainGrace)
 
         if watchdog.didFire {
             throw TmuxError.timedOut(args: args, after: timeout)
         }
         guard p.terminationStatus == 0 else {
-            let errString = String(
-                data: stderr.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            ) ?? ""
             throw TmuxError.cliFailed(
                 args: args,
                 status: p.terminationStatus,
                 stdout: "",
-                stderr: errString
+                stderr: String(data: stderrBox.snapshot(), encoding: .utf8) ?? ""
             )
         }
     }
@@ -374,19 +396,98 @@ public struct TmuxController: Sendable {
     }
 
     public static func versionString(tmuxBinary: String) -> String? {
+        // Reachable from `captureDiagnostics` on the MainActor, so it needs the
+        // same two bounds as `run()`. It previously had neither: no watchdog at
+        // all, and a `readDataToEndOfFile()` *after* the exit wait — the >64 KB
+        // deadlock the doc on `run()` warns about (CROW-874).
         let p = Process()
         p.executableURL = URL(fileURLWithPath: tmuxBinary)
         p.arguments = ["-V"]
         let out = Pipe()
+        let err = Pipe()
         p.standardOutput = out
-        p.standardError = Pipe()
+        p.standardError = err
         // Arm the termination signal BEFORE run() (see makeTerminationSignal, #653).
         let done = makeTerminationSignal(for: p)
         guard (try? p.run()) != nil else { return nil }
+
+        let outBox = PipeBox()
+        let errBox = PipeBox()
+        let group = DispatchGroup()
+        drain(out.fileHandleForReading, into: outBox, group: group)
+        drain(err.fileHandleForReading, into: errBox, group: group)
+
+        let watchdog = ProcessWatchdog(p, timeout: defaultTimeout)
         done.wait()
-        guard p.terminationStatus == 0 else { return nil }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        watchdog.cancel()
+        _ = group.wait(timeout: .now() + drainGrace)
+
+        guard !watchdog.didFire, p.terminationStatus == 0 else { return nil }
+        return String(data: outBox.snapshot(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+/// Read `handle` into `box` until EOF, on a background queue.
+///
+/// Uses raw `read(2)` rather than any `FileHandle` read method, and that is
+/// load-bearing (CROW-874):
+///
+/// - `readDataToEndOfFile()` is all-or-nothing — it buffers internally and hands
+///   back a `Data` only at EOF, so on a bounded-drain timeout the box would hold
+///   **zero** bytes rather than the output the child already wrote.
+/// - `read(upToCount:)` reads that many bytes, not *up to* that many: measured
+///   on Darwin, it blocks until the full count or EOF, so with a 64 KB request
+///   it behaves exactly like `readDataToEndOfFile()` for our purposes.
+/// - `availableData` returns after one read, but raises an uncatchable
+///   Objective-C exception on read error.
+///
+/// A single `read(2)` returns as soon as any bytes are available, so once the
+/// child has exited every byte it wrote is in the box even when EOF never
+/// arrives because some other process inherited the write end.
+///
+/// The closure retains `handle`, which owns the descriptor — the reader may
+/// outlive the call that started it, and closing an fd under a blocked `read(2)`
+/// is undefined behavior on Darwin.
+private func drain(_ handle: FileHandle, into box: PipeBox, group: DispatchGroup) {
+    group.enter()
+    DispatchQueue.global(qos: .userInitiated).async {
+        let fd = handle.fileDescriptor
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = buffer.withUnsafeMutableBytes { read(fd, $0.baseAddress, 64 * 1024) }
+            if n > 0 {
+                box.append(Data(buffer[0..<n]))
+                continue
+            }
+            if n < 0 && errno == EINTR { continue }
+            break  // 0 = EOF; < 0 = a real error, nothing more to read.
+        }
+        group.leave()
+    }
+}
+
+/// Lock-protected accumulator for a pipe drain.
+/// Once the drain wait is bounded, the reader can still be running when the
+/// caller snapshots — there is no way to interrupt a blocking read on a pipe fd,
+/// and closing the fd out from under it is undefined behavior on Darwin and
+/// invites fd-number reuse. So the accessor has to be race-free on its own
+/// rather than relying on the wait having guaranteed the writers finished; that
+/// guarantee is exactly what bounding the wait gives up.
+private final class PipeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
     }
 }
 
@@ -438,25 +539,37 @@ private func makeTerminationSignal(for p: Process) -> DispatchSemaphore {
     return done
 }
 
-/// One-shot SIGTERM watchdog for a child Process. Schedules a timer
-/// on a background queue at construction; if the timer fires before
-/// `cancel()` is called, the wrapped process is sent `terminate()` and
-/// `didFire` flips to true. Used by `run()` and `loadBufferFromStdin`
-/// to keep the UI thread from wedging on a hung tmux server (spec
-/// §10.1).
+/// One-shot SIGTERM watchdog for a child Process, escalating to SIGKILL.
+/// Schedules a timer on a background queue at construction; if the timer
+/// fires before `cancel()` is called, the wrapped process is sent
+/// `terminate()` and `didFire` flips to true. Used by `run()` and
+/// `loadBufferFromStdin` to keep the caller from wedging on a hung tmux
+/// server (spec §10.1).
+///
+/// The timer repeats so a child that ignores or blocks SIGTERM gets SIGKILL on
+/// the next tick. Without that, `done.wait()` is bounded only in theory: the
+/// semaphore is signalled by `terminationHandler`, which needs the child to
+/// actually die (CROW-874).
 private final class ProcessWatchdog: @unchecked Sendable {
     private let timer: DispatchSourceTimer
     private let lock = NSLock()
     private var fired = false
 
-    init(_ p: Process, timeout: TimeInterval) {
+    init(_ p: Process, timeout: TimeInterval, killAfter: TimeInterval = 1.0) {
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-        timer.schedule(deadline: .now() + timeout)
+        timer.schedule(deadline: .now() + timeout, repeating: killAfter)
         self.timer = timer
         timer.setEventHandler { [weak p, weak self] in
-            guard let p, p.isRunning else { return }
-            self?.fire()
-            p.terminate()
+            guard let self else { return }
+            guard let p, p.isRunning else { self.timer.cancel(); return }
+            if self.didFire {
+                // Second tick: SIGTERM was ignored or the child is wedged.
+                kill(p.processIdentifier, SIGKILL)
+                self.timer.cancel()
+            } else {
+                self.fire()
+                p.terminate()
+            }
         }
         timer.resume()
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxOrphanReaper.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxOrphanReaper.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Reaps orphaned, *legacy PID-keyed* tmux sockets left behind by pre-#330
@@ -51,11 +52,11 @@ public enum TmuxOrphanReaper {
             let socketPath = (tmpdir as NSString).appendingPathComponent(name)
             killServer(tmuxBinary: tmuxBinary, socketPath: socketPath)
             try? fm.removeItem(atPath: socketPath)
-            NSLog("[CrowTelemetry tmux:orphan_reaped pid=\(pid) socket=\(socketPath)]")
+            CrowLog.info("[CrowTelemetry tmux:orphan_reaped pid=\(pid) socket=\(socketPath)]")
             reaped += 1
         }
         if reaped > 0 {
-            NSLog("[Crow] Reaped \(reaped) orphan tmux server(s) from past Crow runs")
+            CrowLog.info("[Crow] Reaped \(reaped) orphan tmux server(s) from past Crow runs")
         }
         return reaped
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/XTermSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/XTermSurfaceView.swift
@@ -3,6 +3,7 @@
 // (CROW-581), so this whole file compiles away.
 #if canImport(AppKit)
 import AppKit
+import CrowCore
 import WebKit
 
 /// NSView hosting xterm.js in a WKWebView, backed by a native PTY running the
@@ -214,10 +215,10 @@ public final class XTermSurfaceView: NSView {
     }
 
     private func log(_ message: String) {
-        NSLog("[XTermSurfaceView] %@", message)
-        if let data = "[XTermSurfaceView] \(message)\n".data(using: .utf8) {
-            FileHandle.standardError.write(data)
-        }
+        // One sink, not two: this used to write the same line via NSLog *and* a
+        // synchronous stderr write, either of which can block on a tty nobody is
+        // draining (CROW-874).
+        CrowLog.info("[XTermSurfaceView] \(message)")
     }
 
     private func handlePTYOutput(_ data: Data) {

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/ProcessDrainTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/ProcessDrainTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import CrowTerminal
+
+/// Regression tests for the CROW-874 subprocess wedge.
+///
+/// Deliberately **not** gated on `discoveredTmuxBinary`: these exercise the
+/// process/pipe plumbing, not tmux, so they must run everywhere — including CI
+/// hosts with no tmux formula. `CrowTerminal` is excluded from PR CI entirely
+/// (ADR 0007), which is all the more reason not to add a second gate.
+@Suite("Process drain (CROW-874)")
+struct ProcessDrainTests {
+    /// `run()` builds argv as `[tmuxBinary, "-S", socketPath] + args`. Parking
+    /// `sh -c` in the socket slot and pointing the binary at `env -S` turns that
+    /// into `env sh -c <script>` — a real `run()` call against a real child, with
+    /// no stub binary to install.
+    private func shellController() -> TmuxController {
+        TmuxController(tmuxBinary: "/usr/bin/env", socketPath: "sh -c", sessionName: "drain-probe")
+    }
+
+    @Test func drainIsBoundedWhenAGrandchildHoldsThePipeOpen() throws {
+        // `sleep 30 &` inherits the stdout pipe and outlives the shell, so the
+        // read end never sees EOF. Before the fix this blocked for the full 30s
+        // — on the MainActor, for `reload-tmux-config` and friends.
+        let started = Date()
+        let out = try shellController().run(["printf ALPHA; sleep 30 &"], timeout: 1.0)
+        let elapsed = Date().timeIntervalSince(started)
+
+        // Lower bound as well as upper: without it this passes vacuously if a
+        // later change makes the drain return early for some unrelated reason.
+        #expect(elapsed >= TmuxController.drainGrace)
+        #expect(elapsed < TmuxController.drainGrace + 2.0,
+                "drain took \(elapsed)s; should be bounded by drainGrace, not the grandchild")
+        // The child exited before the drain deadline, so every byte it wrote is
+        // already captured — this is what the incremental reader buys.
+        // `readDataToEndOfFile` would have yielded "" here.
+        #expect(out == "ALPHA")
+    }
+
+    @Test func drainDoesNotDelayTheNormalPath() throws {
+        // The bound must not tax the 99.9% case: with no fd holder, EOF arrives
+        // immediately and `run()` must not wait out drainGrace.
+        let started = Date()
+        let out = try shellController().run(["printf BRAVO"], timeout: 2.0)
+        #expect(out == "BRAVO")
+        #expect(Date().timeIntervalSince(started) < TmuxController.drainGrace)
+    }
+
+    @Test func nonZeroExitStillReportsStderr() throws {
+        // Bounding the drain must not cost the diagnostics on the failure path.
+        #expect(throws: TmuxError.self) {
+            try shellController().run(["printf CHARLIE 1>&2; exit 3"], timeout: 2.0)
+        }
+        do {
+            _ = try shellController().run(["printf CHARLIE 1>&2; exit 3"], timeout: 2.0)
+        } catch let TmuxError.cliFailed(_, status, _, stderr) {
+            #expect(status == 3)
+            #expect(stderr == "CHARLIE")
+        }
+    }
+
+    @Test func ptyChildDoesNotInheritUnrelatedDescriptors() throws {
+        // The root cause: posix_spawn hands the child a copy of the whole fd
+        // table unless CLOEXEC_DEFAULT is set, and PTYProcess's children are the
+        // cockpit attach clients — the longest-lived processes Crow spawns. A
+        // TmuxController pipe write end captured that way is exactly why the
+        // drain above never saw EOF.
+        //
+        // Asks the child to *use* the descriptor rather than watching the pipe
+        // for EOF: EOF is a property of every holder of the write end, so any
+        // other test spawning concurrently would make that signal lie. A write
+        // that lands can only have come from this child.
+        var fds: [Int32] = [0, 0]
+        #expect(pipe(&fds) == 0)
+        let (readEnd, writeEnd) = (fds[0], fds[1])
+        defer { close(readEnd); close(writeEnd) }
+
+        let pty = PTYProcess(deliverOnMainQueue: false)
+        try pty.start(command: "echo LEAKED >&\(writeEnd); sleep 1", workingDirectory: nil)
+        defer { pty.terminate() }
+
+        // Give the child time to run the echo, then look for its output. The
+        // shell's own error text goes to the PTY, not this pipe, so anything
+        // arriving here is proof of inheritance.
+        var poller = pollfd(fd: readEnd, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&poller, 1, 1500)
+
+        if ready > 0 {
+            var buffer = [UInt8](repeating: 0, count: 64)
+            let n = buffer.withUnsafeMutableBytes { read(readEnd, $0.baseAddress, 64) }
+            let text = n > 0 ? String(decoding: buffer[0..<n], as: UTF8.self) : ""
+            #expect(!text.contains("LEAKED"),
+                    "PTY child inherited fd \(writeEnd) — posix_spawn needs CLOEXEC_DEFAULT (CROW-874)")
+        }
+    }
+}

--- a/docs/adr/0017-non-blocking-logging.md
+++ b/docs/adr/0017-non-blocking-logging.md
@@ -1,0 +1,114 @@
+# 0017 — No blocking I/O on the MainActor: logging goes through `CrowLog`
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+- **Deciders:** @dustinhilgaertner
+
+## Context
+
+`crowd` is the sole authority ([0009](./0009-crowd-sole-authority-clients-only.md)), and
+its RPC handlers mutate `@MainActor`-isolated state — roughly half of the 64 handlers in
+`RPCHandlers.swift` hop to the main actor to do it. That serialization is deliberate and
+is what makes concurrent CLI use safe. It also means the main actor is a **shared,
+single-threaded resource for every CLI and web client at once**: anything that blocks it
+stalls the whole daemon, not one request.
+
+`NSLog` blocks it. It funnels into CoreFoundation's `_logToStderr`, which calls
+`writev(2)` on the controlling tty. A tty whose output queue is full and which nobody is
+draining — Ctrl-S, a stopped terminal, an unread pane — blocks that `writev` in the
+kernel with no timeout. A `sample` of a wedged daemon caught exactly this: one `NSLog`
+inside `MainActor.run` holding the main actor while `crow reload-tmux-config` hung to the
+CLI's 30 s read timeout and `open-terminal` timed out behind it (#874).
+
+The reproducer was incidental. `reload-tmux-config` is not special — it just logs
+unconditionally on its success path. There were **199 `NSLog` calls across 31 files**,
+all of them in `crowd`'s dependency graph, and the heaviest users (`SessionService` 65,
+`TmuxBackend` 21, `IssueTracker` 12) are `@MainActor` types. Three uncoordinated sinks had
+grown up alongside each other — bare `NSLog`, `CrowDaemon.log`'s synchronous
+`FileHandle.standardError.write`, and `CrowLog.automation` (which mirrored to `NSLog`, so
+the durable-logging fix from CROW-782 was itself a wedge vector).
+
+The same "blocking call on the main actor" shape appeared a second time in the same
+issue, in `TmuxController.run`'s unbounded pipe drain. That is the same class of defect
+arriving through a different door, which is what makes this a convention worth writing
+down rather than two bug fixes.
+
+## Decision
+
+**`NSLog` is banned outside `CrowLog.swift`, enforced by `scripts/check-no-nslog.sh` in
+CI. All logging goes through `CrowLog.info` / `.error` / `.automation`, which never block
+the caller.**
+
+`CrowLog` mirrors to `os_log` **on the calling thread** — a bounded `memcpy` into the
+process's trace buffer, which cannot block — and then enqueues onto a bounded backlog
+that a dedicated thread drains to stderr. When the sink is wedged, lines past the cap are
+dropped and counted rather than queued, and the drain reports the gap when it resumes.
+
+More generally: **a blocking syscall reached from the main actor must be bounded, moved
+off the actor, or both.**
+
+## Consequences
+
+**Easier.** A stalled terminal can no longer take the daemon's RPC surface with it. The
+unified log becomes a reliable second copy that survives a wedged stderr *and* `execv`,
+so `log stream --predicate 'subsystem == "com.corveil.crowd"'` works during a hang — when
+it is most wanted. One sink means one format and one place to change it.
+
+**Also easier, unintentionally.** `NSLog` treats its first argument as a printf format
+string, and 92 of the 199 sites passed interpolated, externally-influenced text (branch
+names, PR titles, raw `gh` stderr, user paths) into that position, where a stray `%` reads
+garbage varargs. `CrowLog.info(_ message: String)` makes that impossible by construction.
+Two sites also passed a 64-bit `Int` to `%d`, which worked only by ABI accident.
+
+**Harder / to live with.**
+
+- **Delivery is asynchronous.** Anything that must be on disk before the process ends
+  needs an explicit `CrowLog.flush(timeout:)` — `exit()` and `execv` paths do this, and
+  tests that assert on file contents must too. `flush` is a barrier, not a guarantee: a
+  wedged sink stays wedged and it returns `false`.
+- **Logs can now have holes.** Bounded backpressure means dropping under sustained
+  pressure. That is the deliberate trade: a gap plus a `dropped N line(s)` marker beats a
+  hung daemon. The `os_log` copy is made before the drop, so nothing is lost outright.
+- **The stderr line format changed.** `<ISO8601> processName[pid] <message>`, dropping
+  `NSLog`'s thread id. This matches `crowd-automation.log`, so both sinks now sort and
+  grep alike; `[crowd] …` lines gain a timestamp they never had.
+- **`os_log` truncates around 1 KB.** Multi-line diagnostic bundles (e.g.
+  `TmuxBackend.captureDiagnostics`) arrive whole on stderr but truncated in the unified
+  log.
+- **A dedicated thread, permanently.** It is parked on a condition variable when idle.
+- **`~/Library/Logs/crow/crowd.log` still has no rotation** — launchd writes it by stream
+  redirection, and each line is now slightly longer. Pre-existing, but worth a ticket.
+
+## Alternatives considered
+
+- **`os_log` only, dropping stderr.** Loses the dev-mode inner loop: `scripts/daemon-run.sh`
+  output is the terminal, and the `[CrowTelemetry …]` markers exist to be grepped there.
+- **A bare serial `DispatchQueue`.** `DispatchQueue.async` already never blocks the
+  caller, so it would fix the reported bug — but its queue is unbounded, so a wedged tty
+  trades a hang for unbounded memory growth. Bounding it requires a structure in front,
+  at which point the queue is only a thread-wakeup mechanism.
+- **`O_NONBLOCK` on the daemon's stderr** (suggested on the issue). The flag lives on the
+  *shared open file description*, so setting it on an inherited tty mutates the parent
+  shell's stderr too, and every other process on that tty starts seeing `EAGAIN`.
+- **A `CrowLog.info(_:_ args: CVarArg...)` overload**, which would have made all 199 sites
+  a token swap. Rejected: it perpetuates printf in a Swift 6 codebase and preserves the
+  format-string injection hole the single-`String` signature closes.
+- **Retrofitting log levels across all 199 sites.** 199 judgment calls in one diff.
+  `error(_:)` ships unused; reclassification is incremental.
+- **Redirecting stderr to a file by default outside launchd.** Narrows the window but does
+  not close it (a full disk or a stalled network mount still blocks), and it takes the
+  daemon's output away from the terminal a developer is watching.
+
+## References
+
+- Issue: [#874](https://github.com/corveil/crow/issues/874)
+- Related ADRs: [0007](./0007-linux-ci-swift.md) (CrowCore builds on Linux, so `import os`
+  is `#if canImport(Darwin)`-fenced), [0009](./0009-crowd-sole-authority-clients-only.md)
+  (why the main actor is shared by every client), [0012](./0012-tests-never-touch-live-data.md)
+  (the log directory resolves to a temp dir under a test runner)
+- Code: `Packages/CrowCore/Sources/CrowCore/CrowLog.swift`,
+  `scripts/check-no-nslog.sh`,
+  `Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift` (the bounded-drain
+  half of the same defect class),
+  `Packages/CrowTerminal/Sources/CrowTerminal/PTYProcess.swift` (`CLOEXEC_DEFAULT`, its
+  root cause)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,3 +53,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0014 | [Pluggable `CodingAgent` adapter](./0014-pluggable-coding-agent-adapter.md) | Accepted | 2026-07-23 |
 | 0015 | [Harness capability tiers & phased parity](./0015-harness-capability-tiers.md) | Accepted | 2026-07-23 |
 | 0016 | [Every user-mutable capability has a CLI path](./0016-cli-control-plane-parity.md) | Accepted | 2026-07-27 |
+| 0017 | [No blocking I/O on the MainActor: logging goes through `CrowLog`](./0017-non-blocking-logging.md) | Accepted | 2026-07-27 |

--- a/scripts/check-no-nslog.sh
+++ b/scripts/check-no-nslog.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Guard: NSLog() is banned outside CrowLog.swift (CROW-874).
+#
+# NSLog funnels into CoreFoundation's `_logToStderr`, which calls writev(2) on
+# the controlling tty. When that tty's output queue is full and nobody is
+# draining it (Ctrl-S, a stopped terminal, an unread pane), writev blocks in the
+# kernel with no timeout. crowd's RPC handlers hop to the MainActor, so one such
+# call inside MainActor.run stalls every other MainActor-bound RPC until the tty
+# drains — a `sample` of a wedged daemon caught exactly that, with
+# `crow reload-tmux-config` hanging and `open-terminal` timing out behind it.
+#
+# CrowLog.info()/error() mirror to os_log on the calling thread (a bounded
+# memcpy into this process's trace buffer, which cannot block) and enqueue onto
+# a bounded backlog that a dedicated thread drains. A wedged sink costs dropped
+# lines, not a dead daemon.
+#
+# Second reason: NSLog treats its first argument as a printf format string. Most
+# converted call sites passed interpolated, externally-influenced text (branch
+# names, PR titles, raw `gh` stderr, user paths) there, where a stray % reads
+# garbage varargs. `CrowLog.info(_ message: String)` makes that impossible.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+SINK="Packages/CrowCore/Sources/CrowCore/CrowLog.swift"
+
+# Match `NSLog(` with the paren so prose mentioning NSLog stays legal. The sink
+# itself is exempt (its doc comment explains what it replaced), as are tests and
+# vendored checkouts under .build.
+hits="$(grep -rn --include='*.swift' 'NSLog(' Packages Sources \
+        | grep -v '/\.build/' \
+        | grep -v '/Tests/' \
+        | grep -v "^${SINK}:" || true)"
+
+if [ -n "$hits" ]; then
+  count="$(printf '%s\n' "$hits" | wc -l | tr -d ' ')"
+  echo "ERROR: $count NSLog() call(s) outside $SINK (CROW-874)." >&2
+  echo "       Use CrowLog.info(\"…\") or CrowLog.error(\"…\") instead." >&2
+  echo >&2
+  printf '%s\n' "$hits" >&2
+  exit 1
+fi
+
+echo "✓ no NSLog() outside $SINK"


### PR DESCRIPTION
Closes #874

## The bug, and its blast radius

`crowd` serves every CLI and web client through RPC handlers that hop to the MainActor — roughly half of the 64 in `RPCHandlers.swift`. That serialization is what makes concurrent `crow` use safe, and it also means the main actor is a shared single-threaded resource for all clients at once. Anything that blocks it stalls the **whole daemon**.

`NSLog` blocks it: CoreFoundation `_logToStderr` → `writev(2)` on the controlling tty, which blocks in the kernel with no timeout when that tty's output queue is full and unread. The `sample` in the issue caught it exactly.

`reload-tmux-config` was the reproducer, not the bug. It just logs unconditionally on its success path. There were **199 `NSLog` calls across 31 files**, all in `crowd`'s graph, and the heaviest users — `SessionService` (65), `TmuxBackend` (21), `IssueTracker` (12) — are `@MainActor` types.

## What changed

**A non-blocking sink.** `CrowLog` mirrors to `os_log` **on the calling thread** (a bounded memcpy into the process trace buffer — cannot block) and enqueues onto a bounded backlog drained by a dedicated thread. Past the cap, lines are dropped and counted rather than queued, so a wedged tty costs a gap in the log instead of a hang. `flush(timeout:)` covers `exit`/`execv`.

Three uncoordinated sinks collapse into it: bare `NSLog`, `CrowDaemon.log`'s synchronous `FileHandle.standardError.write`, and `CrowLog.automation` — which mirrored to `NSLog`, making CROW-782's durable-logging fix a wedge vector on every automation decision.

**All 199 sites migrated, with a CI guard** (`scripts/check-no-nslog.sh`) so site #200 doesn't land next week. It runs as a third gate in the `parity` target and its CI job, alongside the CLI/RPC parity and notification-catalog checks (CROW-807, CROW-768).

**The secondary finding, plus a root cause the issue didn't identify.** `PTYProcess` spawned with `POSIX_SPAWN_SETSID` only. `posix_spawn` copies the whole fd table into the child without `CLOEXEC_DEFAULT`, and these children are the cockpit attach clients — the longest-lived processes Crow spawns, one per browser session. A `TmuxController.run()` pipe write end captured that way keeps its pipe from ever reaching EOF, which is why the drain never completed. `run()` now also bounds the drain (0.25s) as defense in depth.

## Things worth a reviewer's attention

**A drain timeout does not throw.** The child has exited and its status is authoritative, and `TmuxError.timedOut` drives `TmuxBackend.onUnresponsive`, which offers the user *"Restart tmux server"* — destroying their terminals over our own fd hygiene. It logs instead.

**Readers use raw `read(2)`, and that is load-bearing.** Neither obvious alternative works: `readDataToEndOfFile()` only returns at EOF, and Darwin's `read(upToCount:)` blocks for the *full* count — measured, both leave the buffer **empty** on a drain timeout rather than holding partial output. A single `read(2)` returns as soon as bytes are available, so once the child exits every byte it wrote is captured even though EOF never arrives. `PipeBox` is now `NSLock`-guarded, since a bounded wait means the reader can still be running when the caller snapshots.

**One comment was rewritten rather than corrected.** Three claimed `run()` blocks on `waitUntilExit()` and pumps the run loop — untrue since #653. Two were merely stale. The third justifies `ensureCockpitSession`'s adopt branch, and its stated in-process re-entrancy really is gone — but the branch is still required, because `TerminalCockpit.ensureSession` in `crowd` runs the identical `hasSession()` → `newSessionDetached` against the same socket (#330) on every startup. That's a cross-process TOCTOU no in-process argument closes. Deleting the branch on the strength of "no more re-entrancy" would reintroduce #326's blank terminals.

**Two bugs fixed incidentally.** 92 of the 199 sites passed interpolated, externally-influenced text (branch names, PR titles, raw `gh` stderr, user paths) as `NSLog`'s *format string*, where a stray `%` reads garbage varargs. And two passed a 64-bit `Int` to `%d`, working only by ABI accident. `CrowLog.info(_ message: String)` closes both structurally.

## Verification

`make build` and `make test` clean — **2011 tests, 0 failures**, both guard scripts passing.

The mechanism was reproduced directly against a real pty whose output queue was full and unread:

| | result |
|---|---|
| 6000 × `CrowLog.info` | returned in **6 ms**, 0 dropped |
| 1 × `NSLog` (same conditions) | **blocked indefinitely** — hung the test process past a 3 s timeout |

New tests need no tmux binary, so they run even where the integration suites skip — worth noting since `CrowTerminal` is excluded from PR CI entirely (ADR 0007), along with `CrowEngine`, `CrowTelemetry`, and `CrowDaemon`. **129 of the 199 migrated sites are in packages this PR's CI will not compile**, so all of them were built and tested locally. The drain test asserts a lower bound as well as an upper one so it can't pass vacuously, and the PTY test was confirmed to fail with the `CLOEXEC_DEFAULT` flag reverted.

## Known residual and follow-ups

On the drain-timeout path the two reader blocks stay parked until the fd holder dies — 2 leaked worker threads per event, self-healing on disconnect. Strictly better than before, which leaked those *plus* the caller's thread permanently. Eliminating it needs a `DispatchSourceRead` drain (in-repo precedent at `PTYProcess.startReading()`); that's a real rewrite of `run()`, deliberately not smuggled in here.

`reloadBundledConfig` moved off the MainActor, but it's 1 of ~24 `@MainActor` entry points on `TmuxBackend` that call `TmuxController` synchronously — several are sync `throws` APIs that can't go `async` without touching every caller. Bounding `run()` is the actual fix. A follow-up should move the rest: `TmuxBackend.runShortCommand` still calls `waitUntilExit()` on the MainActor at `:1498` (the nested-run-loop SIGSEGV hazard #653 removed from `TmuxController`), as does `TmuxOrphanReaper.swift:76`. Separately, `~/Library/Logs/crow/crowd.log` has no rotation — pre-existing, and each line is now slightly longer.

Conventions and trade-offs are recorded in [ADR 0017](docs/adr/0017-non-blocking-logging.md).

## Rebase notes

Rebased twice. Conflicts were structural rather than semantic:

- **#883** moved `make test`'s drift gates into a new `parity` target, so `check-no-nslog.sh` became a third gate there and the standalone `guards` job I'd added folded into the new `parity` job. #883 also claimed ADR 0016, so this one is now 0017.
- **#893** rewrote the auto-rebase region of `IssueTracker` and, independently, moved several of the `NSLog` sites this PR targets to `CrowLog.automation` — the better sink for automation decisions, and a stronger choice than the `CrowLog.info` this PR would have given them. Resolved by taking #893's version wholesale and re-running the migration on the 4 `NSLog` calls left in it. `IssueTracker` now differs from `main` by exactly those 4 conversions; `deferRebase`, `autoRebaseDeferrals`, and the `outOfSyncAhead`/`outOfSyncDiverged` split are intact.

⚠️ **`scripts/check-cli-parity.sh` fails on `main` as of `0672fd4`, independently of this PR** — `automation-get` / `automation-set` (#884) are registered but absent from `ParityLedger.rpcMethods` (#883). Verified by running the gate in clean `origin/main` worktrees at two different heads. This also fails `CrowDaemon`'s `RPC ledger parity` suite, which is the only failing test on this branch.

Because that step precedes the NSLog step in the `parity` job, **the NSLog gate will not execute in CI until main is fixed.** The fix is two rows next to the existing `agents-*` pair — deliberately not included here, as it belongs to CROW-807:

```swift
.read("automation-get", cli: "automation get"),
.write("automation-set", cli: "automation set"),
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
