### PR TITLE
Hooks: stop a main clone's block from firing in every worktree session (CROW-915)

### DIFF
--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -310,10 +310,40 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
     /// swallowed — this is best-effort and must never fail a launch.
     @discardableResult
     public static func ensureCrowCLISymlink(devRoot: String, appCrowPath: String? = nil) -> String? {
-        let fm = FileManager.default
         let binDir = (devRoot as NSString).appendingPathComponent(".claude/bin")
         let link = (binDir as NSString).appendingPathComponent("crow")
-        let resolved = appCrowPath ?? appCrowBinary()
+        return materializeCrowSymlink(at: link, target: appCrowPath ?? appCrowBinary())
+    }
+
+    /// `{HOME}/.local/share/crow/bin/crow` — the stable link used when the dev
+    /// root's own cannot be made (unwritable, or no dev root at all).
+    ///
+    /// `~/.local/share/crow/` is already Crow's state directory (the daemon
+    /// socket lives there), so this introduces no new convention. It exists so
+    /// `resolveCrowBinary` always has *some* stable path to emit and never has
+    /// to fall back to a `.build/` product (#915) — the failure that put a dead
+    /// worktree's binary into every hook command in #897.
+    static func stableFallbackLinkPath() -> String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/crow/bin/crow").path
+    }
+
+    /// Point `link` at `target`, creating the parent directory as needed.
+    /// Returns the **link** path once it resolves to an executable, `nil`
+    /// otherwise. Idempotent; safe to call on every launch.
+    ///
+    /// Two deliberate behaviors, both load-bearing:
+    /// - A link already pointing at `target` is left alone rather than
+    ///   unlink+relink'd — that window is one where a concurrently firing hook
+    ///   sees ENOENT.
+    /// - A **non-symlink** `crow` at that path is never replaced. We only ever
+    ///   own symlinks here; a real file is the user's.
+    ///
+    /// All errors are logged and swallowed — this is best-effort and must never
+    /// fail a launch.
+    private static func materializeCrowSymlink(at link: String, target resolved: String?) -> String? {
+        let fm = FileManager.default
+        let binDir = (link as NSString).deletingLastPathComponent
 
         guard let target = resolved, fm.isExecutableFile(atPath: target) else {
             // Drop a link we can no longer back, so a broken pointer doesn't
@@ -363,26 +393,53 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
 
     /// The `crow` path to bake into a hook command (or any other file on disk).
     ///
-    /// Ensures the stable `{devRoot}/.claude/bin/crow` symlink first and returns
-    /// *that*, so an emitted command never contains a `.build/…` product path
-    /// belonging to whichever worktree the running daemon happened to be built
-    /// in — the root cause of #897.
+    /// **Never returns a `.build/…` path.** A build product belongs to whichever
+    /// worktree the running daemon was built in; when that worktree is reaped the
+    /// command dies with it, every hook event fails in `/bin/sh` before `crow`
+    /// runs, and the session silently records no telemetry. That is the root
+    /// cause of #897, and — because a worktree session also loads its *main
+    /// clone's* settings — one such command breaks every session on the repo
+    /// (#915).
     ///
-    /// Falls back to `appCrowBinary()` only when there is no dev root or the
-    /// link could not be created, warning loudly if that fallback is itself a
-    /// build product. Deliberately not a `precondition`: crashing the daemon
-    /// over an unwritable dev root would be worse than the noise it prevents.
-    public static func resolveCrowBinary(devRoot: String?, appCrowPath: String? = nil) -> String? {
+    /// Resolution order, each step a stable path that survives a rebuild:
+    ///   1. `{devRoot}/.claude/bin/crow` (also on the agent's PATH)
+    ///   2. `~/.local/share/crow/bin/crow`, for an unwritable or absent dev root
+    ///   3. `appCrowBinary()`, but only when it is not itself a build product —
+    ///      i.e. a real install on PATH or in a release `.app`
+    ///   4. `nil`
+    ///
+    /// Returning `nil` means the caller writes no hook block at all. That costs
+    /// telemetry for the session, but it is strictly better than writing a
+    /// command that is already broken: a dangling block outlives the session,
+    /// and every worktree of the repo inherits its errors. Deliberately not a
+    /// `precondition` — crashing the daemon would be worse than either.
+    ///
+    /// `appCrowPath` and `stableFallbackLink` are injectable for tests, which
+    /// must not write into the real `~/.local/share` (ADR 0012).
+    public static func resolveCrowBinary(
+        devRoot: String?, appCrowPath: String? = nil, stableFallbackLink: String? = nil
+    ) -> String? {
         if let devRoot, let link = ensureCrowCLISymlink(devRoot: devRoot, appCrowPath: appCrowPath) {
             return link
         }
-        let fallback = appCrowPath ?? appCrowBinary()
-        if let fallback, fallback.contains("/.build/") {
+        let target = appCrowPath ?? appCrowBinary()
+        let fallbackLink = stableFallbackLink ?? stableFallbackLinkPath()
+        if let link = materializeCrowSymlink(at: fallbackLink, target: target) {
             CrowLog.info(
-                "[ClaudeHookConfigWriter] WARNING: falling back to build-product crow path \(fallback)"
-                + " — hook commands written now will break when that build directory is removed."
-                + " Check that \(devRoot ?? "<no dev root>")/.claude/bin is writable.")
+                "[ClaudeHookConfigWriter] \(devRoot ?? "<no dev root>")/.claude/bin is not usable"
+                + " — writing hook commands against \(link) instead.")
+            return link
         }
-        return fallback
+        // Both stable links failed. Only hand back the raw binary if it is one
+        // that will still exist after the next rebuild.
+        if let target, !target.contains("/.build/") {
+            return target
+        }
+        CrowLog.error(
+            "[ClaudeHookConfigWriter] no stable crow path available"
+            + " (candidate \(target ?? "<none>") is a build product); writing no hook config."
+            + " Check that \(devRoot ?? "<no dev root>")/.claude/bin or"
+            + " \(fallbackLink) is writable.")
+        return nil
     }
 }

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
@@ -265,7 +265,30 @@ public enum ClaudeHookRepair {
     /// cwd-authoritative `hook-event` resolution drops it when it fires inside a
     /// *worktree* session, and accepts it when it fires in the main clone itself.
     ///
-    /// Performs blocking file I/O; call off the MainActor (#892).
+    /// ## Actor context
+    ///
+    /// Performs blocking file I/O, and **the launch path deliberately runs it on
+    /// the MainActor** (`SessionService.prepareWorktreeForAgentLaunch`, which is
+    /// synchronous and MainActor-bound). That is not an oversight and must not be
+    /// "fixed" by detaching: the block has to be gone from disk *before* the agent
+    /// process opens the directory, and the launch paths type the agent's command
+    /// into its pane in the same synchronous block. A detached reconcile would
+    /// race the very launch it exists to protect — the agent would start with the
+    /// inherited block still live, which is the bug.
+    ///
+    /// The cost is bounded so that is affordable: one `stat` for anything that is
+    /// not a linked worktree (main clones, review clones, the Manager's dev root —
+    /// the early-out in `resolveMainClone`), and for a real worktree three more
+    /// small reads (`.git`, `commondir`, the settings file). A *write* happens only
+    /// when a block is actually stale or foreign, which is a once-per-defect event,
+    /// not once per launch. `prepareWorktreeForAgentLaunch` already does MainActor
+    /// file I/O for the trust seed and the Grok/Antigravity strip, so this adds no
+    /// new category of work to that gate (#892).
+    ///
+    /// The reaper reaches it through `Task.detached` instead — there is no launch
+    /// to order against there, and it is already off the MainActor. Taking the
+    /// AppState facts as a value snapshot (`HookOwnership`) is what makes that
+    /// possible: this function needs no actor of its own.
     public static func reconcileMainClone(
         worktreePath: String,
         crowPath: String?,

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
@@ -216,6 +216,259 @@ public enum ClaudeHookRepair {
         return candidates
     }
 
+    // MARK: - Main-clone reconciliation (#915)
+
+    /// What `reconcileMainClone` did, for the launch log.
+    public enum MainCloneOutcome: Equatable, Sendable {
+        /// `worktreePath` is not a linked worktree (its `.git` is a directory),
+        /// so there is no separate main clone to reconcile.
+        case notAWorktree
+        /// The main clone holds no Crow-managed hook block.
+        case noBlock
+        /// The block belongs to the session that owns that directory and is
+        /// healthy — left untouched.
+        case healthy
+        /// Rewritten to the owning session and a good binary.
+        case repaired(mainClone: String)
+        /// Crow entries removed: nothing legitimately runs from that directory.
+        case stripped(mainClone: String)
+        /// Present but not safely actionable (unparseable or unwritable).
+        case skipped(mainClone: String)
+    }
+
+    /// Reconcile the **main clone's** hook block before launching an agent in
+    /// one of its worktrees (#915).
+    ///
+    /// A linked worktree's `.git` is a file pointing at the main clone, and
+    /// project-root resolution follows it — so the main clone's
+    /// `.claude/settings.local.json` is loaded *in addition to* the worktree's
+    /// own, and both hook sets run. Crow writes the per-worktree file and treats
+    /// it as the session's configuration; it is not. One stale block in a main
+    /// clone breaks hooks and telemetry for **every** session on that repo, and
+    /// one merely *foreign* block (naming a different live session) misattributes
+    /// their events and fires each twice.
+    ///
+    /// `sweep` cannot cover this. It is boot-time only, walks devRoot at a fixed
+    /// depth of 2 (so a clone living anywhere else is invisible), and — decisively
+    /// — its health test is per-directory: a block naming a live session *is*
+    /// healthy by that test, which is exactly the case that must still go.
+    ///
+    /// The decision, given the directory the block sits in:
+    ///
+    /// | Main clone is… | Action |
+    /// |---|---|
+    /// | this session's own worktree | leave (it is this session's own block) |
+    /// | another live session's worktree | repair in place for that session |
+    /// | no live session's worktree | strip Crow entries |
+    ///
+    /// Note "repair" keeps a legitimately-hosted block working: the daemon's
+    /// cwd-authoritative `hook-event` resolution drops it when it fires inside a
+    /// *worktree* session, and accepts it when it fires in the main clone itself.
+    ///
+    /// Performs blocking file I/O; call off the MainActor (#892).
+    public static func reconcileMainClone(
+        worktreePath: String,
+        crowPath: String?,
+        liveSessionIDs: Set<UUID>,
+        sessionByWorktreePath: [String: UUID]
+    ) -> MainCloneOutcome {
+        guard let mainClone = resolveMainClone(worktreePath: worktreePath) else {
+            return .notAWorktree
+        }
+        // A worktree whose main clone is itself (shouldn't happen, but a
+        // hand-made `.git` file could say so) needs no reconciliation.
+        let worktree = (worktreePath as NSString).standardizingPath
+        guard mainClone != worktree else { return .notAWorktree }
+
+        return reconcileHookBlock(
+            inDirectory: mainClone, crowPath: crowPath,
+            liveSessionIDs: liveSessionIDs, sessionByWorktreePath: sessionByWorktreePath)
+    }
+
+    /// `reconcileMainClone` for a directory already known to be the main clone.
+    ///
+    /// Split out for the retention reaper, which reconciles *after*
+    /// `git worktree remove` has deleted the worktree — so `resolveMainClone`
+    /// has no `.git` file left to read, but `WorktreeCleanupItem.repoPath`
+    /// already names the clone directly.
+    public static func reconcileHookBlock(
+        inDirectory dir: String,
+        crowPath: String?,
+        liveSessionIDs: Set<UUID>,
+        sessionByWorktreePath: [String: UUID]
+    ) -> MainCloneOutcome {
+        let dir = (dir as NSString).standardizingPath
+        // The session that legitimately owns that directory, if any. Only a
+        // *live* one counts — a row for a deleted session must not keep a block
+        // alive.
+        let owner = sessionByWorktreePath[dir].flatMap {
+            liveSessionIDs.contains($0) ? $0 : nil
+        }
+        return reconcileDirectory(dir, owner: owner, crowPath: crowPath)
+    }
+
+    /// The main clone backing a linked worktree, or `nil` when `worktreePath`
+    /// is not a linked worktree.
+    ///
+    /// Reads the gitdir chain directly rather than shelling out to
+    /// `git rev-parse --git-common-dir`: it is the same resolution, but with no
+    /// subprocess on the launch path, no dependency on `git` being found, and no
+    /// async hop in a `nonisolated static` caller. It also mirrors what the agent
+    /// harness itself does, which is the behavior we are compensating for.
+    ///
+    /// - `.git` a directory → this is a main clone (or a bare repo); no separate
+    ///   main clone exists.
+    /// - `.git` a file → `gitdir: <path>` names the worktree's private gitdir,
+    ///   e.g. `<main>/.git/worktrees/<name>`. The shared dir is that gitdir's
+    ///   `commondir` (git writes it, normally `../..`), and the main clone is its
+    ///   parent.
+    static func resolveMainClone(worktreePath: String) -> String? {
+        let fm = FileManager.default
+        let dotGit = (worktreePath as NSString).appendingPathComponent(".git")
+
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: dotGit, isDirectory: &isDirectory) else { return nil }
+        if isDirectory.boolValue { return nil }
+
+        guard let raw = try? String(contentsOfFile: dotGit, encoding: .utf8) else { return nil }
+        // A `.git` file is a single `gitdir: <path>` line. Anything else is not
+        // a shape we understand, and guessing would be worse than doing nothing.
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("gitdir:") else { return nil }
+        let pointer = String(trimmed.dropFirst("gitdir:".count))
+            .trimmingCharacters(in: .whitespaces)
+        guard !pointer.isEmpty else { return nil }
+        let gitDir = absolutePath(pointer, relativeTo: worktreePath)
+
+        // `commondir` is authoritative when present; the `../..` derivation is
+        // only a fallback for an oddly-shaped gitdir.
+        let commonDirFile = (gitDir as NSString).appendingPathComponent("commondir")
+        let commonDir: String
+        if let contents = try? String(contentsOfFile: commonDirFile, encoding: .utf8) {
+            let value = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { return nil }
+            commonDir = absolutePath(value, relativeTo: gitDir)
+        } else {
+            // No `commondir` — only trust the `../..` derivation when the gitdir
+            // has the shape git gives a linked worktree. Anything else and we do
+            // not know where the shared dir is; guessing would point the strip at
+            // an unrelated directory, so decline instead.
+            let parent = (gitDir as NSString).deletingLastPathComponent
+            guard (parent as NSString).lastPathComponent == "worktrees" else { return nil }
+            commonDir = (parent as NSString).deletingLastPathComponent
+        }
+
+        // `commonDir` is the main clone's `.git`; its parent is the working tree.
+        // Require that name: a shared dir called anything else means we did not
+        // resolve what we think we did.
+        guard (commonDir as NSString).lastPathComponent == ".git" else { return nil }
+        let mainClone = (commonDir as NSString).deletingLastPathComponent
+        guard !mainClone.isEmpty, mainClone != "/" else { return nil }
+        return (mainClone as NSString).standardizingPath
+    }
+
+    /// Resolve `path` against `base` when it is relative, then normalize.
+    private static func absolutePath(_ path: String, relativeTo base: String) -> String {
+        let joined = path.hasPrefix("/")
+            ? path
+            : (base as NSString).appendingPathComponent(path)
+        return (joined as NSString).standardizingPath
+    }
+
+    /// Apply the #915 decision to one directory's settings file.
+    ///
+    /// Distinct from `repairDirectory` in exactly one way, and it is the point of
+    /// the issue: health here means "every entry names `owner`", not merely "the
+    /// binary exists and the session is live". A block naming some *other* live
+    /// session passes the latter and must still fail the former.
+    private static func reconcileDirectory(
+        _ dir: String, owner: UUID?, crowPath: String?
+    ) -> MainCloneOutcome {
+        let fm = FileManager.default
+        let settingsPath = (dir as NSString).appendingPathComponent(".claude/settings.local.json")
+        guard let data = fm.contents(atPath: settingsPath) else { return .noBlock }
+        guard var settings = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = settings["hooks"] as? [String: Any] else {
+            // Same rule as `repairDirectory`: a file that exists but doesn't
+            // parse is left strictly alone — we can't tell our entries from the
+            // user's, and rewriting from `[:]` would drop every unrelated key.
+            return (try? JSONSerialization.jsonObject(with: data)) == nil
+                ? .skipped(mainClone: dir) : .noBlock
+        }
+
+        let parsed = parsedCrowHooks(in: hooks)
+        guard !parsed.isEmpty else { return .noBlock }
+
+        if let owner,
+           parsed.allSatisfy({
+               $0.sessionID == owner && fm.isExecutableFile(atPath: $0.binary)
+           }) {
+            return .healthy
+        }
+
+        let updatedHooks: [String: Any]
+        let outcome: MainCloneOutcome
+        if let owner, let crowPath {
+            updatedHooks = rewriteCommands(in: hooks, crowPath: crowPath, sessionID: owner)
+            outcome = .repaired(mainClone: dir)
+        } else {
+            // No live session owns this directory (or we have no good binary to
+            // write): nothing here can fire correctly, so remove only what we
+            // recognize as ours.
+            updatedHooks = stripCrowEntries(from: hooks)
+            outcome = .stripped(mainClone: dir)
+        }
+
+        if updatedHooks.isEmpty {
+            settings.removeValue(forKey: "hooks")
+        } else {
+            settings["hooks"] = updatedHooks
+        }
+
+        do {
+            try writeSettings(settings, to: settingsPath)
+        } catch {
+            CrowLog.info(
+                "[ClaudeHookRepair] failed to write \(settingsPath): \(error.localizedDescription)")
+            return .skipped(mainClone: dir)
+        }
+        return outcome
+    }
+
+    /// Every Crow-managed hook command in a `hooks` dictionary.
+    static func parsedCrowHooks(in hooks: [String: Any]) -> [ParsedCrowHook] {
+        var parsed: [ParsedCrowHook] = []
+        for event in ClaudeHookConfigWriter.allEvents {
+            for group in (hooks[event] as? [[String: Any]] ?? []) {
+                for entry in (group["hooks"] as? [[String: Any]] ?? []) {
+                    if let command = entry["command"] as? String,
+                       let hook = parseCrowHookCommand(command) {
+                        parsed.append(hook)
+                    }
+                }
+            }
+        }
+        return parsed
+    }
+
+    /// Write a settings dictionary back, deleting the file when nothing is left.
+    ///
+    /// NON-atomic on purpose: `writeGatewayEnv` chmods this file 0600 because its
+    /// `env` block can carry a gateway bearer token, and an atomic write replaces
+    /// the inode, resetting the mode to the umask default. Truncating in place
+    /// preserves both.
+    private static func writeSettings(_ settings: [String: Any], to path: String) throws {
+        if settings.isEmpty {
+            // Nothing of ours or the user's left — the file only ever held the
+            // stale block (exactly the reported case).
+            try FileManager.default.removeItem(atPath: path)
+        } else {
+            let out = try JSONSerialization.data(
+                withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+            try out.write(to: URL(fileURLWithPath: path))
+        }
+    }
+
     // MARK: - Per-directory repair
 
     private static func repairDirectory(
@@ -240,17 +493,7 @@ public enum ClaudeHookRepair {
         }
 
         // Inventory first — decide before touching anything.
-        var parsed: [ParsedCrowHook] = []
-        for event in ClaudeHookConfigWriter.allEvents {
-            for group in (hooks[event] as? [[String: Any]] ?? []) {
-                for entry in (group["hooks"] as? [[String: Any]] ?? []) {
-                    if let command = entry["command"] as? String,
-                       let hook = parseCrowHookCommand(command) {
-                        parsed.append(hook)
-                    }
-                }
-            }
-        }
+        let parsed = parsedCrowHooks(in: hooks)
         guard !parsed.isEmpty else { return }
         summary.scanned += 1
 
@@ -279,19 +522,7 @@ public enum ClaudeHookRepair {
         }
 
         do {
-            if settings.isEmpty {
-                // Nothing of ours or the user's left — the file only ever held
-                // the stale block (exactly the reported case).
-                try fm.removeItem(atPath: settingsPath)
-            } else {
-                let out = try JSONSerialization.data(
-                    withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
-                // NON-atomic on purpose: `writeGatewayEnv` chmods this file 0600
-                // because its `env` block can carry a gateway bearer token, and
-                // an atomic write replaces the inode, resetting the mode to the
-                // umask default. Truncating in place preserves both.
-                try out.write(to: URL(fileURLWithPath: settingsPath))
-            }
+            try writeSettings(settings, to: settingsPath)
         } catch {
             CrowLog.info("[ClaudeHookRepair] failed to write \(settingsPath): \(error.localizedDescription)")
             summary.skipped.append(dir)

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookConfigWriterTests.swift
@@ -182,4 +182,64 @@ struct ClaudeHookConfigWriterCrowPathTests {
         let attrs = try fm.attributesOfItem(atPath: link.path)
         #expect((attrs[.type] as? FileAttributeType) != .typeSymbolicLink)
     }
+
+    /// #915: `{devRoot}/.claude/bin` was found empty on a real install while
+    /// still first on PATH, and the writer fell through to a `.build/` path —
+    /// already stale on arrival. A second stable anchor outside the dev root
+    /// keeps hook commands durable when the first one can't be made.
+    @Test func fallsBackToAStableLinkOutsideAnUnusableDevRoot() throws {
+        let (devRoot, appBinary) = try makeDevRootWithBuildProduct()
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+        let fm = FileManager.default
+        // A regular file where `.claude/bin` must be: the directory can never
+        // be created, so the dev-root link is unavailable.
+        try fm.createDirectory(
+            at: devRoot.appendingPathComponent(".claude"), withIntermediateDirectories: true)
+        try Data("not a directory".utf8).write(to: devRoot.appendingPathComponent(".claude/bin"))
+
+        let fallback = devRoot.appendingPathComponent("elsewhere/bin/crow").path
+        let resolved = try #require(ClaudeHookConfigWriter.resolveCrowBinary(
+            devRoot: devRoot.path, appCrowPath: appBinary, stableFallbackLink: fallback))
+
+        #expect(resolved == fallback)
+        #expect(!resolved.contains("/.build/"))
+        #expect(try fm.destinationOfSymbolicLink(atPath: resolved) == appBinary)
+    }
+
+    /// With no stable anchor available at all, refuse rather than bake in a
+    /// build product. The caller writes no hook block — that session loses
+    /// telemetry, but a dangling block outlives its session and breaks every
+    /// worktree of the repo that inherits it (#915).
+    @Test func refusesToEmitABuildProductWhenNoStableLinkIsPossible() throws {
+        let (devRoot, appBinary) = try makeDevRootWithBuildProduct()
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: devRoot.appendingPathComponent(".claude"), withIntermediateDirectories: true)
+        try Data("not a directory".utf8).write(to: devRoot.appendingPathComponent(".claude/bin"))
+        try Data("also not a directory".utf8).write(to: devRoot.appendingPathComponent("blocked"))
+
+        #expect(ClaudeHookConfigWriter.resolveCrowBinary(
+            devRoot: devRoot.path, appCrowPath: appBinary,
+            stableFallbackLink: devRoot.appendingPathComponent("blocked/bin/crow").path) == nil)
+    }
+
+    /// A real install on PATH is already stable, so it is returned directly
+    /// rather than refused when neither link can be made.
+    @Test func acceptsANonBuildBinaryWhenNoStableLinkIsPossible() throws {
+        let devRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-crowpath-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: devRoot) }
+        let fm = FileManager.default
+        try fm.createDirectory(at: devRoot, withIntermediateDirectories: true)
+        let installed = devRoot.appendingPathComponent("usr-local-bin-crow")
+        try Data("#!/bin/sh\n".utf8).write(to: installed)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: installed.path)
+        try Data("not a directory".utf8).write(to: devRoot.appendingPathComponent("blocked"))
+
+        #expect(ClaudeHookConfigWriter.resolveCrowBinary(
+            devRoot: nil, appCrowPath: installed.path,
+            stableFallbackLink: devRoot.appendingPathComponent("blocked/bin/crow").path)
+                == installed.path)
+    }
 }

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookRepairTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeHookRepairTests.swift
@@ -432,3 +432,337 @@ struct ClaudeHookRepairSweepTests {
         #expect(try String(contentsOfFile: settingsPath(worktree), encoding: .utf8) == "{ not json")
     }
 }
