### PR TITLE
Auto-rebase: fast-forward behind worktrees instead of hot-looping

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -185,8 +185,34 @@ public final class IssueTracker {
     /// head (new key), and a delegated conflict resolution that pushes a new
     /// head also re-arms. Transient outcomes (`.dirtyWorktree`,
     /// `.outOfSyncWithRemote`, and bounded `.failed` retries) un-set the key so
-    /// the next poll retries. In-memory only.
+    /// a later poll retries; for the two deferrals, `autoRebaseDeferrals` then
+    /// paces how much later. In-memory only.
     private var autoRebaseAttempted: Set<String> = []
+
+    /// A deferred auto-rebase attempt: why it deferred, how many consecutive
+    /// times this head state has deferred, and when it may be retried.
+    private struct AutoRebaseDeferral {
+        let reason: AutoRebaseDeferReason
+        let count: Int
+        let retryAt: Date
+    }
+
+    /// Deferred auto-rebase attempts per head-key. A deferral un-sets the
+    /// `autoRebaseAttempted` key so the head can be re-dispatched, so without
+    /// this the retry cadence is "every poll, forever" — a clean-but-stale
+    /// worktree re-fetched and re-logged a bare `dispatched` line every 60s
+    /// with no outcome ever recorded (#889). Cleared on any non-deferral
+    /// outcome. In-memory only.
+    private var autoRebaseDeferrals: [String: AutoRebaseDeferral] = [:]
+
+    /// Why an auto-rebase attempt deferred rather than rebasing. Raw values are
+    /// grep-stable — they are written verbatim to the automation log, like
+    /// `AutoMergeSkipReason`.
+    enum AutoRebaseDeferReason: String {
+        case dirtyWorktree = "dirty-worktree"
+        case outOfSyncAhead = "out-of-sync-ahead"
+        case outOfSyncDiverged = "out-of-sync-diverged"
+    }
 
     /// Consecutive `.failed` rebase attempts per head-key, so a transient git
     /// failure (fetch flake, rejected lease, unreachable base) is retried a
@@ -198,6 +224,12 @@ public final class IssueTracker {
     /// Max consecutive `.failed` auto-rebase attempts per head state before
     /// the watcher gives up until the head commit changes.
     nonisolated static let maxAutoRebaseFailureRetries = 3
+
+    /// Backoff bounds for deferred auto-rebase attempts. The base matches one
+    /// board poll so the first retry is immediate-ish; the cap keeps a
+    /// permanently stuck branch to ~4 attempts an hour.
+    nonisolated static let autoRebaseDeferralBaseDelay: TimeInterval = 60
+    nonisolated static let autoRebaseDeferralMaxDelay: TimeInterval = 900
 
     /// Last observed `PRStatus` per session. Ephemeral (not persisted across
     /// Crow restarts post-CROW-508): only used for in-process `.checksFailing`
@@ -2740,6 +2772,16 @@ public final class IssueTracker {
         guard !viewerPRs.isEmpty else { return }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
+        // Drop per-head bookkeeping for heads no longer in the poll, so these
+        // maps don't grow for the lifetime of the daemon. Guarded by the
+        // non-empty check above so a failed/empty poll can't wipe live state;
+        // a PR that briefly drops out and returns just gets re-dispatched once.
+        let liveHeadKeys = Set(viewerPRs.map { "\($0.url)\n\($0.headRefOid)" })
+        autoRebaseAttempted.formIntersection(liveHeadKeys)
+        autoRebaseFailureCounts = autoRebaseFailureCounts.filter { liveHeadKeys.contains($0.key) }
+        autoRebaseDeferrals = autoRebaseDeferrals.filter { liveHeadKeys.contains($0.key) }
+
+        let now = Date()
         var dispatched = 0
         for session in appState.sessions where Self.sessionEligibleForAutoRebase(session) {
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
@@ -2758,6 +2800,9 @@ public final class IssueTracker {
             }
 
             let key = "\(prLink.url)\n\(pr.headRefOid)"
+            // A deferral re-arms `autoRebaseAttempted`, so the backoff window is
+            // what actually paces retries for a head that keeps deferring.
+            if let deferral = autoRebaseDeferrals[key], now < deferral.retryAt { continue }
             guard !autoRebaseAttempted.contains(key) else { continue }
             autoRebaseAttempted.insert(key)
             autoRebaseInFlight.insert(prLink.url)
@@ -2770,7 +2815,6 @@ public final class IssueTracker {
             // Hourly, not per-poll: an idle-but-enabled watcher is the steady
             // state, and one line per 60s would rotate the interesting entries
             // out of the log (review #787).
-            let now = Date()
             if lastAutoRebaseIdleLogAt.map({ now.timeIntervalSince($0) >= 3600 }) ?? true {
                 lastAutoRebaseIdleLogAt = now
                 CrowLog.automation("auto-rebase: enabled, no candidates this poll")
@@ -2788,11 +2832,29 @@ public final class IssueTracker {
         failureCount < maxAutoRebaseFailureRetries
     }
 
+    /// How long to wait before re-attempting a deferred auto-rebase, given how
+    /// many consecutive times this head state has already deferred. Doubles
+    /// from one poll interval up to a 15-minute cap.
+    ///
+    /// A deferral re-arms the per-head key, so without a delay a permanently
+    /// stuck branch (unpushed commits, a long-running agent edit) re-dispatched
+    /// a `git fetch` and a bare `dispatched` log line every single poll (#889).
+    /// The first retry still lands on the very next poll, so the common
+    /// transient case — an agent mid-edit — recovers as promptly as before.
+    /// Pure so the policy is unit-testable without an `IssueTracker`.
+    nonisolated static func autoRebaseDeferralBackoff(deferralCount: Int) -> TimeInterval {
+        let doublings = max(0, min(deferralCount - 1, 16))
+        return min(autoRebaseDeferralBaseDelay * pow(2, Double(doublings)), autoRebaseDeferralMaxDelay)
+    }
+
     /// Locate the session's primary worktree, verify Crow authorship, then
     /// rebase it onto base and force-push. On conflicts, fire
     /// `onAutoRebaseConflicts` so the caller hands resolution to Claude.
     /// Transient outcomes (dirty tree, out-of-sync branch, bounded failures)
-    /// un-set the per-head key so the next poll retries.
+    /// un-set the per-head key so a later poll retries; deferrals additionally
+    /// stamp a backoff deadline. Every outcome — including the early skips —
+    /// writes exactly one line to the automation log, so a `dispatched` line is
+    /// always paired with the reason it did or didn't rebase (#889).
     private func attemptRebase(session: Session, pr: ViewerPR) async {
         let headKey = "\(pr.url)\n\(pr.headRefOid)"
         defer { autoRebaseInFlight.remove(pr.url) }
@@ -2805,15 +2867,18 @@ public final class IssueTracker {
         guard let primary = worktrees.first(where: { $0.isPrimary }) ?? worktrees.first,
               !primary.isMainRepoCheckout,
               primary.branch == pr.headRefName else {
-            NSLog("[Crow] auto-rebase skipped on %@ — no usable worktree or branch mismatch (expected %@)",
-                  pr.url as NSString, pr.headRefName as NSString)
+            CrowLog.automation(
+                "auto-rebase: #\(pr.number) skipped:no-usable-worktree "
+                + "(no worktree, main-repo checkout, or branch != \(pr.headRefName))")
             return
         }
 
-        guard let backend = codeBackend(for: session) else { return }
+        guard let backend = codeBackend(for: session) else {
+            CrowLog.automation("auto-rebase: #\(pr.number) skipped:no-backend")
+            return
+        }
         guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
-            NSLog("[Crow] auto-rebase skipped on %@ — no Crow-Session trailer matching a known session",
-                  pr.url as NSString)
+            CrowLog.automation("auto-rebase: #\(pr.number) skipped:no-crow-session-trailer")
             return
         }
 
@@ -2825,45 +2890,64 @@ public final class IssueTracker {
         switch outcome {
         case .rebasedAndPushed:
             autoRebaseFailureCounts[headKey] = nil
+            autoRebaseDeferrals[headKey] = nil
             let priorState = pr.mergeable == "CONFLICTING" ? "CONFLICTING" : "BEHIND"
-            NSLog("[Crow] Auto-rebased & force-pushed %@ (session %@, was %@)",
-                  pr.url as NSString, session.id.uuidString as NSString, priorState as NSString)
+            CrowLog.automation(
+                "auto-rebase: #\(pr.number) rebased & force-pushed (was \(priorState), session \(session.id))")
             onAutoRebasePushed?(session.id, pr.url, pr.number)
         case .conflicts:
             autoRebaseFailureCounts[headKey] = nil
-            NSLog("[Crow] Auto-rebase hit conflicts on %@ (session %@) — delegating to Claude",
-                  pr.url as NSString, session.id.uuidString as NSString)
+            autoRebaseDeferrals[headKey] = nil
+            CrowLog.automation(
+                "auto-rebase: #\(pr.number) conflicts — delegating to agent (session \(session.id))")
             onAutoRebaseConflicts?(session.id, pr.url, pr.number)
         case .dirtyWorktree:
-            // Transient (a Claude session is mid-edit). Re-arm so the next
-            // poll retries once the tree is clean.
-            autoRebaseFailureCounts[headKey] = nil
-            autoRebaseAttempted.remove(headKey)
-            NSLog("[Crow] Auto-rebase deferred on %@ — worktree has uncommitted changes",
-                  pr.url as NSString)
-        case .outOfSyncWithRemote:
-            // Transient: local branch has unpushed commits or is stale relative
-            // to the remote. Re-arm so the next poll retries once it's in sync.
-            autoRebaseFailureCounts[headKey] = nil
-            autoRebaseAttempted.remove(headKey)
-            NSLog("[Crow] Auto-rebase deferred on %@ — local branch not in sync with origin",
-                  pr.url as NSString)
+            // Transient (a Claude session is mid-edit). Re-arm so a later poll
+            // retries once the tree is clean.
+            deferRebase(headKey: headKey, reason: .dirtyWorktree, prNumber: pr.number)
+        case .outOfSyncWithRemote(let divergence):
+            // Transient: local has unpushed commits, or local and origin have
+            // both moved. Either way a force-push would destroy work, so wait
+            // for a human to reconcile and retry on a later poll. (A branch
+            // that is merely behind is fast-forwarded by `rebaseOntoBase` and
+            // never lands here — that was the #889 hot loop.)
+            deferRebase(
+                headKey: headKey,
+                reason: divergence == .ahead ? .outOfSyncAhead : .outOfSyncDiverged,
+                prNumber: pr.number)
         case .failed(let msg):
             // Transient git failures (fetch flake, rejected lease, unreachable
             // base) shouldn't silently stall the watcher until the head commit
             // changes. Retry a bounded number of times, then give up for this
             // head state to avoid hot-looping on a broken config.
+            autoRebaseDeferrals[headKey] = nil
             let failures = (autoRebaseFailureCounts[headKey] ?? 0) + 1
             autoRebaseFailureCounts[headKey] = failures
-            if Self.shouldRetryFailedRebase(failureCount: failures) {
-                autoRebaseAttempted.remove(headKey)
-                NSLog("[Crow] Auto-rebase failed on %@ (attempt %d/%d, will retry): %@",
-                      pr.url as NSString, failures, Self.maxAutoRebaseFailureRetries, msg as NSString)
-            } else {
-                NSLog("[Crow] Auto-rebase failed on %@ (attempt %d/%d, giving up until head changes): %@",
-                      pr.url as NSString, failures, Self.maxAutoRebaseFailureRetries, msg as NSString)
-            }
+            let willRetry = Self.shouldRetryFailedRebase(failureCount: failures)
+            if willRetry { autoRebaseAttempted.remove(headKey) }
+            CrowLog.automation(
+                "auto-rebase: #\(pr.number) failed (attempt \(failures)/"
+                + "\(Self.maxAutoRebaseFailureRetries), "
+                + "\(willRetry ? "will retry" : "giving up until head changes")): \(msg)")
         }
+    }
+
+    /// Record a deferred auto-rebase attempt: re-arm the per-head key so it can
+    /// be dispatched again, but stamp a backoff deadline so a head that keeps
+    /// deferring doesn't re-fetch every poll forever (#889). A *different*
+    /// reason than last time restarts the backoff — the branch moved to a new
+    /// situation, which deserves a prompt retry rather than the previous
+    /// reason's accumulated delay.
+    private func deferRebase(headKey: String, reason: AutoRebaseDeferReason, prNumber: Int) {
+        autoRebaseFailureCounts[headKey] = nil
+        autoRebaseAttempted.remove(headKey)
+        let count = autoRebaseDeferrals[headKey].map { $0.reason == reason ? $0.count + 1 : 1 } ?? 1
+        let delay = Self.autoRebaseDeferralBackoff(deferralCount: count)
+        autoRebaseDeferrals[headKey] = AutoRebaseDeferral(
+            reason: reason, count: count, retryAt: Date().addingTimeInterval(delay))
+        CrowLog.automation(
+            "auto-rebase: #\(prNumber) deferred:\(reason.rawValue) "
+            + "(deferral \(count), retry in \(Int(delay))s)")
     }
 
     /// Pure projection of a provider PR record onto the UI-facing `PRStatus`.

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoRebaseTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerAutoRebaseTests.swift
@@ -150,4 +150,52 @@ struct IssueTrackerAutoRebaseTests {
         #expect(!IssueTracker.shouldRetryFailedRebase(failureCount: 3))
         #expect(!IssueTracker.shouldRetryFailedRebase(failureCount: 4))
     }
+
+    // MARK: - Deferral backoff (#889)
+
+    @Test func firstDeferralRetriesOnTheNextPoll() {
+        // The common transient case (agent mid-edit) must still recover
+        // promptly — one poll interval, not a long backoff.
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 1)
+            == IssueTracker.autoRebaseDeferralBaseDelay)
+    }
+
+    @Test func backoffDoublesPerConsecutiveDeferral() {
+        let base = IssueTracker.autoRebaseDeferralBaseDelay
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 2) == base * 2)
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 3) == base * 4)
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 4) == base * 8)
+    }
+
+    @Test func backoffIsMonotonicAndSaturatesAtTheCap() {
+        let cap = IssueTracker.autoRebaseDeferralMaxDelay
+        var previous: TimeInterval = 0
+        for count in 1...64 {
+            let delay = IssueTracker.autoRebaseDeferralBackoff(deferralCount: count)
+            #expect(delay >= previous)
+            #expect(delay <= cap)
+            previous = delay
+        }
+        // Saturated, and stable well past the cap — no overflow to 0 or inf
+        // from the repeated doubling.
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 64) == cap)
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 100_000) == cap)
+    }
+
+    @Test func backoffHandlesNonPositiveCountsDefensively() {
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: 0)
+            == IssueTracker.autoRebaseDeferralBaseDelay)
+        #expect(IssueTracker.autoRebaseDeferralBackoff(deferralCount: -1)
+            == IssueTracker.autoRebaseDeferralBaseDelay)
+    }
+
+    // MARK: - Deferral reasons
+
+    /// These land verbatim in `crowd-automation.log` as `deferred:<raw>`;
+    /// changing one breaks anyone grepping the log for a stuck branch.
+    @Test func deferReasonRawValuesAreStableForGrepping() {
+        #expect(IssueTracker.AutoRebaseDeferReason.dirtyWorktree.rawValue == "dirty-worktree")
+        #expect(IssueTracker.AutoRebaseDeferReason.outOfSyncAhead.rawValue == "out-of-sync-ahead")
+        #expect(IssueTracker.AutoRebaseDeferReason.outOfSyncDiverged.rawValue == "out-of-sync-diverged")
+    }
 }

