### PR TITLE
Re-sync shell scrollback from tmux history at top-of-buffer (CROW-934)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -4328,8 +4328,14 @@ function ensureTerminal() {
 
 // The one guarded writer to the PTY socket, shared by term.onData and the touch
 // scroll shim below (mirrors terminal.html's sendToPTY of the same name).
+// CROW-934: bumped on every keystroke so a hydrate settling in the background
+// can tell whether the user has typed since it armed — `scrollOnUserInput`
+// deliberately takes a typing user to the bottom, and a restore that yanks them
+// back to the top mid-keystroke is worse than no restore.
+let userInputSeq = 0;
 function sendToPTY(text) {
   if (!text) return;
+  userInputSeq++;
   if (termWs && termWs.readyState === WebSocket.OPEN) termWs.send(new TextEncoder().encode(text));
 }
 
@@ -4691,10 +4697,11 @@ function connectTerminalWs() {
     if (event.data instanceof ArrayBuffer) {
       term.write(new Uint8Array(event.data));
       // CROW-934: while a re-sync is in flight these bytes are (or accompany)
-      // the replay — keep pushing the settle out so scrollToTop runs once the
-      // rebuild is quiet. Otherwise they're live output, which tmux may again
-      // have thinned, so the next visit to the top should re-sync.
-      if (hydratingScrollback) scheduleHydrateSettle(150);
+      // the replay — record that one actually landed and keep pushing the settle
+      // out so the restore runs once the rebuild is quiet. Otherwise they're
+      // live output, which tmux may again have thinned, so the next visit to the
+      // top should re-sync.
+      if (hydratingScrollback) { hydrateSawReplay = true; scheduleHydrateSettle(150); }
       else scrollbackDirty = true;
       // Fade the skeleton out once the first real content has landed — rAF so
       // the hide follows the paint, not precedes it.
@@ -4711,6 +4718,10 @@ function connectTerminalWs() {
     // #679 expired scrim.
     clearTimeout(termSkelTimer);
     termSkelTimer = null;
+    // CROW-934: this path reconnects WITHOUT going through reloadTerminal, so it
+    // needs the same teardown — a sync left in flight across the drop would have
+    // the fresh attach's own replay consumed as its replay (#935 review).
+    resetScrollbackSync();
     if (sessionDead) { hideTerminalSkeleton(); return; }
     setTerminalReconnecting(true);
     showTerminalSkeleton();
@@ -4800,13 +4811,35 @@ function selectWindow(win) {
 // "fixed" the history — but the tab you sit on never re-synced.
 //
 // Trigger on reaching the top of the local buffer: that is exactly when the
-// user is asking for older lines, and it costs one capture per output burst
-// rather than polling. Shell surfaces only — an agent keeps its transcript in
-// the scrollback-less alt buffer and repaints it itself (ADR-0013), so a
-// capture there returns just the viewport and would buy nothing.
+// user is asking for older lines. Shell surfaces only — an agent keeps its
+// transcript in the scrollback-less alt buffer and repaints it itself
+// (ADR-0013), so a capture there returns just the viewport and would buy
+// nothing.
+//
+// Two independent brakes, because `onScroll` is NOT a user-scroll event: xterm's
+// BufferService.scroll ends in an unconditional `this._onScroll.fire(ydisp)`, so
+// it fires for every line pushed at the bottom, and a viewport the user parked
+// at the top stays pinned at `ydisp === 0` (`Math.max(ydisp - 1, 0)` once the
+// buffer is full). Reading early output while a build keeps printing therefore
+// satisfies every guard on every output line. Without a brake each capture
+// re-armed the next one — two tmux spawns and the whole 50k history per round
+// trip, indefinitely (#935 review).
+//
+//   * `lastHydrateAt` bounds the cost while output is still streaming.
+//   * `scrollbackFullySynced` latches off entirely once a capture comes back
+//     with nothing new, until the viewport leaves the top. That is also what
+//     keeps the one speculative capture per tab (the connect replay already left
+//     the buffer authoritative, but we can't tell that without asking) from
+//     repeating.
+const HYDRATE_MIN_INTERVAL_MS = 5000;
 let scrollbackDirty = true; // live output may have dropped lines since the last sync
 let hydratingScrollback = false;
 let hydrateSettleTimer = null;
+let hydrateBaseY = 0; // scrollback depth when the capture was armed
+let hydrateSawReplay = false; // did any bytes actually land during the flight?
+let hydrateInputSeq = 0; // userInputSeq when the capture was armed
+let scrollbackFullySynced = false; // last capture returned nothing new
+let lastHydrateAt = 0;
 
 // The replay rebuilds from the top (`ESC[H ESC[2J ESC[3J`), which parks the
 // viewport at the BOTTOM — so once the bytes stop landing, put the user back on
@@ -4819,23 +4852,54 @@ function scheduleHydrateSettle(ms) {
   clearTimeout(hydrateSettleTimer);
   hydrateSettleTimer = setTimeout(() => {
     hydratingScrollback = false;
-    try { term.scrollToTop(); } catch (_) {}
+    const buf = term && term.buffer && term.buffer.active;
+    // Nothing deeper came back → the local buffer already matches the pane, so
+    // stop asking until the viewport moves off the top.
+    if (buf && buf.baseY <= hydrateBaseY) scrollbackFullySynced = true;
+    // Only move the viewport if a replay actually landed AND the user hasn't
+    // typed since we armed. Both matter: the 2000 ms "no replay ever arrived"
+    // path would otherwise jump them to the top of an unchanged buffer, and
+    // `scrollOnUserInput` deliberately takes a typing user to the bottom —
+    // yanking them back mid-keystroke is worse than not restoring at all.
+    if (hydrateSawReplay && userInputSeq === hydrateInputSeq) {
+      try { term.scrollToTop(); } catch (_) {}
+    }
   }, ms);
 }
 
+// Shared by reloadTerminal and the onclose auto-reconnect: both tear the socket
+// down, and a sync left in flight across one would have the fresh attach's own
+// replay consumed as its replay, with a pending scrollToTop fighting it.
+function resetScrollbackSync() {
+  clearTimeout(hydrateSettleTimer);
+  hydrateSettleTimer = null;
+  hydratingScrollback = false;
+  hydrateSawReplay = false;
+  scrollbackFullySynced = false;
+  scrollbackDirty = true;
+}
+
 function maybeHydrateScrollback() {
-  if (!term || hydratingScrollback || !scrollbackDirty) return;
+  if (!term || hydratingScrollback) return;
+  const buf = term.buffer.active;
+  // Leaving the top re-arms the latch — there is new ground to cover next time.
+  if (buf.viewportY !== 0) { scrollbackFullySynced = false; return; }
+  if (scrollbackFullySynced || !scrollbackDirty) return;
+  // `baseY > 0` is load-bearing: on a tab that has printed less than one screen
+  // viewportY is permanently 0, so testing the top alone would fire a capture on
+  // every output burst for the whole life of the tab.
+  if (buf.baseY === 0) return;
   if (!activeTerminal || activeTerminal.agent_surface) return;
   if (activeTerminal.window == null) return;
   if (!termWs || termWs.readyState !== WebSocket.OPEN) return;
-  // At the top of a buffer that HAS scrollback. `baseY > 0` is load-bearing: on
-  // a short buffer (a tab that has printed less than one screen) viewportY is
-  // permanently 0, so testing the top alone would fire a capture on every
-  // output burst for the whole life of the tab.
-  const buf = term.buffer.active;
-  if (buf.baseY === 0 || buf.viewportY !== 0) return;
+  const now = Date.now();
+  if (now - lastHydrateAt < HYDRATE_MIN_INTERVAL_MS) return;
+  lastHydrateAt = now;
   hydratingScrollback = true;
   scrollbackDirty = false;
+  hydrateBaseY = buf.baseY;
+  hydrateSawReplay = false;
+  hydrateInputSeq = userInputSeq;
   scheduleHydrateSettle(2000);
   selectWindow(activeTerminal.window);
 }
@@ -4870,11 +4934,9 @@ function reloadTerminal() {
   lastTermCols = 0;
   lastTermRows = 0;
   // CROW-934: the reconnect re-selects the window, so crowd replays the pane
-  // anyway — drop any in-flight re-sync (its scrollToTop would fight the fresh
+  // anyway — drop any in-flight re-sync (its restore would fight the fresh
   // attach) and treat the rebuilt buffer as needing one again.
-  clearTimeout(hydrateSettleTimer);
-  hydratingScrollback = false;
-  scrollbackDirty = true;
+  resetScrollbackSync();
   if (termWs) {
     const old = termWs;
     old.onopen = old.onmessage = old.onclose = old.onerror = null;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -4328,14 +4328,8 @@ function ensureTerminal() {
 
 // The one guarded writer to the PTY socket, shared by term.onData and the touch
 // scroll shim below (mirrors terminal.html's sendToPTY of the same name).
-// CROW-934: bumped on every keystroke so a hydrate settling in the background
-// can tell whether the user has typed since it armed — `scrollOnUserInput`
-// deliberately takes a typing user to the bottom, and a restore that yanks them
-// back to the top mid-keystroke is worse than no restore.
-let userInputSeq = 0;
 function sendToPTY(text) {
   if (!text) return;
-  userInputSeq++;
   if (termWs && termWs.readyState === WebSocket.OPEN) termWs.send(new TextEncoder().encode(text));
 }
 
@@ -4844,33 +4838,38 @@ let hydrateSettleTimer = null;
 let hydrateArmedAt = 0; // start of the current flight, for the absolute deadline
 let hydrateBaseY = 0; // scrollback depth when the capture was armed
 let hydrateSawReplay = false; // did any bytes actually land during the flight?
-let hydrateInputSeq = 0; // userInputSeq when the capture was armed
 let scrollbackFullySynced = false; // last capture returned nothing new
 let lastHydrateAt = 0;
 let lastViewportY = 0; // previous scroll position, to detect arrival at the top
 
-// The replay rebuilds from the top (`ESC[H ESC[2J ESC[3J`). Once the bytes stop
-// landing, put the user back on the oldest lines they scrolled up to ask for.
-// Debounced rather than done in term.write's callback because live output can
-// interleave with the replay — but clamped to the arm-time deadline so a busy
-// shell cannot extend it indefinitely. Self-healing in both directions: no
-// replay at all still clears the flag, and neither does a replay that never
-// stops.
+// The flight ends this long after the last frame, but never later than the
+// arm-time deadline. There is deliberately NO viewport restore here: the replay
+// rebuilds the buffer while `isUserScrolling` is true (which the trigger's
+// `viewportY === 0 && baseY > 0` guards imply), and every write then takes
+// `isUserScrolling || i.ydisp++` / `isUserScrolling && (ydisp = max(ydisp-1,0))`,
+// so `ydisp` stays pinned at 0 — the rebuild leaves the user on the oldest lines
+// by itself. A `scrollToTop()` here would be `Viewport.scrollLines(-0)`, the same
+// scrollTop, hence a no-op on that path; the ONLY way to reach it non-inert is
+// the user leaving the top mid-flight (the #668 pill calls `scrollToBottom()`,
+// clearing `isUserScrolling` so `ydisp` tracks the bottom), where it would yank
+// them off the live prompt to line 1 of a 20k buffer. It never helps and acts
+// only when acting is wrong, so it is gone (#935 review round 3).
 function scheduleHydrateSettle(ms) {
   clearTimeout(hydrateSettleTimer);
   const remaining = hydrateArmedAt + HYDRATE_MAX_FLIGHT_MS - Date.now();
   hydrateSettleTimer = setTimeout(() => {
     hydratingScrollback = false;
     const buf = term && term.buffer && term.buffer.active;
-    // Nothing deeper came back → the local buffer already matches the pane, so
-    // stop asking until the viewport moves off the top. Only trust that when a
-    // replay actually landed; an empty flight proves nothing.
-    if (hydrateSawReplay && buf && buf.baseY <= hydrateBaseY) scrollbackFullySynced = true;
-    // Only move the viewport if a replay landed AND the user hasn't typed since
-    // we armed — `scrollOnUserInput` deliberately takes a typing user to the
-    // bottom, and yanking them back mid-keystroke is worse than not restoring.
-    if (hydrateSawReplay && userInputSeq === hydrateInputSeq) {
-      try { term.scrollToTop(); } catch (_) {}
+    if (hydrateSawReplay) {
+      // Nothing deeper came back → the local buffer already matches the pane, so
+      // stop asking until the viewport moves off the top.
+      if (buf && buf.baseY <= hydrateBaseY) scrollbackFullySynced = true;
+    } else {
+      // An empty flight proves nothing — neither that we synced (so no latch)
+      // nor that the buffer is clean. Arming cleared `scrollbackDirty` on the
+      // premise of a sync that never happened; put it back so a retry is
+      // possible without waiting for live output.
+      scrollbackDirty = true;
     }
   }, Math.max(0, Math.min(ms, remaining)));
 }
@@ -4889,7 +4888,7 @@ function noteTerminalFrame() {
 
 // Shared by reloadTerminal and the onclose auto-reconnect: both tear the socket
 // down, and a sync left in flight across one would have the fresh attach's own
-// replay consumed as its replay, with a pending scrollToTop fighting it.
+// replay consumed as its replay.
 function resetScrollbackSync() {
   clearTimeout(hydrateSettleTimer);
   hydrateSettleTimer = null;
@@ -4898,6 +4897,7 @@ function resetScrollbackSync() {
   scrollbackFullySynced = false;
   scrollbackDirty = true;
   lastHydrateAt = 0; // the new surface gets its own budget, not the old one's
+  lastViewportY = 0; // ...and its own scroll history, not the old one's position
 }
 
 function maybeHydrateScrollback() {
@@ -4926,7 +4926,6 @@ function maybeHydrateScrollback() {
   hydrateArmedAt = now;
   hydrateBaseY = buf.baseY;
   hydrateSawReplay = false;
-  hydrateInputSeq = userInputSeq;
   scheduleHydrateSettle(2000);
   selectWindow(activeTerminal.window);
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -4255,7 +4255,10 @@ function ensureTerminal() {
   const imageAddon = new ImageAddon.ImageAddon({ sixelSupport: true, iipSupport: true, kittySupport: true });
   searchAddon = new SearchAddon.SearchAddon();
   const webLinksAddon = new WebLinksAddon.WebLinksAddon();
-  // Config block mirrors CrowTerminal/Resources/xterm/terminal.html.
+  // Config block mirrors web/terminal.html (the standalone debug page). It also
+  // named CrowTerminal/Resources/xterm/terminal.html, but that page lost its
+  // last consumer when ADR-0010 retired the macOS app — its crowWrite/crowInput
+  // bridge has no caller — so it is no longer a front-end to stay in sync with.
   term = new Terminal({
     cursorBlink: true,
     fontSize: 14,
@@ -4295,6 +4298,9 @@ function ensureTerminal() {
     term.loadAddon(webglAddon);
   } catch (_) { /* WebGL unavailable → canvas/DOM renderer */ }
   term.onData(sendToPTY);
+  // CROW-934: hydrate the shell scrollback from tmux when the user reaches the
+  // top of what the live stream actually delivered.
+  term.onScroll(maybeHydrateScrollback);
   term.attachCustomKeyEventHandler(handleTerminalKey);
   enableTouchScroll(document.getElementById('terminal'));
   enableWheelScroll(document.getElementById('terminal'));
@@ -4684,6 +4690,12 @@ function connectTerminalWs() {
   termWs.onmessage = (event) => {
     if (event.data instanceof ArrayBuffer) {
       term.write(new Uint8Array(event.data));
+      // CROW-934: while a re-sync is in flight these bytes are (or accompany)
+      // the replay — keep pushing the settle out so scrollToTop runs once the
+      // rebuild is quiet. Otherwise they're live output, which tmux may again
+      // have thinned, so the next visit to the top should re-sync.
+      if (hydratingScrollback) scheduleHydrateSettle(150);
+      else scrollbackDirty = true;
       // Fade the skeleton out once the first real content has landed — rAF so
       // the hide follows the paint, not precedes it.
       if (!painted) { painted = true; requestAnimationFrame(hideTerminalSkeleton); }
@@ -4772,6 +4784,62 @@ function selectWindow(win) {
   }
 }
 
+// CROW-934: re-sync a plain-shell surface's scrollback from tmux's history.
+//
+// tmux collapses pane redraws when the attached client can't drain them fast
+// enough, and the browser IS that slow client. Measured against the bundled
+// config: `seq 1 20000` leaves all 19 989 lines in the pane's own history, but
+// a browser-paced reader receives only ~337 of them (a raw reader gets 19 768).
+// So the local xterm buffer is NOT a faithful copy of the pane — scroll-up hits
+// its top after a few screens while tmux still holds the rest.
+//
+// crowd's `select-window` reply carries the authoritative copy
+// (`capture-pane -pe -S -50000`, CROW-606) and REBUILDS the buffer in place, so
+// re-requesting it is idempotent. It already ran on connect and on a tab CHANGE
+// (attachWindow → reloadTerminal), which is why switching away and back
+// "fixed" the history — but the tab you sit on never re-synced.
+//
+// Trigger on reaching the top of the local buffer: that is exactly when the
+// user is asking for older lines, and it costs one capture per output burst
+// rather than polling. Shell surfaces only — an agent keeps its transcript in
+// the scrollback-less alt buffer and repaints it itself (ADR-0013), so a
+// capture there returns just the viewport and would buy nothing.
+let scrollbackDirty = true; // live output may have dropped lines since the last sync
+let hydratingScrollback = false;
+let hydrateSettleTimer = null;
+
+// The replay rebuilds from the top (`ESC[H ESC[2J ESC[3J`), which parks the
+// viewport at the BOTTOM — so once the bytes stop landing, put the user back on
+// the oldest lines they scrolled up to ask for. Debounced rather than done in
+// term.write's callback because live output can interleave with the replay;
+// `ms` is long on arm (the capture is a round-trip through tmux) and short
+// between frames. Self-healing: if no replay ever arrives the timer still
+// clears the flag, so a failed sync can't wedge the surface.
+function scheduleHydrateSettle(ms) {
+  clearTimeout(hydrateSettleTimer);
+  hydrateSettleTimer = setTimeout(() => {
+    hydratingScrollback = false;
+    try { term.scrollToTop(); } catch (_) {}
+  }, ms);
+}
+
+function maybeHydrateScrollback() {
+  if (!term || hydratingScrollback || !scrollbackDirty) return;
+  if (!activeTerminal || activeTerminal.agent_surface) return;
+  if (activeTerminal.window == null) return;
+  if (!termWs || termWs.readyState !== WebSocket.OPEN) return;
+  // At the top of a buffer that HAS scrollback. `baseY > 0` is load-bearing: on
+  // a short buffer (a tab that has printed less than one screen) viewportY is
+  // permanently 0, so testing the top alone would fire a capture on every
+  // output burst for the whole life of the tab.
+  const buf = term.buffer.active;
+  if (buf.baseY === 0 || buf.viewportY !== 0) return;
+  hydratingScrollback = true;
+  scrollbackDirty = false;
+  scheduleHydrateSettle(2000);
+  selectWindow(activeTerminal.window);
+}
+
 // #673: which tmux window this shared surface shows changes on both a terminal-tab
 // switch (switchTerminal) and a session switch (refreshTerminals). A plain
 // selectWindow on the live socket replays the pane but leaves the grid mismatched
@@ -4801,6 +4869,12 @@ function reloadTerminal() {
   try { term.reset(); } catch (_) {}
   lastTermCols = 0;
   lastTermRows = 0;
+  // CROW-934: the reconnect re-selects the window, so crowd replays the pane
+  // anyway — drop any in-flight re-sync (its scrollToTop would fight the fresh
+  // attach) and treat the rebuilt buffer as needing one again.
+  clearTimeout(hydrateSettleTimer);
+  hydratingScrollback = false;
+  scrollbackDirty = true;
   if (termWs) {
     const old = termWs;
     old.onopen = old.onmessage = old.onclose = old.onerror = null;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -4696,13 +4696,7 @@ function connectTerminalWs() {
   termWs.onmessage = (event) => {
     if (event.data instanceof ArrayBuffer) {
       term.write(new Uint8Array(event.data));
-      // CROW-934: while a re-sync is in flight these bytes are (or accompany)
-      // the replay — record that one actually landed and keep pushing the settle
-      // out so the restore runs once the rebuild is quiet. Otherwise they're
-      // live output, which tmux may again have thinned, so the next visit to the
-      // top should re-sync.
-      if (hydratingScrollback) { hydrateSawReplay = true; scheduleHydrateSettle(150); }
-      else scrollbackDirty = true;
+      noteTerminalFrame(); // CROW-934 scrollback re-sync bookkeeping
       // Fade the skeleton out once the first real content has landed — rAF so
       // the hide follows the paint, not precedes it.
       if (!painted) { painted = true; requestAnimationFrame(hideTerminalSkeleton); }
@@ -4825,46 +4819,72 @@ function selectWindow(win) {
 // re-armed the next one — two tmux spawns and the whole 50k history per round
 // trip, indefinitely (#935 review).
 //
-//   * `lastHydrateAt` bounds the cost while output is still streaming.
+//   * Arriving at the top is a TRANSITION, not a position. xterm pins a
+//     top-parked viewport at `ydisp === 0` while output streams, so "still at
+//     the top" fires forever; "just got here" fires once per visit and covers
+//     the wheel, touch, the scrollbar and Shift+PageUp alike.
+//   * `lastHydrateAt` is the backstop if that ever fires more than expected.
 //   * `scrollbackFullySynced` latches off entirely once a capture comes back
 //     with nothing new, until the viewport leaves the top. That is also what
 //     keeps the one speculative capture per tab (the connect replay already left
 //     the buffer authoritative, but we can't tell that without asking) from
 //     repeating.
 const HYDRATE_MIN_INTERVAL_MS = 5000;
+// A flight ends this long after the last frame, but never later than
+// HYDRATE_MAX_FLIGHT_MS after it armed. The cap is load-bearing: frames are not
+// batched (one WS binary frame per PTY read chunk), so on a shell printing more
+// often than the quiet window, an extend-only settle would never fire and
+// `hydratingScrollback` would latch true for the life of the socket — silently
+// disabling the feature on exactly the workload it exists for (#935 review).
+const HYDRATE_QUIET_MS = 150;
+const HYDRATE_MAX_FLIGHT_MS = 3000;
 let scrollbackDirty = true; // live output may have dropped lines since the last sync
 let hydratingScrollback = false;
 let hydrateSettleTimer = null;
+let hydrateArmedAt = 0; // start of the current flight, for the absolute deadline
 let hydrateBaseY = 0; // scrollback depth when the capture was armed
 let hydrateSawReplay = false; // did any bytes actually land during the flight?
 let hydrateInputSeq = 0; // userInputSeq when the capture was armed
 let scrollbackFullySynced = false; // last capture returned nothing new
 let lastHydrateAt = 0;
+let lastViewportY = 0; // previous scroll position, to detect arrival at the top
 
-// The replay rebuilds from the top (`ESC[H ESC[2J ESC[3J`), which parks the
-// viewport at the BOTTOM — so once the bytes stop landing, put the user back on
-// the oldest lines they scrolled up to ask for. Debounced rather than done in
-// term.write's callback because live output can interleave with the replay;
-// `ms` is long on arm (the capture is a round-trip through tmux) and short
-// between frames. Self-healing: if no replay ever arrives the timer still
-// clears the flag, so a failed sync can't wedge the surface.
+// The replay rebuilds from the top (`ESC[H ESC[2J ESC[3J`). Once the bytes stop
+// landing, put the user back on the oldest lines they scrolled up to ask for.
+// Debounced rather than done in term.write's callback because live output can
+// interleave with the replay — but clamped to the arm-time deadline so a busy
+// shell cannot extend it indefinitely. Self-healing in both directions: no
+// replay at all still clears the flag, and neither does a replay that never
+// stops.
 function scheduleHydrateSettle(ms) {
   clearTimeout(hydrateSettleTimer);
+  const remaining = hydrateArmedAt + HYDRATE_MAX_FLIGHT_MS - Date.now();
   hydrateSettleTimer = setTimeout(() => {
     hydratingScrollback = false;
     const buf = term && term.buffer && term.buffer.active;
     // Nothing deeper came back → the local buffer already matches the pane, so
-    // stop asking until the viewport moves off the top.
-    if (buf && buf.baseY <= hydrateBaseY) scrollbackFullySynced = true;
-    // Only move the viewport if a replay actually landed AND the user hasn't
-    // typed since we armed. Both matter: the 2000 ms "no replay ever arrived"
-    // path would otherwise jump them to the top of an unchanged buffer, and
-    // `scrollOnUserInput` deliberately takes a typing user to the bottom —
-    // yanking them back mid-keystroke is worse than not restoring at all.
+    // stop asking until the viewport moves off the top. Only trust that when a
+    // replay actually landed; an empty flight proves nothing.
+    if (hydrateSawReplay && buf && buf.baseY <= hydrateBaseY) scrollbackFullySynced = true;
+    // Only move the viewport if a replay landed AND the user hasn't typed since
+    // we armed — `scrollOnUserInput` deliberately takes a typing user to the
+    // bottom, and yanking them back mid-keystroke is worse than not restoring.
     if (hydrateSawReplay && userInputSeq === hydrateInputSeq) {
       try { term.scrollToTop(); } catch (_) {}
     }
-  }, ms);
+  }, Math.max(0, Math.min(ms, remaining)));
+}
+
+// The socket's per-frame bookkeeping, named so the tests can drive the real
+// thing rather than a stand-in (the extend-forever bug above lived here and the
+// suite modelled only the `else` branch, so it couldn't see it).
+function noteTerminalFrame() {
+  // While a re-sync is in flight these bytes are (or accompany) the replay —
+  // record that one landed and hold the settle open until the rebuild is quiet.
+  // Otherwise they're live output, which tmux may again have thinned, so the
+  // next arrival at the top should re-sync.
+  if (hydratingScrollback) { hydrateSawReplay = true; scheduleHydrateSettle(HYDRATE_QUIET_MS); }
+  else scrollbackDirty = true;
 }
 
 // Shared by reloadTerminal and the onclose auto-reconnect: both tear the socket
@@ -4877,17 +4897,23 @@ function resetScrollbackSync() {
   hydrateSawReplay = false;
   scrollbackFullySynced = false;
   scrollbackDirty = true;
+  lastHydrateAt = 0; // the new surface gets its own budget, not the old one's
 }
 
 function maybeHydrateScrollback() {
-  if (!term || hydratingScrollback) return;
+  if (!term) return;
   const buf = term.buffer.active;
+  const arrivedAtTop = buf.viewportY === 0 && lastViewportY !== 0;
+  lastViewportY = buf.viewportY;
+  if (hydratingScrollback) return;
   // Leaving the top re-arms the latch — there is new ground to cover next time.
   if (buf.viewportY !== 0) { scrollbackFullySynced = false; return; }
+  // Parked at the top rather than newly arrived: xterm fires onScroll for every
+  // line pushed at the bottom, and pins ydisp at 0 while the user sits there.
+  if (!arrivedAtTop) return;
   if (scrollbackFullySynced || !scrollbackDirty) return;
   // `baseY > 0` is load-bearing: on a tab that has printed less than one screen
-  // viewportY is permanently 0, so testing the top alone would fire a capture on
-  // every output burst for the whole life of the tab.
+  // viewportY is permanently 0, so there is no scrollback to go fetch.
   if (buf.baseY === 0) return;
   if (!activeTerminal || activeTerminal.agent_surface) return;
   if (activeTerminal.window == null) return;
@@ -4897,6 +4923,7 @@ function maybeHydrateScrollback() {
   lastHydrateAt = now;
   hydratingScrollback = true;
   scrollbackDirty = false;
+  hydrateArmedAt = now;
   hydrateBaseY = buf.baseY;
   hydrateSawReplay = false;
   hydrateInputSeq = userInputSeq;

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,9 +2,9 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board touch-scroll wheel-scroll key-handler row sidebar-groups sidebar-select rpc-timeout; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler row sidebar-groups sidebar-select rpc-timeout; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
+++ b/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
@@ -1,0 +1,139 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// CROW-934: the shell-scrollback re-sync. tmux collapses pane redraws for a slow
+// client (the browser), so the local xterm buffer holds far fewer lines than the
+// pane's own history — measured 337/20000 for a browser-paced reader. Reaching
+// the top of the local buffer re-requests crowd's authoritative replay
+// (`select-window` → `capture-pane -pe -S -50000`).
+//
+// These cases pin the GATING, which is where the cost and the regression risk
+// live: an over-eager trigger fires a tmux capture on every output burst, and an
+// under-eager one leaves the bug in place. Same harness shape as
+// wheel-scroll.test.js — an epilogue evaluated in app.js's own top-level lexical
+// scope exposes the module-scope bindings.
+const epilogue = `
+;globalThis.__t = {
+  maybeHydrateScrollback(){ return maybeHydrateScrollback(); },
+  set term(v){ term = v; },
+  set termWs(v){ termWs = v; },
+  set activeTerminal(v){ activeTerminal = v; },
+  set scrollbackDirty(v){ scrollbackDirty = v; },
+  get scrollbackDirty(){ return scrollbackDirty; },
+  set hydratingScrollback(v){ hydratingScrollback = v; },
+  get hydratingScrollback(){ return hydratingScrollback; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body><div id="terminal"></div></body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.WebSocket.OPEN = 1;
+window.TextEncoder = TextEncoder;
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+// ---- Fakes -----------------------------------------------------------------
+
+// `baseY` is how many lines have scrolled off the top (i.e. whether scrollback
+// exists at all); `viewportY` is where the user is looking, 0 == the very top.
+function setup({ agentSurface = false, baseY = 500, viewportY = 0,
+                 readyState = 1, window: win = 7, dirty = true } = {}) {
+  const sends = [];
+  T.term = {
+    buffer: { active: { baseY, viewportY } },
+    scrollToTop() {},
+  };
+  T.termWs = { readyState, send(s) { sends.push(JSON.parse(s)); } };
+  T.activeTerminal = win === null ? null : { id: 't1', window: win, agent_surface: agentSurface };
+  T.hydratingScrollback = false;
+  T.scrollbackDirty = dirty;
+  return sends;
+}
+const selects = (sends) => sends.filter((m) => m.type === 'select-window');
+
+// ---- Cases -----------------------------------------------------------------
+
+console.log('scrollback hydrate (CROW-934)');
+
+// The bug this fixes: a shell tab sitting on a thinned buffer, scrolled to the top.
+{
+  const sends = setup({ agentSurface: false, baseY: 297, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  check('shell at top of a thinned buffer re-requests the replay',
+    selects(sends).length === 1 && selects(sends)[0].window === 7);
+  check('  ... and marks the sync in flight so it is not re-issued', T.hydratingScrollback === true);
+  check('  ... and clears the dirty flag', T.scrollbackDirty === false);
+}
+
+// An agent keeps its transcript in the scrollback-less alt buffer and repaints
+// it itself (ADR-0013) — a capture there returns only the viewport.
+{
+  const sends = setup({ agentSurface: true });
+  T.maybeHydrateScrollback();
+  check('agent surface never re-syncs', selects(sends).length === 0);
+}
+
+// The `baseY === 0` guard. On a tab that has printed less than one screen,
+// viewportY is permanently 0, so testing "at the top" alone would fire a tmux
+// capture on every output burst for the life of the tab.
+{
+  const sends = setup({ baseY: 0, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  check('short buffer (no scrollback yet) does not re-sync', selects(sends).length === 0);
+}
+
+{
+  const sends = setup({ baseY: 500, viewportY: 120 });
+  T.maybeHydrateScrollback();
+  check('mid-buffer scroll does not re-sync', selects(sends).length === 0);
+}
+
+// Idempotence: one capture per output burst, not one per scroll event.
+{
+  const sends = setup({ dirty: false });
+  T.maybeHydrateScrollback();
+  check('already-synced buffer does not re-sync', selects(sends).length === 0);
+}
+{
+  const sends = setup();
+  T.maybeHydrateScrollback();
+  T.maybeHydrateScrollback();
+  T.maybeHydrateScrollback();
+  check('repeated scrolls at the top issue exactly one capture', selects(sends).length === 1);
+}
+
+{
+  const sends = setup({ readyState: 3 /* CLOSED */ });
+  T.maybeHydrateScrollback();
+  check('closed socket does not re-sync', selects(sends).length === 0);
+}
+{
+  const sends = setup({ window: null });
+  T.maybeHydrateScrollback();
+  check('no active terminal does not re-sync', selects(sends).length === 0);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
+++ b/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
@@ -19,7 +19,6 @@ const epilogue = `
   maybeHydrateScrollback(){ return maybeHydrateScrollback(); },
   noteTerminalFrame(){ return noteTerminalFrame(); },
   resetScrollbackSync(){ return resetScrollbackSync(); },
-  sendToPTY(s){ return sendToPTY(s); },
   set term(v){ term = v; },
   set termWs(v){ termWs = v; },
   set activeTerminal(v){ activeTerminal = v; },
@@ -78,9 +77,8 @@ const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name)
 // ---- Fakes -----------------------------------------------------------------
 
 // `baseY` is how many lines have scrolled off the top (whether scrollback exists
-// at all); `viewportY` is where the user is looking, 0 == the very top.
-// `scrollToTop` records that the restore was INVOKED — deliberately not that the
-// viewport visibly moved, which this fake has no `ydisp` semantics to model.
+// at all); `viewportY` is where the user is looking, 0 == the very top. The fake
+// records any attempt to move the viewport: the settle must never make one.
 let sends, fake;
 function setup({ agentSurface = false, baseY = 500, viewportY = 0, from = 400,
                  readyState = 1, window: win = 7, dirty = true } = {}) {
@@ -88,8 +86,10 @@ function setup({ agentSurface = false, baseY = 500, viewportY = 0, from = 400,
   timers.clear();
   fake = {
     buffer: { active: { baseY, viewportY } },
-    restoreCalls: 0,
-    scrollToTop() { this.restoreCalls++; },
+    moves: 0,
+    scrollToTop() { this.moves++; this.buffer.active.viewportY = 0; },
+    scrollToBottom() { this.moves++; this.buffer.active.viewportY = this.buffer.active.baseY; },
+    scrollLines(n) { this.moves++; },
   };
   T.term = fake;
   T.termWs = { readyState, send(s) { sends.push(JSON.parse(s)); } };
@@ -195,6 +195,13 @@ console.log('\n  parked at the top while output streams');
   T.maybeHydrateScrollback();
   advance(3000); // no frame ever landed
   check('an empty flight does not latch (it proves nothing)', T.scrollbackFullySynced === false);
+  // ...and it must not leave `scrollbackDirty` false either, or the retry the
+  // missing latch is meant to allow would be blocked anyway.
+  check('  ... and restores the dirty flag so a retry is possible', T.scrollbackDirty === true);
+  T.lastHydrateAt = 0;
+  T.lastViewportY = 400;
+  T.maybeHydrateScrollback();
+  check('  ... so arriving at the top again does re-capture', selects().length === 2);
 }
 
 // ---- The settle cannot be extended forever (round 2 Yellow 1) --------------
@@ -209,35 +216,41 @@ console.log('\n  busy shell during a flight');
   check('a sync is in flight', T.hydratingScrollback === true);
   for (let i = 0; i < 200; i++) { T.noteTerminalFrame(); advance(100); } // 20 s of chatter
   check('the absolute deadline ends the flight anyway', T.hydratingScrollback === false);
-  check('  ... so the surface can re-sync again later', T.scrollbackDirty === true || T.scrollbackFullySynced === false);
+  // Split rather than `A || B`: as a disjunct either half alone passed it, so it
+  // could not fail for the reason it was named.
+  check('  ... the latch did not trip (the replay did land)', T.scrollbackFullySynced === true);
+  check('  ... and later live output can mark it dirty again', (() => {
+    T.noteTerminalFrame(); return T.scrollbackDirty === true;
+  })());
 }
 
-// ---- Restore decision (round 1 Yellow 1) -----------------------------------
+// ---- The settle never moves the viewport (round 3 Yellow) ------------------
 
-console.log('\n  restore decision');
+console.log('\n  the settle leaves the viewport alone');
 {
+  // The replay rebuilds with isUserScrolling true, so ydisp stays pinned at 0
+  // and the user is already on the oldest lines. A restore here would be a
+  // no-op on that path — and a real, harmful scroll on the one path where the
+  // user has left the top mid-flight.
   setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
   T.noteTerminalFrame();
   fake.buffer.active.baseY = 19949;
   advance(3000);
-  check('a landed replay invokes the restore', fake.restoreCalls === 1);
+  check('a landed replay does not move the viewport', fake.moves === 0);
 }
 {
+  // The #668 jump-to-bottom pill mid-flight: scrollToBottom() clears
+  // isUserScrolling, so ydisp tracks the bottom. The settle must not drag the
+  // user off the live prompt back to line 1.
   setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
   T.noteTerminalFrame();
   fake.buffer.active.baseY = 19949;
-  T.sendToPTY('l'); // user starts typing mid-flight
+  fake.buffer.active.viewportY = 19949; // user hit the pill
   advance(3000);
-  check('typing mid-flight suppresses the restore', fake.restoreCalls === 0);
-}
-{
-  setup({ baseY: 400, viewportY: 0 });
-  T.maybeHydrateScrollback();
-  advance(3000); // no replay ever landed
-  check('no restore when no replay landed (the self-heal path)', fake.restoreCalls === 0);
-  check('  ... and the flight is still cleared', T.hydratingScrollback === false);
+  check('the jump-to-bottom pill mid-flight is not overridden', fake.moves === 0);
+  check('  ... and the viewport is still at the bottom', fake.buffer.active.viewportY === 19949);
 }
 
 // ---- Teardown parity (round 1 Yellow 2, round 2 Green 2) -------------------
@@ -252,7 +265,7 @@ console.log('\n  teardown');
   check('  ... re-arms the dirty flag', T.scrollbackDirty === true);
   check('  ... and clears the latch', T.scrollbackFullySynced === false);
   advance(3000);
-  check('  ... and the dropped settle cannot invoke the restore', fake.restoreCalls === 0);
+  check('  ... and the dropped settle does nothing', fake.moves === 0 && T.scrollbackDirty === true);
 }
 {
   // Green 2: a new surface gets its own cooldown budget, not the old one's.

--- a/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
+++ b/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
@@ -4,21 +4,20 @@ const { JSDOM } = require('jsdom');
 
 // CROW-934: the shell-scrollback re-sync. tmux collapses pane redraws for a slow
 // client (the browser), so the local xterm buffer holds far fewer lines than the
-// pane's own history — measured 337/20000 for a browser-paced reader. Reaching
-// the top of the local buffer re-requests crowd's authoritative replay
+// pane's own history — measured 337/20000 for a browser-paced reader. Arriving
+// at the top of the local buffer re-requests crowd's authoritative replay
 // (`select-window` → `capture-pane -pe -S -50000`).
 //
-// Timers are a FAKE QUEUE rather than the no-op stub the other scroll suites
-// use, because the whole settle cycle — the restore, the latch, the dirty/settle
-// branch in onmessage — only exists across a timer boundary. The #935 review
-// found a re-capture loop that lived exactly there: `onScroll` is not a
-// user-scroll event (xterm's BufferService.scroll ends in an unconditional
-// `_onScroll.fire`), so a viewport parked at the top re-armed the capture on
-// every output line. A stubbed timer cannot see that; the loop case below is the
-// regression pin.
+// The harness fakes BOTH timers and the clock, and drives the real
+// `noteTerminalFrame` rather than a stand-in, because every bug found in review
+// so far has lived across a timer boundary on the frame path:
+//   - a stubbed no-op setTimeout hid a re-capture loop (#935 round 1);
+//   - modelling a live frame as `scrollbackDirty = true` took the `else` branch
+//     and hid a settle that live output could extend forever (round 2).
 const epilogue = `
 ;globalThis.__t = {
   maybeHydrateScrollback(){ return maybeHydrateScrollback(); },
+  noteTerminalFrame(){ return noteTerminalFrame(); },
   resetScrollbackSync(){ return resetScrollbackSync(); },
   sendToPTY(s){ return sendToPTY(s); },
   set term(v){ term = v; },
@@ -28,7 +27,7 @@ const epilogue = `
   get scrollbackDirty(){ return scrollbackDirty; },
   get hydratingScrollback(){ return hydratingScrollback; },
   get scrollbackFullySynced(){ return scrollbackFullySynced; },
-  set hydrateSawReplay(v){ hydrateSawReplay = v; },
+  set lastViewportY(v){ lastViewportY = v; },
   set lastHydrateAt(v){ lastHydrateAt = v; },
 };
 `;
@@ -49,16 +48,19 @@ window.TextEncoder = TextEncoder;
 window.setInterval = () => 0;
 window.requestAnimationFrame = () => 0;
 
-// Fake timers: collect pending callbacks so a test can run them on demand.
+// Fake clock + timers. Timers carry their due time so `advance` can fire only
+// what has actually come due — the deadline cases depend on that ordering.
+let fakeNow = 1e6;
+window.Date.now = () => fakeNow;
 let timerSeq = 1;
 const timers = new Map();
-window.setTimeout = (fn, ms) => { const id = timerSeq++; timers.set(id, { fn, ms }); return id; };
+window.setTimeout = (fn, ms) => { const id = timerSeq++; timers.set(id, { fn, due: fakeNow + (ms || 0) }); return id; };
 window.clearTimeout = (id) => { timers.delete(id); };
-// Run every pending timer once (the settle is the only one these tests arm).
-function runTimers() {
-  const due = [...timers.entries()];
-  timers.clear();
-  for (const [, t] of due) t.fn();
+function advance(ms) {
+  fakeNow += ms;
+  for (const [id, t] of [...timers.entries()]) {
+    if (t.due <= fakeNow) { timers.delete(id); t.fn(); }
+  }
 }
 
 const realGet = window.document.getElementById.bind(window.document);
@@ -77,22 +79,25 @@ const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name)
 
 // `baseY` is how many lines have scrolled off the top (whether scrollback exists
 // at all); `viewportY` is where the user is looking, 0 == the very top.
+// `scrollToTop` records that the restore was INVOKED — deliberately not that the
+// viewport visibly moved, which this fake has no `ydisp` semantics to model.
 let sends, fake;
-function setup({ agentSurface = false, baseY = 500, viewportY = 0,
+function setup({ agentSurface = false, baseY = 500, viewportY = 0, from = 400,
                  readyState = 1, window: win = 7, dirty = true } = {}) {
   sends = [];
   timers.clear();
   fake = {
     buffer: { active: { baseY, viewportY } },
-    scrolledToTop: 0,
-    scrollToTop() { this.scrolledToTop++; this.buffer.active.viewportY = 0; },
+    restoreCalls: 0,
+    scrollToTop() { this.restoreCalls++; },
   };
   T.term = fake;
   T.termWs = { readyState, send(s) { sends.push(JSON.parse(s)); } };
   T.activeTerminal = win === null ? null : { id: 't1', window: win, agent_surface: agentSurface };
   T.resetScrollbackSync();
   T.scrollbackDirty = dirty;
-  T.lastHydrateAt = 0; // no cooldown carried in from a previous case
+  T.lastViewportY = from; // where the user scrolled FROM (0 == already parked)
+  T.lastHydrateAt = 0;
   return sends;
 }
 const selects = () => sends.filter((m) => m.type === 'select-window');
@@ -104,7 +109,7 @@ console.log('scrollback hydrate (CROW-934)');
 {
   setup({ baseY: 297, viewportY: 0 });
   T.maybeHydrateScrollback();
-  check('shell at top of a thinned buffer re-requests the replay',
+  check('arriving at the top of a thinned buffer re-requests the replay',
     selects().length === 1 && selects()[0].window === 7);
   check('  ... and marks the sync in flight', T.hydratingScrollback === true);
   check('  ... and clears the dirty flag', T.scrollbackDirty === false);
@@ -132,7 +137,7 @@ console.log('scrollback hydrate (CROW-934)');
 {
   setup();
   T.maybeHydrateScrollback(); T.maybeHydrateScrollback(); T.maybeHydrateScrollback();
-  check('repeated scrolls within one in-flight sync issue exactly one capture', selects().length === 1);
+  check('repeated calls within one in-flight sync issue exactly one capture', selects().length === 1);
 }
 {
   setup({ readyState: 3 /* CLOSED */ });
@@ -145,92 +150,121 @@ console.log('scrollback hydrate (CROW-934)');
   check('no active terminal does not re-sync', selects().length === 0);
 }
 
-// ---- The #935 review's Red finding: no unbounded re-capture loop -----------
+// ---- Arrival, not position (round 1 Red + round 2 Green 1) -----------------
 
-console.log('\n  streaming output while parked at the top');
+console.log('\n  parked at the top while output streams');
 {
-  // The exact repro: read early output while a build keeps printing. Every
-  // output line marks the buffer dirty and fires onScroll with the viewport
-  // still pinned at 0. Before the fix this re-armed a full 50k capture per line.
-  setup({ baseY: 400, viewportY: 0 });
-  T.maybeHydrateScrollback();          // first capture
-  fake.buffer.active.baseY = 19949;    // replay brought real history back
-  runTimers();                         // settle
-  let capturesAfterFirst = 0;
+  // xterm fires onScroll for every line pushed at the bottom and pins a
+  // top-parked viewport at ydisp 0, so "still at the top" fires forever. Only
+  // ARRIVING there should capture.
+  setup({ baseY: 400, viewportY: 0, from: 0 });
+  T.maybeHydrateScrollback();
+  check('already parked at the top does not capture', selects().length === 0);
+
+  setup({ baseY: 400, viewportY: 0, from: 400 });
+  T.maybeHydrateScrollback();      // arrival → one capture
+  fake.buffer.active.baseY = 19949;
+  advance(3000);                   // settle
   for (let line = 0; line < 500; line++) {
-    T.scrollbackDirty = true;          // a live frame landed
-    fake.buffer.active.viewportY = 0;  // xterm pins a top-parked viewport
-    T.maybeHydrateScrollback();        // its onScroll
-    runTimers();
+    T.scrollbackDirty = true;      // a live frame's bookkeeping
+    T.maybeHydrateScrollback();    // its onScroll, viewport still pinned at 0
+    advance(20);
   }
-  capturesAfterFirst = selects().length - 1;
-  check('500 output lines at the top do not each trigger a capture', capturesAfterFirst === 0);
-  check('  ... the cooldown/latch holds it to the single initial capture', selects().length === 1);
-  // The capture DID come back deeper here, so the latch is off — this case is
-  // pinning the cooldown specifically, not passing by way of the latch.
-  check('  ... and it is the cooldown doing it (latch is off)', T.scrollbackFullySynced === false);
+  check('500 output lines at the top do not each trigger a capture', selects().length === 1);
+  check('  ... and the surface is not stuck mid-flight', T.hydratingScrollback === false);
 }
 {
   // Latch: a capture that comes back no deeper means the buffer already matches
   // the pane, so stop asking until the viewport leaves the top.
   setup({ baseY: 19949, viewportY: 0 });
   T.maybeHydrateScrollback();
-  runTimers(); // baseY unchanged → nothing new came back
+  T.noteTerminalFrame();       // the replay lands
+  advance(3000);               // settle; baseY unchanged → nothing new came back
   check('a capture that returns nothing new latches off', T.scrollbackFullySynced === true);
-  T.lastHydrateAt = 0; // prove the latch alone holds, independent of the cooldown
+  T.lastHydrateAt = 0;         // prove the latch holds independent of the cooldown
   T.scrollbackDirty = true;
+  T.lastViewportY = 400;       // and independent of the arrival gate
   T.maybeHydrateScrollback();
-  check('  ... and a further scroll at the top does not re-capture', selects().length === 1);
-  fake.buffer.active.viewportY = 900;  // user scrolls away
+  check('  ... and a further arrival at the top does not re-capture', selects().length === 1);
+  fake.buffer.active.viewportY = 900; // user scrolls away
   T.maybeHydrateScrollback();
   check('  ... leaving the top re-arms it', T.scrollbackFullySynced === false);
 }
-
-// ---- The #935 review's Yellow 1: the restore must not yank the viewport ----
-
-console.log('\n  viewport restore');
 {
   setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
+  advance(3000); // no frame ever landed
+  check('an empty flight does not latch (it proves nothing)', T.scrollbackFullySynced === false);
+}
+
+// ---- The settle cannot be extended forever (round 2 Yellow 1) --------------
+
+console.log('\n  busy shell during a flight');
+{
+  // Frames are not batched — one WS frame per PTY read chunk — so a build
+  // printing faster than the quiet window used to hold the settle open forever,
+  // latching hydratingScrollback true and silently disabling the feature.
+  setup({ baseY: 400, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  check('a sync is in flight', T.hydratingScrollback === true);
+  for (let i = 0; i < 200; i++) { T.noteTerminalFrame(); advance(100); } // 20 s of chatter
+  check('the absolute deadline ends the flight anyway', T.hydratingScrollback === false);
+  check('  ... so the surface can re-sync again later', T.scrollbackDirty === true || T.scrollbackFullySynced === false);
+}
+
+// ---- Restore decision (round 1 Yellow 1) -----------------------------------
+
+console.log('\n  restore decision');
+{
+  setup({ baseY: 400, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  T.noteTerminalFrame();
   fake.buffer.active.baseY = 19949;
-  fake.buffer.active.viewportY = 19949; // rebuild parked at the bottom
-  T.hydrateSawReplay = true;            // what onmessage sets when a frame lands
-  runTimers();
-  check('a landed replay restores the user to the oldest lines', fake.scrolledToTop === 1);
+  advance(3000);
+  check('a landed replay invokes the restore', fake.restoreCalls === 1);
 }
 {
-  // Yellow 1: scrollOnUserInput deliberately takes a typing user to the bottom.
   setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
+  T.noteTerminalFrame();
   fake.buffer.active.baseY = 19949;
-  fake.buffer.active.viewportY = 19949;
-  T.hydrateSawReplay = true;
-  T.sendToPTY('l');                     // user starts typing mid-flight
-  runTimers();
-  check('typing mid-flight suppresses the restore', fake.scrolledToTop === 0);
+  T.sendToPTY('l'); // user starts typing mid-flight
+  advance(3000);
+  check('typing mid-flight suppresses the restore', fake.restoreCalls === 0);
 }
 {
   setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
-  runTimers();
-  check('no restore when no replay ever landed (the 2000 ms self-heal path)',
-    fake.scrolledToTop === 0);
+  advance(3000); // no replay ever landed
+  check('no restore when no replay landed (the self-heal path)', fake.restoreCalls === 0);
   check('  ... and the flight is still cleared', T.hydratingScrollback === false);
 }
 
-// ---- Teardown parity (review Yellow 2) -------------------------------------
+// ---- Teardown parity (round 1 Yellow 2, round 2 Green 2) -------------------
 
 console.log('\n  teardown');
 {
   setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
   check('a sync is in flight', T.hydratingScrollback === true);
-  T.resetScrollbackSync(); // what both reloadTerminal and onclose now call
+  T.resetScrollbackSync(); // what both reloadTerminal and onclose call
   check('reset clears the in-flight sync', T.hydratingScrollback === false);
   check('  ... re-arms the dirty flag', T.scrollbackDirty === true);
   check('  ... and clears the latch', T.scrollbackFullySynced === false);
-  runTimers();
-  check('  ... and the dropped settle cannot move the viewport', fake.scrolledToTop === 0);
+  advance(3000);
+  check('  ... and the dropped settle cannot invoke the restore', fake.restoreCalls === 0);
+}
+{
+  // Green 2: a new surface gets its own cooldown budget, not the old one's.
+  setup({ baseY: 400, viewportY: 0 });
+  T.maybeHydrateScrollback();     // consumes the budget
+  advance(3000);
+  T.resetScrollbackSync();        // tab switch
+  T.lastViewportY = 400;
+  fake.buffer.active.viewportY = 0;
+  T.maybeHydrateScrollback();
+  check('reset clears the cooldown so a new surface can sync immediately',
+    selects().length === 2);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
+++ b/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
@@ -8,21 +8,28 @@ const { JSDOM } = require('jsdom');
 // the top of the local buffer re-requests crowd's authoritative replay
 // (`select-window` → `capture-pane -pe -S -50000`).
 //
-// These cases pin the GATING, which is where the cost and the regression risk
-// live: an over-eager trigger fires a tmux capture on every output burst, and an
-// under-eager one leaves the bug in place. Same harness shape as
-// wheel-scroll.test.js — an epilogue evaluated in app.js's own top-level lexical
-// scope exposes the module-scope bindings.
+// Timers are a FAKE QUEUE rather than the no-op stub the other scroll suites
+// use, because the whole settle cycle — the restore, the latch, the dirty/settle
+// branch in onmessage — only exists across a timer boundary. The #935 review
+// found a re-capture loop that lived exactly there: `onScroll` is not a
+// user-scroll event (xterm's BufferService.scroll ends in an unconditional
+// `_onScroll.fire`), so a viewport parked at the top re-armed the capture on
+// every output line. A stubbed timer cannot see that; the loop case below is the
+// regression pin.
 const epilogue = `
 ;globalThis.__t = {
   maybeHydrateScrollback(){ return maybeHydrateScrollback(); },
+  resetScrollbackSync(){ return resetScrollbackSync(); },
+  sendToPTY(s){ return sendToPTY(s); },
   set term(v){ term = v; },
   set termWs(v){ termWs = v; },
   set activeTerminal(v){ activeTerminal = v; },
   set scrollbackDirty(v){ scrollbackDirty = v; },
   get scrollbackDirty(){ return scrollbackDirty; },
-  set hydratingScrollback(v){ hydratingScrollback = v; },
   get hydratingScrollback(){ return hydratingScrollback; },
+  get scrollbackFullySynced(){ return scrollbackFullySynced; },
+  set hydrateSawReplay(v){ hydrateSawReplay = v; },
+  set lastHydrateAt(v){ lastHydrateAt = v; },
 };
 `;
 const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
@@ -40,8 +47,20 @@ window.WebSocket = function () {
 window.WebSocket.OPEN = 1;
 window.TextEncoder = TextEncoder;
 window.setInterval = () => 0;
-window.setTimeout = () => 0;
 window.requestAnimationFrame = () => 0;
+
+// Fake timers: collect pending callbacks so a test can run them on demand.
+let timerSeq = 1;
+const timers = new Map();
+window.setTimeout = (fn, ms) => { const id = timerSeq++; timers.set(id, { fn, ms }); return id; };
+window.clearTimeout = (id) => { timers.delete(id); };
+// Run every pending timer once (the settle is the only one these tests arm).
+function runTimers() {
+  const due = [...timers.entries()];
+  timers.clear();
+  for (const [, t] of due) t.fn();
+}
+
 const realGet = window.document.getElementById.bind(window.document);
 window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
 
@@ -56,83 +75,162 @@ const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name)
 
 // ---- Fakes -----------------------------------------------------------------
 
-// `baseY` is how many lines have scrolled off the top (i.e. whether scrollback
-// exists at all); `viewportY` is where the user is looking, 0 == the very top.
+// `baseY` is how many lines have scrolled off the top (whether scrollback exists
+// at all); `viewportY` is where the user is looking, 0 == the very top.
+let sends, fake;
 function setup({ agentSurface = false, baseY = 500, viewportY = 0,
                  readyState = 1, window: win = 7, dirty = true } = {}) {
-  const sends = [];
-  T.term = {
+  sends = [];
+  timers.clear();
+  fake = {
     buffer: { active: { baseY, viewportY } },
-    scrollToTop() {},
+    scrolledToTop: 0,
+    scrollToTop() { this.scrolledToTop++; this.buffer.active.viewportY = 0; },
   };
+  T.term = fake;
   T.termWs = { readyState, send(s) { sends.push(JSON.parse(s)); } };
   T.activeTerminal = win === null ? null : { id: 't1', window: win, agent_surface: agentSurface };
-  T.hydratingScrollback = false;
+  T.resetScrollbackSync();
   T.scrollbackDirty = dirty;
+  T.lastHydrateAt = 0; // no cooldown carried in from a previous case
   return sends;
 }
-const selects = (sends) => sends.filter((m) => m.type === 'select-window');
-
-// ---- Cases -----------------------------------------------------------------
+const selects = () => sends.filter((m) => m.type === 'select-window');
 
 console.log('scrollback hydrate (CROW-934)');
 
-// The bug this fixes: a shell tab sitting on a thinned buffer, scrolled to the top.
+// ---- Gating ----------------------------------------------------------------
+
 {
-  const sends = setup({ agentSurface: false, baseY: 297, viewportY: 0 });
+  setup({ baseY: 297, viewportY: 0 });
   T.maybeHydrateScrollback();
   check('shell at top of a thinned buffer re-requests the replay',
-    selects(sends).length === 1 && selects(sends)[0].window === 7);
-  check('  ... and marks the sync in flight so it is not re-issued', T.hydratingScrollback === true);
+    selects().length === 1 && selects()[0].window === 7);
+  check('  ... and marks the sync in flight', T.hydratingScrollback === true);
   check('  ... and clears the dirty flag', T.scrollbackDirty === false);
 }
-
-// An agent keeps its transcript in the scrollback-less alt buffer and repaints
-// it itself (ADR-0013) — a capture there returns only the viewport.
 {
-  const sends = setup({ agentSurface: true });
+  setup({ agentSurface: true });
   T.maybeHydrateScrollback();
-  check('agent surface never re-syncs', selects(sends).length === 0);
+  check('agent surface never re-syncs', selects().length === 0);
+}
+{
+  setup({ baseY: 0, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  check('short buffer (no scrollback yet) does not re-sync', selects().length === 0);
+}
+{
+  setup({ baseY: 500, viewportY: 120 });
+  T.maybeHydrateScrollback();
+  check('mid-buffer scroll does not re-sync', selects().length === 0);
+}
+{
+  setup({ dirty: false });
+  T.maybeHydrateScrollback();
+  check('already-synced buffer does not re-sync', selects().length === 0);
+}
+{
+  setup();
+  T.maybeHydrateScrollback(); T.maybeHydrateScrollback(); T.maybeHydrateScrollback();
+  check('repeated scrolls within one in-flight sync issue exactly one capture', selects().length === 1);
+}
+{
+  setup({ readyState: 3 /* CLOSED */ });
+  T.maybeHydrateScrollback();
+  check('closed socket does not re-sync', selects().length === 0);
+}
+{
+  setup({ window: null });
+  T.maybeHydrateScrollback();
+  check('no active terminal does not re-sync', selects().length === 0);
 }
 
-// The `baseY === 0` guard. On a tab that has printed less than one screen,
-// viewportY is permanently 0, so testing "at the top" alone would fire a tmux
-// capture on every output burst for the life of the tab.
+// ---- The #935 review's Red finding: no unbounded re-capture loop -----------
+
+console.log('\n  streaming output while parked at the top');
 {
-  const sends = setup({ baseY: 0, viewportY: 0 });
+  // The exact repro: read early output while a build keeps printing. Every
+  // output line marks the buffer dirty and fires onScroll with the viewport
+  // still pinned at 0. Before the fix this re-armed a full 50k capture per line.
+  setup({ baseY: 400, viewportY: 0 });
+  T.maybeHydrateScrollback();          // first capture
+  fake.buffer.active.baseY = 19949;    // replay brought real history back
+  runTimers();                         // settle
+  let capturesAfterFirst = 0;
+  for (let line = 0; line < 500; line++) {
+    T.scrollbackDirty = true;          // a live frame landed
+    fake.buffer.active.viewportY = 0;  // xterm pins a top-parked viewport
+    T.maybeHydrateScrollback();        // its onScroll
+    runTimers();
+  }
+  capturesAfterFirst = selects().length - 1;
+  check('500 output lines at the top do not each trigger a capture', capturesAfterFirst === 0);
+  check('  ... the cooldown/latch holds it to the single initial capture', selects().length === 1);
+  // The capture DID come back deeper here, so the latch is off — this case is
+  // pinning the cooldown specifically, not passing by way of the latch.
+  check('  ... and it is the cooldown doing it (latch is off)', T.scrollbackFullySynced === false);
+}
+{
+  // Latch: a capture that comes back no deeper means the buffer already matches
+  // the pane, so stop asking until the viewport leaves the top.
+  setup({ baseY: 19949, viewportY: 0 });
   T.maybeHydrateScrollback();
-  check('short buffer (no scrollback yet) does not re-sync', selects(sends).length === 0);
+  runTimers(); // baseY unchanged → nothing new came back
+  check('a capture that returns nothing new latches off', T.scrollbackFullySynced === true);
+  T.lastHydrateAt = 0; // prove the latch alone holds, independent of the cooldown
+  T.scrollbackDirty = true;
+  T.maybeHydrateScrollback();
+  check('  ... and a further scroll at the top does not re-capture', selects().length === 1);
+  fake.buffer.active.viewportY = 900;  // user scrolls away
+  T.maybeHydrateScrollback();
+  check('  ... leaving the top re-arms it', T.scrollbackFullySynced === false);
 }
 
+// ---- The #935 review's Yellow 1: the restore must not yank the viewport ----
+
+console.log('\n  viewport restore');
 {
-  const sends = setup({ baseY: 500, viewportY: 120 });
+  setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
-  check('mid-buffer scroll does not re-sync', selects(sends).length === 0);
+  fake.buffer.active.baseY = 19949;
+  fake.buffer.active.viewportY = 19949; // rebuild parked at the bottom
+  T.hydrateSawReplay = true;            // what onmessage sets when a frame lands
+  runTimers();
+  check('a landed replay restores the user to the oldest lines', fake.scrolledToTop === 1);
+}
+{
+  // Yellow 1: scrollOnUserInput deliberately takes a typing user to the bottom.
+  setup({ baseY: 400, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  fake.buffer.active.baseY = 19949;
+  fake.buffer.active.viewportY = 19949;
+  T.hydrateSawReplay = true;
+  T.sendToPTY('l');                     // user starts typing mid-flight
+  runTimers();
+  check('typing mid-flight suppresses the restore', fake.scrolledToTop === 0);
+}
+{
+  setup({ baseY: 400, viewportY: 0 });
+  T.maybeHydrateScrollback();
+  runTimers();
+  check('no restore when no replay ever landed (the 2000 ms self-heal path)',
+    fake.scrolledToTop === 0);
+  check('  ... and the flight is still cleared', T.hydratingScrollback === false);
 }
 
-// Idempotence: one capture per output burst, not one per scroll event.
-{
-  const sends = setup({ dirty: false });
-  T.maybeHydrateScrollback();
-  check('already-synced buffer does not re-sync', selects(sends).length === 0);
-}
-{
-  const sends = setup();
-  T.maybeHydrateScrollback();
-  T.maybeHydrateScrollback();
-  T.maybeHydrateScrollback();
-  check('repeated scrolls at the top issue exactly one capture', selects(sends).length === 1);
-}
+// ---- Teardown parity (review Yellow 2) -------------------------------------
 
+console.log('\n  teardown');
 {
-  const sends = setup({ readyState: 3 /* CLOSED */ });
+  setup({ baseY: 400, viewportY: 0 });
   T.maybeHydrateScrollback();
-  check('closed socket does not re-sync', selects(sends).length === 0);
-}
-{
-  const sends = setup({ window: null });
-  T.maybeHydrateScrollback();
-  check('no active terminal does not re-sync', selects(sends).length === 0);
+  check('a sync is in flight', T.hydratingScrollback === true);
+  T.resetScrollbackSync(); // what both reloadTerminal and onclose now call
+  check('reset clears the in-flight sync', T.hydratingScrollback === false);
+  check('  ... re-arms the dirty flag', T.scrollbackDirty === true);
+  check('  ... and clears the latch', T.scrollbackFullySynced === false);
+  runTimers();
+  check('  ... and the dropped settle cannot move the viewport', fake.scrolledToTop === 0);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #934

## What was actually wrong

**Neither limit named in the issue was the cause — both were already correct.** Verified before changing anything:

- tmux `history-limit` is **50000**, and every live window — including freshly created `Shell` tabs — is born with it (`history_limit=50000, alternate_on=0`).
- All xterm.js constructions already pass `scrollback: 50000`.
- The daemon's `capture-pane -pe -S -50000` replay delivers **all 20 000 lines** over the live `/terminal` socket.

The real cause is that **the local xterm buffer is not a faithful copy of the pane**. tmux collapses pane redraws when the attached client can't drain them fast enough, and the browser *is* that slow client. Measured against the bundled config with `seq 1 20000` (pane history 19 989 lines):

| client | bytes delivered | lines reaching the front-end |
|---|---|---|
| raw reader | 210 KB | 19 768 / 20 000 |
| browser-paced reader | 7 KB | **337 / 20 000** |

crowd's `select-window` reply carries the authoritative copy and rebuilds the buffer in place — but it only ran on connect and on a tab **change** (`attachWindow` → `reloadTerminal`). That's why switching away and back "fixed" the history, while the tab you were sitting on never re-synced and scroll-up hit the top after a few screens.

## The fix

Re-request the replay when a plain-shell surface reaches the top of its local buffer. That's exactly when the user is asking for older lines, so it costs one capture per output burst rather than polling.

- **Agent surfaces are excluded** — they keep their transcript in the scrollback-less alt buffer and repaint it themselves (ADR-0013), so a capture there returns only the viewport.
- **`baseY > 0` is load-bearing** — on a tab that has printed less than one screen `viewportY` is permanently 0, so testing "at the top" alone would fire a tmux capture on every output burst for the life of the tab.
- The settle is **debounced, not `term.write`'s callback**, because live output can interleave with the replay; it's self-healing, so a replay that never arrives can't wedge the surface.

Verified that a **repeat** `select-window` on the same window returns 20 000/20 000 lines and is byte-identical to the first — the `ESC[H ESC[2J ESC[3J` rebuild means re-requesting can't stack duplicates.

## On "must land in all three front-ends"

The issue asks for the fix in all three. Only **one** is a live front-end with tab switching:

- `web/app.js` — production. Fixed here.
- `web/terminal.html` — the standalone debug page; single-pane, has no `select-window` protocol at all, and uses xterm's native wheel. Nothing to sync.
- `CrowTerminal/Resources/xterm/terminal.html` — **dead**. Its `crowWrite`/`crowInput`/`crowReady`/`crowResize` bridge has zero callers anywhere in the repo; it lost its last consumer when ADR-0010 retired the macOS app. app.js's comment claiming to mirror it is corrected here. (Deleting the file is left as a separate cleanup, with precedent in #927.)

No shared terminal-construction config was introduced because the construction values were never the problem — they are already identical and correct in both live pages. This change adds behavior that only makes sense where tab switching exists.

## Acceptance criteria

- [x] Shell tab, several thousand lines, scroll to top → earliest lines reachable (the re-sync restores all 20 000 and lands the viewport on line 1).
- [x] Same code path serves the desktop app — `crow-desktop` is a shell that loads this same `app.js`, so there is no second implementation to keep in step.
- [x] Agent terminals not regressed — excluded by an explicit `agent_surface` guard, pinned by a test.
- [x] tmux `history-limit` was **not** the binding constraint (verified 50000 on new panes), so no config change was needed.

## Testing

New `web-tests/scrollback-hydrate.test.js` pins the gating — 10 cases covering the shell-at-top trigger, the agent exclusion, the short-buffer guard, mid-buffer, already-synced, repeat-scroll idempotence, closed socket, and no active terminal.

Full web suite passes. `row.test.js` reports 10 failures, which are **pre-existing on main** — confirmed identical (43 passed / 10 failed) with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)