### PR TITLE
Sidebar polish: center the right icon stack + group the ticket counts (CROW-922)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -645,13 +645,11 @@ html, body {
 .tickets-card {
   background: var(--bg-surface); border: 1px solid var(--border-subtle);
   border-radius: 8px; padding: 8px; cursor: pointer;
-  /* Full width of the left column, ~2 button-rows tall so it lines up with the
-     Notifications+Settings pair in the right icon column (CROW-917). `min-height`
-     not `height`: a raised browser minimum-font-size grows the title/counts past
-     the resting 46px content box, and a hard height would clip the counts row out
-     the bottom border (the #913 fixed-px failure mode). Growing is safe — the
-     right column stretches to whatever the left resolves to, re-deriving the
-     4-icon alignment for free. */
+  /* Full width of the left column. `min-height` not `height`: a raised browser
+     minimum-font-size grows the title/counts past the resting 46px content box, and
+     a hard height would clip the counts row out the bottom border (the #913 fixed-px
+     failure mode). The right icon column no longer divides the left's height
+     (CROW-922), so growing here just makes the row taller — nothing to re-derive. */
   margin: 0; box-sizing: border-box; min-height: 64px;
   display: flex; flex-direction: column; justify-content: space-between;
 }
@@ -675,24 +673,30 @@ html, body {
    matching the detail-header action-button spinner (CROW-749). */
 .tickets-refresh.spinning { opacity: 0.6; cursor: default; }
 /* Two-column sidebar top (CROW-917): left stack (tickets over the nav rows) beside
-   a one-icon-wide right column. `align-items: stretch` still makes the right column
-   as tall as the left, but its icon buttons no longer flex-fill — `justify-content:
-   center` groups them as a centered block instead of spreading across the height
-   (CROW-922). */
+   a one-icon-wide right column. `align-items: stretch` keeps the two columns the
+   same height — whichever is taller sets it (usually the left, though the fixed
+   4-icon right stack can win on a Manager-less / cold-start render). The right
+   column's buttons no longer flex-fill: `justify-content: center` groups them as a
+   centered block rather than spreading across the height (CROW-922). */
 .sidebar-top { display: flex; align-items: stretch; gap: 6px; margin: 2px 2px 8px; }
 .sidebar-left { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
 .sidebar-right { flex: 0 0 auto; width: 30px; display: flex; flex-direction: column; justify-content: center; gap: 6px; }
-/* Each icon button keeps a fixed square size instead of stretching, so bell/gear/+/
-   select read as one tight centered stack (CROW-922). The 28px height stays above
-   the WCAG 2.2 §2.5.8 target-size minimum (24px) — the sidebar is the full-width
-   touch view on mobile — and `width: 100%` keeps them column-wide. */
-.sidebar-right > button { flex: 0 0 auto; width: 100%; height: 28px; }
+/* Each icon button keeps its natural size (grouped, not stretched) with a 28px
+   floor, so bell/gear/+/select read as one tight centered stack (CROW-922).
+   `min-height` not `height` — same reasoning as .tickets-card above — keeps it
+   grow-safe: .nav-plus renders a 15px text "+" that a raised browser min-font-size
+   would push past a fixed box. 28px clears the WCAG 2.2 §2.5.8 target-size minimum
+   (24px; box-sizing: border-box, so the 30×28 border box counts), and the sidebar
+   is the full-width touch view on mobile. `width: 100%` keeps them column-wide. */
+.sidebar-right > button { flex: 0 0 auto; width: 100%; min-height: 28px; }
 /* 5 status mini-counts grouped and centered rather than spread edge-to-edge
    (CROW-922); each .tk-count is content-sized so glyph+number stay together. */
 .tickets-counts { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 0 2px; }
+/* Bell + gear live only in .sidebar-right, so `.sidebar-right > button` owns their
+   box size (column width + 28px floor); this rule carries just the chrome (CROW-922). */
 .tk-tool {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 30px; height: 29px; border-radius: 6px; cursor: pointer;
+  border-radius: 6px; cursor: pointer;
   border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--gold-dark);
 }
 .tk-tool:hover { color: var(--gold); border-color: var(--border-strong); }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -675,21 +675,21 @@ html, body {
    matching the detail-header action-button spinner (CROW-749). */
 .tickets-refresh.spinning { opacity: 0.6; cursor: default; }
 /* Two-column sidebar top (CROW-917): left stack (tickets over the nav rows) beside
-   a one-icon-wide right column. `align-items: stretch` makes the right column match
-   the left column's height so its four icon buttons (flex:1 each) divide it evenly
-   and self-align to the tickets(2) + Reviews-row(1) + Manager-row(1) = 4 rows. */
+   a one-icon-wide right column. `align-items: stretch` still makes the right column
+   as tall as the left, but its icon buttons no longer flex-fill — `justify-content:
+   center` groups them as a centered block instead of spreading across the height
+   (CROW-922). */
 .sidebar-top { display: flex; align-items: stretch; gap: 6px; margin: 2px 2px 8px; }
 .sidebar-left { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
-.sidebar-right { flex: 0 0 auto; width: 30px; display: flex; flex-direction: column; gap: 6px; }
-/* Every icon button in the right column stretches to the column width and shares
-   the height evenly, so bell/gear/+/select read as one aligned stack regardless of
-   each control's intrinsic size. `min-height: 24px` is a hard floor: the four
-   flex:1 buttons divide whatever height `.sidebar-left` resolves to, and a short
-   left column (no Manager pill / cold-start render) would otherwise divide to
-   ~20px — under the WCAG 2.2 §2.5.8 target-size minimum, and the sidebar is the
-   full-width touch view on mobile (CROW-917 review). */
-.sidebar-right > button { flex: 1 1 0; width: 100%; height: auto; min-height: 24px; }
-.tickets-counts { display: flex; align-items: center; justify-content: space-between; gap: 4px; padding: 0 2px; }
+.sidebar-right { flex: 0 0 auto; width: 30px; display: flex; flex-direction: column; justify-content: center; gap: 6px; }
+/* Each icon button keeps a fixed square size instead of stretching, so bell/gear/+/
+   select read as one tight centered stack (CROW-922). The 28px height stays above
+   the WCAG 2.2 §2.5.8 target-size minimum (24px) — the sidebar is the full-width
+   touch view on mobile — and `width: 100%` keeps them column-wide. */
+.sidebar-right > button { flex: 0 0 auto; width: 100%; height: 28px; }
+/* 5 status mini-counts grouped and centered rather than spread edge-to-edge
+   (CROW-922); each .tk-count is content-sized so glyph+number stay together. */
+.tickets-counts { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 0 2px; }
 .tk-tool {
   display: inline-flex; align-items: center; justify-content: center;
   width: 30px; height: 29px; border-radius: 6px; cursor: pointer;
@@ -817,7 +817,7 @@ html, body {
 
 /* Select-sessions toggle (CROW-913 → far-right icon column, CROW-917): sized/coloured
    like .nav-plus; reads red while a selection is active, matching .nav-selecting elsewhere.
-   In .sidebar-right it flex-fills to align under the bell/gear/+ stack. */
+   In .sidebar-right it sits in the centered, fixed-size icon stack (CROW-922). */
 .nav-select {
   flex: 0 0 auto; width: 30px; padding: 0; display: inline-flex; align-items: center; justify-content: center;
   border-radius: 6px; cursor: pointer;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1006,7 +1006,7 @@ function renderSidebar() {
 
   // Two-column sidebar top (CROW-917): a left stack [tickets → Reviews/Allowlist/
   // Scorecard → Manager] over a far-right column of four stacked icon buttons
-  // [bell, gear, +, select], which flex evenly to align alongside the left rows.
+  // [bell, gear, +, select], grouped and centered in the column (CROW-922).
   const top = el('div', 'sidebar-top');
   top.appendChild(sidebarLeftStack());
   top.appendChild(sidebarIconColumn());
@@ -1264,8 +1264,8 @@ function renderStatusBar() {
 
 // Far-right sidebar column (CROW-917): the four global icon buttons stacked
 // vertically — Notifications bell, Settings gear, "+" new-manager, and the
-// Select-sessions toggle. They flex evenly to align alongside the left stack's
-// rows (tickets = 2 rows, Reviews-row = 1, Manager-row = 1 → 4 icons).
+// Select-sessions toggle. Fixed-size and centered as a block in the column
+// (CROW-922), not stretched to divide its height.
 function sidebarIconColumn() {
   const col = el('div', 'sidebar-right');
   // Notification center (CROW-909): bell + unread badge, first so it's the most

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -1323,9 +1323,9 @@ function sidebarLeftStack() {
   // Row 2: the primary Manager pill, spanning the full left-column width. Only
   // appended when a primary manager exists — an empty .nav-pills-row still consumes
   // a flex-gap slot, so appending one would leave a stray 6px gap below row 1. (The
-  // separate concern — a shorter left column dividing the right icon column's four
-  // flex:1 buttons below the 24px WCAG floor on a Manager-less / cold-start render —
-  // is handled by `.sidebar-right > button { min-height: 24px }`, not by this guard.)
+  // right icon column no longer divides the left column's height — its buttons are a
+  // fixed-size centered stack since CROW-922 — so a Manager-less render can't shrink
+  // them below the WCAG floor.)
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
     const row2 = el('div', 'nav-pills-row');

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -375,21 +375,31 @@ import Testing
             "the relocated Select toggle needs its .nav-select styles")
     }
 
-    /// CROW-917/922: two layout decisions with no other pin, both verified to regress
-    /// silently (deleting either leaves every suite green). The right column's icon
-    /// buttons are fixed-size with a `min-height` floor (CROW-922 replaced the earlier
-    /// flex:1 divide-the-column-height), keeping them above the WCAG 2.2 §2.5.8
-    /// target-size minimum and grow-safe against a raised browser min-font-size; and
-    /// relocating the new-manager `"+"` into that column (out of the nav rows) is half
-    /// this PR's purpose, yet the Select pin above only anchors on `.nav-select`.
+    /// CROW-917/922: layout decisions with no other pin, verified to regress silently
+    /// (reverting any leaves every suite green). CROW-922 made the right column's icon
+    /// buttons natural-size (`flex: 0 0 auto`) with a `min-height` floor above the WCAG
+    /// 2.2 §2.5.8 target-size minimum, and centers the stack (`justify-content: center`)
+    /// so the non-stretching buttons don't bunch at the top under `align-items: stretch`
+    /// — both pinned as whole-rule text below, so a revert to `flex: 1 1 0` or a dropped
+    /// `justify-content` is caught, not just a changed floor value. Separately, relocating
+    /// the new-manager `"+"` into that column (out of the nav rows) is half CROW-917's
+    /// purpose, yet the Select pin above only anchors on `.nav-select`.
     @Test func iconColumnHasWcagFloorAndHoldsTheNewManagerButton() throws {
-        // stripComments the CSS: the floor's value is also named in the rule's doc
-        // comment, so a bare whole-file `contains` false-passes off the prose once
-        // the declaration itself is deleted (caught by mutation-testing this pin).
+        // stripComments the CSS: the floor value + `flex: 0 0 auto` are also named in the
+        // rules' doc comments, so a whole-file `contains` would false-pass off the prose
+        // once a declaration is deleted (this pin is mutation-checked against that).
         let css = Self.stripComments(try Self.webAsset("app.css"))
+        // Pin the whole button rule, not just the floor: the CROW-922 regressions to
+        // guard are `flex: 1 1 0` creeping back (buttons stretch again) and losing the
+        // 28px floor, so anchor both to the `.sidebar-right > button` selector.
         #expect(
-            css.contains("min-height: 28px"),
-            "the right column's icon buttons need the min-height floor above the WCAG 2.5.8 target-size minimum (CROW-917/922)")
+            css.contains(".sidebar-right > button { flex: 0 0 auto; width: 100%; min-height: 28px; }"),
+            "the right column's buttons must be natural-size (flex:0 0 auto) with the 28px WCAG 2.5.8 floor, not flex-filling (CROW-917/922)")
+        // And that the column centers its now-non-stretching stack — dropping this leaves
+        // the buttons bunched at the top under `.sidebar-top`'s `align-items: stretch`.
+        #expect(
+            css.contains(".sidebar-right { flex: 0 0 auto; width: 30px; display: flex; flex-direction: column; justify-content: center; gap: 6px; }"),
+            "the right icon column must center its fixed-size button stack (CROW-922)")
         // Pin the append, not the `el('button', 'nav-plus', …)` construction: the
         // regression the review names is the "+" being built but not rendered, so a
         // `contains("'nav-plus'")` would miss a dropped appendChild (also mutation-checked).
@@ -400,10 +410,12 @@ import Testing
             "the new-manager \"+\" must be appended to the icon column, not the nav rows (CROW-917)")
     }
 
-    /// CROW-917: the ticket box spans the full width of the left column and is
-    /// only ~2 button-rows tall, so it lines up with the Notifications+Settings
-    /// pair in the right icon column. Pin `min-height` (NOT a hard `height`, which
-    /// would clip the counts row out the bottom when a raised browser min-font
+    /// CROW-917/922: the ticket box spans the full width of the left column and is
+    /// only ~2 button-rows tall. (Pre-CROW-922 the same `min-height` also lined the
+    /// box up with the right column's icon pair; that column no longer derives its
+    /// height from the left, so `min-height: 64px` is now just the box's own size, not
+    /// load-bearing for cross-column alignment.) Pin `min-height` (NOT a hard `height`,
+    /// which would clip the counts row out the bottom when a raised browser min-font
     /// grows them — the #913 fixed-px failure mode) and the single-row flex counts
     /// (the #913 two-column grid only existed to keep the width-capped box narrow;
     /// #917 supersedes that cap, so the counts are one horizontal row again).

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -375,21 +375,21 @@ import Testing
             "the relocated Select toggle needs its .nav-select styles")
     }
 
-    /// CROW-917: two layout decisions with no other pin, both verified to regress
-    /// silently (deleting either leaves every suite green). The right column's four
-    /// `flex:1` icons divide the left column's height, so a short Manager-less /
-    /// cold-start column would push them under the WCAG 2.2 §2.5.8 target-size
-    /// minimum without the `min-height` floor a prior review round mandated; and
-    /// relocating the new-manager `"+"` into that column (out of the nav rows) is
-    /// half this PR's purpose, yet the Select pin above only anchors on `.nav-select`.
+    /// CROW-917/922: two layout decisions with no other pin, both verified to regress
+    /// silently (deleting either leaves every suite green). The right column's icon
+    /// buttons are fixed-size with a `min-height` floor (CROW-922 replaced the earlier
+    /// flex:1 divide-the-column-height), keeping them above the WCAG 2.2 §2.5.8
+    /// target-size minimum and grow-safe against a raised browser min-font-size; and
+    /// relocating the new-manager `"+"` into that column (out of the nav rows) is half
+    /// this PR's purpose, yet the Select pin above only anchors on `.nav-select`.
     @Test func iconColumnHasWcagFloorAndHoldsTheNewManagerButton() throws {
         // stripComments the CSS: the floor's value is also named in the rule's doc
         // comment, so a bare whole-file `contains` false-passes off the prose once
         // the declaration itself is deleted (caught by mutation-testing this pin).
         let css = Self.stripComments(try Self.webAsset("app.css"))
         #expect(
-            css.contains("min-height: 24px"),
-            "the right column's icon buttons need the 24px WCAG 2.5.8 target-size floor (CROW-917 review)")
+            css.contains("min-height: 28px"),
+            "the right column's icon buttons need the min-height floor above the WCAG 2.5.8 target-size minimum (CROW-917/922)")
         // Pin the append, not the `el('button', 'nav-plus', …)` construction: the
         // regression the review names is the "+" being built but not rendered, so a
         // `contains("'nav-plus'")` would miss a dropped appendChild (also mutation-checked).


### PR DESCRIPTION
Closes #922

Follow-up to the two-column sidebar top (#918 / CROW-917). Two spacing/alignment tweaks now that the grid is in place — both in the served `web/app.css` (+ comment/guard updates in `web/app.js`).

## Changes
**Right icon column — group + center (was: spread across 4 rows).**
`.sidebar-right > button` no longer flex-fills the column (`flex: 1 1 0` → `flex: 0 0 auto`, fixed `height: 28px`), and `.sidebar-right` gains `justify-content: center`. The bell/gear/+/select buttons now read as one tight, vertically-centered stack instead of dividing the full column height. 28px stays above the WCAG 2.2 §2.5.8 24px target-size minimum, so the old `min-height: 24px` floor (and its coupling to the left column's height) is dropped. The bell's unread badge is `position: absolute` on `.tk-bell`, so it stays anchored to the bell.

**Ticket counts — group + center (was: edge-to-edge).**
`.tickets-counts` switches `justify-content: space-between` → `center` (gap 4px → 8px) so the 5 status mini-counts sit together, centered, in the wide box. Each `.tk-count` is content-sized, so glyph + number stay together.

Drift-prone comments in `app.css` and the Manager-pill guard note in `app.js` were rewritten to match the new fixed-size/centered behavior.

## Test plan
Visual (per ticket — subjective polish; box height and column width from #918 unchanged):
- Sidebar top right column: bell / gear / + / select sit as a centered block at natural size, no big vertical gaps; bell unread badge still pinned to the bell's top-right corner.
- Tickets box: the 5 status counts (Backlog · Ready · In Progress · In Review · Done·24h) sit grouped and centered, not stretched edge-to-edge.
- Cold-start / Manager-less render: icon buttons keep their 28px size (no shrink below the touch-target floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)