### PR TITLE
Repair hook blocks that outlived the worktree their crow binary came from

### DIFF
--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -27,13 +27,24 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
 
     // MARK: - Generate Hook Configuration
 
+    /// The exact hook command Crow writes. Single source of truth shared with
+    /// `ClaudeHookRepair`, which both parses this shape to decide what it owns
+    /// and re-emits it when repairing a stale entry (#897).
+    ///
+    /// `crowPath` is shell-quoted: Claude runs hook commands through `/bin/sh
+    /// -c`, so an unquoted dev root containing a space (`/Users/x/My Dev`)
+    /// silently broke all 17 hooks. Matches `CursorHookConfigWriter` and
+    /// `AntigravityHookConfigWriter`, which already quote for this reason.
+    static func hookCommand(crowPath: String, sessionID: UUID, event: String) -> String {
+        "\(ClaudeLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --event \(event)"
+    }
+
     /// Generate the hooks dictionary for a session.
     static func generateHooks(sessionID: UUID, crowPath: String) -> [String: Any] {
-        let sid = sessionID.uuidString
         var hooks: [String: Any] = [:]
 
         for event in allEvents {
-            let command = "\(crowPath) hook-event --session \(sid) --event \(event)"
+            let command = hookCommand(crowPath: crowPath, sessionID: sessionID, event: event)
             var hookEntry: [String: Any] = [
                 "type": "command",
                 "command": command,
@@ -196,7 +207,7 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
     /// Resolve the running app's own `crow` CLI — the bundled binary in a
     /// release `.app` (`Contents/MacOS/crow`), or `.build/{config}/crow` in
     /// dev. Does not consult `{devRoot}/.claude/bin/crow`; use that for
-    /// agent-facing resolution via `findCrowBinary(devRoot:)`.
+    /// agent-facing resolution via `resolveCrowBinary(devRoot:)`.
     public static func appCrowBinary() -> String? {
         // Same directory as the running executable (dev + release bundles).
         let execURL = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
@@ -226,6 +237,12 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
     /// Find the `crow` binary agents and hook configs should invoke. Prefers
     /// `{devRoot}/.claude/bin/crow` when scaffolded and executable (CROW-552),
     /// then falls back to `appCrowBinary()` and common install locations.
+    ///
+    /// Read-only — it never *creates* the symlink, so a dev build whose link is
+    /// missing or dangling falls through to a `.build/…/debug/crow` path that
+    /// dies with the worktree it was built in. Anything whose result is written
+    /// to disk must use `resolveCrowBinary` instead (#897); this stays for
+    /// callers that only need to *locate* a crow to run right now.
     public static func findCrowBinary(devRoot: String? = nil) -> String? {
         if let devRoot {
             let symlink = (devRoot as NSString).appendingPathComponent(".claude/bin/crow")
@@ -234,5 +251,100 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
             }
         }
         return appCrowBinary()
+    }
+
+    /// Materialize `{devRoot}/.claude/bin/crow` → `appCrowPath ?? appCrowBinary()`,
+    /// returning the **link** path once it resolves to an executable (`nil`
+    /// otherwise). Idempotent; safe to call on every launch.
+    ///
+    /// The link is the stable anchor that makes hook commands survive worktree
+    /// churn: only its target moves when a dev build is rebuilt elsewhere, so
+    /// one relink at boot heals every `settings.local.json` at once (#897).
+    ///
+    /// Two deliberate behaviors, both load-bearing:
+    /// - A link already pointing at `target` is left alone rather than
+    ///   unlink+relink'd — that window is one where a concurrently firing hook
+    ///   sees ENOENT.
+    /// - A **non-symlink** `crow` at that path is never replaced. We only ever
+    ///   own symlinks here; a real file is the user's.
+    ///
+    /// `appCrowPath` is injectable for tests. All errors are logged and
+    /// swallowed — this is best-effort and must never fail a launch.
+    @discardableResult
+    public static func ensureCrowCLISymlink(devRoot: String, appCrowPath: String? = nil) -> String? {
+        let fm = FileManager.default
+        let binDir = (devRoot as NSString).appendingPathComponent(".claude/bin")
+        let link = (binDir as NSString).appendingPathComponent("crow")
+        let resolved = appCrowPath ?? appCrowBinary()
+
+        guard let target = resolved, fm.isExecutableFile(atPath: target) else {
+            // Drop a link we can no longer back, so a broken pointer doesn't
+            // shadow a working PATH install.
+            if let attrs = try? fm.attributesOfItem(atPath: link),
+               (attrs[.type] as? FileAttributeType) == .typeSymbolicLink {
+                try? fm.removeItem(atPath: link)
+            }
+            if let resolved {
+                CrowLog.info("[ClaudeHookConfigWriter] app crow binary not executable at \(resolved) — skipping symlink")
+            }
+            return nil
+        }
+
+        // Unlike Scaffolder, this can run against a dev root no scaffold pass
+        // has touched yet (a `crow send` before the first boot scaffold), so
+        // create the directory rather than assuming it.
+        do {
+            try fm.createDirectory(atPath: binDir, withIntermediateDirectories: true)
+        } catch {
+            CrowLog.info("[ClaudeHookConfigWriter] could not create bin dir \(binDir): \(error.localizedDescription)")
+            return nil
+        }
+
+        // Drive off attributesOfItem, not fileExists — the latter follows
+        // symlinks, so a dangling `crow` link (target moved/deleted) looks
+        // absent and we'd skip removal, then createSymbolicLink hits EEXIST.
+        if let attrs = try? fm.attributesOfItem(atPath: link) {
+            guard (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else {
+                CrowLog.info("[ClaudeHookConfigWriter] crow exists at \(link) but is not a symlink — leaving alone")
+                return fm.isExecutableFile(atPath: link) ? link : nil
+            }
+            if (try? fm.destinationOfSymbolicLink(atPath: link)) == target {
+                return link
+            }
+            try? fm.removeItem(atPath: link)
+        }
+
+        do {
+            try fm.createSymbolicLink(atPath: link, withDestinationPath: target)
+            return link
+        } catch {
+            CrowLog.info("[ClaudeHookConfigWriter] failed to symlink \(link) -> \(target): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// The `crow` path to bake into a hook command (or any other file on disk).
+    ///
+    /// Ensures the stable `{devRoot}/.claude/bin/crow` symlink first and returns
+    /// *that*, so an emitted command never contains a `.build/…` product path
+    /// belonging to whichever worktree the running daemon happened to be built
+    /// in — the root cause of #897.
+    ///
+    /// Falls back to `appCrowBinary()` only when there is no dev root or the
+    /// link could not be created, warning loudly if that fallback is itself a
+    /// build product. Deliberately not a `precondition`: crashing the daemon
+    /// over an unwritable dev root would be worse than the noise it prevents.
+    public static func resolveCrowBinary(devRoot: String?, appCrowPath: String? = nil) -> String? {
+        if let devRoot, let link = ensureCrowCLISymlink(devRoot: devRoot, appCrowPath: appCrowPath) {
+            return link
+        }
+        let fallback = appCrowPath ?? appCrowBinary()
+        if let fallback, fallback.contains("/.build/") {
+            CrowLog.info(
+                "[ClaudeHookConfigWriter] WARNING: falling back to build-product crow path \(fallback)"
+                + " — hook commands written now will break when that build directory is removed."
+                + " Check that \(devRoot ?? "<no dev root>")/.claude/bin is writable.")
+        }
+        return fallback
     }
 }

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
@@ -1,0 +1,371 @@
+import Foundation
+import CrowCore
+
+/// Repairs Crow-written Claude Code hook blocks that have gone stale on disk
+/// (#897).
+///
+/// The failure this exists for: an old dev build baked its own
+/// `.build/{arch}/debug/crow` path into every hook command it wrote. That
+/// worktree was later reaped, the session it named was deleted, and nothing in
+/// Crow ever revisits a `settings.local.json` once written — so the directory
+/// kept emitting `No such file or directory` on every hook event, and every
+/// session run there recorded no telemetry at all.
+///
+/// `ClaudeHookConfigWriter.resolveCrowBinary` stops *new* files from going
+/// stale (commands now name the `{devRoot}/.claude/bin/crow` symlink, whose
+/// target is re-pointed on every boot). This type cleans up the files written
+/// before that, and any that go stale some other way.
+///
+/// The scan is deliberately **filesystem-driven, not state-driven**: the whole
+/// point is that the broken directory's session is gone from `AppState`, which
+/// is exactly why enumerating live worktrees would miss it.
+public enum ClaudeHookRepair {
+
+    // MARK: - Parsing
+
+    /// A hook command recognized as one Crow wrote.
+    public struct ParsedCrowHook: Equatable, Sendable {
+        /// The crow binary path, already unquoted.
+        public let binary: String
+        public let sessionID: UUID
+        public let event: String
+    }
+
+    /// Shell metacharacters that turn a command into something more than a
+    /// plain invocation. A user hook that *wraps* `crow hook-event` in a
+    /// pipeline or chain is theirs, not ours — we must not rewrite it.
+    private static let disqualifyingCharacters: Set<Character> = [";", "|", "&", ">", "<", "`", "$", "(", ")", "\n"]
+
+    /// Parse `<abs-path> hook-event --session <uuid> [--agent <kind>] --event <Name>`,
+    /// as emitted by `ClaudeHookConfigWriter.hookCommand`. Returns `nil` for
+    /// anything that isn't exactly that shape.
+    ///
+    /// This predicate is the entire safety boundary for the sweep — everything
+    /// it accepts may be rewritten or deleted — so it is intentionally strict
+    /// and rejects on any surprise.
+    ///
+    /// Not a single anchored regex: `\S+` for the binary would fail on the
+    /// legacy *unquoted* path-containing-a-space form, which is itself broken
+    /// and is precisely a case worth repairing. So the binary is taken as
+    /// everything before the first ` hook-event ` instead.
+    public static func parseCrowHookCommand(_ command: String) -> ParsedCrowHook? {
+        let marker = " hook-event "
+        guard let markerRange = command.range(of: marker) else { return nil }
+
+        var binary = String(command[command.startIndex..<markerRange.lowerBound])
+            .trimmingCharacters(in: .whitespaces)
+        // Reverse `ClaudeLaunchArgs.shellQuote`. Only a fully-wrapped value is
+        // accepted; a partially quoted path is a shape we never wrote. Content
+        // inside single quotes is inert to the shell, so it needs no further
+        // scrutiny — but an *unquoted* segment (every pre-#897 file on disk) is
+        // raw shell, so any metacharacter there means it isn't a plain
+        // invocation and isn't ours.
+        if binary.count >= 2, binary.hasPrefix("'"), binary.hasSuffix("'") {
+            binary = String(binary.dropFirst().dropLast())
+                .replacingOccurrences(of: "'\\''", with: "'")
+        } else if binary.contains("'") || binary.contains("\"")
+                    || binary.contains(where: disqualifyingCharacters.contains) {
+            return nil
+        }
+        // Crow always writes an absolute path.
+        guard binary.hasPrefix("/") else { return nil }
+
+        let rest = String(command[markerRange.upperBound...])
+        guard !rest.contains(where: disqualifyingCharacters.contains) else { return nil }
+        let tokens = rest.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+
+        var sessionID: UUID?
+        var event: String?
+        var index = 0
+        while index < tokens.count {
+            let flag = tokens[index]
+            guard index + 1 < tokens.count else { return nil }
+            let value = tokens[index + 1]
+            switch flag {
+            case "--session":
+                guard sessionID == nil, let parsed = UUID(uuidString: value) else { return nil }
+                sessionID = parsed
+            case "--event":
+                guard event == nil else { return nil }
+                event = value
+            case "--agent":
+                break  // Optional; its value is not load-bearing for repair.
+            default:
+                return nil  // Any token we don't recognize means this isn't ours.
+            }
+            index += 2
+        }
+
+        guard let sessionID, let event, ClaudeHookConfigWriter.allEvents.contains(event) else { return nil }
+        return ParsedCrowHook(binary: binary, sessionID: sessionID, event: event)
+    }
+
+    // MARK: - Sweep
+
+    /// What one sweep did, for the boot log.
+    public struct Summary: Equatable, Sendable {
+        /// Directories that held a Crow-managed hook block.
+        public var scanned: Int = 0
+        /// Of those, the ones already correct — not written to at all.
+        public var healthy: Int = 0
+        /// Directories whose commands were rewritten to a live session + good binary.
+        public var repaired: [String] = []
+        /// Directories whose Crow-managed entries were removed (no live session).
+        public var stripped: [String] = []
+        /// Directories skipped because the file was unparseable or unwritable.
+        public var skipped: [String] = []
+
+        public init() {}
+
+        /// One-line form for `crowd`'s boot log.
+        public var logLine: String {
+            var line = "scanned \(scanned) hook block(s), \(healthy) healthy"
+            if !repaired.isEmpty { line += ", repaired \(repaired.count): \(repaired.joined(separator: ", "))" }
+            if !stripped.isEmpty { line += ", stripped \(stripped.count): \(stripped.joined(separator: ", "))" }
+            if !skipped.isEmpty { line += ", skipped \(skipped.count): \(skipped.joined(separator: ", "))" }
+            return line
+        }
+    }
+
+    /// Scan under `devRoot` and repair (or remove) stale Crow hook blocks.
+    ///
+    /// - Parameters:
+    ///   - crowPath: the binary to write into repaired commands, normally
+    ///     `ClaudeHookConfigWriter.resolveCrowBinary(devRoot:)`. When `nil`
+    ///     nothing can be repaired, so stale blocks are stripped instead —
+    ///     which still stops the hook errors and is better than leaving
+    ///     dangling commands in place.
+    ///   - liveSessionIDs / sessionByWorktreePath: a value snapshot of
+    ///     `AppState`, so this stays off the MainActor. Worktree paths must be
+    ///     `standardizingPath`-normalized.
+    ///   - managerSessionID: `AppState.managerSessionID`. The Manager's block
+    ///     lives at `{devRoot}/.claude/settings.local.json` and its session has
+    ///     no `SessionWorktree` row, so it is matched by this constant rather
+    ///     than by path lookup — without that it would be stripped, and nothing
+    ///     rewrites it on a warm daemon restart.
+    ///
+    /// Performs blocking file I/O; call from a detached task, never the
+    /// MainActor (#892).
+    public static func sweep(
+        devRoot: String,
+        crowPath: String?,
+        liveSessionIDs: Set<UUID>,
+        sessionByWorktreePath: [String: UUID],
+        managerSessionID: UUID,
+        excludeDirs: Set<String> = [],
+        maxDirs: Int = 2000
+    ) -> Summary {
+        var summary = Summary()
+        for dir in candidateDirectories(
+            devRoot: devRoot, excludeDirs: excludeDirs, maxDirs: maxDirs
+        ) {
+            let desiredSession = (dir == (devRoot as NSString).standardizingPath)
+                ? managerSessionID
+                : sessionByWorktreePath[dir]
+            repairDirectory(
+                dir, crowPath: crowPath, liveSessionIDs: liveSessionIDs,
+                desiredSession: desiredSession, into: &summary)
+        }
+        return summary
+    }
+
+    // MARK: - Traversal
+
+    /// `devRoot` itself (the Manager) plus every directory two levels down —
+    /// `{devRoot}/{workspace}/{repo-or-worktree}`, which covers work and job
+    /// worktrees, main clones (the reported case), and review clones under
+    /// `crow-reviews/`.
+    ///
+    /// Depth is capped at 2 on purpose: it matches the layout `Scaffolder`,
+    /// `detectOrphanedWorktrees`, and `workspaceName(forWorktreePath:devRoot:)`
+    /// already assume, and it means `.build`/`node_modules` (depth 3+) are
+    /// never reached at all.
+    static func candidateDirectories(
+        devRoot: String, excludeDirs: Set<String>, maxDirs: Int
+    ) -> [String] {
+        let fm = FileManager.default
+        let root = (devRoot as NSString).standardizingPath
+        var candidates = [root]
+
+        func children(of path: String) -> [String] {
+            guard let entries = try? fm.contentsOfDirectory(atPath: path) else { return [] }
+            return entries.sorted().compactMap { name in
+                // Dotted names cover `.claude`, `.git`, and every other dot dir.
+                guard !name.hasPrefix("."), !excludeDirs.contains(name) else { return nil }
+                let child = (path as NSString).appendingPathComponent(name)
+                // `attributesOfItem` lstats — unlike `fileExists(isDirectory:)`,
+                // which follows symlinks. A workspace symlinked outside devRoot
+                // must not be walked.
+                guard let attrs = try? fm.attributesOfItem(atPath: child),
+                      (attrs[.type] as? FileAttributeType) == .typeDirectory else { return nil }
+                return child
+            }
+        }
+
+        outer: for workspace in children(of: root) {
+            for candidate in children(of: workspace) {
+                candidates.append(candidate)
+                if candidates.count >= maxDirs {
+                    CrowLog.info(
+                        "[ClaudeHookRepair] hit the \(maxDirs)-directory cap under \(root)"
+                        + " — stopping the scan early; later directories were not checked.")
+                    break outer
+                }
+            }
+        }
+        return candidates
+    }
+
+    // MARK: - Per-directory repair
+
+    private static func repairDirectory(
+        _ dir: String,
+        crowPath: String?,
+        liveSessionIDs: Set<UUID>,
+        desiredSession: UUID?,
+        into summary: inout Summary
+    ) {
+        let fm = FileManager.default
+        let settingsPath = (dir as NSString).appendingPathComponent(".claude/settings.local.json")
+        guard let data = fm.contents(atPath: settingsPath) else { return }
+        guard var settings = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = settings["hooks"] as? [String: Any] else {
+            // A file that exists but doesn't parse is left strictly alone: we
+            // can't tell our entries from the user's, and rewriting from `[:]`
+            // would drop every unrelated key.
+            if (try? JSONSerialization.jsonObject(with: data)) == nil {
+                summary.skipped.append(dir)
+            }
+            return
+        }
+
+        // Inventory first — decide before touching anything.
+        var parsed: [ParsedCrowHook] = []
+        for event in ClaudeHookConfigWriter.allEvents {
+            for group in (hooks[event] as? [[String: Any]] ?? []) {
+                for entry in (group["hooks"] as? [[String: Any]] ?? []) {
+                    if let command = entry["command"] as? String,
+                       let hook = parseCrowHookCommand(command) {
+                        parsed.append(hook)
+                    }
+                }
+            }
+        }
+        guard !parsed.isEmpty else { return }
+        summary.scanned += 1
+
+        let allHealthy = parsed.allSatisfy {
+            fm.isExecutableFile(atPath: $0.binary) && liveSessionIDs.contains($0.sessionID)
+        }
+        if allHealthy {
+            summary.healthy += 1
+            return  // No write at all — mtime and contents untouched.
+        }
+
+        let updatedHooks: [String: Any]
+        let action: String
+        if let sessionID = desiredSession, let crowPath {
+            updatedHooks = rewriteCommands(in: hooks, crowPath: crowPath, sessionID: sessionID)
+            action = "repaired"
+        } else {
+            updatedHooks = stripCrowEntries(from: hooks)
+            action = "stripped"
+        }
+
+        if updatedHooks.isEmpty {
+            settings.removeValue(forKey: "hooks")
+        } else {
+            settings["hooks"] = updatedHooks
+        }
+
+        do {
+            if settings.isEmpty {
+                // Nothing of ours or the user's left — the file only ever held
+                // the stale block (exactly the reported case).
+                try fm.removeItem(atPath: settingsPath)
+            } else {
+                let out = try JSONSerialization.data(
+                    withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+                // NON-atomic on purpose: `writeGatewayEnv` chmods this file 0600
+                // because its `env` block can carry a gateway bearer token, and
+                // an atomic write replaces the inode, resetting the mode to the
+                // umask default. Truncating in place preserves both.
+                try out.write(to: URL(fileURLWithPath: settingsPath))
+            }
+        } catch {
+            CrowLog.info("[ClaudeHookRepair] failed to write \(settingsPath): \(error.localizedDescription)")
+            summary.skipped.append(dir)
+            return
+        }
+
+        if action == "repaired" {
+            summary.repaired.append(dir)
+        } else {
+            summary.stripped.append(dir)
+        }
+    }
+
+    /// Rewrite every Crow-managed command in place, keeping the file's existing
+    /// shape: same event keys, same matcher groups, same `type`/`timeout`/`async`.
+    ///
+    /// Deliberately not `ClaudeHookConfigWriter.writeHookConfig`, which expands
+    /// to all 17 events and replaces each event key's whole array — on a
+    /// directory that only ever had a subset that silently re-broadens Crow's
+    /// footprint and destroys user matcher groups. Taking the event name from
+    /// the *key* rather than the parsed command also self-heals a key/command
+    /// mismatch for free.
+    private static func rewriteCommands(
+        in hooks: [String: Any], crowPath: String, sessionID: UUID
+    ) -> [String: Any] {
+        var updated = hooks
+        for event in ClaudeHookConfigWriter.allEvents {
+            guard let groups = hooks[event] as? [[String: Any]] else { continue }
+            updated[event] = groups.map { group -> [String: Any] in
+                guard let entries = group["hooks"] as? [[String: Any]] else { return group }
+                var group = group
+                group["hooks"] = entries.map { entry -> [String: Any] in
+                    guard let command = entry["command"] as? String,
+                          parseCrowHookCommand(command) != nil else { return entry }
+                    var entry = entry
+                    entry["command"] = ClaudeHookConfigWriter.hookCommand(
+                        crowPath: crowPath, sessionID: sessionID, event: event)
+                    return entry
+                }
+                return group
+            }
+        }
+        return updated
+    }
+
+    /// Remove only the entries we recognize as ours, dropping groups and event
+    /// keys that end up empty.
+    ///
+    /// Deliberately not `ClaudeHookConfigWriter.removeHookConfig`, which drops
+    /// all 17 event keys wholesale — including a user's own hand-authored
+    /// `Stop` or `PreToolUse` entry that merely shares an event name.
+    /// `SessionService.writeManagerHookConfig` already documents refusing to
+    /// run that against the dev root for the same reason.
+    private static func stripCrowEntries(from hooks: [String: Any]) -> [String: Any] {
+        var updated = hooks
+        for event in ClaudeHookConfigWriter.allEvents {
+            guard let groups = hooks[event] as? [[String: Any]] else { continue }
+            let kept = groups.compactMap { group -> [String: Any]? in
+                guard let entries = group["hooks"] as? [[String: Any]] else { return group }
+                let survivors = entries.filter { entry in
+                    guard let command = entry["command"] as? String else { return true }
+                    return parseCrowHookCommand(command) == nil
+                }
+                if survivors.isEmpty { return nil }
+                var group = group
+                group["hooks"] = survivors
+                return group
+            }
+            if kept.isEmpty {
+                updated.removeValue(forKey: event)
+            } else {
+                updated[event] = kept
+            }
+        }
+        return updated
+    }
+}

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
@@ -77,3 +77,109 @@ struct ClaudeHookConfigWriterTests {
         #expect(try posixPerms(at: dir) == 0o600)
     }
 }
+
+/// #897: a hook command must never name a build product. An old dev build baked
+/// its own `.build/{arch}/debug/crow` into every command it wrote; when that
+/// worktree was reaped the commands became permanently dangling, so every hook
+/// event failed and all telemetry from that directory was silently lost.
+@Suite("ClaudeHookConfigWriter crow-path resolution")
+struct ClaudeHookConfigWriterCrowPathTests {
+    /// A temp dev root plus a fake "app binary" living under a `.build/` tree,
+    /// standing in for a `swift build` product inside a worktree.
+    private func makeDevRootWithBuildProduct() throws -> (devRoot: URL, appBinary: String) {
+        let devRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-crowpath-\(UUID().uuidString)")
+        let buildDir = devRoot.appendingPathComponent(".build/arm64-apple-macosx/debug")
+        try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+        let binary = buildDir.appendingPathComponent("crow")
+        try Data("#!/bin/sh\n".utf8).write(to: binary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        return (devRoot, binary.path)
+    }
+
+    @Test func resolveReturnsStableSymlinkNotBuildProduct() throws {
+        let (devRoot, appBinary) = try makeDevRootWithBuildProduct()
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+
+        let resolved = try #require(
+            ClaudeHookConfigWriter.resolveCrowBinary(devRoot: devRoot.path, appCrowPath: appBinary))
+
+        #expect(resolved == devRoot.appendingPathComponent(".claude/bin/crow").path)
+        #expect(!resolved.contains("/.build/"))
+        // The link is what makes the path stable; its target is the build product.
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: resolved) == appBinary)
+    }
+
+    /// The issue's explicit acceptance criterion.
+    @Test func generatedCommandsNeverContainABuildPath() throws {
+        let (devRoot, appBinary) = try makeDevRootWithBuildProduct()
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+
+        let crowPath = try #require(
+            ClaudeHookConfigWriter.resolveCrowBinary(devRoot: devRoot.path, appCrowPath: appBinary))
+        let hooks = ClaudeHookConfigWriter.generateHooks(sessionID: UUID(), crowPath: crowPath)
+
+        #expect(hooks.count == ClaudeHookConfigWriter.allEvents.count)
+        for event in ClaudeHookConfigWriter.allEvents {
+            let groups = try #require(hooks[event] as? [[String: Any]])
+            let entries = try #require(groups.first?["hooks"] as? [[String: Any]])
+            let command = try #require(entries.first?["command"] as? String)
+            #expect(!command.contains("/.build/"), "\(event) command names a build product: \(command)")
+        }
+    }
+
+    /// A dev root containing a space used to kill all 17 hooks: the path was
+    /// interpolated raw into a command Claude runs through `/bin/sh -c`.
+    @Test func commandsAreShellSafeForDevRootsContainingSpaces() throws {
+        let session = UUID()
+        let command = ClaudeHookConfigWriter.hookCommand(
+            crowPath: "/Users/x/My Dev/.claude/bin/crow", sessionID: session, event: "Stop")
+
+        #expect(command.hasPrefix("'/Users/x/My Dev/.claude/bin/crow' "))
+        let parsed = try #require(ClaudeHookRepair.parseCrowHookCommand(command))
+        #expect(parsed.binary == "/Users/x/My Dev/.claude/bin/crow")
+        #expect(parsed.sessionID == session)
+        #expect(parsed.event == "Stop")
+    }
+
+    @Test func ensureRepairsADanglingLinkAndIsIdempotent() throws {
+        let (devRoot, appBinary) = try makeDevRootWithBuildProduct()
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+        let fm = FileManager.default
+        let binDir = devRoot.appendingPathComponent(".claude/bin")
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let link = binDir.appendingPathComponent("crow").path
+
+        // A link left over from a worktree that has since been deleted.
+        try fm.createSymbolicLink(atPath: link, withDestinationPath: "/nonexistent/gone/crow")
+
+        #expect(ClaudeHookConfigWriter.ensureCrowCLISymlink(devRoot: devRoot.path, appCrowPath: appBinary) == link)
+        #expect(try fm.destinationOfSymbolicLink(atPath: link) == appBinary)
+
+        // Second pass must not unlink+relink — that window is one where a
+        // concurrently firing hook sees ENOENT.
+        let inodeBefore = try #require(
+            (try fm.attributesOfItem(atPath: link)[.systemFileNumber] as? NSNumber)?.uint64Value)
+        #expect(ClaudeHookConfigWriter.ensureCrowCLISymlink(devRoot: devRoot.path, appCrowPath: appBinary) == link)
+        let inodeAfter = try #require(
+            (try fm.attributesOfItem(atPath: link)[.systemFileNumber] as? NSNumber)?.uint64Value)
+        #expect(inodeBefore == inodeAfter)
+    }
+
+    @Test func ensureNeverReplacesANonSymlinkFile() throws {
+        let (devRoot, appBinary) = try makeDevRootWithBuildProduct()
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+        let fm = FileManager.default
+        let binDir = devRoot.appendingPathComponent(".claude/bin")
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let link = binDir.appendingPathComponent("crow")
+        try Data("user's own script".utf8).write(to: link)
+
+        _ = ClaudeHookConfigWriter.ensureCrowCLISymlink(devRoot: devRoot.path, appCrowPath: appBinary)
+
+        // Still the user's file, untouched — we only ever own symlinks here.
+        #expect(try String(contentsOf: link, encoding: .utf8) == "user's own script")
+        let attrs = try fm.attributesOfItem(atPath: link.path)
+        #expect((attrs[.type] as? FileAttributeType) != .typeSymbolicLink)
+    }
+}

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookRepairTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookRepairTests.swift
@@ -1,0 +1,434 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowClaude
+
+/// #897: an old dev build baked `.build/{arch}/debug/crow` into every hook
+/// command it wrote. That worktree was later reaped and its session deleted, so
+/// the `settings.local.json` it left behind in a long-lived main clone failed
+/// every hook event forever — noisy, and it silently dropped all telemetry for
+/// sessions run there. `ClaudeHookRepair` is the only code that mutates a
+/// settings file Crow did not itself just write, so these tests pin down what
+/// it will and (mostly) will not touch.
+@Suite("ClaudeHookRepair.parseCrowHookCommand")
+struct ClaudeHookRepairParseTests {
+    private let session = UUID(uuidString: "2BEF7A0D-743B-47A3-819A-C39C180F6977")!
+
+    @Test func acceptsTheQuotedFormWeWriteToday() throws {
+        let parsed = try #require(ClaudeHookRepair.parseCrowHookCommand(
+            "'/Users/x/Dev/.claude/bin/crow' hook-event --session \(session.uuidString) --event Stop"))
+        #expect(parsed.binary == "/Users/x/Dev/.claude/bin/crow")
+        #expect(parsed.sessionID == session)
+        #expect(parsed.event == "Stop")
+    }
+
+    /// Every file already on disk predates the quoting, so the parser must
+    /// still recognize the legacy shape — that is the whole point.
+    @Test func acceptsTheLegacyUnquotedForm() throws {
+        let parsed = try #require(ClaudeHookRepair.parseCrowHookCommand(
+            "/Users/x/Dev/crow-136/.build/arm64-apple-macosx/debug/crow"
+            + " hook-event --session \(session.uuidString) --event PostToolUse"))
+        #expect(parsed.binary.hasSuffix("/.build/arm64-apple-macosx/debug/crow"))
+        #expect(parsed.event == "PostToolUse")
+    }
+
+    /// An unquoted path with a space is itself broken (the shell splits it) and
+    /// is exactly a case worth repairing, so it must parse rather than be
+    /// dismissed as "not ours".
+    @Test func acceptsAnUnquotedPathContainingSpaces() throws {
+        let parsed = try #require(ClaudeHookRepair.parseCrowHookCommand(
+            "/Users/x/My Dev/.claude/bin/crow hook-event --session \(session.uuidString) --event Stop"))
+        #expect(parsed.binary == "/Users/x/My Dev/.claude/bin/crow")
+    }
+
+    @Test func acceptsTheOptionalAgentFlag() throws {
+        let parsed = try #require(ClaudeHookRepair.parseCrowHookCommand(
+            "/bin/crow hook-event --session \(session.uuidString) --agent claude-code --event Stop"))
+        #expect(parsed.event == "Stop")
+    }
+
+    @Test(arguments: [
+        // A user hook that merely *wraps* our command is theirs, not ours.
+        "/bin/crow hook-event --session 2BEF7A0D-743B-47A3-819A-C39C180F6977 --event Stop | tee /tmp/log",
+        "/bin/crow hook-event --session 2BEF7A0D-743B-47A3-819A-C39C180F6977 --event Stop; rm -rf /",
+        "echo hi && /bin/crow hook-event --session 2BEF7A0D-743B-47A3-819A-C39C180F6977 --event Stop",
+        // Crow always writes an absolute path.
+        "crow hook-event --session 2BEF7A0D-743B-47A3-819A-C39C180F6977 --event Stop",
+        // Unknown flags, malformed uuid, unmanaged event name.
+        "/bin/crow hook-event --session 2BEF7A0D-743B-47A3-819A-C39C180F6977 --event Stop --extra x",
+        "/bin/crow hook-event --session not-a-uuid --event Stop",
+        "/bin/crow hook-event --session 2BEF7A0D-743B-47A3-819A-C39C180F6977 --event MadeUpEvent",
+        // Not a hook-event invocation at all.
+        "/bin/crow list-sessions",
+        "npm run lint",
+    ])
+    func rejectsAnythingThatIsNotExactlyOurShape(command: String) {
+        #expect(ClaudeHookRepair.parseCrowHookCommand(command) == nil, "should not claim: \(command)")
+    }
+}
+
+@Suite("ClaudeHookRepair.sweep")
+struct ClaudeHookRepairSweepTests {
+    private let deadSession = UUID(uuidString: "2BEF7A0D-743B-47A3-819A-C39C180F6977")!
+    private let deadBinary = "/Users/x/Dev/crow-136-session-analytics-otel/.build/arm64-apple-macosx/debug/crow"
+
+    // MARK: - Fixtures
+
+    /// A dev root with a real, executable `crow` at the stable symlink path.
+    private func makeDevRoot() throws -> (root: URL, crowPath: String) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-hookrepair-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent(".claude/bin")
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let crow = binDir.appendingPathComponent("crow")
+        try Data("#!/bin/sh\n".utf8).write(to: crow)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: crow.path)
+        return (root, crow.path)
+    }
+
+    @discardableResult
+    private func makeDir(_ root: URL, _ components: String) throws -> URL {
+        let url = root.appendingPathComponent(components)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// The exact shape the old writer emitted: 17 event keys, one group each,
+    /// one entry each.
+    private func staleHookBlock(binary: String, session: UUID) -> [String: Any] {
+        var hooks: [String: Any] = [:]
+        for event in ClaudeHookConfigWriter.allEvents {
+            hooks[event] = [[
+                "hooks": [[
+                    "type": "command",
+                    "command": "\(binary) hook-event --session \(session.uuidString) --event \(event)",
+                    "timeout": 5,
+                ] as [String: Any]]
+            ] as [String: Any]]
+        }
+        return hooks
+    }
+
+    private func writeSettings(_ settings: [String: Any], into dir: URL) throws {
+        let claudeDir = dir.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: claudeDir.appendingPathComponent("settings.local.json"))
+    }
+
+    private func settingsPath(_ dir: URL) -> String {
+        dir.appendingPathComponent(".claude/settings.local.json").path
+    }
+
+    /// The sweep standardizes every path it reports, and `LaunchScaffold` does
+    /// the same to the worktree paths it snapshots — so tests must compare
+    /// against standardized paths too. On macOS the temp dir is `/var/...`,
+    /// a symlink to `/private/var/...`.
+    private func std(_ url: URL) -> String { (url.path as NSString).standardizingPath }
+
+    private func readSettings(_ dir: URL) throws -> [String: Any] {
+        let data = try #require(FileManager.default.contents(atPath: settingsPath(dir)))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func commands(in settings: [String: Any], event: String) throws -> [String] {
+        let hooks = try #require(settings["hooks"] as? [String: Any])
+        let groups = try #require(hooks[event] as? [[String: Any]])
+        return groups.flatMap { group in
+            (group["hooks"] as? [[String: Any]] ?? []).compactMap { $0["command"] as? String }
+        }
+    }
+
+    // MARK: - Repair
+
+    @Test func repairsAStaleBlockInPlaceWhenTheDirectoryIsALiveWorktree() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "RadiusMethod/crow-900-thing")
+        let liveSession = UUID()
+
+        try writeSettings([
+            "hooks": staleHookBlock(binary: deadBinary, session: deadSession),
+            "permissions": ["allow": ["Bash(git status)"]],
+            "env": ["USER_VAR": "keep-me"],
+        ], into: worktree)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [liveSession],
+            sessionByWorktreePath: [std(worktree): liveSession],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.repaired == [std(worktree)])
+        #expect(summary.stripped.isEmpty)
+
+        let updated = try readSettings(worktree)
+        let hooks = try #require(updated["hooks"] as? [String: Any])
+        // Every command now names the live session and the good binary…
+        for event in ClaudeHookConfigWriter.allEvents {
+            let commands = try commands(in: updated, event: event)
+            #expect(commands == [ClaudeHookConfigWriter.hookCommand(
+                crowPath: crowPath, sessionID: liveSession, event: event)])
+        }
+        // …with no keys added or removed, and unrelated settings preserved.
+        #expect(Set(hooks.keys) == Set(ClaudeHookConfigWriter.allEvents))
+        #expect(updated["permissions"] != nil)
+        #expect((updated["env"] as? [String: Any])?["USER_VAR"] as? String == "keep-me")
+    }
+
+    /// A file that only ever had a subset of the events must not be expanded to
+    /// all 17 — that would silently broaden Crow's footprint.
+    @Test func repairDoesNotAddEventKeysTheFileNeverHad() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "ws/repo-1")
+        let liveSession = UUID()
+
+        var subset = staleHookBlock(binary: deadBinary, session: deadSession)
+        for event in ClaudeHookConfigWriter.allEvents where event != "Stop" {
+            subset.removeValue(forKey: event)
+        }
+        try writeSettings(["hooks": subset], into: worktree)
+
+        _ = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [liveSession],
+            sessionByWorktreePath: [std(worktree): liveSession],
+            managerSessionID: AppState.managerSessionID)
+
+        let hooks = try #require(try readSettings(worktree)["hooks"] as? [String: Any])
+        #expect(Set(hooks.keys) == ["Stop"])
+    }
+
+    /// The Manager's block lives at `{devRoot}/.claude/settings.local.json` and
+    /// its session has no worktree row, so a path lookup would find nothing and
+    /// strip it — and nothing rewrites it on a warm daemon restart.
+    @Test func managerBlockAtDevRootIsRepairedNotStripped() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: deadBinary, session: AppState.managerSessionID)],
+            into: root)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [],                      // Manager not in the snapshot
+            sessionByWorktreePath: [:],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.repaired == [std(root)])
+        let commands = try commands(in: try readSettings(root), event: "Stop")
+        #expect(commands == [ClaudeHookConfigWriter.hookCommand(
+            crowPath: crowPath, sessionID: AppState.managerSessionID, event: "Stop")])
+    }
+
+    @Test func repairPreservesOwnerOnlyPermissions() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "ws/repo-1")
+        let liveSession = UUID()
+
+        try writeSettings([
+            "hooks": staleHookBlock(binary: deadBinary, session: deadSession),
+            // The env block can carry a resolved gateway bearer token, which is
+            // why writeGatewayEnv chmods this file 0600.
+            "env": ["ANTHROPIC_CUSTOM_HEADERS": "X-Api-Key: secret"],
+        ], into: worktree)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: settingsPath(worktree))
+
+        _ = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [liveSession],
+            sessionByWorktreePath: [std(worktree): liveSession],
+            managerSessionID: AppState.managerSessionID)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: settingsPath(worktree))
+        #expect((attrs[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+    }
+
+    // MARK: - Strip
+
+    /// The reported case, end to end: a long-lived main clone whose session is
+    /// gone. The file held nothing but the stale block, so it goes away.
+    @Test func deletesTheFileWhenNothingButStaleCrowHooksRemain() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mainClone = try makeDir(root, "RadiusMethod/corveil")
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: deadBinary, session: deadSession)], into: mainClone)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.stripped == [std(mainClone)])
+        #expect(!FileManager.default.fileExists(atPath: settingsPath(mainClone)))
+    }
+
+    /// Stripping must be surgical. `removeHookConfig` drops all 17 event keys
+    /// wholesale, which would take a user's own `Stop` hook with it.
+    @Test func stripKeepsUserHooksSharingAManagedEventName() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mainClone = try makeDir(root, "RadiusMethod/corveil")
+
+        var hooks = staleHookBlock(binary: deadBinary, session: deadSession)
+        // A hand-authored entry alongside ours, under the same event key.
+        hooks["Stop"] = [
+            (hooks["Stop"] as! [[String: Any]])[0],
+            ["hooks": [["type": "command", "command": "make lint"] as [String: Any]]] as [String: Any],
+        ]
+        try writeSettings(["hooks": hooks, "permissions": ["allow": ["Bash"]]], into: mainClone)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.stripped == [std(mainClone)])
+        let updated = try readSettings(mainClone)
+        // Our 16 other event keys are gone; the user's Stop entry survives alone.
+        let remaining = try #require(updated["hooks"] as? [String: Any])
+        #expect(Set(remaining.keys) == ["Stop"])
+        #expect(try commands(in: updated, event: "Stop") == ["make lint"])
+        #expect(updated["permissions"] != nil)
+    }
+
+    /// With no resolvable crow binary there is nothing to repair *to*, but
+    /// leaving dangling commands in place is worse than removing them.
+    @Test func stripsWhenNoCrowBinaryCanBeResolved() throws {
+        let (root, _) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "ws/repo-1")
+        let liveSession = UUID()
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: deadBinary, session: deadSession)], into: worktree)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: nil,
+            liveSessionIDs: [liveSession],
+            sessionByWorktreePath: [std(worktree): liveSession],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.stripped == [std(worktree)])
+    }
+
+    // MARK: - Leave alone
+
+    @Test func leavesAHealthyFileByteIdenticalAndUnwritten() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "ws/repo-1")
+        let liveSession = UUID()
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: crowPath, session: liveSession)], into: worktree)
+        let before = try #require(FileManager.default.contents(atPath: settingsPath(worktree)))
+        let mtimeBefore = try #require(
+            FileManager.default.attributesOfItem(atPath: settingsPath(worktree))[.modificationDate] as? Date)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [liveSession],
+            sessionByWorktreePath: [std(worktree): liveSession],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.scanned == 1)
+        #expect(summary.healthy == 1)
+        #expect(summary.repaired.isEmpty && summary.stripped.isEmpty)
+        #expect(try #require(FileManager.default.contents(atPath: settingsPath(worktree))) == before)
+        let mtimeAfter = try #require(
+            FileManager.default.attributesOfItem(atPath: settingsPath(worktree))[.modificationDate] as? Date)
+        #expect(mtimeAfter == mtimeBefore)
+    }
+
+    @Test func ignoresFilesWithNoCrowManagedHooks() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "ws/repo-1")
+
+        let userOnly: [String: Any] = [
+            "hooks": [
+                "Stop": [["hooks": [["type": "command", "command": "make lint"] as [String: Any]]] as [String: Any]],
+                "MyCustomEvent": [["hooks": [["type": "command", "command": "echo hi"] as [String: Any]]] as [String: Any]],
+            ],
+        ]
+        try writeSettings(userOnly, into: worktree)
+        let before = try #require(FileManager.default.contents(atPath: settingsPath(worktree)))
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.scanned == 0)
+        #expect(try #require(FileManager.default.contents(atPath: settingsPath(worktree))) == before)
+    }
+
+    // MARK: - Traversal
+
+    @Test func skipsHiddenExcludedDeeperAndSymlinkedDirectories() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stale: [String: Any] = ["hooks": staleHookBlock(binary: deadBinary, session: deadSession)]
+
+        // Depth 3 — inside a build tree we must never descend into.
+        let tooDeep = try makeDir(root, "ws/repo/.build/checkouts/dep")
+        try writeSettings(stale, into: tooDeep)
+        // An excluded directory name at depth 1.
+        let excluded = try makeDir(root, "node_modules/pkg")
+        try writeSettings(stale, into: excluded)
+        // A dotted directory at depth 1.
+        let hidden = try makeDir(root, ".cache/thing")
+        try writeSettings(stale, into: hidden)
+
+        // A workspace symlinked to somewhere outside the dev root.
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-hookrepair-outside-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outside) }
+        try writeSettings(stale, into: try makeDir(outside, "repo"))
+        try FileManager.default.createSymbolicLink(
+            atPath: root.appendingPathComponent("linked-ws").path,
+            withDestinationPath: outside.path)
+
+        // The one directory that SHOULD be visited, so the test can't pass by
+        // the sweep doing nothing at all.
+        let real = try makeDir(root, "ws/repo-real")
+        try writeSettings(stale, into: real)
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:],
+            managerSessionID: AppState.managerSessionID,
+            excludeDirs: ["node_modules"])
+
+        #expect(summary.scanned == 1)
+        #expect(summary.stripped == [std(real)])
+        for untouched in [tooDeep, excluded, hidden, outside.appendingPathComponent("repo")] {
+            #expect(FileManager.default.fileExists(atPath: settingsPath(untouched)),
+                    "should not have been swept: \(untouched.path)")
+        }
+    }
+
+    @Test func leavesUnparseableFilesAlone() throws {
+        let (root, crowPath) = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktree = try makeDir(root, "ws/repo-1")
+        let claudeDir = worktree.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        try Data("{ not json".utf8).write(to: claudeDir.appendingPathComponent("settings.local.json"))
+
+        let summary = ClaudeHookRepair.sweep(
+            devRoot: root.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:],
+            managerSessionID: AppState.managerSessionID)
+
+        #expect(summary.skipped == [std(worktree)])
+        #expect(try String(contentsOfFile: settingsPath(worktree), encoding: .utf8) == "{ not json")
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -664,9 +664,9 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
     /// Binary-override name `Scaffolder` owns outright.
     ///
     /// Mirrors its `managedBinarySymlinks`: the reap loop skips this key and
