### PR TITLE
Sidebar: center the "Tickets" title in the tickets box (CROW-924)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -651,21 +651,28 @@ html, body {
      failure mode). The right icon column no longer divides the left's height
      (CROW-922), so growing here just makes the row taller — nothing to re-derive. */
   margin: 0; box-sizing: border-box; min-height: 64px;
+  /* Refresh-button edge, shared by .tickets-refresh's box and the mirror spacer track in
+     .tickets-head — one source of truth so the two can't drift and silently de-centre the
+     title (CROW-924). At/below the WCAG 2.2 §2.5.8 24px target min today; a future bump to
+     match the sibling icon column (app.css :688 uses 28px) is a one-token change here. */
+  --tk-refresh: 22px;
   display: flex; flex-direction: column; justify-content: space-between;
 }
 .tickets-card:hover { border-color: var(--border-strong); }
 .tickets-card.selected { border-color: var(--gold); }
 /* Centred title, refresh right (CROW-924): now the .tickets-card is full-width (CROW-922)
    the compact-card overlap that forced a left-aligned space-between row (CROW-913) is gone.
-   A 3-column grid — a spacer matching the button width, the title in 1fr, then the refresh —
-   centres the title relative to the whole box while the ↻ stays balanced at the right edge
-   and in-flow (no overlap even when the title ellipsises under a raised min-font-size). */
-.tickets-head { display: grid; grid-template-columns: 22px 1fr 22px; align-items: center; gap: 4px; }
+   A 3-column grid — a left spacer track that mirrors the button width via --tk-refresh, the
+   title in 1fr, then the refresh — centres the title relative to the whole box while the ↻
+   stays balanced at the right edge and in-flow (no overlap even when the title ellipsises
+   under a raised min-font-size). Both spacer and button read the one --tk-refresh so they
+   can't disagree and drift the title off-centre. */
+.tickets-head { display: grid; grid-template-columns: var(--tk-refresh) 1fr var(--tk-refresh); align-items: center; gap: 4px; }
 .tickets-title { grid-column: 2; text-align: center; color: var(--gold); font-weight: 700; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .tickets-refresh {
   grid-column: 3;
   display: inline-flex; align-items: center; justify-content: center;
-  width: 22px; height: 22px; padding: 0; border-radius: 6px; cursor: pointer; line-height: 1;
+  width: var(--tk-refresh); height: var(--tk-refresh); padding: 0; border-radius: 6px; cursor: pointer; line-height: 1;
   border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--text-secondary); font-size: 12px;
 }
 .tickets-refresh:hover { color: var(--text-primary); border-color: var(--border-strong); }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -655,14 +655,15 @@ html, body {
 }
 .tickets-card:hover { border-color: var(--border-strong); }
 .tickets-card.selected { border-color: var(--gold); }
