### PR TITLE
Resolve the workspace AI gateway for review sessions

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/DevRootLayout.swift
+++ b/Packages/CrowCore/Sources/CrowCore/DevRootLayout.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The one place the dev root's own reserved directory names live, so the code
+/// that *creates* review clones, the repo scan that *skips* them, workspace-name
+/// validation, and gateway resolution can never drift (CROW-891).
+///
+/// The dev root holds one directory per workspace plus a small number of
+/// Crow-owned directories that are *not* workspaces. Those are indistinguishable
+/// from a workspace folder by path shape alone, so anything deriving a workspace
+/// from a path has to know which names are reserved.
+public enum DevRootLayout {
+    /// Holds transient PR-review clones at `{devRoot}/crow-reviews/{repo}-pr-{N}`.
+    ///
+    /// Deliberately *not* a workspace: review clones sit here rather than under
+    /// the owning workspace's folder, which is why a review session resolves its
+    /// workspace by repo slug instead of by path (CROW-891).
+    public static let reviewsDirName = "crow-reviews"
+
+    /// Directory names a workspace may not take, because a workspace folder of
+    /// that name would collide with Crow's own dev-root layout.
+    public static let reservedWorkspaceNames: Set<String> = [reviewsDirName]
+
+    /// Whether `name` collides with a reserved dev-root directory.
+    ///
+    /// Case-insensitive: APFS is case-preserving but case-insensitive, so a
+    /// workspace named `Crow-Reviews` would be the very same directory as the
+    /// review-clone root.
+    public static func isReservedWorkspaceName(_ name: String) -> Bool {
+        reservedWorkspaceNames.contains(name.lowercased())
+    }
+
+    /// The review-clone root under a dev root.
+    public static func reviewsDir(devRoot: String) -> String {
+        (devRoot as NSString).appendingPathComponent(reviewsDirName)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -636,6 +636,13 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         if name == "." || name == ".." {
             return "Name cannot be “.” or “..”"
         }
+        // Crow owns some dev-root directories that aren't workspaces. A workspace
+        // folder of that name would collide with them on disk, and anything
+        // deriving a workspace from a path would bind those sessions to it —
+        // review sessions in particular (CROW-891).
+        if DevRootLayout.isReservedWorkspaceName(name) {
+            return "“\(name)” is reserved by Crow and cannot be a workspace name"
+        }
         let lowercased = name.lowercased()
         if existingNames.contains(where: { $0.lowercased() == lowercased }) {
             return "A workspace with this name already exists"

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -97,6 +97,36 @@ public struct AppConfig: Codable, Sendable, Equatable {
         defaults.excludeReviewRepos + workspaces.flatMap(\.excludeReviewRepos)
     }
 
+    /// The workspace that owns a repo, addressed by its `owner/repo` slug.
+    ///
+    /// Membership is `alwaysInclude` ∪ `autoReviewRepos` — the two lists that name
+    /// repos a workspace *works on*. `excludeReviewRepos` is deliberately **not**
+    /// subtracted: it's a review-board *visibility* filter, not a membership
+    /// statement, so a repo hidden from the board still belongs to the workspace
+    /// and still gets its gateway (CROW-891).
+    ///
+    /// Patterns use ``repoMatchesPatterns`` glob semantics — case-insensitive, one
+    /// `*`. Ambiguity resolves deterministically so two workspaces claiming the
+    /// same repo can't flip the answer between launches: a workspace naming the
+    /// slug **exactly** beats one matching only through a glob, and among equals
+    /// the earlier entry in `workspaces` (config file order) wins.
+    ///
+    /// Returns nil when no workspace claims the slug. Callers must treat that as
+    /// "unset", not "inherit" — see `SessionService.workspaceGatewayResolved`.
+    public func workspace(forRepoSlug slug: String) -> WorkspaceInfo? {
+        let lowerSlug = slug.lowercased()
+        var globMatch: WorkspaceInfo?
+        for workspace in workspaces {
+            let patterns = workspace.alwaysInclude + workspace.autoReviewRepos
+            guard repoMatchesPatterns(slug, patterns: patterns) else { continue }
+            if patterns.contains(where: { $0.lowercased() == lowerSlug }) {
+                return workspace  // exact beats glob; first exact in config order wins
+            }
+            if globMatch == nil { globMatch = workspace }
+        }
+        return globMatch
+    }
+
     public init(
         workspaces: [WorkspaceInfo] = [],
         defaults: ConfigDefaults = ConfigDefaults(),

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigWorkspaceForRepoSlugTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigWorkspaceForRepoSlugTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+
+@testable import CrowCore
+
+/// Coverage for `AppConfig.workspace(forRepoSlug:)` — the repo→workspace lookup
+/// that lets a review clone under `{devRoot}/crow-reviews/` find its workspace's
+/// AI gateway, which path-based resolution alone can never do (CROW-891).
+///
+/// Pure function over in-memory config, so no temp dirs and no `ConfigStore`.
+
+// MARK: - Fixtures
+
+private func ws(
+    _ name: String,
+    alwaysInclude: [String] = [],
+    autoReviewRepos: [String] = [],
+    excludeReviewRepos: [String] = [],
+    gateway: WorkspaceGateway? = nil
+) -> WorkspaceInfo {
+    WorkspaceInfo(
+        name: name,
+        alwaysInclude: alwaysInclude,
+        autoReviewRepos: autoReviewRepos,
+        excludeReviewRepos: excludeReviewRepos,
+        gateway: gateway
+    )
+}
+
+private let probeGateway = WorkspaceGateway(
+    baseURL: "https://gateway.invalid",
+    customHeaders: ["x-probe": "value"]
+)
+
+// MARK: - Membership
+
+@Test func workspaceForRepoSlugMatchesAlwaysInclude() {
+    let config = AppConfig(workspaces: [ws("Acme", alwaysInclude: ["acme/widget"])])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "Acme")
+}
+
+@Test func workspaceForRepoSlugMatchesAutoReviewRepos() {
+    // Membership is the *union* — a repo named only in autoReviewRepos still
+    // belongs to the workspace.
+    let config = AppConfig(workspaces: [ws("Acme", autoReviewRepos: ["acme/widget"])])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "Acme")
+}
+
+@Test func workspaceForRepoSlugIsCaseInsensitive() {
+    let config = AppConfig(workspaces: [ws("Acme", alwaysInclude: ["Acme/Widget"])])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "Acme")
+
+    let lowerConfig = AppConfig(workspaces: [ws("Acme", alwaysInclude: ["acme/widget"])])
+    #expect(lowerConfig.workspace(forRepoSlug: "ACME/WIDGET")?.name == "Acme")
+}
+
+@Test func workspaceForRepoSlugHonorsGlobs() {
+    let config = AppConfig(workspaces: [
+        ws("Acme", alwaysInclude: ["acme/*"]),
+        ws("Widgets", alwaysInclude: ["*/gadget"]),
+    ])
+    #expect(config.workspace(forRepoSlug: "acme/anything")?.name == "Acme")
+    #expect(config.workspace(forRepoSlug: "other/gadget")?.name == "Widgets")
+    #expect(config.workspace(forRepoSlug: "other/unclaimed") == nil)
+}
+
+@Test func workspaceForRepoSlugIgnoresExcludeReviewRepos() {
+    // excludeReviewRepos hides a repo from the review *board*; it is not a
+    // membership statement. A manually started review on an excluded repo still
+    // gets the workspace's gateway (CROW-891 decision).
+    let config = AppConfig(workspaces: [
+        ws(
+            "Acme",
+            alwaysInclude: ["acme/widget"],
+            excludeReviewRepos: ["acme/widget"],
+            gateway: probeGateway
+        )
+    ])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.gateway == probeGateway)
+}
+
+// MARK: - No match
+
+@Test func workspaceForRepoSlugReturnsNilWhenUnclaimed() {
+    let config = AppConfig(workspaces: [ws("Acme", alwaysInclude: ["acme/*"])])
+    #expect(config.workspace(forRepoSlug: "stranger/repo") == nil)
+}
+
+@Test func workspaceForRepoSlugReturnsNilForEmptyWorkspaces() {
+    #expect(AppConfig().workspace(forRepoSlug: "acme/widget") == nil)
+}
+
+@Test func workspaceForRepoSlugReturnsNilForWorkspaceWithNoPatterns() {
+    // Both lists empty → claims nothing. Such a workspace is still reachable via
+    // the worktree-path fast path.
+    let config = AppConfig(workspaces: [ws("Acme", gateway: probeGateway)])
+    #expect(config.workspace(forRepoSlug: "acme/widget") == nil)
+}
+
+// MARK: - Ambiguity
+
+@Test func workspaceForRepoSlugPrefersExactOverGlob() {
+    // The glob is FIRST in config order and still loses — exactness outranks
+    // position, so the answer can't flip when workspaces are reordered.
+    let config = AppConfig(workspaces: [
+        ws("Catchall", alwaysInclude: ["acme/*"]),
+        ws("Widget", alwaysInclude: ["acme/widget"]),
+    ])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "Widget")
+}
+
+@Test func workspaceForRepoSlugBreaksGlobTiesByConfigOrder() {
+    let config = AppConfig(workspaces: [
+        ws("First", alwaysInclude: ["acme/*"]),
+        ws("Second", alwaysInclude: ["acme/*"]),
+    ])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "First")
+}
+
+@Test func workspaceForRepoSlugBreaksExactTiesByConfigOrder() {
+    let config = AppConfig(workspaces: [
+        ws("First", alwaysInclude: ["acme/widget"]),
+        ws("Second", autoReviewRepos: ["acme/widget"]),
+    ])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "First")
+}
+
+@Test func workspaceForRepoSlugExactMatchAcrossListsBeatsGlob() {
+    // The exact hit lives in autoReviewRepos while the glob is in alwaysInclude —
+    // the union is searched as one pattern set.
+    let config = AppConfig(workspaces: [
+        ws("Catchall", alwaysInclude: ["*"]),
+        ws("Widget", autoReviewRepos: ["acme/widget"]),
+    ])
+    #expect(config.workspace(forRepoSlug: "acme/widget")?.name == "Widget")
+    // …and the catch-all still owns everything else it claims.
+    #expect(config.workspace(forRepoSlug: "stranger/repo")?.name == "Catchall")
+}
+
+// MARK: - Membership ≠ gateway
+
+@Test func workspaceForRepoSlugReturnsWorkspaceWithoutGateway() {
+    // The lookup answers "who owns this repo", not "who has a gateway" — the
+    // caller guards on `.gateway`.
+    let config = AppConfig(workspaces: [ws("Acme", alwaysInclude: ["acme/widget"])])
+    let matched = config.workspace(forRepoSlug: "acme/widget")
+    #expect(matched?.name == "Acme")
+    #expect(matched?.gateway == nil)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/DevRootLayoutTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/DevRootLayoutTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import CrowCore
+
+/// Coverage for `DevRootLayout` — the reserved dev-root directory names, and the
+/// workspace-name validation that keeps a workspace from taking one.
+///
+/// A workspace named `crow-reviews` would collide with the review-clone root on
+/// disk *and* capture every review session's gateway resolution through the path
+/// fast path, shadowing the repo-slug fallback (PR #898 review of CROW-891).
+
+@Test func reviewsDirNameIsReserved() {
+    #expect(DevRootLayout.isReservedWorkspaceName(DevRootLayout.reviewsDirName))
+}
+
+/// Case-insensitive, because APFS is: `Crow-Reviews` is the same directory.
+@Test func reservedWorkspaceNameCheckIsCaseInsensitive() {
+    #expect(DevRootLayout.isReservedWorkspaceName("Crow-Reviews"))
+    #expect(DevRootLayout.isReservedWorkspaceName("CROW-REVIEWS"))
+}
+
+@Test func ordinaryWorkspaceNamesAreNotReserved() {
+    #expect(!DevRootLayout.isReservedWorkspaceName("Spotlight"))
+    // Near-misses stay usable — the reservation is exact, not a prefix match.
+    #expect(!DevRootLayout.isReservedWorkspaceName("crow-reviews-archive"))
+    #expect(!DevRootLayout.isReservedWorkspaceName("crow"))
+}
+
+@Test func reviewsDirIsBuiltUnderDevRoot() {
+    #expect(DevRootLayout.reviewsDir(devRoot: "/Users/dev/Dev") == "/Users/dev/Dev/crow-reviews")
+}
+
+@Test func validateNameRejectsReservedNames() {
+    #expect(WorkspaceInfo.validateName("crow-reviews", existingNames: []) != nil)
+    #expect(WorkspaceInfo.validateName("Crow-Reviews", existingNames: []) != nil)
+}
+
+@Test func validateNameStillAcceptsOrdinaryNames() {
+    #expect(WorkspaceInfo.validateName("Spotlight", existingNames: []) == nil)
+    #expect(WorkspaceInfo.validateName("crow-reviews-archive", existingNames: []) == nil)
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
@@ -78,7 +78,7 @@ public struct Scaffolder {
         try fm.createDirectory(atPath: showImageSkillsDir, withIntermediateDirectories: true)
 
         // Create crow-reviews directory for PR review clones
-        let reviewsDir = (devRoot as NSString).appendingPathComponent("crow-reviews")
+        let reviewsDir = DevRootLayout.reviewsDir(devRoot: devRoot)
         try fm.createDirectory(atPath: reviewsDir, withIntermediateDirectories: true)
 
         // Always update CLAUDE.md — but preserve the "Known Issues / Corrections" section

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1577,29 +1577,94 @@ public final class SessionService {
         return GatewayResolver.resolve(gateway)
     }
 
-    /// Resolve the AI gateway for a non-Manager session from its worktree's
-    /// workspace (CROW-402). The worktree lives at `{devRoot}/{workspace}/…`, so
-    /// the workspace folder name is the first path component under devRoot.
-    /// Returns nil when there's no matching workspace or no (non-empty) gateway.
+    /// Resolve the AI gateway for a non-Manager session (CROW-402, CROW-891).
+    ///
+    /// Two lookups, in order:
+    ///
+    /// 1. **Path** — `.work`/`.job` worktrees live at `{devRoot}/{workspace}/…`,
+    ///    so the first component under devRoot names the workspace. Fast, and the
+    ///    only lookup that can tell apart two workspaces sharing a repo.
+    /// 2. **Repo slug** — a `.review` clone lives at `{devRoot}/crow-reviews/…`,
+    ///    so path math yields the literal `"crow-reviews"` and matches nothing.
+    ///    That silently unset the gateway for *every* review (CROW-891). Fall
+    ///    back to the PR link's `owner/repo` and ask which workspace claims it.
+    ///
+    /// Returns nil when nothing claims the session — deliberate and logged, not
+    /// an oversight: the callers then **unset** `ANTHROPIC_*` so a global
+    /// `~/.zshrc` export (or a sibling workspace's gateway) can't bleed into a
+    /// session Crow has no gateway for. There is no `managerGateway` fallback —
+    /// the Manager's gateway is the Manager's alone.
     private func workspaceGatewayResolved(for sessionID: UUID) -> GatewayResolver.Resolved? {
         guard let devRoot = ConfigStore.loadDevRoot(),
-              let config = ConfigStore.loadConfig(devRoot: devRoot),
-              let worktree = appState.primaryWorktree(for: sessionID),
-              let wsName = Self.workspaceName(forWorktreePath: worktree.worktreePath, devRoot: devRoot),
-              let workspace = config.workspaces.first(where: { $0.name == wsName }),
+              let config = ConfigStore.loadConfig(devRoot: devRoot)
+        else { return nil }
+
+        var matched: WorkspaceInfo?
+
+        // 1. Path fast path. Case-insensitive: APFS is case-preserving but
+        // case-insensitive, so an on-disk folder can differ in case from the
+        // configured workspace name and still be the same directory.
+        if let worktree = appState.primaryWorktree(for: sessionID),
+           let wsName = Self.workspaceName(
+               forWorktreePath: worktree.worktreePath, devRoot: devRoot) {
+            matched = config.workspaces.first { $0.name.lowercased() == wsName.lowercased() }
+        }
+
+        // 2. Repo-slug fallback — reviews, and any session whose worktree isn't
+        // under a configured workspace folder. Gated on the precondition rather
+        // than `session.kind == .review` because work sessions also carry `.pr`
+        // links once their PR opens, and one whose path lookup failed should
+        // inherit its repo's workspace gateway too.
+        if matched == nil, let slug = Self.repoSlug(fromPRLinks: appState.links(for: sessionID)) {
+            matched = config.workspace(forRepoSlug: slug)
+            if matched == nil {
+                CrowLog.info(
+                    "[SessionService] No workspace claims repo \(slug) (session \(sessionID)); "
+                        + "ANTHROPIC_* will be unset for this session")
+            }
+        }
+
+        guard let workspace = matched,
               let gateway = workspace.gateway, !gateway.isEmpty
         else { return nil }
         return GatewayResolver.resolve(gateway)
     }
 
+    /// First parseable `owner/repo` slug among a session's PR links, or nil.
+    ///
+    /// Uses the same `Session.parseReviewPR` that `createReviewSession` used to
+    /// build the clone directory, so gateway resolution can never disagree with
+    /// what creation decided the repo was. Extracted as a pure function so the
+    /// link-selection rule is unit-testable without standing up the terminal
+    /// machinery (same reasoning as `shouldStripCursorReviewCloneOnHandoff`).
+    ///
+    /// GitLab MR URLs don't fit `parseReviewPR`'s shape and yield a slug that
+    /// claims nothing — which lands on "unset", exactly today's behavior. The
+    /// mis-parse is upstream of here (clone naming uses the same parser).
+    nonisolated static func repoSlug(fromPRLinks links: [SessionLink]) -> String? {
+        for link in links where link.linkType == .pr {
+            if let parsed = Session.parseReviewPR(url: link.url) {
+                return "\(parsed.owner)/\(parsed.repo)"
+            }
+        }
+        return nil
+    }
+
     /// Derive the workspace folder name from a worktree path:
-    /// `{devRoot}/{workspace}/{repo-folder}` → `{workspace}`. Pure path math.
+    /// `{devRoot}/{workspace}/{repo-folder}` → `{workspace}`. Pure path math, so
+    /// `nonisolated` — it touches no instance state and is unit-testable without
+    /// hopping to the main actor.
     ///
     /// Public because this string *is* the link between a session and its
     /// workspace — there is no id on either side — so `workspace-edit` and
     /// `workspace-remove` need it to count what a rename or removal would orphan
     /// (CROW-809).
-    public static func workspaceName(forWorktreePath path: String, devRoot: String) -> String? {
+    ///
+    /// Review clones live at `{devRoot}/crow-reviews/{repo}-pr-{N}`, so this
+    /// returns the literal `"crow-reviews"` for them — never a workspace name.
+    /// That's what `workspaceGatewayResolved`'s slug fallback exists for
+    /// (CROW-891).
+    public nonisolated static func workspaceName(forWorktreePath path: String, devRoot: String) -> String? {
         let root = (devRoot as NSString).standardizingPath
         let full = (path as NSString).standardizingPath
         guard full.hasPrefix(root + "/") else { return nil }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1604,9 +1604,17 @@ public final class SessionService {
         // 1. Path fast path. Case-insensitive: APFS is case-preserving but
         // case-insensitive, so an on-disk folder can differ in case from the
         // configured workspace name and still be the same directory.
+        //
+        // Reserved dev-root directories are skipped rather than looked up. A
+        // review clone's first path component is `crow-reviews`, so a workspace
+        // that had taken that name would match here and bind *every* review to
+        // itself, shadowing the slug fallback below. `validateName` now rejects
+        // the name, but a config written before that still has to resolve
+        // correctly.
         if let worktree = appState.primaryWorktree(for: sessionID),
            let wsName = Self.workspaceName(
-               forWorktreePath: worktree.worktreePath, devRoot: devRoot) {
+               forWorktreePath: worktree.worktreePath, devRoot: devRoot),
+           !DevRootLayout.isReservedWorkspaceName(wsName) {
             matched = config.workspaces.first { $0.name.lowercased() == wsName.lowercased() }
         }
 
@@ -2732,7 +2740,7 @@ public final class SessionService {
         // the PR head advances without an explicit re-request (CROW-290).
         let headRefOid: String? = prMetadata.headRefOid.isEmpty ? nil : prMetadata.headRefOid
 
-        let reviewsDir = (devRoot as NSString).appendingPathComponent("crow-reviews")
+        let reviewsDir = DevRootLayout.reviewsDir(devRoot: devRoot)
         let cloneDirName = "\(repoName)-pr-\(prNumber)"
         let clonePath = (reviewsDir as NSString).appendingPathComponent(cloneDirName)
 

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceGatewayResolutionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceGatewayResolutionTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowEngine
+
+/// Coverage for the two pure helpers behind `workspaceGatewayResolved` — the
+/// path lookup that names a session's workspace, and the PR-link lookup that
+/// names its repo (CROW-891).
+///
+/// `workspaceGatewayResolved` itself isn't directly testable: it reads
+/// `ConfigStore.loadDevRoot()`, which is all-static with no injection seam, and
+/// `SessionService.init` takes no devRoot/config — so exercising it would mean
+/// touching the live devroot pointer, which ADR 0012 forbids. Every *decision*
+/// it makes lives in these two helpers plus `AppConfig.workspace(forRepoSlug:)`
+/// (covered in CrowCore), so testing them covers the resolution logic without
+/// standing up the terminal machinery.
+@Suite("Gateway workspace resolution")
+struct SessionServiceGatewayResolutionTests {
+
+    private static let devRoot = "/Users/dev/Dev"
+
+    // MARK: - workspaceName(forWorktreePath:devRoot:) — the path fast path
+
+    /// The worker/job layout: `{devRoot}/{workspace}/{repo}-{n}-{slug}`.
+    @Test func workspaceNameFromStandardWorktreePath() {
+        let path = "\(Self.devRoot)/Spotlight/props-197-fix-tab-url-hash"
+        #expect(
+            SessionService.workspaceName(forWorktreePath: path, devRoot: Self.devRoot)
+                == "Spotlight")
+    }
+
+    /// The CROW-891 root cause, pinned as an executable assertion: a review clone
+    /// lives in a flat sibling directory, so path math yields the literal
+    /// `"crow-reviews"` — never a workspace name. This is why the repo-slug
+    /// fallback has to exist.
+    @Test func workspaceNameOfReviewCloneIsCrowReviews() {
+        let path = "\(Self.devRoot)/crow-reviews/props-pr-42"
+        #expect(
+            SessionService.workspaceName(forWorktreePath: path, devRoot: Self.devRoot)
+                == "crow-reviews")
+    }
+
+    @Test func workspaceNameNilOutsideDevRoot() {
+        #expect(
+            SessionService.workspaceName(
+                forWorktreePath: "/somewhere/else/props", devRoot: Self.devRoot) == nil)
+    }
+
+    /// devRoot itself has no component under it — the `hasPrefix(root + "/")`
+    /// guard rejects it rather than returning the dev-root folder's own name.
+    @Test func workspaceNameNilForDevRootItself() {
+        #expect(
+            SessionService.workspaceName(forWorktreePath: Self.devRoot, devRoot: Self.devRoot)
+                == nil)
+    }
+
+    @Test func workspaceNameStandardizesPaths() {
+        let path = "\(Self.devRoot)/Spotlight/../Spotlight/props-197"
+        #expect(
+            SessionService.workspaceName(forWorktreePath: path, devRoot: Self.devRoot)
+                == "Spotlight")
+    }
+
+    // MARK: - repoSlug(fromPRLinks:) — the review fallback's input
+
+    private static func prLink(_ url: String) -> SessionLink {
+        SessionLink(sessionID: UUID(), label: "PR", url: url, linkType: .pr)
+    }
+
+    @Test func repoSlugFromGitHubPRLink() {
+        let links = [Self.prLink("https://github.com/acme/widget/pull/42")]
+        #expect(SessionService.repoSlug(fromPRLinks: links) == "acme/widget")
+    }
+
+    /// A ticket URL is the same shape as a PR URL in the segments the parser
+    /// reads, so selection has to key on `linkType`, not on parseability.
+    @Test func repoSlugIgnoresNonPRLinks() {
+        let sessionID = UUID()
+        let links = [
+            SessionLink(
+                sessionID: sessionID, label: "Issue",
+                url: "https://github.com/other/repo/issues/7", linkType: .ticket),
+            SessionLink(
+                sessionID: sessionID, label: "Repo",
+                url: "https://github.com/other/repo", linkType: .repo),
+        ]
+        #expect(SessionService.repoSlug(fromPRLinks: links) == nil)
+    }
+
+    /// First *parseable* PR link, not first PR link — a malformed one is skipped
+    /// rather than poisoning resolution for the whole session.
+    @Test func repoSlugReturnsFirstParseableLink() {
+        let links = [
+            Self.prLink("not a url"),
+            Self.prLink("https://github.com/acme/widget/pull/42"),
+        ]
+        #expect(SessionService.repoSlug(fromPRLinks: links) == "acme/widget")
+    }
+
+    @Test func repoSlugReturnsNilWithNoLinks() {
+        #expect(SessionService.repoSlug(fromPRLinks: []) == nil)
+    }
+
+    /// GitLab MR URLs don't fit `parseReviewPR`'s trailing-5-segment shape, so
+    /// they yield a slug that claims no workspace → gateway unset, which is
+    /// exactly the pre-CROW-891 behavior (no regression). The mis-parse is
+    /// upstream — `createReviewSession` names the clone with the same parser.
+    /// Pinned so a future GitLab fix updates this consciously rather than drifts.
+    @Test func repoSlugForGitLabMRIsMalformedButStable() {
+        let links = [Self.prLink("https://gitlab.com/group/proj/-/merge_requests/12")]
+        #expect(SessionService.repoSlug(fromPRLinks: links) == "proj/-")
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceGatewayResolutionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceGatewayResolutionTests.swift
@@ -40,6 +40,17 @@ struct SessionServiceGatewayResolutionTests {
                 == "crow-reviews")
     }
 
+    /// …and because that literal *is* a plausible workspace name, resolution must
+    /// treat it as reserved rather than looking it up. A workspace that had taken
+    /// the name would otherwise match the path fast path and capture every review
+    /// session, shadowing the slug fallback entirely (PR #898 review).
+    @Test func reviewCloneDirNameIsReservedForWorkspaces() {
+        let path = "\(Self.devRoot)/crow-reviews/props-pr-42"
+        let wsName = SessionService.workspaceName(
+            forWorktreePath: path, devRoot: Self.devRoot)
+        #expect(wsName.map(DevRootLayout.isReservedWorkspaceName) == true)
+    }
+
     @Test func workspaceNameNilOutsideDevRoot() {
         #expect(
             SessionService.workspaceName(

--- a/Packages/CrowGit/Sources/CrowGit/GitManager.swift
+++ b/Packages/CrowGit/Sources/CrowGit/GitManager.swift
@@ -32,7 +32,7 @@ public actor GitManager {
             // crow-reviews holds transient PR-review clones (full clones that
             // resolve to the same org/repo slug as the canonical checkout); never
             // discover them or they'd duplicate the real repo in the summary scan.
-            guard wsDir != "crow-reviews" else { continue }
+            guard !DevRootLayout.isReservedWorkspaceName(wsDir) else { continue }
 
             let wsConfig = config.workspaces[wsDir]
             let provider = wsConfig?.provider ?? config.defaults.provider

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -342,7 +342,10 @@ identity (`if …kind == .claudeCode`), because no other harness has an analogue
   no-registered-agent fallback). The **two** Manager
   gateway writes — `createManagerTerminal` and the hydrate path's
   `writeManagerGatewayEnv` — are **unconditional** (harmless: a non-Claude agent
-  ignores `settings.local.json`).
+  ignores `settings.local.json`). Which workspace's gateway applies is resolved
+  by worktree path, falling back to the PR's `owner/repo` for review clones,
+  which live outside any workspace folder (CROW-891) — see
+  [configuration.md](configuration.md#which-gateway-applies).
 - **OTEL telemetry env** — `AgentLaunch.prepareAgentLaunchText` prepends the
   `OTEL_*` exporter vars, gated on `agent.kind == .claudeCode` (Codex has no OTLP
   equivalent).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
 | `{devRoot}/.claude/skills/crow-workspace/setup.sh`                    | Deterministic setup script called by the skill                |
 | `{devRoot}/.claude/skills/crow-review-pr/SKILL.md`                    | PR review skill invoked via `/crow-review-pr`                 |
 | `{devRoot}/.claude/skills/crow-batch-workspace/SKILL.md`              | Batch workspace setup skill                                   |
-| `{devRoot}/crow-reviews/`                                             | Temporary clones used when reviewing PRs                      |
+| `{devRoot}/crow-reviews/`                                             | Temporary clones used when reviewing PRs (reserved name)      |
 
 ## Workspace Configuration
 
@@ -157,7 +157,7 @@ When no workspace claims the session — or the one that does has **no** `gatewa
 
 Crow resolves a session's workspace two ways, in order:
 
-1. **By worktree location** — work and job worktrees live at `{devRoot}/{workspace}/{repo}-{n}-{slug}`, so the folder directly under the dev root names the workspace. Matched case-insensitively.
+1. **By worktree location** — work and job worktrees live at `{devRoot}/{workspace}/{repo}-{n}-{slug}`, so the folder directly under the dev root names the workspace. Matched case-insensitively. Crow-owned dev-root directories are skipped rather than looked up, so `crow-reviews` is reserved and cannot be a workspace name.
 2. **By repo** — review sessions clone to `{devRoot}/crow-reviews/{repo}-pr-{N}`, which sits outside any workspace folder, so there's no path to read a workspace from. Crow instead takes the PR's `owner/repo` and finds the workspace that claims it: a slug matching `alwaysInclude` or `autoReviewRepos` (the same `org/*` glob syntax those lists use elsewhere). Before CROW-891 this step didn't exist, so **every** review silently ran with `ANTHROPIC_*` unset regardless of its workspace's gateway.
 
 Notes on the repo lookup:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,17 +139,33 @@ A workspace can route its Claude Code sessions through a proxy/gateway (e.g. an 
 }
 ```
 
-- **`baseURL`** — exported as `ANTHROPIC_BASE_URL` for the workspace's `claude` launches.
+- **`baseURL`** — exported as `ANTHROPIC_BASE_URL` for the session's `claude` launches.
 - **`customHeaders`** — a `Name: Value` map exported as `ANTHROPIC_CUSTOM_HEADERS` (newline-separated). Both fields must be set together; a `baseURL` with no headers (or vice versa) is rejected when the config is loaded.
 
-When a workspace has a `gateway`, Crow injects these vars two ways so they apply on the initial launch *and* survive manual `claude` re-runs:
+When a session resolves to a workspace with a `gateway`, Crow injects these vars two ways so they apply on the initial launch *and* survive manual `claude` re-runs:
 
 1. **Launch line** — the `claude` invocation is prefixed with the env-var assignments, overriding any global `~/.zshrc` export for that launch. (When a workspace has multiple headers, the header value can't go on the line — an embedded newline would submit the command early — so it's carried by `settings.local.json` and the launch line instead `unset`s any inherited `ANTHROPIC_CUSTOM_HEADERS` so the gateway's `baseURL` is never paired with stale global headers.)
 2. **`settings.local.json`** — the resolved values are written to the worktree's `.claude/settings.local.json` `env` block (gitignored, mode `0600`), which Claude Code reads on every run.
 
-When a workspace has **no** `gateway`, Crow instead prefixes the launch with `unset ANTHROPIC_BASE_URL ANTHROPIC_CUSTOM_HEADERS` so a global shell export — or a sibling workspace's gateway — can't bleed into it. Edit a workspace's gateway in **Settings → Workspaces**.
+When no workspace claims the session — or the one that does has **no** `gateway` — Crow instead prefixes the launch with `unset ANTHROPIC_BASE_URL ANTHROPIC_CUSTOM_HEADERS` so a global shell export, or a sibling workspace's gateway, can't bleed into it. Edit a workspace's gateway in **Settings → Workspaces**.
 
 > **Precedence note:** the launch-line assignment is what reliably overrides a value exported by your shell for the initial launch. Whether Claude Code's `settings.local.json` `env` block *alone* overrides an inherited shell variable (e.g. an `ANTHROPIC_BASE_URL` still left in `~/.zshrc`) is not something Crow controls — so the intended end state is to delete the global `~/.zshrc` exports once per-workspace gateways are configured, leaving `config.json` the single source of truth.
+
+> **Applied at launch:** the gateway env is resolved and written when the agent **starts** (or is handed off to another agent). A session that was already running when you edited a gateway keeps the environment it launched with — relaunch it, or hand it off, to pick up the change.
+
+### Which gateway applies
+
+Crow resolves a session's workspace two ways, in order:
+
+1. **By worktree location** — work and job worktrees live at `{devRoot}/{workspace}/{repo}-{n}-{slug}`, so the folder directly under the dev root names the workspace. Matched case-insensitively.
+2. **By repo** — review sessions clone to `{devRoot}/crow-reviews/{repo}-pr-{N}`, which sits outside any workspace folder, so there's no path to read a workspace from. Crow instead takes the PR's `owner/repo` and finds the workspace that claims it: a slug matching `alwaysInclude` or `autoReviewRepos` (the same `org/*` glob syntax those lists use elsewhere). Before CROW-891 this step didn't exist, so **every** review silently ran with `ANTHROPIC_*` unset regardless of its workspace's gateway.
+
+Notes on the repo lookup:
+
+- **`excludeReviewRepos` is not consulted.** It controls what the review board *shows*, not which workspace a repo belongs to — a repo you've hidden from the board still gets its workspace's gateway when you review it manually.
+- **Ambiguity is deterministic.** If two workspaces claim the same repo, one naming it exactly (`acme/widget`) beats one matching only through a glob (`acme/*`); among equals, the earlier workspace in `config.json` wins.
+- **A `"*"` pattern claims everything**, making that workspace the fallback owner for any repo no other workspace names.
+- **No match means unset, not inherit.** A PR in a repo no workspace claims runs against the vanilla Anthropic API and logs `No workspace claims repo …`. The Manager's gateway is never inherited by other sessions — see [Manager gateway](#manager-gateway).
 
 ### Secret storage
 
@@ -159,6 +175,8 @@ A header value can be either:
 - **A plaintext value** — stored as-is in `config.json` (mode `0600`). Convenient for local dev, but **anyone with read access to the file can see the key**. The Settings UI shows a warning. Prefer an `op://` reference for production keys.
 
 `op://` keeps secrets out of `config.json` — but note it does **not** mean "no secret on disk." The *resolved* value is written into the worktree's `.claude/settings.local.json` `env` block (so manual re-runs inherit it) and cached there for the worktree's lifetime. That file is gitignored and written `0600` (owner-only), the same protection `config.json` gets. Resolved secret values are never logged.
+
+Since CROW-891 this also applies to **review clones**, which contain code from the PR's author. The file is still `0600` and Crow never executes the clone, but the resolved header now lives inside a directory of untrusted code — so an agent in a review session can read it if a hostile PR talks it into doing so. If that matters for your gateway key, exclude those repos from the workspace's `alwaysInclude`/`autoReviewRepos` so reviews on them resolve to no gateway.
 
 ### Manager gateway
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,8 @@ Notes on the repo lookup:
 - **A `"*"` pattern claims everything**, making that workspace the fallback owner for any repo no other workspace names.
 - **No match means unset, not inherit.** A PR in a repo no workspace claims runs against the vanilla Anthropic API and logs `No workspace claims repo …`. The Manager's gateway is never inherited by other sessions — see [Manager gateway](#manager-gateway).
 
+Both membership lists are editable from **Settings → Workspaces** or with `crow workspace edit --workspace NAME --always-include acme/widget --auto-review-repo 'acme/*'` (note those flags replace the whole list rather than appending — see [cli-reference.md](cli-reference.md#workspace-commands)). So a review that resolved to no gateway is usually fixed by adding its repo to the owning workspace.
+
 ### Secret storage
 
 A header value can be either:


### PR DESCRIPTION
Closes #891

## The bug

A workspace can route its Claude Code sessions through an internal LLM gateway (CROW-402). Review sessions never got one.

`SessionService.workspaceGatewayResolved(for:)` derived the workspace purely from path math — the first component under the dev root. That works for work and job sessions, whose worktrees live at `{devRoot}/{workspace}/{repo}-{n}-{slug}`. Review clones don't: `prepareReviewClone` puts them in a flat sibling directory, `{devRoot}/crow-reviews/{repo}-pr-{N}`. So the derived name was the literal string `"crow-reviews"`, which matches no workspace, and resolution returned `nil` for **every review, always**.

`nil` is not a no-op — it actively strips the gateway:

- `ClaudeLaunchArgs.gatewayEnvPrefix(nil)` prefixes the launch with `unset ANTHROPIC_BASE_URL ANTHROPIC_CUSTOM_HEADERS &&`
- `ClaudeHookConfigWriter.writeGatewayEnv(resolved: nil)` removes the `env` block from the clone's `settings.local.json`

So a review didn't merely miss the gateway; it defeated the workaround too. Exporting the vars in `~/.zshrc` couldn't help, because the launch line unsets them after the shell has run.

## The fix

Keep path lookup as the fast path, add a repo-slug fallback.

**`AppConfig.workspace(forRepoSlug:)`** (new, CrowCore) answers "which workspace owns `owner/repo`?" by matching the slug against `alwaysInclude` ∪ `autoReviewRepos` using the existing `repoMatchesPatterns` glob semantics.

**`workspaceGatewayResolved`** now tries the path, then — if nothing matched — the PR link's `owner/repo` via a new pure `repoSlug(fromPRLinks:)`. That helper reuses `Session.parseReviewPR`, the same parser `createReviewSession` used to name the clone, so resolution can't disagree with creation about what the repo is.

### Two decisions worth flagging

**`excludeReviewRepos` is deliberately not consulted.** It's a review-board *visibility* filter, not a membership statement. Subtracting it would mean a repo you'd hidden from the board silently lost its gateway when you reviewed it by hand — and because `effectiveExcludeReviewRepos` is a global union, one workspace's exclusion would suppress every workspace's match. Pinned by `workspaceForRepoSlugIgnoresExcludeReviewRepos`.

**No match still means unset, now deliberately and logged.** A PR in a repo no workspace claims runs vanilla and logs `No workspace claims repo …`. Falling back to `managerGateway` was considered and rejected: it would route a one-off PR from an unrelated org through your corporate gateway without asking. The Manager's gateway stays the Manager's alone.

Ambiguity is resolved deterministically so the answer can't flip when workspaces are reordered: an exact slug beats a glob, then config order. `workspaceForRepoSlugPrefersExactOverGlob` puts the glob *first* in config order and asserts the exact match still wins.

## Things a reviewer should look at

**The fallback is not gated on `session.kind == .review`.** It's gated on the precondition — path lookup empty *and* a PR link parses. The path fast path strictly dominates for any session under a workspace folder, so a kind gate would be dead weight there. And `.pr` links are not review-only: `IssueTracker.swift:1214`, `:1654` and `SessionService.swift:2171` attach them to **work** sessions once their PR opens. What a kind gate would suppress is therefore real and desirable — a work session whose worktree sits outside the dev root currently gets its gateway stripped, and now inherits its repo's workspace gateway instead. That is a behavior change beyond reviews; the log line makes it observable.

**The path fast path became case-insensitive.** It was `$0.name == wsName`, exact. APFS is case-preserving but case-*insensitive*, so a workspace named `Spotlight` with an on-disk folder `spotlight` is the same directory yet failed to match — silently stripping the gateway for every session in it. This widens matching only; it cannot turn a current match into a non-match. Note `resolvedCodeProvider` (`SessionService.swift:2180`) still does the case-sensitive compare against the same field; fixing that belongs to whatever ticket owns code-provider resolution, not this one.

**GitLab MR URLs resolve to a garbage slug**, and therefore to "unset" — exactly today's behavior, no regression. The mis-parse is upstream: `createReviewSession` uses the same `parseReviewPR`, so a GitLab review clone is *already* named `--pr-12`. Deliberately not fixed here, but pinned by `repoSlugForGitLabMRIsMalformedButStable` so a future GitLab fix updates it consciously rather than drifting.

**A resolved secret now lands in review clones**, which contain the PR author's code. The file is still `0600` and Crow never executes the clone, but the header is now readable by an agent working in a directory of untrusted code — a hostile PR could try to talk it into `cat`-ing `settings.local.json`. The risk is inherent to the mechanism and already applies to work and job sessions; extending it to reviews should be a conscious choice, so it's documented in `configuration.md` alongside the opt-out (drop the repo from the workspace's `alwaysInclude`/`autoReviewRepos`).

## Testing

23 new tests, all passing.

**CrowCore (13)** — `AppConfigWorkspaceForRepoSlugTests`. Runs in the PR Linux lane, which is why the lookup lives in CrowCore rather than CrowEngine (ADR 0007 excludes CrowEngine from `ci.yml`). Covers the `alwaysInclude` ∪ `autoReviewRepos` union, case-insensitivity both directions, globs, the `excludeReviewRepos` guard, both ambiguity rules, and membership-without-a-gateway.

**CrowEngine (10)** — `SessionServiceGatewayResolutionTests`, local `make test` only. Covers `repoSlug(fromPRLinks:)` (link-type selection, first-*parseable* rather than first, the GitLab shape) and `workspaceName(forWorktreePath:devRoot:)`, which had no tests at all despite being the function the bug lived in. `workspaceNameOfReviewCloneIsCrowReviews` pins the root cause as an executable assertion.

`workspaceGatewayResolved` itself is not directly tested: it reads `ConfigStore.loadDevRoot()`, which is all-static with no injection seam, and `SessionService.init` takes no devRoot or config — exercising it would mean touching the live devroot pointer, which ADR 0012 forbids. Every *decision* it makes now lives in the three pure helpers above, which is what made this testable at all. `workspaceName` and `repoSlug` are `nonisolated` for the same reason the file's existing `shouldStripCursorReviewCloneOnHandoff` is.

**Parity gate untouched, as intended.** The new member is a *method* on `AppConfig`, and `ParityGateTests` walks stored properties via `Mirror` — confirmed by the existing computed `effectiveExcludeReviewRepos`, which likewise has no ledger row. `make parity` passes with no `ParityLedger` edit.

**Parity gate: two rows added, eleven exemptions retired.** `make parity` was already red on `main` — `automation-get`/`automation-set` shipped with #884 but never got `ParityLedger` rows, the gap `b21ab1a` documented and left to CROW-807. Since the gate blocks this PR, it's fixed here rather than worked around:

- Added `.read("automation-get", cli: "automation get")` and `.write("automation-set", cli: "automation set")` — `check-cli-parity.sh` now reports 89 methods agreeing, up from a 87-vs-89 mismatch.
- Retired the eleven `automation.*` **config-field** exemptions. Each read "Web Settings toggle; no verb reads or writes it", which stopped being true when the automation verbs shipped; they're now covered rows pointing at `automation get`/`automation set`. This is the same cleanup #883's own history describes for the `agents-*` and `defaults.*` rows — closing a gap by deleting exemptions is what the ledger is for.

This is unrelated to the gateway bug and reviewable independently — it's the first two commits' worth of change in one file, and reverting it leaves the CROW-891 fix intact.

## Docs

`configuration.md` gains a **Which gateway applies** section — the two-step resolution, the `excludeReviewRepos` carve-out, the ambiguity rule, and the explicit "no match means unset, and the Manager's gateway is never inherited". The section previously said "per-workspace" throughout and never mentioned reviews at all.

Also adds the note the ticket asked for: gateway env is applied at agent **launch**, so a session already running when you edit a gateway keeps its old environment until it's relaunched or handed off.

## Not addressed

The ticket's third note — that the settings UI stores a header value verbatim after the first `:`, so a value pasted with surrounding shell quotes is sent as `x-citadel-api-key: "Bearer sk-…"` and silently 401s. That's a `Resources/web/settings.js` validation change with no overlap with this code path; it deserves its own ticket rather than a drive-by here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