-    /// `installCrowCLISymlink` re-points it at the running app's own CLI on
-    /// every launch, while `BinaryOverrides` never consults it (it is not an
-    /// `AgentKind`). An override here can therefore never take effect.
+    /// `ClaudeHookConfigWriter.ensureCrowCLISymlink` re-points it at the running
+    /// app's own CLI on every launch, while `BinaryOverrides` never consults it
+    /// (it is not an `AgentKind`). An override here can therefore never take effect.
     public static let reservedBinaryName = "crow"
 
     /// Whether a `binaries` key is safe to write.

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -108,6 +108,15 @@ public enum CrowDaemon {
             devRoot: options.devRoot, configured: options.devRootConfigured)
         await MainActor.run { appState.corveilSkillInstallWarning = scaffoldWarning }
 
+        // Repair hook blocks left dangling by an earlier build (#897). Must run
+        // AFTER `LaunchScaffold.run` (which re-points `.claude/bin/crow`, the
+        // path repairs are written with) and after `seedAppState` above (whose
+        // sessions decide what is still live), but BEFORE `startBoardPoll` —
+        // its first tick runs `ensureManagerSession`, the Manager's own hook
+        // writer.
+        await LaunchScaffold.repairStaleHooks(
+            devRoot: options.devRoot, configured: options.devRootConfigured, appState: appState)
+
         // Providers back both the board tracker (M-C) and the spawn engine
         // (M-E2). Zero-config at construction — it reads gh/glab/config lazily.
         let providerManager = ProviderManager()

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -65,6 +65,61 @@ enum LaunchScaffold {
         return warning
     }
 
