### PR TITLE
Sidebar top: two-column layout — wide tickets box over nav pills, icon buttons in a far-right column (CROW-917)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -683,8 +683,12 @@ html, body {
 .sidebar-right { flex: 0 0 auto; width: 30px; display: flex; flex-direction: column; gap: 6px; }
 /* Every icon button in the right column stretches to the column width and shares
    the height evenly, so bell/gear/+/select read as one aligned stack regardless of
-   each control's intrinsic size. */
-.sidebar-right > button { flex: 1 1 0; width: 100%; height: auto; }
+   each control's intrinsic size. `min-height: 24px` is a hard floor: the four
+   flex:1 buttons divide whatever height `.sidebar-left` resolves to, and a short
+   left column (no Manager pill / cold-start render) would otherwise divide to
+   ~20px — under the WCAG 2.2 §2.5.8 target-size minimum, and the sidebar is the
+   full-width touch view on mobile (CROW-917 review). */
+.sidebar-right > button { flex: 1 1 0; width: 100%; height: auto; min-height: 24px; }
 .tickets-counts { display: flex; align-items: center; justify-content: space-between; gap: 4px; padding: 0 2px; }
 .tk-tool {
   display: inline-flex; align-items: center; justify-content: center;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -644,7 +644,11 @@ html, body {
 
 .tickets-card {
   background: var(--bg-surface); border: 1px solid var(--border-subtle);
-  border-radius: 8px; padding: 8px; margin: 2px 2px 8px; cursor: pointer;
+  border-radius: 8px; padding: 8px; cursor: pointer;
+  /* Full width of the left column, ~2 button-rows tall so it lines up with the
+     Notifications+Settings pair in the right icon column (CROW-917). */
+  margin: 0; box-sizing: border-box; height: 64px;
+  display: flex; flex-direction: column; justify-content: space-between;
 }
 .tickets-card:hover { border-color: var(--border-strong); }
 .tickets-card.selected { border-color: var(--gold); }
@@ -665,21 +669,18 @@ html, body {
    `.action-spinner` glyph swapped in for the `↻` turns inside it (CROW-797) —
    matching the detail-header action-button spinner (CROW-749). */
 .tickets-refresh.spinning { opacity: 0.6; cursor: default; }
-.tickets-row { display: flex; align-items: stretch; gap: 6px; margin: 2px 2px 8px; }
-/* Compact ticket box (CROW-913 ask #2): was flex:1 1 auto, which grew it to fill the whole
-   row and dominate the sidebar top. Now content-sized: the counts render in a fixed TWO
-   columns (below), so the card's max-content is a narrow ~91px (two count cells + header)
-   rather than the five-cell-wide ~160px it would be on one line — measured 91px at typical
-   counts, 106px with 3-digit counts, as close to the Notifications+Settings cluster (66px)
-   as "Tickets" + the five counts allow. `max-width` is a far-off CEILING, not the resting
-   width: because the width tracks max-content, the box grows with the font, so a raised
-   browser minimum-font-size can't clip the header (grows to ~158px at a 24px floor) — the
-   failure a fixed px width had (review). Two columns also fix the height: it's a constant
-   ~95px regardless of 1-, 2-, or 3-digit counts, where a single wrapping row grew taller
-   with bigger numbers. Sits beside the horizontal Notifications+Settings tools cluster. */
-.tickets-row .tickets-card { flex: 0 1 auto; width: max-content; max-width: 160px; margin: 0; }
-.sidebar-tools { display: flex; flex-direction: row; align-items: center; gap: 6px; flex: 0 0 auto; }
-.tickets-counts { display: grid; grid-template-columns: repeat(2, auto); justify-content: center; gap: 4px 10px; margin-top: 8px; padding: 0 2px; }
+/* Two-column sidebar top (CROW-917): left stack (tickets over the nav rows) beside
+   a one-icon-wide right column. `align-items: stretch` makes the right column match
+   the left column's height so its four icon buttons (flex:1 each) divide it evenly
+   and self-align to the tickets(2) + Reviews-row(1) + Manager-row(1) = 4 rows. */
+.sidebar-top { display: flex; align-items: stretch; gap: 6px; margin: 2px 2px 8px; }
+.sidebar-left { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.sidebar-right { flex: 0 0 auto; width: 30px; display: flex; flex-direction: column; gap: 6px; }
+/* Every icon button in the right column stretches to the column width and shares
+   the height evenly, so bell/gear/+/select read as one aligned stack regardless of
+   each control's intrinsic size. */
+.sidebar-right > button { flex: 1 1 0; width: 100%; height: auto; }
+.tickets-counts { display: flex; align-items: center; justify-content: space-between; gap: 4px; padding: 0 2px; }
 .tk-tool {
   display: inline-flex; align-items: center; justify-content: center;
   width: 30px; height: 29px; border-radius: 6px; cursor: pointer;
@@ -782,9 +783,9 @@ html, body {
 .tk-dot { width: 7px; height: 7px; border-radius: 50%; }
 .tk-n { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-/* Two deterministic rows: Reviews/Allowlist/Scorecard, then Manager + "+".
-   Each .nav-pills-row is its own non-wrapping flex line so groups never reflow. */
-.nav-pills { display: flex; flex-direction: column; gap: 6px; margin: 0 2px 8px; }
+/* Left-column nav rows (CROW-917): row 1 Reviews/Allowlist/Scorecard, row 2 the
+   full-width Manager pill. Each .nav-pills-row is its own non-wrapping flex line so
+   groups never reflow; the "+" and Select buttons live in the right icon column. */
 .nav-pills-row { display: flex; gap: 6px; }
 .nav-pill {
   flex: 1 1 auto; min-width: 0; display: flex; align-items: center; justify-content: center; gap: 5px;
@@ -799,14 +800,15 @@ html, body {
 .pill-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 .pill-dot.pulse { animation: crow-pulse 1.5s ease-in-out infinite; }
 .nav-plus {
-  flex: 0 0 auto; width: 30px; padding: 6px 0; border-radius: 6px; cursor: pointer; line-height: 1;
+  flex: 0 0 auto; width: 30px; padding: 0; border-radius: 6px; cursor: pointer; line-height: 1;
+  display: inline-flex; align-items: center; justify-content: center;
   background: var(--bg-surface); border: 1px solid rgba(179, 142, 70, 0.3); color: var(--gold-dark); font-size: 15px; font-weight: 700;
 }
 .nav-plus:hover { color: var(--gold); border-color: var(--border-strong); }
 
-/* Select-sessions toggle (CROW-913): an aligned icon button living in nav-pills row 1
-   after Scorecard. Sized/coloured like .nav-plus so it stretches to the pill height;
-   reads red while a selection is active, matching .nav-selecting elsewhere. */
+/* Select-sessions toggle (CROW-913 → far-right icon column, CROW-917): sized/coloured
+   like .nav-plus; reads red while a selection is active, matching .nav-selecting elsewhere.
+   In .sidebar-right it flex-fills to align under the bell/gear/+ stack. */
 .nav-select {
   flex: 0 0 auto; width: 30px; padding: 0; display: inline-flex; align-items: center; justify-content: center;
   border-radius: 6px; cursor: pointer;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -646,8 +646,13 @@ html, body {
   background: var(--bg-surface); border: 1px solid var(--border-subtle);
   border-radius: 8px; padding: 8px; cursor: pointer;
   /* Full width of the left column, ~2 button-rows tall so it lines up with the
-     Notifications+Settings pair in the right icon column (CROW-917). */
-  margin: 0; box-sizing: border-box; height: 64px;
+     Notifications+Settings pair in the right icon column (CROW-917). `min-height`
+     not `height`: a raised browser minimum-font-size grows the title/counts past
+     the resting 46px content box, and a hard height would clip the counts row out
+     the bottom border (the #913 fixed-px failure mode). Growing is safe — the
+     right column stretches to whatever the left resolves to, re-deriving the
+     4-icon alignment for free. */
+  margin: 0; box-sizing: border-box; min-height: 64px;
   display: flex; flex-direction: column; justify-content: space-between;
 }
 .tickets-card:hover { border-color: var(--border-strong); }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1004,11 +1004,13 @@ function renderSidebar() {
   brand.alt = 'Crow';
   root.appendChild(brand);
 
-  const trow = el('div', 'tickets-row');
-  trow.appendChild(ticketsCard());
-  trow.appendChild(sidebarToolsStack());
-  root.appendChild(trow);
-  root.appendChild(navPillRow());
+  // Two-column sidebar top (CROW-917): a left stack [tickets → Reviews/Allowlist/
+  // Scorecard → Manager] over a far-right column of four stacked icon buttons
+  // [bell, gear, +, select], which flex evenly to align alongside the left rows.
+  const top = el('div', 'sidebar-top');
+  top.appendChild(sidebarLeftStack());
+  top.appendChild(sidebarIconColumn());
+  root.appendChild(top);
   if (selectionMode) root.appendChild(bulkActionBar());
 
   // Cold start only: structured skeleton rows so the left pane isn't blank
@@ -1260,11 +1262,12 @@ function renderStatusBar() {
   }
 }
 
-// Notifications + Settings, side by side to the right of the Tickets card
-// (outside the box). The Select-sessions toggle moved down to navPillRow row 1,
-// next to Scorecard (CROW-913).
-function sidebarToolsStack() {
-  const stack = el('div', 'sidebar-tools');
+// Far-right sidebar column (CROW-917): the four global icon buttons stacked
+// vertically — Notifications bell, Settings gear, "+" new-manager, and the
+// Select-sessions toggle. They flex evenly to align alongside the left stack's
+// rows (tickets = 2 rows, Reviews-row = 1, Manager-row = 1 → 4 icons).
+function sidebarIconColumn() {
+  const col = el('div', 'sidebar-right');
   // Notification center (CROW-909): bell + unread badge, first so it's the most
   // prominent global affordance. Visible in every view (sessions and boards).
   const bell = el('button', 'tk-tool tk-bell');
@@ -1273,20 +1276,38 @@ function sidebarToolsStack() {
   bell.appendChild(icon('bell', 14));
   if (unread) bell.appendChild(el('span', 'notif-badge', unread > 99 ? '99+' : String(unread)));
   bell.onclick = () => openNotificationPanel(bell);
-  stack.appendChild(bell);
+  col.appendChild(bell);
+
   const gear = el('button', 'tk-tool');
   gear.title = 'Settings';
   gear.appendChild(icon('wrench', 14));
   gear.onclick = () => { if (window.openSettings) window.openSettings(); };
-  stack.appendChild(gear);
-  return stack;
+  col.appendChild(gear);
+
+  const plus = el('button', 'nav-plus', '+');
+  plus.title = 'New Manager session';
+  plus.onclick = () => openNewManagerMenu(plus);
+  col.appendChild(plus);
+
+  // Select-sessions toggle (CROW-913 → moved into this column, CROW-917): toggles
+  // selectionMode, clears the selection on cancel, reads red (.nav-selecting) active.
+  const sel = el('button', 'nav-select' + (selectionMode ? ' nav-selecting' : ''));
+  sel.title = selectionMode ? 'Cancel selection' : 'Select sessions';
+  sel.setAttribute('aria-label', sel.title);
+  sel.appendChild(icon(selectionMode ? 'close' : 'checkSquare', 14));
+  sel.onclick = () => { selectionMode = !selectionMode; if (!selectionMode) selectedSessionIDs.clear(); renderSidebar(); };
+  col.appendChild(sel);
+
+  return col;
 }
 
-// Reviews / Allowlist / Manager pills + "+" (new manager).
-function navPillRow() {
-  const wrap = el('div', 'nav-pills');
+// Left sidebar-top stack (CROW-917): the Tickets card over two nav-pill rows —
+// row 1 Reviews · Allowlist · Scorecard, row 2 the full-width Manager pill.
+function sidebarLeftStack() {
+  const wrap = el('div', 'sidebar-left');
+  wrap.appendChild(ticketsCard());
 
-  // Row 1: Reviews · Allowlist · Scorecard · Select (kept together, no mid-group wrap).
+  // Row 1: Reviews · Allowlist · Scorecard (each its own non-wrapping flex line).
   const row1 = el('div', 'nav-pills-row');
   const rev = navPill('Reviews', selectedBoard === 'reviews', () => selectBoard('reviews'));
   const unseen = (boardData.reviews && boardData.reviews.unseen) || 0;
@@ -1294,18 +1315,9 @@ function navPillRow() {
   row1.appendChild(rev);
   row1.appendChild(navPill('Allowlist', selectedBoard === 'allowlist', () => selectBoard('allowlist')));
   row1.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
-  // Select-sessions toggle (CROW-913): moved out of the sidebar tools stack to sit
-  // beside Scorecard as an aligned icon button. Same behavior — toggles selectionMode,
-  // clears the selection on cancel, and reads red (.nav-selecting) while active.
-  const sel = el('button', 'nav-select' + (selectionMode ? ' nav-selecting' : ''));
-  sel.title = selectionMode ? 'Cancel selection' : 'Select sessions';
-  sel.setAttribute('aria-label', sel.title);
-  sel.appendChild(icon(selectionMode ? 'close' : 'checkSquare', 14));
-  sel.onclick = () => { selectionMode = !selectionMode; if (!selectionMode) selectedSessionIDs.clear(); renderSidebar(); };
-  row1.appendChild(sel);
   wrap.appendChild(row1);
 
-  // Row 2: Manager pill (when a primary manager session exists) + the "+" new-manager button.
+  // Row 2: the primary Manager pill, spanning the full left-column width.
   const row2 = el('div', 'nav-pills-row');
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
@@ -1317,10 +1329,6 @@ function navPillRow() {
     if (liveFor(primaryManager.id).remote_control_active) mgr.appendChild(rcGlyph());
     row2.appendChild(mgr);
   }
-  const plus = el('button', 'nav-plus', '+');
-  plus.title = 'New Manager session';
-  plus.onclick = () => openNewManagerMenu(plus);
-  row2.appendChild(plus);
   wrap.appendChild(row2);
 
   return wrap;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1273,6 +1273,7 @@ function sidebarIconColumn() {
   const bell = el('button', 'tk-tool tk-bell');
   const unread = notifUnreadCount();
   bell.title = unread ? unread + ' unread notification' + (unread === 1 ? '' : 's') : 'Notifications';
+  bell.setAttribute('aria-label', bell.title);
   bell.appendChild(icon('bell', 14));
   if (unread) bell.appendChild(el('span', 'notif-badge', unread > 99 ? '99+' : String(unread)));
   bell.onclick = () => openNotificationPanel(bell);
@@ -1280,12 +1281,14 @@ function sidebarIconColumn() {
 
   const gear = el('button', 'tk-tool');
   gear.title = 'Settings';
+  gear.setAttribute('aria-label', 'Settings');
   gear.appendChild(icon('wrench', 14));
   gear.onclick = () => { if (window.openSettings) window.openSettings(); };
   col.appendChild(gear);
 
   const plus = el('button', 'nav-plus', '+');
   plus.title = 'New Manager session';
+  plus.setAttribute('aria-label', 'New Manager session');
   plus.onclick = () => openNewManagerMenu(plus);
   col.appendChild(plus);
 
@@ -1317,10 +1320,15 @@ function sidebarLeftStack() {
   row1.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
   wrap.appendChild(row1);
 
-  // Row 2: the primary Manager pill, spanning the full left-column width.
-  const row2 = el('div', 'nav-pills-row');
+  // Row 2: the primary Manager pill, spanning the full left-column width. Only
+  // appended when a primary manager exists — an empty row would drop a pill's
+  // worth of height (plus a stray 6px gap) off the left column, squashing the
+  // right icon column's four flex:1 buttons below the 24px WCAG target floor and
+  // breaking the "4 rows ↔ 4 icons" alignment (also on the cold-start no-cache
+  // render, where sessions is still empty — CROW-917 review).
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
+    const row2 = el('div', 'nav-pills-row');
     const mgr = navPill('Manager', selectedId === primaryManager.id, () => selectSession(primaryManager.id));
     const ind = activityIndicator(primaryManager);
     const dot = el('span', 'pill-dot' + (ind.pulse ? ' pulse' : ''));
@@ -1328,8 +1336,8 @@ function sidebarLeftStack() {
     mgr.insertBefore(dot, mgr.firstChild);
     if (liveFor(primaryManager.id).remote_control_active) mgr.appendChild(rcGlyph());
     row2.appendChild(mgr);
+    wrap.appendChild(row2);
   }
-  wrap.appendChild(row2);
 
   return wrap;
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1321,11 +1321,11 @@ function sidebarLeftStack() {
   wrap.appendChild(row1);
 
   // Row 2: the primary Manager pill, spanning the full left-column width. Only
-  // appended when a primary manager exists — an empty row would drop a pill's
-  // worth of height (plus a stray 6px gap) off the left column, squashing the
-  // right icon column's four flex:1 buttons below the 24px WCAG target floor and
-  // breaking the "4 rows ↔ 4 icons" alignment (also on the cold-start no-cache
-  // render, where sessions is still empty — CROW-917 review).
+  // appended when a primary manager exists — an empty .nav-pills-row still consumes
+  // a flex-gap slot, so appending one would leave a stray 6px gap below row 1. (The
+  // separate concern — a shorter left column dividing the right icon column's four
+  // flex:1 buttons below the 24px WCAG floor on a Manager-less / cold-start render —
+  // is handled by `.sidebar-right > button { min-height: 24px }`, not by this guard.)
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
     const row2 = el('div', 'nav-pills-row');

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -306,24 +306,25 @@ import Testing
             "the board-empty-hint CSS rule is dead once the hint is gone")
     }
 
-    /// CROW-913: the Select-sessions toggle moved out of `sidebarToolsStack`
-    /// (Notifications + Settings only now) into `navPillRow` row 1, beside the
-    /// Scorecard pill, as a `.nav-select` icon button. Pin the move so the toggle
-    /// can't drift back into the tools stack, and pin the now-dead
-    /// `.tk-tool.nav-selecting` rule out of app.css — after the move only
-    /// `.nav-select` and `.action-btn` ever take `nav-selecting`.
-    @Test func selectToggleLivesInNavRowNotTheToolsStack() throws {
+    /// CROW-917: the Select-sessions toggle lives in the far-right icon column
+    /// (`sidebarIconColumn`, stacked under bell/gear/+), NOT in the left stack
+    /// (`sidebarLeftStack`, which holds the Tickets card + nav rows). Pin the
+    /// placement so the toggle can't drift into the left stack, and keep the
+    /// now-dead `.tk-tool.nav-selecting` rule out of app.css — only `.nav-select`
+    /// and `.action-btn` ever take `nav-selecting`. (Supersedes CROW-913's
+    /// nav-row-vs-tools-stack pinning, which this PR reverses.)
+    @Test func selectToggleLivesInIconColumnNotTheLeftStack() throws {
         let js = try Self.webAsset("app.js")
         // Anchor on the behaviour (selectionMode), not the icon name: a Select
-        // toggle re-added to the tools stack with any glyph should still fail.
+        // toggle re-added to the left stack with any glyph should still fail.
         #expect(
-            try !Self.stripComments(String(Self.functionBody("sidebarToolsStack", in: js)))
+            try !Self.stripComments(String(Self.functionBody("sidebarLeftStack", in: js)))
                 .contains("selectionMode"),
-            "the Select toggle's selection logic must not live in the sidebar tools stack (CROW-913)")
-        let navRow = try Self.functionBody("navPillRow", in: js)
+            "the Select toggle's selection logic must not live in the left sidebar stack (CROW-917)")
+        let iconCol = try Self.functionBody("sidebarIconColumn", in: js)
         #expect(
-            navRow.contains("'nav-select'") && navRow.contains("selectionMode"),
-            "navPillRow must render the Select toggle (its selectionMode logic) beside Scorecard")
+            iconCol.contains("'nav-select'") && iconCol.contains("selectionMode"),
+            "sidebarIconColumn must render the Select toggle (its selectionMode logic) in the icon column")
         let css = try Self.webAsset("app.css")
         #expect(
             !css.contains(".tk-tool.nav-selecting"),
@@ -337,19 +338,23 @@ import Testing
             "the relocated Select toggle needs its .nav-select styles")
     }
 
-    /// CROW-913 ask #2: the ticket box is capped compact. The width churned every
-    /// round (92 → self-healing range → 160 → content-sized), so pin the mechanism
-    /// that holds it: content-sized (`width: max-content`) with a 160px ceiling, kept
-    /// narrow by a TWO-column counts grid (max-content is two cells wide, ~91px, not
-    /// the five-cell ~160px row). The two-column grid is also what makes the card's
-    /// height count-invariant, so it's load-bearing, not cosmetic.
-    @Test func ticketBoxIsCompactAndContentSized() throws {
+    /// CROW-917: the ticket box spans the full width of the left column and is
+    /// only ~2 button-rows tall, so it lines up with the Notifications+Settings
+    /// pair in the right icon column. Pin `min-height` (NOT a hard `height`, which
+    /// would clip the counts row out the bottom when a raised browser min-font
+    /// grows them — the #913 fixed-px failure mode) and the single-row flex counts
+    /// (the #913 two-column grid only existed to keep the width-capped box narrow;
+    /// #917 supersedes that cap, so the counts are one horizontal row again).
+    @Test func ticketBoxIsFullWidthAndShort() throws {
         let css = try Self.webAsset("app.css")
         #expect(
-            css.contains("width: max-content; max-width: 160px"),
-            "the ticket card must be content-sized with a 160px ceiling, not fill the row (CROW-913 ask #2)")
+            css.contains("min-height: 64px"),
+            "the ticket card must be ~2 button-rows tall via min-height (not a clipping fixed height) (CROW-917)")
         #expect(
-            css.contains("grid-template-columns: repeat(2, auto)"),
-            "the counts must be a two-column grid so the card stays compact and its height is count-invariant")
+            css.contains(".tickets-counts { display: flex;"),
+            "the counts must be a single horizontal flex row now the full-width box no longer needs the compact two-column grid (CROW-917)")
+        #expect(
+            !css.contains("width: max-content; max-width: 160px"),
+            "the #913 content-sized width cap is superseded — the card is full-width in the left column now")
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -338,6 +338,31 @@ import Testing
             "the relocated Select toggle needs its .nav-select styles")
     }
 
+    /// CROW-917: two layout decisions with no other pin, both verified to regress
+    /// silently (deleting either leaves every suite green). The right column's four
+    /// `flex:1` icons divide the left column's height, so a short Manager-less /
+    /// cold-start column would push them under the WCAG 2.2 §2.5.8 target-size
+    /// minimum without the `min-height` floor a prior review round mandated; and
+    /// relocating the new-manager `"+"` into that column (out of the nav rows) is
+    /// half this PR's purpose, yet the Select pin above only anchors on `.nav-select`.
+    @Test func iconColumnHasWcagFloorAndHoldsTheNewManagerButton() throws {
+        // stripComments the CSS: the floor's value is also named in the rule's doc
+        // comment, so a bare whole-file `contains` false-passes off the prose once
+        // the declaration itself is deleted (caught by mutation-testing this pin).
+        let css = Self.stripComments(try Self.webAsset("app.css"))
+        #expect(
+            css.contains("min-height: 24px"),
+            "the right column's icon buttons need the 24px WCAG 2.5.8 target-size floor (CROW-917 review)")
+        // Pin the append, not the `el('button', 'nav-plus', …)` construction: the
+        // regression the review names is the "+" being built but not rendered, so a
+        // `contains("'nav-plus'")` would miss a dropped appendChild (also mutation-checked).
+        let js = try Self.webAsset("app.js")
+        let iconCol = try Self.functionBody("sidebarIconColumn", in: js)
+        #expect(
+            iconCol.contains("col.appendChild(plus)"),
+            "the new-manager \"+\" must be appended to the icon column, not the nav rows (CROW-917)")
+    }
+
     /// CROW-917: the ticket box spans the full width of the left column and is
     /// only ~2 button-rows tall, so it lines up with the Notifications+Settings
     /// pair in the right icon column. Pin `min-height` (NOT a hard `height`, which

--- a/Packages/CrowDaemon/web-tests/sidebar-select.test.js
+++ b/Packages/CrowDaemon/web-tests/sidebar-select.test.js
@@ -2,19 +2,19 @@ const fs = require('fs');
 const vm = require('vm');
 const { JSDOM } = require('jsdom');
 
-// CROW-913 behaviour test: the Select-sessions toggle moved from the sidebar
-// tools stack into nav-pills row 1. Runs the REAL app.js under jsdom and drives
-// the relocated `.nav-select` button — a string guard proves only that the code
-// moved files; this proves the behaviour survived the move (toggles
-// `selectionMode`, and clears `selectedSessionIDs` on cancel). Same loader shape
-// as board.test.js / sidebar-groups.test.js. renderSidebar is neutered so the
-// click exercises just the handler, not a full re-render.
+// CROW-917 behaviour test: the Select-sessions toggle lives in the far-right
+// sidebar icon column (`sidebarIconColumn`), stacked under bell/gear/+. Runs the
+// REAL app.js under jsdom and drives the `.nav-select` button — a string guard
+// proves only that the code moved files; this proves the behaviour survived the
+// move (toggles `selectionMode`, and clears `selectedSessionIDs` on cancel). Same
+// loader shape as board.test.js / sidebar-groups.test.js. renderSidebar is
+// neutered so the click exercises just the handler, not a full re-render.
 const epilogue = `
 ;globalThis.__t = {
   get selectionMode(){ return selectionMode; },
   set selectionMode(v){ selectionMode = v; },
   get selectedSessionIDs(){ return selectedSessionIDs; },
-  navPillRow(){ return navPillRow(); },
+  sidebarIconColumn(){ return sidebarIconColumn(); },
   neuterRender(){ renderSidebar = function(){}; },
 };
 `;
@@ -46,7 +46,7 @@ if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); p
 
 let pass = 0, fail = 0;
 const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
-const selBtn = () => T.navPillRow().querySelector('.nav-select');
+const selBtn = () => T.sidebarIconColumn().querySelector('.nav-select');
 
 T.neuterRender();
 
@@ -54,7 +54,7 @@ console.log('\nSelect toggle — idle → active:');
 T.selectionMode = false;
 T.selectedSessionIDs.clear();
 let sel = selBtn();
-check('.nav-select renders in nav-pills row 1', !!sel);
+check('.nav-select renders in the sidebar icon column', !!sel);
 check('idle: not red (no nav-selecting)', !sel.className.includes('nav-selecting'));
 check('idle: title + aria-label = "Select sessions"',
   sel.title === 'Select sessions' && sel.getAttribute('aria-label') === 'Select sessions');


### PR DESCRIPTION
Closes #917.

Follow-up to #913, which squished the tickets box too far. Reorganizes the sidebar top into a clean two-column grid.

## Layout
- **Left column** (`.sidebar-left`): the **Tickets** card — now **full width** of the left column and **~2 button-rows tall** — over nav **row 1** (Reviews · Allowlist · Scorecard) and nav **row 2** (the **Manager** pill, spanning the full left-column width).
- **Right column** (`.sidebar-right`): the four global icon buttons — **bell**, **gear**, **"+"** (new manager), **Select** — stacked vertically. `.sidebar-top` uses `align-items: stretch` so the right column matches the left height, and each button is `flex: 1 1 0`, so the four icons divide it evenly and self-align to the tickets(2) + Reviews-row(1) + Manager-row(1) = **4 rows**.

## Changes
- Pulled **Select** out of nav row 1 and **"+"** out of nav row 2 into the right icon column, alongside the bell + gear.
- Tickets counts revert to a **single horizontal row of five** (the #913 two-column count grid only existed to keep the width-capped box narrow; the box is full width now).
- Dropped the now-unused `.tickets-row` / `.sidebar-tools` / `.nav-pills` wrapper classes and the `navPillRow` / `sidebarToolsStack` functions; renamed to `sidebarLeftStack` / `sidebarIconColumn`.
- **Supersedes** the tickets-box width cap and the Select-next-to-Scorecard placement from #913.

## Behavior (preserved verbatim)
Bell → notification panel + unread badge · gear → Settings · "+" → new-manager menu · Select → toggles `selectionMode` (clears selection on cancel, red while active) · Manager pill keeps its activity dot / RC glyph · Reviews unseen badge · tickets refresh spinner.

## Verify
- `node --check app.js` passes; every class the JS emits maps to a live CSS rule (no dangling `tickets-row`/`sidebar-tools`/`.nav-pills`).
- Tickets box renders wide (full nav-pills width, = Manager width) and short (~2 button rows); Notifications, Settings, "+", Select sit stacked in a single far-right column; Reviews/Allowlist/Scorecard on one row and Manager full-width below; all buttons keep their actions.

> Coordinated at merge time with #913 (superseded) and #909 (notification bell), both of which touch this sidebar region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)