--- a/Packages/CrowGit/Sources/CrowGit/GitManager.swift
+++ b/Packages/CrowGit/Sources/CrowGit/GitManager.swift
@@ -108,9 +108,12 @@ public actor GitManager {
     /// - **Verifies HEAD is on `branch`** before rebasing, so a worktree that
     ///   was switched to another branch is left alone (`.failed`).
     /// - **Requires the local branch to match the remote PR head** before
-    ///   rewriting — committed-but-unpushed local commits (or a stale local
-    ///   branch) yield `.outOfSyncWithRemote` so a force-push can't publish
-    ///   unpushed work or revert remote commits.
+    ///   rewriting. A branch that is *strictly behind* its remote is
+    ///   fast-forwarded onto it first (loss-free — the tree is already known
+    ///   clean), because that is the only way the rebase can target the head
+    ///   the PR is actually about (#889). Only *ahead* and *diverged* yield
+    ///   `.outOfSyncWithRemote`, so a force-push can't publish unpushed work
+    ///   or revert remote commits.
     /// - **Aborts on conflict** to restore a clean checkout, then reports
     ///   `.conflicts` so the caller can hand resolution to a Claude session.
     /// - **`--force-with-lease`** (against the remote head of `branch` fetched
@@ -143,17 +146,47 @@ public actor GitManager {
             // `--force-with-lease` baseline reflect the current remote state.
             _ = try await run(["git", "-C", worktreePath, "fetch", "origin", baseBranch, branch])
 
-            // Refuse to rewrite a branch that isn't in sync with its remote:
-            // local commits not yet pushed (ahead) would be published
-            // unexpectedly, and a stale local branch (behind/diverged) would
-            // revert remote commits on force-push. Only proceed when the local
-            // head exactly matches the remote PR head.
+            // Reconcile the local branch with the remote PR head before
+            // rewriting it. The three ways they can differ need different
+            // answers, so classify rather than comparing for equality:
+            //
+            //   behind   → fast-forward onto the remote head and carry on. The
+            //              tree is clean (checked above), so this is loss-free,
+            //              and it's the only way the rebase targets the commit
+            //              the PR is actually about. Refusing here instead left
+            //              a clean-but-stale worktree retrying forever (#889).
+            //   ahead    → refuse: force-pushing would publish unpushed work.
+            //   diverged → refuse: force-pushing would revert remote commits.
             let localSha = try await run(["git", "-C", worktreePath, "rev-parse", "HEAD"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let remoteSha = try await run(["git", "-C", worktreePath, "rev-parse", "origin/\(branch)"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard localSha == remoteSha else {
-                return .outOfSyncWithRemote
+            if localSha != remoteSha {
+                // `merge-base --is-ancestor` signals via exit code, which `run`
+                // surfaces only as a thrown `GitError` — so probe with `try?`.
+                let isBehind = (try? await run([
+                    "git", "-C", worktreePath, "merge-base", "--is-ancestor", "HEAD", "origin/\(branch)",
+                ])) != nil
+                guard isBehind else {
+                    let isAhead = (try? await run([
+                        "git", "-C", worktreePath, "merge-base", "--is-ancestor", "origin/\(branch)", "HEAD",
+                    ])) != nil
+                    return .outOfSyncWithRemote(isAhead ? .ahead : .diverged)
+                }
+                // Equality was ruled out above, so this is a strict
+                // fast-forward. It can still fail if the remote moved between
+                // the fetch and here — report that rather than rebasing (and
+                // then force-pushing) from a head we didn't intend.
+                do {
+                    _ = try await run([
+                        "git", "-C", worktreePath, "merge", "--ff-only", "origin/\(branch)",
+                    ])
+                } catch let error as GitError {
+                    if case .commandFailed(_, _, let stderr) = error {
+                        return .failed("fast-forward to origin/\(branch) failed: \(stderr.prefix(300))")
+                    }
+                    return .failed("fast-forward to origin/\(branch) failed")
+                }
             }
 
             // Attempt the rebase. A failure here is almost always conflicts.
@@ -277,14 +310,25 @@ public enum RebaseOutcome: Sendable, Equatable {
     /// The worktree had uncommitted changes; nothing was touched. Transient —
     /// retry once the tree is clean.
     case dirtyWorktree
-    /// The local branch head doesn't match the remote PR head — there are
-    /// committed-but-unpushed local commits (ahead) or the worktree is stale
-    /// relative to the remote (behind/diverged). Nothing was touched, since a
-    /// rebase + force-push would either publish unpushed work or revert remote
-    /// commits. Transient — retry once the branch is back in sync.
-    case outOfSyncWithRemote
+    /// The local branch can't be safely force-pushed: it is ahead of, or has
+    /// diverged from, the remote PR head. Nothing was touched, since a rebase +
+    /// force-push would either publish unpushed work or revert remote commits.
+    /// Transient — retry once the branch is back in sync. A branch that is
+    /// merely *behind* is fast-forwarded instead of reported here (#889).
+    case outOfSyncWithRemote(RemoteDivergence)
     /// Any other failure (branch mismatch, fetch error, rejected push, …).
     case failed(String)
+}
+
+/// Why a local branch can't be safely force-pushed onto its remote. Raw values
+/// are grep-stable — they are written verbatim to the automation log (#889).
+public enum RemoteDivergence: String, Sendable, Equatable {
+    /// Local has commits `origin/<branch>` doesn't — force-pushing would
+    /// publish committed-but-unpushed work.
+    case ahead
+    /// Both sides have commits the other doesn't — force-pushing would revert
+    /// the remote's.
+    case diverged
 }
 
 public struct RepoInfo: Sendable {

--- a/Packages/CrowGit/Tests/CrowGitTests/RebaseTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/RebaseTests.swift
@@ -156,9 +156,86 @@ struct RebaseTests {
         let outcome = await GitManager().rebaseOntoBase(
             worktreePath: work, branch: "feature", baseBranch: "main"
         )
-        #expect(outcome == .outOfSyncWithRemote)
+        #expect(outcome == .outOfSyncWithRemote(.ahead))
         // The unpushed commit is still HEAD — nothing was rewritten or pushed.
         #expect(git(["log", "-1", "--format=%s"], in: work).out.contains("local unpushed work"))
+    }
+
+    /// The #889 shape: a clean worktree strictly behind `origin/<branch>` (the
+    /// remote gained commits from elsewhere) used to defer forever. It should
+    /// now fast-forward onto the PR head and then rebase onto base.
+    @Test func behindRemoteIsFastForwardedThenRebased() async throws {
+        try #require(gitAvailable())
+        guard let (root, work) = makeRepo() else { Issue.record("setup failed"); return }
+        defer { cleanup(root) }
+
+        // Advance `feature` on the remote from a second clone, so `work` is
+        // behind origin/feature without knowing it.
+        let other = (root as NSString).appendingPathComponent("other-clone")
+        let remote = (root as NSString).appendingPathComponent("origin.git")
+        #expect(git(["clone", remote, other]).code == 0)
+        git(["switch", "feature"], in: other)
+        write((other as NSString).appendingPathComponent("remote-only.txt"), "remote\n")
+        git(["add", "."], in: other)
+        git(["commit", "-m", "remote-only feature work"], in: other)
+        #expect(git(["push", "origin", "feature"], in: other).code == 0)
+
+        // Advance main too, so there is something to rebase onto.
+        git(["switch", "main"], in: work)
+        write((work as NSString).appendingPathComponent("other.txt"), "other\n")
+        git(["add", "."], in: work)
+        git(["commit", "-m", "main moves on"], in: work)
+        #expect(git(["push", "origin", "main"], in: work).code == 0)
+        git(["switch", "feature"], in: work)
+
+        let outcome = await GitManager().rebaseOntoBase(
+            worktreePath: work, branch: "feature", baseBranch: "main"
+        )
+        #expect(outcome == .rebasedAndPushed)
+
+        // The ff picked up the remote-only commit, and the rebase picked up
+        // main's — the branch is now both in sync and on top of base.
+        #expect(FileManager.default.fileExists(
+            atPath: (work as NSString).appendingPathComponent("remote-only.txt")))
+        #expect(FileManager.default.fileExists(
+            atPath: (work as NSString).appendingPathComponent("other.txt")))
+        #expect(git(["status", "--porcelain"], in: work).out
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        let local = git(["rev-parse", "HEAD"], in: work).out.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pushed = git(["rev-parse", "origin/feature"], in: work).out.trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(local == pushed)
+    }
+
+    /// Both sides moved: force-pushing would revert the remote's commits, so
+    /// this must still refuse — the fast-forward path is behind-only.
+    @Test func divergedLocalIsSkipped() async throws {
+        try #require(gitAvailable())
+        guard let (root, work) = makeRepo() else { Issue.record("setup failed"); return }
+        defer { cleanup(root) }
+
+        let other = (root as NSString).appendingPathComponent("other-clone")
+        let remote = (root as NSString).appendingPathComponent("origin.git")
+        #expect(git(["clone", remote, other]).code == 0)
+        git(["switch", "feature"], in: other)
+        write((other as NSString).appendingPathComponent("remote-only.txt"), "remote\n")
+        git(["add", "."], in: other)
+        git(["commit", "-m", "remote-only feature work"], in: other)
+        #expect(git(["push", "origin", "feature"], in: other).code == 0)
+        let remoteHead = git(["rev-parse", "HEAD"], in: other)
+            .out.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Local commits its own work on top of the *old* head → diverged.
+        write((work as NSString).appendingPathComponent("local.txt"), "local\n")
+        git(["add", "."], in: work)
+        git(["commit", "-m", "local unpushed work"], in: work)
+
+        let outcome = await GitManager().rebaseOntoBase(
+            worktreePath: work, branch: "feature", baseBranch: "main"
+        )
+        #expect(outcome == .outOfSyncWithRemote(.diverged))
+        // The branch on the origin itself is untouched — no force-push happened.
+        #expect(git(["rev-parse", "refs/heads/feature"], in: remote)
+            .out.trimmingCharacters(in: .whitespacesAndNewlines) == remoteHead)
     }
 
     @Test func dirtyWorktreeIsSkipped() async throws {


### PR DESCRIPTION
Closes #889

## Problem

`GitManager.rebaseOntoBase` refused to rewrite unless `localSha == remoteSha`. That equality is **symmetric**, so it collapsed ahead / behind / diverged into one `.outOfSyncWithRemote`. The guard is correct for *ahead* and *diverged* — a force-push would publish unpushed work or revert remote commits — but wrong for *behind + clean*, which is trivially fast-forwardable to the exact commit the PR is about.

`IssueTracker.attemptRebase` treated that as transient and cleared the per-head key every poll, so a clean-but-stale worktree re-fetched and re-logged `auto-rebase: dispatched #N` every ~60s forever and never rebased. Every *outcome* used bare `NSLog` while only the *dispatch* used `CrowLog.automation`, so `crowd-automation.log` showed endless `dispatched` with no paired reason. Users saw only the manual **Rebase & Fix Conflicts** button and concluded automation had not run.

## Changes

**`GitManager`** — classify with `merge-base --is-ancestor` instead of comparing SHAs:

- strictly behind → `merge --ff-only origin/<branch>`, then rebase onto base as before. The tree is already known clean, so this is loss-free, and it is the only way the rebase targets the PR head. A remote that moves between the fetch and the merge reports `.failed` rather than rewriting from an unintended head.
- ahead / diverged → still refuse, now distinguished via `.outOfSyncWithRemote(RemoteDivergence)`.

The existing bare `--force-with-lease` keeps its correct baseline: after the ff, `HEAD == origin/<branch>`, and the lease is still the remote-tracking ref refreshed by the pre-existing fetch, so a concurrent push fails the lease rather than being clobbered.

**`IssueTracker`**:

- Every outcome — including the three early skips, one of which returned completely silently — writes one `CrowLog.automation` line, so each `dispatched` is paired with the reason it did or did not rebase. Reason strings are grep-stable, matching the existing `AutoMergeSkipReason` pattern. (`CrowLog.automation` mirrors to `NSLog`, so nothing is lost by the migration.)
- Deferrals (dirty tree, ahead, diverged) back off 60s → 120 → 240 → 480 → 900s instead of retrying every poll. A *change* of reason restarts the backoff, and the first retry still lands on the next poll, so the common transient case (an agent mid-edit) recovers as promptly as before.
- Prune the three per-head maps against live PR heads; they previously grew for the lifetime of the daemon.

Log shape now:

```
auto-rebase: dispatched #884 (DIRTY, mergeable=CONFLICTING)
auto-rebase: #884 rebased & force-pushed (was CONFLICTING, session <uuid>)
auto-rebase: #884 deferred:out-of-sync-ahead (deferral 2, retry in 120s)
auto-rebase: #884 skipped:no-crow-session-trailer
```

## Acceptance

- [x] Clean worktree behind origin, PR `CONFLICTING`/`BEHIND` → ff-pulls, rebases onto base, and either force-pushes or hands real conflicts to the agent, without the manual button — `behindRemoteIsFastForwardedThenRebased`
- [x] Automation log shows a clear per-attempt outcome, not only repeated `dispatched`
- [x] Ahead/diverged still refuse to force-push — `unpushedLocalCommitsAreSkipped` (asserts `.ahead`), `divergedLocalIsSkipped` (asserts the branch on the origin is unchanged afterward)
- [x] Dirty worktrees still defer without clobbering in-progress agent edits — `dirtyWorktreeIsSkipped`, unchanged

## Testing

`make build` clean. `swift test` green on both touched packages: 21/21 CrowGit (7 real-git rebase tests, confirmed run rather than skipped) and 472/472 CrowEngine.

Not covered: `attemptRebase`'s outcome handling itself. `IssueTracker.gitManager` is a hardcoded `private let GitManager()` with no injection seam, so the new backoff/logging is tested as pure functions (`autoRebaseDeferralBackoff`, `AutoRebaseDeferReason`) alongside the real-git coverage of the git layer — consistent with the existing test strategy. Adding a protocol seam was considered and deliberately deferred.

Out of scope: the ticket's nice-to-have #4 (surfacing deferral state in the web session UI). The automation log is the diagnostic surface for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