+
+/// #915 — a linked worktree's `.git` is a file pointing at the main clone, and
+/// project-root resolution follows it, so the main clone's
+/// `.claude/settings.local.json` is loaded *in addition to* the worktree's own.
+/// One block in a main clone therefore reaches every session on the repo.
+///
+/// These use real `git init` + `git worktree add` rather than fabricated `.git`
+/// files: the resolution being compensated for is git's own, so a hand-made
+/// fixture could agree with the code while both disagree with git.
+@Suite("ClaudeHookRepair.reconcileMainClone")
+struct ClaudeHookRepairMainCloneTests {
+    private let deadSession = UUID(uuidString: "2BEF7A0D-743B-47A3-819A-C39C180F6977")!
+    private let deadBinary = "/Users/x/Dev/crow-136-session-analytics-otel/.build/arm64-apple-macosx/debug/crow"
+
+    private func std(_ url: URL) -> String { (url.path as NSString).standardizingPath }
+    private func std(_ path: String) -> String { (path as NSString).standardizingPath }
+
+    @discardableResult
+    private func git(_ args: [String], cwd: String? = nil) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let out = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let text = String(decoding: out, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw NSError(domain: "git", code: Int(process.terminationStatus),
+                          userInfo: [NSLocalizedDescriptionKey: text])
+        }
+        return text
+    }
+
+    /// A real main clone with one commit, plus one linked worktree beside it —
+    /// the `{devRoot}/{workspace}/{repo}` + `{repo}-{n}-{slug}` sibling layout
+    /// Crow uses.
+    private func makeRepoWithWorktree() throws -> (root: URL, mainClone: URL, worktree: URL, crowPath: String) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-mainclone-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent(".claude/bin")
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let crow = binDir.appendingPathComponent("crow")
+        try Data("#!/bin/sh\n".utf8).write(to: crow)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: crow.path)
+
+        let mainClone = root.appendingPathComponent("ws/repo")
+        try FileManager.default.createDirectory(at: mainClone, withIntermediateDirectories: true)
+        try git(["init", "--initial-branch=main", mainClone.path])
+        try git(["-C", mainClone.path, "config", "user.email", "t@example.com"])
+        try git(["-C", mainClone.path, "config", "user.name", "T"])
+        try Data("x".utf8).write(to: mainClone.appendingPathComponent("README"))
+        try git(["-C", mainClone.path, "add", "README"])
+        try git(["-C", mainClone.path, "commit", "-m", "init"])
+
+        // Sibling, not child — the layout that makes `/x/repo` a string prefix
+        // of `/x/repo-1-slug` without being a parent of it.
+        let worktree = root.appendingPathComponent("ws/repo-1-slug")
+        try git(["-C", mainClone.path, "worktree", "add", worktree.path, "-b", "feature/x"])
+
+        return (root, mainClone, worktree, crow.path)
+    }
+
+    private func staleHookBlock(binary: String, session: UUID) -> [String: Any] {
+        var hooks: [String: Any] = [:]
+        for event in ClaudeHookConfigWriter.allEvents {
+            hooks[event] = [[
+                "hooks": [[
+                    "type": "command",
+                    "command": "\(binary) hook-event --session \(session.uuidString) --event \(event)",
+                    "timeout": 5,
+                ] as [String: Any]]
+            ] as [String: Any]]
+        }
+        return hooks
+    }
+
+    private func writeSettings(_ settings: [String: Any], into dir: URL) throws {
+        let claudeDir = dir.appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: claudeDir.appendingPathComponent("settings.local.json"))
+    }
+
+    private func settingsPath(_ dir: URL) -> String {
+        dir.appendingPathComponent(".claude/settings.local.json").path
+    }
+
+    private func commands(in dir: URL, event: String) throws -> [String] {
+        let data = try #require(FileManager.default.contents(atPath: settingsPath(dir)))
+        let settings = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try #require(settings["hooks"] as? [String: Any])
+        let groups = try #require(hooks[event] as? [[String: Any]])
+        return groups.flatMap { group in
+            (group["hooks"] as? [[String: Any]] ?? []).compactMap { $0["command"] as? String }
+        }
+    }
+
+    // MARK: - Resolution
+
+    @Test("resolves the main clone from a real linked worktree")
+    func resolvesMainCloneFromWorktree() throws {
+        let (root, mainClone, worktree, _) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(ClaudeHookRepair.resolveMainClone(worktreePath: worktree.path) == std(mainClone))
+        // Agrees with git's own answer, which is what the agent harness follows.
+        let commonDir = try git(["-C", worktree.path, "rev-parse", "--path-format=absolute",
+                                 "--git-common-dir"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(std((commonDir as NSString).deletingLastPathComponent) == std(mainClone))
+    }
+
+    @Test("a main clone has no separate main clone")
+    func mainCloneResolvesToNil() throws {
+        let (root, mainClone, _, _) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(ClaudeHookRepair.resolveMainClone(worktreePath: mainClone.path) == nil)
+    }
+
+    @Test("a plain directory is not a worktree")
+    func plainDirectoryIsNotAWorktree() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-notrepo-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(ClaudeHookRepair.resolveMainClone(worktreePath: dir.path) == nil)
+    }
+
+    /// A `.git` file we can't confidently interpret must resolve to nothing.
+    /// Guessing would aim the strip at an unrelated directory — and this code
+    /// deletes hook entries.
+    @Test("an unrecognizable gitdir pointer resolves to nothing")
+    func malformedGitFileResolvesToNil() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-badgit-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for (name, contents) in [
+            // No `commondir`, and not the `<main>/.git/worktrees/<name>` shape.
+            ("odd-shape", "gitdir: \(root.path)/somewhere/else"),
+            ("not-a-pointer", "just some text"),
+            ("empty-pointer", "gitdir:"),
+        ] {
+            let dir = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data(contents.utf8).write(to: dir.appendingPathComponent(".git"))
+            #expect(ClaudeHookRepair.resolveMainClone(worktreePath: dir.path) == nil,
+                    "\(name) should not resolve")
+        }
+    }
+
+    // MARK: - Reconciliation
+
+    /// The reported case: the main clone's file holds *only* the stale block, so
+    /// reconciliation removes the file outright and the repo's worktree sessions
+    /// stop erroring.
+    @Test("strips a stale block from a main clone no session owns")
+    func stripsStaleBlockFromUnownedMainClone() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let liveSession = UUID()
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: deadBinary, session: deadSession)], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [liveSession],
+            sessionByWorktreePath: [std(worktree): liveSession])
+
+        #expect(outcome == .stripped(mainClone: std(mainClone)))
+        #expect(!FileManager.default.fileExists(atPath: settingsPath(mainClone)))
+    }
+
+    /// The #915 case #900's sweep cannot see: the block is *healthy* by its
+    /// per-directory test (good binary, live session) and is left alone there —
+    /// yet it still fires in every worktree session of the repo.
+    @Test("strips a live-but-foreign block from a main clone no session owns")
+    func stripsHealthyForeignBlock() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let worktreeSession = UUID()
+        let otherLiveSession = UUID()
+
+        try writeSettings([
+            "hooks": staleHookBlock(binary: crowPath, session: otherLiveSession),
+            "permissions": ["allow": ["Bash(git status)"]],
+        ], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [worktreeSession, otherLiveSession],
+            sessionByWorktreePath: [std(worktree): worktreeSession])
+
+        #expect(outcome == .stripped(mainClone: std(mainClone)))
+        // The user's own keys survive; only our entries go.
+        let data = try #require(FileManager.default.contents(atPath: settingsPath(mainClone)))
+        let settings = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(settings["hooks"] == nil)
+        #expect(settings["permissions"] != nil)
+    }
+
+    /// A main clone can legitimately host a session (`crow add-worktree` for an
+    /// `alwaysInclude` reference repo). Its block is repaired for that session
+    /// rather than removed — the daemon's cwd-authoritative resolution is what
+    /// keeps it from firing in the repo's *worktree* sessions.
+    @Test("repairs a stale block for the session that owns the main clone")
+    func repairsBlockOwnedByALiveSession() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mainCloneSession = UUID()
+        let worktreeSession = UUID()
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: deadBinary, session: deadSession)], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [mainCloneSession, worktreeSession],
+            sessionByWorktreePath: [
+                std(mainClone): mainCloneSession, std(worktree): worktreeSession,
+            ])
+
+        #expect(outcome == .repaired(mainClone: std(mainClone)))
+        let stop = try commands(in: mainClone, event: "Stop")
+        #expect(stop.count == 1)
+        #expect(stop[0].contains(mainCloneSession.uuidString))
+        #expect(!stop[0].contains("/.build/"))
+    }
+
+    @Test("leaves a correct, owned block untouched")
+    func leavesHealthyOwnedBlockAlone() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mainCloneSession = UUID()
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: crowPath, session: mainCloneSession)], into: mainClone)
+        let before = try #require(FileManager.default.contents(atPath: settingsPath(mainClone)))
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [mainCloneSession],
+            sessionByWorktreePath: [std(mainClone): mainCloneSession])
+
+        #expect(outcome == .healthy)
+        #expect(FileManager.default.contents(atPath: settingsPath(mainClone)) == before)
+    }
+
+    /// A row whose session is gone must not keep a block alive — otherwise a
+    /// failed delete leaves the repo emitting hook errors indefinitely.
+    @Test("a row for a dead session does not count as an owner")
+    func deadOwnerIsNotAnOwner() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let ghost = UUID()
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: crowPath, session: ghost)], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [],  // ghost is not live
+            sessionByWorktreePath: [std(mainClone): ghost])
+
+        #expect(outcome == .stripped(mainClone: std(mainClone)))
+    }
+
+    @Test("a main clone with no Crow block is left alone")
+    func noBlockIsANoOp() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeSettings(["permissions": ["allow": ["Bash(git status)"]]], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:])
+
+        #expect(outcome == .noBlock)
+        #expect(FileManager.default.fileExists(atPath: settingsPath(mainClone)))
+    }
+
+    /// A user's own hook that happens to share a managed event name is not ours
+    /// to remove — the same boundary `stripCrowEntries` holds for the sweep.
+    @Test("a user's own hook under a managed event name survives a strip")
+    func userHookSurvivesStrip() throws {
+        let (root, mainClone, worktree, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var hooks = staleHookBlock(binary: deadBinary, session: deadSession)
+        hooks["Stop"] = [
+            [
+                "hooks": [
+                    ["type": "command",
+                     "command": "\(deadBinary) hook-event --session \(deadSession.uuidString) --event Stop",
+                     "timeout": 5] as [String: Any],
+                    ["type": "command", "command": "say done", "timeout": 5] as [String: Any],
+                ]
+            ] as [String: Any]
+        ]
+        try writeSettings(["hooks": hooks], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktree.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:])
+
+        #expect(outcome == .stripped(mainClone: std(mainClone)))
+        #expect(try commands(in: mainClone, event: "Stop") == ["say done"])
+    }
+
+    /// The reaper's entry point: it reconciles after `git worktree remove`, so
+    /// the worktree that would have resolved the clone is already gone.
+    @Test("reconciles a main clone directly, without a worktree to resolve it")
+    func reconcilesDirectoryDirectly() throws {
+        let (root, mainClone, _, crowPath) = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeSettings(
+            ["hooks": staleHookBlock(binary: deadBinary, session: deadSession)], into: mainClone)
+
+        let outcome = ClaudeHookRepair.reconcileHookBlock(
+            inDirectory: mainClone.path, crowPath: crowPath,
+            liveSessionIDs: [], sessionByWorktreePath: [:])
+
+        #expect(outcome == .stripped(mainClone: std(mainClone)))
+        #expect(!FileManager.default.fileExists(atPath: settingsPath(mainClone)))
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -538,13 +538,41 @@ public final class AppState {
     /// the agent (e.g. Codex) doesn't carry the session UUID in its hook
     /// invocation — the `cwd` field of the payload is matched against
     /// worktree paths to recover the session.
+    ///
+    /// Prefer `sessionIDs(forWorktreePath:)` where the answer decides routing:
+    /// `worktrees` is a dictionary, so "the first match" is a nondeterministic
+    /// pick when two sessions share a path — reachable through orphan recovery
+    /// and a `setup.sh` retry.
     public func sessionID(forWorktreePath path: String) -> UUID? {
-        for (sessionID, wts) in worktrees {
-            if wts.contains(where: { $0.worktreePath == path }) {
-                return sessionID
+        sessionIDs(forWorktreePath: path).first
+    }
+
+    /// Every session with a worktree registered at `path`.
+    ///
+    /// Normally zero or one. More than one is reachable — orphan recovery can
+    /// mint a second session for a path it already knows, a `setup.sh` retry
+    /// without `--session-id` re-runs `new-session` against the same worktree,
+    /// and a multi-repo session registers a secondary repo's *main clone* as a
+    /// worktree row, which a second such session registers again. Callers that
+    /// route on this must decide what an ambiguous answer means rather than
+    /// accept a coin flip; `sessionID(forWorktreePath:)` takes whichever the
+    /// dictionary yields first.
+    ///
+    /// Both sides are `standardizingPath`-normalized: an agent's reported cwd
+    /// and the stored row can disagree on spelling (trailing slash, `/tmp` vs
+    /// `/private/tmp`), and `LaunchScaffold.repairStaleHooks` already normalizes
+    /// its own view of the same data — routing and repair disagreeing about who
+    /// owns a directory is the failure this avoids.
+    ///
+    /// Ordered by session id so the result is stable across processes.
+    public func sessionIDs(forWorktreePath path: String) -> [UUID] {
+        let wanted = (path as NSString).standardizingPath
+        return worktrees
+            .filter { _, wts in
+                wts.contains { ($0.worktreePath as NSString).standardizingPath == wanted }
             }
-        }
-        return nil
+            .keys
+            .sorted { $0.uuidString < $1.uuidString }
     }
 
     public func links(for sessionID: UUID) -> [SessionLink] {

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppStateSessionLookupTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppStateSessionLookupTests.swift
@@ -38,3 +38,48 @@ import Testing
     ]
     #expect(appState.sessionID(forWorktreePath: "/wt/does-not-exist") == nil)
 }
+
+/// #915 — once cwd decides hook-event routing, "the first match" is no longer
+/// good enough: `worktrees` is a dictionary, so a path registered by two
+/// sessions would resolve nondeterministically, and a losing coin flip means a
+/// session records nothing for the life of the daemon.
+@MainActor
+@Test func sessionIDsForWorktreePathReturnsEveryOwnerDeterministically() {
+    let appState = AppState()
+    let first = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    let second = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    for id in [second, first] {  // inserted out of order on purpose
+        appState.worktrees[id] = [
+            SessionWorktree(
+                sessionID: id, repoName: "shared",
+                repoPath: "/repos/shared", worktreePath: "/wt/shared",
+                branch: "main"
+            ),
+        ]
+    }
+
+    #expect(appState.sessionIDs(forWorktreePath: "/wt/shared") == [first, second])
+    #expect(appState.sessionIDs(forWorktreePath: "/wt/absent").isEmpty)
+}
+
+/// An agent's reported cwd and the stored row can disagree on spelling. A miss
+/// makes the #915 routing silently inert, so both sides are normalized —
+/// matching what `LaunchScaffold.repairStaleHooks` already does to the same data.
+@MainActor
+@Test func sessionIDForWorktreePathNormalizesBothSides() {
+    let appState = AppState()
+    let session = UUID()
+    appState.worktrees[session] = [
+        SessionWorktree(
+            sessionID: session, repoName: "alpha",
+            repoPath: "/repos/alpha", worktreePath: "/wt/alpha/",
+            branch: "main"
+        ),
+    ]
+
+    #expect(appState.sessionID(forWorktreePath: "/wt/alpha") == session)
+    #expect(appState.sessionID(forWorktreePath: "/wt/./alpha") == session)
+    // Exact-match, not prefix: a sibling worktree whose name extends the main
+    // clone's must never resolve to it.
+    #expect(appState.sessionID(forWorktreePath: "/wt/alpha-1-slug") == nil)
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -72,13 +72,29 @@ func hookToolName(from payload: [String: JSONValue]) -> String? {
 /// acceptable for a diagnostic.
 @MainActor private var loggedUnresolvedHookDrops: Set<String> = []
 
+/// Neutralize a caller-supplied value before it reaches the log: cap length (the
+/// per-set count caps bound record *count*; this bounds record *size*), and
+/// escape every C0 control (and DEL) so an embedded ESC/ANSI sequence can't
+/// mangle a terminal that `cat`s the launchd log. `\n`/`\r` get readable forms;
+/// the rest become `\xNN`. Shared by both hook-drop loggers below.
+private func oneLineForLog(_ s: String) -> String {
+    var out = ""
+    for scalar in String(s.prefix(200)).unicodeScalars {
+        switch scalar {
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case let c where c.value < 0x20 || c.value == 0x7F:
+            out += String(format: "\\x%02x", c.value)
+        default: out.unicodeScalars.append(scalar)
+        }
+    }
+    return out
+}
+
 /// Log an unresolved hook-event drop at most once per `cwd`. Only the no-id /
 /// no-cwd-match branch calls this, where `session_id` is always absent — so the
 /// key is `cwd` alone (a `nil` cwd and a literal cwd of "none" are kept
-/// distinct). `eventName`/`cwd` are caller-supplied (via the local agent), so
-/// each is control-stripped and length-capped before it reaches the log: an
-/// embedded newline/ANSI can't forge or mangle a record, and a value bounded
-/// only by the 1 MB message limit can't turn the count cap into a size flood.
+/// distinct).
 @MainActor private func logUnresolvedHookDropOnce(eventName: String, cwd: String?) {
     // Distinguish nil from a literal "none" path so the dedup key can't collide.
     let key = cwd.map { "cwd:" + $0 } ?? "<nil>"
@@ -91,26 +107,41 @@ func hookToolName(from payload: [String: JSONValue]) -> String? {
     // socket access, not a remote /rpc peer.
     guard loggedUnresolvedHookDrops.count < 256 else { return }
     loggedUnresolvedHookDrops.insert(key)
-    // Neutralize caller-supplied values before logging: cap length (the count
-    // cap bounds record *count*; this bounds record *size*), and escape every C0
-    // control (and DEL) so an embedded ESC/ANSI sequence can't mangle a terminal
-    // that `cat`s the launchd log. \n/\r get readable forms; the rest become \xNN.
-    func oneLine(_ s: String) -> String {
-        var out = ""
-        for scalar in String(s.prefix(200)).unicodeScalars {
-            switch scalar {
-            case "\n": out += "\\n"
-            case "\r": out += "\\r"
-            case let c where c.value < 0x20 || c.value == 0x7F:
-                out += String(format: "\\x%02x", c.value)
-            default: out.unicodeScalars.append(scalar)
-            }
-        }
-        return out
-    }
     CrowLog.error(
-        "[hook-event] dropped \(oneLine(eventName)): unresolved session "
-        + "(no session_id, cwd=\(cwd.map(oneLine) ?? "<none>"))"
+        "[hook-event] dropped \(oneLineForLog(eventName)): unresolved session "
+        + "(no session_id, cwd=\(cwd.map(oneLineForLog) ?? "<none>"))"
+    )
+}
+
+/// Inherited-config drops already logged, keyed on `cwd` **and** the foreign
+/// session id — unlike the unresolved set above, one cwd can legitimately see
+/// several foreign ids over a daemon's life (a main clone rewritten for a new
+/// session while its worktrees keep running), and collapsing them onto `cwd`
+/// alone would hide all but the first.
+@MainActor private var loggedForeignHookDrops: Set<String> = []
+
+/// Log an inherited-block drop at most once per (cwd, foreign id) pair.
+///
+/// This one is worth a log line rather than silence: it is the visible symptom
+/// of a main clone still carrying a hook block, which `reconcileMainClone`
+/// should have cleared at launch. Seeing it repeatedly means reconciliation is
+/// not reaching that directory.
+///
+/// Same shape as the unresolved logger — 256-key cap held by refusing new keys,
+/// never reset for the daemon's lifetime — because this fires on essentially
+/// every tool call of every affected session.
+@MainActor private func logForeignHookDropOnce(
+    eventName: String, cwd: String, provided: UUID, resolved: UUID
+) {
+    let key = "\(cwd)|\(provided.uuidString)"
+    guard !loggedForeignHookDrops.contains(key) else { return }
+    guard loggedForeignHookDrops.count < 256 else { return }
+    loggedForeignHookDrops.insert(key)
+    CrowLog.error(
+        "[hook-event] dropped \(oneLineForLog(eventName)): hook config for session "
+        + "\(provided.uuidString) fired in \(oneLineForLog(cwd)), which belongs to "
+        + "\(resolved.uuidString) — an inherited main-clone block (#915). "
+        + "Its .claude/settings.local.json still carries Crow hooks."
     )
 }
 
@@ -1149,7 +1180,9 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                             SessionService.prepareWorktreeForAgentLaunch(
                                 agentKind: session.agentKind,
                                 sessionKind: session.kind,
-                                worktreePath: wtPath)
+                                worktreePath: wtPath,
+                                ownership: SessionService.HookOwnership.snapshot(
+                                    capturedAppState, crowPath: crowPath))
                         }
                         let prepared = AgentLaunch.prepareAgentLaunchText(
                             command: text,
@@ -1340,32 +1373,78 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }()
 
                 return try await MainActor.run {
-                    // Resolve session — an explicit param wins only if it names
-                    // a session we still have; otherwise fall back to the
-                    // worktree matching `cwd`.
+                    // Resolve session — `cwd` is authoritative, and a provided
+                    // id is trusted only when cwd can't answer.
                     //
-                    // A stale `settings.local.json` bakes in a `--session` uuid
-                    // that can outlive the session itself (#897), and trusting
-                    // it unconditionally minted hook state — and a persisted
-                    // `hookStates` row — for a session that no longer exists.
-                    // Rerouting by cwd repairs those events instead of dropping
-                    // them.
+                    // cwd wins because it describes which session is *actually
+                    // running*, whereas `--session` only describes which file
+                    // the command was written into — and one settings file is
+                    // read by more sessions than the one it was written for. A
+                    // git worktree's `.git` is a file pointing at the main
+                    // clone, and project-root resolution follows it, so a
+                    // worktree session loads the **main clone's**
+                    // `.claude/settings.local.json` in addition to its own
+                    // (#915). The main clone's block therefore fires inside
+                    // every worktree session of that repo.
                     //
-                    // Deliberately never throws for an unknown-but-provided id:
-                    // recording the event under the id the hook handed us beats
-                    // dropping it. (Before #903 there was a second reason — a
-                    // thrown RPC error became a non-zero `crow hook-event` exit
-                    // that Claude Code rendered as "hook error" noise — but
-                    // hook-event is fire-and-forget now, so the client never
-                    // reads the reply. Dropping the event is still the worse
-                    // outcome.) Unresolvable ids fall through with today's
-                    // behavior, minus the store write.
+                    // That block is not necessarily stale — if a session really
+                    // does run in the main clone, its uuid is live and
+                    // `ClaudeHookRepair` rightly leaves the file alone — so the
+                    // old "a live id wins" rule attributed every worktree
+                    // session's events to the main clone's session, and fired
+                    // each event twice (once per block). Dropping the mismatch
+                    // fixes attribution and the duplicate in one step, for the
+                    // files already on disk, with no change to what we write.
+                    //
+                    // Unchanged below the first branch: an unknown-but-provided
+                    // id is still recorded rather than dropped (#897 — a stale
+                    // file's uuid can outlive its session, and recording under
+                    // the id we were handed beats losing the event), and an
+                    // agent whose cwd matches no registered worktree still
+                    // falls back to the provided id.
                     let liveSessionIDs = Set(capturedAppState.sessions.map(\.id))
                     let sessionID: UUID
-                    if let provided = providedSessionID, liveSessionIDs.contains(provided) {
-                        sessionID = provided
-                    } else if let cwd, let resolved = capturedAppState.sessionID(forWorktreePath: cwd) {
-                        sessionID = resolved
+                    // Only *live* owners count. A row can outlive its session
+                    // (orphan recovery, a failed delete), and letting a dead one
+                    // own the directory would drop a live session's events.
+                    let owners = cwd.map {
+                        capturedAppState.sessionIDs(forWorktreePath: $0)
+                            .filter(liveSessionIDs.contains)
+                    } ?? []
+                    if let cwd, !owners.isEmpty {
+                        let provided = providedSessionID
+                        // Ids we honor over `owners`' arbitrary pick:
+                        //
+                        //  - One that owns the directory. With two rows on one
+                        //    path the pick is a coin flip, so an id that owns it
+                        //    is always preferred over whichever came first.
+                        //  - The Manager. Its block lives at devRoot and is
+                        //    matched by constant, never by path, everywhere else
+                        //    (cf. `ClaudeHookRepair.sweep`); if devRoot were ever
+                        //    registered as a worktree, path-based routing would
+                        //    hijack — or silence — the session that orchestrates
+                        //    everything.
+                        let honored = provided.map {
+                            owners.contains($0) || $0 == AppState.managerSessionID
+                        } ?? false
+                        // Anything else that is live is foreign to this
+                        // directory: an inherited block. A provided id that is
+                        // *not* live is #897's stale uuid, which
+                        // `unknownSessionFallsBackToCwd` re-routes here rather
+                        // than discards.
+                        if let provided, !honored, liveSessionIDs.contains(provided) {
+                            logForeignHookDropOnce(
+                                eventName: eventName, cwd: cwd,
+                                provided: provided, resolved: owners[0])
+                            throw RPCError.invalidParams(
+                                "hook config for session \(provided.uuidString) fired in a"
+                                + " worktree owned by \(owners[0].uuidString); dropped as inherited")
+                        }
+                        if let provided, honored {
+                            sessionID = provided
+                        } else {
+                            sessionID = owners[0]
+                        }
                     } else if let provided = providedSessionID {
                         sessionID = provided
                     } else {

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -801,6 +801,7 @@ public final class SessionService {
         if let session = appState.sessions.first(where: { $0.id == sessionID }),
            let agent = AgentRegistry.shared.agent(for: session.agentKind) {
             let worktreePath = appState.primaryWorktree(for: sessionID)?.worktreePath
+            let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot())
             // Strip a Grok `.review` clone's committed config, then pre-seed folder
             // trust — both via the one shared gate (#861 review r11/r14, unified r17).
             // A brand-new managed terminal from `crow new-terminal --command` — how
@@ -813,14 +814,15 @@ public final class SessionService {
                 Self.prepareWorktreeForAgentLaunch(
                     agentKind: session.agentKind,
                     sessionKind: session.kind,
-                    worktreePath: worktreePath)
+                    worktreePath: worktreePath,
+                    ownership: HookOwnership.snapshot(appState, crowPath: crowPath))
             }
             text = AgentLaunch.prepareAgentLaunchText(
                 command: command,
                 agent: agent,
                 sessionID: sessionID,
                 worktreePath: worktreePath,
-                crowPath: ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot()),
+                crowPath: crowPath,
                 telemetryPort: telemetryPort
             ).text
         }
@@ -869,9 +871,56 @@ public final class SessionService {
         }
     }
 
+    /// The AppState facts `ClaudeHookRepair.reconcileMainClone` needs, captured
+    /// as values so the reconciliation itself (blocking file I/O) stays off the
+    /// MainActor (#892).
+    struct HookOwnership: Sendable {
+        /// The binary to write into repaired commands. `nil` means nothing can
+        /// be repaired, so a foreign block is stripped instead — which still
+        /// stops the hook errors.
+        let crowPath: String?
+        let liveSessionIDs: Set<UUID>
+        /// `standardizingPath`-normalized worktree path → owning session.
+        let sessionByWorktreePath: [String: UUID]
+
+        /// No binary, no sessions — every directory reads as unowned. For tests
+        /// exercising the *other* steps of the launch gate, and as the safe
+        /// value when there is nothing to snapshot. Deliberately not a default
+        /// argument on `prepareWorktreeForAgentLaunch`: a default is how a new
+        /// launch path silently skips reconciliation.
+        static let empty = HookOwnership(
+            crowPath: nil, liveSessionIDs: [], sessionByWorktreePath: [:])
+
+        @MainActor
+        static func snapshot(_ appState: AppState, crowPath: String?) -> HookOwnership {
+            HookOwnership(
+                crowPath: crowPath,
+                liveSessionIDs: Set(appState.sessions.map(\.id)),
+                // `uniquingKeysWith`, not `uniqueKeysWithValues`: the latter
+                // traps on duplicate keys, and two rows sharing a worktree path
+                // is reachable through orphan recovery. Matches
+                // `LaunchScaffold.repairStaleHooks`.
+                sessionByWorktreePath: Dictionary(
+                    appState.worktrees.values.flatMap { $0 }.map {
+                        (($0.worktreePath as NSString).standardizingPath, $0.sessionID)
+                    },
+                    uniquingKeysWith: { first, _ in first }))
+        }
+
+        /// The same snapshot with one session treated as already gone — what the
+        /// retention reaper needs, since it runs while the session is still in
+        /// `AppState`.
+        func excluding(sessionID: UUID) -> HookOwnership {
+            HookOwnership(
+                crowPath: crowPath,
+                liveSessionIDs: liveSessionIDs.subtracting([sessionID]),
+                sessionByWorktreePath: sessionByWorktreePath.filter { $0.value != sessionID })
+        }
+    }
+
     /// Everything that must be applied to a worktree **before an agent process
     /// opens it**, as ONE gate so no launch path can drift (#861 review r17,
-    /// Yellow 1 / Green 1). Two independent, each self-gated steps:
+    /// Yellow 1 / Green 1). Three independent, each self-gated steps:
     ///
     ///  1. **Strip** a Grok `.review` clone's committed config (`.grok/`,
     ///     `.cursor/`, `.claude/settings{,.local}.json`, repo-root `.mcp.json`)
@@ -886,18 +935,28 @@ public final class SessionService {
     ///     attacker's hooks from the PR head.
     ///  2. **Seed** the agent's folder trust (Claude/Codex/Grok, never `.review`),
     ///     gated via `shouldSeedFolderTrust`.
+    ///  3. **Reconcile the main clone's** hook block (#915). A linked worktree
+    ///     loads the main clone's `.claude/settings.local.json` in addition to
+    ///     its own, so a stale block there breaks hooks and telemetry for every
+    ///     session on that repo, and a merely foreign one misattributes their
+    ///     events. No-op when `worktreePath` is not a linked worktree.
     ///
-    /// Both are no-ops for the agents/kinds that don't need them, so this is safe
-    /// to call from every launch path unconditionally. **The call sites of this
-    /// symbol ARE the answer to "how many Grok/Antigravity launch paths open a
+    /// All are no-ops for the agents/kinds/layouts that don't need them, so this
+    /// is safe to call from every launch path unconditionally. **The call sites of
+    /// this symbol ARE the answer to "how many Grok/Antigravity launch paths open a
     /// review clone"** — `rg prepareWorktreeForAgentLaunch`, never a hand-maintained
     /// count (which went stale four rounds running). Today: `pasteDeferredLaunch`,
     /// `launchAgent`, `handoffAgent`, `createManagerTerminal` (seed only — Manager
     /// is never `.review`), and the `send` RPC (`EngineRouter`). `prepareReviewClone`
     /// strips at *clone-creation* time and deliberately does NOT go through here:
     /// it must strip WITHOUT seeding, since the clone is not yet a launch target.
+    ///
+    /// `ownership` is required rather than defaulted: a default would let a new
+    /// launch path silently skip step 3, which is the drift this gate exists to
+    /// prevent.
     nonisolated static func prepareWorktreeForAgentLaunch(
-        agentKind: AgentKind, sessionKind: SessionKind, worktreePath: String) {
+        agentKind: AgentKind, sessionKind: SessionKind, worktreePath: String,
+        ownership: HookOwnership) {
         if shouldStripGrokReviewClone(agentKind: agentKind, sessionKind: sessionKind) {
             stripGrokConfigFromReviewClone(clonePath: worktreePath)
         }
@@ -906,6 +965,51 @@ public final class SessionService {
         }
         seedTrustIfNeeded(
             agentKind: agentKind, sessionKind: sessionKind, worktreePath: worktreePath)
+        reconcileMainCloneHooks(worktreePath: worktreePath, ownership: ownership)
+    }
+
+    /// Step 3 of the launch gate: clear or repair the main clone's inherited
+    /// hook block (#915).
+    ///
+    /// Runs for every agent kind, not just Claude. The inherited file is
+    /// `.claude/settings.local.json` either way, and Grok/Codex read Claude-compat
+    /// settings — so a Cursor or Codex session in a worktree is just as exposed to
+    /// a stale block in the repo's main clone as a Claude one.
+    nonisolated static func reconcileMainCloneHooks(
+        worktreePath: String, ownership: HookOwnership) {
+        logMainCloneOutcome(ClaudeHookRepair.reconcileMainClone(
+            worktreePath: worktreePath,
+            crowPath: ownership.crowPath,
+            liveSessionIDs: ownership.liveSessionIDs,
+            sessionByWorktreePath: ownership.sessionByWorktreePath))
+    }
+
+    /// The same reconciliation for a directory already known to be a main clone
+    /// — the retention reaper's entry point, where the worktree that would have
+    /// resolved it is being deleted.
+    nonisolated static func reconcileMainCloneHooks(
+        directory: String, ownership: HookOwnership) {
+        logMainCloneOutcome(ClaudeHookRepair.reconcileHookBlock(
+            inDirectory: directory,
+            crowPath: ownership.crowPath,
+            liveSessionIDs: ownership.liveSessionIDs,
+            sessionByWorktreePath: ownership.sessionByWorktreePath))
+    }
+
+    private nonisolated static func logMainCloneOutcome(
+        _ outcome: ClaudeHookRepair.MainCloneOutcome) {
+        switch outcome {
+        case .notAWorktree, .noBlock, .healthy:
+            break  // The common case — stay quiet.
+        case .repaired(let dir):
+            CrowLog.info("[SessionService] repaired inherited hook block in main clone \(dir)")
+        case .stripped(let dir):
+            CrowLog.info("[SessionService] stripped inherited hook block from main clone \(dir)")
+        case .skipped(let dir):
+            CrowLog.info(
+                "[SessionService] could not reconcile the hook block in main clone \(dir)"
+                + " — sessions in this repo's worktrees may keep emitting hook errors.")
+        }
     }
 
     /// Pre-seed the agent's folder trust for `worktreePath` so an unattended launch
@@ -1061,13 +1165,15 @@ public final class SessionService {
         // creation-time strip alone is not enough. The strip is a no-op unless this
         // is a Grok `.review` clone; the seed a no-op for `.review` / a trustless
         // agent (never `--dangerously-bypass`; Claude CROW-600, Codex #830, Grok #859).
+        let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot())
         Self.prepareWorktreeForAgentLaunch(
             agentKind: agent.kind, sessionKind: session.kind,
-            worktreePath: worktree.worktreePath)
+            worktreePath: worktree.worktreePath,
+            ownership: HookOwnership.snapshot(appState, crowPath: crowPath))
 
         // Write/refresh hook config (Claude path). Codex's writer is a
         // no-op — its global config was installed once at app launch.
-        if let crowPath = ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot()) {
+        if let crowPath {
             do {
                 try agent.hookConfigWriter.writeHookConfig(
                     worktreePath: worktree.worktreePath,
@@ -1400,7 +1506,10 @@ public final class SessionService {
         // agents.
         Self.prepareWorktreeForAgentLaunch(
             agentKind: target.kind, sessionKind: session.kind,
-            worktreePath: worktree.worktreePath)
+            worktreePath: worktree.worktreePath,
+            ownership: HookOwnership.snapshot(
+                appState,
+                crowPath: ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot())))
         if target.kind == .claudeCode {
             // Claude inherits the workspace AI gateway env on handoff.
             ClaudeHookConfigWriter.writeGatewayEnv(
@@ -1918,7 +2027,10 @@ public final class SessionService {
         // path can't forget the strip (#861 review r8/r17). Manager sessions are
         // never `.review`, so here the shared helper only seeds (the strip no-ops).
         Self.prepareWorktreeForAgentLaunch(
-            agentKind: session.agentKind, sessionKind: session.kind, worktreePath: cwd)
+            agentKind: session.agentKind, sessionKind: session.kind, worktreePath: cwd,
+            ownership: HookOwnership.snapshot(
+                appState,
+                crowPath: ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot())))
         // CROW-402: write the Manager gateway env block to {devRoot}/.claude so
         // manual `claude` re-runs in this terminal inherit the same routing. The
         // Manager's cwd is the devRoot. #861 review r17/r18 (Yellow 2): the env can
@@ -2035,6 +2147,13 @@ public final class SessionService {
                 agentKind: session?.agentKind ?? .claudeCode
             )
         }
+        // Ownership as it will be *after* this delete: the session is still in
+        // `appState` here (it is removed once cleanup succeeds), so counting it
+        // as live would let a main clone keep a hook block naming a session that
+        // is going away — which is precisely how #897's stale file was created.
+        let ownershipAfterDelete = HookOwnership.snapshot(
+            appState, crowPath: ClaudeHookConfigWriter.resolveCrowBinary(devRoot: ConfigStore.loadDevRoot())
+        ).excluding(sessionID: id)
 
         appState.isDeletingSession[id] = true
         appState.sessionDeletionError.removeValue(forKey: id)
@@ -2042,7 +2161,8 @@ public final class SessionService {
         // Slow git + filesystem work runs on a background thread so the main actor
         // stays free to render the spinner and respond to other input.
         let cleanupError: String? = await Task.detached(priority: .utility) {
-            Self.performDiskCleanup(items: items, isReview: isReview)
+            Self.performDiskCleanup(
+                items: items, isReview: isReview, ownership: ownershipAfterDelete)
         }.value
 
         if let cleanupError {
@@ -2112,7 +2232,8 @@ public final class SessionService {
     /// Soft failures (branch delete, prune) only get NSLog'd.
     nonisolated static func performDiskCleanup(
         items: [WorktreeCleanupItem],
-        isReview: Bool
+        isReview: Bool,
+        ownership: HookOwnership
     ) -> String? {
         var firstFatalError: String? = nil
 
@@ -2145,6 +2266,17 @@ public final class SessionService {
             let cleanupWriter = AgentRegistry.shared.agent(for: item.agentKind)?.hookConfigWriter
                 ?? ClaudeHookConfigWriter()
             cleanupWriter.removeHookConfig(worktreePath: item.worktreePath)
+
+            // …and from the **main clone**, which this worktree's sessions were
+            // also loading (#915). Removing the worktree does not remove the
+            // block that named it, so without this a reaped worktree can leave
+            // its binary/session id behind in a long-lived clone — exactly the
+            // April artifact in #897 — until the next boot sweep. `repoPath` is
+            // the clone, and doing it here rather than after `git worktree
+            // remove` means we don't need the (soon-deleted) worktree's `.git`
+            // to resolve it. Non-fatal: this loop's first hard error aborts the
+            // whole session delete, and a settings file is not worth that.
+            reconcileMainCloneHooks(directory: item.repoPath, ownership: ownership)
 
             var gitRemoveFailed = false
             do {

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -872,8 +872,12 @@ public final class SessionService {
     }
 
     /// The AppState facts `ClaudeHookRepair.reconcileMainClone` needs, captured
-    /// as values so the reconciliation itself (blocking file I/O) stays off the
-    /// MainActor (#892).
+    /// as values so the reconciliation needs no actor of its own.
+    ///
+    /// That is what lets the **reaper** run it inside `Task.detached`
+    /// (`performDiskCleanup`). The **launch** path deliberately runs it inline on
+    /// the MainActor instead — see `reconcileMainCloneHooks` for why detaching
+    /// there would race the launch it protects.
     struct HookOwnership: Sendable {
         /// The binary to write into repaired commands. `nil` means nothing can
         /// be repaired, so a foreign block is stripped instead — which still
@@ -939,7 +943,10 @@ public final class SessionService {
     ///     loads the main clone's `.claude/settings.local.json` in addition to
     ///     its own, so a stale block there breaks hooks and telemetry for every
     ///     session on that repo, and a merely foreign one misattributes their
-    ///     events. No-op when `worktreePath` is not a linked worktree.
+    ///     events. No-op when `worktreePath` is not a linked worktree. Like the
+    ///     other two, it runs **inline on the MainActor** — every step of this
+    ///     gate must complete before the caller launches the agent, so none of
+    ///     them may be detached (`reconcileMainCloneHooks` documents the cost).
     ///
     /// All are no-ops for the agents/kinds/layouts that don't need them, so this
     /// is safe to call from every launch path unconditionally. **The call sites of
@@ -975,6 +982,15 @@ public final class SessionService {
     /// `.claude/settings.local.json` either way, and Grok/Codex read Claude-compat
     /// settings — so a Cursor or Codex session in a worktree is just as exposed to
     /// a stale block in the repo's main clone as a Claude one.
+    ///
+    /// **Runs inline on the MainActor, by design.** `prepareWorktreeForAgentLaunch`
+    /// is synchronous and MainActor-bound, and its callers type the agent's launch
+    /// command into the pane in the same block — so the reconcile must finish
+    /// first. Detaching it (the reflex for blocking I/O under #892) would let the
+    /// agent start while the inherited block is still on disk, which is precisely
+    /// the failure this exists to prevent. The I/O is bounded to a single `stat`
+    /// for anything that is not a linked worktree and three small reads for one
+    /// that is; see `ClaudeHookRepair.reconcileMainClone` for the full accounting.
     nonisolated static func reconcileMainCloneHooks(
         worktreePath: String, ownership: HookOwnership) {
         logMainCloneOutcome(ClaudeHookRepair.reconcileMainClone(

--- a/Packages/CrowEngine/Tests/CrowEngineTests/HookEventSessionResolutionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/HookEventSessionResolutionTests.swift
@@ -69,8 +69,129 @@ struct HookEventSessionResolutionTests {
 
     /// A live session id always wins, even when `cwd` would resolve elsewhere —
     /// the fallback must not change routing for anything that works today.
-    @Test("a live session_id is used verbatim")
+    @Test("a live session_id is used verbatim when no worktree matches the cwd")
     func liveSessionIDWins() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let a = Session(name: "a")
+        appState.sessions.append(a)
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(a.id.uuidString),
+                "event_name": .string("Stop"),
+                // An agent that `cd`s outside its worktree, or a directory Crow
+                // has no row for: cwd can't answer, so the provided id stands.
+                "payload": .object(["cwd": .string(tmp.appendingPathComponent("elsewhere").path)]),
+            ]))
+
+        #expect(response.result?["session_id"]?.stringValue == a.id.uuidString)
+    }
+
+    /// #915 — the inversion of the old `liveSessionIDWins` contract.
+    ///
+    /// That test asserted a live `session_id` beat a `cwd` resolving elsewhere.
+    /// It was the bug: a linked worktree also loads its **main clone's**
+    /// `.claude/settings.local.json`, so the main clone's block fires inside
+    /// every worktree session of that repo. If the main clone hosts a live
+    /// session, the old rule attributed the worktree session's events to it and
+    /// double-counted every one (both blocks fire). cwd is the only signal that
+    /// says which session is actually running, so it wins — and a live id that
+    /// does not own this directory is an inherited copy, not an event.
+    @Test("a live session_id that doesn't own the cwd is dropped as inherited")
+    func foreignLiveSessionIDIsDropped() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let mainClone = Session(name: "main-clone")
+        let worktree = Session(name: "worktree")
+        appState.sessions.append(contentsOf: [mainClone, worktree])
+        let worktreePath = tmp.appendingPathComponent("ws/repo-1").path
+        appState.worktrees[worktree.id] = [
+            SessionWorktree(sessionID: worktree.id, repoName: "repo", repoPath: worktreePath,
+                            worktreePath: worktreePath, branch: "feature/x", isPrimary: true),
+        ]
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(mainClone.id.uuidString),
+                "event_name": .string("Stop"),
+                "payload": .object(["cwd": .string(worktreePath)]),
+            ]))
+
+        #expect(response.result == nil)
+        #expect(response.error != nil)
+        // The worktree session's own block reports the same event, so nothing
+        // is lost — and neither session gets a spurious row from this copy.
+        #expect(store.data.hookStates?[mainClone.id.uuidString] == nil)
+    }
+
+    @Test("a session_id that owns the cwd is used")
+    func owningSessionIDIsUsed() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let live = Session(name: "live")
+        appState.sessions.append(live)
+        let worktreePath = tmp.appendingPathComponent("ws/repo-1").path
+        appState.worktrees[live.id] = [
+            SessionWorktree(sessionID: live.id, repoName: "repo", repoPath: worktreePath,
+                            worktreePath: worktreePath, branch: "feature/x", isPrimary: true),
+        ]
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(live.id.uuidString),
+                "event_name": .string("Stop"),
+                "payload": .object(["cwd": .string(worktreePath)]),
+            ]))
+
+        #expect(response.result?["session_id"]?.stringValue == live.id.uuidString)
+    }
+
+    /// A worktree row can outlive its session (orphan recovery, a failed
+    /// delete). A dead owner must not be allowed to drop a live session's
+    /// events — the old code never liveness-checked the cwd side.
+    @Test("a worktree row for a dead session doesn't drop a live session's event")
+    func deadOwnerDoesNotDropLiveSession() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let live = Session(name: "live")
+        appState.sessions.append(live)
+        let ghost = UUID()  // never added to `sessions`
+        let worktreePath = tmp.appendingPathComponent("ws/repo-1").path
+        appState.worktrees[ghost] = [
+            SessionWorktree(sessionID: ghost, repoName: "repo", repoPath: worktreePath,
+                            worktreePath: worktreePath, branch: "feature/x", isPrimary: true),
+        ]
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(live.id.uuidString),
+                "event_name": .string("Stop"),
+                "payload": .object(["cwd": .string(worktreePath)]),
+            ]))
+
+        #expect(response.result?["session_id"]?.stringValue == live.id.uuidString)
+    }
+
+    /// Two sessions on one path is reachable (orphan recovery, a `setup.sh`
+    /// retry, a shared secondary repo). The winner is then an arbitrary
+    /// dictionary pick, so a provided id that is *among* the owners must be
+    /// honored — otherwise a coin flip decides whether a session records
+    /// anything at all for the life of the daemon.
+    @Test("an ambiguous worktree path honors the provided owner")
+    func ambiguousPathPrefersProvidedOwner() async throws {
         let tmp = tempDir()
         let appState = AppState()
         let store = JSONStore(directory: tmp)
@@ -78,21 +199,54 @@ struct HookEventSessionResolutionTests {
         let a = Session(name: "a")
         let b = Session(name: "b")
         appState.sessions.append(contentsOf: [a, b])
-        let bPath = tmp.appendingPathComponent("ws/repo-b").path
-        appState.worktrees[b.id] = [
-            SessionWorktree(sessionID: b.id, repoName: "repo", repoPath: bPath,
-                            worktreePath: bPath, branch: "feature/b", isPrimary: true),
+        let shared = tmp.appendingPathComponent("ws/repo-1").path
+        for id in [a.id, b.id] {
+            appState.worktrees[id] = [
+                SessionWorktree(sessionID: id, repoName: "repo", repoPath: shared,
+                                worktreePath: shared, branch: "feature/x", isPrimary: true),
+            ]
+        }
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        for session in [a, b] {
+            let response = await router.handle(request: JSONRPCRequest(
+                id: 1, method: "hook-event", params: [
+                    "session_id": .string(session.id.uuidString),
+                    "event_name": .string("Stop"),
+                    "payload": .object(["cwd": .string(shared)]),
+                ]))
+            #expect(response.result?["session_id"]?.stringValue == session.id.uuidString)
+        }
+    }
+
+    /// The Manager's cwd is the dev root and it has no `SessionWorktree` row, so
+    /// it normally lands in the provided-id branch. Should devRoot ever be
+    /// registered as a worktree, a path-based drop would silence the session
+    /// that orchestrates everything — so the Manager is never dropped.
+    @Test("the Manager is never dropped, even if its cwd is a registered worktree")
+    func managerIsNeverDropped() async throws {
+        let tmp = tempDir()
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+
+        let manager = Session(id: AppState.managerSessionID, name: "Manager")
+        let other = Session(name: "other")
+        appState.sessions.append(contentsOf: [manager, other])
+        appState.worktrees[other.id] = [
+            SessionWorktree(sessionID: other.id, repoName: "repo", repoPath: tmp.path,
+                            worktreePath: tmp.path, branch: "main", isPrimary: true),
         ]
 
         let router = makeRouter(appState, store, devRoot: tmp.path)
         let response = await router.handle(request: JSONRPCRequest(
             id: 1, method: "hook-event", params: [
-                "session_id": .string(a.id.uuidString),
+                "session_id": .string(AppState.managerSessionID.uuidString),
                 "event_name": .string("Stop"),
-                "payload": .object(["cwd": .string(bPath)]),
+                "payload": .object(["cwd": .string(tmp.path)]),
             ]))
 
-        #expect(response.result?["session_id"]?.stringValue == a.id.uuidString)
+        #expect(response.result?["session_id"]?.stringValue
+                == AppState.managerSessionID.uuidString)
     }
 
     /// An unresolvable id must still succeed. `crow hook-event` surfaces an RPC

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceDiskCleanupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceDiskCleanupTests.swift
@@ -29,7 +29,7 @@ struct SessionServiceDiskCleanupTests {
             isMainCheckout: true
         )
 
-        let error = SessionService.performDiskCleanup(items: [item], isReview: true)
+        let error = SessionService.performDiskCleanup(items: [item], isReview: true, ownership: .empty)
 
         #expect(error == nil)
         #expect(!FileManager.default.fileExists(atPath: clone.path))
@@ -47,7 +47,7 @@ struct SessionServiceDiskCleanupTests {
             isMainCheckout: true
         )
 
-        let error = SessionService.performDiskCleanup(items: [item], isReview: true)
+        let error = SessionService.performDiskCleanup(items: [item], isReview: true, ownership: .empty)
 
         #expect(error == nil)
     }
@@ -63,7 +63,7 @@ struct SessionServiceDiskCleanupTests {
             isMainCheckout: true
         )
 
-        let error = SessionService.performDiskCleanup(items: [item], isReview: false)
+        let error = SessionService.performDiskCleanup(items: [item], isReview: false, ownership: .empty)
 
         #expect(error == nil)
         #expect(FileManager.default.fileExists(atPath: checkout.path))
@@ -82,7 +82,7 @@ struct SessionServiceDiskCleanupTests {
             isMainCheckout: true
         )
 
-        let error = SessionService.performDiskCleanup(items: [item], isReview: true)
+        let error = SessionService.performDiskCleanup(items: [item], isReview: true, ownership: .empty)
 
         #expect(error == nil)
         #expect(!FileManager.default.fileExists(atPath: clone.path))

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceGrokReviewCloneStripTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceGrokReviewCloneStripTests.swift
@@ -184,7 +184,7 @@ struct SessionServiceGrokReviewCloneStripTests {
         // Grok + .review → strip fires; seed is skipped (shouldSeedFolderTrust is
         // false for `.review`), so no global trust file is written by this call.
         SessionService.prepareWorktreeForAgentLaunch(
-            agentKind: .grok, sessionKind: .review, worktreePath: clone)
+            agentKind: .grok, sessionKind: .review, worktreePath: clone, ownership: .empty)
 
         #expect(!FileManager.default.fileExists(atPath: grokDir))
     }
@@ -203,7 +203,7 @@ struct SessionServiceGrokReviewCloneStripTests {
         // Cursor + .review → strip gate false (not Grok), seed gate false (no trust
         // store): a pure no-op that leaves the tree untouched.
         SessionService.prepareWorktreeForAgentLaunch(
-            agentKind: .cursor, sessionKind: .review, worktreePath: clone)
+            agentKind: .cursor, sessionKind: .review, worktreePath: clone, ownership: .empty)
 
         #expect(FileManager.default.fileExists(atPath: grokDir))
     }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
