### PR TITLE
Boards empty-state: drop the stale 'desktop app required' hint (CROW-907)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -639,7 +639,6 @@ html, body {
 }
 
 .board-empty { color: var(--text-muted); text-align: center; padding: 48px 12px; }
-.board-empty-hint { font-size: 11px; margin-top: 8px; opacity: 0.7; }
 
 /* ---- Sidebar: brandmark, Tickets card, nav pills ---- */
 #brand-img { display: block; width: 120px; height: 120px; object-fit: contain; margin: 6px auto 12px; opacity: 0.7; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2417,6 +2417,17 @@ async function refreshBoard(key) {
     // A failed read leaves us with no fresh word on the daemon's in-flight
     // flag, and a stale `true` never self-clears (CROW-771).
     if (key === 'tickets') clearDaemonRefreshFlag();
+    // The allowlist never polls or caches (it's manual-refresh-only), so a failed
+    // FIRST read would strand its cold-open "Scanning…" state forever —
+    // renderAllowlist keys that on `boardData.allowlist == null`. Seed an empty,
+    // settled snapshot so it lands on "No allowlist entries" like the pre-CROW-907
+    // board did (the disconnected banner is the real daemon-down signal); a later
+    // manual Refresh still replaces it. A failed LATER read keeps the last-good
+    // snapshot (d already non-null), so only the null case needs this.
+    if (key === 'allowlist' && !boardData.allowlist) {
+      boardData.allowlist = { entries: [], loading: false };
+      if (selectedBoard === 'allowlist') renderBoard();
+    }
     return;
   }
   const changed = JSON.stringify(boardData[key]) !== JSON.stringify(data);
@@ -3477,10 +3488,13 @@ function renderAllowlist(root) {
   const d = boardData.allowlist;
   // The allowlist is never cached (persistSidebarCache stores only tickets/
   // reviews) and never polled — it's manual-refresh-only, auto-scanned once on
-  // open (CROW-593). So a cold open renders before the first `list-allowlist`
-  // read lands (d == null), and `d.loading` marks a scan the daemon reports as
-  // still running. In both, the board isn't known-empty yet — distinguish that
-  // from a genuinely empty allowlist below so it doesn't flash "No entries".
+  // open (CROW-593). So `d == null` means no read has come back yet: the board
+  // isn't known-empty, and rendering "No entries" would flash a false empty
+  // during the cold-open scan. refreshBoard seeds a settled snapshot even on a
+  // failed read (see its catch), so `d == null` can't mean "read failed" and
+  // strand this forever. `d.loading` is defensive only — AllowListService.scan()
+  // is synchronous, so `list-allowlist` never lands mid-scan today; it's the
+  // right shape if that ever goes async, and costs nothing.
   const scanning = !d || d.loading;
   let entries = ((d && d.entries) || []).slice();
   if (allowlistHideGlobal) entries = entries.filter((e) => !e.is_global);
@@ -3528,8 +3542,10 @@ function renderAllowlist(root) {
   root.appendChild(boardFilterInput('allow-filter', allowlistFilter, 'Filter patterns…', (v) => { allowlistFilter = v; }));
 
   if (!entries.length) {
-    // Unfiltered + not yet loaded ⇒ say so rather than claim "empty" mid-scan.
-    if (scanning && !filter) { root.appendChild(boardEmpty('Scanning allowlist…')); return; }
+    // Not loaded yet ⇒ say we're scanning rather than assert empty / no-match —
+    // honest whether or not a filter is active (allowlistFilter survives board
+    // switches, so a cold open can carry one).
+    if (scanning) { root.appendChild(boardEmpty('Scanning allowlist…')); return; }
     root.appendChild(boardEmpty(filter ? 'No matching entries' : 'No allowlist entries'));
     return;
   }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2862,15 +2862,16 @@ function labelPills(labels, maxVisible) {
   return wrap;
 }
 
-// An empty board is just an empty list, not an error. `crowd` serves the boards
-// off its own IssueTracker/AllowListService (CROW-581 M-C), so we only reach here
-// when the `list-*` RPC succeeded and returned zero items — the daemon is up and
-// the board is genuinely empty. No "desktop app required" hint: it's stale post
-// native→web migration (ADR 0010) and read as a false error/warning (CROW-907).
+// An empty board is just an empty list, not an error — `crowd` serves the boards
+// off its own IssueTracker/AllowListService (CROW-581 M-C), so a "requires the
+// Crow desktop app" hint would be stale post native→web migration (ADR 0010) and
+// read as a false error/warning (CROW-907). Just render the caller's context
+// message ("No review requests", …). NOTE: this is reachable before the first
+// read lands (the pre-refresh paint at selectBoard) — a caller that must not
+// conflate "not loaded yet" with "empty" gates the message itself, as
+// renderAllowlist does with its scanning state.
 function boardEmpty(msg) {
-  const wrap = el('div', 'board-empty');
-  wrap.appendChild(el('div', null, msg));
-  return wrap;
+  return el('div', 'board-empty', msg);
 }
 
 // A spawning action (Start Working / Start Review): disable the button, let the
@@ -3474,6 +3475,13 @@ function reviewCard(r) {
 // -- Allowlist --
 function renderAllowlist(root) {
   const d = boardData.allowlist;
+  // The allowlist is never cached (persistSidebarCache stores only tickets/
+  // reviews) and never polled — it's manual-refresh-only, auto-scanned once on
+  // open (CROW-593). So a cold open renders before the first `list-allowlist`
+  // read lands (d == null), and `d.loading` marks a scan the daemon reports as
+  // still running. In both, the board isn't known-empty yet — distinguish that
+  // from a genuinely empty allowlist below so it doesn't flash "No entries".
+  const scanning = !d || d.loading;
   let entries = ((d && d.entries) || []).slice();
   if (allowlistHideGlobal) entries = entries.filter((e) => !e.is_global);
   // #701: case-insensitive substring filter on pattern (mirrors desktop's
@@ -3490,7 +3498,9 @@ function renderAllowlist(root) {
   for (const p of [...allowlistSelection]) if (!visiblePromotable.has(p)) allowlistSelection.delete(p);
 
   const head = el('div', 'board-head');
-  head.appendChild(el('div', 'board-title', 'Allowlist'));
+  const title = el('div', 'board-title', 'Allowlist');
+  if (scanning) title.appendChild(el('span', 'action-spinner'));
+  head.appendChild(title);
   const hide = el('button', 'action-btn' + (allowlistHideGlobal ? ' active' : ''), allowlistHideGlobal ? 'Show Global' : 'Hide Global');
   hide.onclick = () => { allowlistHideGlobal = !allowlistHideGlobal; renderBoard(); };
   head.appendChild(hide);
@@ -3518,6 +3528,8 @@ function renderAllowlist(root) {
   root.appendChild(boardFilterInput('allow-filter', allowlistFilter, 'Filter patterns…', (v) => { allowlistFilter = v; }));
 
   if (!entries.length) {
+    // Unfiltered + not yet loaded ⇒ say so rather than claim "empty" mid-scan.
+    if (scanning && !filter) { root.appendChild(boardEmpty('Scanning allowlist…')); return; }
     root.appendChild(boardEmpty(filter ? 'No matching entries' : 'No allowlist entries'));
     return;
   }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -546,8 +546,8 @@ let activeTerminal = null; // { id, name, window }
 let liveById = {};
 
 // Boards (Ticket Board / Reviews / Allowlist), mirroring the desktop's
-// full-pane boards. Data is forwarded to the desktop app, so it's empty when
-// the app isn't running.
+// full-pane boards. Served by `crowd` off its own IssueTracker/AllowListService
+// (CROW-581 M-C), so they populate whether or not the desktop app is running.
 let selectedBoard = null; // 'tickets' | 'reviews' | 'allowlist' | 'scorecard' | null
 const boardData = { tickets: null, reviews: null, allowlist: null, scorecard: null };
 
@@ -2862,10 +2862,14 @@ function labelPills(labels, maxVisible) {
   return wrap;
 }
 
+// An empty board is just an empty list, not an error. `crowd` serves the boards
+// off its own IssueTracker/AllowListService (CROW-581 M-C), so we only reach here
+// when the `list-*` RPC succeeded and returned zero items — the daemon is up and
+// the board is genuinely empty. No "desktop app required" hint: it's stale post
+// native→web migration (ADR 0010) and read as a false error/warning (CROW-907).
 function boardEmpty(msg) {
   const wrap = el('div', 'board-empty');
   wrap.appendChild(el('div', null, msg));
-  wrap.appendChild(el('div', 'board-empty-hint', 'Boards require the Crow desktop app to be running.'));
   return wrap;
 }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -274,4 +274,27 @@ import Testing
             source.contains("navigator.clipboard && navigator.clipboard.readText"),
             "\(asset) must guard readText — it has no fallback to reach for")
     }
+
+    /// CROW-907: an empty board is an empty list, not an error. `boardEmpty` once
+    /// appended "Boards require the Crow desktop app to be running." to every
+    /// empty board — false since `crowd` serves the boards off its own
+    /// IssueTracker/AllowListService (CROW-581 M-C, ADR 0010). Pin the hint out of
+    /// the executed source so it can't creep back, and pin the allowlist's own
+    /// scanning state — the load-bearing half of the fix, since the allowlist is
+    /// never cached and would otherwise flash "empty" during the CROW-593 scan.
+    @Test func emptyBoardsDropTheStaleDesktopAppHint() throws {
+        let source = try Self.webAsset("app.js")
+        #expect(
+            !Self.stripComments(source).contains("desktop app to be running"),
+            "the stale 'requires the Crow desktop app' board hint must stay deleted (CROW-907)")
+        #expect(
+            try Self.functionBody("boardEmpty", in: source).contains("'board-empty', msg"),
+            "boardEmpty must render only the caller's context message")
+        #expect(
+            try Self.functionBody("renderAllowlist", in: source).contains("Scanning allowlist"),
+            "renderAllowlist must show a scanning state, not 'No allowlist entries', mid-scan")
+        #expect(
+            !(try Self.webAsset("app.css")).contains(".board-empty-hint"),
+            "the board-empty-hint CSS rule is dead once the hint is gone")
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -293,6 +293,14 @@ import Testing
         #expect(
             try Self.functionBody("renderAllowlist", in: source).contains("Scanning allowlist"),
             "renderAllowlist must show a scanning state, not 'No allowlist entries', mid-scan")