+    /// Repair Crow-written Claude hook blocks that have gone stale on disk
+    /// (#897) — commands naming a `crow` binary that no longer exists, or a
+    /// session that has been deleted. Both make every hook event in that
+    /// directory fail, which is noisy *and* silently drops all telemetry for
+    /// sessions run there.
+    ///
+    /// Runs on every boot, right after `run(...)` has re-pointed the
+    /// `{devRoot}/.claude/bin/crow` symlink, and before `startBoardPoll` —
+    /// whose first tick calls `ensureManagerSession` — so it never races the
+    /// Manager's own hook writer.
+    ///
+    /// Set `CROW_HOOK_REPAIR=0` to disable: this is the only code that mutates
+    /// `settings.local.json` files Crow did not itself just write, so it ships
+    /// with an escape hatch.
+    static func repairStaleHooks(devRoot: String, configured: Bool, appState: AppState) async {
+        guard configured else { return }
+        guard ProcessInfo.processInfo.environment["CROW_HOOK_REPAIR"] != "0" else {
+            CrowDaemon.log("hook repair: skipped (CROW_HOOK_REPAIR=0)")
+            return
+        }
+
+        // Snapshot the live state as values so the scan itself needs no actor.
+        let (liveSessionIDs, sessionByWorktreePath) = await MainActor.run {
+            let live = Set(appState.sessions.map(\.id))
+            // `uniquingKeysWith`, not `uniqueKeysWithValues`: the latter traps
+            // on duplicate keys, and two rows sharing a worktree path is
+            // reachable through orphan recovery.
+            let byPath = Dictionary(
+                appState.worktrees.values.flatMap { $0 }.map {
+                    (($0.worktreePath as NSString).standardizingPath, $0.sessionID)
+                },
+                uniquingKeysWith: { first, _ in first })
+            return (live, byPath)
+        }
+
+        let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: devRoot)
+        let excludeDirs = Set(ConfigStore.loadConfig(devRoot: devRoot)?.defaults.excludeDirs ?? [])
+
+        // Detached: a filesystem walk is blocking I/O and must not sit on the
+        // MainActor (#892). Awaiting the task keeps boot ordering intact.
+        let summary = await Task.detached(priority: .utility) {
+            ClaudeHookRepair.sweep(
+                devRoot: devRoot,
+                crowPath: crowPath,
+                liveSessionIDs: liveSessionIDs,
+                sessionByWorktreePath: sessionByWorktreePath,
+                managerSessionID: AppState.managerSessionID,
+                excludeDirs: excludeDirs)
+        }.value
+
+        if summary.scanned > 0 {
+            CrowDaemon.log("hook repair: \(summary.logLine)")
+        }
+    }
+
     /// Per-agent dev-root files and global hook configs, each gated on the agent
     /// actually being registered (i.e. its binary resolved on PATH or via a
     /// `defaults.binaries.*` override) — so a user without Codex installed never