-/* Title left, refresh right (CROW-913): the compact .tickets-card is too narrow for a
-   centred title + absolutely-positioned refresh (they overlap below ~110px), so the head
-   is a space-between row with the refresh in-flow. The title ellipsises only under a
-   heavily raised browser minimum-font-size, where the card also grows toward its cap. */
-.tickets-head { display: flex; align-items: center; justify-content: space-between; gap: 4px; }
-.tickets-title { color: var(--gold); font-weight: 700; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+/* Centred title, refresh right (CROW-924): now the .tickets-card is full-width (CROW-922)
+   the compact-card overlap that forced a left-aligned space-between row (CROW-913) is gone.
+   A 3-column grid — a spacer matching the button width, the title in 1fr, then the refresh —
+   centres the title relative to the whole box while the ↻ stays balanced at the right edge
+   and in-flow (no overlap even when the title ellipsises under a raised min-font-size). */
+.tickets-head { display: grid; grid-template-columns: 22px 1fr 22px; align-items: center; gap: 4px; }
+.tickets-title { grid-column: 2; text-align: center; color: var(--gold); font-weight: 700; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .tickets-refresh {
-  flex: 0 0 auto;
+  grid-column: 3;
   display: inline-flex; align-items: center; justify-content: center;
   width: 22px; height: 22px; padding: 0; border-radius: 6px; cursor: pointer; line-height: 1;
   border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--text-secondary); font-size: 12px;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -653,8 +653,9 @@ html, body {
   margin: 0; box-sizing: border-box; min-height: 64px;
   /* Refresh-button edge, shared by .tickets-refresh's box and the mirror spacer track in
      .tickets-head — one source of truth so the two can't drift and silently de-centre the
-     title (CROW-924). At/below the WCAG 2.2 §2.5.8 24px target min today; a future bump to
-     match the sibling icon column (app.css :688 uses 28px) is a one-token change here. */
+     title (CROW-924). 22px is below the WCAG 2.2 §2.5.8 24px target-size minimum; a bump to
+     match the sibling `.sidebar-right > button` (28px) is a one-token change here, deferred
+     to a repo-wide a11y pass (the whole #917→#923 sidebar chain sits under 24px too). */
   --tk-refresh: 22px;
   display: flex; flex-direction: column; justify-content: space-between;
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -431,4 +431,26 @@ import Testing
             !css.contains("width: max-content; max-width: 160px"),
             "the #913 content-sized width cap is superseded — the card is full-width in the left column now")
     }
+
+    /// CROW-924: the "Tickets" title centres in the full-width box, superseding the
+    /// left-pinning `space-between` head CROW-913 used while the card was compact. The
+    /// centring is a 3-column grid whose two outer tracks both read `--tk-refresh` — the
+    /// same token the refresh button sizes from — so the left spacer can't drift from the
+    /// button's width and silently de-centre the title. That single source of truth is the
+    /// durability fix; the two literal `22px`s it replaces were a standing, untested trap
+    /// (a WCAG target-size bump to one would de-centre with every suite still green). Pin
+    /// the whole grid rule (a revert to `space-between` or to hardcoded outer widths fails
+    /// here) and that the button derives its box from the same token.
+    @Test func ticketTitleCentresViaGrid() throws {
+        // stripComments: `--tk-refresh`, "grid", and "space-between" all appear in the
+        // .tickets-card / .tickets-head doc comments, so a raw-file `contains` would
+        // false-pass off the prose once a declaration is deleted (mutation-checked).
+        let css = Self.stripComments(try Self.webAsset("app.css"))
+        #expect(
+            css.contains(".tickets-head { display: grid; grid-template-columns: var(--tk-refresh) 1fr var(--tk-refresh); align-items: center; gap: 4px; }"),
+            "the title must centre via the var-driven 3-column grid, not a left-pinning space-between row (CROW-924)")
+        #expect(
+            css.contains("width: var(--tk-refresh); height: var(--tk-refresh);"),
+            "the refresh button must size from --tk-refresh so the mirror spacer track can't drift from it and de-centre the title (CROW-924)")
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -440,8 +440,9 @@ import Testing
     /// durability fix; the two literal `22px`s it replaces were a standing, untested trap
     /// (a WCAG target-size bump to one would de-centre with every suite still green). Pin
     /// the whole grid rule (a revert to `space-between` or to hardcoded outer widths fails
-    /// here), that the button derives its box from the same token, and that the token is
-    /// actually defined (a dangling var() drops the grid to `none` and the button to `auto`).
+    /// here), the title's own centre-track placement + alignment (the invariant itself),
+    /// that the button derives its box from the same token, and that the token is actually
+    /// defined (a dangling var() drops the grid to `none` and the button to `auto`).
     @Test func ticketTitleCentresViaGrid() throws {
         // stripComments: `--tk-refresh`, "grid", and "space-between" all appear in the
         // .tickets-card / .tickets-head doc comments, so a raw-file `contains` would
@@ -453,14 +454,25 @@ import Testing
         #expect(
             css.contains("width: var(--tk-refresh); height: var(--tk-refresh);"),
             "the refresh button must size from --tk-refresh so the mirror spacer track can't drift from it and de-centre the title (CROW-924)")
+        // Pin the title's own placement + alignment — the invariant this change exists for.
+        // Both declarations are load-bearing and drop silently: without `text-align: center`
+        // the title left-aligns in the 1fr track (the pre-CROW-924 look); without
+        // `grid-column: 2` too, the title (first child) auto-places into the 22px spacer
+        // track and ellipsises to nothing at the left edge. Anchor on the selector so a
+        // revert of either fails here.
+        #expect(
+            css.contains(".tickets-title { grid-column: 2; text-align: center;"),
+            "the title must sit in the centre track and centre its text there, or it auto-places into the 22px spacer (CROW-924)")
         // Pin the token's DEFINITION, not just its two consumers: an unresolvable var()
         // computes to the property's unset value — grid-template-columns → `none` (the
         // explicit grid vanishes, title no longer centred or ellipsising) and the button's
         // width/height → `auto` (collapses to the glyph, losing the CROW-797 stationary box).