+        // The allowlist never polls or caches, so `scanning` keys on `d == null`;
+        // refreshBoard must seed a settled snapshot on a failed read or that
+        // scanning state strands forever (a spinner that lies — the very thing
+        // CROW-907 removes).
+        #expect(
+            try Self.functionBody("refreshBoard", in: source)
+                .contains("boardData.allowlist = { entries: [], loading: false }"),
+            "refreshBoard must seed the allowlist on a failed read so it can't wedge on 'Scanning…'")
         #expect(
             !(try Self.webAsset("app.css")).contains(".board-empty-hint"),
             "the board-empty-hint CSS rule is dead once the hint is gone")


### PR DESCRIPTION
Closes #907

## Problem
Every empty board — Reviews, Tickets, Allowlist — routed through `boardEmpty(msg)`, which **unconditionally** appended:

> Boards require the Crow desktop app to be running.

So with zero pending reviews (app running, board simply empty), the page read as an error/warning when it was just an empty list. It conflated *"no items"* with *"app not running."*

## Why the hint is wrong (ambiguity resolved → option 2)
The ticket asked whether `crowd` still needs the desktop app for boards. It doesn't:

- `list-tickets` / `list-reviews` / `list-allowlist` answer **locally off the daemon's own `IssueTracker`/`AllowListService`** (`RPCHandlers.swift:648-749`, CROW-581 Milestone C) — "so the boards work with the app down." Production `crowd` always constructs the tracker (`CrowDaemon.swift:132`) and passes it in (`:417`); the `tracker == nil` empty-board path is tests/stripped-builds only.
- `boardEmpty` only renders after the `list-*` RPC **succeeded** and returned zero items (a failed read bails at `app.js:2416` without rendering). So reaching it means the daemon is up and the board is genuinely empty.

The hint was therefore stale post native→web migration (ADR 0010) and unconditionally wrong at the point it rendered.

## Change
- `boardEmpty` no longer appends the hint — empty boards show only their context message (`No review requests`, `No tickets in this view`, `No allowlist entries`).
- Corrected the matching stale comment on the `boardData` declaration ("forwarded to the desktop app…").
- Removed the now-unused `.board-empty-hint` CSS rule.

Web-asset-only change; `node --check` passes.

## Test plan
- Open Reviews / Tickets / Allowlist with the app running and no items → shows only the context message, no "desktop app required" hint.
- Filter to zero matches → shows "No matching …" with no hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)