@@ -72,7 +127,7 @@ enum LaunchScaffold {
     /// idempotent and preserve the user-edited `## Known Issues / Corrections`
     /// section, so co-existence is safe.
     private static func scaffoldAgents(devRoot: String, mirrorClaudeMCPToCodex: Bool) {
-        let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot)
+        let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: devRoot)
 
         if AgentRegistry.shared.agent(for: .codex) != nil {
             attempt("Codex scaffold") { try CodexScaffolder.scaffold(devRoot: devRoot) }

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -1052,6 +1052,11 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 text = text.replacingOccurrences(of: "\\n", with: "\n")
                 text = text.replacingOccurrences(of: "\\t", with: "\t")
                 CrowLog.info("crow send: text length=\(text.count), ends_with_newline=\(text.hasSuffix("\n")), ends_with_cr=\(text.hasSuffix("\r"))")
+                // Resolved OFF the MainActor: `resolveCrowBinary` stats and may
+                // create the `.claude/bin/crow` symlink, and blocking I/O on the
+                // MainActor is what wedged the daemon's RPC surface in #892.
+                // It only needs `devRoot`, so hoisting costs nothing.
+                let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: devRoot)
                 await MainActor.run {
                     let routedTerminal = capturedAppState.terminals[sessionID]?.first(where: { $0.id == terminalID })
                     // tmux-backed terminals already have their window from
@@ -1073,7 +1078,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                             agent: agent,
                             sessionID: sessionID,
                             worktreePath: capturedAppState.primaryWorktree(for: sessionID)?.worktreePath,
-                            crowPath: ClaudeHookConfigWriter.findCrowBinary(devRoot: devRoot),
+                            crowPath: crowPath,
                             telemetryPort: capturedTelemetryPort
                         )
                         text = prepared.text
