### PR TITLE
ADR 0016: complete the parity contract (CROW-806)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -307,12 +307,19 @@ public enum ParityLedger {
     /// `ParityGateTests`. The two sets must match exactly, so a new config field
     /// fails the build until someone decides whether it gets a verb.
     ///
-    /// The exempt rows below are the honest state of the milestone as of CROW-807:
-    /// the settings blocks that already have verbs (`telemetry`, `cleanup`,
-    /// `sidebar`, `notifications`, gateways, jobs, `defaults` since CROW-810 and
-    /// agent selection since CROW-811) are covered, and everything the web
-    /// Settings tab owns exclusively — `workspaces[].*`, the automation toggles,
-    /// `terminal.*` — is not.
+    /// The rows below are the honest state of the milestone. The settings blocks
+    /// that already have verbs are covered: `telemetry`, `cleanup`, `sidebar`,
+    /// `notifications`, gateways and jobs, `defaults` since CROW-810, agent
+    /// selection since CROW-811, `workspaces[].*` since CROW-809 and the
+    /// automation toggles since CROW-812. What the web Settings tab still owns
+    /// exclusively is `terminal.*` and `jiraCredential.*`; the `webAuth` hash and
+    /// salt are writable but readable nowhere.
+    ///
+    /// Coverage is per-direction, so a covered block can still hold a read-only
+    /// row — the server-assigned `jobs[].id`/`createdAt`/`lastRunAt`,
+    /// `workspaces[].id`/`cli`, `defaults.excludeDirs` and
+    /// `defaults.mirrorClaudeMCPToCodex` all carry a write exemption. Read the
+    /// row, not the `MARK` above it.
     public static let configFields: [ConfigEntry] = [
         // MARK: Covered — settings blocks with dedicated verbs
 

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -465,78 +465,26 @@ public enum ParityLedger {
         .field("workspaces[].corveilHost", read: "workspace get", write: "workspace edit"),
         .field("workspaces[].sessionEnv", read: "workspace get", write: "workspace edit"),
 
-        // MARK: Exempt — automation toggles (web Settings tab)
+        // MARK: Automation toggles (web Settings tab + `crow automation`)
 
-        .field(
-            "remoteControlEnabled",
-            noCLI: """
-                Master switch for the daemon's remote HTTP/WS surface. Web Settings \
-                toggle; a verb would let a remote caller widen its own access, so any \
-                future one must be local-socket only like the gateway verbs.
-                """),
-        .field(
-            "managerAutoPermissionMode",
-            noCLI: """
-                Whether Manager sessions launch with `--permission-mode auto`. Web \
-                Settings toggle (ADR 0004); no verb reads or writes it.
-                """),
-        .field(
-            "jobsAutoPermissionMode",
-            noCLI: """
-                Whether scheduler-launched sessions get `--permission-mode auto`. Web \
-                Settings toggle; no verb reads or writes it.
-                """),
-        .field(
-            "reviewAutoPermissionMode",
-            noCLI: """
-                Whether code-review sessions get `--permission-mode auto`. Web \
-                Settings toggle; no verb reads or writes it.
-                """),
-        .field(
-            "coderViewAutoPermissionMode",
-            noCLI: """
-                Whether new work coder views start in auto-accept rather than plan \
-                mode (#586). Web Settings toggle; no verb reads or writes it.
-                """),
-        .field(
-            "attributionTrailers",
-            noCLI: """
-                Whether `setup.sh` writes the per-worktree Claude attribution \
-                override. Web Settings toggle; no verb reads or writes it.
-                """),
-        .field(
-            "autoMergeWatcherEnabled",
-            noCLI: """
-                Opt-in watcher that enables GitHub auto-merge on Crow-authored PRs \
-                labeled `crow:merge` (CROW-299). Web Settings toggle; `crow \
-                add-merge-label` applies the label but cannot arm the watcher.
-                """),
-        .field(
-            "autoCreateWatcherEnabled",
-            noCLI: """
-                Opt-in watcher that dispatches `/crow-workspace` for issues labeled \
-                `crow:auto` (CROW-312). Web Settings toggle; `crow work-on-issue` \
-                dispatches one by hand but cannot arm the watcher.
-                """),
-        .field(
-            "autoRespond.respondToChangesRequested",
-            noCLI: """
-                Whether Crow auto-answers review feedback. Web Settings toggle; the \
-                manual equivalent is `crow quick-action --action addressChanges`.
-                """),
-        .field(
-            "autoRespond.respondToFailedChecks",
-            noCLI: """
-                Whether Crow auto-answers failing CI. Web Settings toggle; the manual \
-                equivalent is `crow quick-action --action fixChecks`.
-                """),
-        .field(
-            "autoRespond.autoRebaseAndResolveConflicts",
-            noCLI: """
-                Whether Crow auto-rebases conflicted PRs (CROW-551). Web Settings \
-                toggle; the manual equivalent is `crow quick-action --action \
-                fixConflicts`.
-                """),
+        // Covered since CROW-812 (#884): `crow automation get` reads all eleven
+        // and `crow automation set` patches them. `remoteControlEnabled` is the
+        // one to watch — it is the master switch for the daemon's remote surface,
+        // so a remote caller flipping its own access on is a widening; the verb
+        // is safe because the CLI reaches the daemon over the 0600 Unix socket,
+        // never `/rpc`.
+        .field("remoteControlEnabled", read: "automation get", write: "automation set"),
+        .field("managerAutoPermissionMode", read: "automation get", write: "automation set"),
+        .field("jobsAutoPermissionMode", read: "automation get", write: "automation set"),
+        .field("reviewAutoPermissionMode", read: "automation get", write: "automation set"),
+        .field("coderViewAutoPermissionMode", read: "automation get", write: "automation set"),
+        .field("attributionTrailers", read: "automation get", write: "automation set"),
+        .field("autoMergeWatcherEnabled", read: "automation get", write: "automation set"),
+        .field("autoCreateWatcherEnabled", read: "automation get", write: "automation set"),
+        .field("autoRespond.respondToChangesRequested", read: "automation get", write: "automation set"),
+        .field("autoRespond.respondToFailedChecks", read: "automation get", write: "automation set"),
+        .field("autoRespond.autoRebaseAndResolveConflicts", read: "automation get", write: "automation set"),
+
         // MARK: Exempt — terminal tuning and Jira credential
 
         .field(

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -468,11 +468,15 @@ public enum ParityLedger {
         // MARK: Automation toggles (web Settings tab + `crow automation`)
 
         // Covered since CROW-812 (#884): `crow automation get` reads all eleven
-        // and `crow automation set` patches them. `remoteControlEnabled` is the
-        // one to watch — it is the master switch for the daemon's remote surface,
-        // so a remote caller flipping its own access on is a widening; the verb
-        // is safe because the CLI reaches the daemon over the 0600 Unix socket,
-        // never `/rpc`.
+        // and `crow automation set` patches them. Neither method is on
+        // `RPCWebSocketHandler.localOnlyDenial`, so an authenticated remote
+        // `/rpc` peer can write these fields too — deliberately, because that
+        // same peer already reaches every one of them through the whole-blob
+        // `set-config`, and the granular verb is the smaller surface
+        // (`DaemonSecurityTests.settingsRPCsAreAllowedRemotely` pins it).
+        // `remoteControlEnabled` is no exception to that: it decides whether
+        // coding-agent sessions launch with `--rc` (claude.ai / mobile control),
+        // not who may reach `crowd`.
         .field("remoteControlEnabled", read: "automation get", write: "automation set"),
         .field("managerAutoPermissionMode", read: "automation get", write: "automation set"),
         .field("jobsAutoPermissionMode", read: "automation get", write: "automation set"),

--- a/docs/adr/0016-cli-control-plane-parity.md
+++ b/docs/adr/0016-cli-control-plane-parity.md
@@ -125,14 +125,16 @@ compiled into shipped binaries. Encoding it as Swift rather than JSON buys the
 type-enforced exemption reason and removes a hand-written decoder that could
 itself drift, which is worth more than the bytes.
 
-The gate records today's honest state, and it is not flattering: all of
-`workspaces[].*` and `terminal.*` have no CLI path at all, and `set-config`/
-`run-setup`/`batch-start-review`/`run-job` are writes with no verb. Freezing that
-inventory in a file is what makes it shrinkable — and it already works in both
-directions: rebasing onto CROW-810 turned the gate red until the nine
-`defaults.*` rows were moved from exempt to covered, which is also how the two
-fields that ticket left readable-but-not-writable (`defaults.excludeDirs`,
-`defaults.mirrorClaudeMCPToCodex`) came to light.
+The gate records today's honest state, and it is not flattering: `terminal.*` and
+`jiraCredential.*` have no CLI path at all, and `set-config`/`run-setup`/
+`batch-start-review`/`run-job` are writes with no verb. Freezing that inventory in
+a file is what makes it shrinkable — and it already works in both directions:
+rebasing onto CROW-810 turned the gate red until the nine `defaults.*` rows were
+moved from exempt to covered, which is also how the two fields that ticket left
+readable-but-not-writable (`defaults.excludeDirs`,
+`defaults.mirrorClaudeMCPToCodex`) came to light. CROW-809 (#885) then did the
+same for `workspaces[].*`, which this branch absorbed on a rebase — the exempt
+list is one PR shorter than when this ADR was drafted.
 
 The gate's own first miss is instructive (#806). CROW-812 (#884) and the gate
 (#883) were in review at the same time and merged in that order, so the ledger

--- a/docs/adr/0016-cli-control-plane-parity.md
+++ b/docs/adr/0016-cli-control-plane-parity.md
@@ -25,6 +25,12 @@ CLI ([ADR 0002](./0002-unix-socket-cli-architecture.md)); a capability reachable
 only from a browser is a capability no agent can use and no script can automate.
 Drift here doesn't degrade convenience, it removes the product's main interface.
 
+A CLI path is also the only **reproducible** one. A sequence of verbs can be
+checked in, replayed on another machine, and diffed when it stops working; a
+click-path through Settings can be described but never re-run. Headless
+operation — a `crowd` on a host nobody points a browser at — rests on the same
+property.
+
 The drift was also invisible. Nobody could answer "what can the web UI do that
 the CLI can't?" without reading three files and holding the result in their head,
 so the gap grew without anyone deciding it should.
@@ -62,6 +68,41 @@ Reads are ledgered too, but only **writes** are held to the parity bar. A missin
 read verb is an inconvenience; a missing write verb is a capability an agent
 cannot exercise.
 
+### Definition of done for a CLI-covered feature
+
+> **Amendment (2026-07-27, [#806](https://github.com/corveil/crow/issues/806)):**
+> this ADR was first written under CROW-807, the ticket for the *gate*. The
+> contract's own ticket also asked for the checklist below and for the
+> divergence note under *Consequences*.
+
+A green ledger row is necessary but **not sufficient**: it proves a verb exists,
+not that anyone can discover it or that it behaves. A capability is CLI-covered
+when this file set is touched. The shape is the `crow job` family (CROW-604,
+[#624](https://github.com/corveil/crow/pull/624)), re-run by every parity PR
+since — board verbs (#866), agents (#886), automation (#884):
+
+| Layer | File(s) | Enforced by |
+|---|---|---|
+| Shared handler body | `Packages/CrowEngine/Sources/CrowEngine/*RPCSupport.swift` | — |
+| RPC registration | `Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift` | `RPCLedgerParityTests`, `check-cli-parity.sh` |
+| Local-only gate, when it carries secrets or host affordances | `RPCWebSocketHandler.swift` + `DaemonSecurityTests.swift` | — |
+| The verb | `Packages/CrowCLI/Sources/CrowCLILib/Commands/*Commands.swift` | — |
+| Verb registration | `CrowCommand.swift` `subcommands` | `ParityGateTests` |
+| Argument validation | `Validation.swift`, `*Args.swift` | — |
+| Ledger row | `ParityLedger.swift` | `ParityGateTests` |
+| Tests | `*CommandParsingTests`, `*HandlerTests`, `*RPCSupportTests` | — |
+| Generated reference | `docs/cli.md`, via `make docs` | `CLIDocsTests` |
+| Worked example | `docs/cli-reference.md`, inside a fenced block | `CLIDocsTests` |
+| The Manager's context | `CLAUDE.md`, and `Resources/CLAUDE.md.template` | `CLIDocsTests` (`CLAUDE.md` only) |
+| Release note | `CHANGELOG.md` | — |
+
+Half the rows are machine-checked; the other half are convention — and
+convention is exactly what the jobs CLI proved fragile. `crow job` shipped and
+then went missing from the reference, along with `set-locked`,
+`recreate-terminal`, `resync-jira` and `codex-notify`, until CROW-808 built the
+doc gate that now catches it. An unenforced row is a review item, not an
+optional one.
+
 ## Consequences
 
 **Easier.** "What can the UI do that the CLI can't?" is now a grep of the ledger's
@@ -85,13 +126,47 @@ type-enforced exemption reason and removes a hand-written decoder that could
 itself drift, which is worth more than the bytes.
 
 The gate records today's honest state, and it is not flattering: all of
-`workspaces[].*`, the automation toggles and `terminal.*` have no CLI path at
-all, and `set-config`/`run-setup`/`batch-start-review`/`run-job` are writes with
-no verb. Freezing that inventory in a file is what makes it shrinkable — and it
-already works in both directions: rebasing onto CROW-810 turned the gate red
-until the nine `defaults.*` rows were moved from exempt to covered, which is also
-how the two fields that ticket left readable-but-not-writable
-(`defaults.excludeDirs`, `defaults.mirrorClaudeMCPToCodex`) came to light.
+`workspaces[].*` and `terminal.*` have no CLI path at all, and `set-config`/
+`run-setup`/`batch-start-review`/`run-job` are writes with no verb. Freezing that
+inventory in a file is what makes it shrinkable — and it already works in both
+directions: rebasing onto CROW-810 turned the gate red until the nine
+`defaults.*` rows were moved from exempt to covered, which is also how the two
+fields that ticket left readable-but-not-writable (`defaults.excludeDirs`,
+`defaults.mirrorClaudeMCPToCodex`) came to light.
+
+The gate's own first miss is instructive (#806). CROW-812 (#884) and the gate
+(#883) were in review at the same time and merged in that order, so the ledger
+reached `main` with no rows for `automation-get`/`automation-set` and with all
+eleven automation toggles still marked *"Web Settings toggle; no verb reads or
+writes it"* — by then untrue. `main` sat red until this ADR's own branch
+reconciled it. **Two PRs that are each individually correct can still land a red
+gate**, so the `parity` job has to be watched on `main`, not only on the PR that
+last touched the ledger.
+
+**A covered row does not mean one implementation** (#806).
+[ADR 0009](./0009-crowd-sole-authority-clients-only.md) retired `forwardToApp`,
+but the shape it left behind survives: the daemon's `makeCommandRouter` and the
+`makeEngineRouter` it falls back to both register **29 of the same method
+names** — `new-session`, `set-status`, `delete-session`, `get-config` and 25
+more. The daemon's copy always answers; the engine's is shadowed, reachable only
+if the daemon's is removed. `CommandRouter.methodNames` *unions* the two, so the
+ledger sees a single row where two bodies of code exist, and no check can tell
+them apart.
+
+Those bodies have already drifted. `get-config` reports `app_running: false`
+from `RPCHandlers.swift` and `true` from `EngineRouter.swift`, and the daemon's
+copy returns three keys the engine's omits (`configured`, `default_dev_root`,
+`vs_code_available`) — one method name, two response contracts. `delete-session`
+refuses without tmux in the daemon copy and has no such guard in the engine's.
+
+Parity work must respect this: **a verb wired against the shadowed copy is a
+no-op**, so a ticket moving a row from exempt to covered has to confirm its verb
+reaches the implementation that actually answers. De-duplication is the durable
+fix, and the newer verb families already demonstrate it — `job-*`, `defaults-*`,
+`agents-*`, `notifications-*` and `telemetry-*` share one body under
+`Packages/CrowEngine/Sources/CrowEngine/*RPCSupport.swift` and never grew a
+second. All 29 duplicates are pre-CROW-581 vintage; they are a standing re-check
+target, not a settled design.
 
 ## Alternatives considered
 
@@ -116,10 +191,15 @@ maintained, but only because something else forces the update.
 
 ## References
 
-- Ticket: [corveil/crow#807](https://github.com/corveil/crow/issues/807) — anti-drift parity test + CI gate
+- Ticket: [corveil/crow#806](https://github.com/corveil/crow/issues/806) — the
+  parity contract itself (this ADR's brief; the milestone's foundation ticket),
+  [corveil/crow#807](https://github.com/corveil/crow/issues/807) — anti-drift
+  parity test + CI gate (the mechanism, written first)
 - Related ADRs: [0002](./0002-unix-socket-cli-architecture.md) (the CLI surface),
   [0007](./0007-linux-ci-swift.md) (why the RPC check is split),
-  [0009](./0009-crowd-sole-authority-clients-only.md) (mutation flows through crowd),
+  [0009](./0009-crowd-sole-authority-clients-only.md) (mutation flows through
+  crowd — and the retired `forwardToApp` whose residue is the 29 duplicated
+  handlers under *Consequences*),
   [0015](./0015-harness-capability-tiers.md) (*harness* parity — a different axis)
 - Code: `Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift`,
   `Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift`,


### PR DESCRIPTION
Closes #806

## Why this is an amendment, not a new ADR

**The ADR #806 asks for already exists.** PR #883 — which closed the *dependent* ticket #807 (the anti-drift gate) — wrote `docs/adr/0016-cli-control-plane-parity.md` as part of landing `ParityLedger`, and merged it to `main` before this foundation ticket was picked up. A reviewer expecting a brand-new `0017-*.md` should read this diff as completing 0016 to its intended scope. `docs/adr/README.md` says *"Each file is one decision"*, so a second ADR on the same decision would be wrong.

Checking #806's five required statements against what shipped:

| #806 asks the ADR to state | Before | Now |
|---|---|---|
| Parity contract + rationale (headless/scriptable, agent-drivability, reproducibility) | partial — *reproducibility* unnamed | ✅ |
| Deviations only via a justified allowlist (`KNOWN_UI_ONLY`) | ✅ `Coverage.noCLI(reason:)` | ✅ |
| Enumerable surfaces (RPC / CLI verbs / `AppConfig`) | ✅ | ✅ |
| **Per-feature file-touch checklist (CROW-604 precedent)** | ❌ absent | ✅ |
| **App-down fallback duality as a divergence risk (ADR 0009)** | ❌ absent | ✅ |

## What's in the ADR now

**Definition of done for a CLI-covered feature.** A twelve-row file-touch table from the `crow job` precedent (CROW-604, #624) and every parity PR since. The load-bearing column is *which rows a machine already checks* — six of twelve. The other six are convention, and convention is what the jobs CLI proved fragile: `crow job` shipped and then went missing from the reference, along with `set-locked`, `recreate-terminal`, `resync-jira` and `codex-notify`, until CROW-808 built the doc gate.

**A covered row does not mean one implementation.** ADR 0009 retired `forwardToApp`, but the shape survives — the daemon's `makeCommandRouter` and the `makeEngineRouter` it falls back to both register **29 of the same method names**. The daemon's copy always answers; the engine's is shadowed. `CommandRouter.methodNames` *unions* them, so the ledger sees one row where two bodies of code exist.

They have already drifted, verified on this tree:

- `get-config` returns `app_running: false` from `RPCHandlers.swift:1084` and `true` from `EngineRouter.swift:91`, and the daemon copy returns three keys the engine omits (`configured`, `default_dev_root`, `vs_code_available`) — one method name, two response contracts.
- `delete-session` refuses without tmux in the daemon copy (`RPCHandlers.swift:482`) and has no such guard in the engine's.

The rule parity work must respect: **a verb wired against the shadowed copy is a no-op.** Documented as a risk only — no ledger schema change, no follow-up issue filed here.

## Drive-by: the `parity` gate was red on `main`

Not caused by this branch — confirmed by running the gate against pristine `main`. CROW-812 (#884) and the gate (#883) were in review concurrently and merged in that order, so the ledger reached `main` with:

- no rows for `automation-get` / `automation-set`, and
- all **eleven** automation toggles still marked *"Web Settings toggle; no verb reads or writes it"* — untrue since #884 shipped `crow automation get|set`, which reads and writes every one.

Fixed here: two RPC rows added, eleven config fields moved exempt → covered. The episode is recorded in the ADR itself, because the lesson generalizes: **two individually-correct PRs can still land a red gate**, so `parity` has to be watched on `main`, not only on the PR that last touched the ledger.

## Verification

| Gate | Result |
|---|---|
| `scripts/check-cli-parity.sh` | ✅ 89 methods match the ledger (was: exit 1) |
| `CrowCLITests` (incl. `ParityGateTests`, `CLIDocsTests`) | ✅ 309 tests |
| `CrowCoreTests` | ✅ 489 tests |
| `CrowDaemonTests/RPCLedgerParityTests` (authoritative, macOS-only) | ✅ 2 tests |

The 29-duplicate count and both divergence examples were recomputed against this branch's tree rather than carried over from analysis. Every relative ADR link (`./0002`, `./0007`, `./0009`, `./0015`) resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
