### PR TITLE
CI: capture Swift test coverage and upload it as a build artifact (CROW-928)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,24 @@ jobs:
             # --no-parallel: the CrowIPC socket tests spin up real servers with
             # blocking I/O; running them in parallel starves each other on the
             # constrained CI runner and intermittently hits the read timeout.
-            swift test --no-parallel --package-path "Packages/$pkg"
+            # --enable-code-coverage leaves an llvm-cov export under
+            # Packages/$pkg/.build/<triple>/debug/codecov/ for the step below.
+            swift test --no-parallel --enable-code-coverage --package-path "Packages/$pkg"
           done
+
+      # Measurement only — no gate, no ratchet, no third-party upload (CROW-928).
+      # This lane can only ever see the 12 packages above: the 5 Darwin-only ones
+      # (CrowEngine, CrowDaemon, CrowTerminal, CrowTelemetry, CrowAutostart) are
+      # ~64% of the tree and refresh at release tags, per ADR 0007. The full
+      # picture lives in release.yml's macOS test job.
+      - name: Summarize coverage
+        run: bash scripts/coverage-summary.sh
+
+      - name: Upload coverage summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary-linux
+          path: coverage/
 
   # Source-level drift gates: cheap text checks that need no Swift build, so they
   # cover packages the Linux lane above cannot compile. `check-cli-parity.sh` is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,28 +59,45 @@ jobs:
                           CrowAntigravity CrowGit CrowOpenCode CrowGrok CrowPersistence CrowProvider CrowCLI)
           for pkg in "${LINUX_PACKAGES[@]}"; do
             echo "==> Building & testing $pkg on Linux..."
-            swift build --package-path "Packages/$pkg"
+            # --enable-code-coverage on BOTH invocations, deliberately: toggling
+            # the flag invalidates SwiftPM's build plan, so an uninstrumented
+            # build here would be thrown away and recompiled from scratch by the
+            # instrumented `swift test` below. That is a full second compile of
+            # all 12 packages on a lane that keeps no compiled products between
+            # runs (ADR 0007) — sharing the flag makes the build reusable.
+            swift build --enable-code-coverage --package-path "Packages/$pkg"
             # --no-parallel: the CrowIPC socket tests spin up real servers with
             # blocking I/O; running them in parallel starves each other on the
             # constrained CI runner and intermittently hits the read timeout.
-            # --enable-code-coverage leaves an llvm-cov export under
-            # Packages/$pkg/.build/<triple>/debug/codecov/ for the step below.
+            # The export lands at Packages/$pkg/.build/<triple>/debug/codecov/.
             swift test --no-parallel --enable-code-coverage --package-path "Packages/$pkg"
           done
 
       # Measurement only — no gate, no ratchet, no third-party upload (CROW-928).
-      # This lane can only ever see the 12 packages above: the 5 Darwin-only ones
-      # (CrowEngine, CrowDaemon, CrowTerminal, CrowTelemetry, CrowAutostart) are
-      # ~64% of the tree and refresh at release tags, per ADR 0007. The full
-      # picture lives in release.yml's macOS test job.
+      # This lane measures only what LINUX_PACKAGES lists; the rest of the tree is
+      # ~64% of the lines and refreshes at release tags, per ADR 0007.
+      #
+      # "Not in the allow-list" is not the same as "cannot build here":
+      # CrowAutostart is #if canImport-guarded and CrowCLI links it, so it does
+      # compile on Linux and shows up in the report as a "—" row (linked, never
+      # tested in this lane) rather than as a measured number. Adding it to
+      # LINUX_PACKAGES would turn that into a real figure — deliberately left as
+      # a follow-up, since ADR 0007 wants allow-list changes made consciously.
       - name: Summarize coverage
-        run: bash scripts/coverage-summary.sh
+        if: always()
+        run: bash scripts/coverage-summary.sh --allow-empty
 
+      # always(): a red suite is exactly when the covered/uncovered split is worth
+      # having. The summary describes only the exports that exist, so a lane that
+      # died partway yields a smaller table, never a wrong one.
       - name: Upload coverage summary
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-summary-linux
           path: coverage/