@@ -1252,16 +1257,34 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }()
 
                 return try await MainActor.run {
-                    // Resolve session — explicit param wins, else look up by
-                    // worktree path matching `cwd`.
+                    // Resolve session — an explicit param wins only if it names
+                    // a session we still have; otherwise fall back to the
+                    // worktree matching `cwd`.
+                    //
+                    // A stale `settings.local.json` bakes in a `--session` uuid
+                    // that can outlive the session itself (#897), and trusting
+                    // it unconditionally minted hook state — and a persisted
+                    // `hookStates` row — for a session that no longer exists.
+                    // Rerouting by cwd repairs those events instead of dropping
+                    // them.
+                    //
+                    // Deliberately never throws for an unknown-but-provided id:
+                    // `crow hook-event` surfaces an RPC error as a non-zero
+                    // exit, which Claude Code renders as the very "hook error"
+                    // noise this change exists to remove. Unresolvable ids fall
+                    // through with today's behavior, minus the store write.
+                    let liveSessionIDs = Set(capturedAppState.sessions.map(\.id))
                     let sessionID: UUID
-                    if let provided = providedSessionID {
+                    if let provided = providedSessionID, liveSessionIDs.contains(provided) {
                         sessionID = provided
                     } else if let cwd, let resolved = capturedAppState.sessionID(forWorktreePath: cwd) {
                         sessionID = resolved
+                    } else if let provided = providedSessionID {
+                        sessionID = provided
                     } else {
                         throw RPCError.invalidParams("session_id required or resolvable from payload cwd")
                     }
+                    let sessionIsLive = liveSessionIDs.contains(sessionID)
                     let sessionIDStr = sessionID.uuidString
 
                     if hookDebug {
@@ -1364,8 +1387,13 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                     // Persist the color-driving state only when it actually changed,
                     // so sidebar colors survive a quit→relaunch (#367). Excluding
                     // lastToolActivity means frequent PostToolUse events don't write.
+                    //
+                    // Gated on the session still existing: a stale hook block
+                    // naming a deleted session would otherwise keep appending
+                    // `hookStates` rows keyed to a uuid nothing ever prunes
+                    // (#897). `reseed` only filters those on read.
                     let snapshotAfter = state.persistedSnapshot
-                    if snapshotAfter != snapshotBefore {
+                    if sessionIsLive && snapshotAfter != snapshotBefore {
                         capturedStore.mutate { data in
                             var map = data.hookStates ?? [:]
                             map[sessionIDStr] = snapshotAfter

--- a/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
@@ -196,7 +196,18 @@ public struct Scaffolder {
         // user rc — so `corveil`, `codex`, `cursor` resolve to the
         // user-configured binary regardless of what's on PATH.
         installBinarySymlinks(binaryOverrides, claudeDir: claudeDir)
-        installCrowCLISymlink(claudeDir: claudeDir, appCrowPath: appCrowBinaryPath)
+        // Always re-point `{devRoot}/.claude/bin/crow` at the running app's own
+        // CLI (CROW-552). Independent of `defaults.binaries` so every agent kind
+        // discovers `crow` via the tmux shell wrapper's PATH prepend, and run
+        // AFTER `installBinarySymlinks` so a user-set `defaults.binaries["crow"]`
+        // is overwritten here by design — the app binary always wins.
+        //
+        // Lives in `ClaudeHookConfigWriter` because that is also where hook
+        // commands resolve their crow path, and the two must agree: the link is
+        // what makes a written hook command survive the worktree its build came
+        // from being deleted (#897).
+        ClaudeHookConfigWriter.ensureCrowCLISymlink(
+            devRoot: devRoot, appCrowPath: appCrowBinaryPath)
 
         // Re-install the embedded /query-corveil slash command from the
         // user-configured corveil binary on every launch (CROW-482). Failure
@@ -264,48 +275,6 @@ public struct Scaffolder {
             } catch {
                 CrowLog.info("[Scaffolder] failed to symlink \(link) -> \(trimmed): \(error.localizedDescription)")
             }
-        }
-    }
-
-    /// Always materialize `{devRoot}/.claude/bin/crow` pointing at the running
-    /// app's own CLI (CROW-552). Independent of `defaults.binaries` so every
-    /// agent kind discovers `crow` via the tmux shell wrapper's PATH prepend.
-    /// Runs after `installBinarySymlinks`, so a user-set
-    /// `defaults.binaries["crow"]` is overwritten here by design — the app
-    /// binary always wins for PATH discovery.
-    /// Idempotent — re-run on every scaffold pass; only ever owns symlinks.
-    private func installCrowCLISymlink(claudeDir: String, appCrowPath: String?) {
-        let fm = FileManager.default
-        let binDir = (claudeDir as NSString).appendingPathComponent("bin")
-        let link = (binDir as NSString).appendingPathComponent("crow")
-        let resolved = appCrowPath ?? ClaudeHookConfigWriter.appCrowBinary()
-
-        guard let target = resolved, fm.isExecutableFile(atPath: target) else {
-            if let attrs = try? fm.attributesOfItem(atPath: link),
-               (attrs[.type] as? FileAttributeType) == .typeSymbolicLink {
-                try? fm.removeItem(atPath: link)
-            }
-            if let resolved {
-                CrowLog.info("[Scaffolder] app crow binary not executable at \(resolved) — skipping symlink")
-            }
-            return
-        }
-
-        // Drive off attributesOfItem, not fileExists — the latter follows
-        // symlinks, so a dangling `crow` link (target moved/deleted) looks
-        // absent and we'd skip removal, then createSymbolicLink hits EEXIST.
-        if let attrs = try? fm.attributesOfItem(atPath: link) {
-            guard (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else {
-                CrowLog.info("[Scaffolder] crow exists at \(link) but is not a symlink — leaving alone")
-                return
-            }
-            try? fm.removeItem(atPath: link)
-        }
-
-        do {
-            try fm.createSymbolicLink(atPath: link, withDestinationPath: target)
-        } catch {
-            CrowLog.info("[Scaffolder] failed to symlink \(link) -> \(target): \(error.localizedDescription)")
         }
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -617,7 +617,7 @@ public final class SessionService {
                 if trackReadiness {
                     // Re-write hook config so the adopted Claude's hooks still
                     // route back to the correct session if the config was lost.
-                    if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()),
+                    if let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot()),
                        let worktree = appState.primaryWorktree(for: terminal.sessionID) {
                         do {
                             try ClaudeHookConfigWriter().writeHookConfig(
@@ -787,7 +787,7 @@ public final class SessionService {
                 agent: agent,
                 sessionID: sessionID,
                 worktreePath: appState.primaryWorktree(for: sessionID)?.worktreePath,
-                crowPath: ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()),
+                crowPath: ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot()),
                 telemetryPort: telemetryPort
             ).text
         }
@@ -905,7 +905,7 @@ public final class SessionService {
 
         // Write/refresh hook config (Claude path). Codex's writer is a
         // no-op — its global config was installed once at app launch.
-        if let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()) {
+        if let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot()) {
             do {
                 try agent.hookConfigWriter.writeHookConfig(
                     worktreePath: worktree.worktreePath,
@@ -1523,7 +1523,7 @@ public final class SessionService {
             other.hookConfigWriter.removeHookConfig(worktreePath: dirPath)
         }
         guard let agent = AgentRegistry.shared.agent(for: session.agentKind),
-              let crowPath = ClaudeHookConfigWriter.findCrowBinary(devRoot: ConfigStore.loadDevRoot()) else { return }
+              let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot()) else { return }
         do {
             try agent.hookConfigWriter.writeHookConfig(
                 worktreePath: dirPath,

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AgentLaunchTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AgentLaunchTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowClaude
 @testable import CrowEngine
 
 /// Re-homes the root-suite coverage for launch-token detection and the shared
@@ -157,5 +158,33 @@ private struct MockAgent: CodingAgent {
             worktreePath: nil, crowPath: nil, telemetryPort: 4318)
         #expect(didLaunch)
         #expect(text == "cursor-agent chat")
+    }
+
+    /// #897 end-to-end on the wiring: the launch path resolves its crow binary
+    /// the way production does, so what lands in the hook file is the stable
+    /// `{devRoot}/.claude/bin/crow` symlink — never the `.build/…` product of
+    /// whichever worktree the daemon happened to be built in.
+    @Test func launchResolvesTheStableSymlinkNotABuildProduct() throws {
+        let fm = FileManager.default
+        let devRoot = fm.temporaryDirectory.appendingPathComponent("agentlaunch-crowpath-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: devRoot) }
+        let buildDir = devRoot.appendingPathComponent(".build/arm64-apple-macosx/debug")
+        try fm.createDirectory(at: buildDir, withIntermediateDirectories: true)
+        let appBinary = buildDir.appendingPathComponent("crow")
+        try Data("#!/bin/sh\n".utf8).write(to: appBinary)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: appBinary.path)
+
+        let a = agent(.claudeCode)
+        let sid = UUID()
+        _ = AgentLaunch.prepareAgentLaunchText(
+            command: "claude --continue", agent: a, sessionID: sid,
+            worktreePath: "/tmp/wt",
+            crowPath: ClaudeHookConfigWriter.resolveCrowBinary(
+                devRoot: devRoot.path, appCrowPath: appBinary.path),
+            telemetryPort: nil)
+
+        let written = try #require(a.spy.calls.first)
+        #expect(written.crowPath == devRoot.appendingPathComponent(".claude/bin/crow").path)
+        #expect(!written.crowPath.contains("/.build/"))
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/DefaultsRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/DefaultsRPCSupportTests.swift
@@ -217,7 +217,7 @@ struct DefaultsRPCSupportTests {
     }
 
     /// `crow` is owned by `Scaffolder`: `managedBinarySymlinks` exempts it from
-    /// reaping and `installCrowCLISymlink` overwrites it every launch, while
+    /// reaping and `ensureCrowCLISymlink` overwrites it every launch, while
     /// `BinaryOverrides` never consults it (not an `AgentKind`). Accepting it
     /// would answer `saved: true, restart_required: true` for a write that cannot
     /// take effect.

--- a/Packages/CrowEngine/Tests/CrowEngineTests/HookEventSessionResolutionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/HookEventSessionResolutionTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowClaude
+import CrowPersistence
+import CrowIPC
+@testable import CrowEngine
+
+/// #897: a `settings.local.json` bakes `--session <uuid>` into every hook
+/// command, so a settings file can outlive the session it names — indefinitely,
+/// in a long-lived main clone that nothing ever rewrites. The `hook-event`
+/// handler used to trust that uuid unconditionally, minting hook state and a
+/// persisted `hookStates` row for a session that no longer exists.
+@Suite("hook-event session resolution")
+@MainActor
+struct HookEventSessionResolutionTests {
+
+    private func makeRouter(
+        _ appState: AppState, _ store: JSONStore, devRoot: String
+    ) -> CommandRouter {
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+        return makeEngineRouter(EngineContext(
+            appState: appState,
+            store: store,
+            sessionService: service,
+            issueTracker: nil,
+            telemetryPort: nil,
+            devRoot: devRoot,
+            hostBridge: NoopHostBridge(),
+            loadConfig: { nil },
+            applyConfig: { _ in nil }
+        ))
+    }
+
+    private func tempDir() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-hookevent-\(UUID().uuidString)")
+    }
+
+    /// The repair case: a stale command names a dead session, but the payload's
+    /// `cwd` still identifies a live worktree — so the event is re-routed there
+    /// rather than attributed to a session that no longer exists.
+    @Test("an unknown session_id falls back to the worktree matching cwd")
+    func unknownSessionFallsBackToCwd() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let live = Session(name: "live")
+        appState.sessions.append(live)
+        let worktreePath = tmp.appendingPathComponent("ws/repo-1").path
+        appState.worktrees[live.id] = [
+            SessionWorktree(sessionID: live.id, repoName: "repo", repoPath: worktreePath,
+                            worktreePath: worktreePath, branch: "feature/x", isPrimary: true),
+        ]
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let deadSession = UUID()
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(deadSession.uuidString),
+                "event_name": .string("Stop"),
+                "payload": .object(["cwd": .string(worktreePath)]),
+            ]))
+
+        #expect(response.error == nil)
+        #expect(response.result?["session_id"]?.stringValue == live.id.uuidString)
+    }
+
+    /// A live session id always wins, even when `cwd` would resolve elsewhere —
+    /// the fallback must not change routing for anything that works today.
+    @Test("a live session_id is used verbatim")
+    func liveSessionIDWins() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let a = Session(name: "a")
+        let b = Session(name: "b")
+        appState.sessions.append(contentsOf: [a, b])
+        let bPath = tmp.appendingPathComponent("ws/repo-b").path
+        appState.worktrees[b.id] = [
+            SessionWorktree(sessionID: b.id, repoName: "repo", repoPath: bPath,
+                            worktreePath: bPath, branch: "feature/b", isPrimary: true),
+        ]
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(a.id.uuidString),
+                "event_name": .string("Stop"),
+                "payload": .object(["cwd": .string(bPath)]),
+            ]))
+
+        #expect(response.result?["session_id"]?.stringValue == a.id.uuidString)
+    }
+
+    /// An unresolvable id must still succeed. `crow hook-event` surfaces an RPC
+    /// error as a non-zero exit, which Claude Code renders as exactly the
+    /// "hook error" noise this work exists to remove — so we accept the event
+    /// and simply decline to persist state for a session we don't have.
+    @Test("an unresolvable session_id still succeeds and writes no hookStates row")
+    func unresolvableSessionDoesNotErrorOrPersist() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+
+        let deadSession = UUID()
+        // SessionStart drives an activity-state change, so this would persist a
+        // snapshot if the live-session gate were missing.
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(deadSession.uuidString),
+                "event_name": .string("SessionStart"),
+                "payload": .object([:]),
+            ]))
+
+        #expect(response.error == nil)
+        #expect(response.result?["received"]?.boolValue == true)
+        #expect(store.data.hookStates?[deadSession.uuidString] == nil)
+    }
+}


