### PR TITLE
Grok Build: identity-probe the resolved `grok` before marking available (CROW-911)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentDiscovery.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentDiscovery.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// The outcome of deciding whether a discovered agent is launchable.
+public enum AgentAvailability: Sendable, Equatable {
+    /// The agent's binary didn't resolve on PATH / override / fallback.
+    case unavailableNotFound
+    /// The binary resolved via PATH/fallback but **failed the identity probe** —
+    /// a different tool sharing the launch token (e.g. `superagent-ai/grok-cli`
+    /// standing in for `xai-org/grok-build`). `path` is the impostor, for the
+    /// log line (CROW-911).
+    case unavailableFailedProbe(path: String)
+    /// The binary resolved and is genuinely this agent. `viaOverride` is `true`
+    /// when it came from an explicit `defaults.binaries.<kind>` pin (which is
+    /// authoritative and bypasses the identity probe).
+    case available(path: String, viaOverride: Bool)
+}
+
+/// Pure, host-agnostic availability decision for a discovered agent, extracted
+/// so it's unit-testable without the daemon's `registerAgents` (which writes the
+/// registry and logs). Both the daemon and the desktop mirror wrap this
+/// (CROW-911 review — the registration-layer behavior had no test because the
+/// decision lived inside a `private static` local function).
+public enum AgentDiscovery {
+    /// Resolve `agent`'s binary and decide availability. An explicit
+    /// `.override` pin is trusted without probing; a PATH/`.fallback` match on a
+    /// collision-prone token is identity-probed (`verifyBinaryIdentity`) so a
+    /// foreign same-named binary is reported unavailable rather than launchable.
+    public static func evaluate(_ agent: any CodingAgent) async -> AgentAvailability {
+        guard let resolved = agent.resolveBinary() else {
+            return .unavailableNotFound
+        }
+        if resolved.source == .override {
+            return .available(path: resolved.path, viaOverride: true)
+        }
+        if await agent.verifyBinaryIdentity(atPath: resolved.path) {
+            return .available(path: resolved.path, viaOverride: false)
+        }
+        return .unavailableFailedProbe(path: resolved.path)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+/// How `CodingAgent.resolveBinary()` located a binary. Lets registration branch
+/// on provenance — an explicit `.override` pin is authoritative and bypasses the
+/// identity probe — from one source of truth instead of re-deriving the
+/// override-first precedence a second time (CROW-911 review).
+public enum BinaryResolutionSource: Sendable, Equatable {
+    /// An explicit `defaults.binaries.<kind>` pin.
+    case override
+    /// A `command -v`-style PATH walk on `launchCommandToken`.
+    case path
+    /// A hardcoded `fallbackCandidates` entry (exotic-PATH last resort).
+    case fallback
+}
+
+/// A resolved agent binary and how it was found.
+public struct ResolvedBinary: Sendable, Equatable {
+    public let path: String
+    public let source: BinaryResolutionSource
+    public init(path: String, source: BinaryResolutionSource) {
+        self.path = path
+        self.source = source
+    }
+}
+
 /// A coding agent that Crow can launch in a terminal and observe via hook
 /// events. Phase A wraps the existing Claude Code integration; later phases
 /// introduce additional conformers.
@@ -41,9 +64,16 @@ public protocol CodingAgent: Sendable {
     /// empty list is fine — most agents will resolve through PATH first.
     var fallbackCandidates: [String] { get }
 
+    /// Resolve this agent's binary on disk **with its provenance**, or `nil` if
+    /// it isn't installed. The single owner of the override → PATH → fallback
+    /// precedence; `findBinary()` and registration both read from it so the two
+    /// can't drift (CROW-911 review). Drives binary-presence gating for the
+    /// per-session picker and the launch-command builder below.
+    func resolveBinary() -> ResolvedBinary?
+
     /// Resolve this agent's binary on disk, or return `nil` if it isn't
-    /// installed. Drives binary-presence gating for the per-session picker
-    /// and the launch-command builder below.
+    /// installed. Convenience over `resolveBinary()` for the many callers that
+    /// only need the path.
     func findBinary() -> String?
 
     /// Confirm the binary resolved at `path` is genuinely *this* agent and not
@@ -163,29 +193,35 @@ public extension CodingAgent {
             sessionID: sessionID, worktreePath: worktreePath, prompt: prompt)
     }
 
-    /// Default binary discovery: explicit `BinaryOverrides` → PATH walk
-    /// (using the agent's `launchCommandToken` as the binary name) →
-    /// hardcoded `fallbackCandidates`. Returns the first resolved absolute
-    /// path, or `nil` if nothing matches.
+    /// Default binary discovery with provenance: explicit `BinaryOverrides`
+    /// (`.override`) → PATH walk on `launchCommandToken` (`.path`) → hardcoded
+    /// `fallbackCandidates` (`.fallback`). Returns the first resolved absolute
+    /// path + how it was found, or `nil` if nothing matches.
     ///
     /// This replaces the per-agent hardcoded-list-only impl that left
     /// nvm/Volta/pnpm/asdf installs invisible to Crow (CROW-484).
-    func findBinary() -> String? {
+    func resolveBinary() -> ResolvedBinary? {
         let fm = FileManager.default
         // 1. Explicit user override from `defaults.binaries.<kind>`. Verify
         //    the path is still executable so a stale override falls through
         //    to discovery rather than breaking registration outright.
         if let configured = BinaryOverrides.shared.path(for: kind),
            fm.isExecutableFile(atPath: configured) {
-            return configured
+            return ResolvedBinary(path: configured, source: .override)
         }
         // 2. Walk the user's resolved PATH the same way `command -v` does.
         if let found = ShellEnvironment.shared.findExecutable(launchCommandToken) {
-            return found
+            return ResolvedBinary(path: found, source: .path)
         }
         // 3. Hardcoded last-resort fallback covers the exotic-PATH case.
-        return fallbackCandidates.first { fm.isExecutableFile(atPath: $0) }
+        if let fb = fallbackCandidates.first(where: { fm.isExecutableFile(atPath: $0) }) {
+            return ResolvedBinary(path: fb, source: .fallback)
+        }
+        return nil
     }
+
+    /// Default `findBinary()`: the resolved path from `resolveBinary()`, or `nil`.
+    func findBinary() -> String? { resolveBinary()?.path }
 
     /// Default identity check: trust a bare match. Agents with an unambiguous
     /// launch token don't need to probe — overridden only by collision-prone

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -46,6 +46,24 @@ public protocol CodingAgent: Sendable {
     /// and the launch-command builder below.
     func findBinary() -> String?
 
+    /// Confirm the binary resolved at `path` is genuinely *this* agent and not
+    /// a different tool that happens to share the launch token (CROW-911).
+    ///
+    /// Registration runs this after `findBinary()` resolves a path **via the
+    /// PATH walk or `fallbackCandidates`** — never for an explicit
+    /// `defaults.binaries.<kind>` pin, which is authoritative (the user has
+    /// named the exact binary). A `false` return marks the agent unavailable
+    /// even though a same-named binary exists, so a colliding tool is shown
+    /// disabled rather than falsely active.
+    ///
+    /// The default returns `true`: an unambiguous launch token is trusted on a
+    /// bare match, preserving today's behavior for every agent. Only agents
+    /// whose token is known to collide override this to run a cheap
+    /// `--version` / `--help` identity probe — today just Grok Build (`grok`
+    /// collides with the community `superagent-ai/grok-cli`); Cursor's generic
+    /// `agent` token has the same shape and can adopt this seam later.
+    func verifyBinaryIdentity(atPath path: String) async -> Bool
+
     /// Build the full shell command (ending with `\n`) that auto-launches
     /// this agent in `worktreePath`. Returns `nil` when the agent can't be
     /// launched — typically because the binary is missing or the session
@@ -168,6 +186,12 @@ public extension CodingAgent {
         // 3. Hardcoded last-resort fallback covers the exotic-PATH case.
         return fallbackCandidates.first { fm.isExecutableFile(atPath: $0) }
     }
+
+    /// Default identity check: trust a bare match. Agents with an unambiguous
+    /// launch token don't need to probe — overridden only by collision-prone
+    /// tokens (Grok Build today) so a foreign same-named binary is shown
+    /// disabled instead of falsely active (CROW-911).
+    func verifyBinaryIdentity(atPath path: String) async -> Bool { true }
 
     /// Default Manager launch command: invoke the agent's CLI binary by
     /// name with no extra flags. The tmux terminal backend owns

--- a/Packages/CrowCore/Sources/CrowCore/ShellRunner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ShellRunner.swift
@@ -68,28 +68,45 @@ public struct ProcessShellRunner: ShellRunner {
         if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
         process.standardOutput = pipe
         process.standardError = pipe
+        // No `ShellRunner` caller feeds stdin (the protocol has no stdin knob),
+        // so detach it from the parent's — under a foreground `crowd` that's the
+        // controlling tty. A subprocess that reads stdin then EOFs immediately
+        // instead of blocking, which matters for the boot-time identity probe
+        // that runs an unvetted third-party `grok` (CROW-911).
+        process.standardInput = FileHandle.nullDevice
 
         // Drain the pipe on a background task so a >64KB output can't deadlock waitUntilExit.
-        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<String, Error>) in
-            Task.detached {
-                do {
-                    try process.run()
-                } catch {
-                    cont.resume(throwing: error)
-                    return
-                }
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                process.waitUntilExit()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                if process.terminationStatus == 0 {
-                    cont.resume(returning: output)
-                } else {
-                    cont.resume(throwing: ShellRunnerError.nonZeroExit(
-                        exitCode: process.terminationStatus,
-                        output: output
-                    ))
+        // Wrapped in a cancellation handler so a cancelled run (e.g. the identity
+        // probe's timeout losing the race) best-effort `terminate()`s the child
+        // rather than leaving it running. `onCancel` only signals the process; the
+        // detached task remains the sole resumer of the continuation, so there's
+        // no double-resume.
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<String, Error>) in
+                Task.detached {
+                    do {
+                        try process.run()
+                    } catch {
+                        cont.resume(throwing: error)
+                        return
+                    }
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    process.waitUntilExit()
+                    let output = String(data: data, encoding: .utf8) ?? ""
+                    if process.terminationStatus == 0 {
+                        cont.resume(returning: output)
+                    } else {
+                        cont.resume(throwing: ShellRunnerError.nonZeroExit(
+                            exitCode: process.terminationStatus,
+                            output: output
+                        ))
+                    }
                 }
             }
+        } onCancel: {
+            // `isRunning` is false before launch (terminate() would raise) and
+            // after exit, so this is a no-op outside the running window.
+            if process.isRunning { process.terminate() }
         }
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentDiscoveryTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentDiscoveryTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite("AgentDiscovery")
+struct AgentDiscoveryTests {
+    private final class NoopHookConfigWriter: HookConfigWriter, @unchecked Sendable {
+        func writeHookConfig(worktreePath: String, sessionID: UUID, crowPath: String) throws {}
+        func removeHookConfig(worktreePath: String) {}
+    }
+
+    private struct NoopStateSignalSource: StateSignalSource {
+        func transition(
+            for event: AgentHookEvent,
+            currentActivityState: AgentActivityState,
+            currentNotificationType: String?,
+            currentLastTopLevelStopAt: Date?
+        ) -> AgentStateTransition { AgentStateTransition() }
+    }
+
+    /// A `CodingAgent` whose binary resolution and identity probe are fully
+    /// controllable, so `AgentDiscovery.evaluate` — the registration decision —
+    /// is tested without touching PATH or spawning a subprocess (CROW-911 review:
+    /// the decision used to live inside a `private static` local and had no test).
+    private struct StubAgent: CodingAgent {
+        let kind: AgentKind = .grok
+        var displayName: String { "Stub" }
+        var iconSystemName: String { "sparkles" }
+        var supportsRemoteControl: Bool { false }
+        var launchCommandToken: String { "stub" }
+        let hookConfigWriter: any HookConfigWriter = NoopHookConfigWriter()
+        let stateSignalSource: any StateSignalSource = NoopStateSignalSource()
+
+        var resolved: ResolvedBinary?
+        var identity: Bool
+
+        func resolveBinary() -> ResolvedBinary? { resolved }
+        func verifyBinaryIdentity(atPath path: String) async -> Bool { identity }
+
+        func autoLaunchCommand(
+            session: Session, worktreePath: String, remoteControlEnabled: Bool,
+            autoPermissionMode: Bool, telemetryPort: UInt16?
+        ) -> String? { nil }
+        func generatePrompt(
+            session: Session, worktrees: [SessionWorktree], ticketURL: String?,
+            provider: Provider?, codeProvider: Provider?
+        ) async -> String { "" }
+        func launchCommand(sessionID: UUID, worktreePath: String, prompt: String) async throws -> String { "" }
+        func managerLaunchCommand(
+            sessionName: String, remoteControlEnabled: Bool,
+            autoPermissionMode: Bool, telemetryPort: UInt16?
+        ) -> String { "stub" }
+    }
+
+    @Test func notFoundWhenBinaryDoesNotResolve() async {
+        let agent = StubAgent(resolved: nil, identity: true)
+        #expect(await AgentDiscovery.evaluate(agent) == .unavailableNotFound)
+    }
+
+    @Test func overridePinIsAvailableWithoutProbing() async {
+        // An explicit `.override` pin is authoritative — available even though
+        // the probe would reject it (`identity: false` must not be consulted).
+        let agent = StubAgent(
+            resolved: ResolvedBinary(path: "/pin/grok", source: .override),
+            identity: false
+        )
+        #expect(await AgentDiscovery.evaluate(agent) == .available(path: "/pin/grok", viaOverride: true))
+    }
+
+    @Test func pathMatchPassingProbeIsAvailable() async {
+        let agent = StubAgent(
+            resolved: ResolvedBinary(path: "/usr/bin/grok", source: .path),
+            identity: true
+        )
+        #expect(await AgentDiscovery.evaluate(agent) == .available(path: "/usr/bin/grok", viaOverride: false))
+    }
+
+    @Test func pathMatchFailingProbeIsUnavailable() async {
+        // The CROW-911 false positive: a foreign `grok` resolved on PATH fails
+        // the probe → reported unavailable rather than launchable.
+        let agent = StubAgent(
+            resolved: ResolvedBinary(path: "/usr/bin/grok", source: .path),
+            identity: false
+        )
+        #expect(await AgentDiscovery.evaluate(agent) == .unavailableFailedProbe(path: "/usr/bin/grok"))
+    }
+
+    @Test func fallbackMatchIsProbedNotTrusted() async {
+        // A `.fallback` match is treated like `.path` — probed, not trusted like
+        // an override.
+        let agent = StubAgent(
+            resolved: ResolvedBinary(path: "/opt/grok", source: .fallback),
+            identity: false
+        )
+        #expect(await AgentDiscovery.evaluate(agent) == .unavailableFailedProbe(path: "/opt/grok"))
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -927,7 +927,7 @@ public enum CrowDaemon {
     /// (#879). Reads binary overrides from the same on-disk config the app uses
     /// so both hosts gate identically (CROW-581, M-B).
     @MainActor
-    private static func registerAgents(devRoot: String) {
+    private static func registerAgents(devRoot: String) async {
         if let config = ConfigStore.loadConfig(devRoot: devRoot) {
             BinaryOverrides.shared.set(config.defaults.binaries)
         }
@@ -936,14 +936,30 @@ public enum CrowDaemon {
         // binary resolves. Logs either the resolved path or a "not found on PATH"
         // line so the boot log matches what the picker shows — a greyed-out row
         // now has a corresponding log entry (#879).
-        func registerDiscovered(_ agent: any CodingAgent) {
-            if let path = agent.findBinary() {
-                AgentRegistry.shared.registerKnown(agent, available: true)
-                log("\(agent.displayName) agent registered at \(path)")
-            } else {
+        //
+        // A resolved binary is additionally identity-probed for collision-prone
+        // launch tokens (`agent.verifyBinaryIdentity`) so a foreign same-named
+        // binary is shown disabled rather than falsely active — today only Grok
+        // Build, whose `grok` token collides with `superagent-ai/grok-cli`
+        // (CROW-911). The probe is **skipped for an explicit `defaults.binaries.<kind>`
+        // pin**: the user has named the exact binary, so it's authoritative
+        // (matching `findBinary()`'s override-first resolution) and can't be
+        // greyed out by a version-pinned probe that upstream churn broke.
+        func registerDiscovered(_ agent: any CodingAgent) async {
+            guard let path = agent.findBinary() else {
                 AgentRegistry.shared.registerKnown(agent, available: false)
                 log("\(agent.displayName) agent not found on PATH — shown disabled in the picker")
+                return
             }
+            let pinned = BinaryOverrides.shared.path(for: agent.kind)
+                .map { FileManager.default.isExecutableFile(atPath: $0) } ?? false
+            if !pinned, await !agent.verifyBinaryIdentity(atPath: path) {
+                AgentRegistry.shared.registerKnown(agent, available: false)
+                log("\(agent.displayName) binary at \(path) failed the identity probe (likely a different tool sharing the name) — shown disabled; pin the real path via defaults.binaries.\(agent.kind.rawValue)")
+                return
+            }
+            AgentRegistry.shared.registerKnown(agent, available: true)
+            log("\(agent.displayName) agent registered at \(path)")
         }
 
         // Claude Code is the baseline harness and the registry fallback default,
@@ -954,20 +970,22 @@ public enum CrowDaemon {
         // to the honest-availability rule is intentional; don't "fix" it.
         AgentRegistry.shared.registerKnown(ClaudeCodeAgent(), available: true)
 
-        registerDiscovered(OpenAICodexAgent())
-        registerDiscovered(CursorAgent())
-        registerDiscovered(OpenCodeAgent())
+        await registerDiscovered(OpenAICodexAgent())
+        await registerDiscovered(CursorAgent())
+        await registerDiscovered(OpenCodeAgent())
         // Google Antigravity (`agy`) — Tier-2 / experimental (#860). Surfaced in
         // the picker regardless of install state; off-PATH ⇒ shown disabled with
         // a "not found on PATH" tooltip rather than silently absent (#879,
         // updating ADR 0014). Crow never installs `agy` itself — it only resolves
         // whatever the official `antigravity.google` installer placed.
-        registerDiscovered(AntigravityAgent())
+        await registerDiscovered(AntigravityAgent())
         // Grok Build (`grok`, xai-org/grok-build) — #859. `registerDiscovered`
         // uses the override-aware `findBinary()`, so a `defaults.binaries.grok`
-        // pin resolves the `superagent-ai/grok-cli` name collision; off-PATH ⇒
-        // shown disabled in the picker rather than silently absent (#879).
-        registerDiscovered(GrokAgent())
+        // pin resolves the `superagent-ai/grok-cli` name collision; without a
+        // pin, a bare PATH match is identity-probed (`grok --version`/`--help`)
+        // so the foreign `grok` is shown disabled rather than falsely active
+        // (CROW-911); genuinely off-PATH ⇒ shown disabled too (#879).
+        await registerDiscovered(GrokAgent())
     }
 
     /// (Re)populate `appState` from the store snapshot — sessions + their

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -933,33 +933,29 @@ public enum CrowDaemon {
         }
 
         // Register a discovered agent as *known*, marking it available iff its
-        // binary resolves. Logs either the resolved path or a "not found on PATH"
-        // line so the boot log matches what the picker shows — a greyed-out row
-        // now has a corresponding log entry (#879).
+        // binary resolves **and** passes identity checks. `AgentDiscovery.evaluate`
+        // owns the decision (resolve → probe a non-override match); this wrapper
+        // only writes the registry + logs, so the "greyed-out row ⇒ matching boot
+        // log line" contract (#879) holds for all three outcomes.
         //
-        // A resolved binary is additionally identity-probed for collision-prone
-        // launch tokens (`agent.verifyBinaryIdentity`) so a foreign same-named
-        // binary is shown disabled rather than falsely active — today only Grok
-        // Build, whose `grok` token collides with `superagent-ai/grok-cli`
-        // (CROW-911). The probe is **skipped for an explicit `defaults.binaries.<kind>`
-        // pin**: the user has named the exact binary, so it's authoritative
-        // (matching `findBinary()`'s override-first resolution) and can't be
-        // greyed out by a version-pinned probe that upstream churn broke.
+        // A resolved binary is identity-probed for collision-prone launch tokens
+        // so a foreign same-named binary is shown disabled rather than falsely
+        // active — today only Grok Build, whose `grok` token collides with
+        // `superagent-ai/grok-cli` (CROW-911). The probe is skipped for an
+        // explicit `defaults.binaries.<kind>` pin (`.available(viaOverride:)`):
+        // the user has named the exact binary, so it's authoritative.
         func registerDiscovered(_ agent: any CodingAgent) async {
-            guard let path = agent.findBinary() else {
+            switch await AgentDiscovery.evaluate(agent) {
+            case .unavailableNotFound:
                 AgentRegistry.shared.registerKnown(agent, available: false)
                 log("\(agent.displayName) agent not found on PATH — shown disabled in the picker")
-                return
-            }
-            let pinned = BinaryOverrides.shared.path(for: agent.kind)
-                .map { FileManager.default.isExecutableFile(atPath: $0) } ?? false
-            if !pinned, await !agent.verifyBinaryIdentity(atPath: path) {
+            case .unavailableFailedProbe(let path):
                 AgentRegistry.shared.registerKnown(agent, available: false)
                 log("\(agent.displayName) binary at \(path) failed the identity probe (likely a different tool sharing the name) — shown disabled; pin the real path via defaults.binaries.\(agent.kind.rawValue)")
-                return
+            case .available(let path, _):
+                AgentRegistry.shared.registerKnown(agent, available: true)
+                log("\(agent.displayName) agent registered at \(path)")
             }
-            AgentRegistry.shared.registerKnown(agent, available: true)
-            log("\(agent.displayName) agent registered at \(path)")
         }
 
         // Claude Code is the baseline harness and the registry fallback default,

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -35,16 +35,22 @@ public struct GrokAgent: CodingAgent {
 
     private let launcher: GrokLauncher
 
+    /// Runs the `--version` / `--help` identity probe. Injectable so tests can
+    /// stub the binary's output without spawning a real subprocess; production
+    /// uses `ProcessShellRunner` (the same runner provider backends use).
+    private let probeRunner: any ShellRunner
+
     /// Last-resort search paths for the `grok` binary, used only when the
     /// configured `BinaryOverrides` and a PATH walk both miss (CROW-484).
     ///
     /// ⚠️ **`grok` collides** with the community `superagent-ai/grok-cli`, which
-    /// also installs a binary named `grok`. Like Cursor's generic `agent` token
-    /// (CROW-484), we accept the false-positive risk — a real workstation rarely
-    /// has both — and users pin xAI's Grok Build via `defaults.binaries.grok`
-    /// in `{devRoot}/.claude/config.json`; the explicit override is consulted
+    /// also installs a binary named `grok`. So a bare PATH/fallback match is
+    /// **identity-probed** before registration marks Grok Build available
+    /// (`verifyBinaryIdentity` — a foreign `grok` is shown disabled, CROW-911).
+    /// Users can also pin xAI's Grok Build via `defaults.binaries.grok` in
+    /// `{devRoot}/.claude/config.json`; that explicit override is consulted
     /// before the PATH walk (`BinaryOverrides`, keyed on `AgentKind.rawValue` =
-    /// `"grok"`).
+    /// `"grok"`) **and bypasses the probe** as authoritative.
     public let fallbackCandidates: [String] = [
         "/opt/homebrew/bin/grok",
         "/usr/local/bin/grok",
@@ -54,10 +60,12 @@ public struct GrokAgent: CodingAgent {
 
     public init(
         hookConfigWriter: any HookConfigWriter = GrokHookConfigWriter(),
-        stateSignalSource: any StateSignalSource = GrokSignalSource()
+        stateSignalSource: any StateSignalSource = GrokSignalSource(),
+        probeRunner: any ShellRunner = ProcessShellRunner()
     ) {
         self.hookConfigWriter = hookConfigWriter
         self.stateSignalSource = stateSignalSource
+        self.probeRunner = probeRunner
         self.launcher = GrokLauncher()
     }
 
@@ -164,5 +172,80 @@ public struct GrokAgent: CodingAgent {
     /// stays in sync (CROW-629).
     public func sessionRenameSlashCommand(newName: String) -> String? {
         "/rename \(newName)\n"
+    }
+
+    /// Substrings that identify a resolved `grok` binary as xAI's grok-build
+    /// rather than the colliding community `superagent-ai/grok-cli`. Matched
+    /// case-insensitively against the combined `grok --version` + `grok --help`
+    /// output; **any** one match confirms identity (OR, not AND) so a single
+    /// upstream flag rename can't grey out a genuine install, while the Node-
+    /// based community CLI — which carries none of these — is rejected.
+    ///
+    /// These are all grok-build-specific **flag names** already verified against
+    /// `xai-org/grok-build@main` in `GrokLaunchArgs` (headless + permission
+    /// surface); clap lists every flag in `--help`, so a real grok-build always
+    /// prints them. Deliberately **not** vendor branding (`xai` / `x.ai`): the
+    /// community `grok-cli` is *itself* an xAI Grok API client and may reference
+    /// xAI in its own help text, which would false-positive a branding match.
+    /// The conversational Node CLI has a wholly different flag set (`--model`,
+    /// `--api-key`, …) and none of these.
+    ///
+    /// ⚠️ **Version-pinned re-check target** — grok-build's `--help`/`--version`
+    /// text is upstream (a PR-closed mirror of xAI's monorepo, same as the
+    /// launch flags), so re-verify these markers on each sync. If a rewrite ever
+    /// drops all of them, the user's escape hatch is an explicit
+    /// `defaults.binaries.grok` pin, which bypasses this probe entirely.
+    static let identityMarkers = [
+        "--prompt-file", "--prompt-json", "--permission-mode", "--always-approve",
+    ]
+
+    /// Identity-probe the resolved `grok` binary before registration marks it
+    /// available (CROW-911). Runs `grok --version` and `grok --help`, then looks
+    /// for any `identityMarkers` substring — a match means xAI's grok-build, no
+    /// match (or empty output, e.g. a binary that fails/hangs) means the
+    /// colliding community `grok` and the agent is shown disabled.
+    ///
+    /// Only reached for a PATH/fallback match: an explicit `defaults.binaries.grok`
+    /// pin is trusted without probing (see `CrowDaemon.registerAgents`).
+    public func verifyBinaryIdentity(atPath path: String) async -> Bool {
+        let haystack = await Self.probeText(binary: path, runner: probeRunner).lowercased()
+        guard !haystack.isEmpty else { return false }
+        return Self.identityMarkers.contains { haystack.contains($0) }
+    }
+
+    /// Combined `<binary> --version` + `<binary> --help` output, tolerating a
+    /// non-zero exit (both flags normally exit 0, but a foreign tool might not —
+    /// its stderr is still captured for marker matching). Each probe is bounded
+    /// by a short timeout so a binary that blocks on stdin can't stall daemon
+    /// boot; a timed-out probe contributes empty text.
+    static func probeText(binary: String, runner: any ShellRunner) async -> String {
+        let version = await probeArg(binary, "--version", runner: runner)
+        let help = await probeArg(binary, "--help", runner: runner)
+        return version + "\n" + help
+    }
+
+    /// Run `<binary> <arg>` and return its merged stdout+stderr regardless of
+    /// exit status, or `""` on spawn failure / timeout. The 3s cap protects
+    /// daemon boot: cancelling the race can't kill the subprocess (it may
+    /// linger harmlessly), but control returns so registration proceeds.
+    private static func probeArg(_ binary: String, _ arg: String, runner: any ShellRunner) async -> String {
+        await withTaskGroup(of: String?.self) { group in
+            group.addTask {
+                do {
+                    return try await runner.run(args: [binary, arg], env: [:], cwd: nil)
+                } catch let ShellRunnerError.nonZeroExit(_, output) {
+                    return output
+                } catch {
+                    return nil
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 3 * 1_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first ?? ""
+        }
     }
 }

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 import CrowCore
 
 /// `CodingAgent` conformer for Grok Build (`xai-org/grok-build`, binary
@@ -244,15 +243,10 @@ public struct GrokAgent: CodingAgent {
         runner: any ShellRunner,
         timeoutNanos: UInt64 = probeTimeoutNanos
     ) async -> String {
-        let gate = OSAllocatedUnfairLock(initialState: false)
+        let gate = ResumeOnceGate()
         return await withCheckedContinuation { (cont: CheckedContinuation<String, Never>) in
             @Sendable func finish(_ result: String) {
-                let shouldResume = gate.withLock { resumed -> Bool in
-                    if resumed { return false }
-                    resumed = true
-                    return true
-                }
-                if shouldResume { cont.resume(returning: result) }
+                if gate.claim() { cont.resume(returning: result) }
             }
             let work = Task {
                 let out: String
@@ -271,5 +265,22 @@ public struct GrokAgent: CodingAgent {
                 finish("")
             }
         }
+    }
+}
+
+/// A cross-platform (no Darwin `os`) resume-once guard for `probeArg`'s
+/// race: `claim()` returns `true` exactly once — for the first of the run and
+/// timeout tasks to finish — so the continuation is resumed a single time. An
+/// `NSLock`-backed `Bool` rather than `OSAllocatedUnfairLock`, which is
+/// Apple-platforms-only and breaks the Linux CI build (#912).
+private final class ResumeOnceGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+
+    func claim() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if resumed { return false }
+        resumed = true
+        return true
     }
 }

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import CrowCore
 
 /// `CodingAgent` conformer for Grok Build (`xai-org/grok-build`, binary
@@ -200,52 +201,75 @@ public struct GrokAgent: CodingAgent {
     ]
 
     /// Identity-probe the resolved `grok` binary before registration marks it
-    /// available (CROW-911). Runs `grok --version` and `grok --help`, then looks
-    /// for any `identityMarkers` substring — a match means xAI's grok-build, no
-    /// match (or empty output, e.g. a binary that fails/hangs) means the
-    /// colliding community `grok` and the agent is shown disabled.
+    /// available (CROW-911). Probes `grok --help` (and, only if that yields no
+    /// marker, `grok --version`) and looks for any `identityMarkers` substring —
+    /// a match means xAI's grok-build, no match means the colliding community
+    /// `grok` and the agent is shown disabled.
     ///
     /// Only reached for a PATH/fallback match: an explicit `defaults.binaries.grok`
-    /// pin is trusted without probing (see `CrowDaemon.registerAgents`).
+    /// pin is trusted without probing (`AgentDiscovery.evaluate`).
     public func verifyBinaryIdentity(atPath path: String) async -> Bool {
-        let haystack = await Self.probeText(binary: path, runner: probeRunner).lowercased()
-        guard !haystack.isEmpty else { return false }
-        return Self.identityMarkers.contains { haystack.contains($0) }
+        // `--help` first: every marker is a `--help` flag, so a genuine
+        // grok-build matches on the first spawn and `--version` never runs (one
+        // fewer subprocess per boot). `--version` is only a fallback for a
+        // foreign binary that prints its banner there instead. An empty result
+        // (a binary that prints nothing, or a probe timeout) simply matches no
+        // marker and returns false — no separate empty-string branch needed.
+        for arg in ["--help", "--version"] {
+            let out = await Self.probeArg(path, arg, runner: probeRunner).lowercased()
+            if Self.identityMarkers.contains(where: { out.contains($0) }) { return true }
+        }
+        return false
     }
 
-    /// Combined `<binary> --version` + `<binary> --help` output, tolerating a
-    /// non-zero exit (both flags normally exit 0, but a foreign tool might not —
-    /// its stderr is still captured for marker matching). Each probe is bounded
-    /// by a short timeout so a binary that blocks on stdin can't stall daemon
-    /// boot; a timed-out probe contributes empty text.
-    static func probeText(binary: String, runner: any ShellRunner) async -> String {
-        let version = await probeArg(binary, "--version", runner: runner)
-        let help = await probeArg(binary, "--help", runner: runner)
-        return version + "\n" + help
-    }
+    /// Per-leg cap for the `--help` / `--version` probe. Injectable via
+    /// `probeArg` so tests exercise the timeout without a real 3s wait.
+    static let probeTimeoutNanos: UInt64 = 3 * 1_000_000_000
 
-    /// Run `<binary> <arg>` and return its merged stdout+stderr regardless of
-    /// exit status, or `""` on spawn failure / timeout. The 3s cap protects
-    /// daemon boot: cancelling the race can't kill the subprocess (it may
-    /// linger harmlessly), but control returns so registration proceeds.
-    private static func probeArg(_ binary: String, _ arg: String, runner: any ShellRunner) async -> String {
-        await withTaskGroup(of: String?.self) { group in
-            group.addTask {
-                do {
-                    return try await runner.run(args: [binary, arg], env: [:], cwd: nil)
-                } catch let ShellRunnerError.nonZeroExit(_, output) {
-                    return output
-                } catch {
-                    return nil
+    /// Run `<binary> <arg>` and return its merged stdout+stderr, or `""` on spawn
+    /// failure **or timeout**. The cap is a *hard* bound on the awaiting task: it
+    /// races the run against a sleep behind a resume-once guard and returns
+    /// whichever finishes first — so even a runner that never completes and
+    /// ignores cancellation (a `grok` that reads stdin, or forks a child holding
+    /// the stdout pipe so `readDataToEndOfFile()` never sees EOF) **cannot stall
+    /// `registerAgents` at boot** (CROW-911 review — the earlier `withTaskGroup`
+    /// form awaited the losing child and so bounded nothing).
+    ///
+    /// On timeout the run `Task` is cancelled: with the cancellation-aware
+    /// `ProcessShellRunner` that `terminate()`s the child so it doesn't leak; a
+    /// genuinely uncancellable runner leaks one blocked reader but boot proceeds.
+    static func probeArg(
+        _ binary: String,
+        _ arg: String,
+        runner: any ShellRunner,
+        timeoutNanos: UInt64 = probeTimeoutNanos
+    ) async -> String {
+        let gate = OSAllocatedUnfairLock(initialState: false)
+        return await withCheckedContinuation { (cont: CheckedContinuation<String, Never>) in
+            @Sendable func finish(_ result: String) {
+                let shouldResume = gate.withLock { resumed -> Bool in
+                    if resumed { return false }
+                    resumed = true
+                    return true
                 }
+                if shouldResume { cont.resume(returning: result) }
             }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 3 * 1_000_000_000)
-                return nil
+            let work = Task {
+                let out: String
+                do {
+                    out = try await runner.run(args: [binary, arg], env: [:], cwd: nil)
+                } catch let ShellRunnerError.nonZeroExit(_, output) {
+                    out = output
+                } catch {
+                    out = ""
+                }
+                finish(out)
             }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first ?? ""
+            Task {
+                try? await Task.sleep(nanoseconds: timeoutNanos)
+                work.cancel()
+                finish("")
+            }
         }
     }
 }

--- a/Packages/CrowGrok/Tests/CrowGrokTests/GrokAgentTests.swift
+++ b/Packages/CrowGrok/Tests/CrowGrokTests/GrokAgentTests.swift
@@ -201,4 +201,82 @@ struct GrokAgentTests {
         #expect(cmd.contains("--prompt-file"))
         #expect(cmd.contains(" -c"))
     }
+
+    // MARK: - Identity probe (CROW-911)
+
+    /// A resolved binary whose `--help` lists grok-build's own flags is xAI's
+    /// grok-build — even with no vendor branding — so the probe accepts it.
+    @Test func identityProbeAcceptsGrokBuildFlags() async {
+        let runner = FakeProbeRunner(outputs: [
+            "--version": "grok 0.4.1",
+            "--help": """
+                Usage: grok [OPTIONS]
+                Options:
+                  --prompt-file <PATH>     Read the prompt from a file (headless)
+                  --prompt-json <JSON>     Structured prompt input
+                  --permission-mode <MODE> ask | auto | bypassPermissions
+                  --always-approve         Approve every tool call (alias --yolo)
+                  -c, --continue           Resume the last session
+                """,
+        ])
+        let agent = GrokAgent(probeRunner: runner)
+        #expect(await agent.verifyBinaryIdentity(atPath: "/opt/homebrew/bin/grok") == true)
+    }
+
+    /// The colliding community `superagent-ai/grok-cli` (a Node conversational
+    /// client for xAI's API) carries none of grok-build's flags — even though it
+    /// legitimately mentions xAI — so the probe rejects it. This is the exact
+    /// false-positive CROW-911 fixes.
+    @Test func identityProbeRejectsCommunityGrokCli() async {
+        let runner = FakeProbeRunner(outputs: [
+            "--version": "1.2.3",
+            "--help": """
+                Grok CLI — a conversational AI assistant powered by xAI's Grok.
+                Usage: grok [prompt]
+                Options:
+                  --model <NAME>   Model to use
+                  --api-key <KEY>  xAI API key
+                  --help           Show help
+                """,
+        ])
+        let agent = GrokAgent(probeRunner: runner)
+        #expect(await agent.verifyBinaryIdentity(atPath: "/opt/homebrew/bin/grok") == false)
+    }
+
+    /// A binary that prints nothing (or a spawn failure that yields `""`) can't
+    /// be identified, so it's treated as the foreign tool and rejected.
+    @Test func identityProbeRejectsEmptyOutput() async {
+        let agent = GrokAgent(probeRunner: FakeProbeRunner(outputs: [:]))
+        #expect(await agent.verifyBinaryIdentity(atPath: "/opt/homebrew/bin/grok") == false)
+    }
+
+    /// A foreign `grok --version` may exit non-zero yet still print a marker; the
+    /// probe merges stdout+stderr and matches it regardless of exit status.
+    @Test func identityProbeToleratesNonZeroExit() async {
+        let runner = FakeProbeRunner(
+            outputs: ["--version": "grok --prompt-file supported", "--help": ""],
+            failing: ["--version"]
+        )
+        let agent = GrokAgent(probeRunner: runner)
+        #expect(await agent.verifyBinaryIdentity(atPath: "/opt/homebrew/bin/grok") == true)
+    }
+}
+
+/// Canned `--version` / `--help` responder for the identity probe, keyed by the
+/// probe arg — lets a test hand `verifyBinaryIdentity` grok-build vs the
+/// colliding community `grok` output without spawning a subprocess. Args listed
+/// in `failing` throw `.nonZeroExit` carrying their output (a foreign binary
+/// that exits non-zero but still prints).
+private struct FakeProbeRunner: ShellRunner {
+    let outputs: [String: String]
+    var failing: Set<String> = []
+
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        let arg = args.dropFirst().first ?? ""
+        let out = outputs[arg] ?? ""
+        if failing.contains(arg) {
+            throw ShellRunnerError.nonZeroExit(exitCode: 2, output: out)
+        }
+        return out
+    }
 }

--- a/Packages/CrowGrok/Tests/CrowGrokTests/GrokAgentTests.swift
+++ b/Packages/CrowGrok/Tests/CrowGrokTests/GrokAgentTests.swift
@@ -260,6 +260,20 @@ struct GrokAgentTests {
         let agent = GrokAgent(probeRunner: runner)
         #expect(await agent.verifyBinaryIdentity(atPath: "/opt/homebrew/bin/grok") == true)
     }
+
+    /// The Red from #912 review: a `grok` that never exits and ignores
+    /// cancellation must not stall boot. `probeArg`'s timeout is a *hard* bound
+    /// on the awaiting task — it returns `""` at the cap even against a runner
+    /// that never completes. Uses a tiny injected timeout so the test is instant.
+    @Test func probeArgHardBoundsAgainstNeverCompletingRunner() async {
+        let out = await GrokAgent.probeArg(
+            "/opt/homebrew/bin/grok",
+            "--help",
+            runner: NeverRunner(),
+            timeoutNanos: 50_000_000  // 50ms
+        )
+        #expect(out == "")
+    }
 }
 
 /// Canned `--version` / `--help` responder for the identity probe, keyed by the
@@ -278,5 +292,17 @@ private struct FakeProbeRunner: ShellRunner {
             throw ShellRunnerError.nonZeroExit(exitCode: 2, output: out)
         }
         return out
+    }
+}
+
+/// A `ShellRunner` that never completes and ignores cancellation — the exact
+/// shape from the #912 review repro. Proves `probeArg`'s timeout bounds the
+/// awaiting task rather than relying on the runner cooperating. Uses an *unsafe*
+/// continuation deliberately: the leak (never resumed) is the intended scenario,
+/// so a checked continuation would only emit a spurious misuse diagnostic.
+private struct NeverRunner: ShellRunner {
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        await withUnsafeContinuation { (_: UnsafeContinuation<Void, Never>) in }
+        return ""  // unreachable
     }
 }

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -25,7 +25,7 @@ capabilities, update this table in the same PR.
 
 | Dimension | Claude Code | Cursor | Codex | OpenCode | Grok Build | Antigravity (Tier-2) |
 |---|---|---|---|---|---|---|
-| Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` | `grok` ⚠️ collision (`grok-cli`) | `agy` ✅ low collision |
+| Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` | `grok` ⚠️ collision (`grok-cli`) — identity-probed | `agy` ✅ low collision |
 | Registered at boot | **always** (default out of the box) | only if binary found | only if binary found | only if binary found | only if binary found | only if binary found |
 | Resume / continue | ✅ `--continue` | ✅ `--continue` (job/review restart, #829) | ✅ `resume --last` | ⚠️ `--continue` re-enters TUI, no history | ✅ `-c`/`-r` (run-then-`-c`; job/review restart) | ⚠️ `-c` (machine-global most-recent; no per-run id, FR #7) |
 | Remote control | ✅ native `--rc --name` | ⚠️ faked via `crow send` stdin | ❌ `supportsRemoteControl=false` (experimental `--remote` unwired) | ⚠️ faked via `crow send` stdin | ⚠️ faked via `crow send` stdin (native ACP `grok agent serve` deferred) | ⚠️ faked via `crow send` stdin (no native RC) |
@@ -100,10 +100,16 @@ managed-terminal command needs hook/env prep.
   risk and lets users pin the real path via `defaults.binaries.cursor`
   (`CursorAgent.swift` launch-token comment, CROW-484).
 - **Grok's token is `grok`, which collides** with the community
-  `superagent-ai/grok-cli` (also installs `grok`). Same posture as Cursor: Crow
-  accepts the false-positive risk and users pin xAI's Grok Build via
-  `defaults.binaries.grok` (`GrokAgent.swift` `fallbackCandidates` comment,
-  #859). `BinaryOverrides` keys on `AgentKind.rawValue` = `"grok"`.
+  `superagent-ai/grok-cli` (also installs `grok`). Unlike Cursor, Crow does
+  **not** just accept the false positive: registration **identity-probes** a
+  bare PATH/fallback match (`grok --version` / `--help`, matched against
+  grok-build-specific flag markers in `GrokAgent.identityMarkers`) and shows
+  Grok Build **disabled** when the resolved binary is the foreign `grok-cli`
+  (`GrokAgent.verifyBinaryIdentity`, CROW-911). An explicit
+  `defaults.binaries.grok` pin is authoritative and **skips the probe**
+  (`CrowDaemon.registerAgents`); `BinaryOverrides` keys on
+  `AgentKind.rawValue` = `"grok"`. The probe is a reusable `CodingAgent` seam
+  Cursor's `agent` token can adopt later.
 - **Registration order = default.** `AgentRegistry.register` sets the default to
   the *first* kind registered
   ([`AgentRegistry.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)).
@@ -576,7 +582,7 @@ against current upstream CLIs.
 | Antigravity bounded auto-permission has no verified interactive launch flag | `agy` **v1.1.7**; headless `-p` ignores `permissions.allow` (issue #548) | `AntigravityLaunchArgs.autoPermissionSuffix` | 2026-07-26 |
 | Antigravity official-installer provenance (supply-chain gate) unconfirmed | `google-antigravity` org `is_verified: false`; pin `antigravity.google` | `AntigravityAgent.fallbackCandidates` | 2026-07-26 — confirm before promoting out of Tier-2 |
 | **Entire Grok flag set** — hooks event names, `-p`/`--single`, `-c`/`-r`, `--allow`/`--deny`, `--permission-mode`, `--trust`, `/rename` | `xai-org/grok-build` **@ 2026-07-25** (periodic mirror of xAI's monorepo, **PRs closed** → churn likely) | `GrokAgent` / `GrokLaunchArgs` / `GrokHookConfigWriter` / `GrokSignalSource` | 2026-07-26 — verified against repo source (`crates/codegen/xai-grok-*`), not blog posts |
-| Grok `grok` binary collides with community `superagent-ai/grok-cli` | — (collision; pin path via `defaults.binaries.grok`) | `GrokAgent.fallbackCandidates` | 2026-07-26 |
+| Grok `grok` binary collides with community `superagent-ai/grok-cli` | **Identity probe** at registration (`grok --version`/`--help` vs grok-build flag markers) greys out the foreign `grok`; explicit `defaults.binaries.grok` pin bypasses the probe. Probe markers (`--prompt-file`, `--prompt-json`, `--permission-mode`, `--always-approve`) are the same upstream flag set as the row above — re-verify together | `GrokAgent.identityMarkers` / `verifyBinaryIdentity` · `CrowDaemon.registerAgents` | 2026-07-29 (CROW-911) |
 | Grok **`--permission-mode auto` now exists** — the ticket's pinned probe (#859) reported it absent; current docs show `grok --permission-mode auto`. Bounded `.job` posture stays `--permission-mode auto` + a minimal `--deny` backstop (never `--yolo`) regardless | Grok mirror **@ 2026-07-25** | `GrokLaunchArgs.autoPermissionSuffix` | 2026-07-26 |
 | Grok `Stop` / `Notification` fire on the transitions Crow's state machine needs — **confirm empirically** | — (empirical, #859) | `GrokSignalSource` | 2026-07-26 |
 | Grok double-fire: only the **global** `~/.claude`/`~/.cursor` hook configs Grok also discovers (its compat scanning) firing alongside `.grok/hooks/crow.json` — dedup deferred (genuinely user-controlled config, no Crow session UUID, not RCE; cf. Codex §3b). *Project* compat sources are handled: stripped on `.review` clones (`stripGrokConfigFromReviewClone`, RCE) and neutralized on `.work`/`.job` handoff + warm-adopt (`stripPriorCompatHooksForGrokHandoff` + session-own adopt write, #861 r9-r10). The Grok-**Manager** devRoot case stays a documented limitation (`writeManagerHookConfig`). | — (empirical, #859) | `GrokHookConfigWriter` / `SessionService` | 2026-07-27 |

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -96,20 +96,32 @@ managed-terminal command needs hook/env prep.
   (`ClaudeCodeAgent`, `CursorAgent`, `OpenAICodexAgent`, `OpenCodeAgent`,
   `GrokAgent`, `AntigravityAgent`).
 - **Cursor's token is `agent`, a generic name.** CI runners (Azure DevOps,
-  TeamCity) also ship a binary called `agent`; Crow accepts the false-positive
-  risk and lets users pin the real path via `defaults.binaries.cursor`
-  (`CursorAgent.swift` launch-token comment, CROW-484).
+  TeamCity) also ship a binary called `agent` — and, confirmed in the field,
+  **xAI's grok-build installer symlinks `agent → grok`** (`~/.grok/bin/agent`,
+  mirrored into `~/.local/bin/agent`), so on a box with grok-build ahead of
+  Cursor on PATH the `agent` token resolves to grok-build, not Cursor. Crow
+  still only accepts the false-positive risk here and lets users pin the real
+  path via `defaults.binaries.cursor` (`CursorAgent.swift` launch-token comment,
+  CROW-484). The durable fix is to adopt the CROW-911 identity-probe seam for
+  Cursor — with a PATH-walk-that-verifies (take the first `agent` on PATH that
+  passes the probe, since the wrong one can be first) — tracked as a follow-up.
 - **Grok's token is `grok`, which collides** with the community
   `superagent-ai/grok-cli` (also installs `grok`). Unlike Cursor, Crow does
   **not** just accept the false positive: registration **identity-probes** a
-  bare PATH/fallback match (`grok --version` / `--help`, matched against
-  grok-build-specific flag markers in `GrokAgent.identityMarkers`) and shows
+  bare PATH/fallback match — `grok --help` (then `--version`), matched against
+  grok-build-specific flag markers in `GrokAgent.identityMarkers` — and shows
   Grok Build **disabled** when the resolved binary is the foreign `grok-cli`
-  (`GrokAgent.verifyBinaryIdentity`, CROW-911). An explicit
-  `defaults.binaries.grok` pin is authoritative and **skips the probe**
-  (`CrowDaemon.registerAgents`); `BinaryOverrides` keys on
-  `AgentKind.rawValue` = `"grok"`. The probe is a reusable `CodingAgent` seam
-  Cursor's `agent` token can adopt later.
+  (`GrokAgent.verifyBinaryIdentity`, CROW-911). The decision is the pure
+  `AgentDiscovery.evaluate` (resolve → probe a non-override match), which
+  `CrowDaemon.registerAgents` wraps with registry writes + logging. An explicit
+  `defaults.binaries.grok` pin is authoritative and **skips the probe**;
+  `BinaryOverrides` keys on `AgentKind.rawValue` = `"grok"`. The probe is a
+  reusable `CodingAgent` seam Cursor's `agent` token can adopt (see above).
+  ⚠️ **Trust-boundary delta:** `crowd` now *executes* the PATH-resolved `grok`
+  (an unvetted third-party binary) at boot to probe it — inherent to identity
+  probing, on the user's own PATH, output only substring-matched (never logged
+  or evaluated); the probe is hard-bounded so a hanging binary can't stall boot
+  (`GrokAgent.probeArg`).
 - **Registration order = default.** `AgentRegistry.register` sets the default to
   the *first* kind registered
   ([`AgentRegistry.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)).
@@ -582,7 +594,7 @@ against current upstream CLIs.
 | Antigravity bounded auto-permission has no verified interactive launch flag | `agy` **v1.1.7**; headless `-p` ignores `permissions.allow` (issue #548) | `AntigravityLaunchArgs.autoPermissionSuffix` | 2026-07-26 |
 | Antigravity official-installer provenance (supply-chain gate) unconfirmed | `google-antigravity` org `is_verified: false`; pin `antigravity.google` | `AntigravityAgent.fallbackCandidates` | 2026-07-26 — confirm before promoting out of Tier-2 |
 | **Entire Grok flag set** — hooks event names, `-p`/`--single`, `-c`/`-r`, `--allow`/`--deny`, `--permission-mode`, `--trust`, `/rename` | `xai-org/grok-build` **@ 2026-07-25** (periodic mirror of xAI's monorepo, **PRs closed** → churn likely) | `GrokAgent` / `GrokLaunchArgs` / `GrokHookConfigWriter` / `GrokSignalSource` | 2026-07-26 — verified against repo source (`crates/codegen/xai-grok-*`), not blog posts |
-| Grok `grok` binary collides with community `superagent-ai/grok-cli` | **Identity probe** at registration (`grok --version`/`--help` vs grok-build flag markers) greys out the foreign `grok`; explicit `defaults.binaries.grok` pin bypasses the probe. Probe markers (`--prompt-file`, `--prompt-json`, `--permission-mode`, `--always-approve`) are the same upstream flag set as the row above — re-verify together | `GrokAgent.identityMarkers` / `verifyBinaryIdentity` · `CrowDaemon.registerAgents` | 2026-07-29 (CROW-911) |
+| Grok `grok` binary collides with community `superagent-ai/grok-cli` | **Identity probe** at registration (`grok --help`/`--version` vs grok-build flag markers) greys out the foreign `grok`; explicit `defaults.binaries.grok` pin bypasses it. Decision is pure `AgentDiscovery.evaluate`; probe markers (`--prompt-file`, `--prompt-json`, `--permission-mode`, `--always-approve`) are the same upstream flag set as the row above — re-verify together | `GrokAgent.identityMarkers` / `verifyBinaryIdentity` · `AgentDiscovery.evaluate` | 2026-07-26 (CROW-911) |
 | Grok **`--permission-mode auto` now exists** — the ticket's pinned probe (#859) reported it absent; current docs show `grok --permission-mode auto`. Bounded `.job` posture stays `--permission-mode auto` + a minimal `--deny` backstop (never `--yolo`) regardless | Grok mirror **@ 2026-07-25** | `GrokLaunchArgs.autoPermissionSuffix` | 2026-07-26 |
 | Grok `Stop` / `Notification` fire on the transitions Crow's state machine needs — **confirm empirically** | — (empirical, #859) | `GrokSignalSource` | 2026-07-26 |
 | Grok double-fire: only the **global** `~/.claude`/`~/.cursor` hook configs Grok also discovers (its compat scanning) firing alongside `.grok/hooks/crow.json` — dedup deferred (genuinely user-controlled config, no Crow session UUID, not RCE; cf. Codex §3b). *Project* compat sources are handled: stripped on `.review` clones (`stripGrokConfigFromReviewClone`, RCE) and neutralized on `.work`/`.job` handoff + warm-adopt (`stripPriorCompatHooksForGrokHandoff` + session-own adopt write, #861 r9-r10). The Grok-**Manager** devRoot case stays a documented limitation (`writeManagerHookConfig`). | — (empirical, #859) | `GrokHookConfigWriter` / `SessionService` | 2026-07-27 |


### PR DESCRIPTION
Closes #911

## Problem
`grok` collides with the community `superagent-ai/grok-cli`, which installs a same-named binary. Availability was decided purely by whether `findBinary()` resolved *any* `grok` on PATH (`CrowDaemon.registerDiscovered` → `registerKnown(available: true)`), so a user with grok-cli but not xAI's grok-build saw **Grok Build shown as available/active** — a name match, not an identity match.

## Fix (ticket direction 1 — identity probe)
Registration now identity-probes a bare PATH/fallback match before marking Grok Build available:

- **`CodingAgent.verifyBinaryIdentity(atPath:) async -> Bool`** — new protocol seam, default `true` (unambiguous tokens are trusted, no behavior change for Claude/Codex/Cursor/OpenCode/Antigravity). Reusable; Cursor's generic `agent` token can adopt it later (scoped here to Grok per the ticket).
- **`GrokAgent`** overrides it: runs `grok --version` / `--help` (bounded 3s, tolerates non-zero exit) and matches the output against grok-build-specific **flag markers** — `--prompt-file`, `--prompt-json`, `--permission-mode`, `--always-approve` (the same upstream flag set the launch args are pinned to). The conversational Node `grok-cli` carries none of them → shown **disabled**. Markers are flag names, **not** vendor branding, precisely because grok-cli is itself an xAI Grok API client and may reference "xAI" in its help text (which would false-positive a branding match).
- **`CrowDaemon.registerAgents`** — now async; probes on a PATH/fallback match, **skips the probe for an explicit `defaults.binaries.grok` pin** (authoritative, so a version-pinned probe broken by upstream churn can't grey out a correctly-pinned install), and logs an honest "failed identity probe … pin the real path" line for the foreign case.

`ShellRunner` is injected into `GrokAgent` so the probe is unit-testable without spawning a subprocess.

## Tests
`GrokAgentTests` (5 new): accepts grok-build flags, rejects community grok-cli (the exact false positive), rejects empty output, tolerates non-zero exit. Full suites green — **CrowGrok 55, CrowCore 520, CrowDaemon 322**.

## Docs
`docs/agent-harness-matrix.md`: the collision mitigation is now the identity probe rather than "accept the false positive + manual pin" (token-collision prose, the token-row cell, and the version-pinned re-check row).

## Verify (ticket test plan)
With `superagent-ai/grok-cli` on PATH but xAI grok-build absent, Grok Build renders **disabled** (probe finds no grok-build flags). Installing real `xai-org/grok-build` (or pinning `defaults.binaries.grok`) + restarting `crowd` flips it to available. The probe logic is covered by unit tests; the end-to-end PATH scenario needs a machine with grok-cli installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)