### PR TITLE
Stop chained session-menu actions from timing out client-side (CROW-931)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCDispatcher.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCDispatcher.swift
@@ -1,0 +1,259 @@
+import Foundation
+
+/// Per-connection dispatcher for `/rpc` requests (#931).
+///
+/// The reader task used to `await commandRouter.handle(request:)` inline, so one
+/// slow method held the socket's read loop and everything queued behind it hit
+/// the browser's timeout — a `refresh-tickets` behind a `gh` call stalled the
+/// unrelated `set-status` the user clicked next. The reader now hands each
+/// request here and immediately reads the next frame.
+///
+/// Three invariants, in the order they matter:
+///
+/// 1. **Lane ordering.** Requests in the same ``Lane`` run one at a time in
+///    arrival order, via a `Task` chain per lane — the same shape as
+///    ``ReviewKickoffSerializer``, whose single global chain this generalizes to
+///    one chain per lane. `set-status` then `complete-session` on one session
+///    still cannot reorder.
+/// 2. **Bounded work.** At most `maxConcurrent` operations *execute* at once,
+///    and at most `maxInFlight` are *accepted* before the dispatcher refuses.
+///    A queued lane task waits for its predecessor **before** taking a permit,
+///    never while holding one — see ``run(id:lane:predecessor:operation:)``.
+/// 3. **Drain before finish.** ``drain()`` returns only once every accepted
+///    operation has yielded its response, so the reader can end the writer's
+///    stream without truncating a reply. ``shutdown()`` releases every waiter so
+///    an abnormal close never parks the reader.
+///
+/// One instance per connection, created in `onUpgrade`. Nothing is shared
+/// between connections — the daemon already served those concurrently
+/// (`SocketServer` dispatches each CLI connection to the global concurrent
+/// queue, and every browser tab is its own upgrade), so this change makes
+/// intra-connection concurrency match the inter-connection concurrency that
+/// already existed rather than introducing a new kind.
+actor RPCDispatcher {
+
+    /// A serialization lane. Same lane → strict arrival order. Different lanes,
+    /// and lane-less requests, run concurrently.
+    ///
+    /// Ordering is **not** preserved *across* lanes: a `set-config` and a
+    /// `set-status` sent back to back can land in either order. That is the
+    /// deliberate cost of the fix, and it matches what two open browser tabs
+    /// could already produce. Every `app.js` call site awaits its response
+    /// before issuing a dependent one.
+    enum Lane: Hashable, Sendable {
+        /// Serialize on one request parameter's value — `session_id`,
+        /// `terminal_id`, `job_id`. The parameter *name* is part of the key so a
+        /// session UUID and a terminal UUID can never collide into one lane.
+        case param(name: String, value: String)
+
+        /// The `config.json` read-modify-write family.
+        ///
+        /// Two reasons, and the second is the load-bearing one:
+        /// `ConfigStore.withConfigLock` already makes each mutation atomic, so
+        /// the lane is what keeps two *pipelined* mutations from landing out of
+        /// order — but that lock is an `NSLock` held across synchronous disk
+        /// I/O, so concurrent config writers would **block cooperative-pool
+        /// threads**, the shape that wedged the daemon in #874. One lane means
+        /// `/rpc` never contends for that lock with itself.
+        case config
+
+        /// The Manager window and the tmux server it lives in. Typing into the
+        /// Manager (`work-on-issue`) must not race creating or restarting it.
+        case manager
+
+        /// `start-review` / `batch-start-review`. They already funnel through
+        /// ``ReviewKickoffSerializer`` — and `start-review` *awaits* its chained
+        /// task, so without a lane N pipelined kickoffs would each hold a
+        /// concurrency permit for the whole serialized clone-and-spawn run and
+        /// re-create #931 one level down.
+        case reviewKickoff
+
+        /// The global `~/.claude/settings.json` allowlist: promote, then scan.
+        case allowlist
+
+        /// Whole-board provider sweeps (`resync-jira`), which walk every session
+        /// and transition its ticket. Two at once would double every provider
+        /// call.
+        case tracker
+    }
+
+    // MARK: - Configuration
+
+    /// Ceiling on operations executing at once.
+    ///
+    /// Deliberately small. Most handlers hop to `@MainActor`, which is the real
+    /// bottleneck — raising this buys queueing, not throughput — and several
+    /// take `ConfigStore.withConfigLock`, an `NSLock` that blocks a cooperative
+    /// thread while held. 8 keeps blocked threads well under the pool width on
+    /// any host `crowd` runs on, and the ``Lane/config`` lane keeps `/rpc`'s own
+    /// contribution to that lock at one.
+    private let maxConcurrent: Int
+
+    /// Ceiling on operations *accepted* per connection before ``dispatch(lane:operation:)``
+    /// starts refusing.
+    ///
+    /// Non-blocking rejection rather than reader backpressure, matching
+    /// `TerminalConnectionLimiter`: a client holding 64 requests open on one
+    /// socket is not one the daemon should quietly queue for. The web UI never
+    /// exceeds a handful, so this only fires on a runaway caller — which learns
+    /// immediately instead of timing out 64 times.
+    private let maxInFlight: Int
+
+    // MARK: - State
+
+    private struct LaneTail {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private var lanes: [Lane: LaneTail] = [:]
+    private var pending: [UUID: Task<Void, Never>] = [:]
+    private var inFlight = 0
+    private var running = 0
+    private var permitWaiters: [CheckedContinuation<Bool, Never>] = []
+    private var drainWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isShutDown = false
+
+    init(maxConcurrent: Int = 8, maxInFlight: Int = 64) {
+        self.maxConcurrent = maxConcurrent
+        self.maxInFlight = maxInFlight
+    }
+
+    // MARK: - Introspection (tests)
+
+    /// Live lane count. Zero once every chain has drained — the assertion that
+    /// the lane map is bounded by *live* lanes rather than by every session id a
+    /// long-lived connection has ever addressed.
+    var laneCount: Int { lanes.count }
+    var inFlightCount: Int { inFlight }
+    var runningCount: Int { running }
+
+    // MARK: - Dispatch
+
+    /// Accept `operation` for execution, ordered behind anything already queued
+    /// in `lane`. Returns immediately — the operation runs on its own task.
+    ///
+    /// Returns `false` when the connection is at its in-flight ceiling or the
+    /// dispatcher has shut down; the caller answers the request itself rather
+    /// than dropping it, since a dropped request would sit until the client's
+    /// deadline — the exact symptom this change exists to remove.
+    @discardableResult
+    func dispatch(lane: Lane?, operation: @escaping @Sendable () async -> Void) -> Bool {
+        guard !isShutDown, inFlight < maxInFlight else { return false }
+        inFlight += 1
+
+        let id = UUID()
+        let predecessor = lane.flatMap { lanes[$0]?.task }
+        let task = Task {
+            await self.run(id: id, lane: lane, predecessor: predecessor, operation: operation)
+        }
+        pending[id] = task
+        if let lane { lanes[lane] = LaneTail(id: id, task: task) }
+        return true
+    }
+
+    /// Return once every accepted operation has yielded its response.
+    ///
+    /// Called by the reader after inbound closes, so ending the writer's stream
+    /// cannot truncate a reply that is still being computed. ``shutdown()`` also
+    /// releases this, so a reader parked here when the *writer* is what died
+    /// unwinds instead of hanging the connection's task group.
+    func drain() async {
+        guard inFlight > 0, !isShutDown else { return }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            drainWaiters.append(c)
+        }
+    }
+
+    /// Stop accepting, cancel every chain, and release every waiter.
+    ///
+    /// Cancellation reaches the *waiting*, not the running: `CommandRouter`
+    /// handlers are not cancellation-aware (most are a synchronous
+    /// `MainActor.run`), so an `add-worktree` already inside `git` finishes its
+    /// work exactly as it does today. What this guarantees is that nothing is
+    /// left suspended on a lane predecessor, a permit, or ``drain()``.
+    func shutdown() {
+        guard !isShutDown else { return }
+        isShutDown = true
+
+        for task in pending.values { task.cancel() }
+
+        let permits = permitWaiters
+        permitWaiters.removeAll()
+        for c in permits { c.resume(returning: false) }
+
+        let drains = drainWaiters
+        drainWaiters.removeAll()
+        for c in drains { c.resume() }
+    }
+
+    // MARK: - Internals
+
+    /// The body of every dispatched task.
+    ///
+    /// `nonisolated` on purpose: a `Task {}` created inside an actor inherits
+    /// that actor's isolation, which would run each operation's non-suspended
+    /// stretches — including JSON encoding — on the dispatcher itself. Hopping
+    /// straight out keeps the actor to the four short isolated calls below.
+    ///
+    /// **The permit is taken after the lane wait, never before.** A task parked
+    /// on its predecessor holds nothing, so (a) a burst on one session cannot
+    /// starve the pool, and (b) the classic deadlock — every permit held by a
+    /// task waiting on a predecessor that can never get a permit — is
+    /// structurally impossible: a permit holder only ever waits on `operation`,
+    /// which waits on nothing this actor owns.
+    private nonisolated func run(
+        id: UUID,
+        lane: Lane?,
+        predecessor: Task<Void, Never>?,
+        operation: @escaping @Sendable () async -> Void
+    ) async {
+        if let predecessor {
+            await predecessor.value
+        }
+        if !Task.isCancelled, await acquirePermit() {
+            await operation()
+            await releasePermit()
+        }
+        await complete(id: id, lane: lane)
+    }
+
+    /// `true` when a permit was granted. `false` only on shutdown, in which case
+    /// the caller must skip the operation and must not release.
+    private func acquirePermit() async -> Bool {
+        if isShutDown { return false }
+        if running < maxConcurrent {
+            running += 1
+            return true
+        }
+        return await withCheckedContinuation { (c: CheckedContinuation<Bool, Never>) in
+            permitWaiters.append(c)
+        }
+    }
+
+    /// Hand the permit straight to the oldest waiter rather than decrementing and
+    /// letting it re-check — FIFO, and no window where `running` dips below the
+    /// ceiling while work is queued.
+    private func releasePermit() {
+        if permitWaiters.isEmpty {
+            running -= 1
+        } else {
+            let waiter = permitWaiters.removeFirst()
+            waiter.resume(returning: true)
+        }
+    }
+
+    /// Retire the task and, if it was still its lane's tail, the lane with it —
+    /// this is what keeps `lanes` bounded. A lane whose chain is still running
+    /// keeps exactly one entry.
+    private func complete(id: UUID, lane: Lane?) {
+        pending[id] = nil
+        if let lane, lanes[lane]?.id == id { lanes[lane] = nil }
+        inFlight -= 1
+        if inFlight == 0 {
+            let waiters = drainWaiters
+            drainWaiters.removeAll()
+            for c in waiters { c.resume() }
+        }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -1,0 +1,164 @@
+import CrowCore
+import CrowIPC
+
+/// Which `/rpc` requests must not overtake each other (#931).
+///
+/// Stated per method, never inferred. A rule derived from "does it carry a
+/// `session_id`" would silently hand full concurrency to the next write that
+/// happens to key on something else — `launch-agent` keys on `terminal_id` and
+/// `job-run` on `job_id`, and both were already in the surface when this was
+/// written. ``RPCLanePolicyTests`` gates the table against
+/// `ParityLedger.rpcMethods`, so a new write method fails the build until
+/// somebody decides its lane.
+///
+/// Reads are absent by design: they take no lane. Lanes order *writes to a
+/// resource*; putting `get-pr-status` behind a `delete-session` on the same
+/// session would trade the bug for a smaller one.
+enum RPCLanePolicy {
+
+    /// How a method's lane is derived.
+    enum Rule: Sendable, Equatable {
+        /// Serialize on this parameter's value. A request that omits it gets no
+        /// lane — the handler rejects it as `invalidParams` anyway, and an
+        /// "absent" bucket would serialize every malformed request against
+        /// every other one.
+        case on(String)
+        /// Serialize on a fixed resource lane.
+        case fixed(RPCDispatcher.Lane)
+        /// No ordering constraint. Stated explicitly rather than by omission so
+        /// the ledger gate can tell "decided" from "forgotten".
+        case concurrent
+    }
+
+    static let rules: [String: Rule] = [
+        // MARK: Sessions
+        // A brand-new id has nothing to order against, and the append is one
+        // synchronous MainActor block.
+        "new-session": .concurrent,
+        "rename-session": .on("session_id"),
+        "select-session": .on("session_id"),
+        "set-status": .on("session_id"),
+        "set-locked": .on("session_id"),
+        "set-pinned": .on("session_id"),
+        "delete-session": .on("session_id"),
+        "handoff-agent": .on("session_id"),
+
+        // MARK: Lifecycle
+        // `mark-issue-done` is the one that makes this mandatory: it awaits a
+        // provider CLI call and *then* writes the session's status in a second
+        // MainActor hop. Unlaned, a `complete-session` could land in that gap.
+        "mark-in-review": .on("session_id"),
+        "complete-session": .on("session_id"),
+        "set-session-active": .on("session_id"),
+        "mark-issue-done": .on("session_id"),
+        "add-merge-label": .on("session_id"),
+
+        // MARK: Metadata & links
+        "set-ticket": .on("session_id"),
+        "set-goal": .on("session_id"),
+        "add-link": .on("session_id"),
+        "remove-link": .on("session_id"),
+        "edit-link": .on("session_id"),
+        "transition-ticket": .on("session_id"),
+        // Walks every session and transitions its ticket; two at once would
+        // double every provider call.
+        "resync-jira": .fixed(.tracker),
+
+        // MARK: Worktrees
+        "add-worktree": .on("session_id"),
+
+        // MARK: Terminals
+        // Keyed on the session, not the terminal: these mutate the session's
+        // terminal *list*. `send` in particular must never reorder — two lines
+        // typed at one agent in the wrong order is a corrupt prompt.
+        "new-terminal": .on("session_id"),
+        "close-terminal": .on("session_id"),
+        "recreate-terminal": .on("session_id"),
+        "rename-terminal": .on("session_id"),
+        "send": .on("session_id"),
+        // These two carry only a `terminal_id`.
+        "launch-agent": .on("terminal_id"),
+        "retry-readiness": .on("terminal_id"),
+
+        // MARK: Manager window + the tmux server it lives in
+        // `work-on-issue` types into the Manager terminal; the restart verbs
+        // create or destroy it. Typing into a Manager being restarted is a lost
+        // prompt.
+        "create-manager": .fixed(.manager),
+        "restart-manager": .fixed(.manager),
+        "restart-tmux-server": .fixed(.manager),
+        "reload-tmux-config": .fixed(.manager),
+        "work-on-issue": .fixed(.manager),
+        "batch-work-on-issues": .fixed(.manager),
+
+        // MARK: Host apps
+        "open-in-vscode": .on("session_id"),
+        "open-terminal": .on("session_id"),
+
+        // MARK: Boards
+        // `IssueTracker.refresh()` self-guards with `isRefreshing` and returns
+        // early, which is the behaviour the web's manual-refresh path is written
+        // against. Laning it would convert that early return into a wait and
+        // make a timeout more likely, not less.
+        "refresh-tickets": .concurrent,
+        "start-review": .fixed(.reviewKickoff),
+        "batch-start-review": .fixed(.reviewKickoff),
+        "quick-action": .on("session_id"),
+        "promote-allowlist": .fixed(.allowlist),
+        "refresh-allowlist": .fixed(.allowlist),
+        // `ScorecardRebuilder` is already single-flight: a second caller awaits
+        // the in-flight run instead of starting one.
+        "rebuild-scorecard": .concurrent,
+
+        // MARK: config.json
+        "set-config": .fixed(.config),
+        "run-setup": .fixed(.config),
+        "defaults-set": .fixed(.config),
+        "agents-set": .fixed(.config),
+        "automation-set": .fixed(.config),
+        "telemetry-set": .fixed(.config),
+        "cleanup-set": .fixed(.config),
+        "ui-set": .fixed(.config),
+        "notifications-set": .fixed(.config),
+        "workspace-add": .fixed(.config),
+        "workspace-edit": .fixed(.config),
+        "workspace-remove": .fixed(.config),
+        "gateway-set": .fixed(.config),
+        "web-password-set": .fixed(.config),
+        "job-add": .fixed(.config),
+        "job-edit": .fixed(.config),
+        "job-enable": .fixed(.config),
+        "job-disable": .fixed(.config),
+        "job-delete": .fixed(.config),
+        "job-duplicate": .fixed(.config),
+
+        // MARK: Job runs
+        // Not `.config`: these await a full worktree + tmux spawn, and parking
+        // every settings write behind that would be a worse stall than the one
+        // this change removes. Keyed on the job so one job cannot double-spawn.
+        "job-run": .on("job_id"),
+        "run-job": .on("job_id"),
+
+        // MARK: Hooks
+        // Never reaches `/rpc` — `RPCWebSocketHandler.localOnlyDenial` denies it
+        // — but declared so the ledger gate stays complete rather than carrying
+        // an exemption.
+        "hook-event": .on("session_id"),
+    ]
+
+    /// The lane for `request`, or `nil` when it may run concurrently with
+    /// everything else on the connection.
+    static func lane(for request: JSONRPCRequest) -> RPCDispatcher.Lane? {
+        switch rules[request.method] ?? .concurrent {
+        case .concurrent:
+            return nil
+        case .fixed(let lane):
+            return lane
+        case .on(let param):
+            guard let value = request.params?[param]?.stringValue, !value.isEmpty else {
+                return nil
+            }
+            return .param(name: param, value: value)
+        }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -16,6 +16,14 @@ import HummingbirdWebSocket
 /// A single writer task owns `outbound`: both RPC responses and `EventHub`
 /// broadcast notifications flow through one per-connection `AsyncStream`, so
 /// they never interleave frames on the socket (CROW-581, M-D).
+///
+/// The reader does **not** run handlers itself. It hands each request to a
+/// per-connection ``RPCDispatcher`` and immediately reads the next frame, so a
+/// slow method can no longer hold the socket's read loop and time out every
+/// request queued behind it (#931). Responses may therefore arrive out of
+/// order — safe by construction, since the client correlates by JSON-RPC id —
+/// while ``RPCLanePolicy`` keeps writes to the same session (or the same config
+/// file, Manager, or job) in strict arrival order.
 enum RPCWebSocketHandler {
     static func mount(
         on router: Router<CrowWSContext>,
@@ -51,23 +59,33 @@ enum RPCWebSocketHandler {
                 remoteAddress: wsContext.requestContext.remoteAddress,
                 forwardedFor: wsContext.request.headers[HTTPField.Name("x-forwarded-for")!])
             // One outbound channel per connection: RPC responses (from the
-            // reader task) and hub notifications (fanned in via `subscribe`)
-            // both feed the single writer below.
+            // dispatched operations) and hub notifications (fanned in via
+            // `subscribe`) both feed the single writer below.
             let (outStream, outCont) = AsyncStream.makeStream(of: String.self)
             let subscription = await eventHub.subscribe(outCont)
+            // Handlers no longer run on the read loop (#931).
+            let dispatcher = RPCDispatcher()
 
             try await withThrowingTaskGroup(of: Void.self) { group in
-                // Writer — the sole owner of `outbound`.
+                // Writer — the sole owner of `outbound`. Unchanged: responses
+                // may now arrive out of order, but they still cross the socket
+                // one frame at a time from one task, and the client correlates
+                // by JSON-RPC id.
                 group.addTask {
                     for await text in outStream {
                         try await outbound.write(.text(text))
                     }
                 }
-                // Reader — decode requests, dispatch, enqueue responses.
+                // Reader — decode, hand off, read the next frame.
                 group.addTask {
+                    // Single-threaded on this task, so it stays hoisted. The
+                    // encoder does NOT: `JSONEncoder` isn't `Sendable`, and the
+                    // dispatched operations encode concurrently (see `emit`).
                     let decoder = JSONDecoder()
-                    let encoder = JSONEncoder()
-                    encoder.outputFormatting = [.sortedKeys]
+                    // The writer's stream must end however this task exits, or
+                    // the group never unwinds. `finish()` is idempotent.
+                    defer { outCont.finish() }
+
                     for try await message in inbound.messages(maxSize: 1 << 20) {
                         let payload: Data?
                         switch message {
@@ -78,30 +96,74 @@ enum RPCWebSocketHandler {
                               let request = try? decoder.decode(JSONRPCRequest.self, from: data) else {
                             continue
                         }
-                        let response: JSONRPCResponse
+
+                        // The local-only gate stays on the sequential path. It
+                        // is the security boundary, and for `set-config` it
+                        // reads config.json from disk — a decision that must not
+                        // be taken against a config another dispatch is mid-write
+                        // on.
                         if !localDirect, let deny = Self.localOnlyDenial(for: request, devRoot: devRoot) {
-                            response = .error(
-                                id: request.id,
-                                code: RPCErrorCode.invalidParams,
-                                message: deny)
-                        } else {
-                            response = await commandRouter.handle(request: request)
+                            Self.emit(
+                                .error(id: request.id, code: RPCErrorCode.invalidParams, message: deny),
+                                to: outCont)
+                            continue
                         }
-                        if let out = try? encoder.encode(response), let text = String(data: out, encoding: .utf8) {
-                            outCont.yield(text)
+
+                        let lane = RPCLanePolicy.lane(for: request)
+                        let accepted = await dispatcher.dispatch(lane: lane) {
+                            let response = await commandRouter.handle(request: request)
+                            Self.emit(response, to: outCont)
+                        }
+                        // Answer rather than drop: a refused request that got no
+                        // reply would sit until the client's deadline, which is
+                        // the symptom this whole change exists to remove.
+                        if !accepted {
+                            Self.emit(
+                                .error(
+                                    id: request.id,
+                                    code: RPCErrorCode.applicationError,
+                                    message: "Too many requests in flight on this connection"),
+                                to: outCont)
                         }
                     }
-                    // Inbound closed → end the writer so the group can unwind.
-                    outCont.finish()
+
+                    // Inbound closed cleanly → let everything already accepted
+                    // reach the writer before `defer` ends its stream. Released
+                    // early by `shutdown()` below when the *writer* is what died.
+                    await dispatcher.drain()
                 }
 
                 // When either side finishes (socket closed), tear the other down.
                 _ = try? await group.next()
+                // Before `cancelAll`: this releases the reader if it is parked in
+                // `drain()`, and unparks anything queued on a lane or a permit.
+                // Cancelling the group first would leave those waiters suspended
+                // — `Task<Void, Never>.value` and `withCheckedContinuation` do
+                // not resume on cancellation — and the group would never unwind.
+                await dispatcher.shutdown()
                 group.cancelAll()
+                outCont.finish()
             }
 
             await eventHub.unsubscribe(subscription)
         }
+    }
+
+    /// Encode and enqueue one response for the connection's single writer.
+    ///
+    /// The encoder is built per call rather than hoisted per connection as it
+    /// once was: `JSONEncoder` is not `Sendable`, and dispatched operations now
+    /// encode concurrently (#931). Allocation is cheap next to the handler that
+    /// produced the response.
+    private static func emit(
+        _ response: JSONRPCResponse,
+        to continuation: AsyncStream<String>.Continuation
+    ) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let out = try? encoder.encode(response),
+              let text = String(data: out, encoding: .utf8) else { return }
+        continuation.yield(text)
     }
 
     /// Methods / fields that must stay local-direct (loopback, no XFF), matching

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -7,6 +7,67 @@
 // ---------------------------------------------------------------------------
 const rpcState = { nextId: 1, pending: new Map(), ready: null };
 
+// Per-method RPC deadlines, mirroring the CLI's table so the two clients agree
+// on how long a verb is allowed to take (`CrowCLILib/Helpers.swift` default 30s,
+// plus each command's explicit `timeoutSeconds:`). The flat 10s this replaced
+// was shorter than the work for most write verbs — `add-merge-label` alone did a
+// label create, a label add, and a full multi-provider board poll — so the modal
+// that popped said "failed" about an action that was running fine and usually
+// went on to succeed (#931).
+//
+// KEYS ARE WIRE METHOD NAMES, NOT CLI VERBS. `crow job run` sends `job-run`;
+// Settings' "Run now" button sends `run-job` (a distinct handler). Both do the
+// same work, so both are listed — keying off the CLI verb alone would leave the
+// web button on the default.
+const RPC_DEFAULT_TIMEOUT_MS = 30000;
+const RPC_TIMEOUTS_MS = {
+  // Rebuilds the whole scorecard from the event log.
+  'rebuild-scorecard': 180000,
+  // Shell out to gh/glab/Jira across every configured repo; clone a repo and
+  // spawn tmux; run a job's full command.
+  'refresh-tickets': 120000,
+  'start-review': 120000,
+  'batch-start-review': 120000, // no CLI twin; at least as slow as start-review
+  'job-run': 120000,
+  'run-job': 120000,
+  // Board reads and Manager-keystroke writes (the CLI's `boardTimeout`).
+  'work-on-issue': 60000,
+  'batch-work-on-issues': 60000,
+  'create-manager': 60000,
+  'quick-action': 60000,
+  'list-tickets': 60000,
+  'list-reviews': 60000,
+  'get-state': 60000,
+  'promote-allowlist': 60000,
+  'refresh-allowlist': 60000,
+  'mark-issue-done': 60000,
+  'add-merge-label': 60000,
+};
+function rpcTimeoutFor(method) {
+  const ms = RPC_TIMEOUTS_MS[method];
+  return typeof ms === 'number' ? ms : RPC_DEFAULT_TIMEOUT_MS;
+}
+
+// A timed-out request keeps its `pending` entry, flagged `settled`, so the
+// eventual reply can reach `onLate` instead of being dropped by `onmessage`'s
+// `!waiter` guard. That means the map no longer empties itself: sweep on every
+// new call. Ten minutes is far past any method's deadline, and the cap bounds a
+// pathological run of timeouts.
+const RPC_LATE_WINDOW_MS = 600000;
+const RPC_MAX_SETTLED = 64;
+function gcSettledRPCs() {
+  const now = Date.now();
+  const settled = [];
+  rpcState.pending.forEach((w, id) => {
+    if (!w.settled) return;
+    if (now - w.settledAt > RPC_LATE_WINDOW_MS) rpcState.pending.delete(id);
+    else settled.push(id);
+  });
+  // Map iteration is insertion order and ids are monotonic, so `settled` is
+  // oldest-first — trim from the head, the least likely to still answer.
+  for (let i = 0; i < settled.length - RPC_MAX_SETTLED; i++) rpcState.pending.delete(settled[i]);
+}
+
 function wsURL(path) {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   return proto + '://' + location.host + path;
@@ -43,7 +104,20 @@ function rpcConnect() {
       const waiter = rpcState.pending.get(msg.id);
       if (!waiter) return;
       rpcState.pending.delete(msg.id);
-      if (msg.error) waiter.reject(new Error(msg.error.message || 'rpc error'));
+      if (waiter.timer) clearTimeout(waiter.timer);
+      const rpcErr = msg.error ? new Error(msg.error.message || 'rpc error') : null;
+      // Late: this call's promise already rejected on its timeout, so settling
+      // it again is a no-op and the answer would be lost. Hand it to `onLate`
+      // instead — that is what lets a caller retract a "still running" advisory
+      // once the daemon does answer (#931).
+      if (waiter.settled) {
+        if (waiter.onLate) {
+          try { waiter.onLate(rpcErr ? null : (msg.result || {}), rpcErr); }
+          catch (_) { /* a caller's late-handler must not kill the socket pump */ }
+        }
+        return;
+      }
+      if (rpcErr) waiter.reject(rpcErr);
       else waiter.resolve(msg.result || {});
     };
     ws.onclose = () => {
@@ -51,8 +125,16 @@ function rpcConnect() {
       // Fail fast: a socket that closed before opening must reject so `await
       // rpcState.ready` can't hang when the daemon is down (review #8).
       if (!opened) reject(new Error('rpc: socket closed before open'));
-      // Reject in-flight rpcs instead of leaving them stuck until the 10s timeout.
-      rpcState.pending.forEach((w) => w.reject(new Error('rpc: connection closed')));
+      // Reject in-flight rpcs instead of leaving them stuck until their
+      // deadline. Entries already settled by a timeout are dropped WITHOUT
+      // firing `onLate`: the socket died before the daemon answered, so we
+      // genuinely don't know the outcome, and "connection closed" is not an
+      // honest replacement for a "still running" advisory the user can already
+      // dismiss. Dropping them also keeps the map empty across a reconnect.
+      rpcState.pending.forEach((w) => {
+        if (w.timer) clearTimeout(w.timer);
+        if (!w.settled) w.reject(new Error('rpc: connection closed'));
+      });
       rpcState.pending.clear();
       // Daemon's gone, so its in-flight refresh flag will never be cleared for
       // us. Drop it here rather than waiting for a board poll that may not run
@@ -74,17 +156,44 @@ function rpcConnect() {
   return p;
 }
 
-async function rpc(method, params) {
+// `opts.timeoutMs` overrides the per-method table; `opts.onLate(result, error)`
+// fires if the response arrives *after* this call already rejected on timeout —
+// exactly once, with one of the two arguments non-null.
+async function rpc(method, params, opts) {
   // Session is dead (cookie invalid): don't spin up doomed reconnects — fail fast so
   // background pollers stop churning and the "Log in" affordance stands (CROW-593).
   if (sessionDead) throw new Error('session expired — log in');
   if (!rpcState.ready) rpcState.ready = rpcConnect();
   const ws = await rpcState.ready;
   const id = rpcState.nextId++;
+  const o = opts || {};
+  const ms = typeof o.timeoutMs === 'number' ? o.timeoutMs : rpcTimeoutFor(method);
+  gcSettledRPCs();
   return new Promise((resolve, reject) => {
-    rpcState.pending.set(id, { resolve, reject });
+    const waiter = {
+      method, resolve, reject,
+      settled: false, settledAt: 0,
+      onLate: typeof o.onLate === 'function' ? o.onLate : null,
+      timer: 0,
+    };
+    rpcState.pending.set(id, waiter);
     ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params: params || {} }));
-    setTimeout(() => { if (rpcState.pending.delete(id)) reject(new Error('rpc timeout: ' + method)); }, 10000);
+    waiter.timer = setTimeout(() => {
+      const w = rpcState.pending.get(id);
+      if (!w || w.settled) return;
+      // Keep the entry, flagged — deleting it (as this used to) makes a late
+      // reply hit `onmessage`'s `!waiter` guard and vanish, which is why the
+      // failure modal could never be taken back down (#931).
+      w.settled = true;
+      w.settledAt = Date.now();
+      const err = new Error(
+        'rpc timeout: ' + method + ' (no response in ' + Math.round(ms / 1000) + 's)');
+      // Tagged so a caller can tell "we stopped waiting" from "the daemon said
+      // no" — the two deserve different words on screen.
+      err.rpcTimeout = true;
+      err.rpcMethod = method;
+      w.reject(err);
+    }, ms);
   });
 }
 
@@ -2023,10 +2132,49 @@ async function openHandoffAgentMenu(session, anchorEl) {
 // SELECTED session's surface while this runs from any row's context menu, so a
 // terminal write would land in an unrelated session's scrollback.
 async function sessionAction(method, id, extra) {
+  // Identity for the advisory this call may raise. A fresh object per call, so a
+  // late reply can only ever retract the modal *it* put up.
+  const token = {};
+  let advisoryUp = false;
   try {
-    const res = await rpc(method, Object.assign({ session_id: id }, extra || {}));
+    const res = await rpc(method, Object.assign({ session_id: id }, extra || {}), {
+      // Fires only when the response beat us back after the deadline. The
+      // advisory below promised this window would update; this is that update.
+      onLate: (result, error) => {
+        if (!advisoryUp) return;
+        advisoryUp = false;
+        if (error) {
+          // We said "still running"; the daemon has now said it failed. The
+          // truth changed — replace the advisory rather than stacking on it.
+          dismissModalDialog(token);
+          alertModal(method + ' failed: ' + (error.message || error));
+          return;
+        }
+        const dismissed = dismissModalDialog(token);
+        // An additive `warning` is information the user still needs even if they
+        // already closed the advisory (that omission is #888), so it is shown
+        // either way. A clean late success just takes the advisory down.
+        const warning = result && typeof result.warning === 'string' ? result.warning : '';
+        if (warning) alertModal(warning);
+        else if (!dismissed) { /* user moved on and it worked — stay quiet */ }
+      },
+    });
     if (res && typeof res.warning === 'string' && res.warning) alertModal(res.warning);
-  } catch (e) { alertModal(method + ' failed: ' + (e.message || e)); }
+  } catch (e) {
+    if (e && e.rpcTimeout) {
+      // NOT "failed": we stopped waiting, the daemon did not stop working.
+      // Saying otherwise invites the user to retry an action that is already in
+      // flight — which for `add-merge-label` or `complete-session` is a
+      // duplicate write, and for all of them is a lie (#931).
+      advisoryUp = true;
+      alertModal(
+        method + ' is taking longer than expected. It is still running on the daemon — '
+        + 'this message will update when it finishes.',
+        { title: 'Still running', token });
+    } else {
+      alertModal(method + ' failed: ' + (e.message || e));
+    }
+  }
 }
 
 // "In Review" with an in-flight spinner — mirrors native's ProgressView swap
@@ -2411,7 +2559,7 @@ async function quickAction(id, action, label) {
 // In-page confirm/alert modal → Promise<boolean> (true = OK/confirm). Replaces
 // window.confirm/alert, which render as native chrome (and are jarring inside the
 // desktop wrapper). cancelLabel:null makes it an alert (single OK). (CROW-593)
-function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', danger = false } = {}) {
+function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', danger = false, token = null } = {}) {
   return new Promise((resolve) => {
     let done = false;
     const backdrop = el('div', 'text-prompt-backdrop modal-dialog-backdrop');
@@ -2428,6 +2576,9 @@ function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', dang
       resolve(v);
     }
     backdrop.__finish = finish;
+    // Identity for `dismissModalDialog` — lets an async caller retract *its own*
+    // dialog and only its own, never one the user opened afterwards (#931).
+    backdrop.__token = token;
     function onKey(e) {
       if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); finish(false); }
       else if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); finish(true); }
@@ -2461,8 +2612,21 @@ function modalDialog({ title, body, okLabel = 'OK', cancelLabel = 'Cancel', dang
 function confirmModal(body, { title = 'Confirm', okLabel = 'OK', danger = false } = {}) {
   return modalDialog({ title, body, okLabel, cancelLabel: 'Cancel', danger });
 }
-function alertModal(body, { title = 'Crow' } = {}) {
-  return modalDialog({ title, body, okLabel: 'OK', cancelLabel: null });
+function alertModal(body, { title = 'Crow', token = null } = {}) {
+  return modalDialog({ title, body, okLabel: 'OK', cancelLabel: null, token });
+}
+
+// Take down the on-screen modalDialog iff it is the one created with `token`.
+// Returns whether it dismissed anything. A no-op when the dialog was already
+// dismissed by the user, or superseded by a later one — an async retraction must
+// never yank a modal someone is mid-read of. Only ever one modalDialog is
+// mounted (modalDialog supersedes its predecessors), so one query suffices.
+function dismissModalDialog(token) {
+  if (!token) return false;
+  const backdrop = document.querySelector('.modal-dialog-backdrop');
+  if (!backdrop || backdrop.__token !== token) return false;
+  if (backdrop.__finish) backdrop.__finish(false); else backdrop.remove();
+  return true;
 }
 
 function textPrompt(title, current, { placeholder = '', okLabel = 'Save' } = {}) {
@@ -3595,7 +3759,7 @@ async function startWorkingSelected(btn) {
 // Two sources, OR'd together:
 //   • `boardData.tickets.loading` — the daemon's own `isLoadingIssues`, already
 //     shipped by `list-tickets`. Covers the *automatic* board poll (and any
-//     manual refresh outliving the client's 10s rpc timeout), which is what the
+//     manual refresh outliving the client's rpc deadline), which is what the
 //     native every-minute spinner showed.
 //   • `ticketRefreshPending` — local, optimistic. Covers the gap between the
 //     click and the first board re-read so the button reacts instantly.
@@ -3632,8 +3796,9 @@ async function refreshTickets() {
   ticketRefreshPending = true;
   paintRefreshState();
   try {
-    try { await rpc('refresh-tickets'); } catch (_) { /* app down, or >10s — the
-      daemon's own `loading` flag covers the rest; never leave the spinner on */ }
+    try { await rpc('refresh-tickets'); } catch (_) { /* app down, or past the
+      120s deadline — the daemon's own `loading` flag covers the rest; never
+      leave the spinner on */ }
     // `refresh-tickets` returns before the fetch lands, so keep the settle
     // delay rather than re-reading an unchanged board.
     await new Promise((r) => setTimeout(r, 1200));
@@ -3729,7 +3894,7 @@ function toggleReviewSelect(url) {
 
 // Batch "Start Review (N)": ONE batch-start-review call with every selected PR.
 // The daemon queues the kickoffs on its review serializer and acks immediately
-// — each one clones a PR and spawns tmux, well past our 10s rpc timeout — so
+// — each one clones a PR and spawns tmux, well past our rpc deadline — so
 // the new sessions surface via the sidebar poll rather than this response
 // (CROW-865). Then clear selection and exit selection mode.
 async function startReviewSelected(btn) {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCDispatcherTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCDispatcherTests.swift
@@ -1,0 +1,269 @@
+import CrowIPC
+import Foundation
+import Testing
+@testable import CrowDaemon
+
+/// The `/rpc` read loop hands every request to ``RPCDispatcher`` instead of
+/// awaiting it inline (#931). These pin the four properties that makes safe:
+/// unrelated requests overtake a slow one, same-lane requests never do, the pool
+/// is bounded, and nothing is lost or left parked at teardown.
+@Suite struct RPCDispatcherTests {
+
+    private actor Recorder {
+        var order: [String] = []
+        func add(_ s: String) { order.append(s) }
+    }
+
+    /// Counts concurrent operations and remembers the high-water mark.
+    private actor Peak {
+        private var current = 0
+        private(set) var peak = 0
+        func enter() { current += 1; peak = max(peak, current) }
+        func leave() { current -= 1 }
+    }
+
+    /// Parks operations until opened, so a test can hold work in flight.
+    private actor Gate {
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var opened = false
+        func wait() async {
+            if opened { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+        func open() {
+            opened = true
+            let w = waiters
+            waiters.removeAll()
+            w.forEach { $0.resume() }
+        }
+    }
+
+    // MARK: - The bug
+
+    @Test func aSlowLaneDoesNotDelayAnotherLane() async {
+        let dispatcher = RPCDispatcher()
+        let recorder = Recorder()
+
+        await dispatcher.dispatch(lane: .param(name: "session_id", value: "A")) {
+            try? await Task.sleep(nanoseconds: 60_000_000)
+            await recorder.add("slow")
+        }
+        await dispatcher.dispatch(lane: .param(name: "session_id", value: "B")) {
+            await recorder.add("fast")
+        }
+        await dispatcher.drain()
+
+        // Inline dispatch — the #931 shape — would give ["slow", "fast"].
+        #expect(await recorder.order == ["fast", "slow"])
+    }
+
+    @Test func aLanelessRequestOvertakesASlowLane() async {
+        let dispatcher = RPCDispatcher()
+        let recorder = Recorder()
+
+        await dispatcher.dispatch(lane: .config) {
+            try? await Task.sleep(nanoseconds: 60_000_000)
+            await recorder.add("config")
+        }
+        await dispatcher.dispatch(lane: nil) { await recorder.add("read") }
+        await dispatcher.drain()
+
+        #expect(await recorder.order == ["read", "config"])
+    }
+
+    // MARK: - Ordering
+
+    @Test func sameLaneRunsInArrivalOrderEvenWhenLaterOpsAreFaster() async {
+        let dispatcher = RPCDispatcher()
+        let recorder = Recorder()
+        let lane = RPCDispatcher.Lane.param(name: "session_id", value: "S")
+
+        // The set-status / complete-session pair from the issue.
+        await dispatcher.dispatch(lane: lane) {
+            try? await Task.sleep(nanoseconds: 40_000_000)
+            await recorder.add("set-status")
+        }
+        await dispatcher.dispatch(lane: lane) { await recorder.add("complete-session") }
+        await dispatcher.drain()
+
+        #expect(await recorder.order == ["set-status", "complete-session"])
+    }
+
+    @Test func distinctParamNamesDoNotShareALane() async {
+        // A session UUID and a terminal UUID can be equal strings; they must not
+        // collide into one lane.
+        let dispatcher = RPCDispatcher()
+        let recorder = Recorder()
+        let shared = UUID().uuidString
+
+        await dispatcher.dispatch(lane: .param(name: "session_id", value: shared)) {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            await recorder.add("session")
+        }
+        await dispatcher.dispatch(lane: .param(name: "terminal_id", value: shared)) {
+            await recorder.add("terminal")
+        }
+        await dispatcher.drain()
+
+        #expect(await recorder.order == ["terminal", "session"])
+    }
+
+    // MARK: - Bounds
+
+    @Test func neverRunsMoreThanTheConcurrencyCap() async {
+        let dispatcher = RPCDispatcher(maxConcurrent: 3, maxInFlight: 64)
+        let peak = Peak()
+        for _ in 0..<24 {
+            await dispatcher.dispatch(lane: nil) {
+                await peak.enter()
+                try? await Task.sleep(nanoseconds: 10_000_000)
+                await peak.leave()
+            }
+        }
+        await dispatcher.drain()
+        #expect(await peak.peak <= 3)
+        // …and it really is running them in parallel, not one at a time.
+        #expect(await peak.peak > 1)
+    }
+
+    /// The deadlock this design is shaped to avoid: if a queued lane task took
+    /// its permit *before* awaiting its predecessor, a burst deeper than the cap
+    /// would hold every permit waiting on tasks that can never get one.
+    @Test func aLaneBurstDeeperThanTheCapStillCompletesInOrder() async {
+        let dispatcher = RPCDispatcher(maxConcurrent: 2, maxInFlight: 64)
+        let recorder = Recorder()
+        let lane = RPCDispatcher.Lane.param(name: "session_id", value: "S")
+
+        for i in 0..<8 {
+            await dispatcher.dispatch(lane: lane) {
+                try? await Task.sleep(nanoseconds: 2_000_000)
+                await recorder.add("\(i)")
+            }
+        }
+        await dispatcher.drain()
+
+        #expect(await recorder.order == (0..<8).map(String.init))
+        #expect(await dispatcher.runningCount == 0)
+    }
+
+    /// And the same burst must not monopolise the pool: one lane holds at most
+    /// one permit, so an unrelated request still gets through promptly.
+    @Test func aLaneBurstDoesNotStarveOtherLanes() async {
+        let dispatcher = RPCDispatcher(maxConcurrent: 2, maxInFlight: 64)
+        let recorder = Recorder()
+        let lane = RPCDispatcher.Lane.param(name: "session_id", value: "S")
+
+        for _ in 0..<8 {
+            await dispatcher.dispatch(lane: lane) {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                await recorder.add("burst")
+            }
+        }
+        await dispatcher.dispatch(lane: nil) { await recorder.add("other") }
+        await dispatcher.drain()
+
+        // "other" lands well before the 8-deep chain finishes.
+        #expect((await recorder.order.firstIndex(of: "other") ?? .max) < 4)
+    }
+
+    @Test func refusesBeyondTheInFlightCeiling() async {
+        let dispatcher = RPCDispatcher(maxConcurrent: 8, maxInFlight: 2)
+        let gate = Gate()
+
+        #expect(await dispatcher.dispatch(lane: nil) { await gate.wait() })
+        #expect(await dispatcher.dispatch(lane: nil) { await gate.wait() })
+        // The third is refused, so the reader answers it itself rather than
+        // letting it sit until the client's deadline.
+        #expect(await dispatcher.dispatch(lane: nil) {} == false)
+
+        await gate.open()
+        await dispatcher.drain()
+        // Capacity returns once the ceiling clears.
+        #expect(await dispatcher.dispatch(lane: nil) {})
+        await dispatcher.drain()
+    }
+
+    // MARK: - Lifecycle
+
+    @Test func drainReturnsOnlyAfterEveryResponseIsYielded() async {
+        let dispatcher = RPCDispatcher()
+        let (stream, cont) = AsyncStream.makeStream(of: String.self)
+
+        for i in 0..<5 {
+            await dispatcher.dispatch(lane: nil) {
+                try? await Task.sleep(nanoseconds: UInt64((5 - i) * 10_000_000))
+                cont.yield("r\(i)")
+            }
+        }
+        await dispatcher.drain()
+        // Exactly what the reader does next: nothing may still be in flight.
+        cont.finish()
+
+        var received: [String] = []
+        for await text in stream { received.append(text) }
+        #expect(received.count == 5)
+        #expect(Set(received) == Set((0..<5).map { "r\($0)" }))
+    }
+
+    @Test func shutdownReleasesADrainerAndSkipsQueuedWork() async {
+        let dispatcher = RPCDispatcher(maxConcurrent: 1, maxInFlight: 64)
+        let gate = Gate()
+        let recorder = Recorder()
+        let lane = RPCDispatcher.Lane.param(name: "session_id", value: "S")
+
+        await dispatcher.dispatch(lane: lane) {
+            await gate.wait()
+            await recorder.add("running")
+        }
+        await dispatcher.dispatch(lane: lane) { await recorder.add("queued") }
+
+        // The writer died: teardown shuts the dispatcher down, which must unpark
+        // a reader sitting in drain() rather than hang the connection's group.
+        let drained = Task { await dispatcher.drain() }
+        await dispatcher.shutdown()
+        await drained.value // returns without gate.open()
+
+        await gate.open()
+        // The queued operation was cancelled before it ever took a permit.
+        #expect(await recorder.order.contains("queued") == false)
+    }
+
+    @Test func laneTailsAreEvictedSoTheMapCannotGrowWithSessionCount() async {
+        let dispatcher = RPCDispatcher()
+        for i in 0..<200 {
+            await dispatcher.dispatch(lane: .param(name: "session_id", value: "s\(i)")) {}
+        }
+        await dispatcher.drain()
+        #expect(await dispatcher.laneCount == 0)
+        #expect(await dispatcher.inFlightCount == 0)
+    }
+
+    // MARK: - Through a real router
+
+    /// The end-to-end shape of the fix without a socket: a slow method and a
+    /// fast one on one `CommandRouter`, dispatched as the reader dispatches
+    /// them. The fast reply must reach the stream first.
+    @Test func aSlowHandlerDoesNotHoldUpAFastOneOnTheSameRouter() async {
+        let router = CommandRouter(handlers: [
+            "slow": { _ in
+                try? await Task.sleep(nanoseconds: 60_000_000)
+                return ["ok": .bool(true)]
+            },
+            "fast": { _ in ["ok": .bool(true)] },
+        ])
+        let dispatcher = RPCDispatcher()
+        let recorder = Recorder()
+
+        await dispatcher.dispatch(lane: nil) {
+            let r = await router.handle(request: JSONRPCRequest(id: 1, method: "slow"))
+            await recorder.add("\(r.id)")
+        }
+        await dispatcher.dispatch(lane: nil) {
+            let r = await router.handle(request: JSONRPCRequest(id: 2, method: "fast"))
+            await recorder.add("\(r.id)")
+        }
+        await dispatcher.drain()
+
+        #expect(await recorder.order == ["2", "1"])
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLanePolicyTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/RPCLanePolicyTests.swift
@@ -1,0 +1,112 @@
+import CrowCore
+import CrowIPC
+import Foundation
+import Testing
+@testable import CrowDaemon
+
+/// Lane classification is a decision, not a default (#931). This is the gate:
+/// it fails when a new write RPC ships without one, in the same spirit as
+/// `RPCLedgerParityTests`.
+@Suite struct RPCLanePolicyTests {
+
+    private func request(_ method: String, _ params: [String: JSONValue]? = nil) -> JSONRPCRequest {
+        JSONRPCRequest(id: 1, method: method, params: params)
+    }
+
+    /// The gate. `ParityLedger.rpcMethods` is already proven against the live
+    /// router pair, so classifying against its write half classifies against the
+    /// real surface — no second hand-maintained list of method names.
+    @Test("every ledgered write declares a lane, and nothing else does")
+    func everyWriteMethodIsClassified() {
+        let writes = Set(ParityLedger.rpcMethods.filter(\.isWrite).map(\.method))
+        let declared = Set(RPCLanePolicy.rules.keys)
+        #expect(
+            writes.subtracting(declared).isEmpty,
+            "unclassified write RPCs: \(writes.subtracting(declared).sorted())")
+        #expect(
+            declared.subtracting(writes).isEmpty,
+            "lane rules for methods that are not ledgered writes: \(declared.subtracting(writes).sorted())")
+    }
+
+    @Test func readsTakeNoLane() {
+        for entry in ParityLedger.rpcMethods where !entry.isWrite {
+            #expect(RPCLanePolicy.lane(for: request(entry.method)) == nil, "\(entry.method)")
+        }
+    }
+
+    @Test func sessionWritesKeyOnTheirSessionID() {
+        let sid = UUID().uuidString
+        let lane = RPCLanePolicy.lane(for: request("set-status", ["session_id": .string(sid)]))
+        #expect(lane == .param(name: "session_id", value: sid))
+        // The pair from the issue shares it, so they cannot reorder.
+        #expect(RPCLanePolicy.lane(for: request("complete-session", ["session_id": .string(sid)])) == lane)
+        // A different session does not.
+        #expect(
+            RPCLanePolicy.lane(for: request("set-status", ["session_id": .string(UUID().uuidString)]))
+                != lane)
+    }
+
+    @Test func aSessionWriteWithoutASessionIDTakesNoLane() {
+        // The handler rejects it as invalidParams; bucketing every malformed
+        // request into one lane would serialize them against each other.
+        #expect(RPCLanePolicy.lane(for: request("set-status")) == nil)
+        #expect(RPCLanePolicy.lane(for: request("set-status", ["session_id": .string("")])) == nil)
+    }
+
+    @Test func everyConfigMutationSharesOneLane() {
+        // The lane that keeps `/rpc` from contending with itself for
+        // `ConfigStore.withConfigLock` — an NSLock held across disk I/O.
+        for method in [
+            "set-config", "defaults-set", "job-add", "workspace-edit",
+            "telemetry-set", "gateway-set", "run-setup",
+        ] {
+            #expect(RPCLanePolicy.lane(for: request(method)) == .config, "\(method)")
+        }
+    }
+
+    @Test func reviewKickoffsShareOneLaneSoTheyCannotHoldEveryPermit() {
+        #expect(RPCLanePolicy.lane(for: request("start-review")) == .reviewKickoff)
+        #expect(RPCLanePolicy.lane(for: request("batch-start-review")) == .reviewKickoff)
+    }
+
+    @Test func managerWritesShareOneLane() {
+        for method in [
+            "create-manager", "restart-manager", "work-on-issue",
+            "batch-work-on-issues", "restart-tmux-server", "reload-tmux-config",
+        ] {
+            #expect(RPCLanePolicy.lane(for: request(method)) == .manager, "\(method)")
+        }
+    }
+
+    @Test func terminalAndJobWritesKeyOnTheirOwnIdentifiers() {
+        let tid = UUID().uuidString
+        #expect(
+            RPCLanePolicy.lane(for: request("launch-agent", ["terminal_id": .string(tid)]))
+                == .param(name: "terminal_id", value: tid))
+        #expect(
+            RPCLanePolicy.lane(for: request("retry-readiness", ["terminal_id": .string(tid)]))
+                == .param(name: "terminal_id", value: tid))
+        let jid = UUID().uuidString
+        #expect(
+            RPCLanePolicy.lane(for: request("job-run", ["job_id": .string(jid)]))
+                == .param(name: "job_id", value: jid))
+        #expect(
+            RPCLanePolicy.lane(for: request("run-job", ["job_id": .string(jid)]))
+                == .param(name: "job_id", value: jid))
+    }
+
+    @Test func selfGuardingMethodsAreDeliberatelyConcurrent() {
+        // `IssueTracker.refresh()` early-returns on `isRefreshing` and
+        // `ScorecardRebuilder` coalesces, so laning either would turn an
+        // immediate return into a wait and make a client timeout *more* likely.
+        #expect(RPCLanePolicy.lane(for: request("refresh-tickets")) == nil)
+        #expect(RPCLanePolicy.lane(for: request("rebuild-scorecard")) == nil)
+        // A brand-new id has nothing to order against.
+        #expect(RPCLanePolicy.lane(for: request("new-session")) == nil)
+    }
+
+    @Test func anUnknownMethodTakesNoLane() {
+        // methodNotFound returns instantly; there is nothing to order.
+        #expect(RPCLanePolicy.lane(for: request("no-such-method")) == nil)
+    }
+}

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -58,6 +58,27 @@ auto-merge-enabled glyph, the composed `aria-label`, graceful degradation when
 the live `pr` entry is missing or `has_pr: false`, and the ticket-label pills
 (2-pill cap + `+N` overflow, hidden under `hideSessionDetails`).
 
+## `rpc-timeout.test.js` — JSON-RPC deadlines + late responses (#931)
+
+Drives `rpc`, `rpcTimeoutFor`, `sessionAction` and `dismissModalDialog` against
+a fake `/rpc` socket and a controllable timer queue. Coverage: the per-method
+timeout table mirroring the CLI's (incl. the wire-name check — `crow job run`
+sends `job-run` while Settings' "Run now" sends `run-job`, so both must be
+listed) and the 30s default; a timeout rejecting with a tagged `err.rpcTimeout`
+while *retaining* the pending entry rather than deleting it; a late response
+routing to the `onLate` hook instead of vanishing into `onmessage`'s `!waiter`
+guard; `sessionAction` showing a "Still running" advisory rather than a "failed"
+modal, then dismissing it on late success, surfacing an additive `warning` (#888)
+if one comes back, and replacing it with the real error on late failure;
+`dismissModalDialog` refusing to yank a dialog that superseded its own;
+`ws.onclose` rejecting unsettled calls and dropping settled ones without firing
+`onLate`; and the settled-entry GC.
+
+Unlike the other files, this one's fake `WebSocket` actually fires `onopen` (so
+`rpcState.ready` resolves) and its `setTimeout`/`clearTimeout` are a controllable
+queue rather than no-ops — deadlines have to fire on demand, and firing them *by
+delay* is what proves each method was armed from the table.
+
 ## Run
 
 ```sh

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,9 +2,9 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board touch-scroll wheel-scroll key-handler row sidebar-groups sidebar-select; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board touch-scroll wheel-scroll key-handler row sidebar-groups sidebar-select rpc-timeout; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/rpc-timeout.test.js
+++ b/Packages/CrowDaemon/web-tests/rpc-timeout.test.js
@@ -1,0 +1,282 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// #931 regression tests for the RPC layer: per-method deadlines mirroring the
+// CLI, and a timeout that can never leave a spurious "failed" modal on screen
+// after the daemon answers. Same loader shape as row.test.js — the REAL app.js
+// in a jsdom VM plus an epilogue exposing module-scope internals — with two
+// necessary deviations, both because this file tests the transport itself:
+//   • the fake WebSocket must FIRE onopen (row.test.js discards it), or
+//     `rpcState.ready` never resolves and rpc() can't send;
+//   • setTimeout/clearTimeout are a controllable queue rather than `() => 0`,
+//     so a deadline can be fired on demand AND selected by its delay — which is
+//     how we assert the table is keyed to the right wire method name.
+const epilogue = `
+;globalThis.__t = {
+  rpc(m, p, o){ return rpc(m, p, o); },
+  rpcState,
+  rpcTimeoutFor(m){ return rpcTimeoutFor(m); },
+  gcSettledRPCs(){ return gcSettledRPCs(); },
+  sessionAction(m, id, x){ return sessionAction(m, id, x); },
+  dismissModalDialog(t){ return dismissModalDialog(t); },
+  RPC_DEFAULT_TIMEOUT_MS,
+  RPC_LATE_WINDOW_MS,
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body>
+     <div id="sidebar"></div><div id="board"></div><div id="header"></div>
+   </body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+
+// --- controllable timers ----------------------------------------------------
+let timerSeq = 0;
+const timers = [];
+window.setTimeout = (fn, ms) => { timers.push({ id: ++timerSeq, fn, ms: ms || 0 }); return timerSeq; };
+window.clearTimeout = (id) => { const i = timers.findIndex((t) => t.id === id); if (i >= 0) timers.splice(i, 1); };
+window.setInterval = () => 0;
+window.requestAnimationFrame = () => 0;
+// Fire (and remove) every queued timer scheduled with exactly `ms`. Selecting by
+// delay is the point: it proves `add-merge-label` was armed at 60s and not at
+// the 30s default.
+function fireTimersAt(ms) {
+  const hits = timers.filter((t) => t.ms === ms);
+  hits.forEach((t) => { timers.splice(timers.indexOf(t), 1); t.fn(); });
+  return hits.length;
+}
+
+// --- fake /rpc socket -------------------------------------------------------
+const sockets = [];
+window.WebSocket = function () {
+  const s = {
+    sent: [], closed: false,
+    send(d) { this.sent.push(JSON.parse(d)); },
+    close() { this.closed = true; if (this._onclose) this._onclose(); },
+    deliver(msg) { if (this._onmessage) this._onmessage({ data: JSON.stringify(msg) }); },
+  };
+  // rpcConnect assigns `ws.onopen` on the line after `new WebSocket(...)`, so
+  // `ws` is already bound and calling the handler straight from the setter
+  // resolves `rpcState.ready`.
+  Object.defineProperty(s, 'onopen', { set(fn) { s._onopen = fn; fn(); } });
+  Object.defineProperty(s, 'onmessage', { set(fn) { s._onmessage = fn; } });
+  Object.defineProperty(s, 'onclose', { set(fn) { s._onclose = fn; } });
+  Object.defineProperty(s, 'onerror', { set(fn) { s._onerror = fn; } });
+  sockets.push(s);
+  return s;
+};
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+// Node's own setTimeout — the VM's is the fake above.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const doc = window.document;
+const modalNode = () => doc.querySelector('.modal-dialog-backdrop');
+const modalText = () => {
+  const b = modalNode();
+  return b ? ((b.querySelector('.text-prompt-body') || {}).textContent || '') : null;
+};
+const modalTitle = () => {
+  const b = modalNode();
+  return b ? ((b.querySelector('.text-prompt-title') || {}).textContent || '') : null;
+};
+
+async function reset() {
+  T.rpcState.pending.clear();
+  timers.length = 0;
+  doc.querySelectorAll('.modal-dialog-backdrop').forEach((b) => b.remove());
+  if (cur()) cur().sent.length = 0;
+  await flush();
+}
+
+// The newest socket. `ws.onclose` nulls `rpcState.ready`, so the next rpc()
+// opens a fresh one — after the onclose block below, a captured reference would
+// be stale.
+const cur = () => sockets[sockets.length - 1];
+const lastId = () => cur().sent[cur().sent.length - 1].id;
+const deliver = (msg) => cur().deliver(msg);
+
+(async function run() {
+  // Boot may or may not have opened the socket; force one so `cur()` exists.
+  T.rpc('list-sessions').catch(() => {});
+  await flush();
+  check('a single /rpc socket backs every call', sockets.length === 1);
+
+  console.log('\nPer-method timeout table mirrors the CLI:');
+  check('default is 30s', T.rpcTimeoutFor('list-sessions') === 30000);
+  check('unknown method falls back to the default',
+    T.rpcTimeoutFor('no-such-method') === T.RPC_DEFAULT_TIMEOUT_MS);
+  check('rebuild-scorecard 180s', T.rpcTimeoutFor('rebuild-scorecard') === 180000);
+  check('refresh-tickets 120s', T.rpcTimeoutFor('refresh-tickets') === 120000);
+  check('start-review 120s', T.rpcTimeoutFor('start-review') === 120000);
+  check('batch-start-review 120s', T.rpcTimeoutFor('batch-start-review') === 120000);
+  // The wire-name check: `crow job run` sends job-run, Settings' "Run now" sends
+  // run-job. Keying only off the CLI verb would leave the web button on 30s.
+  check('job-run 120s (CLI wire name)', T.rpcTimeoutFor('job-run') === 120000);
+  check('run-job 120s (web wire name)', T.rpcTimeoutFor('run-job') === 120000);
+  check('add-merge-label 60s', T.rpcTimeoutFor('add-merge-label') === 60000);
+  check('mark-issue-done 60s', T.rpcTimeoutFor('mark-issue-done') === 60000);
+  check('quick-action 60s', T.rpcTimeoutFor('quick-action') === 60000);
+  check('get-state 60s', T.rpcTimeoutFor('get-state') === 60000);
+  check('batch-work-on-issues 60s', T.rpcTimeoutFor('batch-work-on-issues') === 60000);
+
+  console.log('\nTimeout rejects tagged and RETAINS the pending entry:');
+  await reset();
+  let caught = null;
+  const p = T.rpc('add-merge-label', { session_id: 's1' }).catch((e) => { caught = e; });
+  await flush();
+  const id1 = lastId();
+  check('armed at the table value, not the default', fireTimersAt(60000) === 1);
+  await p;
+  check('rejected', !!caught);
+  check('tagged err.rpcTimeout', caught.rpcTimeout === true);
+  check('tagged err.rpcMethod', caught.rpcMethod === 'add-merge-label');
+  check('message names the method and the deadline',
+    /add-merge-label/.test(caught.message) && /60s/.test(caught.message));
+  check('pending entry retained (not deleted)', T.rpcState.pending.has(id1));
+  check('entry flagged settled', T.rpcState.pending.get(id1).settled === true);
+
+  console.log('\nA late response routes to onLate, not the dropped-message path:');
+  await reset();
+  let late = null;
+  const p2 = T.rpc('add-merge-label', { session_id: 's1' }, {
+    onLate: (result, error) => { late = { result, error }; },
+  }).catch(() => {});
+  await flush();
+  const id2 = lastId();
+  fireTimersAt(60000);
+  await p2;
+  deliver({ jsonrpc: '2.0', id: id2, result: { ok: true, warning: 'watcher is off' } });
+  check('onLate fired with the result', late && late.result && late.result.ok === true);
+  check('onLate error arg is null on success', late && late.error === null);
+  check('entry dropped once delivered', !T.rpcState.pending.has(id2));
+
+  console.log('\nA late *error* response reaches onLate as an Error:');
+  await reset();
+  late = null;
+  const p3 = T.rpc('add-merge-label', {}, { onLate: (r, e) => { late = { r, e }; } }).catch(() => {});
+  await flush();
+  const id3 = lastId();
+  fireTimersAt(60000);
+  await p3;
+  deliver({ jsonrpc: '2.0', id: id3, error: { message: 'label create denied' } });
+  check('onLate result arg is null on failure', late && late.r === null);
+  check('onLate carries the daemon message', late && /label create denied/.test(late.e.message));
+
+  console.log('\nsessionAction: timeout shows an advisory, not "failed":');
+  await reset();
+  const sa = T.sessionAction('add-merge-label', 's1');
+  await flush();
+  const id4 = lastId();
+  fireTimersAt(60000);
+  await flush();
+  check('a modal is up', modalText() !== null);
+  check('titled "Still running"', modalTitle() === 'Still running');
+  check('does NOT say failed', !/failed/i.test(modalText()));
+  check('says it is still running on the daemon', /still running on the daemon/.test(modalText()));
+
+  console.log('\n…and a late success takes that advisory down:');
+  deliver({ jsonrpc: '2.0', id: id4, result: { ok: true } });
+  await flush();
+  await sa;
+  check('advisory dismissed', modalNode() === null);
+
+  console.log('\n…a late success WITH a warning replaces it with the warning (#888):');
+  await reset();
+  const sa2 = T.sessionAction('add-merge-label', 's1');
+  await flush();
+  const id5 = lastId();
+  fireTimersAt(60000);
+  await flush();
+  deliver({ jsonrpc: '2.0', id: id5, result: { ok: true, warning: 'auto-merge watcher is off' } });
+  await flush();
+  await sa2;
+  check('warning shown', /auto-merge watcher is off/.test(modalText() || ''));
+  check('not the advisory any more', modalTitle() !== 'Still running');
+
+  console.log('\n…and a late failure replaces it with the real error:');
+  await reset();
+  const sa3 = T.sessionAction('add-merge-label', 's1');
+  await flush();
+  const id6 = lastId();
+  fireTimersAt(60000);
+  await flush();
+  deliver({ jsonrpc: '2.0', id: id6, error: { message: 'gh: not authenticated' } });
+  await flush();
+  await sa3;
+  check('one modal, not two', doc.querySelectorAll('.modal-dialog-backdrop').length === 1);
+  check('reads as a real failure',
+    /add-merge-label failed: gh: not authenticated/.test(modalText()));
+
+  console.log('\nA non-timeout rejection still reads as a plain failure:');
+  await reset();
+  const sa4 = T.sessionAction('set-locked', 's1', { locked: true });
+  await flush();
+  deliver({ jsonrpc: '2.0', id: lastId(), error: { message: 'session not found' } });
+  await sa4;
+  check('titled Crow (alertModal default), not "Still running"', modalTitle() === 'Crow');
+  check('says failed', /set-locked failed: session not found/.test(modalText()));
+
+  console.log('\ndismissModalDialog only retracts its own dialog:');
+  await reset();
+  const sa5 = T.sessionAction('add-merge-label', 's1');
+  await flush();
+  const id7 = lastId();
+  fireTimersAt(60000);
+  await flush();
+  check('advisory up', modalTitle() === 'Still running');
+  // Something else (a user action) supersedes it before the reply lands.
+  modalNode().__token = { someone: 'else' };
+  deliver({ jsonrpc: '2.0', id: id7, result: { ok: true } });
+  await flush();
+  await sa5;
+  check('a superseding dialog is never yanked', modalNode() !== null);
+  check('stale token is a no-op', T.dismissModalDialog({}) === false);
+  check('null token is a no-op', T.dismissModalDialog(null) === false);
+
+  console.log('\nonclose clears both settled and unsettled entries:');
+  await reset();
+  let closeErr = null, lateAfterClose = false;
+  const pA = T.rpc('list-sessions').catch((e) => { closeErr = e; });
+  await flush();
+  const pB = T.rpc('add-merge-label', {}, { onLate: () => { lateAfterClose = true; } }).catch(() => {});
+  await flush();
+  fireTimersAt(60000); // B times out and is retained
+  await pB;
+  check('one settled + one live entry before close', T.rpcState.pending.size === 2);
+  cur().close();
+  await pA;
+  check('unsettled rejected with connection closed',
+    closeErr && /connection closed/.test(closeErr.message));
+  check('map fully cleared', T.rpcState.pending.size === 0);
+  check('settled entry dropped silently — no onLate on an unknown outcome',
+    lateAfterClose === false);
+
+  console.log('\nSettled entries are garbage-collected:');
+  await reset();
+  const pC = T.rpc('add-merge-label', {}).catch(() => {});
+  await flush();
+  const id8 = lastId();
+  fireTimersAt(60000);
+  await pC;
+  check('retained immediately after the timeout', T.rpcState.pending.has(id8));
+  T.rpcState.pending.get(id8).settledAt = Date.now() - (T.RPC_LATE_WINDOW_MS + 1000);
+  T.gcSettledRPCs();
+  check('swept once past the late window', !T.rpcState.pending.has(id8));
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -201,6 +201,34 @@ public final class IssueTracker {
     /// In-memory only; a restart re-evaluates, which is harmless.
     private var autoUpdateBranchAttempted: Set<String> = []
 
+    /// Repos whose `crow:merge` label we have already created — or confirmed
+    /// present — this process lifetime. Keyed `"<provider>\n<owner/repo>"`,
+    /// provider-qualified because an `owner/repo` slug is not unique across
+    /// hosts.
+    ///
+    /// `ensureMergeLabel` is a `gh label create` shell-out that succeeds by
+    /// swallowing "already exists", so after the first call it is pure latency:
+    /// the watcher pays it once per dispatched PR per poll and `addMergeLabel`
+    /// pays it on every click (#931). `GitHubCodeBackend` is a `struct` rebuilt
+    /// by every `ProviderManager.codeBackend(for:)` call, so the memo cannot
+    /// live there without static mutable state; `IssueTracker` is the one
+    /// long-lived `@MainActor` object both callers already route through.
+    ///
+    /// Populated ONLY on success — a throw leaves the key absent so the next
+    /// call retries. Latching a repo the token couldn't reach would be exactly
+    /// the "reported success for work it never did" failure CROW-816 removed.
+    /// Never invalidated: a label deleted out from under a running daemon is
+    /// re-created after the next restart, and in between `addMergeLabel` still
+    /// *throws* on the real `gh pr edit --add-label` failure.
+    private var ensuredMergeLabelRepos: Set<String> = []
+
+    /// In-flight `ensureMergeLabel` calls, same key as
+    /// ``ensuredMergeLabelRepos``. Without this, the first poll that dispatches
+    /// N PRs in one repo fires N concurrent identical shell-outs before any of
+    /// them can populate the memo — which would only take effect from the
+    /// *second* poll onward.
+    private var ensureMergeLabelTasks: [String: Task<Void, Error>] = [:]
+
     /// PR URLs with an auto-rebase attempt currently in flight. Cleared when
     /// the attempt finishes so the next poll can re-evaluate.
     private var autoRebaseInFlight: Set<String> = []
@@ -1241,6 +1269,40 @@ public final class IssueTracker {
             changesRequestedReviewerLogins: pr.changesRequestedReviewerLogins,
             pendingReviewerLogins: pr.pendingReviewerLogins,
             hasPendingReviewRequest: pr.hasPendingReviewRequest,
+            updatedAt: pr.updatedAt,
+            mergeCommitOid: pr.mergeCommitOid,
+            repoAutoMergeAllowed: pr.repoAutoMergeAllowed
+        )
+    }
+
+    /// Copy `pr` with `labels` replaced. Companion to ``withURL(_:url:)``, and
+    /// unlike it this preserves **every** field — `repoAutoMergeAllowed` in
+    /// particular decides a branch in ``evaluateAutoMerge(session:byURL:)``, so
+    /// dropping it here would silently change the verdict.
+    ///
+    /// Used by ``reevaluateAutoMergeAfterLabel(session:prURL:)`` to union in a
+    /// label we just provably added but the provider's read side may not report
+    /// yet (#931).
+    nonisolated static func withLabels(_ pr: ViewerPR, labels: [LabelInfo]) -> ViewerPR {
+        PRRecord(
+            number: pr.number,
+            url: pr.url,
+            state: pr.state,
+            mergeable: pr.mergeable,
+            mergeStateStatus: pr.mergeStateStatus,
+            reviewDecision: pr.reviewDecision,
+            isDraft: pr.isDraft,
+            headRefName: pr.headRefName,
+            headRefOid: pr.headRefOid,
+            baseRefName: pr.baseRefName,
+            repoNameWithOwner: pr.repoNameWithOwner,
+            labels: labels,
+            linkedIssueReferences: pr.linkedIssueReferences,
+            checksState: pr.checksState,
+            failedCheckNames: pr.failedCheckNames,
+            latestReviewStates: pr.latestReviewStates,
+            lastChangesRequestedAt: pr.lastChangesRequestedAt,
+            lastSubstantiveCommitAt: pr.lastSubstantiveCommitAt,
             updatedAt: pr.updatedAt,
             mergeCommitOid: pr.mergeCommitOid,
             repoAutoMergeAllowed: pr.repoAutoMergeAllowed
@@ -2956,12 +3018,29 @@ public final class IssueTracker {
         syncPRAttributionMirror()
     }
 
+    /// What one session's auto-merge evaluation did. Returned by
+    /// ``evaluateAutoMerge(session:byURL:)`` so the per-poll caller can keep its
+    /// aggregate summary line without the loop body reaching into the caller's
+    /// counters — the single-session caller has no counters at all.
+    struct AutoMergeOutcome {
+        enum Dispatch: String { case none, enable, updateBranch, directMerge }
+        var dispatch: Dispatch = .none
+        /// Pre-formatted `<key>:<reason>` token for the per-poll summary line.
+        /// `nil` when the session was never a candidate (no `.pr` link) — that
+        /// is not a skip, it's a session the watcher doesn't speak about.
+        var skip: String?
+    }
+
     /// Per-refresh entry point. Picks candidate (session, PR) pairs and
     /// kicks off the async enable flow once each. Publishes a per-session
     /// verdict to `appState.autoMergeState` on the way through, so the reason a
     /// PR didn't merge reaches the UI and not just the automation log (#888).
     /// No-op (beyond publishing an `off` verdict) when the global
     /// `autoMergeWatcherEnabled` setting is off.
+    ///
+    /// A thin aggregator over ``evaluateAutoMerge(session:byURL:)`` since #931:
+    /// `addMergeLabel` re-evaluates a single session through the same function
+    /// rather than paying for a whole board poll.
     private func applyAutoMerge(viewerPRs: [ViewerPR]) {
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
@@ -2974,13 +3053,7 @@ public final class IssueTracker {
             // applied `crow:merge` needs to see *on that session* that nothing
             // is listening — that specific confusion is the whole of #888.
             for session in appState.sessions where !session.isManager {
-                guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }),
-                      let pr = byURL[prLink.url],
-                      Self.hasAutoMergeLabel(pr: pr) else {
-                    appState.autoMergeState.removeValue(forKey: session.id)
-                    continue
-                }
-                publishAutoMergeVerdict(.watcherOff, session: session, pr: pr)
+                publishWatcherOffVerdict(session: session, byURL: byURL)
             }
             return
         }
@@ -2995,88 +3068,13 @@ public final class IssueTracker {
         var skips: [String] = []
 
         for session in appState.sessions where !session.isManager {
-            guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else {
-                appState.autoMergeState.removeValue(forKey: session.id)
-                continue
-            }
-            guard !autoMergeInFlight.contains(prLink.url) else {
-                // A permanent outcome keeps its marker set on purpose — report
-                // the reason it stopped, not the bare marker (review #787).
-                let latched = autoMergePermanentSkips[prLink.url]
-                    .flatMap(AutoMergeSkipReason.init(rawValue:)) ?? .inFlight
-                skips.append("\(prLink.url):\(latched.rawValue)")
-                // The async attempt publishes its own verdict; don't overwrite a
-                // richer one with the bare in-flight marker.
-                if appState.autoMergeState[session.id] == nil {
-                    publishAutoMergeVerdict(latched, session: session, pr: byURL[prLink.url])
-                }
-                continue
-            }
-            guard let pr = byURL[prLink.url] else {
-                // The PR is linked to a live session but absent from the
-                // viewer-PR fetch — a fetch/scope problem, not an eligibility
-                // one, and invisible before CROW-782. The log line is
-                // unconditional (it's fetch health, not an auto-merge verdict);
-                // the *chip* is not.
-                skips.append("\(prLink.url):\(AutoMergeSkipReason.notInViewerPRs.rawValue)")
-                // Only speak auto-merge vocabulary about a PR that actually
-                // asked for auto-merge. `pr` is nil here, so the label can't be
-                // read off the record — fall back to what we already know:
-                // the last fetch that *did* see it, or the fact that Crow has
-                // already armed it. Without that, an ordinary feature PR aging
-                // out of the 50-most-recently-updated window would grow an
-                // "Auto-merge waiting" chip it never earned — the exact class
-                // of misleading signal #888 exists to remove (review #899).
-                let everArmed = appState.prStatus[session.id]?.hasMergeLabel == true
-                    || session.autoMergeEnabledAt != nil
-                if everArmed {
-                    publishAutoMergeVerdict(.notInViewerPRs, session: session, pr: nil)
-                } else {
-                    appState.autoMergeState.removeValue(forKey: session.id)
-                }
-                continue
-            }
-            if let reason = Self.autoMergeSkipReason(pr: pr, session: session) {
-                skips.append("#\(pr.number):\(reason.rawValue)")
-                publishAutoMergeVerdict(reason, session: session, pr: pr)
-                continue
-            }
-
-            let capturedSession = session
-            if Self.shouldDirectMerge(pr: pr, session: session) {
-                // The repo forbids GitHub's auto-merge queue, so `--auto` can
-                // never succeed here — but the PR is green and approved, which
-                // is exactly the case that used to sit labeled forever (#888).
-                autoMergeInFlight.insert(prLink.url)
-                directMergeCount += 1
-                Task { await self.attemptDirectMerge(session: capturedSession, pr: pr) }
-            } else if Self.shouldUpdateBranchBeforeMerge(pr: pr, session: session) {
-                // Behind base: bring the branch up to date this turn instead
-                // of merging. One attempt per head commit (loop safety); the
-                // next poll re-evaluates once GitHub recomputes mergeability.
-                let key = "\(prLink.url)\n\(pr.headRefOid)"
-                guard !autoUpdateBranchAttempted.contains(key) else {
-                    skips.append("#\(pr.number):\(AutoMergeSkipReason.updateBranchAlreadyAttempted.rawValue)")
-                    publishAutoMergeVerdict(.updateBranchAlreadyAttempted, session: session, pr: pr)
-                    continue
-                }
-                autoUpdateBranchAttempted.insert(key)
-                autoMergeInFlight.insert(prLink.url)
-                updateBranchCount += 1
-                Task { await self.attemptUpdateBranch(session: capturedSession, pr: pr) }
-            } else if pr.repoAutoMergeAllowed == false {
-                // Repo forbids auto-merge, so `enableAutoMerge` can never
-                // succeed — but the PR isn't green enough for a direct merge
-                // *yet*. Deliberately NOT latched: labels are usually applied
-                // while CI is still running, so latching here would freeze the
-                // PR before it ever had a chance to qualify for the fallback,
-                // which is the case #888 exists to fix. Re-evaluated every poll.
-                skips.append("#\(pr.number):\(AutoMergeSkipReason.repoDisallowsAutoMergePending.rawValue)")
-                publishAutoMergeVerdict(.repoDisallowsAutoMergePending, session: session, pr: pr)
-            } else {
-                autoMergeInFlight.insert(prLink.url)
-                enabledCount += 1
-                Task { await self.attemptEnableAutoMerge(session: capturedSession, pr: pr) }
+            let outcome = evaluateAutoMerge(session: session, byURL: byURL)
+            if let skip = outcome.skip { skips.append(skip) }
+            switch outcome.dispatch {
+            case .enable: enabledCount += 1
+            case .updateBranch: updateBranchCount += 1
+            case .directMerge: directMergeCount += 1
+            case .none: break
             }
         }
 
@@ -3086,6 +3084,189 @@ public final class IssueTracker {
         CrowLog.automation(
             "auto-merge: dispatched=\(enabledCount) updateBranch=\(updateBranchCount) "
             + "directMerge=\(directMergeCount) skipped=\(skips.count)\(skipDetail)")
+    }
+
+    /// The watcher-off verdict for one session. Split out of ``applyAutoMerge``'s
+    /// early return so ``reevaluateAutoMergeAfterLabel(session:prURL:)`` publishes
+    /// the *same* verdict from the same code rather than a second hand-rolled
+    /// copy that drifts — the class of bug #888 was.
+    ///
+    /// Only speaks about a PR that actually asked for auto-merge: an unlabeled
+    /// PR has no 🏷 and must not grow auto-merge vocabulary it never earned.
+    ///
+    /// Internal (not private) so `@testable` tests can drive one session's
+    /// verdict without standing up a fake provider backend, matching
+    /// ``pendingMergeLabelSessions``.
+    func publishWatcherOffVerdict(session: Session, byURL: [String: ViewerPR]) {
+        guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }),
+              let pr = byURL[prLink.url],
+              Self.hasAutoMergeLabel(pr: pr) else {
+            appState.autoMergeState.removeValue(forKey: session.id)
+            return
+        }
+        publishAutoMergeVerdict(.watcherOff, session: session, pr: pr)
+    }
+
+    /// Evaluate one session against a PR snapshot: publish its verdict and, if
+    /// it is a candidate, dispatch exactly one of the three attempts.
+    ///
+    /// This is the *whole* of ``applyAutoMerge``'s per-session decision, lifted
+    /// so the poll path and the post-`add-merge-label` targeted path share one
+    /// implementation (#931). Callers must have already checked the watcher
+    /// toggle (see ``publishWatcherOffVerdict(session:byURL:)``) — that toggle is
+    /// global and its verdict a different shape, so folding it in here would
+    /// mean every caller paying for a guard it already made.
+    ///
+    /// `byURL` is the caller's snapshot keyed by PR URL. The poll path passes
+    /// every PR in the fetch; the targeted path passes a single-entry map. The
+    /// `.notInViewerPRs` branch reads "this PR wasn't in the snapshot", which is
+    /// the honest answer for both.
+    ///
+    /// Internal (not private) so `@testable` tests can assert that the targeted
+    /// path publishes the same verdict as the poll path without standing up a
+    /// fake provider backend, matching ``pendingMergeLabelSessions``.
+    @discardableResult
+    func evaluateAutoMerge(session: Session, byURL: [String: ViewerPR]) -> AutoMergeOutcome {
+        guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else {
+            appState.autoMergeState.removeValue(forKey: session.id)
+            return AutoMergeOutcome()
+        }
+        guard !autoMergeInFlight.contains(prLink.url) else {
+            // A permanent outcome keeps its marker set on purpose — report
+            // the reason it stopped, not the bare marker (review #787).
+            let latched = autoMergePermanentSkips[prLink.url]
+                .flatMap(AutoMergeSkipReason.init(rawValue:)) ?? .inFlight
+            // The async attempt publishes its own verdict; don't overwrite a
+            // richer one with the bare in-flight marker.
+            if appState.autoMergeState[session.id] == nil {
+                publishAutoMergeVerdict(latched, session: session, pr: byURL[prLink.url])
+            }
+            return AutoMergeOutcome(skip: "\(prLink.url):\(latched.rawValue)")
+        }
+        guard let pr = byURL[prLink.url] else {
+            // The PR is linked to a live session but absent from the
+            // viewer-PR fetch — a fetch/scope problem, not an eligibility
+            // one, and invisible before CROW-782. The log line is
+            // unconditional (it's fetch health, not an auto-merge verdict);
+            // the *chip* is not.
+            //
+            // Only speak auto-merge vocabulary about a PR that actually
+            // asked for auto-merge. `pr` is nil here, so the label can't be
+            // read off the record — fall back to what we already know:
+            // the last fetch that *did* see it, or the fact that Crow has
+            // already armed it. Without that, an ordinary feature PR aging
+            // out of the 50-most-recently-updated window would grow an
+            // "Auto-merge waiting" chip it never earned — the exact class
+            // of misleading signal #888 exists to remove (review #899).
+            let everArmed = appState.prStatus[session.id]?.hasMergeLabel == true
+                || session.autoMergeEnabledAt != nil
+            if everArmed {
+                publishAutoMergeVerdict(.notInViewerPRs, session: session, pr: nil)
+            } else {
+                appState.autoMergeState.removeValue(forKey: session.id)
+            }
+            return AutoMergeOutcome(skip: "\(prLink.url):\(AutoMergeSkipReason.notInViewerPRs.rawValue)")
+        }
+        if let reason = Self.autoMergeSkipReason(pr: pr, session: session) {
+            publishAutoMergeVerdict(reason, session: session, pr: pr)
+            return AutoMergeOutcome(skip: "#\(pr.number):\(reason.rawValue)")
+        }
+
+        if Self.shouldDirectMerge(pr: pr, session: session) {
+            // The repo forbids GitHub's auto-merge queue, so `--auto` can
+            // never succeed here — but the PR is green and approved, which
+            // is exactly the case that used to sit labeled forever (#888).
+            autoMergeInFlight.insert(prLink.url)
+            Task { await self.attemptDirectMerge(session: session, pr: pr) }
+            return AutoMergeOutcome(dispatch: .directMerge)
+        }
+        if Self.shouldUpdateBranchBeforeMerge(pr: pr, session: session) {
+            // Behind base: bring the branch up to date this turn instead
+            // of merging. One attempt per head commit (loop safety); the
+            // next poll re-evaluates once GitHub recomputes mergeability.
+            let key = "\(prLink.url)\n\(pr.headRefOid)"
+            guard !autoUpdateBranchAttempted.contains(key) else {
+                publishAutoMergeVerdict(.updateBranchAlreadyAttempted, session: session, pr: pr)
+                return AutoMergeOutcome(
+                    skip: "#\(pr.number):\(AutoMergeSkipReason.updateBranchAlreadyAttempted.rawValue)")
+            }
+            autoUpdateBranchAttempted.insert(key)
+            autoMergeInFlight.insert(prLink.url)
+            Task { await self.attemptUpdateBranch(session: session, pr: pr) }
+            return AutoMergeOutcome(dispatch: .updateBranch)
+        }
+        if pr.repoAutoMergeAllowed == false {
+            // Repo forbids auto-merge, so `enableAutoMerge` can never
+            // succeed — but the PR isn't green enough for a direct merge
+            // *yet*. Deliberately NOT latched: labels are usually applied
+            // while CI is still running, so latching here would freeze the
+            // PR before it ever had a chance to qualify for the fallback,
+            // which is the case #888 exists to fix. Re-evaluated every poll.
+            publishAutoMergeVerdict(.repoDisallowsAutoMergePending, session: session, pr: pr)
+            return AutoMergeOutcome(
+                skip: "#\(pr.number):\(AutoMergeSkipReason.repoDisallowsAutoMergePending.rawValue)")
+        }
+        autoMergeInFlight.insert(prLink.url)
+        Task { await self.attemptEnableAutoMerge(session: session, pr: pr) }
+        return AutoMergeOutcome(dispatch: .enable)
+    }
+
+    /// Re-evaluate auto-merge for exactly one session, right after its
+    /// `crow:merge` label landed, using a targeted per-PR fetch instead of a
+    /// full board poll.
+    ///
+    /// Replaces `await refresh()` in ``addMergeLabel(sessionID:)`` (#931). Two
+    /// problems with that call, one of them a live correctness bug:
+    ///
+    /// - **Cost.** `refresh()` re-queries every configured GitHub / GitLab /
+    ///   Jira / Corveil surface — 4-5s measured — to learn one PR's label state,
+    ///   and the RPC (so the CLI, and the web client's whole `/rpc` socket)
+    ///   blocked on all of it.
+    /// - **Correctness.** `refresh()` opens with `guard !isRefreshing else
+    ///   { return }` and `guard shouldPoll()`. A scheduled poll already in
+    ///   flight, or a rate-limit suspension, makes it a silent no-op — and the
+    ///   `autoMergeWarning` read below it then reports the *previous* poll's
+    ///   verdict, or nothing at all on a freshly linked PR, while claiming to
+    ///   have re-read. This path has no such guard: it always fetches.
+    ///
+    /// Deliberately does NOT touch `appState.prStatus` beyond the optimistic
+    /// write the caller already made. `fetchStalePRStates` returns partial
+    /// records (no reviews, no commits), so running them through
+    /// `applyPRStatuses` would overwrite `previousPRStatus` with a snapshot
+    /// missing the very fields the checks-failing and needs-refine edges are
+    /// computed from — turning a targeted read into a source of phantom
+    /// transitions. `pendingMergeLabelSessions` stays set for the same reason:
+    /// it exists to survive an in-flight poll that started *before* the add
+    /// (#838), and clearing it here would hand that clobber back its opening.
+    private func reevaluateAutoMergeAfterLabel(session: Session, prURL: String) async {
+        let result = await fetchStalePRStates(urls: [prURL])
+        var byURL = Dictionary(result.prs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
+
+        // Read-your-write: `backend.addMergeLabel` threw on failure, so the
+        // label provably IS on the PR — but the provider's read side can lag a
+        // fetch issued milliseconds later. Without this union the evaluation
+        // below reads "no merge label", publishes nothing, dispatches nothing,
+        // and the user gets a bare success for a label the watcher won't look
+        // at until the next poll: #888's exact shape. This is the watcher-side
+        // analogue of the `pendingMergeLabelSessions` marker on the icon side
+        // (#838).
+        if let fetched = byURL[prURL], !Self.hasAutoMergeLabel(pr: fetched) {
+            byURL[prURL] = Self.withLabels(
+                fetched, labels: fetched.labels + [LabelInfo(name: Self.autoMergeLabel)])
+        }
+
+        guard autoMergeWatcherEnabledProvider() else {
+            logAutoMergeDisabledIfDue()
+            publishWatcherOffVerdict(session: session, byURL: byURL)
+            return
+        }
+        let outcome = evaluateAutoMerge(session: session, byURL: byURL)
+        // Same grep-stable vocabulary as the per-poll summary, tagged so the
+        // automation log distinguishes a click-driven pass from a timed one.
+        CrowLog.automation(
+            "auto-merge: targeted re-evaluation after add-merge-label — "
+            + "pr=\(prURL) fetched=\(result.prs.count) complete=\(result.complete) "
+            + "dispatch=\(outcome.dispatch.rawValue) skip=\(outcome.skip ?? "-")")
     }
 
     /// Record a verdict for the session's PR pill, and push a notification the
@@ -3358,14 +3539,47 @@ public final class IssueTracker {
         return Self.crowAuthored(commitMessages: commits.map(\.message), knownSessionIDs: knownIDs)
     }
 
-    /// Best-effort: ensure the `crow:merge` label exists in the repo so
-    /// repo owners don't need to pre-create it. The backend swallows the
-    /// "already exists" failure.
-    private func ensureMergeLabel(repo: String, backend: CodeBackend) async {
+    /// Memo key for ``ensuredMergeLabelRepos`` / ``ensureMergeLabelTasks``.
+    private static func mergeLabelMemoKey(provider: Provider, repo: String) -> String {
+        "\(provider.rawValue)\n\(repo)"
+    }
+
+    /// Ensure the `crow:merge` label exists in `repo`, at most once per
+    /// (provider, repo) per process (#931).
+    ///
+    /// **Throws exactly what the backend throws.** The memo is a latency
+    /// optimization, not a policy change: `addMergeLabel` calls this directly
+    /// and must keep reporting a real label-creation failure (CROW-816), so the
+    /// throwing form is the primitive and the watcher's best-effort behaviour
+    /// is a `do`/`catch` on top of it — not the other way round.
+    private func ensureMergeLabelOnce(repo: String, backend: CodeBackend) async throws {
         guard !repo.isEmpty else { return }
         guard backend.capabilities.contains(.autoMergeLabel) else { return }
+        let key = Self.mergeLabelMemoKey(provider: backend.provider, repo: repo)
+        if ensuredMergeLabelRepos.contains(key) { return }
+        if let inFlight = ensureMergeLabelTasks[key] {
+            // Join the existing call rather than issuing a duplicate. Awaiting
+            // `.value` rethrows its error, so a joiner sees the same outcome an
+            // originator would; the originator owns the map cleanup.
+            try await inFlight.value
+            return
+        }
+        let task = Task { @MainActor in try await backend.ensureMergeLabel(repo: repo) }
+        ensureMergeLabelTasks[key] = task
+        defer { ensureMergeLabelTasks[key] = nil }
+        try await task.value
+        // Reached only on success — see `ensuredMergeLabelRepos`.
+        ensuredMergeLabelRepos.insert(key)
+    }
+
+    /// Best-effort: ensure the `crow:merge` label exists in the repo so
+    /// repo owners don't need to pre-create it. The backend swallows the
+    /// "already exists" failure; this swallows the rest, because the auto-merge
+    /// watcher's next step (`enableAutoMerge`) reports its own failures and a
+    /// missing label is not on its own a reason to abandon the attempt.
+    private func ensureMergeLabel(repo: String, backend: CodeBackend) async {
         do {
-            try await backend.ensureMergeLabel(repo: repo)
+            try await ensureMergeLabelOnce(repo: repo, backend: backend)
         } catch {
             // Best-effort — swallow.
         }
@@ -4648,7 +4862,7 @@ public final class IssueTracker {
             throw SessionActionError.unparseableRepo(prLink.url)
         }
         do {
-            try await backend.ensureMergeLabel(repo: repo)
+            try await ensureMergeLabelOnce(repo: repo, backend: backend)
             try await backend.addMergeLabel(prURL: prLink.url)
             CrowLog.info("[Crow] Added crow:merge to \(prLink.url)")
             // Optimistically flip the merge icon so the user sees the label
@@ -4659,12 +4873,15 @@ public final class IssueTracker {
             // fetch confirms the label; `applyPRStatuses` clears it then.
             pendingMergeLabelSessions.insert(sessionID)
             appState.prStatus[sessionID]?.hasMergeLabel = true
-            // Targeted re-fetch so the auto-merge watcher re-evaluates promptly
-            // with the label present instead of on the next scheduled poll.
-            await refresh()
-            // Read the verdict *after* the refresh: that pass is what populates
-            // `autoMergeState`, so asking before it would report the previous
-            // poll's answer — or nothing at all on a freshly linked PR (#888).
+            // Targeted re-evaluation so the auto-merge watcher acts on this PR
+            // now, with the label present, instead of on the next scheduled
+            // poll — without paying for (or being silently skipped by) a full
+            // multi-provider board refresh (#931, #888).
+            await reevaluateAutoMergeAfterLabel(session: session, prURL: prLink.url)
+            // Read the verdict *after* the re-evaluation: that pass is what
+            // populates `autoMergeState`, so asking before it would report the
+            // previous poll's answer — or nothing at all on a freshly linked
+            // PR (#888).
             return autoMergeWarning(sessionID: sessionID)
         } catch {
             let detail = String(error.localizedDescription.prefix(200))

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerTargetedAutoMergeTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerTargetedAutoMergeTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowProvider
+@testable import CrowEngine
+
+/// #931: `addMergeLabel` used to end with `await refresh()` — a full
+/// multi-provider board poll (4-5s measured) run solely so `autoMergeWarning`
+/// could read a freshly populated `autoMergeState`. It now does a targeted
+/// per-PR fetch and evaluates that one session through `evaluateAutoMerge`, the
+/// *same* function the poll path runs for every session.
+///
+/// Two things have to hold for that swap to be safe, and both are asserted here:
+/// the single-session path must reach the same verdict the poll path would, and
+/// the read-your-write label union must survive a fetch that comes back without
+/// the label GitHub was told about milliseconds earlier.
+@Suite("add-merge-label re-evaluates one session, not the whole board (#931)")
+@MainActor
+struct IssueTrackerTargetedAutoMergeTests {
+    private static func tempStore() -> JSONStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-targeted-automerge-\(UUID().uuidString)")
+        return JSONStore(directory: dir)
+    }
+
+    private static let crowMergeLabel = LabelInfo(name: "crow:merge", color: "1D76DB")
+    private static let prURL = "https://github.com/corveil/crow/pull/931"
+
+    private func makeTracker(
+        watcherEnabled: Bool = true,
+        autoMergeEnabledAt: Date? = nil
+    ) -> (tracker: IssueTracker, session: Session, state: AppState) {
+        let state = AppState()
+        let session = Session(name: "feature/x", kind: .work, autoMergeEnabledAt: autoMergeEnabledAt)
+        state.sessions = [session]
+        state.links[session.id] = [
+            SessionLink(sessionID: session.id, label: "PR #931", url: Self.prURL, linkType: .pr)
+        ]
+        let tracker = IssueTracker(
+            appState: state, providerManager: ProviderManager(), store: Self.tempStore())
+        tracker.autoMergeWatcherEnabledProvider = { watcherEnabled }
+        return (tracker, session, state)
+    }
+
+    /// Labeled, open, and a real auto-merge candidate — but the repo has
+    /// GitHub's "Allow auto-merge" off and checks are still running, so it lands
+    /// on `.repoDisallowsAutoMergePending`. That branch *publishes a verdict and
+    /// dispatches nothing*, which is what these tests need: a real published
+    /// verdict, no `Task` spawned, and `autoMergeInFlight` left clear so a second
+    /// evaluation reaches the same branch rather than the in-flight one.
+    ///
+    /// A draft would be simpler but publishes *nothing* — `.draft` maps to a nil
+    /// state on purpose (the PR already reads as a draft on screen, so a second
+    /// chip would be redundant).
+    private func labeledPendingPR() -> PRRecord {
+        PRRecord(
+            number: 931, url: Self.prURL, state: "OPEN",
+            mergeable: "MERGEABLE", mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED",
+            isDraft: false, headRefOid: "abc", repoNameWithOwner: "corveil/crow",
+            labels: [Self.crowMergeLabel], checksState: "PENDING",
+            repoAutoMergeAllowed: false)
+    }
+
+    /// The same PR as the provider's read side reports it when it hasn't caught
+    /// up with the label we just added.
+    private func unlabeledPendingPR() -> PRRecord {
+        PRRecord(
+            number: 931, url: Self.prURL, state: "OPEN",
+            mergeable: "MERGEABLE", mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED",
+            isDraft: false, headRefOid: "abc", repoNameWithOwner: "corveil/crow",
+            labels: [], checksState: "PENDING",
+            repoAutoMergeAllowed: false)
+    }
+
+    // MARK: - The extraction is a single code path
+
+    @Test("a single-session evaluation matches what the poll path publishes")
+    func targetedEvaluationMatchesThePollPath() {
+        let pr = labeledPendingPR()
+
+        // Poll path: every session, through applyPRStatuses → applyAutoMerge.
+        let (pollTracker, _, pollState) = makeTracker()
+        pollTracker.applyPRStatuses(viewerPRs: [pr])
+        let pollVerdict = pollState.autoMergeState[pollState.sessions[0].id]
+
+        // Targeted path: one session, one-entry snapshot.
+        let (oneTracker, oneSession, oneState) = makeTracker()
+        oneTracker.evaluateAutoMerge(session: oneSession, byURL: [Self.prURL: pr])
+        let oneVerdict = oneState.autoMergeState[oneSession.id]
+
+        #expect(pollVerdict != nil, "the poll path publishes a verdict for this PR")
+        #expect(oneVerdict?.reason == pollVerdict?.reason)
+        #expect(oneVerdict?.phase == pollVerdict?.phase)
+    }
+
+    @Test("the watcher-off verdict is the same from either caller")
+    func watcherOffVerdictMatchesThePollPath() {
+        let pr = labeledPendingPR()
+
+        let (pollTracker, _, pollState) = makeTracker(watcherEnabled: false)
+        pollTracker.applyPRStatuses(viewerPRs: [pr])
+        let pollVerdict = pollState.autoMergeState[pollState.sessions[0].id]
+
+        let (oneTracker, oneSession, oneState) = makeTracker(watcherEnabled: false)
+        oneTracker.publishWatcherOffVerdict(session: oneSession, byURL: [Self.prURL: pr])
+
+        #expect(pollVerdict != nil)
+        #expect(oneState.autoMergeState[oneSession.id]?.reason == pollVerdict?.reason)
+    }
+
+    // MARK: - Read-your-write
+
+    @Test("withLabels preserves every field, including repoAutoMergeAllowed")
+    func withLabelsIsAFullCopy() {
+        // `repoAutoMergeAllowed` decides a branch in `evaluateAutoMerge`, and
+        // `withURL` (the older sibling helper) drops it — so this must not.
+        let pr = PRRecord(
+            number: 931, url: Self.prURL, state: "OPEN",
+            mergeable: "MERGEABLE", mergeStateStatus: "BEHIND", reviewDecision: "APPROVED",
+            headRefName: "feature/x", headRefOid: "abc", baseRefName: "main",
+            repoNameWithOwner: "corveil/crow", labels: [], checksState: "SUCCESS",
+            mergeCommitOid: "deadbeef", repoAutoMergeAllowed: false)
+
+        let relabeled = IssueTracker.withLabels(pr, labels: [Self.crowMergeLabel])
+
+        #expect(IssueTracker.hasAutoMergeLabel(pr: relabeled))
+        #expect(relabeled.repoAutoMergeAllowed == false)
+        #expect(relabeled.mergeCommitOid == "deadbeef")
+        #expect(relabeled.mergeStateStatus == "BEHIND")
+        #expect(relabeled.headRefOid == "abc")
+        #expect(relabeled.baseRefName == "main")
+        #expect(relabeled.url == Self.prURL)
+    }
+
+    @Test("a fetch that lags the label still evaluates as labeled")
+    func aLaggingFetchStillEvaluatesAsLabeled() {
+        // `backend.addMergeLabel` threw on failure, so the label provably IS on
+        // the PR — but GitHub's read side can lag a fetch issued milliseconds
+        // later. Without the union, the evaluation reads "no merge label",
+        // publishes nothing, dispatches nothing, and the user gets a bare
+        // success for a label the watcher won't look at until the next poll:
+        // #888's exact shape.
+        let (tracker, session, state) = makeTracker()
+        let lagging = unlabeledPendingPR()
+
+        tracker.evaluateAutoMerge(session: session, byURL: [Self.prURL: lagging])
+        #expect(state.autoMergeState[session.id] == nil,
+                "without the union an unlabeled record earns no auto-merge verdict")
+
+        let unioned = IssueTracker.withLabels(lagging, labels: lagging.labels + [Self.crowMergeLabel])
+        tracker.evaluateAutoMerge(session: session, byURL: [Self.prURL: unioned])
+        #expect(state.autoMergeState[session.id] != nil,
+                "the read-your-write union makes the targeted pass see the label it just added")
+    }
+
+    // MARK: - A failed targeted fetch must not become a false alarm
+
+    @Test("an empty targeted fetch stalls rather than warning")
+    func anEmptyFetchDoesNotProduceAWarning() {
+        // Crow already armed this PR, so `.notInViewerPRs` is the honest verdict
+        // — but it is `.stalled`, and `autoMergeWarning` only speaks for
+        // `.blocked`. `addMergeLabel` therefore returns nil: an honest success
+        // for a label that really did land, not a false alarm about a fetch.
+        let (tracker, session, state) = makeTracker(autoMergeEnabledAt: Date())
+
+        let outcome = tracker.evaluateAutoMerge(session: session, byURL: [:])
+
+        #expect(outcome.dispatch == .none)
+        #expect(outcome.skip?.contains("not-in-viewer-prs") == true)
+        #expect(state.autoMergeState[session.id]?.phase == .stalled)
+        #expect(tracker.autoMergeWarning(sessionID: session.id) == nil)
+    }
+
+    @Test("an empty targeted fetch on a never-armed PR says nothing at all")
+    func anEmptyFetchOnANeverArmedPRIsSilent() {
+        // Review #899: auto-merge vocabulary only for PRs that asked for it.
+        let (tracker, session, state) = makeTracker()
+
+        tracker.evaluateAutoMerge(session: session, byURL: [:])
+
+        #expect(state.autoMergeState[session.id] == nil)
+        #expect(tracker.autoMergeWarning(sessionID: session.id) == nil)
+    }
+
+    @Test("the watcher-off warning does not depend on any fetch succeeding")
+    func watcherOffWarningIsIndependentOfTheFetch() {
+        // The one warning `addMergeLabel` can still return when the targeted
+        // fetch comes back empty — it's read off the setting, not off a PR.
+        let (tracker, session, _) = makeTracker(watcherEnabled: false)
+
+        let warning = tracker.autoMergeWarning(sessionID: session.id)
+
+        #expect(warning?.contains("auto-merge watcher is off") == true)
+    }
+}


### PR DESCRIPTION
Closes #931

Chaining session-menu actions from the sidebar produced a cascade of `rpc timeout: <method>` modals. **The actions all succeeded** — only the client gave up, and the natural response (retry) made it worse.

I verified every line number in the ticket against `ca07f1b` before building on it: **zero drift**. Taking **A, B, C, E**; skipping **D** (see below).

## A — `add-merge-label` no longer runs a full board poll

`IssueTracker.addMergeLabel` ended with `await refresh()` — the complete multi-provider read (GitHub GraphQL, every GitLab host, Jira REST which may shell `op read`, Corveil CLI), 4–5s, run *solely* so `autoMergeWarning` could read a freshly populated `autoMergeState`. It now does a targeted per-PR fetch through the existing `fetchStalePRStates` and evaluates that one session.

**That call was also a live correctness bug, not just latency.** `refresh()` opens with `guard !isRefreshing` and `guard shouldPoll()`, so a scheduled poll already in flight made it a silent no-op — and the `autoMergeWarning` read below it then reported the *previous* poll's verdict, or nothing at all on a freshly linked PR, while claiming to have re-read. The new path has no such guard: it always fetches.

To keep **one** code path rather than a second hand-rolled copy that drifts, `applyAutoMerge`'s per-session loop body is lifted verbatim into `evaluateAutoMerge(session:byURL:)` and its watcher-off branch into `publishWatcherOffVerdict(session:byURL:)`. `applyAutoMerge` is now a thin aggregator over both, preserving its exact per-poll summary line. **The existing 221 `IssueTracker` tests pass unchanged** — that is the evidence the extraction was behaviour-preserving, and it was landed and verified before the targeted tail was added.

A read-your-write union (new `withLabels` helper, sibling to the existing `withURL`) adds the label to the fetched record when the provider's read side lags the write we just made. Without it the targeted pass reads "no merge label", publishes nothing, dispatches nothing, and the user gets a bare success for a label the watcher won't look at until the next poll — #888's exact shape. `withLabels` preserves *every* field, unlike `withURL`, because `repoAutoMergeAllowed` decides a branch in the evaluation.

## B — the `/rpc` reader loop no longer blocks head-of-line

`RPCWebSocketHandler.swift:88` awaited `commandRouter.handle(request:)` **inline** inside the read loop, so one slow method stalled every request queued behind it on the browser's single shared socket. The reader now hands each request to a per-connection `RPCDispatcher` and reads the next frame immediately.

**`RPCDispatcher`** (new) — an actor with three invariants:
- **Lane ordering** via a `Task` chain per lane, generalizing `ReviewKickoffSerializer`'s single global chain. Tails are evicted on completion, so the map is bounded by *live* lanes, not by every session id a long-lived connection ever addressed.
- **Bounded work** — permits gate execution, an admission ceiling gates accepted work. **The permit is taken *after* the lane wait, never before**, so the classic deadlock (every permit held by a task waiting on a predecessor that can never get one) is structurally impossible.
- **Explicit lifecycle** — `drain()` returns only once every accepted operation has yielded its response; `shutdown()` releases every waiter so an abnormal close never parks the reader.

**`RPCLanePolicy`** (new) — states each method's lane rather than inferring one. A "does it carry a `session_id`" heuristic would silently hand full concurrency to `launch-agent` (keys on `terminal_id`) and `job-run` (`job_id`). It's gated against `ParityLedger.rpcMethods`' write half, so **a new write RPC fails the build until someone decides its lane**. Three non-session families need one: the `config.json` set (ordering, but the load-bearing reason is that `ConfigStore.withConfigLock` is an `NSLock` held across disk I/O — the #874 shape), the Manager surface, and the review kickoffs (permit conservation, not ordering: `start-review` awaits its serializer task, so unlaned kickoffs would reproduce #931 one level down).

Three things worth a careful look in review:
1. **`Task {}`, not `group.addTask`** — `_ = try? await group.next()` returns on the *first* child to finish, and that return *is* the teardown trigger; adding dispatch tasks to that group would make the first completed RPC look like a socket close.
2. **`shutdown()` must precede `group.cancelAll()`** — `Task<Void, Never>.value` and `withCheckedContinuation` don't resume on cancellation, so cancelling first would leave the reader suspended in `drain()` and leak a connection per disconnect. The most fragile line in the diff.
3. **The hoisted `JSONEncoder` had to go** — it isn't `Sendable` and dispatched operations now encode concurrently. Encoding moved into a per-call `emit` helper. The `JSONDecoder` stays hoisted; it's still single-threaded on the reader task.

**Risk note:** MainActor reentrancy here is not new. `SocketServer` already dispatches each CLI connection to the global concurrent queue, and every browser tab is its own upgrade — the router has always been reentrant in production. What changes is that *one* client can now trigger it. Cross-lane ordering is gone and cannot be recovered (`set-config` then `set-status` can land in either order); every `app.js` call site awaits its response before issuing a dependent one.

## C — per-method client timeouts, and no spurious failure modal

`app.js` hardcoded 10s for every method while the CLI already passed `timeoutSeconds: 60` for these exact verbs. The knowledge existed in the repo; it just never reached the browser. The web now mirrors the CLI's table (30s default). **Keys are wire method names, not CLI verbs** — `crow job run` sends `job-run`, Settings' "Run now" sends `run-job`, so both are listed.

A timeout no longer *deletes* the pending entry — which is why the late response vanished at `onmessage`'s `!waiter` guard and the "failed" modal could never be taken back down. It now flags the entry `settled`, rejects with a tagged `err.rpcTimeout`, and routes the eventual reply to an `onLate` hook (with a GC sweep so the map stays bounded).

`sessionAction` shows an honest **"Still running"** advisory rather than "failed": a timeout means *we stopped waiting*, not that the daemon stopped working, and saying otherwise invites a retry that duplicates a write already in flight. Its `onLate` dismisses that advisory on late success, surfaces an additive `warning` (#888) if one comes back, or replaces it with the real error on late failure. A small `dismissModalDialog(token)` helper scopes the retraction by token, so it can never yank a dialog the user opened afterwards.

## E — `ensureMergeLabel` memoized

It unconditionally shelled `gh label create` and caught "already exists" as control flow — a guaranteed wasted round trip per call. `GitHubCodeBackend` is a struct rebuilt by every `ProviderManager.codeBackend(for:)` call, so the memo lives on the long-lived `@MainActor IssueTracker` that both callers already route through. Populated **only on success**, so a repo the token couldn't reach retries rather than latching a failure as done (CROW-816). The throwing form is the primitive and the watcher's best-effort behaviour is a `do`/`catch` on top — not the other way round — so `addMergeLabel` still reports a real label-creation failure.

## Deliberately out of scope

- **Fix D** (`batch-session-action`, following the CROW-865 `batch-start-review` precedent). A+B+C already make chained actions work; D answers "I selected twelve sessions", which needs sidebar multi-select the UI doesn't have yet. Worth its own ticket with its own UI.
- **`run-setup`** stays on the default timeout. It has a separate pre-existing bug — the daemon re-execs, `ws.onclose` rejects, and `completeSetup` aborts into `state.error` before its reconnect loop runs. Not #931; papering over it with a longer timeout would hide it.
- **`start-review`** (`RPCHandlers.swift:837`) awaits its serializer task where `batch-start-review` doesn't — same exposure class, out of scope here.

## Acceptance

| | |
|---|---|
| Chaining ≥5 session-menu actions produces no `rpc timeout` modal | A (~6s → ~1s) + B + C |
| A slow RPC no longer delays unrelated RPCs behind it | B |
| Ordering preserved for multiple writes to the same session | B (`RPCLanePolicy` + lane chains) |
| A single `add-merge-label` no longer triggers a full board poll | A |
| A late response can never leave a spurious failure modal | C |
| Web client timeouts match the CLI's per-method budgets | C |

## Testing

- `make build` and `make test` — pass, **0 failures**, CLI/RPC parity gates green (94 methods).
- New Swift suites: `RPCDispatcherTests` (12) and `RPCLanePolicyTests` (10) — including the ledger gate, the deadlock case (a lane burst deeper than the concurrency cap), lane-tail eviction, and `drain()`/`shutdown()` lifecycle.
- `IssueTrackerTargetedAutoMergeTests` (7) — the targeted path reaches the same verdict as the poll path, the read-your-write union works, and a failed targeted fetch stalls rather than raising a false alarm.
- `web-tests/rpc-timeout.test.js` (47) — drives the **real** `app.js` in jsdom against a fake socket and a controllable timer queue. Firing deadlines *by delay* is what proves each method was armed from the table rather than the default.
- `npm test` in `web-tests`: all suites pass except `row.test.js` (43 passed, 10 failed) — **pre-existing on `main`, verified identical on a clean tree**, unrelated to this change.

**Not verified live:** timing `crow add-merge-label` end-to-end and the browser repro would require restarting the daemon that hosts this session. Notably, `crow refresh-tickets` against the running daemon returned in 0.03s — the `isRefreshing`/`shouldPoll` early-return path, which is itself the silent no-op that fix A removes from this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