### PR DESCRIPTION
Closes #897

## The bug

An old dev build baked its own `.build/{arch}/debug/crow` into every hook command it wrote. That worktree was later reaped and the session it named deleted — but nothing in Crow ever revisits a `settings.local.json` once written. So `{devRoot}/RadiusMethod/corveil/.claude/settings.local.json` (a long-lived **main clone**, mtime Apr 13) kept failing all 17 hook events with `No such file or directory`, and every session run there recorded **no telemetry at all**.

Two compounding causes, both addressed here.

## 1. Never emit a build product

`findCrowBinary(devRoot:)` preferred `{devRoot}/.claude/bin/crow` but was read-only — and `isExecutableFile` follows symlinks, so a *dangling* link fell through to the raw build path just like a missing one.

`resolveCrowBinary` now **ensures** the symlink (creating or re-pointing it) and returns the link. Hook commands name a path that survives worktree churn: only the target moves, and every boot re-points it, so one relink heals every settings file at once. All six writers that persist a crow path use it; `findCrowBinary` stays for callers that only need to *locate* a crow to run now.

`Scaffolder.installCrowCLISymlink` moved to `ClaudeHookConfigWriter.ensureCrowCLISymlink` so the symlink and the commands depending on it have one owner. It also gained a no-op fast path when the link already points at the target — the old unlink+relink left a window where a concurrently firing hook saw ENOENT.