@@ -248,7 +248,7 @@ struct SessionServiceReviewCloneStripTests {
             atomically: true, encoding: .utf8)
 
         SessionService.prepareWorktreeForAgentLaunch(
-            agentKind: .antigravity, sessionKind: .review, worktreePath: clone)
+            agentKind: .antigravity, sessionKind: .review, worktreePath: clone, ownership: .empty)
 
         #expect(!FileManager.default.fileExists(atPath: agentsDir))
     }
@@ -263,7 +263,7 @@ struct SessionServiceReviewCloneStripTests {
             atPath: agentsDir, withIntermediateDirectories: true)
 
         SessionService.prepareWorktreeForAgentLaunch(
-            agentKind: .antigravity, sessionKind: .work, worktreePath: clone)
+            agentKind: .antigravity, sessionKind: .work, worktreePath: clone, ownership: .empty)
 
         #expect(FileManager.default.fileExists(atPath: agentsDir))
     }

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -228,9 +228,29 @@ harness's sessions
 All harnesses report lifecycle events by shelling out to `crow hook-event`, but
 **where the hook config lives** and **how the session is resolved** differ.
 
+> **`cwd` outranks the baked UUID (#915).** A linked worktree's `.git` is a file
+> pointing at the main clone, and project-root resolution follows it — so a
+> worktree session loads the **main clone's** `.claude/settings.local.json` in
+> addition to its own, and *both* hook blocks fire. A baked `--session <UUID>`
+> therefore says which file the command was written into, not which session is
+> running. The handler resolves the payload's `cwd` against registered worktrees
+> first; a *live* UUID that doesn't own that directory is an inherited copy and
+> is **dropped**, since the session that owns the cwd reports the same event from
+> its own block. A UUID is still honored when it owns the cwd, when no worktree
+> matches (an agent that `cd`s away), when it is the Manager (matched by
+> constant, never by path), and when it is not live — that last one is #897's
+> stale uuid, which is re-routed by `cwd` rather than discarded.
+>
+> The inherited block is also removed *at launch*:
+> `ClaudeHookRepair.reconcileMainClone` resolves the main clone through the
+> gitdir chain and strips its Crow entries unless a live session owns that
+> directory, in which case it repairs them in place. That is the half the daemon
+> cannot do — a dangling binary fails in `/bin/sh` before `crow` ever runs.
+
 - **Claude** — per-worktree `.claude/settings.local.json`, written per session
   with `hook-event --session <UUID>`, so the session is resolved by **UUID**
-  ([`ClaudeHookConfigWriter`](../Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift)).
+  ([`ClaudeHookConfigWriter`](../Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift)),
+  subject to the `cwd` precedence above.
 - **Cursor** — per-worktree `.cursor/hooks.json`, written per session with
   `hook-event --session <UUID>`, resolved by **UUID** (#829,
   `CursorHookConfigWriter`). No global config: Cursor merges global + project and


### PR DESCRIPTION
Closes #915. Also closes #897 — see "Relationship to #897" below.

## The defect

A linked worktree's `.git` is a *file* pointing at the main clone, and
project-root resolution follows it. So a worktree session loads the **main
clone's** `.claude/settings.local.json` *in addition to* its own, and both hook
blocks fire. Crow writes the per-worktree file and treats it as the session's
hook configuration; it never was. One block in one main clone reaches every
session on that repo.

**Verified on this machine rather than assumed.** Exactly one file under the dev
root contains the dead `crow-136-session-analytics-otel` path — the `corveil`
main clone's settings file — yet the sessions logging those errors all run from
worktrees whose own settings files are clean and name a live binary. The only
possible source is the main clone. `git rev-parse --git-common-dir` from a
worktree lands on the main clone's `.git`, and the `claude` binary's
settings-resolution region references `commondir` / `worktrees` /
`^gitdir:\s*(.+)$` adjacent to `settings.local.json`, which is consistent with
that being the mechanism.

Two failures follow, and #900 addresses neither:

| | Symptom | Why the existing sweep misses it |
|---|---|---|
| **Dangling** block | `/bin/sh` fails before `crow` runs → every hook event errors, no telemetry, for every worktree session of the repo | `ClaudeHookRepair.sweep` is boot-only and walks devRoot at a fixed depth of 2 |
| **Live** block | Events attributed to the main clone's session and fired twice | Its health test is per-directory — good binary + live session reads as *healthy*, so it is deliberately left in place |

The second row is what #915 adds over #897, and nothing addressed it.

## Changes

**1. `cwd` outranks the baked UUID in `hook-event`** (`EngineRouter`).

A `--session` id says which *file* the command was written into; `cwd` says which
*session is running*. A live id that doesn't own the cwd is an inherited copy and
is dropped — the session that owns the cwd reports the same event from its own
block, so nothing is lost. This fixes attribution and the duplicate for every
file already on disk, with no change to what Crow writes.

Carve-outs, each a case where dropping would lose a real event:

- an id that **owns** the directory (two rows on one path is reachable through
  orphan recovery and a `setup.sh` retry, and the pick between them is a
  dictionary coin flip — so an owning id always wins over it);
- the **Manager**, matched by constant and never by path everywhere else;
- a **non-live** id — that is #897's stale uuid, still re-routed by `cwd` rather
  than discarded.

`AppState.sessionIDs(forWorktreePath:)` is new: every owner, stable order, both
sides `standardizingPath`-normalized. Without the normalization the fix goes
silently inert on a spelling mismatch, and routing could disagree with
`repairStaleHooks` (which already normalizes) about who owns a directory.

**2. `ClaudeHookRepair.reconcileMainClone`** — resolves the main clone through the
gitdir chain (`.git` file → `commondir`; no subprocess, no `git` on PATH, no
async hop) and reconciles its block:

| Main clone is… | Action |
|---|---|
| this session's own worktree | leave |
| another live session's worktree | repair in place for that session |
| no live session's worktree | strip Crow entries |

This is the half the daemon cannot do — a dangling binary fails before `crow` is
ever reached. Wired into `prepareWorktreeForAgentLaunch`, the one shared gate
whose call sites are already the canonical enumeration of launch paths, and into
`performDiskCleanup` so a reaped worktree's binary and session id are scrubbed
from the clone immediately rather than at next boot. The reaper's snapshot
excludes the session being deleted — it is still in `AppState` at that point, and
counting it as live is how a block outlives its session in the first place.

Strip removes only entries matching the strict `parseCrowHookCommand` shape, so a
user's own hook under a managed event name survives (covered by a test).

**3. `resolveCrowBinary` never returns a `.build/` path.**

It previously fell back to one with only a log warning. That is not hypothetical:
`{devRoot}/.claude/bin` was empty on this machine while still first on `PATH`, and
the session this PR was written in has `…/crow/.build/arm64-apple-macosx/debug/crow`
baked into all 17 of its hook commands. New order — devRoot link, else a stable
link under `~/.local/share/crow/bin`, else a non-build binary, else `nil`. Writing
no hook block costs that session telemetry; writing a broken one costs every
session on the repo, forever.

## Relationship to #897

#900 fixed #897's dangling-binary case for directories the boot sweep reaches.
This closes the two directions it left open — *validate the effective set at
launch* (2) and *never emit a build-product path* (3) — and extends both to the
main clone that #897's impact analysis did not know was in play. Closing both.

## Test note

`liveSessionIDWins` asserted that a live `session_id` beats a `cwd` resolving
elsewhere ("the fallback must not change routing for anything that works
today"). **That assertion was the bug** — it is the exact misattribution #915
reports, written down as intended behavior. It is inverted here deliberately,
not bent to fit the code.

## Verification

`make build && make test` — full suite green, including CLI/RPC parity.

New coverage: the `reconcileMainClone` suite builds **real** `git init` +
`git worktree add` fixtures (a fabricated `.git` could agree with the code while
both disagree with git) and cross-checks resolution against
`git rev-parse --git-common-dir`. Resolution declines rather than guesses on a
gitdir shape it doesn't recognize — this code deletes hook entries, so a wrong
answer would aim the strip at an unrelated directory.

Not yet run against the live repro on the reporter's machine: that needs a
`crowd` restart, which would interrupt running sessions. Expected there —
`RadiusMethod/corveil/.claude/settings.local.json` is deleted outright (it holds
only the stale block), `Dev2/.claude/bin/crow` is repopulated, and the corveil
worktree sessions stop emitting `PreToolUse:Bash hook error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
