### PR TITLE
Notification center: bell + unread badge with history and click-through (CROW-909)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -675,6 +675,44 @@ html, body {
 .tk-tool:hover { color: var(--gold); border-color: var(--border-strong); }
 .tk-tool.nav-selecting { color: var(--red); border-color: var(--red); }
 
+/* Notification bell (CROW-909): unread count as a badge over the top-right
+   corner of the bell button. Mirrors the Reviews pill's badge palette. */
+.tk-bell { position: relative; }
+.notif-badge {
+  position: absolute; top: -5px; right: -5px; min-width: 15px; height: 15px;
+  padding: 0 3px; box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 8px; font-size: 9px; font-weight: 700; line-height: 1;
+  font-variant-numeric: tabular-nums;
+  background: var(--gold); color: var(--bg-deep);
+  border: 1px solid var(--bg-card);
+}
+
+/* Notification center panel: a wider, scrollable variant of the .ctx-menu shell
+   with a header (title + Clear all) and two-line rows. */
+.notif-panel { width: 320px; max-width: calc(100vw - 16px); padding: 0; }
+.notif-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 12px; border-bottom: 1px solid var(--border-subtle);
+}
+.notif-title { font-size: 12px; font-weight: 700; color: var(--gold); }
+.notif-clear {
+  padding: 2px 8px; border-radius: 5px; cursor: pointer;
+  font-size: 11px; font-weight: 600; color: var(--text-secondary);
+  background: transparent; border: 1px solid var(--border-subtle);
+}
+.notif-clear:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.notif-empty { padding: 18px 12px; text-align: center; font-size: 12px; color: var(--text-secondary); }
+.notif-list { max-height: 340px; overflow-y: auto; padding: 4px; }
+.notif-item { padding: 7px 9px; border-radius: 6px; cursor: pointer; }
+.notif-item:hover { background: rgba(221, 196, 130, 0.14); }
+.notif-item.notif-static { cursor: default; }
+.notif-item.notif-static:hover { background: transparent; }
+.notif-row1 { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.notif-item-title { font-size: 12px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.notif-time { flex: 0 0 auto; font-size: 10px; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+.notif-item-body { margin-top: 2px; font-size: 11px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
 /* ---- Fixed connection/status bar (bottom-left, CROW-593) ---- */
 #statusbar {
   position: fixed;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -445,7 +445,8 @@ function showEventNotification(event, key, detail) {
   } catch (_) { /* Notification ctor can throw in restricted contexts */ }
 }
 
-// Both channels fire from one call in the detectors below; each self-gates.
+// All three channels fire from one call in the detectors below; each self-gates
+// (sound + banner on the full toggle cascade, the history on the master levels).
 function emitEvent(event, key, detail) {
   playEventSound(event, key);
   showEventNotification(event, key, detail);
@@ -463,20 +464,22 @@ function emitEvent(event, key, detail) {
 // larger follow-up.
 const NOTIF_HISTORY_KEY = 'crow.notif.history';
 const NOTIF_HISTORY_CAP = 100; // keep the last ~100; older entries drop off
-let notifHistory = [];         // [{ id, event, key, title, body, ts, seen, kind, target }]
-let _notifSeq = 0;             // disambiguates entries appended in the same ms
+let notifHistory = [];         // [{ event, key, title, body, ts, seen, kind, target }]
 
 function restoreNotifHistory() {
   try {
     const raw = localStorage.getItem(NOTIF_HISTORY_KEY);
     if (!raw) return;
     const data = JSON.parse(raw);
-    // Filter to plain objects: a parseable-but-wrong array (`[null, …]`, a
+    // Filter to well-formed entries: a parseable-but-wrong array (`[null, …]`, a
     // foreign schema) would otherwise let a later `e.seen` read throw inside
     // notifUnreadCount → sidebarSignature → every renderSidebar, wedging the
-    // whole sidebar until the key is cleared by hand (review).
+    // whole sidebar until the key is cleared by hand. The `ts` check also keeps
+    // a ts-less entry from rendering "Invalid Date" in relTime (review).
     if (Array.isArray(data)) {
-      notifHistory = data.filter((e) => e && typeof e === 'object').slice(-NOTIF_HISTORY_CAP);
+      notifHistory = data
+        .filter((e) => e && typeof e === 'object' && typeof e.ts === 'number')
+        .slice(-NOTIF_HISTORY_CAP);
     }
   } catch (_) { /* corrupt cache — start empty */ }
 }
@@ -488,6 +491,21 @@ function notifUnreadCount() {
   let n = 0;
   for (const e of notifHistory) if (e && !e.seen) n++;
   return n;
+}
+
+// One coalesced sidebar repaint per task, so a detector tick that records k
+// events triggers a single innerHTML rebuild rather than k of them (the unread
+// count is in sidebarSignature, so the cheap signature short-circuit never
+// applies to an append). A microtask, not rAF, so the badge is current before
+// the next paint and onServerNotify still repaints within the same turn (review).
+let _notifRepaintScheduled = false;
+function scheduleNotifRepaint() {
+  if (_notifRepaintScheduled) return;
+  _notifRepaintScheduled = true;
+  Promise.resolve().then(() => {
+    _notifRepaintScheduled = false;
+    try { renderSidebar(); } catch (_) { /* pre-boot — badge paints on first render */ }
+  });
 }
 
 // Another tab wrote the shared history (append, mark-seen, or clear). Re-read so
@@ -511,13 +529,22 @@ function classifyNotification(event, key) {
   return { kind: 'none', target: null };
 }
 
-// Append one event to the history and bump the unread counter. Called from
-// emitEvent unconditionally: the detectors already gate on the arm window, so
-// this can't be flooded by a page load. A 2s per-(key,event) dedup mirrors the
-// sound/banner channels — a flapping poll or a repeated server push produced
-// duplicate popups there, and would produce duplicate rows here (review).
+// Append one event to the history and bump the unread counter. Gated on only the
+// MASTER levels — globalMute and the per-event `enabled` toggle — so a user who
+// muted everything, or switched this event category off in Settings, doesn't get
+// a growing badge they can't opt out of. The per-event sound/system SUB-toggles
+// and the focus-suppression rule are deliberately NOT applied: the center is a
+// passive log, not an interruption, so it keeps events whose transient banner you
+// chose not to see live. A 2s per-(key,event) dedup mirrors the sound/banner
+// channels, where repeated pushes / a flapping poll produced duplicate popups
+// (review).
 const _lastRecordAt = {};
 function recordNotification(event, key, detail) {
+  const N = uiConfig.notifications;
+  if (!N) return;                          // config not loaded — mirror the sibling channels
+  if (N.globalMute) return;                // master mute silences the log too
+  const cfg = N.events[event] || {};
+  if (cfg.enabled === false) return;       // event category switched off entirely
   const k = (key || '') + '|' + event;
   const now = Date.now();
   if (_lastRecordAt[k] && now - _lastRecordAt[k] < 2000) return;
@@ -527,16 +554,12 @@ function recordNotification(event, key, detail) {
   restoreNotifHistory();
   const { title, body } = eventNotificationText(event, key, detail);
   const { kind, target } = classifyNotification(event, key);
-  notifHistory.push({
-    id: now + '.' + (_notifSeq++),
-    event, key: key || '', title, body, ts: now, seen: false, kind, target,
-  });
+  notifHistory.push({ event, key: key || '', title, body, ts: now, seen: false, kind, target });
   if (notifHistory.length > NOTIF_HISTORY_CAP) {
     notifHistory = notifHistory.slice(-NOTIF_HISTORY_CAP);
   }
   persistNotifHistory();
-  // The unread count is part of sidebarSignature, so this repaints the badge.
-  try { renderSidebar(); } catch (_) { /* pre-boot — badge paints on first render */ }
+  scheduleNotifRepaint();
 }
 
 // Relative "5m ago" timestamp for panel rows; falls back to a locale date past a
@@ -709,6 +732,19 @@ let sidebarCacheHit = false;
 function clearSidebarCache() {
   try { localStorage.removeItem(SIDEBAR_CACHE_KEY); } catch (_) {}
   sidebarCacheHit = false;
+}
+// Drop EVERY localStorage payload that could leak one user's workspace to the
+// next on a shared/kiosk browser, at the two auth boundaries (explicit logout,
+// cookie death). The notification history holds the same class of data as the
+// sidebar cache — session names, server-supplied PR/issue titles and bodies,
+// issue URLs — so it has to be purged alongside it (review, CROW-909). One
+// helper so a future cached store can't be wired into one auth path and missed
+// on the other. NOT called from the boot-catch recovery, which only wants to
+// discard a *corrupt* sidebar cache, not a valid history.
+function purgeSharedBrowserCaches() {
+  clearSidebarCache();
+  notifHistory = [];
+  try { localStorage.removeItem(NOTIF_HISTORY_KEY); } catch (_) {}
 }
 function restoreSidebarCache() {
   try {
@@ -1155,10 +1191,10 @@ async function handleAuthOnDisconnect() {
   try {
     if (await sessionExpired()) {
       sessionDead = true;
-      // Parity with explicit logout: drop cached session/ticket payloads when
-      // the remote web cookie dies (crowd restart) so they don't linger in a
-      // shared browser (CROW-613 review).
-      clearSidebarCache();
+      // Parity with explicit logout: drop cached session/ticket payloads AND the
+      // notification history when the remote web cookie dies (crowd restart) so
+      // they don't linger in a shared browser (CROW-613 review / CROW-909).
+      purgeSharedBrowserCaches();
       renderStatusBar();
     }
   } finally {
@@ -1203,9 +1239,10 @@ function renderStatusBar() {
     out.onclick = async () => {
       if (!await confirmModal('Log out of this web session? You’ll need the web password to sign back in.', { title: 'Log out', okLabel: 'Log out' })) return;
       try { await fetch('/logout', { method: 'POST' }); } catch (_) {}
-      // Drop cached session/ticket payloads so a shared browser can't read them
-      // after logout of a password-protected remote session (CROW-613 review).
-      clearSidebarCache();
+      // Drop cached session/ticket payloads AND the notification history so a
+      // shared browser can't read them after logout of a password-protected
+      // remote session (CROW-613 review / CROW-909).
+      purgeSharedBrowserCaches();
       location.reload();  // now unauthenticated → the auth gate serves the login page
     };
     actions.appendChild(out);
@@ -1339,7 +1376,7 @@ async function openNewManagerMenu(anchorEl) {
   const y = Math.min(rect.bottom + 4, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
   menu.style.top = Math.max(4, y) + 'px';
-  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+  armContextMenuClose();
 }
 
 // Notification center panel (CROW-909): an anchored popover mirroring
@@ -1414,7 +1451,7 @@ function openNotificationPanel(anchorEl) {
   const y = Math.min(rect.bottom + 4, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
   menu.style.top = Math.max(4, y) + 'px';
-  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+  armContextMenuClose();
 }
 
 // Sidebar status/activity indicator, mirroring the desktop: for active
@@ -1717,9 +1754,32 @@ function prBadgeParts(pr, am, autoMergeEnabled) {
 // ---------------------------------------------------------------------------
 // Session right-click context menu (custom — suppresses the browser default).
 // ---------------------------------------------------------------------------
+// The outside-click closer, held module-level so closeContextMenu can remove it.
+// Registered NOT as { once: true } on purpose: a click *inside* a menu that
+// stopPropagations (a notification row, "Clear all") never reaches document, so
+// a once-listener would stay armed with no menu on screen — and the next
+// menu-open's own click would then bubble to it and tear the fresh menu straight
+// back down. Tying the listener's lifetime to closeContextMenu instead of to
+// "some outside click eventually happens" fixes that for all six menu sites
+// (review, CROW-909).
+let _ctxMenuCloser = null;
 function closeContextMenu() {
   const m = document.querySelector('.ctx-menu');
   if (m) m.remove();
+  if (_ctxMenuCloser) {
+    document.removeEventListener('click', _ctxMenuCloser);
+    _ctxMenuCloser = null;
+  }
+}
+// Arm the outside-click close one tick out (so the opening click itself doesn't
+// immediately close the menu). Shared by every menu opener; the deferred arm
+// also means a listener still pending from a prior menu fires against an empty
+// document before this one registers.
+function armContextMenuClose() {
+  setTimeout(() => {
+    _ctxMenuCloser = closeContextMenu;
+    document.addEventListener('click', _ctxMenuCloser);
+  }, 0);
 }
 
 // Right-click a board card → a small menu to copy its link(s). Pass an array of
@@ -1741,7 +1801,7 @@ function showCardMenu(e, items) {
   const y = Math.min(e.clientY, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
   menu.style.top = Math.max(4, y) + 'px';
-  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+  armContextMenuClose();
 }
 
 // Clipboard with a legacy fallback (execCommand) for non-secure contexts where
@@ -1780,7 +1840,7 @@ function showSessionMenu(e, s) {
   const y = Math.min(e.clientY, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
   menu.style.top = Math.max(4, y) + 'px';
-  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+  armContextMenuClose();
 }
 
 // Long-press → context-menu bridge for touch devices. Fires `handler(x, y)` at
@@ -1918,7 +1978,7 @@ async function openHandoffAgentMenu(session, anchorEl) {
   const y = Math.min((rect.bottom || 80) + 4, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
   menu.style.top = Math.max(4, y) + 'px';
-  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+  armContextMenuClose();
 }
 
 // Fire a session RPC from the row menu. A verb can succeed and still not have
@@ -4326,7 +4386,7 @@ function showTerminalMenu(e) {
   const y = Math.min(e.clientY, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
   menu.style.top = Math.max(4, y) + 'px';
-  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+  armContextMenuClose();
 }
 
 function connectTerminalWs() {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -364,6 +364,27 @@ function sessionNameFor(id) {
   return (s && s.name) || 'Session';
 }
 
+// Derive the { title, body } for an event, enriched with the session name (for
+// session events) or the review's repo (for reviews). A server-supplied
+// title/body (automation events) is used verbatim. Shared by the transient
+// browser/Tauri banner and the notification center so both read identically
+// (CROW-909).
+function eventNotificationText(event, key, detail) {
+  const isSession = !!sessions.find((x) => x.id === key);
+  const title = (detail && detail.title) || EVENT_LABEL[event] || event;
+  let body = (detail && detail.body) || '';
+  if (!body) {
+    body = EVENT_DESC[event] || '';
+    if (isSession) {
+      body = `${sessionNameFor(key)} — ${body}`;
+    } else {
+      const r = ((boardData.reviews && boardData.reviews.reviews) || []).find((x) => x.id === key);
+      if (r && r.repo) body = `${r.repo} — ${body}`;
+    }
+  }
+  return { title, body };
+}
+
 // `detail` (optional) carries a server-supplied { title, body } for automation
 // events, whose text is specific (PR number, issue title) rather than derivable
 // from EVENT_DESC (CROW-768).
@@ -394,17 +415,7 @@ function showEventNotification(event, key, detail) {
 
   // A server-supplied title/body already names the PR / issue / session, so it's
   // used verbatim; derived events get the label plus a subject prefix.
-  const label = (detail && detail.title) || EVENT_LABEL[event] || event;
-  let body = (detail && detail.body) || '';
-  if (!body) {
-    body = EVENT_DESC[event] || '';
-    if (isSession) {
-      body = `${sessionNameFor(key)} — ${body}`;
-    } else {
-      const r = ((boardData.reviews && boardData.reviews.reviews) || []).find((x) => x.id === key);
-      if (r && r.repo) body = `${r.repo} — ${body}`;
-    }
-  }
+  const { title: label, body } = eventNotificationText(event, key, detail);
   try {
     // In the desktop app, WKWebView lacks the Web Notification API — post via the
     // Tauri plugin instead. (Click-to-focus below stays web-only.)
@@ -438,6 +449,98 @@ function showEventNotification(event, key, detail) {
 function emitEvent(event, key, detail) {
   playEventSound(event, key);
   showEventNotification(event, key, detail);
+  recordNotification(event, key, detail);
+}
+
+// --- Notification center: history + unread counter (CROW-909) ---------------
+// The sound + banner above are fire-and-forget. The center keeps a client-side
+// history of every event that reaches emitEvent — recorded UNGATED (unlike the
+// banner, which self-suppresses on focus/mute), so the panel is a faithful log
+// even for events whose transient popup you never saw. Per-client (localStorage,
+// same pattern as the sidebar cache): each web tab / the desktop app keep their
+// own; a server-synced history would be a larger follow-up.
+const NOTIF_HISTORY_KEY = 'crow.notif.history';
+const NOTIF_HISTORY_CAP = 100; // keep the last ~100; older entries drop off
+let notifHistory = [];         // [{ id, event, key, title, body, ts, seen, kind, target }]
+let _notifSeq = 0;             // disambiguates entries appended in the same ms
+
+function restoreNotifHistory() {
+  try {
+    const raw = localStorage.getItem(NOTIF_HISTORY_KEY);
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    if (Array.isArray(data)) notifHistory = data.slice(-NOTIF_HISTORY_CAP);
+  } catch (_) { /* corrupt cache — start empty */ }
+}
+function persistNotifHistory() {
+  try { localStorage.setItem(NOTIF_HISTORY_KEY, JSON.stringify(notifHistory)); }
+  catch (_) { /* quota / private mode */ }
+}
+function notifUnreadCount() {
+  let n = 0;
+  for (const e of notifHistory) if (!e.seen) n++;
+  return n;
+}
+
+// Classify the click-through target at append time (event type is stable),
+// while leaving the live lookup (review→session, session existence) to click
+// time where the state is fresh. Mirrors the routing in showEventNotification's
+// Notification.onclick (CROW-909).
+function classifyNotification(event, key) {
+  if (sessions.find((x) => x.id === key)) return { kind: 'session', target: key };
+  if (AUTOMATION_EVENTS.indexOf(event) === -1) return { kind: 'review', target: key };
+  // Automation keyed by an issue URL opens externally; `config`/other → no target.
+  if (typeof key === 'string' && /^https?:\/\//.test(key)) return { kind: 'url', target: key };
+  return { kind: 'none', target: null };
+}
+
+// Append one event to the history and bump the unread counter. Called from
+// emitEvent unconditionally: the detectors already gate on the arm window, so
+// this can't be flooded by a page load.
+function recordNotification(event, key, detail) {
+  const { title, body } = eventNotificationText(event, key, detail);
+  const { kind, target } = classifyNotification(event, key);
+  notifHistory.push({
+    id: Date.now() + '.' + (_notifSeq++),
+    event, key: key || '', title, body, ts: Date.now(), seen: false, kind, target,
+  });
+  if (notifHistory.length > NOTIF_HISTORY_CAP) {
+    notifHistory = notifHistory.slice(-NOTIF_HISTORY_CAP);
+  }
+  persistNotifHistory();
+  // The unread count is part of sidebarSignature, so this repaints the badge.
+  try { renderSidebar(); } catch (_) { /* pre-boot — badge paints on first render */ }
+}
+
+// Relative "5m ago" timestamp for panel rows; falls back to a locale date past a
+// week so old entries stay legible.
+function relTime(ts) {
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (s < 45) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return m + 'm ago';
+  const h = Math.floor(m / 60);
+  if (h < 24) return h + 'h ago';
+  const d = Math.floor(h / 24);
+  if (d < 7) return d + 'd ago';
+  try { return new Date(ts).toLocaleDateString(); } catch (_) { return ''; }
+}
+
+// Route a history entry to its origin, reusing the live state so a review whose
+// session started after the event still lands on that session (CROW-909).
+function navigateToNotification(entry) {
+  try {
+    if (entry.kind === 'session') {
+      if (sessions.find((x) => x.id === entry.target)) selectSession(entry.target);
+    } else if (entry.kind === 'review') {
+      const r = ((boardData.reviews && boardData.reviews.reviews) || []).find((x) => x.id === entry.target);
+      if (r && r.review_session_id) selectSession(r.review_session_id);
+      else selectBoard('reviews');
+    } else if (entry.kind === 'url') {
+      window.open(entry.target, '_blank', 'noopener');
+    }
+    // kind 'none' (config reload, non-URL automation) has no in-app target.
+  } catch (_) { /* nav best-effort */ }
 }
 
 // Server-pushed automation event (CROW-768). The daemon fires these at the point
@@ -786,6 +889,9 @@ function sidebarSignature() {
     boardData.tickets && boardData.tickets.counts,
     boardData.tickets && boardData.tickets.done_last_24h,
     boardData.reviews && boardData.reviews.unseen,
+    // The bell's unread badge (CROW-909) — not store-backed, so name it here so
+    // an appended notification actually repaints the badge.
+    notifUnreadCount(),
     // The ↻ spins off this, and the local half isn't in `boardData` (CROW-771).
     ticketsRefreshing(),
   ]);
@@ -1064,6 +1170,15 @@ function renderStatusBar() {
 // (outside the box): Settings on top, Select below.
 function sidebarToolsStack() {
   const stack = el('div', 'sidebar-tools');
+  // Notification center (CROW-909): bell + unread badge, first so it's the most
+  // prominent global affordance. Visible in every view (sessions and boards).
+  const bell = el('button', 'tk-tool tk-bell');
+  const unread = notifUnreadCount();
+  bell.title = unread ? unread + ' unread notification' + (unread === 1 ? '' : 's') : 'Notifications';
+  bell.appendChild(icon('bell', 14));
+  if (unread) bell.appendChild(el('span', 'notif-badge', unread > 99 ? '99+' : String(unread)));
+  bell.onclick = () => openNotificationPanel(bell);
+  stack.appendChild(bell);
   const gear = el('button', 'tk-tool');
   gear.title = 'Settings';
   gear.appendChild(icon('wrench', 14));
@@ -1181,6 +1296,72 @@ async function openNewManagerMenu(anchorEl) {
   setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
 }
 
+// Notification center panel (CROW-909): an anchored popover mirroring
+// openNewManagerMenu — reuses the .ctx-menu shell (so closeContextMenu closes
+// it) with a .notif-panel modifier for the wider, scrollable, two-line layout.
+// Opening marks every entry seen (clears the unread badge). Clicking a row
+// navigates to its origin; a "Clear all" empties the history.
+function openNotificationPanel(anchorEl) {
+  // Toggle: a second click on the bell dismisses the open panel.
+  if (document.querySelector('.notif-panel')) { closeContextMenu(); return; }
+  closeContextMenu();
+
+  // Opening is "reading" — mark all seen and drop the unread badge.
+  if (notifUnreadCount()) {
+    for (const e of notifHistory) e.seen = true;
+    persistNotifHistory();
+    renderSidebar();
+  }
+
+  const menu = el('div', 'ctx-menu notif-panel');
+  const header = el('div', 'notif-header');
+  header.appendChild(el('span', 'notif-title', 'Notifications'));
+  if (notifHistory.length) {
+    const clear = el('button', 'notif-clear', 'Clear all');
+    clear.onclick = (ev) => {
+      ev.stopPropagation();
+      notifHistory = [];
+      persistNotifHistory();
+      closeContextMenu();
+      renderSidebar();
+    };
+    header.appendChild(clear);
+  }
+  menu.appendChild(header);
+
+  if (!notifHistory.length) {
+    menu.appendChild(el('div', 'notif-empty', 'No notifications yet'));
+  } else {
+    const list = el('div', 'notif-list');
+    // Newest first.
+    for (let i = notifHistory.length - 1; i >= 0; i--) {
+      const entry = notifHistory[i];
+      const navigable = entry.kind === 'session' || entry.kind === 'review' || entry.kind === 'url';
+      const item = el('div', 'notif-item' + (navigable ? '' : ' notif-static'));
+      const line1 = el('div', 'notif-row1');
+      line1.appendChild(el('span', 'notif-item-title', entry.title || EVENT_LABEL[entry.event] || entry.event));
+      line1.appendChild(el('span', 'notif-time', relTime(entry.ts)));
+      item.appendChild(line1);
+      if (entry.body) item.appendChild(el('div', 'notif-item-body', entry.body));
+      if (navigable) {
+        item.onclick = (ev) => { ev.stopPropagation(); closeContextMenu(); navigateToNotification(entry); };
+      } else {
+        item.onclick = (ev) => ev.stopPropagation();
+      }
+      list.appendChild(item);
+    }
+    menu.appendChild(list);
+  }
+
+  document.body.appendChild(menu);
+  const rect = anchorEl.getBoundingClientRect();
+  const x = Math.min(rect.left, window.innerWidth - menu.offsetWidth - 8);
+  const y = Math.min(rect.bottom + 4, window.innerHeight - menu.offsetHeight - 8);
+  menu.style.left = Math.max(4, x) + 'px';
+  menu.style.top = Math.max(4, y) + 'px';
+  setTimeout(() => document.addEventListener('click', closeContextMenu, { once: true }), 0);
+}
+
 // Sidebar status/activity indicator, mirroring the desktop: for active
 // sessions the dot is driven by hook activity (working / needs-attention /
 // done); otherwise by session status.
@@ -1208,6 +1389,7 @@ const ICONS = {
   code: '<path d="M6 5 2.5 8 6 11"/><path d="M10 5l3.5 3-3.5 3"/>',
   terminal: '<rect x="2" y="3" width="12" height="10" rx="1.5"/><path d="M4.5 6.5 6.5 8l-2 1.5"/><path d="M8 9.5h3"/>',
   comment: '<path d="M2.5 3.5h11v7h-6l-3 2.5v-2.5h-2z"/>',
+  bell: '<path d="M4.5 7a3.5 3.5 0 0 1 7 0c0 3 1 4 1.5 4.5H3C3.5 11 4.5 10 4.5 7Z"/><path d="M6.6 13a1.6 1.6 0 0 0 2.8 0"/>',
 };
 function icon(name, size) {
   const span = el('span', 'ico');
@@ -4535,6 +4717,7 @@ document.getElementById('terminal-wrap').addEventListener('contextmenu', showTer
 // cache entry must not abort the rest of boot (polls / refreshSessions).
 try {
   restoreSidebarCache();
+  restoreNotifHistory();
   renderSidebar();
 } catch (_) {
   clearSidebarCache();

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -453,12 +453,14 @@ function emitEvent(event, key, detail) {
 }
 
 // --- Notification center: history + unread counter (CROW-909) ---------------
-// The sound + banner above are fire-and-forget. The center keeps a client-side
-// history of every event that reaches emitEvent — recorded UNGATED (unlike the
-// banner, which self-suppresses on focus/mute), so the panel is a faithful log
-// even for events whose transient popup you never saw. Per-client (localStorage,
-// same pattern as the sidebar cache): each web tab / the desktop app keep their
-// own; a server-synced history would be a larger follow-up.
+// The sound + banner above are fire-and-forget. The center keeps a history of
+// every event that reaches emitEvent — recorded UNGATED (unlike the banner,
+// which self-suppresses on focus/mute), so the panel is a faithful log even for
+// events whose transient popup you never saw. Per-browser, not per-tab:
+// localStorage is shared across every tab on the origin, so a `storage` listener
+// keeps the tabs in sync and each mutate re-reads first to compose rather than
+// clobber (review). Not server-synced — a shared, cross-device history is a
+// larger follow-up.
 const NOTIF_HISTORY_KEY = 'crow.notif.history';
 const NOTIF_HISTORY_CAP = 100; // keep the last ~100; older entries drop off
 let notifHistory = [];         // [{ id, event, key, title, body, ts, seen, kind, target }]
@@ -469,7 +471,13 @@ function restoreNotifHistory() {
     const raw = localStorage.getItem(NOTIF_HISTORY_KEY);
     if (!raw) return;
     const data = JSON.parse(raw);
-    if (Array.isArray(data)) notifHistory = data.slice(-NOTIF_HISTORY_CAP);
+    // Filter to plain objects: a parseable-but-wrong array (`[null, …]`, a
+    // foreign schema) would otherwise let a later `e.seen` read throw inside
+    // notifUnreadCount → sidebarSignature → every renderSidebar, wedging the
+    // whole sidebar until the key is cleared by hand (review).
+    if (Array.isArray(data)) {
+      notifHistory = data.filter((e) => e && typeof e === 'object').slice(-NOTIF_HISTORY_CAP);
+    }
   } catch (_) { /* corrupt cache — start empty */ }
 }
 function persistNotifHistory() {
@@ -478,9 +486,18 @@ function persistNotifHistory() {
 }
 function notifUnreadCount() {
   let n = 0;
-  for (const e of notifHistory) if (!e.seen) n++;
+  for (const e of notifHistory) if (e && !e.seen) n++;
   return n;
 }
+
+// Another tab wrote the shared history (append, mark-seen, or clear). Re-read so
+// this tab's badge/panel reflect it instead of drifting, then repaint. Does not
+// fire in the tab that made the change, so there's no write→event loop (review).
+window.addEventListener('storage', (e) => {
+  if (e.key !== NOTIF_HISTORY_KEY) return;
+  restoreNotifHistory();
+  try { renderSidebar(); } catch (_) { /* pre-boot */ }
+});
 
 // Classify the click-through target at append time (event type is stable),
 // while leaving the live lookup (review→session, session existence) to click
@@ -496,13 +513,23 @@ function classifyNotification(event, key) {
 
 // Append one event to the history and bump the unread counter. Called from
 // emitEvent unconditionally: the detectors already gate on the arm window, so
-// this can't be flooded by a page load.
+// this can't be flooded by a page load. A 2s per-(key,event) dedup mirrors the
+// sound/banner channels — a flapping poll or a repeated server push produced
+// duplicate popups there, and would produce duplicate rows here (review).
+const _lastRecordAt = {};
 function recordNotification(event, key, detail) {
+  const k = (key || '') + '|' + event;
+  const now = Date.now();
+  if (_lastRecordAt[k] && now - _lastRecordAt[k] < 2000) return;
+  _lastRecordAt[k] = now;
+  // Re-read the shared store first so a concurrent tab's entries compose with
+  // this append instead of being overwritten by our stale in-memory copy.
+  restoreNotifHistory();
   const { title, body } = eventNotificationText(event, key, detail);
   const { kind, target } = classifyNotification(event, key);
   notifHistory.push({
-    id: Date.now() + '.' + (_notifSeq++),
-    event, key: key || '', title, body, ts: Date.now(), seen: false, kind, target,
+    id: now + '.' + (_notifSeq++),
+    event, key: key || '', title, body, ts: now, seen: false, kind, target,
   });
   if (notifHistory.length > NOTIF_HISTORY_CAP) {
     notifHistory = notifHistory.slice(-NOTIF_HISTORY_CAP);
@@ -537,7 +564,13 @@ function navigateToNotification(entry) {
       if (r && r.review_session_id) selectSession(r.review_session_id);
       else selectBoard('reviews');
     } else if (entry.kind === 'url') {
-      window.open(entry.target, '_blank', 'noopener');
+      // Re-test the scheme at click time — `entry.target` came from localStorage,
+      // which same-origin script could have tampered with or an older build could
+      // have written under looser rules. classifyNotification already rejects
+      // javascript:/data: at record time; this is cheap defense-in-depth (review).
+      if (typeof entry.target === 'string' && /^https?:\/\//.test(entry.target)) {
+        window.open(entry.target, '_blank', 'noopener');
+      }
     }
     // kind 'none' (config reload, non-URL automation) has no in-app target.
   } catch (_) { /* nav best-effort */ }
@@ -591,6 +624,19 @@ window.crowTestNotify = function (event) {
   };
   if (Notification.permission === 'granted') fire();
   else Notification.requestPermission().then((p) => { if (p === 'granted') fire(); else console.warn('[crowNotify] permission:', p); });
+};
+
+// Manual test hook for the notification center (CROW-909). Unlike crowTestSound
+// / crowTestNotify — which call crowSound.play / new Notification directly and
+// so never touch the history — this drives the real emitEvent path, so it moves
+// the bell's unread badge and appends a row. crowTestEvent() fires taskComplete
+// against the first session; crowTestEvent('reviewRequested', '<id>') targets a
+// specific key. Subject to the same config gating as a real event.
+window.crowTestEvent = function (event, key) {
+  const ev = event || 'taskComplete';
+  const k = key || (sessions[0] && sessions[0].id) || 'test';
+  emitEvent(ev, k);
+  console.log('[crowEvent] test', ev, '→', k, '· unread now', notifUnreadCount());
 };
 
 // Event detection: diff successive state snapshots. Snapshots always update; the
@@ -1306,8 +1352,18 @@ function openNotificationPanel(anchorEl) {
   if (document.querySelector('.notif-panel')) { closeContextMenu(); return; }
   closeContextMenu();
 
-  // Opening is "reading" — mark all seen and drop the unread badge.
+  // Measure the anchor BEFORE the seen-marking repaint below: renderSidebar
+  // rebuilds the tools stack from scratch (root.innerHTML = ''), detaching this
+  // very `bell`. A detached node has no layout box, so a later
+  // getBoundingClientRect() would read all-zeros and the panel would clamp to
+  // the viewport corner instead of under the bell (review).
+  const rect = anchorEl.getBoundingClientRect();
+
+  // Opening is "reading" — mark all seen and drop the unread badge. Re-read
+  // first so a concurrent tab's newer entries aren't clobbered by writing back
+  // our stale in-memory copy (review).
   if (notifUnreadCount()) {
+    restoreNotifHistory();
     for (const e of notifHistory) e.seen = true;
     persistNotifHistory();
     renderSidebar();
@@ -1354,7 +1410,6 @@ function openNotificationPanel(anchorEl) {
   }
 
   document.body.appendChild(menu);
-  const rect = anchorEl.getBoundingClientRect();
   const x = Math.min(rect.left, window.innerWidth - menu.offsetWidth - 8);
   const y = Math.min(rect.bottom + 4, window.innerHeight - menu.offsetHeight - 8);
   menu.style.left = Math.max(4, x) + 'px';
@@ -4722,6 +4777,9 @@ try {
 } catch (_) {
   clearSidebarCache();
   sessions = [];
+  // A poisoned notif history is filtered on restore, but reset here too so this
+  // recovery path can't itself re-throw on the retry render below (review).
+  notifHistory = [];
   lastSidebarSig = null;
   try { renderSidebar(); } catch (_) { /* keep going — RPC refresh will paint */ }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -469,13 +469,19 @@ let notifHistory = [];         // [{ event, key, title, body, ts, seen, kind, ta
 function restoreNotifHistory() {
   try {
     const raw = localStorage.getItem(NOTIF_HISTORY_KEY);
-    if (!raw) return;
+    // Missing key means "empty", not "no change" — a purge in another tab fires a
+    // storage event with newValue === null, and returning early here would leave
+    // this tab's in-memory copy intact, which its next seen-marking would then
+    // persist straight back, re-creating the key the logout just dropped (review).
+    // Safe for the compose path too: recordNotification only reaches here with the
+    // key already absent, where in-memory is [] anyway.
+    if (!raw) { notifHistory = []; return; }
     const data = JSON.parse(raw);
     // Filter to well-formed entries: a parseable-but-wrong array (`[null, …]`, a
     // foreign schema) would otherwise let a later `e.seen` read throw inside
     // notifUnreadCount → sidebarSignature → every renderSidebar, wedging the
-    // whole sidebar until the key is cleared by hand. The `ts` check also keeps
-    // a ts-less entry from rendering "Invalid Date" in relTime (review).
+    // whole sidebar until the key is cleared by hand. The `ts` check also keeps a
+    // ts-less entry from rendering "Invalid Date" in notifRelTime (review).
     if (Array.isArray(data)) {
       notifHistory = data
         .filter((e) => e && typeof e === 'object' && typeof e.ts === 'number')
@@ -508,9 +514,10 @@ function scheduleNotifRepaint() {
   });
 }
 
-// Another tab wrote the shared history (append, mark-seen, or clear). Re-read so
-// this tab's badge/panel reflect it instead of drifting, then repaint. Does not
-// fire in the tab that made the change, so there's no write→event loop (review).
+// Another tab wrote the shared history (append, mark-seen, clear, or purge on
+// logout — restoreNotifHistory treats the removed key as empty). Re-read so this
+// tab's badge/panel reflect it instead of drifting, then repaint. Does not fire
+// in the tab that made the change, so there's no write→event loop (review).
 window.addEventListener('storage', (e) => {
   if (e.key !== NOTIF_HISTORY_KEY) return;
   restoreNotifHistory();
@@ -562,9 +569,13 @@ function recordNotification(event, key, detail) {
   scheduleNotifRepaint();
 }
 
-// Relative "5m ago" timestamp for panel rows; falls back to a locale date past a
-// week so old entries stay legible.
-function relTime(ts) {
+// Relative "5m ago" timestamp for panel rows, from epoch ms; falls back to a
+// locale date past a week so old entries stay legible. NOT named `relTime` — a
+// pre-existing `relTime(iso)` (the card helper, #594) takes an ISO string, and
+// in a classic <script> the later top-level declaration would win for BOTH, so
+// every call would resolve to one of them. Distinct name, distinct input unit
+// (review, CROW-909).
+function notifRelTime(ts) {
   const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
   if (s < 45) return 'just now';
   const m = Math.floor(s / 60);
@@ -1433,7 +1444,7 @@ function openNotificationPanel(anchorEl) {
       const item = el('div', 'notif-item' + (navigable ? '' : ' notif-static'));
       const line1 = el('div', 'notif-row1');
       line1.appendChild(el('span', 'notif-item-title', entry.title || EVENT_LABEL[entry.event] || entry.event));
-      line1.appendChild(el('span', 'notif-time', relTime(entry.ts)));
+      line1.appendChild(el('span', 'notif-time', notifRelTime(entry.ts)));
       item.appendChild(line1);
       if (entry.body) item.appendChild(el('div', 'notif-item-body', entry.body));
       if (navigable) {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebNotificationCenterTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebNotificationCenterTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import CrowDaemon
+
+/// Drift guard for the notification center served out of `Resources/web/app.js`
+/// (CROW-909). There's no JS test runner in this repo, so — like
+/// `WebTerminalAssetTests` — these pin the non-obvious invariants of the feature
+/// against the `app.js` source a reviewer actually edits. The bugs each one
+/// guards were all live at first review (PR #910): a detached-anchor mispositon,
+/// a poisoned-cache render wedge, a multi-tab last-writer-wins clobber, and a
+/// dedup gap.
+@Suite struct WebNotificationCenterTests {
+    /// Walk up to `Resources/web/<name>` and read it (the assets are `.copy`d, so
+    /// the repo copy is the source of truth). Mirrors `WebTerminalAssetTests`.
+    private static func webAsset(_ name: String) throws -> String {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        var found: URL?
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent(
+                "Sources/CrowDaemon/Resources/web/\(name)")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                found = candidate
+                break
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        let url = try #require(found, "could not locate Resources/web/\(name)")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// The body of a top-level `function <name>(` … `\n}` block, so an assertion
+    /// is about one handler rather than the whole file. Same shape as
+    /// `WebTerminalAssetTests.functionBody`.
+    private static func functionBody(_ name: String, in source: String) throws -> Substring {
+        let start = try #require(source.range(of: "function \(name)("), "no \(name)")
+        let rest = source[start.upperBound...]
+        let end = try #require(rest.range(of: "\n}\n"), "unterminated \(name)")
+        return rest[..<end.lowerBound]
+    }
+
+    /// `source` with `/* … */` and `//` comments removed, for negative
+    /// assertions where the prose legitimately names the thing the code must not
+    /// do. Copied from `WebTerminalAssetTests.stripComments`.
+    private static func stripComments(_ source: String) -> String {
+        var withoutBlocks = ""
+        var rest = Substring(source)
+        while let open = rest.range(of: "/*"),
+              let close = rest.range(of: "*/", range: open.upperBound..<rest.endIndex) {
+            withoutBlocks += rest[..<open.lowerBound]
+            rest = rest[close.upperBound...]
+        }
+        withoutBlocks += rest
+        return withoutBlocks.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                guard let marker = line.range(of: "//") else { return line }
+                return line[..<marker.lowerBound]
+            }
+            .joined(separator: "\n")
+    }
+
+    /// Every event funnels through `emitEvent`, so the history append lives there
+    /// — the one chokepoint the whole feature hangs off. If this call is dropped,
+    /// nothing is ever recorded and the bell stays permanently empty.
+    @Test func emitEventRecordsToTheCenter() throws {
+        let body = try Self.functionBody("emitEvent", in: Self.webAsset("app.js"))
+        #expect(
+            body.contains("recordNotification(event, key, detail)"),
+            "emitEvent must append to the history, not just play the sound/banner")
+    }
+
+    /// The Red from review: `renderSidebar()` does `root.innerHTML = ''` and
+    /// rebuilds the tools stack, detaching the `bell` passed in as the anchor. A
+    /// detached node measures all-zeros, so the panel must capture
+    /// getBoundingClientRect BEFORE the seen-marking repaint or it clamps to the
+    /// viewport corner instead of under the bell — and that path fires exactly
+    /// when the badge is showing, i.e. the normal reason to open it.
+    @Test func panelMeasuresAnchorBeforeTheSeenMarkingRepaint() throws {
+        let body = String(try Self.functionBody("openNotificationPanel", in: Self.webAsset("app.js")))
+        let measure = try #require(body.range(of: "getBoundingClientRect("), "panel must measure the anchor")
+        let repaint = try #require(body.range(of: "renderSidebar()"), "panel must repaint after marking seen")
+        #expect(
+            measure.lowerBound < repaint.lowerBound,
+            "the anchor rect must be captured before renderSidebar() detaches the bell")
+    }
+
+    /// The Yellow that wedges the sidebar: `restoreNotifHistory` must drop
+    /// non-object entries, or a parseable-but-wrong array (`[null, …]`, a foreign
+    /// schema) lets a later `e.seen` read throw inside notifUnreadCount →
+    /// sidebarSignature → every renderSidebar, and the sidebar stays dead until
+    /// the key is cleared by hand.
+    @Test func restoreFiltersPoisonedEntries() throws {
+        let body = try Self.functionBody("restoreNotifHistory", in: Self.webAsset("app.js"))
+        #expect(
+            body.contains("typeof e === 'object'"),
+            "restore must filter to plain objects so a poisoned array can't wedge the render")
+    }
+
+    /// The boot recovery path must reset `notifHistory` too, not only the sidebar
+    /// cache — otherwise a poisoned history survives into the retry render (and
+    /// every later poll-driven render, some outside a try) and the recovery
+    /// itself re-throws.
+    @Test func bootCatchResetsTheHistory() throws {
+        let source = Self.stripComments(try Self.webAsset("app.js"))
+        // The boot recovery block is the only place that clears the sidebar cache
+        // and resets `sessions` back-to-back — anchor on that pair so a different
+        // clearSidebarCache() caller (the logout button) isn't matched.
+        let anchor = try #require(
+            source.range(of: "clearSidebarCache();\n  sessions = [];"),
+            "no boot recovery block")
+        let window = source[anchor.lowerBound...].prefix(200)
+        #expect(
+            window.contains("notifHistory = []"),
+            "the boot catch must reset notifHistory so a poisoned key self-heals")
+    }
+
+    /// The multi-tab Yellow: localStorage is per-origin, so `recordNotification`
+    /// must re-read the shared store before appending (compose, not clobber a
+    /// concurrent tab), and a `storage` listener must re-sync this tab. Without
+    /// both, tabs silently drop each other's entries and the badge re-inflates.
+    @Test func recordReReadsAndTabsStayInSync() throws {
+        let source = try Self.webAsset("app.js")
+        let body = try Self.functionBody("recordNotification", in: source)
+        #expect(
+            body.contains("restoreNotifHistory();"),
+            "record must re-read the shared store before appending (multi-tab compose)")
+        #expect(
+            source.contains("addEventListener('storage'"),
+            "a storage listener must re-sync history across tabs on the same origin")
+    }
+
+    /// Record-time dedup mirroring the sound/banner channels' 2s per-(key,event)
+    /// window — a flapping poll or repeated server push produced duplicate popups
+    /// there, and would produce duplicate rows here.
+    @Test func recordDedupsWithinTwoSeconds() throws {
+        let body = try Self.functionBody("recordNotification", in: Self.webAsset("app.js"))
+        #expect(
+            body.contains("_lastRecordAt[k]") && body.contains("< 2000"),
+            "record must carry the same 2s per-(key,event) dedup as the sibling channels")
+    }
+
+    /// The unread count is not store-backed, so it must be named in
+    /// `sidebarSignature` or an appended notification never repaints the badge
+    /// (the signature guard would short-circuit the render).
+    @Test func unreadCountIsInTheSidebarSignature() throws {
+        let body = try Self.functionBody("sidebarSignature", in: Self.webAsset("app.js"))
+        #expect(
+            body.contains("notifUnreadCount()"),
+            "sidebarSignature must include the unread count so the badge repaints")
+    }
+
+    /// External navigation is gated: `classifyNotification` only tags an entry
+    /// `url` after an http(s) scheme test, so `javascript:`/`data:` keys can never
+    /// reach window.open, and the open severs the opener. Both must hold.
+    @Test func externalOpenIsSchemeGuardedAndOpenerSevered() throws {
+        let source = try Self.webAsset("app.js")
+        let classify = try Self.functionBody("classifyNotification", in: source)
+        #expect(
+            classify.contains(#"/^https?:\/\//.test(key)"#),
+            "only http(s) keys may be classified as an external URL")
+        let nav = try Self.functionBody("navigateToNotification", in: source)
+        #expect(
+            nav.contains("'_blank', 'noopener'"),
+            "external open must sever the opener reference")
+        #expect(
+            nav.contains(#"/^https?:\/\//.test(entry.target)"#),
+            "the stored target's scheme must be re-tested at click time (defense-in-depth)")
+    }
+
+    /// The panel renders every user/server string through `el(...)` (textContent),
+    /// never innerHTML — the property that keeps a hostile PR title / issue body
+    /// from being an XSS vector.
+    @Test func panelBuildsRowsWithoutInnerHTML() throws {
+        let body = Self.stripComments(String(
+            try Self.functionBody("openNotificationPanel", in: Self.webAsset("app.js"))))
+        #expect(
+            !body.contains("innerHTML"),
+            "the panel must not use innerHTML — user/server strings go through el()'s textContent")
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebNotificationCenterTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebNotificationCenterTests.swift
@@ -176,4 +176,78 @@ import Testing
             !body.contains("innerHTML"),
             "the panel must not use innerHTML — user/server strings go through el()'s textContent")
     }
+
+    /// Second-round Red 1: the outside-click closer must be removable, not
+    /// `{ once: true }`. A click inside a menu that stopPropagations never reaches
+    /// document, so a once-listener stays armed with no menu on screen and the
+    /// next open's click bubbles up and tears the fresh menu straight down. Every
+    /// menu opener must arm through the shared helper, and closeContextMenu must
+    /// remove the handle — so no site is left on the leaky pattern.
+    @Test func outsideClickCloserIsRemovableNotOnce() throws {
+        let source = try Self.webAsset("app.js")
+        #expect(
+            !source.contains("closeContextMenu, { once: true }"),
+            "no menu may arm the outside-click close as a leaky { once: true } listener")
+        #expect(
+            try Self.functionBody("closeContextMenu", in: source)
+                .contains("removeEventListener('click', _ctxMenuCloser)"),
+            "closeContextMenu must remove the armed outside-click listener")
+        // Every left-click/anchored menu opener arms through the one helper.
+        let arms = source.components(separatedBy: "armContextMenuClose();").count - 1
+        #expect(arms >= 6, "all menu openers must arm via armContextMenuClose(); found \(arms)")
+    }
+
+    /// Second-round Red 2: the notification history holds the same class of data
+    /// as the sidebar cache (session names, PR/issue titles, issue URLs), so it
+    /// must be purged at both auth boundaries — otherwise the next user on a
+    /// shared browser can open the bell and read the previous user's workspace.
+    /// One helper drops both keys; both the logout and cookie-death paths call it.
+    @Test func authBoundariesPurgeTheNotificationHistory() throws {
+        let source = try Self.webAsset("app.js")
+        let helper = try Self.functionBody("purgeSharedBrowserCaches", in: source)
+        #expect(
+            helper.contains("clearSidebarCache()") && helper.contains("removeItem(NOTIF_HISTORY_KEY)"),
+            "the purge helper must drop BOTH the sidebar cache and the notif history key")
+        #expect(
+            try Self.functionBody("handleAuthOnDisconnect", in: source)
+                .contains("purgeSharedBrowserCaches()"),
+            "the cookie-death path must purge the shared caches")
+        // The logout handler is an inline onclick, not a named function — assert
+        // there are at least two call sites (logout + cookie death), and that the
+        // boot-catch recovery is NOT one of them (it must keep a valid history).
+        let calls = source.components(separatedBy: "purgeSharedBrowserCaches();").count - 1
+        #expect(calls >= 2, "both auth boundaries must call the purge helper; found \(calls)")
+    }
+
+    /// Second-round Yellow 3: the center honors the MASTER notification levels —
+    /// globalMute and the per-event `enabled` toggle — so a muted / switched-off
+    /// event doesn't pile up an un-opt-out-able badge. The sub-toggles and focus
+    /// rule stay bypassed (the log isn't an interruption); this only pins the two
+    /// master gates.
+    @Test func recordHonorsGlobalMuteAndThePerEventToggle() throws {
+        let body = try Self.functionBody("recordNotification", in: Self.webAsset("app.js"))
+        #expect(body.contains("N.globalMute"), "record must respect global mute")
+        #expect(
+            body.contains("cfg.enabled === false"),
+            "record must respect the per-event master toggle")
+    }
+
+    /// Second-round Yellow 4: appends coalesce to one sidebar repaint per task,
+    /// not one per event — a detector tick transitioning k sessions must not do k
+    /// full innerHTML rebuilds. record must schedule (not call renderSidebar
+    /// directly), and the scheduler must use a microtask so onServerNotify still
+    /// paints within the turn.
+    @Test func recordCoalescesTheSidebarRepaint() throws {
+        let source = try Self.webAsset("app.js")
+        let body = try Self.functionBody("recordNotification", in: source)
+        #expect(
+            body.contains("scheduleNotifRepaint()"),
+            "record must schedule a coalesced repaint")
+        #expect(
+            !body.contains("renderSidebar()"),
+            "record must not call renderSidebar() directly per event")
+        #expect(
+            try Self.functionBody("scheduleNotifRepaint", in: source).contains("Promise.resolve().then"),
+            "the repaint must coalesce on a microtask")
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebNotificationCenterTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebNotificationCenterTests.swift
@@ -250,4 +250,52 @@ import Testing
             try Self.functionBody("scheduleNotifRepaint", in: source).contains("Promise.resolve().then"),
             "the repaint must coalesce on a microtask")
     }
+
+    /// Third-round Red 1: app.js is loaded as a classic <script>, so two top-level
+    /// `function foo(` declarations in one scope don't error — the LATER one
+    /// silently wins for every call. The new `notifRelTime(ts)` (epoch ms) shipped
+    /// as `relTime`, colliding with the pre-existing `relTime(iso)` card helper, so
+    /// every panel timestamp resolved to the ISO version and rendered empty. Guard
+    /// the whole class rather than the instance: assert no duplicate top-level
+    /// function names. (A per-function assertion can't catch it — `functionBody`
+    /// matches the first declaration, i.e. the dead one.)
+    @Test func noDuplicateTopLevelFunctionNames() throws {
+        let source = try Self.webAsset("app.js")
+        var counts: [String: Int] = [:]
+        for rawLine in source.split(separator: "\n", omittingEmptySubsequences: false) {
+            // Top-level declarations start at column 0 — nested/method functions and
+            // function expressions are indented or preceded by `= `/`(`.
+            for prefix in ["function ", "async function "] where rawLine.hasPrefix(prefix) {
+                let after = rawLine.dropFirst(prefix.count)
+                guard let paren = after.firstIndex(of: "(") else { break }
+                let name = after[..<paren]
+                if !name.isEmpty,
+                   name.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" || $0 == "$" }) {
+                    counts[String(name), default: 0] += 1
+                }
+                break
+            }
+        }
+        let dups = counts.filter { $0.value > 1 }.keys.sorted()
+        #expect(
+            dups.isEmpty,
+            "duplicate top-level function name(s) in app.js — in a classic <script> the later declaration silently wins for every call: \(dups)")
+    }
+
+    /// Third-round Yellow 2: restoreNotifHistory must treat a MISSING key as
+    /// "empty", not "no change". A purge in another tab fires a storage event with
+    /// newValue === null; an early return would leave this tab's stale in-memory
+    /// history intact, which its next seen-marking would persist straight back —
+    /// re-creating the key logout just dropped. The `notifRelTime` rename must have
+    /// landed too (no lingering epoch-ms call to the ISO `relTime`).
+    @Test func restoreTreatsMissingKeyAsEmptyAndTimestampUsesTheRenamedHelper() throws {
+        let source = try Self.webAsset("app.js")
+        #expect(
+            try Self.functionBody("restoreNotifHistory", in: source)
+                .contains("if (!raw) { notifHistory = []; return; }"),
+            "a removed key must reset the in-memory history, so a cross-tab purge can't be re-persisted")
+        #expect(
+            source.contains("notif-time', notifRelTime(entry.ts)"),
+            "the panel timestamp must call the renamed epoch-ms helper, not the ISO relTime")
+    }
 }


### PR DESCRIPTION
Closes #909

## What

Adds an in-app **notification center**: a bell with an unread counter in the sidebar tools stack, and an anchored panel listing the history of notifications that fired. Clicking an entry navigates back to its context. Today notifications are fire-and-forget (transient banner + sound, no history) — once the banner dismisses there's no record.

The whole feature slots in at the one chokepoint every event already funnels through — `emitEvent(event, key, detail)` (`app.js`) — so client-derived events (`detectSessionSounds`, `detectReviewSounds`) and server-pushed automation events (`onServerNotify`) all land in one place.

## Approach

- **History store** — appended in `emitEvent`, **ungated** (unlike the banner, which self-suppresses on focus/mute), so the panel is a faithful log even for events whose popup you never saw. The detectors' arm window still guards it, so a page load can't flood it. Persisted to `localStorage` (same pattern as the sidebar cache), capped at ~100. Entry schema: `{ id, event, key, title, body, ts, seen, kind, target }`.
- **Bell + counter** — a `tk-tool` button in `sidebarToolsStack` (visible in **all** views — sessions *and* boards), with a `.pill-badge`-style unread badge. Unread count joins `sidebarSignature` so an append actually repaints. Opening the panel marks entries `seen`; `seen` persists so a reload doesn't re-inflate the count.
- **Panel** — reuses the `.ctx-menu` shell (so `closeContextMenu` closes it) with a `.notif-panel` modifier for the wider, scrollable, two-line layout; mirrors `openNewManagerMenu`'s anchored-popover positioning. Two-line rows (title + relative timestamp, plus body), a "Clear all", and bell-click toggle.
- **Click-through** — reuses the existing `Notification.onclick` mapping: session events → `selectSession`, `reviewRequested` → the review's session (resolved live) or the reviews board, automation keyed by an issue URL → open externally, config/other → non-navigable.
- **Shared text** — `eventNotificationText()` factored out and used by both the transient banner and the center, so they read identically.

Existing banner/sound behavior is unchanged — the center is purely additive.

## Scope

Client-side history (localStorage) only for v1, so it's **per-client** (each web tab / the desktop app keep their own) — a server-synced, persistent history is a larger follow-up, out of scope here (the `notify` frame already carries `{event, key, title, body}`, so no backend change was needed).

## Test plan / verification

- `node --check app.js` — passes.
- Focused Node harness exercising the store/routing logic (19 assertions, all pass): session/review/automation-URL/config enrichment + classification, unread count, per-append repaint, persist→restore round-trip, seen-persists-across-reload (no re-inflate), 100-entry cap on both append and restore, `relTime` buckets, and routing (session, review→its session, unknown-review→board, deleted-session→no-op, url→open).
- The panel/bell reuse production-proven primitives (`.ctx-menu` menu with the same positioning/outside-click-close, `tk-tool` buttons, `.pill-badge`), so no new visual machinery.

Manual UI check to run in-app: fire an event (`crowTestSound`/`crowTestNotify` exist, or trigger a real transition) → badge increments → open bell → rows list newest-first, badge clears → click a session/review row navigates → "Clear all" empties → reload keeps history but not the unread count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)