**Also fixed while here:** the path was interpolated raw, so a dev root containing a space (`/Users/x/My Dev`) silently killed all 17 hooks. Now shell-quoted, matching `CursorHookConfigWriter` and `AntigravityHookConfigWriter`, which already quote for exactly this reason. It had to land with the sweep anyway, since the parser must handle both forms.

## 2. Repair what is already on disk

`ClaudeHookRepair.sweep` runs once at daemon boot — after the scaffold re-points the symlink, before `startBoardPoll` spawns the Manager. It is **filesystem-driven, not state-driven**: the broken directory's session is gone from `AppState`, which is precisely why enumerating live worktrees would miss it. Depth-2 under devRoot (`{ws}/{repo-or-worktree}`), plus devRoot itself for the Manager.

| State | Action |
|---|---|
| All commands resolve + session live | **No write at all** (contents and mtime untouched) |
| Stale, directory maps to a live worktree | Commands rewritten in place |
| Stale, no live session | Managed entries removed; file deleted only if nothing else remains |

Both mutations are surgical rather than reusing the existing writers: `writeHookConfig` expands a partial file to all 17 events and replaces whole event arrays, and `removeHookConfig` drops all 17 keys wholesale — taking a user's own `Stop` hook with it. (`writeManagerHookConfig` already documents refusing to run it against the dev root for that reason.) Writes are non-atomic so the `0600` that `writeGatewayEnv` applies — the `env` block can hold a gateway bearer token — survives.

