### PR TITLE
Web terminal: send CSI-u for Shift+Enter so agents see a newline (CROW-916)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -4345,13 +4345,41 @@ async function uploadDroppedFiles(files) {
 //
 // Cmd/Ctrl+C copies the selection (falling through to SIGINT when nothing is
 // selected so Ctrl+C still interrupts), Cmd+F opens our find prompt. Lets the
-// browser own copy instead of tmux's copy-mode.
+// browser own copy instead of tmux's copy-mode. Shift+Enter is rewritten to a
+// distinguishable CSI-u sequence (see the branch).
 //
 // A branch that shadows a browser default must preventDefault(): returning
 // false only makes xterm skip its OWN key handling (its _keyDown returns early,
 // before any cancel()), so the browser's default gesture still runs (#875).
 function handleTerminalKey(e) {
   if (e.type !== 'keydown') return true;
+  // Shift+Enter → CSI-u, so Claude Code can tell it from a plain Enter and
+  // inserts a newline instead of submitting (#598/CROW-916). xterm.js's key
+  // table has no shiftKey branch for keyCode 13 — `e.altKey ? ESC+CR : CR` —
+  // so both chords otherwise arrive at the PTY as the same bare \r, and
+  // xterm.js 6.0 has no CSI-u/modifyOtherKeys support of its own to turn on.
+  // crow-tmux.conf's `extended-keys on` + `xterm*:extkeys` carries this to
+  // apps that negotiate extended keys and downgrades it to a plain \r for apps
+  // that don't, so nothing leaks into vim or a shell.
+  //
+  // Option+Enter is deliberately NOT handled: xterm already maps altKey + Enter
+  // to ESC CR natively, so a branch here would only restate the library.
+  // `!e.altKey` keeps Shift+Option+Enter on that native path.
+  //
+  // preventDefault() is load-bearing, not cosmetic. xterm cancels Enter itself
+  // (`o.cancel = true`), but returning false makes its _keyDown return BEFORE
+  // that cancel (#875) — and this handler waves the keypress phase straight
+  // through, so an uncancelled keydown would let keypress fire and write a
+  // second \r.
+  //
+  // Ported from CrowTerminal's terminal.html (#599), which stopped being a live
+  // surface when the macOS app was retired (ADR 0010).
+  if (e.key === 'Enter' && e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
+    sendToPTY('\x1b[13;2u');
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  }
   const mod = e.metaKey || e.ctrlKey;
   if (mod && (e.key === 'c' || e.key === 'C') && term.hasSelection()) {
     copyToClipboard(term.getSelection());

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -152,6 +152,28 @@
       }
       term.attachCustomKeyEventHandler(function (e) {
         if (e.type !== 'keydown') return true;
+        // Shift+Enter → CSI-u, so Claude Code can tell it from a plain Enter
+        // and inserts a newline instead of submitting (#598/CROW-916). xterm's
+        // key table has no shiftKey branch for keyCode 13, so both chords
+        // otherwise reach the PTY as the same bare \r. crow-tmux.conf's
+        // `extended-keys on` + `xterm*:extkeys` carries this to apps that
+        // negotiate extended keys and downgrades it to a plain \r for apps
+        // that don't, so nothing leaks into vim or a shell.
+        //
+        // Option+Enter is deliberately NOT handled: xterm maps altKey + Enter
+        // to ESC CR natively, so a branch here would only restate the library.
+        // `!e.altKey` keeps Shift+Option+Enter on that native path.
+        //
+        // preventDefault() is required: returning false makes xterm's _keyDown
+        // return before its own cancel (#875), and this handler waves the
+        // keypress phase through — an uncancelled keydown would write a second
+        // \r there.
+        if (e.key === 'Enter' && e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
+          sendToPTY('\x1b[13;2u');
+          e.preventDefault();
+          e.stopPropagation();
+          return false;
+        }
         const copyCombo = (e.metaKey && !e.ctrlKey) || (e.ctrlKey && e.shiftKey);
         if (copyCombo && (e.key === 'c' || e.key === 'C')) {
           if (term.hasSelection()) {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -249,6 +249,43 @@ import Testing
             "terminal.html's copy branch must cancel the browser default")
     }
 
+    /// CROW-916: both live surfaces must rewrite Shift+Enter to a sequence the
+    /// agent can tell apart from a plain Enter.
+    ///
+    /// xterm.js's key table has no `shiftKey` branch for keyCode 13
+    /// (`e.altKey ? ESC+CR : CR`), so without this the two chords reach the PTY
+    /// as the same bare `\r` and Claude Code submits on both. CSI-u is the right
+    /// sequence because `crow-tmux.conf`'s extended-keys setup carries it to
+    /// apps that negotiate extended keys and downgrades it to a plain `\r` for
+    /// apps that don't — a literal `ESC CR` would reach vim as "leave insert
+    /// mode, then Enter".
+    ///
+    /// This is the guard that was missing. #599 added the handler to
+    /// CrowTerminal's `terminal.html` and pinned it there
+    /// (`BundledResourcesTests.terminalHTMLHandlesModifiedEnter`) — but ADR 0010
+    /// retired that surface, so the passing test covered a page nothing loads
+    /// while both shipping surfaces regressed unasserted. Parameterized over the
+    /// live assets so it can't happen the same way twice.
+    ///
+    /// Asserted on the comment-stripped source: the rationale prose names the
+    /// sequence too, and a guard that a comment can satisfy guards nothing. The
+    /// branch is matched as one contiguous condition rather than as separate
+    /// `'Enter'` / `shiftKey` mentions — `app.js`'s modal dialogs already test
+    /// `e.key === 'Enter'`, so the loose form passes on the unfixed file.
+    @Test(arguments: ["app.js", "terminal.html"])
+    func modifiedEnterIsDistinguishableFromPlainEnter(asset: String) throws {
+        let code = Self.stripComments(try Self.webAsset(asset))
+        #expect(
+            code.contains(#"sendToPTY('\x1b[13;2u')"#),
+            "\(asset) must SEND CSI-u for Shift+Enter, not a bare \\r (CROW-916)")
+        #expect(
+            code.contains("e.key === 'Enter' && e.shiftKey"),
+            "\(asset)'s terminal key handler must branch on Shift+Enter")
+        #expect(
+            code.contains("e.preventDefault();") && code.contains("e.stopPropagation();"),
+            "\(asset)'s Shift+Enter branch must cancel the event — returning false leaves xterm's own cancel unreached, so the keypress phase writes a second \\r (#875)")
+    }
+
     /// Cancelling a gesture and being able to perform it are one decision: a
     /// surface may only `preventDefault()` the copy chord if its copy always
     /// delivers. `navigator.clipboard` is absent over plain http (a

--- a/Packages/CrowDaemon/web-tests/key-handler.test.js
+++ b/Packages/CrowDaemon/web-tests/key-handler.test.js
@@ -13,12 +13,16 @@ const { JSDOM } = require('jsdom');
 // keydown, its return value deciding only whether xterm runs its OWN key
 // handling. Returning false does NOT cancel the event — that's the bug this
 // file pins.
+//
+// CROW-916 adds the Shift+Enter cases. `termWs` is exposed too so those can
+// assert the bytes that actually reach the socket, through the real sendToPTY.
 const epilogue = `
 ;globalThis.__t = {
   handleTerminalKey(e){ return handleTerminalKey(e); },
   pasteIntoTerminal(){ return pasteIntoTerminal(); },
   set term(v){ term = v; },
   set searchAddon(v){ searchAddon = v; },
+  set termWs(v){ termWs = v; },
 };
 `;
 const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
@@ -53,14 +57,17 @@ const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name)
 // ---- Fakes -----------------------------------------------------------------
 
 // A fake xterm plus recorders for everything the handler can reach: what got
-// pasted into the terminal and what got written to the system clipboard.
+// pasted into the terminal, what got written to the system clipboard, and what
+// reached the PTY socket.
 const pasted = [];
 const copied = [];
+const sent = [];
 let clipboardText = '';
 
 function setup({ selection = '' } = {}) {
   pasted.length = 0;
   copied.length = 0;
+  sent.length = 0;
   window.document.querySelectorAll('.text-prompt-backdrop').forEach((n) => n.remove());
   T.term = {
     hasSelection: () => selection.length > 0,
@@ -69,6 +76,12 @@ function setup({ selection = '' } = {}) {
     focus() {},
   };
   T.searchAddon = { findNext() {} };
+  // The real sendToPTY writes UTF-8 bytes to this, so decoding here measures
+  // exactly what the PTY would receive.
+  T.termWs = {
+    readyState: window.WebSocket.OPEN,
+    send: (bytes) => sent.push(new TextDecoder().decode(bytes)),
+  };
 }
 
 // navigator.clipboard is absent in jsdom (and in a real browser over plain
@@ -88,9 +101,9 @@ function withoutClipboard() {
 
 // xterm hands the handler the raw KeyboardEvent; we count the cancellation calls
 // the handler makes on it.
-function key(k, { meta = false, ctrl = false, shift = false, type = 'keydown' } = {}) {
+function key(k, { meta = false, ctrl = false, shift = false, alt = false, type = 'keydown' } = {}) {
   const e = {
-    type, key: k, metaKey: meta, ctrlKey: ctrl, shiftKey: shift,
+    type, key: k, metaKey: meta, ctrlKey: ctrl, shiftKey: shift, altKey: alt,
     prevented: 0, stopped: 0,
     preventDefault() { e.prevented++; },
     stopPropagation() { e.stopped++; },
@@ -231,6 +244,71 @@ async function main() {
     check('cancels the browser default (its find bar would open over ours)',
       e.prevented === 1 && e.stopped === 1);
     check('opens the find prompt', !!window.document.querySelector('.text-prompt-backdrop'));
+  }
+
+  // ---- Shift+Enter (CROW-916) ------------------------------------------------
+
+  // xterm.js emits the same bare \r for Enter and Shift+Enter, so Claude Code
+  // submitted on both. The handler rewrites Shift+Enter to CSI-u, which tmux
+  // carries to extended-keys apps and downgrades to \r for everything else.
+  console.log('\nShift+Enter reaches the PTY as CSI-u, not a bare \\r:');
+  {
+    withClipboard();
+    setup();
+    const e = key('Enter', { shift: true });
+    const result = T.handleTerminalKey(e);
+    check('returns false so xterm skips its own \\r', result === false);
+    check('sends exactly the CSI-u sequence', sent.join() === '\x1b[13;2u');
+    check('sends it once', sent.length === 1);
+    // Without this the keydown's default survives and the keypress phase —
+    // which this handler waves through — writes a second \r (#875).
+    check('cancels the event', e.prevented === 1 && e.stopped === 1);
+  }
+  {
+    // The criterion that keeps the terminal usable: plain Enter must stay
+    // untouched so xterm's own \r still submits.
+    withClipboard();
+    setup();
+    const e = key('Enter');
+    const result = T.handleTerminalKey(e);
+    check('plain Enter passes through', result === true);
+    check('...sending nothing of our own', sent.length === 0);
+    check('...and is not cancelled', e.prevented === 0 && e.stopped === 0);
+  }
+  {
+    // Deliberately unhandled: xterm's key table already maps altKey + Enter to
+    // ESC CR (`e.altKey ? ESC+CR : CR`), so a branch here would restate the
+    // library. Pinned so a future "add Option+Enter for symmetry" has to
+    // confront the duplication.
+    withClipboard();
+    setup();
+    const e = key('Enter', { alt: true });
+    check('Option+Enter is left to xterm, which sends ESC CR natively',
+      T.handleTerminalKey(e) === true && sent.length === 0 && e.prevented === 0);
+    const both = key('Enter', { alt: true, shift: true });
+    check('Shift+Option+Enter stays on that same native path',
+      T.handleTerminalKey(both) === true && sent.length === 0);
+  }
+  {
+    // Ctrl+Enter and Cmd+Enter are the app's/browser's business, not ours.
+    withClipboard();
+    setup();
+    for (const [label, mods] of [['Ctrl', { ctrl: true }], ['Cmd', { meta: true }]]) {
+      const e = key('Enter', { ...mods, shift: true });
+      check(`${label}+Shift+Enter is untouched`,
+        T.handleTerminalKey(e) === true && e.prevented === 0);
+    }
+    check('...and none of them wrote to the PTY', sent.length === 0);
+  }
+  {
+    withClipboard();
+    setup();
+    for (const type of ['keyup', 'keypress']) {
+      const e = key('Enter', { shift: true, type });
+      check(`Shift+Enter on ${type} is ignored (keydown only)`,
+        T.handleTerminalKey(e) === true && e.prevented === 0);
+    }
+    check('...so the sequence is sent exactly once per press', sent.length === 0);
   }
 
   // ---- Everything else passes through ---------------------------------------

--- a/Packages/CrowTerminal/Sources/CrowTerminal/BundledResources.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/BundledResources.swift
@@ -20,6 +20,14 @@ public enum BundledResources {
     }
 
     /// Path to the xterm.js host page bundled with the terminal surface.
+    ///
+    /// RETIRED (ADR 0010). The only caller is `XTermSurfaceView`, the macOS
+    /// WKWebView surface, which nothing instantiates any more — `crowd` serves
+    /// the browser terminal from `CrowDaemon/Resources/web/` instead, and
+    /// `StaticAssets` takes only the xterm *library* files out of this bundle
+    /// (see `xtermDirectoryURL`). Terminal fixes go to `Resources/web/app.js`
+    /// and `Resources/web/terminal.html`; the page itself carries the same
+    /// warning, and CROW-916 is the bug that earned it.
     public static var terminalHTMLURL: URL? {
         Bundle.module.url(
             forResource: "terminal",

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/terminal.html
@@ -1,4 +1,23 @@
 <!DOCTYPE html>
+<!--
+  RETIRED SURFACE — NOT SERVED BY `crowd`. Editing this page changes nothing a
+  user can see.
+
+  This is the WKWebView host page for the macOS app, loaded over file:// by
+  XTermSurfaceView (itself reachable only via TerminalSurfaceView →
+  TmuxBackend.cockpitSurface(), all `#if canImport(AppKit)`). ADR 0010 retired
+  that app: the web UI is the only client. StaticAssets serves the xterm
+  *library* files out of this directory (/xterm/:file) but never this page —
+  and it couldn't run in a browser anyway, since its transport is
+  `handlers.crowInput.postMessage`, not a WebSocket.
+
+  Fixes belong in Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/
+  (app.js — the real UI — and terminal.html — the debug page). CROW-916 is what
+  this warning is for: #599 added the modified-Enter handler below, the macOS
+  app was retired the next day, and the bug it fixed was live on the web
+  surfaces for a year while `terminalHTMLHandlesModifiedEnter` pinned this copy
+  and stayed green.
+-->
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -82,6 +82,15 @@ struct BundledResourcesTests {
         // Claude Code submits instead of inserting a newline. The xterm
         // resources get re-vendored wholesale (see Resources/xterm/VERSION),
         // so pin the handler's presence against an accidental overwrite.
+        //
+        // CROW-916: this pins a RETIRED surface. ADR 0010 removed the macOS app
+        // the day after #599 landed, so this test kept passing while both
+        // shipping surfaces had no modified-Enter handling at all. The guard
+        // that covers the live pages is
+        // `WebTerminalAssetTests.modifiedEnterIsDistinguishableFromPlainEnter`,
+        // parameterized over `Resources/web/{app.js,terminal.html}` — change
+        // that one when the behavior changes. Kept here only so the retired page
+        // and its live descendants stay comparable while it remains in tree.
         let url = try #require(BundledResources.terminalHTMLURL)
         let body = try String(contentsOf: url, encoding: .utf8)
         #expect(body.contains("attachCustomKeyEventHandler"))


### PR DESCRIPTION
Closes #916

## What was wrong

xterm.js 6.0's key table has no `shiftKey` branch for keyCode 13 (`case 13: o.key = e.altKey ? ESC+CR : CR`), so Enter and Shift+Enter reach the PTY as the same bare `\r` — and xterm has no CSI-u / `modifyOtherKeys` support of its own to enable. The host page has to synthesize the bytes.

It already did, on the surface that no longer ships. #599 added the handler to CrowTerminal's WKWebView page the day before [ADR 0010](docs/adr/0010-retire-the-macos-app.md) retired the macOS app, and `terminalHTMLHandlesModifiedEnter` has pinned that dead page ever since. `WebTerminalAssetTests` parameterizes copy/paste/mouse-mode parity over the two *live* surfaces but had no modified-Enter case — so the pages that regressed were the ones nothing asserted on, and CI stayed green through it.

## What changed

The branch now lives in both live surfaces — `Resources/web/app.js`'s `handleTerminalKey` and the `terminal.html` debug page — and the guard moved onto them.

```js
if (e.key === 'Enter' && e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
  sendToPTY('\x1b[13;2u');
  e.preventDefault();
  e.stopPropagation();
  return false;
}
```

`preventDefault()` is load-bearing, not cosmetic: xterm cancels Enter itself, but returning `false` makes its `_keyDown` return *before* that cancel (#875), and this handler waves the keypress phase straight through — so an uncancelled keydown would write a second `\r`.

No tmux config change: `crow-tmux.conf` already has `extended-keys on` and `xterm*:extkeys`.

## The two calls the ticket left open

**Dropped the Option+Enter branch.** xterm already maps `altKey` + Enter to ESC CR natively, so it would only restate the library; `!e.altKey` keeps Shift+Option+Enter on that native path. A jsdom case pins that the handler leaves Alt+Enter alone, so a future "add it back for symmetry" has to confront the duplication.

**Marked the retired CrowTerminal page unused rather than deleting it.** Deleting means also deleting `BundledResources.terminalHTMLURL`, `XTermSurfaceView`, `TerminalSurfaceView` and `TmuxBackend.cockpitSurface()` — a dead-code sweep that deserves its own change rather than riding along on a key-handling fix. The page and the accessor now carry warnings pointing at `Resources/web/`, and the old test's comment names the live guard that supersedes it. Happy to do the sweep separately if preferred.

## Verification

The daemon isn't buildable to a browser in this environment, so this was verified in two layers that meet in the middle:

**Browser side** — `web-tests/key-handler.test.js` (extended to expose `termWs`) drives the *real* `handleTerminalKey` through the *real* `sendToPTY`: Shift+Enter emits exactly `\x1b[13;2u`, once, and cancels; plain / Option / Ctrl / Cmd + Enter pass through untouched; non-keydown phases emit nothing. 44 assertions pass.

**Transport side** — a probe against real tmux 3.6a started from the bundled `crow-tmux.conf`, injecting bytes at an attached client PTY exactly as the browser would, reading back what the pane process received via `cat -v`:

| Injected | App negotiates extended keys | App does not |
|---|---|---|
| `\x1b[13;2u` | `^[[27;2;13~` — Shift+Enter | bare `\r`, **no `^[`** |
| `\r` | bare `\r` | bare `\r` |

Rows 1-right and 2-right are byte-identical, which is the acceptance criterion for vim and a bare shell. Results were identical under the leaked `TERM=xterm-ghostty` noted in the ticket's out-of-scope section.

**The new guard bites.** Confirmed by stashing only the two source files and re-running: `modifiedEnterIsDistinguishableFromPlainEnter` fails on both assets. It matches `e.key === 'Enter' && e.shiftKey` as one contiguous condition, because the loose form passes on the unfixed `app.js` — its modal dialogs already contain `e.key === 'Enter'`.

`make test` is green (CrowDaemon 325 tests / 54 suites, CrowTerminal all suites, plus the three parity gates). The 10 pre-existing `row.test.js` failures are unrelated and reproduce identically on an unmodified tree.

**Not covered:** the literal browser keydown dispatch into xterm's custom handler — its documented API, already exercised in production by the Cmd+C and Cmd+F branches of this same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