+          if-no-files-found: ignore
+          retention-days: 30
 
   # Source-level drift gates: cheap text checks that need no Swift build, so they
   # cover packages the Linux lane above cannot compile. `check-cli-parity.sh` is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,21 @@ jobs:
           for pkg in Packages/*/; do
             if [ -d "$pkg/Tests" ]; then
               echo "==> Testing $(basename "$pkg")..."
-              swift test --package-path "$pkg"
+              swift test --enable-code-coverage --package-path "$pkg"
             fi
           done
+
+      # The only lane that measures all 17 packages — the PR lane is Linux and
+      # cannot compile the 5 Darwin-only ones, which are ~64% of the tree and
+      # include the two worst-covered (ADR 0007, CROW-928).
+      - name: Summarize coverage
+        run: bash scripts/coverage-summary.sh
+
+      - name: Upload coverage summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary-macos
+          path: coverage/
 
   shellcheck:
     name: Shell Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,17 +28,21 @@ jobs:
             fi
           done
 
-      # The only lane that measures all 17 packages — the PR lane is Linux and
-      # cannot compile the 5 Darwin-only ones, which are ~64% of the tree and
-      # include the two worst-covered (ADR 0007, CROW-928).
+      # The only lane that measures every package with a test target — the PR
+      # lane runs an explicit 12-package allow-list (ADR 0007), which leaves out
+      # ~64% of the lines, including the two worst-covered packages (CROW-928).
       - name: Summarize coverage
-        run: bash scripts/coverage-summary.sh
+        if: always()
+        run: bash scripts/coverage-summary.sh --allow-empty
 
       - name: Upload coverage summary
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-summary-macos
           path: coverage/
+          if-no-files-found: ignore
+          retention-days: 30
 
   shellcheck:
     name: Shell Lint

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ DerivedData/
 *.xcworkspace
 xcuserdata/
 
+# Coverage summaries (`make coverage`) — uploaded as a CI artifact, never committed
+coverage/
+
 # Generated sources
 Sources/Crow/Generated/
 Sources/CrowCLI/Generated/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,15 +42,15 @@ swift test        # Also works (runs root package tests)
 make coverage     # Full sweep with instrumentation (~30 min) → coverage/coverage-summary.{json,md}
 ```
 
-Tests use the Swift Testing framework (`@Test` macros). Currently, tests exist
-in `CrowCore`. When adding new functionality to any package, include a test
+Tests use the Swift Testing framework (`@Test` macros) and live under
+`Packages/*/Tests/`. When adding new functionality to any package, include a test
 target in that package's `Package.swift` and add tests.
 
-`make coverage` produces the same two files CI attaches to every run as the
-`coverage-summary-*` artifact (`gh run download -n coverage-summary-linux`).
-Nothing gates on the numbers — they are there so a change can be seen, not
-enforced. Note that the PR artifact only covers the 12 Linux-buildable
-packages; all 17 are measured only at release tags
+`make coverage` produces the same two files CI attaches as the `coverage-summary-*`
+artifact (`gh run download -n coverage-summary-linux`). Nothing gates on the
+numbers — they are there so a change can be seen, not enforced. Note that the
+per-PR artifact only covers the 12 Linux-buildable packages; every package with a
+test target is measured only on release tags
 (see [ADR 0007](docs/adr/0007-linux-ci-swift.md)).
 
 ## Code Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,19 @@ make build
 ```bash
 make test         # Preferred — runs all package tests
 swift test        # Also works (runs root package tests)
+make coverage     # Full sweep with instrumentation (~30 min) → coverage/coverage-summary.{json,md}
 ```
 
 Tests use the Swift Testing framework (`@Test` macros). Currently, tests exist
 in `CrowCore`. When adding new functionality to any package, include a test
 target in that package's `Package.swift` and add tests.
+
+`make coverage` produces the same two files CI attaches to every run as the
+`coverage-summary-*` artifact (`gh run download -n coverage-summary-linux`).
+Nothing gates on the numbers — they are there so a change can be seen, not
+enforced. Note that the PR artifact only covers the 12 Linux-buildable
+packages; all 17 are measured only at release tags
+(see [ADR 0007](docs/adr/0007-linux-ci-swift.md)).
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -106,12 +106,17 @@ test:
 # byte-comparable over the same package set. This is a full sweep — budget ~30
 # minutes. All 17 packages build here; the Linux PR lane sees only 12, so its
 # artifact reports a different (smaller) tree. See docs/adr/0007-linux-ci-swift.md.
+#
+# `|| exit 1` matters: a shell for-loop does not abort on a failing iteration and
+# a recipe's status is the last iteration's, so without it a suite failing at
+# package 4 of 17 would still print an authoritative-looking table — built partly
+# from the *previous* run's export for the package that just failed — and exit 0.
 coverage:
 	@bash scripts/generate-build-info.sh
 	@for pkg in Packages/*/; do \
 		if [ -d "$$pkg/Tests" ]; then \
 			echo "==> Testing $$(basename $$pkg) with coverage..."; \
-			swift test --enable-code-coverage --package-path "$$pkg"; \
+			swift test --enable-code-coverage --package-path "$$pkg" || exit 1; \
 		fi; \
 	done
 	@bash scripts/coverage-summary.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build daemon app run setup install uninstall clean check test parity help daemon-run docs
+.PHONY: build daemon app run setup install uninstall clean check test coverage parity help daemon-run docs
 
 # Install destination and build config (override on the command line, e.g.
 # `make install BINDIR=/usr/local/bin` or `make build CONFIG=release`).
@@ -53,6 +53,7 @@ help:
 	@echo "  setup      Check build prerequisites"
 	@echo "  check      Verify all build and runtime prerequisites"
 	@echo "  test       Run all package tests, then the parity gates"
+	@echo "  coverage   Run all package tests with coverage → coverage/coverage-summary.{json,md}"
 	@echo "  parity     Run just the source-level drift gates (catalogs + CLI/RPC parity)"
 	@echo "  docs       Regenerate docs/cli.md from the CLI's ArgumentParser metadata"
 	@echo "  install    Symlink crow + crowd into ~/.local/bin (override BINDIR=, CONFIG=release)"
@@ -98,6 +99,22 @@ test:
 		fi; \
 	done
 	@$(MAKE) --no-print-directory parity
+
+# Local twin of the CI coverage artifact (CROW-928). Runs the same suites as
+# `test` with instrumentation, then merges the per-package llvm-cov exports
+# through the same script CI uses, so a local run and a downloaded artifact are
+# byte-comparable over the same package set. This is a full sweep — budget ~30
+# minutes. All 17 packages build here; the Linux PR lane sees only 12, so its
+# artifact reports a different (smaller) tree. See docs/adr/0007-linux-ci-swift.md.
+coverage:
+	@bash scripts/generate-build-info.sh
+	@for pkg in Packages/*/; do \
+		if [ -d "$$pkg/Tests" ]; then \
+			echo "==> Testing $$(basename $$pkg) with coverage..."; \
+			swift test --enable-code-coverage --package-path "$$pkg"; \
+		fi; \
+	done
+	@bash scripts/coverage-summary.sh
 
 # Source-level drift gates. Cheap, no build required, and both also run in CI —
 # see the `parity` job in .github/workflows/ci.yml.

--- a/docs/adr/0007-linux-ci-swift.md
+++ b/docs/adr/0007-linux-ci-swift.md
@@ -21,7 +21,7 @@ PR CI and cache-warm run on `ubuntu-latest` inside the official `swift:6` contai
 - **The root `CrowTests` suite moves from every-PR to release-tag time.** Those tests `@testable import Crow`, and the root `Crow` target imports `CrowTerminal` (AppKit), so they cannot run in the Linux PR lane. They exercise root-target business logic (IssueTracker, Job decisions, Scaffolder, SessionService, …), not just GUI, so to avoid dropping that coverage entirely they now run in `release.yml`'s macOS `test` job at tag time — not on every PR. A logic regression there is caught at release, not on the PR that introduces it.
 - The Linux allow-list in `ci.yml`/`cache-warm.yml` must be updated by hand when a new Linux-compilable package is added. This is deliberate: a glob would silently try to build a new macOS-only package on Linux and turn CI red.
 - Only the SwiftPM dependency cache (`~/.cache/org.swift.swiftpm`) is retained, not compiled `.build` products, so each Linux run recompiles the packages from scratch. Acceptable given each package builds under its own `Packages/$pkg/.build`.
-- `CrowTelemetry` (Apple `Network.framework`) is excluded; it has no test target and nothing in the allow-list depends on it, so excluding it costs no test coverage.
+- `CrowTelemetry` (Apple `Network.framework`) is excluded because it does not compile on Linux, and nothing in the allow-list depends on it. It *does* have a test target — 5 test files, ~1,500 executable lines — so unlike the note originally recorded here, excluding it does cost test coverage on PRs; those tests run only in `release.yml`. (Corrected 2026-07-30 while adding coverage measurement, CROW-928.)
 
 ## Alternatives considered
 

--- a/scripts/coverage-summary.sh
+++ b/scripts/coverage-summary.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Collect Swift test coverage into one repo-wide summary (CROW-928).
+#
+# `swift test --enable-code-coverage` leaves an llvm-cov export at
+# Packages/<Pkg>/.build/<triple>/debug/codecov/<Pkg>.json. This gathers whatever
+# exports are on disk, merges them (scripts/coverage-summary.swift does the
+# arithmetic — read its header for the two ways this can silently go wrong), and
+# writes coverage-summary.json + coverage-summary.md into the output directory.
+#
+# It reports on exactly the packages that were tested, so the numbers differ by
+# lane on purpose: the Linux PR lane covers the 12 packages in ci.yml's
+# LINUX_PACKAGES allow-list (~36% of the tree), while release.yml's macOS job
+# is the only place all 17 are measured — see docs/adr/0007-linux-ci-swift.md.
+# It does not run the tests itself; `make coverage` is the local front door.
+#
+#   bash scripts/coverage-summary.sh [OUT_DIR]     # default: coverage/
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+OUT_DIR="${1:-coverage}"
+
+# Pin the depth so this can only match Packages/<Pkg>/.build/<triple>/debug/
+# codecov/<file>.json. `find` does not follow the .build/debug symlink, so each
+# export is seen once. LC_ALL=C keeps the ordering (and therefore the output)
+# identical across machines.
+REPORTS=()
+while IFS= read -r report; do
+  REPORTS+=("$report")
+done < <(find Packages -mindepth 6 -maxdepth 6 -type f \
+              -path 'Packages/*/.build/*/debug/codecov/*.json' | LC_ALL=C sort)
+
+if [ ${#REPORTS[@]} -eq 0 ]; then
+  echo "ERROR: no coverage exports found under Packages/*/.build/*/debug/codecov/." >&2
+  echo "       Run the suites with coverage instrumentation first, e.g. 'make coverage'" >&2
+  echo "       or 'swift test --enable-code-coverage --package-path Packages/<Pkg>'." >&2
+  exit 1
+fi
+
+echo "==> Merging ${#REPORTS[@]} coverage export(s) into $OUT_DIR/"
+
+# Compile the merger rather than running it through `swift`'s interpreter mode:
+# both work, but an explicit swiftc build behaves identically on macOS and inside
+# the Linux swift container and surfaces compile errors plainly. The toolchain is
+# already present in every lane that could have produced the exports above, so
+# this adds a dependency on nothing new.
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+swiftc -O -o "$WORK_DIR/coverage-summary" "$ROOT/scripts/coverage-summary.swift"
+"$WORK_DIR/coverage-summary" "$ROOT" "$OUT_DIR" "${REPORTS[@]}"

--- a/scripts/coverage-summary.sh
+++ b/scripts/coverage-summary.sh
@@ -13,13 +13,32 @@
 # is the only place all 17 are measured — see docs/adr/0007-linux-ci-swift.md.
 # It does not run the tests itself; `make coverage` is the local front door.
 #
-#   bash scripts/coverage-summary.sh [OUT_DIR]     # default: coverage/
+#   bash scripts/coverage-summary.sh [--allow-empty] [OUT_DIR]   # default: coverage/
+#
+# --allow-empty downgrades "no exports on disk" from an error to a notice. CI
+# passes it because the summarize step runs with if: always(), and a lane that
+# died before any suite finished should not add a second, misleading red step on
+# top of the real failure. `make coverage` does not pass it, so a developer who
+# runs this against an uninstrumented tree still gets told plainly.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-OUT_DIR="${1:-coverage}"
+ALLOW_EMPTY=0
+OUT_DIR="coverage"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --allow-empty) ALLOW_EMPTY=1 ;;
+    -*)
+      echo "ERROR: unknown option: $1" >&2
+      echo "usage: coverage-summary.sh [--allow-empty] [OUT_DIR]" >&2
+      exit 2
+      ;;
+    *) OUT_DIR="$1" ;;
+  esac
+  shift
+done
 
 # Pin the depth so this can only match Packages/<Pkg>/.build/<triple>/debug/
 # codecov/<file>.json. `find` does not follow the .build/debug symlink, so each
@@ -32,6 +51,10 @@ done < <(find Packages -mindepth 6 -maxdepth 6 -type f \
               -path 'Packages/*/.build/*/debug/codecov/*.json' | LC_ALL=C sort)
 
 if [ ${#REPORTS[@]} -eq 0 ]; then
+  if [ "$ALLOW_EMPTY" -eq 1 ]; then
+    echo "==> No coverage exports on disk; nothing to summarize."
+    exit 0
+  fi
   echo "ERROR: no coverage exports found under Packages/*/.build/*/debug/codecov/." >&2
   echo "       Run the suites with coverage instrumentation first, e.g. 'make coverage'" >&2
   echo "       or 'swift test --enable-code-coverage --package-path Packages/<Pkg>'." >&2

--- a/scripts/coverage-summary.swift
+++ b/scripts/coverage-summary.swift
@@ -1,0 +1,409 @@
+#!/usr/bin/env swift
+// Merge the per-package llvm-cov exports SwiftPM writes under
+// Packages/<Pkg>/.build/<triple>/debug/codecov/<Pkg>.json into one repo-wide
+// summary (CROW-928). Driven by scripts/coverage-summary.sh — see that file for
+// the why; this one is the arithmetic.
+//
+// Written in Swift rather than Python/jq on purpose: the PR lane runs inside the
+// `swift:6.1` container, which ships neither a `python3` interpreter nor `jq`
+// (its Python is `libpython3-dev` — headers and stdlib for LLDB, no binary).
+// Swift is the one language guaranteed present in *both* CI lanes and on any
+// machine that can run `make coverage`, so leaning on it keeps the ticket's "no
+// new dependencies" constraint honest.
+//
+// Two things this has to get right, both of which quietly produce garbage if
+// skipped:
+//
+//   1. A test binary compiles its dependencies, so a package's raw export
+//      describes far more than that package. CrowGit's own JSON reports ~3,700
+//      lines at 6% — that is CrowCore and friends dragged in by the link, not
+//      CrowGit. Every file is therefore attributed to the package that *owns*
+//      its source (Packages/<Pkg>/Sources/…), and everything else in an export
+//      is dropped from that package's row.
+//
+//   2. The same source file appears in several exports with different numbers:
+//      covered where some suite exercised it, cold where another package merely
+//      linked it. Summing would double-count and averaging would punish a file
+//      for binaries that never called it, so files are folded across exports by
+//      taking the *maximum* covered.
+//
+// Hence two numbers per file, and they answer different questions:
+//
+//   - own suite  — what <Pkg>'s own tests reach. The actionable one: it names
+//                  the suite to go improve, and it is what the per-package table
+//                  reports.
+//   - any suite  — the max across every binary that linked the file. A CrowCore
+//                  line exercised by CrowEngine's tests is exercised, whatever
+//                  CrowGit's binary saw. The repo total is this, which is why it
+//                  is better than the sum of the table's own-suite columns.
+//
+// Output is deterministic and free of timestamps, hostnames, and absolute
+// paths: the same commit measured over the same package set produces identical
+// bytes locally and in CI. The JSON is emitted by hand rather than through
+// JSONSerialization for the same reason — Darwin escapes `/` as `\/` and
+// swift-corelibs-foundation does not, which would make the two lanes disagree
+// byte-for-byte over nothing.
+//
+// usage: swift scripts/coverage-summary.swift <repo-root> <out-dir> <export.json>…
+
+import Foundation
+
+// MARK: - llvm-cov export shape (the handful of fields we read)
+
+struct Export: Decodable {
+    let data: [Block]
+}
+
+struct Block: Decodable {
+    let files: [FileEntry]
+}
+
+struct FileEntry: Decodable {
+    let filename: String
+    let summary: FileSummary
+}
+
+struct FileSummary: Decodable {
+    let lines: Counter
+    let regions: Counter
+}
+
+struct Counter: Decodable {
+    let count: Int
+    let covered: Int
+}
+
+// MARK: - Tallies
+
+struct Metric {
+    var count = 0
+    var covered = 0
+
+    var missed: Int { max(0, count - covered) }
+    var percent: Double { count == 0 ? 0 : Double(covered) * 100 / Double(count) }
+
+    static func += (lhs: inout Metric, rhs: Metric) {
+        lhs.count += rhs.count
+        lhs.covered += rhs.covered
+    }
+
+    /// Fold in another binary's view of the same file. Counts should already
+    /// agree (same source, same compiler); `max` keeps a truncated export from
+    /// shrinking the denominator.
+    mutating func absorb(_ other: Metric) {
+        count = max(count, other.count)
+        covered = max(covered, other.covered)
+    }
+}
+
+struct Coverage {
+    var lines = Metric()
+    var regions = Metric()
+
+    static func += (lhs: inout Coverage, rhs: Coverage) {
+        lhs.lines += rhs.lines
+        lhs.regions += rhs.regions
+    }
+
+    mutating func absorb(_ other: Coverage) {
+        lines.absorb(other.lines)
+        regions.absorb(other.regions)
+    }
+}
+
+struct FileCoverage {
+    var ownSuite = Coverage()
+    var anySuite = Coverage()
+}
+
+struct PackageCoverage {
+    var name: String
+    /// False when this package's own export was not among the inputs — it was
+    /// seen only because something else linked its sources. Distinguishes "no
+    /// suite ran here" from "the suite covers nothing", which otherwise look
+    /// identical and turn the PR artifact into a false alarm.
+    var ownSuiteMeasured = false
+    var ownSuite = Coverage()
+    var anySuite = Coverage()
+    var files: [(path: String, coverage: FileCoverage)] = []
+}
+
+// MARK: - Formatting helpers (locale-independent, so output stays byte-stable)
+
+func fixed(_ value: Double, _ places: Int) -> String {
+    String(format: "%.\(places)f", value)
+}
+
+/// 40502 → "40,502". Foundation's number formatters are locale-sensitive and
+/// differ across platforms; this does not.
+func grouped(_ value: Int) -> String {
+    let digits = Array(String(abs(value)))
+    var out: [Character] = []
+    for (offset, digit) in digits.enumerated() {
+        if offset > 0, (digits.count - offset) % 3 == 0 { out.append(",") }
+        out.append(digit)
+    }
+    return (value < 0 ? "-" : "") + String(out)
+}
+
+func jsonString(_ raw: String) -> String {
+    var out = "\""
+    for scalar in raw.unicodeScalars {
+        switch scalar {
+        case "\"": out += "\\\""
+        case "\\": out += "\\\\"
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            if scalar.value < 0x20 {
+                out += String(format: "\\u%04x", scalar.value)
+            } else {
+                out.unicodeScalars.append(scalar)
+            }
+        }
+    }
+    return out + "\""
+}
+
+func die(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("coverage-summary: \(message)\n".utf8))
+    exit(1)
+}
+
+// MARK: - Arguments
+
+let argv = CommandLine.arguments
+guard argv.count >= 4 else {
+    die("usage: swift scripts/coverage-summary.swift <repo-root> <out-dir> <export.json>…")
+}
+
+let repoRoot = argv[1].hasSuffix("/") ? String(argv[1].dropLast()) : argv[1]
+let outDir = argv[2]
+let reports = Array(argv.dropFirst(3))
+
+/// llvm-cov records absolute source paths. Re-root them so the report is
+/// portable — and so a file seen through two different exports collapses to one
+/// key. The `/Packages/` fallback covers the case where the compiler recorded a
+/// resolved path (`/private/var/…`) that no longer shares a prefix with the
+/// root we were handed.
+func repoRelative(_ absolute: String) -> String? {
+    if absolute.hasPrefix(repoRoot + "/") {
+        return String(absolute.dropFirst(repoRoot.count + 1))
+    }
+    if let hit = absolute.range(of: "/Packages/") {
+        return String(absolute[absolute.index(after: hit.lowerBound)...])
+    }
+    return nil
+}
+
+/// A file counts only when it is the *source* of some package — that is the
+/// dependency-scoping rule from gotcha 1. Returns the owning package name.
+func owningPackage(of relative: String) -> String? {
+    // SwiftPM's generated XCTest/swift-testing entry point lands in the export
+    // as `…/<Pkg>PackageTests.derived/runner.swift`. It lives under .build so
+    // the Sources check below already rejects it; the explicit guard documents
+    // that this is deliberate rather than incidental.
+    guard !relative.contains(".derived/") else { return nil }
+
+    let parts = relative.split(separator: "/", omittingEmptySubsequences: false)
+    guard parts.count > 3, parts[0] == "Packages", parts[2] == "Sources" else { return nil }
+    return String(parts[1])
+}
+
+/// Which package's test binary produced this export, from
+/// `Packages/<Pkg>/.build/<triple>/debug/codecov/<Pkg>.json`. Used to tell "my
+/// own suite covered this" from "something that linked me did".
+func producingPackage(of reportPath: String) -> String? {
+    let relative = repoRelative(reportPath) ?? reportPath
+    let parts = relative.split(separator: "/", omittingEmptySubsequences: false)
+    guard parts.count > 2, parts[0] == "Packages" else { return nil }
+    return String(parts[1])
+}
+
+// MARK: - Merge
+
+var merged: [String: FileCoverage] = [:]
+var measuredPackages: Set<String> = []
+
+for report in reports {
+    guard let blob = FileManager.default.contents(atPath: report) else {
+        die("cannot read \(report)")
+    }
+    let export: Export
+    do {
+        export = try JSONDecoder().decode(Export.self, from: blob)
+    } catch {
+        die("\(report) is not an llvm-cov export: \(error)")
+    }
+    let producer = producingPackage(of: report)
+    if let producer { measuredPackages.insert(producer) }
+
+    for block in export.data {
+        for file in block.files {
+            guard let relative = repoRelative(file.filename),
+                  let owner = owningPackage(of: relative) else { continue }
+
+            let observed = Coverage(
+                lines: Metric(count: file.summary.lines.count, covered: file.summary.lines.covered),
+                regions: Metric(count: file.summary.regions.count, covered: file.summary.regions.covered)
+            )
+
+            var entry = merged[relative] ?? FileCoverage()
+            entry.anySuite.absorb(observed)
+            if owner == producer { entry.ownSuite.absorb(observed) }
+            merged[relative] = entry
+        }
+    }
+}
+
+guard !merged.isEmpty else {
+    die("""
+        no package sources found in \(reports.count) export(s).
+        Expected files under Packages/<Pkg>/Sources/ — was the repo root (\(repoRoot)) correct?
+        """)
+}
+
+// How many executable lines a file has is a property of the source, not of
+// which binary measured it, so both views share one denominator. For a package
+// with its own test target the two counts already agree; this matters for a
+// package that has none, whose own-suite export does not exist — without it
+// such a package would read "0 lines, 0 missed" instead of "0% of N, all N
+// missed", which is the truth.
+for (path, coverage) in merged {
+    var normalized = coverage
+    normalized.ownSuite.lines.count = coverage.anySuite.lines.count
+    normalized.ownSuite.regions.count = coverage.anySuite.regions.count
+    merged[path] = normalized
+}
+
+// MARK: - Roll up
+
+var packages: [String: PackageCoverage] = [:]
+var total = Coverage()
+
+for (path, coverage) in merged {
+    guard let owner = owningPackage(of: path) else { continue }
+    var bucket = packages[owner] ?? PackageCoverage(name: owner)
+    bucket.ownSuiteMeasured = measuredPackages.contains(owner)
+    bucket.ownSuite += coverage.ownSuite
+    bucket.anySuite += coverage.anySuite
+    bucket.files.append((path: path, coverage: coverage))
+    packages[owner] = bucket
+
+    total += coverage.anySuite
+}
+
+// Worst first — the table exists to point at what needs tests. Packages whose
+// own suite did not run in this lane sort last: they have no own-suite number to
+// rank on, and leaving them at 0% would park them permanently at the top of a
+// list that is supposed to mean "fix these". Name breaks ties so the ordering is
+// total and the output stays byte-stable.
+var ranked: [PackageCoverage] = []
+for var pkg in packages.values {
+    pkg.files.sort { $0.path < $1.path }
+    ranked.append(pkg)
+}
+ranked.sort { lhs, rhs in
+    if lhs.ownSuiteMeasured != rhs.ownSuiteMeasured { return lhs.ownSuiteMeasured }
+    if lhs.ownSuiteMeasured, lhs.ownSuite.lines.percent != rhs.ownSuite.lines.percent {
+        return lhs.ownSuite.lines.percent < rhs.ownSuite.lines.percent
+    }
+    return lhs.name < rhs.name
+}
+
+// Packages present only as somebody else's dependency get a "—" row rather than
+// a fabricated 0%.
+let unmeasured = ranked.filter { !$0.ownSuiteMeasured }
+let measuredCount = ranked.count - unmeasured.count
+
+// MARK: - Emit
+
+func metricJSON(_ metric: Metric, indent: String) -> String {
+    """
+    {
+    \(indent)  "count": \(metric.count),
+    \(indent)  "covered": \(metric.covered),
+    \(indent)  "missed": \(metric.missed),
+    \(indent)  "percent": \(fixed(metric.percent, 2))
+    \(indent)}
+    """
+}
+
+func coverageJSON(_ coverage: Coverage, indent: String) -> String {
+    var out = "{\n"
+    out += "\(indent)  \"lines\": \(metricJSON(coverage.lines, indent: indent + "  ")),\n"
+    out += "\(indent)  \"regions\": \(metricJSON(coverage.regions, indent: indent + "  "))\n"
+    out += "\(indent)}"
+    return out
+}
+
+var json = "{\n"
+json += "  \"schemaVersion\": 1,\n"
+json += "  \"packageCount\": \(ranked.count),\n"
+json += "  \"measuredPackageCount\": \(measuredCount),\n"
+json += "  \"totals\": \(coverageJSON(total, indent: "  ")),\n"
+json += "  \"packages\": [\n"
+for (index, pkg) in ranked.enumerated() {
+    json += "    {\n"
+    json += "      \"name\": \(jsonString(pkg.name)),\n"
+    json += "      \"ownSuiteMeasured\": \(pkg.ownSuiteMeasured),\n"
+    json += "      \"ownSuite\": \(coverageJSON(pkg.ownSuite, indent: "      ")),\n"
+    json += "      \"anySuite\": \(coverageJSON(pkg.anySuite, indent: "      ")),\n"
+    json += "      \"files\": [\n"
+    for (fileIndex, entry) in pkg.files.enumerated() {
+        json += "        {\n"
+        json += "          \"path\": \(jsonString(entry.path)),\n"
+        json += "          \"ownSuite\": \(coverageJSON(entry.coverage.ownSuite, indent: "          ")),\n"
+        json += "          \"anySuite\": \(coverageJSON(entry.coverage.anySuite, indent: "          "))\n"
+        json += "        }\(fileIndex == pkg.files.count - 1 ? "" : ",")\n"
+    }
+    json += "      ]\n"
+    json += "    }\(index == ranked.count - 1 ? "" : ",")\n"
+}
+json += "  ]\n"
+json += "}\n"
+
+var markdown = "# Swift test coverage\n\n"
+markdown += "**Whole repo: \(fixed(total.lines.percent, 1))% line / "
+markdown += "\(fixed(total.regions.percent, 1))% region** — "
+markdown += "\(grouped(total.lines.count)) executable lines, \(grouped(total.lines.missed)) missed.\n\n"
+markdown += "\(measuredCount) package\(measuredCount == 1 ? "" : "s") measured, worst first. "
+markdown += "**Line %**, **Region %** and **Missed** are what each package's *own* test suite\n"
+markdown += "reaches — the number to act on. **Any suite %** additionally credits a file that some\n"
+markdown += "other package's tests exercised through a dependency, which is what the repo total\n"
+markdown += "above is computed from; that is why the total beats the Missed column's sum.\n\n"
+markdown += "| Package | Line % | Region % | Lines | Missed | Any suite % |\n"
+markdown += "|---|---:|---:|---:|---:|---:|\n"
+for pkg in ranked {
+    markdown += "| \(pkg.name)"
+    if pkg.ownSuiteMeasured {
+        markdown += " | \(fixed(pkg.ownSuite.lines.percent, 1))%"
+        markdown += " | \(fixed(pkg.ownSuite.regions.percent, 1))%"
+        markdown += " | \(grouped(pkg.anySuite.lines.count))"
+        markdown += " | \(grouped(pkg.ownSuite.lines.missed))"
+    } else {
+        markdown += " | — | — | \(grouped(pkg.anySuite.lines.count)) | —"
+    }
+    markdown += " | \(fixed(pkg.anySuite.lines.percent, 1))% |\n"
+}
+
+if unmeasured.isEmpty {
+    markdown += "\nPer-file numbers are in `coverage-summary.json`.\n"
+} else {
+    let names = unmeasured.map(\.name).joined(separator: ", ")
+    markdown += "\n**—** means this lane never ran that package's own suite; the sources were seen\n"
+    markdown += "only because another package linked them, so **Any suite %** is all the evidence\n"
+    markdown += "there is. Not a coverage regression. Affects: \(names).\n"
+    markdown += "\nPer-file numbers are in `coverage-summary.json`.\n"
+}
+
+do {
+    try FileManager.default.createDirectory(atPath: outDir, withIntermediateDirectories: true)
+    try json.write(toFile: "\(outDir)/coverage-summary.json", atomically: true, encoding: .utf8)
+    try markdown.write(toFile: "\(outDir)/coverage-summary.md", atomically: true, encoding: .utf8)
+} catch {
+    die("cannot write into \(outDir): \(error)")
+}
+
+print(markdown, terminator: "")

--- a/scripts/coverage-summary.swift
+++ b/scripts/coverage-summary.swift
@@ -184,15 +184,23 @@ let reports = Array(argv.dropFirst(3))
 
 /// llvm-cov records absolute source paths. Re-root them so the report is
 /// portable — and so a file seen through two different exports collapses to one
-/// key. The `/Packages/` fallback covers the case where the compiler recorded a
-/// resolved path (`/private/var/…`) that no longer shares a prefix with the
-/// root we were handed.
+/// key.
+///
+/// The `/Packages/` fallback covers the case where the compiler recorded a
+/// resolved path (`/private/var/…`) that no longer shares a prefix with the root
+/// we were handed. It is confirmed against the filesystem before being trusted:
+/// a dependency checked out at some path that merely *contains*
+/// `/Packages/<Name>/Sources/` would otherwise be re-rooted and attributed to a
+/// package that does not exist in this repo.
 func repoRelative(_ absolute: String) -> String? {
     if absolute.hasPrefix(repoRoot + "/") {
         return String(absolute.dropFirst(repoRoot.count + 1))
     }
     if let hit = absolute.range(of: "/Packages/") {
-        return String(absolute[absolute.index(after: hit.lowerBound)...])
+        let candidate = String(absolute[absolute.index(after: hit.lowerBound)...])
+        if FileManager.default.fileExists(atPath: repoRoot + "/" + candidate) {
+            return candidate
+        }
     }
     return nil
 }
@@ -342,19 +350,40 @@ var json = "{\n"
 json += "  \"schemaVersion\": 1,\n"
 json += "  \"packageCount\": \(ranked.count),\n"
 json += "  \"measuredPackageCount\": \(measuredCount),\n"
+// Provenance: exactly which exports were folded in. Stale leftovers from a
+// deleted package or a removed test target keep contributing to local runs
+// otherwise, with nothing in the output to show for it. Repo-relative and
+// already sorted by the caller, so this stays deterministic.
+json += "  \"exports\": [\n"
+for (index, report) in reports.enumerated() {
+    let relative = repoRelative(report) ?? report
+    json += "    \(jsonString(relative))\(index == reports.count - 1 ? "" : ",")\n"
+}
+json += "  ],\n"
 json += "  \"totals\": \(coverageJSON(total, indent: "  ")),\n"
 json += "  \"packages\": [\n"
 for (index, pkg) in ranked.enumerated() {
     json += "    {\n"
     json += "      \"name\": \(jsonString(pkg.name)),\n"
     json += "      \"ownSuiteMeasured\": \(pkg.ownSuiteMeasured),\n"
-    json += "      \"ownSuite\": \(coverageJSON(pkg.ownSuite, indent: "      ")),\n"
+    // null, not a zeroed object: a consumer that ignores ownSuiteMeasured would
+    // otherwise read "0% covered" where the truth is "this lane never ran that
+    // suite". null cannot be mistaken for a measurement.
+    if pkg.ownSuiteMeasured {
+        json += "      \"ownSuite\": \(coverageJSON(pkg.ownSuite, indent: "      ")),\n"
+    } else {
+        json += "      \"ownSuite\": null,\n"
+    }
     json += "      \"anySuite\": \(coverageJSON(pkg.anySuite, indent: "      ")),\n"
     json += "      \"files\": [\n"
     for (fileIndex, entry) in pkg.files.enumerated() {
         json += "        {\n"
         json += "          \"path\": \(jsonString(entry.path)),\n"
-        json += "          \"ownSuite\": \(coverageJSON(entry.coverage.ownSuite, indent: "          ")),\n"
+        if pkg.ownSuiteMeasured {
+            json += "          \"ownSuite\": \(coverageJSON(entry.coverage.ownSuite, indent: "          ")),\n"
+        } else {
+            json += "          \"ownSuite\": null,\n"
+        }
         json += "          \"anySuite\": \(coverageJSON(entry.coverage.anySuite, indent: "          "))\n"
         json += "        }\(fileIndex == pkg.files.count - 1 ? "" : ",")\n"
     }
@@ -365,13 +394,20 @@ json += "  ]\n"
 json += "}\n"
 
 var markdown = "# Swift test coverage\n\n"
-markdown += "**Whole repo: \(fixed(total.lines.percent, 1))% line / "
+// Deliberately not "Whole repo". This file gets downloaded and quoted out of
+// context, and on the pull-request lane the total is computed over roughly a
+// third of the tree — the one line most likely to be repeated is the one that
+// most needs the qualifier attached to it.
+markdown += "**Measured packages: \(fixed(total.lines.percent, 1))% line / "
 markdown += "\(fixed(total.regions.percent, 1))% region** — "
 markdown += "\(grouped(total.lines.count)) executable lines, \(grouped(total.lines.missed)) missed.\n\n"
+markdown += "That total covers the \(ranked.count) package\(ranked.count == 1 ? "" : "s") in *this* run, "
+markdown += "not necessarily the whole repository — CI's Linux\npull-request lane builds an explicit "
+markdown += "subset of the tree (see `docs/adr/0007-linux-ci-swift.md`).\n\n"
 markdown += "\(measuredCount) package\(measuredCount == 1 ? "" : "s") measured, worst first. "
 markdown += "**Line %**, **Region %** and **Missed** are what each package's *own* test suite\n"
 markdown += "reaches — the number to act on. **Any suite %** additionally credits a file that some\n"
-markdown += "other package's tests exercised through a dependency, which is what the repo total\n"
+markdown += "other package's tests exercised through a dependency, which is what the total\n"
 markdown += "above is computed from; that is why the total beats the Missed column's sum.\n\n"
 markdown += "| Package | Line % | Region % | Lines | Missed | Any suite % |\n"
 markdown += "|---|---:|---:|---:|---:|---:|\n"


### PR DESCRIPTION
Closes #928

`swift test --enable-code-coverage` already makes SwiftPM drop an llvm-cov export at `Packages/<Pkg>/.build/<triple>/debug/codecov/<Pkg>.json`, so this is collect + merge + upload. No new dependencies, no third-party upload, no gate, no ratchet.

## What landed

- **`scripts/coverage-summary.sh`** — gathers whatever exports are on disk and merges them through **`scripts/coverage-summary.swift`** into `coverage-summary.json` (per-package + per-file) and `coverage-summary.md` (the human table).
- **`ci.yml`** — `--enable-code-coverage` on the Linux package loop, then summarize + `actions/upload-artifact@v4` (`coverage-summary-linux`) as the last step of `test`.
- **`release.yml`** — same on the macOS `test` job (`coverage-summary-macos`), the only lane where all 17 packages are measured.
- **`make coverage`** — same sweep, same script, locally.
- **ADR 0007** — corrected line 24: CrowTelemetry *does* have a test target.

## The two gotchas the ticket flagged

1. **Dependency scoping.** A test binary compiles its dependencies, so a package's raw export describes far more than that package — CrowGit's own JSON reports ~3,700 lines at 6%, which is CrowCore and friends dragged in by the link. Every file is attributed to the package that *owns* its source (`Packages/<Pkg>/Sources/…`) instead.
2. **`*.derived/runner.swift`** is filtered (it also fails the `Sources/` check, but the guard is explicit so the intent survives).

## Two numbers per package

The same file appears in several exports — covered where some suite exercised it, cold where another package merely linked it. Summing double-counts; averaging punishes a file for binaries that never called it. Files are folded by taking the **max covered**, which gives:

- **Own suite** — what that package's own tests reach. The actionable number, and what the table's `Line %` / `Missed` columns report.
- **Any suite** — also credits a file some dependent's tests exercised. This is what the repo total is computed from, which is why the total beats the `Missed` column's sum.

A package linked into a lane but never tested there reads **`—`**, not a fabricated `0%`. On Linux that is CrowAutostart, pulled in via CrowCLI:

| Package | Line % | Region % | Lines | Missed | Any suite % |
|---|---:|---:|---:|---:|---:|
| CrowCLI | 59.3% | 64.5% | 2,427 | 988 | 59.3% |
| … | | | | | |
| CrowAutostart | — | — | 418 | — | 5.7% |

## Why Swift and not Python/jq

The PR lane runs inside the `swift:6.1` container, which ships **neither** — its Python is `libpython3-dev`, headers and stdlib for LLDB, with no interpreter binary. Swift is the one language guaranteed present in both CI lanes and on any machine that can run `make coverage`, so this keeps the "no new dependencies" constraint honest. `coverage-summary.sh` compiles it with `swiftc` into a temp dir rather than relying on interpreter mode.

Output carries no timestamps, hostnames, or absolute paths, and the JSON is emitted by hand rather than through `JSONSerialization` (Darwin escapes `/` as `\/`, corelibs-foundation does not). Verified byte-identical across repeat runs.

## Verification against the baseline (`1441c56`, full local sweep, all 17 suites passing)

**15 of 17 packages match the ticket's baseline exactly.** The other three differ by 1–3 missed lines — CrowTelemetry (540 vs 537), CrowTerminal (601 vs 599), CrowIPC (54 vs 53) — all timing-sensitive suites, so this is test variance rather than a merge error. Every package is well inside the ~1% acceptance bar.

Total executable lines match exactly at **40,502**.

One honest gap: the repo total lands at **61.9%** vs the hand-measured **62.7%**. Per-file max is a *lower bound* on cross-package credit — if suite A covers lines 1–10 of a file and suite B covers 11–20, the true union is 20 and per-file max sees 10. Recovering the difference would mean `llvm-profdata merge` across packages and re-exporting against every test binary, which is a materially bigger job than this ticket scoped ("taking the max covered per file"). Flagging it rather than burying it; happy to file a follow-up if the exact number matters.

Similarly, the Linux artifact reports 15,136 lines rather than the ticket's 14,718 — the delta is exactly CrowAutostart's 418 lines, which the lane really does compile via CrowCLI. Showing it with `—` seemed more truthful than dropping it.

## Test plan

- [x] `shellcheck scripts/*.sh` passes
- [x] Full local sweep (17 packages) → per-package numbers match the baseline table
- [x] Repeat runs produce byte-identical `coverage-summary.{json,md}`
- [x] `coverage-summary.json` parses as valid JSON
- [x] Linux lane simulated against the 12 `LINUX_PACKAGES` exports — correct table, `—` row for CrowAutostart
- [x] `coverage/` is gitignored; nothing generated is committed
- [ ] CI green on this PR, with a downloadable `coverage-summary-linux` artifact

## Known trade-offs (per the ticket, not re-litigated here)

Per [ADR 0007](docs/adr/0007-linux-ci-swift.md) the PR lane is Linux, so the per-PR artifact covers ~36% of the tree; CrowEngine and CrowDaemon coverage refreshes only at release tags. Artifacts also expire and are not git-tracked, so there is no long-run trend history — consumers fetch with `gh run download -n coverage-summary-linux`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)