**The parser is the entire safety boundary**, so it is strict: absolute path, exactly `--session <uuid> [--agent <kind>] --event <managed name>`, no shell metacharacters. A user hook that merely *wraps* `crow hook-event` in a pipeline stays theirs. Every mutated path is logged at INFO, and `CROW_HOOK_REPAIR=0` disables the sweep.

## 3. Stop trusting an unknown `session_id`

`hook-event` trusted a provided uuid unconditionally, minting hook state and a persisted `hookStates` row for sessions that no longer exist (nothing prunes those; `reseed` only filters on read). It now prefers the worktree matching the payload cwd when the id isn't live, and skips the store write for a dead session.

Deliberately **still never errors**: `rpc()` throws on any server error and `forwardHookEvent` catches only `connectionFailed`, so an `invalidParams` exits non-zero — which Claude renders as the exact "hook error" noise this PR removes. Strictly monotone: nothing that routes today stops routing.

## Verification

- `make build` clean; **2,234 tests across 16 packages pass**.
- New: `ClaudeHookRepairTests` (parse table incl. quoted / legacy-unquoted / unquoted-with-spaces / pipeline-wrapped / relative / bad uuid; repair-in-place, surgical strip, Manager-at-devRoot, `0600` preservation, byte-identical healthy file, traversal skips), `HookEventSessionResolutionTests`, and crow-path tests asserting **no emitted command contains `/.build/`** — the issue's explicit acceptance criterion.
- **Verified against the real artifact**: a copy of the actual `corveil/.claude/settings.local.json` in a reproduced devRoot layout is stripped and deleted (it held nothing but the stale block), while a healthy neighbor stays byte-identical. The original on disk was left untouched.

## Rebased onto main

Rebased past #895 (ADR 0016 parity contract) and #885 (Workspaces CLI). This branch originally carried a second commit adding the missing `automation-get` / `automation-set` ledger rows, because `make parity` was red on `main`. #895 fixed that independently — same eleven config-field rows, plus a better rationale for why the automation RPCs stay reachable over remote `/rpc` — so that commit was **dropped rather than merged**, and this PR is a single commit again.

Only `AppConfig.swift` and `SessionService.swift` overlapped with upstream; both auto-merged, and all four `resolveCrowBinary` swaps plus the doc reference were verified intact afterward. No new `findCrowBinary` call sites arrived upstream.

`make test` is green on the rebased tree: all 16 package suites, parity (94 methods), notification catalogs, and the `NSLog` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