-        // stripComments drops the doc-comment mentions of the token, so this matches only the
-        // real declaration and fails if it's deleted (the mutation the review found green).
+        // stripComments drops the doc-comment mentions of the token, and `var(--tk-refresh)`
+        // has no colon, so `--tk-refresh:` matches ONLY the declaration and fails if it's
+        // deleted. Value-agnostic on purpose: the documented WCAG 2.5.8 bump (22px→28px)
+        // stays a genuine one-token edit here rather than a two-place change in this test too.
         #expect(
-            css.contains("--tk-refresh: 22px;"),
+            css.contains("--tk-refresh:"),
             "the --tk-refresh token both the head's spacer track and the button derive from must be defined, or the var() references resolve to `none`/`auto` (CROW-924)")
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -440,7 +440,8 @@ import Testing
     /// durability fix; the two literal `22px`s it replaces were a standing, untested trap
     /// (a WCAG target-size bump to one would de-centre with every suite still green). Pin
     /// the whole grid rule (a revert to `space-between` or to hardcoded outer widths fails
-    /// here) and that the button derives its box from the same token.
+    /// here), that the button derives its box from the same token, and that the token is
+    /// actually defined (a dangling var() drops the grid to `none` and the button to `auto`).
     @Test func ticketTitleCentresViaGrid() throws {
         // stripComments: `--tk-refresh`, "grid", and "space-between" all appear in the
         // .tickets-card / .tickets-head doc comments, so a raw-file `contains` would
@@ -452,5 +453,14 @@ import Testing
         #expect(
             css.contains("width: var(--tk-refresh); height: var(--tk-refresh);"),
             "the refresh button must size from --tk-refresh so the mirror spacer track can't drift from it and de-centre the title (CROW-924)")
+        // Pin the token's DEFINITION, not just its two consumers: an unresolvable var()
+        // computes to the property's unset value — grid-template-columns → `none` (the
+        // explicit grid vanishes, title no longer centred or ellipsising) and the button's
+        // width/height → `auto` (collapses to the glyph, losing the CROW-797 stationary box).
+        // stripComments drops the doc-comment mentions of the token, so this matches only the
+        // real declaration and fails if it's deleted (the mutation the review found green).
+        #expect(
+            css.contains("--tk-refresh: 22px;"),
+            "the --tk-refresh token both the head's spacer track and the button derive from must be defined, or the var() references resolve to `none`/`auto` (CROW-924)")
     }
 }


### PR DESCRIPTION
Closes #924

Follow-up to the sidebar tickets box chain (#918 → #923). Small alignment tweak: center the **"Tickets"** title in the box rather than pinning it flush-left.

## What changed
`.tickets-head` (`app.css`) goes from a `space-between` flex row to a 3-column grid:

```css
.tickets-head  { display: grid; grid-template-columns: 22px 1fr 22px; align-items: center; gap: 4px; }
.tickets-title { grid-column: 2; text-align: center; … }
.tickets-refresh { grid-column: 3; … }
```

- A **button-width spacer** (col 1, 22px) balances the refresh button (col 3, 22px), so the title in the middle `1fr` track centers relative to the **whole box** — not just the space left of ↻.
- The ↻ stays **in-flow** in its own column, so it never overlaps the title even when the title ellipsises under a raised browser min-font-size. This is the overlap the CROW-913 comment was guarding against on the old compact card; now that the card is full-width (CROW-922) that constraint is gone, which the rewritten comment records.

No DOM change (`ticketsCard` head is still `[title, refresh]` — the refresh is pinned to col 3 explicitly so grid auto-placement doesn't drop it in the empty col 1).

## Untouched
Refresh hover / disabled / `.spinning` states (CROW-797) — unchanged; box size and counts from CROW-922 stay as-is.

## Test plan
- Open the sidebar: **"Tickets"** reads centered in the box; ↻ sits at the right edge.
- Hover ↻ (chrome highlights), click it → spinner turns inside a stationary button; title stays centered while refreshing.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow