### PR TITLE
Detect when a newer Crow build is available (CROW-938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CROW-938 — Detect when a newer Crow build is available by comparing the stamped `gitSha` against `corveil/crow` `main` (no release tags required). `crowd` owns the GitHub compare call, caches the result, and checks at most once per daemon start plus every ≥6 hours (configurable, opt-out via `versionUpdate.enabled`). Surfaces: `crow version --check` / `crow version check` (human summary with exit codes), `crow version get|set`, Settings → About (status + Check now), and a dismissible web banner when behind. Offline, rate-limited, `dev`, or unknown SHAs report `unknown` — never a false up-to-date.
+
 ## [0.2.0] - 2026-08-05
 
 Backfill of merged PRs since the 0.1.0 release, grouped by theme.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,11 @@ crow cleanup get                                                        → {"cl
 crow cleanup set [--enabled true|false] [--retention-hours N]           → patch; live within ~1 board poll. Deletes completed/archived sessions incl. worktree + branch
 crow ui get                                                             → {"ui":{"sidebar":{"hide_session_details":…}}}
 crow ui set --hide-session-details true|false                           → patch; connected browsers repaint within ~2s
+crow version                                                            → prints the stamped build version
+crow version --check                                                    → compare against corveil/crow main; human summary, exit 0/1/2
+crow version check                                                      → same as --check
+crow version get                                                        → {"version_update":{…},"status":{…}}
+crow version set [--enabled true|false] [--interval-hours N]            → patch; interval floored at 6h
 ```
 
 ### Defaults

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
@@ -45,7 +45,13 @@ public struct VersionCheckCmd: ParsableCommand {
 /// Shared implementation for `crow version --check` and `crow version check`.
 enum VersionCheck {
     static func run() throws {
-        let result = try rpc("version-update-check", params: ["force": .bool(true)])
+        let result: [String: JSONValue]
+        do {
+            result = try rpc("version-update-check", params: ["force": .bool(true)])
+        } catch {
+            warn("Could not check for updates — is crowd running?")
+            throw ExitCode(2)
+        }
         guard let status = result["status"], status != .null else {
             warn("Could not check for updates — is crowd running?")
             throw ExitCode(2)

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
@@ -1,0 +1,154 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+// MARK: - crow version
+
+/// `crow version` — local build info and upstream comparison (CROW-938).
+public struct Version: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "version",
+        abstract: "Show the local build and check for upstream updates",
+        discussion: """
+        Bare `crow version` prints the stamped build version. Pass `--check` or run \
+        `crow version check` to compare against corveil/crow main via the daemon.
+        """,
+        subcommands: [VersionCheckCmd.self, VersionGet.self, VersionSet.self]
+    )
+
+    @Flag(name: .long, help: "Compare this build against corveil/crow main")
+    var check: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        if check {
+            try VersionCheck.run()
+            return
+        }
+        print(CLIVersion.version)
+    }
+}
+
+public struct VersionCheckCmd: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "check",
+        abstract: "Compare this build against corveil/crow main")
+
+    public init() {}
+
+    public func run() throws {
+        try VersionCheck.run()
+    }
+}
+
+/// Shared implementation for `crow version --check` and `crow version check`.
+enum VersionCheck {
+    static func run() throws {
+        let result = try rpc("version-update-check", params: ["force": .bool(true)])
+        guard let status = result["status"], status != .null else {
+            fputs("Could not check for updates — is crowd running?\n", stderr)
+            throw ExitCode(2)
+        }
+        printHuman(status)
+        let state = status.objectValue?["state"]?.stringValue ?? "unknown"
+        switch state {
+        case "up_to_date": throw ExitCode(0)
+        case "behind": throw ExitCode(1)
+        default: throw ExitCode(2)
+        }
+    }
+
+    private static func printHuman(_ status: JSONValue) {
+        let obj = status.objectValue ?? [:]
+        let version = obj["local_version"]?.stringValue ?? "?"
+        let sha = obj["local_sha"]?.stringValue ?? "?"
+        let buildDate = obj["build_date"]?.stringValue ?? ""
+        var localLine = "crow \(version) (\(sha)"
+        if !buildDate.isEmpty { localLine += ", built \(buildDate)" }
+        localLine += ")"
+        print(localLine)
+
+        let state = obj["state"]?.stringValue ?? "unknown"
+        switch state {
+        case "up_to_date":
+            if let remoteSha = obj["remote_sha"]?.stringValue {
+                var remoteLine = "origin/main is at \(remoteSha)"
+                if let remoteDate = obj["remote_date"]?.stringValue, !remoteDate.isEmpty {
+                    remoteLine += " (\(remoteDate))"
+                }
+                print(remoteLine)
+            }
+            print("Up to date.")
+        case "behind":
+            if let remoteSha = obj["remote_sha"]?.stringValue {
+                var remoteLine = "origin/main is at \(remoteSha)"
+                if let remoteDate = obj["remote_date"]?.stringValue, !remoteDate.isEmpty {
+                    remoteLine += " (\(remoteDate))"
+                }
+                print(remoteLine)
+            }
+            if let behind = obj["behind_by"]?.intValue {
+                print("→ \(behind) commit\(behind == 1 ? "" : "s") behind")
+            }
+            if let cmd = obj["update_command"]?.stringValue {
+                print("")
+                print("Update:  \(cmd)")
+            }
+        default:
+            let reason = obj["reason"]?.stringValue ?? "Could not determine update status"
+            print(reason)
+        }
+    }
+}
+
+public struct VersionGet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "get",
+        abstract: "Show version-update settings and the cached check result")
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("version-update-get"))
+    }
+}
+
+public struct VersionSet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Change version-update settings",
+        discussion: """
+        Only the flags you pass change; at least one is required. \
+        --interval-hours is floored at 6 so unauthenticated GitHub checks cannot \
+        exhaust the 60 req/hr limit.
+        """
+    )
+
+    @Option(name: .long, help: "Enable periodic upstream checks (true or false)")
+    var enabled: Bool?
+
+    @Option(
+        name: .customLong("interval-hours"),
+        help: "Hours between automatic checks (minimum 6, default 6)")
+    var intervalHours: Int?
+
+    public init() {}
+
+    public func validate() throws {
+        guard enabled != nil || intervalHours != nil else {
+            throw ValidationError(
+                "Nothing to set — provide at least one of --enabled, --interval-hours.")
+        }
+        if let intervalHours, intervalHours < 6 {
+            throw ValidationError("--interval-hours must be at least 6.")
+        }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = [:]
+        if let enabled { params["enabled"] = .bool(enabled) }
+        if let intervalHours { params["interval_hours"] = .int(intervalHours) }
+        printJSON(try rpc("version-update-set", params: params))
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
@@ -47,7 +47,7 @@ enum VersionCheck {
     static func run() throws {
         let result = try rpc("version-update-check", params: ["force": .bool(true)])
         guard let status = result["status"], status != .null else {
-            fputs("Could not check for updates — is crowd running?\n", stderr)
+            warn("Could not check for updates — is crowd running?")
             throw ExitCode(2)
         }
         printHuman(status)

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -79,6 +79,7 @@ public struct CrowCommand: ParsableCommand {
             HookEventCmd.self,
             CodexNotify.self,
             GenerateDocs.self,
+            Version.self,
         ]
     )
 

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -174,6 +174,7 @@ struct ParityGateTests {
             terminal: TerminalSettings(),
             autoRespond: AutoRespondSettings(),
             cleanup: CleanupConfig(),
+            versionUpdate: VersionUpdateConfig(),
             jobs: [
                 JobConfig(
                     name: "probe",

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -50,6 +50,9 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// can still pick up previously-labeled issues.
     public var autoCreateWatcherEnabled: Bool
     public var cleanup: CleanupConfig
+    /// Periodic check against `corveil/crow` `main` to surface when this build
+    /// is behind upstream (CROW-938). Off-able; interval floored at 6h.
+    public var versionUpdate: VersionUpdateConfig
     /// Scheduled jobs: named sets of prompts that fire automatically on a
     /// schedule, scoped to a repo. Driven by `JobScheduler` (CROW-317).
     public var jobs: [JobConfig]
@@ -144,6 +147,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoMergeWatcherEnabled: Bool = false,
         autoCreateWatcherEnabled: Bool = false,
         cleanup: CleanupConfig = CleanupConfig(),
+        versionUpdate: VersionUpdateConfig = VersionUpdateConfig(),
         jobs: [JobConfig] = [],
         defaultAgentKind: AgentKind = .claudeCode,
         agentsByKind: [String: AgentKind] = [:],
@@ -167,6 +171,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.autoMergeWatcherEnabled = autoMergeWatcherEnabled
         self.autoCreateWatcherEnabled = autoCreateWatcherEnabled
         self.cleanup = cleanup
+        self.versionUpdate = versionUpdate
         self.jobs = jobs
         self.defaultAgentKind = defaultAgentKind
         self.agentsByKind = agentsByKind
@@ -202,6 +207,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
             autoRespond.autoRebaseAndResolveConflicts = true
         }
         cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
+        versionUpdate = try container.decodeIfPresent(VersionUpdateConfig.self, forKey: .versionUpdate)
+            ?? VersionUpdateConfig()
         jobs = try container.decodeIfPresent([JobConfig].self, forKey: .jobs) ?? []
         defaultAgentKind = try container.decodeIfPresent(AgentKind.self, forKey: .defaultAgentKind) ?? .claudeCode
         agentsByKind = try container.decodeIfPresent([String: AgentKind].self, forKey: .agentsByKind) ?? [:]
@@ -245,7 +252,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
     }
 
     /// Resolve the agent that should drive a newly-created session of the

--- a/Packages/CrowCore/Sources/CrowCore/Models/VersionUpdate.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/VersionUpdate.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Settings for the periodic upstream version check (CROW-938).
+public struct VersionUpdateConfig: Codable, Sendable, Equatable {
+    /// When false, `crowd` does not phone GitHub on a schedule. Defaults to
+    /// true — the check is on unless the user opts out.
+    public var enabled: Bool
+    /// Minimum hours between automatic checks. Floored at 6 so an
+    /// unauthenticated GitHub client (60 req/hr/IP) cannot be exhausted by a
+    /// misconfigured interval.
+    public var intervalHours: Int
+
+    public static let minimumIntervalHours = 6
+
+    public init(enabled: Bool = true, intervalHours: Int = 6) {
+        self.enabled = enabled
+        self.intervalHours = max(Self.minimumIntervalHours, intervalHours)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        let raw = try c.decodeIfPresent(Int.self, forKey: .intervalHours) ?? Self.minimumIntervalHours
+        intervalHours = max(Self.minimumIntervalHours, raw)
+    }
+
+    enum CodingKeys: String, CodingKey { case enabled, intervalHours }
+}
+
+/// Build metadata stamped by `scripts/generate-build-info.sh` into
+/// `version.json` and served at `/version.json`.
+public struct BuildInfo: Codable, Sendable, Equatable {
+    public var version: String
+    /// Short SHA for display (`git rev-parse --short`).
+    public var gitSha: String
+    /// Full SHA for GitHub compare; falls back to `gitSha` when absent.
+    public var gitShaFull: String?
+    public var buildDate: String
+
+    public init(version: String, gitSha: String, gitShaFull: String? = nil, buildDate: String) {
+        self.version = version
+        self.gitSha = gitSha
+        self.gitShaFull = gitShaFull
+        self.buildDate = buildDate
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decodeIfPresent(String.self, forKey: .version) ?? "?"
+        gitSha = try c.decodeIfPresent(String.self, forKey: .gitSha) ?? "dev"
+        gitShaFull = try c.decodeIfPresent(String.self, forKey: .gitShaFull)
+        buildDate = try c.decodeIfPresent(String.self, forKey: .buildDate) ?? ""
+    }
+
+    /// SHA sent to GitHub's compare API — full when stamped, else short.
+    public var compareSha: String { gitShaFull ?? gitSha }
+
+    /// Whether this build's SHA is too ambiguous for an upstream comparison.
+    public var isIndeterminate: Bool {
+        let sha = compareSha.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return sha.isEmpty || sha == "dev"
+    }
+
+    enum CodingKeys: String, CodingKey { case version, gitSha, gitShaFull, buildDate }
+}
+
+/// Cached result of comparing the local build against `origin/main`.
+public struct VersionUpdateStatus: Codable, Sendable, Equatable {
+    public enum State: String, Codable, Sendable {
+        case upToDate = "up_to_date"
+        case behind
+        case unknown
+    }
+
+    public var state: State
+    public var localVersion: String
+    public var localSha: String
+    public var buildDate: String
+    public var remoteSha: String?
+    public var remoteDate: String?
+    public var behindBy: Int?
+    public var aheadBy: Int?
+    public var updateCommand: String?
+    /// Human-readable reason when `state == .unknown`.
+    public var reason: String?
+    /// Epoch milliseconds when this result was produced.
+    public var checkedAtMs: Int64?
+
+    public init(
+        state: State,
+        localVersion: String,
+        localSha: String,
+        buildDate: String,
+        remoteSha: String? = nil,
+        remoteDate: String? = nil,
+        behindBy: Int? = nil,
+        aheadBy: Int? = nil,
+        updateCommand: String? = nil,
+        reason: String? = nil,
+        checkedAtMs: Int64? = nil
+    ) {
+        self.state = state
+        self.localVersion = localVersion
+        self.localSha = localSha
+        self.buildDate = buildDate
+        self.remoteSha = remoteSha
+        self.remoteDate = remoteDate
+        self.behindBy = behindBy
+        self.aheadBy = aheadBy
+        self.updateCommand = updateCommand
+        self.reason = reason
+        self.checkedAtMs = checkedAtMs
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -216,6 +216,9 @@ public enum ParityLedger {
         .write("cleanup-set", cli: "cleanup set"),
         .read("ui-get", cli: "ui get"),
         .write("ui-set", cli: "ui set"),
+        .read("version-update-get", cli: "version get"),
+        .write("version-update-set", cli: "version set"),
+        .write("version-update-check", cli: "version check"),
         .read("notifications-get", cli: "notifications get"),
         .write("notifications-set", cli: "notifications set"),
         .read(
@@ -332,6 +335,9 @@ public enum ParityLedger {
 
         .field("cleanup.enabled", read: "cleanup get", write: "cleanup set"),
         .field("cleanup.retentionHours", read: "cleanup get", write: "cleanup set"),
+
+        .field("versionUpdate.enabled", read: "version get", write: "version set"),
+        .field("versionUpdate.intervalHours", read: "version get", write: "version set"),
 
         .field("sidebar.hideSessionDetails", read: "ui get", write: "ui set"),
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -386,6 +386,17 @@ public enum CrowDaemon {
         }
         if let jobScheduler { startJobPoll(scheduler: jobScheduler) }
 
+        // Upstream version check (CROW-938): compare the stamped build SHA against
+        // corveil/crow main. Runs on a long interval and caches the result in
+        // memory — failures are silent and never block startup.
+        let buildInfo = BuildInfoLoader.load(webDir: options.webDir)
+            ?? BuildInfo(version: "?", gitSha: "dev", buildDate: "")
+        let versionUpdateService = await MainActor.run {
+            VersionUpdateService(buildInfo: buildInfo, devRoot: options.devRoot)
+        }
+        startVersionUpdatePoll(
+            service: versionUpdateService, devRoot: options.devRoot, eventHub: eventHub)
+
         // Delegate any method the daemon's curated router doesn't explicitly own
         // to the app's FULL engine router (hook-event, send, link/ticket ops,
         // resync-jira, get-session, list-worktrees, …). This makes a "missing
@@ -416,7 +427,8 @@ public enum CrowDaemon {
             appState: appState, store: store, git: git, devRoot: options.devRoot,
             cockpit: cockpit, tracker: tracker, allowList: allowList,
             sessionService: sessionService, autoRespond: autoRespond, jobScheduler: jobScheduler,
-            rebuildScorecard: rebuildScorecard, fallback: engineFallback)
+            rebuildScorecard: rebuildScorecard, versionUpdateService: versionUpdateService,
+            fallback: engineFallback)
 
         // Unix socket — lets the existing `crow` CLI talk to the daemon. By
         // default this IS the app's well-known `crow.sock` (the daemon owns it in

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -392,7 +392,7 @@ public enum CrowDaemon {
         let buildInfo = BuildInfoLoader.load(webDir: options.webDir)
             ?? BuildInfo(version: "?", gitSha: "dev", buildDate: "")
         let versionUpdateService = await MainActor.run {
-            VersionUpdateService(buildInfo: buildInfo, devRoot: options.devRoot)
+            VersionUpdateService(buildInfo: buildInfo)
         }
         startVersionUpdatePoll(
             service: versionUpdateService, devRoot: options.devRoot, eventHub: eventHub)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -1715,7 +1715,7 @@ func makeCommandRouter(
             }
         },
         "version-update-check": { params in
-            let force = params["force"]?.boolValue ?? true
+            let force = params["force"]?.boolValue ?? false
             guard let versionUpdateService else {
                 return ["status": VersionUpdateRPC.statusJSON(nil)]
             }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -162,6 +162,7 @@ func makeCommandRouter(
     // SessionService and the telemetry receiver are in scope; nil when telemetry
     // is off (there'd be no DB to rebuild from).
     rebuildScorecard: (@MainActor @Sendable () async -> Void)? = nil,
+    versionUpdateService: VersionUpdateService? = nil,
     fallback: CommandRouter? = nil
 ) -> CommandRouter {
     // Serializes review kickoffs (see start-review) — one per router instance.
@@ -1680,6 +1681,55 @@ func makeCommandRouter(
                     "restart_required": .bool(false),
                 ]
             }
+        },
+
+        // Version update check (CROW-938) — `crow version get|set|--check`.
+        "version-update-get": { _ in
+            let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            let status = await versionUpdateService?.cachedStatus
+            return [
+                "version_update": VersionUpdateRPC.configJSON(config.versionUpdate),
+                "status": VersionUpdateRPC.statusJSON(status),
+            ]
+        },
+        "version-update-set": { params in
+            try await mapRPCError {
+                let enabled = try SettingsRPC.patchBool(params, "enabled")
+                let intervalHours = try VersionUpdateRPC.patchIntervalHours(params)
+                guard enabled != nil || intervalHours != nil else {
+                    throw RPCError.invalidParams(
+                        "Nothing to set — provide at least one of enabled, interval_hours.")
+                }
+                let versionUpdate = try mutateConfig(devRoot: devRoot) { config -> VersionUpdateConfig in
+                    if let enabled { config.versionUpdate.enabled = enabled }
+                    if let intervalHours {
+                        config.versionUpdate.intervalHours = max(
+                            VersionUpdateConfig.minimumIntervalHours, intervalHours)
+                    }
+                    return config.versionUpdate
+                }
+                return [
+                    "version_update": VersionUpdateRPC.configJSON(versionUpdate),
+                    "saved": .bool(true),
+                ]
+            }
+        },
+        "version-update-check": { params in
+            let force = params["force"]?.boolValue ?? true
+            guard let versionUpdateService else {
+                return ["status": VersionUpdateRPC.statusJSON(nil)]
+            }
+            let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            let status: VersionUpdateStatus?
+            if force {
+                status = await versionUpdateService.runCheck()
+            } else {
+                status = await versionUpdateService.checkIfDue(
+                    enabled: config.versionUpdate.enabled,
+                    intervalHours: config.versionUpdate.intervalHours,
+                    force: false)
+            }
+            return ["status": VersionUpdateRPC.statusJSON(status)]
         },
 
         // Settings → Automation for `crow automation` (CROW-812). Same shape and

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -131,6 +131,10 @@ enum RPCLanePolicy {
         "job-disable": .fixed(.config),
         "job-delete": .fixed(.config),
         "job-duplicate": .fixed(.config),
+        "version-update-set": .fixed(.config),
+        // Already single-flight: a second caller awaits the in-flight compare
+        // instead of spawning another `gh auth token` subprocess + GitHub call.
+        "version-update-check": .concurrent,
 
         // MARK: Job runs
         // Not `.config`: these await a full worktree + tmux spawn, and parking

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -32,6 +32,30 @@ html, body {
   overflow: hidden;
 }
 
+.update-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px;
+  background: rgba(221, 196, 130, 0.12);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--gold);
+  font-size: 13px;
+}
+.update-banner-text { flex: 1 1 auto; }
+.update-banner-dismiss {
+  flex: 0 0 auto;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.update-banner-dismiss:hover { color: var(--text-primary); }
+
 #app {
   display: grid;
   grid-template-columns: 350px 1fr;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -33,6 +33,7 @@ html, body {
 }
 
 body {
+  height: 100dvh; /* exclude mobile browser chrome so the last row is reachable */
   display: flex;
   flex-direction: column;
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -32,6 +32,11 @@ html, body {
   overflow: hidden;
 }
 
+body {
+  display: flex;
+  flex-direction: column;
+}
+
 .update-banner {
   display: flex;
   align-items: center;
@@ -59,8 +64,8 @@ html, body {
 #app {
   display: grid;
   grid-template-columns: 350px 1fr;
-  height: 100vh;
-  height: 100dvh; /* exclude mobile browser chrome so the last row is reachable */
+  flex: 1;
+  min-height: 0;
 }
 
 /* ---- Sidebar ---- */
@@ -496,6 +501,9 @@ html, body {
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.45);
 }
 #back-to-sidebar:active { transform: translateY(1px); }
+body.update-banner-visible #back-to-sidebar {
+  top: calc(12px + env(safe-area-inset-top) + var(--update-banner-height, 0px));
+}
 
 /* ---- Mobile: one pane at a time ----
    Sidebar shows until a session is selected, then the detail pane takes over

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -219,6 +219,7 @@ function onServerChanged() {
 }
 
 const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
+let versionBannerDismissedWithoutSha = false;
 
 function renderVersionUpdateBanner(status) {
   const banner = document.getElementById('update-banner');
@@ -232,7 +233,12 @@ function renderVersionUpdateBanner(status) {
     return;
   }
   const remoteSha = status.remote_sha || '';
+  if (remoteSha) versionBannerDismissedWithoutSha = false;
   if (remoteSha && localStorage.getItem(VERSION_BANNER_DISMISS_KEY) === remoteSha) {
+    banner.hidden = true;
+    return;
+  }
+  if (!remoteSha && versionBannerDismissedWithoutSha) {
     banner.hidden = true;
     return;
   }
@@ -242,7 +248,11 @@ function renderVersionUpdateBanner(status) {
     + (status.update_command ? (' Update: ' + status.update_command) : '');
   banner.hidden = false;
   dismiss.onclick = () => {
-    if (remoteSha) localStorage.setItem(VERSION_BANNER_DISMISS_KEY, remoteSha);
+    if (remoteSha) {
+      localStorage.setItem(VERSION_BANNER_DISMISS_KEY, remoteSha);
+    } else {
+      versionBannerDismissedWithoutSha = true;
+    }
     banner.hidden = true;
   };
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -221,6 +221,17 @@ function onServerChanged() {
 const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
 let versionBannerDismissedWithoutSha = false;
 
+function syncUpdateBannerLayout(banner) {
+  if (!banner || banner.hidden) {
+    document.body.classList.remove('update-banner-visible');
+    document.documentElement.style.removeProperty('--update-banner-height');
+    return;
+  }
+  document.body.classList.add('update-banner-visible');
+  document.documentElement.style.setProperty(
+    '--update-banner-height', banner.offsetHeight + 'px');
+}
+
 function renderVersionUpdateBanner(status) {
   const banner = document.getElementById('update-banner');
   if (!banner) return;
@@ -230,16 +241,19 @@ function renderVersionUpdateBanner(status) {
 
   if (!status || status.state !== 'behind') {
     banner.hidden = true;
+    syncUpdateBannerLayout(banner);
     return;
   }
   const remoteSha = status.remote_sha || '';
   if (remoteSha) versionBannerDismissedWithoutSha = false;
   if (remoteSha && localStorage.getItem(VERSION_BANNER_DISMISS_KEY) === remoteSha) {
     banner.hidden = true;
+    syncUpdateBannerLayout(banner);
     return;
   }
   if (!remoteSha && versionBannerDismissedWithoutSha) {
     banner.hidden = true;
+    syncUpdateBannerLayout(banner);
     return;
   }
   const n = status.behind_by || 0;
@@ -247,6 +261,7 @@ function renderVersionUpdateBanner(status) {
     + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
     + (status.update_command ? (' Update: ' + status.update_command) : '');
   banner.hidden = false;
+  syncUpdateBannerLayout(banner);
   dismiss.onclick = () => {
     if (remoteSha) {
       localStorage.setItem(VERSION_BANNER_DISMISS_KEY, remoteSha);
@@ -254,6 +269,7 @@ function renderVersionUpdateBanner(status) {
       versionBannerDismissedWithoutSha = true;
     }
     banner.hidden = true;
+    syncUpdateBannerLayout(banner);
   };
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -214,8 +214,53 @@ function onServerChanged() {
     refreshBoard('tickets');
     refreshBoard('reviews');
     if (selectedId) refreshArtifacts(selectedId);
+    refreshVersionUpdateBanner();
   }, 50);
 }
+
+const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
+
+function renderVersionUpdateBanner(status) {
+  const banner = document.getElementById('update-banner');
+  if (!banner) return;
+  const text = banner.querySelector('.update-banner-text');
+  const dismiss = banner.querySelector('.update-banner-dismiss');
+  if (!text || !dismiss) return;
+
+  if (!status || status.state !== 'behind') {
+    banner.hidden = true;
+    return;
+  }
+  const remoteSha = status.remote_sha || '';
+  if (remoteSha && localStorage.getItem(VERSION_BANNER_DISMISS_KEY) === remoteSha) {
+    banner.hidden = true;
+    return;
+  }
+  const n = status.behind_by || 0;
+  text.textContent = 'A newer Crow build is available — '
+    + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
+    + (status.update_command ? (' Update: ' + status.update_command) : '');
+  banner.hidden = false;
+  dismiss.onclick = () => {
+    if (remoteSha) localStorage.setItem(VERSION_BANNER_DISMISS_KEY, remoteSha);
+    banner.hidden = true;
+  };
+}
+
+async function refreshVersionUpdateBanner(cachedStatus) {
+  try {
+    if (cachedStatus) {
+      renderVersionUpdateBanner(cachedStatus);
+      return;
+    }
+    const res = await rpc('version-update-get');
+    renderVersionUpdateBanner(res && res.status);
+  } catch (_) {
+    const banner = document.getElementById('update-banner');
+    if (banner) banner.hidden = true;
+  }
+}
+window.refreshVersionUpdateBanner = refreshVersionUpdateBanner;
 
 // Sidebar-affecting slice of AppConfig (CROW-581). `set-config` doesn't push a
 // `changed`, so we load this on boot and re-load it when the Settings modal
@@ -5592,6 +5637,7 @@ if (document.readyState === 'loading') {
 refreshSessions();
 refreshLive();
 loadUIConfig();
+refreshVersionUpdateBanner();
 // Fallback polls — the `changed` push (onServerChanged) drives the common case,
 // so these are relaxed. refreshLive stays brisk: runtime PR/RC state isn't
 // store-backed and so isn't covered by a nudge (CROW-581, M-D).

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -10,6 +10,10 @@
   <link rel="stylesheet" href="/settings.css">
 </head>
 <body>
+  <div id="update-banner" class="update-banner" hidden role="status">
+    <span class="update-banner-text"></span>
+    <button type="button" class="update-banner-dismiss" aria-label="Dismiss update notice">×</button>
+  </div>
   <div id="app">
     <button id="back-to-sidebar" aria-label="Show sessions" title="Sessions">&#9776;</button>
     <aside id="sidebar"></aside>

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
@@ -256,3 +256,7 @@
 .st-about-logo { width: 46px; height: 46px; flex: 0 0 auto; }
 .st-about-name { font-size: 18px; font-weight: 700; color: var(--gold); line-height: 1.1; }
 .st-about-ver { font-size: 12px; color: var(--text-muted); margin-top: 3px; }
+.st-about-update { font-size: 12px; margin-top: 6px; }
+.st-about-update.st-update-ok { color: var(--text-muted); }
+.st-about-update.st-update-behind { color: var(--gold); }
+.st-about-update.st-update-unknown { color: var(--text-muted); font-style: italic; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -886,6 +886,7 @@
     function renderUpdateStatus(status) {
       updateStatus.textContent = '';
       updateStatus.className = 'st-about-update';
+      updateStatus.title = '';
       if (!status || !status.state) return;
       if (status.state === 'up_to_date') {
         updateStatus.textContent = 'Up to date with origin/main.';

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -873,11 +873,44 @@
     const htext = el('div');
     htext.appendChild(el('div', 'st-about-name', 'Crow'));
     const ver = el('div', 'st-about-ver', 'Loading version…');
+    const updateStatus = el('div', 'st-about-update', '');
     htext.appendChild(ver);
+    htext.appendChild(updateStatus);
     head.append(logo, htext);
     body.appendChild(head);
     body.appendChild(el('div', 'st-help',
       'AI-powered development session manager. crowd is the sole authority; every UI is a client.'));
+
+    cfg.versionUpdate = cfg.versionUpdate || { enabled: true, intervalHours: 6 };
+
+    function renderUpdateStatus(status) {
+      updateStatus.textContent = '';
+      updateStatus.className = 'st-about-update';
+      if (!status || !status.state) return;
+      if (status.state === 'up_to_date') {
+        updateStatus.textContent = 'Up to date with origin/main.';
+        updateStatus.classList.add('st-update-ok');
+      } else if (status.state === 'behind') {
+        const n = status.behind_by || 0;
+        updateStatus.textContent = n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.';
+        updateStatus.classList.add('st-update-behind');
+        if (status.update_command) {
+          updateStatus.title = 'Update: ' + status.update_command;
+        }
+      } else {
+        updateStatus.textContent = status.reason || 'Could not check for updates.';
+        updateStatus.classList.add('st-update-unknown');
+      }
+    }
+
+    function loadUpdateStatus() {
+      rpc('version-update-get').then((res) => {
+        if (res && res.status) renderUpdateStatus(res.status);
+      }).catch(() => {
+        updateStatus.textContent = 'Update check unavailable.';
+        updateStatus.classList.add('st-update-unknown');
+      });
+    }
 
     fetch('/version.json').then((r) => (r.ok ? r.json() : null)).then((v) => {
       if (!v) { ver.textContent = 'Version unavailable'; return; }
@@ -886,6 +919,36 @@
       if (v.buildDate) parts.push(v.buildDate);
       ver.textContent = parts.join(' · ');
     }).catch(() => { ver.textContent = 'Version unavailable'; });
+
+    loadUpdateStatus();
+
+    body.appendChild(group('Updates'));
+    body.appendChild(toggleField('Check for upstream updates', cfg.versionUpdate, 'enabled',
+      'Compare this build against corveil/crow main on a schedule (at least every 6 hours).'));
+    body.appendChild(selectField('Check interval', cfg.versionUpdate, 'intervalHours', [
+      [6, '6 hours'], [12, '12 hours'], [24, '1 day'], [168, '1 week'],
+    ], { number: true, help: 'Minimum 6 hours to stay within GitHub unauthenticated rate limits.' }));
+
+    const checkRow = el('div', 'st-field');
+    const checkBtn = el('button', 'action-btn', 'Check now');
+    checkBtn.type = 'button';
+    checkBtn.onclick = async () => {
+      checkBtn.disabled = true;
+      updateStatus.textContent = 'Checking…';
+      try {
+        const res = await rpc('version-update-check', { force: true });
+        renderUpdateStatus(res && res.status);
+        if (window.refreshVersionUpdateBanner) window.refreshVersionUpdateBanner(res && res.status);
+      } catch (e) {
+        updateStatus.textContent = 'Check failed: ' + (e.message || e);
+        updateStatus.className = 'st-about-update st-update-unknown';
+      } finally {
+        checkBtn.disabled = false;
+      }
+    };
+    checkRow.appendChild(el('div', 'st-label', 'Upstream status'));
+    checkRow.appendChild(checkBtn);
+    body.appendChild(checkRow);
 
     // Maintenance actions — the desktop app's old Restart/Reload menu items,
     // now reachable from any browser (CROW-593).

--- a/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
@@ -1,0 +1,108 @@
+import CrowCore
+import CrowEngine
+import CrowPersistence
+import Foundation
+
+/// Loads `version.json` from the daemon bundle or a live `--web-dir`.
+enum BuildInfoLoader {
+    static func load(webDir: String?) -> BuildInfo? {
+        if let webDir {
+            let url = URL(fileURLWithPath: webDir).appendingPathComponent("version.json")
+            if let data = try? Data(contentsOf: url), let info = decode(data) { return info }
+        }
+        #if SWIFT_PACKAGE
+        if let url = Bundle.module.url(forResource: "version", withExtension: "json", subdirectory: "web"),
+           let data = try? Data(contentsOf: url), let info = decode(data) {
+            return info
+        }
+        #endif
+        return nil
+    }
+
+    private static func decode(_ data: Data) -> BuildInfo? {
+        try? JSONDecoder().decode(BuildInfo.self, from: data)
+    }
+}
+
+/// Periodic upstream version check owned by `crowd` (CROW-938).
+@MainActor
+final class VersionUpdateService {
+    private let shell: ShellRunner
+    private let updateCommand: String
+    private var buildInfo: BuildInfo
+    private var lastCheckAt: Date?
+    private var inFlight = false
+
+    var cachedStatus: VersionUpdateStatus?
+
+    init(buildInfo: BuildInfo, devRoot: String, shell: ShellRunner = ProcessShellRunner()) {
+        self.buildInfo = buildInfo
+        self.shell = shell
+        self.updateCommand = "git -C <clone> pull && make install"
+        _ = devRoot // reserved for a future smarter clone hint
+    }
+
+    func replaceBuildInfo(_ info: BuildInfo) {
+        buildInfo = info
+    }
+
+    /// Run a check when enabled and the interval has elapsed, or when `force`.
+    func checkIfDue(enabled: Bool, intervalHours: Int, force: Bool = false) async -> VersionUpdateStatus? {
+        guard enabled else {
+            cachedStatus = nil
+            return nil
+        }
+        if !force, let lastCheckAt {
+            let interval = TimeInterval(max(VersionUpdateConfig.minimumIntervalHours, intervalHours) * 3600)
+            if Date().timeIntervalSince(lastCheckAt) < interval {
+                return cachedStatus
+            }
+        }
+        return await runCheck()
+    }
+
+    func runCheck() async -> VersionUpdateStatus {
+        if inFlight, let cachedStatus { return cachedStatus }
+        inFlight = true
+        defer { inFlight = false }
+
+        let token = await Self.githubAuthToken(shell: shell)
+        let status = await VersionUpdateClient.check(
+            build: buildInfo,
+            updateCommand: updateCommand,
+            authToken: token
+        )
+        cachedStatus = status
+        lastCheckAt = Date()
+        return status
+    }
+
+    private static func githubAuthToken(shell: ShellRunner) async -> String? {
+        guard let output = try? await shell.run("gh", "auth", "token") else { return nil }
+        let token = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return token.isEmpty ? nil : token
+    }
+}
+
+/// Drive `VersionUpdateService.checkIfDue` on an explicit async loop.
+func startVersionUpdatePoll(
+    service: VersionUpdateService,
+    devRoot: String,
+    eventHub: EventHub,
+    initialDelaySeconds: UInt64 = 5
+) {
+    Task {
+        try? await Task.sleep(nanoseconds: initialDelaySeconds * 1_000_000_000)
+        while !Task.isCancelled {
+            let config = ConfigStore.loadConfig(devRoot: devRoot)?.versionUpdate ?? VersionUpdateConfig()
+            let before = await service.cachedStatus
+            let after = await service.checkIfDue(
+                enabled: config.enabled, intervalHours: config.intervalHours)
+            if after != before {
+                await eventHub.broadcast()
+            }
+            let hours = max(VersionUpdateConfig.minimumIntervalHours, config.intervalHours)
+            try? await Task.sleep(nanoseconds: UInt64(hours) * 3_600 * 1_000_000_000)
+        }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
@@ -33,7 +33,7 @@ enum BuildInfoLoader {
 final class VersionUpdateService {
     /// Minimum spacing between user-initiated forced checks ("Check now", CLI
     /// `--check`) so a remote `/rpc` peer can't burn the GitHub budget.
-    static let minimumForcedSpacing: TimeInterval = 60
+    static let minimumForcedSpacing: TimeInterval = 120
 
     private let shell: ShellRunner
     private let updateCommand: String

--- a/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
@@ -25,21 +25,29 @@ enum BuildInfoLoader {
 }
 
 /// Periodic upstream version check owned by `crowd` (CROW-938).
+///
+/// Single-flight like `ScorecardRebuilder`: overlapping callers await the
+/// in-flight GitHub compare instead of spawning duplicate `gh auth token`
+/// subprocesses.
 @MainActor
 final class VersionUpdateService {
+    /// Minimum spacing between user-initiated forced checks ("Check now", CLI
+    /// `--check`) so a remote `/rpc` peer can't burn the GitHub budget.
+    static let minimumForcedSpacing: TimeInterval = 60
+
     private let shell: ShellRunner
     private let updateCommand: String
     private var buildInfo: BuildInfo
     private var lastCheckAt: Date?
-    private var inFlight = false
+    private var lastForcedCheckAt: Date?
+    private var inFlight: Task<VersionUpdateStatus, Never>?
 
     var cachedStatus: VersionUpdateStatus?
 
-    init(buildInfo: BuildInfo, devRoot: String, shell: ShellRunner = ProcessShellRunner()) {
+    init(buildInfo: BuildInfo, shell: ShellRunner = ProcessShellRunner()) {
         self.buildInfo = buildInfo
         self.shell = shell
         self.updateCommand = "git -C <clone> pull && make install"
-        _ = devRoot // reserved for a future smarter clone hint
     }
 
     func replaceBuildInfo(_ info: BuildInfo) {
@@ -48,33 +56,44 @@ final class VersionUpdateService {
 
     /// Run a check when enabled and the interval has elapsed, or when `force`.
     func checkIfDue(enabled: Bool, intervalHours: Int, force: Bool = false) async -> VersionUpdateStatus? {
-        guard enabled else {
-            cachedStatus = nil
-            return nil
-        }
+        guard enabled else { return cachedStatus }
         if !force, let lastCheckAt {
             let interval = TimeInterval(max(VersionUpdateConfig.minimumIntervalHours, intervalHours) * 3600)
             if Date().timeIntervalSince(lastCheckAt) < interval {
                 return cachedStatus
             }
         }
-        return await runCheck()
+        return await runCheck(force: force)
     }
 
-    func runCheck() async -> VersionUpdateStatus {
-        if inFlight, let cachedStatus { return cachedStatus }
-        inFlight = true
-        defer { inFlight = false }
+    /// Force or schedule a compare. Overlapping callers coalesce onto one
+    /// in-flight task; forced checks are throttled to `minimumForcedSpacing`.
+    func runCheck(force: Bool = true) async -> VersionUpdateStatus {
+        if let inFlight {
+            return await inFlight.value
+        }
+        if force,
+           let lastForcedCheckAt,
+           Date().timeIntervalSince(lastForcedCheckAt) < Self.minimumForcedSpacing,
+           let cachedStatus {
+            return cachedStatus
+        }
 
-        let token = await Self.githubAuthToken(shell: shell)
-        let status = await VersionUpdateClient.check(
-            build: buildInfo,
-            updateCommand: updateCommand,
-            authToken: token
-        )
-        cachedStatus = status
-        lastCheckAt = Date()
-        return status
+        let task = Task { @MainActor [self] in
+            defer { self.inFlight = nil }
+            let token = await Self.githubAuthToken(shell: shell)
+            let status = await VersionUpdateClient.check(
+                build: buildInfo,
+                updateCommand: updateCommand,
+                authToken: token
+            )
+            cachedStatus = status
+            lastCheckAt = Date()
+            if force { lastForcedCheckAt = Date() }
+            return status
+        }
+        inFlight = task
+        return await task.value
     }
 
     private static func githubAuthToken(shell: ShellRunner) async -> String? {
@@ -91,18 +110,34 @@ func startVersionUpdatePoll(
     eventHub: EventHub,
     initialDelaySeconds: UInt64 = 5
 ) {
-    Task {
+    Task { @MainActor in
         try? await Task.sleep(nanoseconds: initialDelaySeconds * 1_000_000_000)
         while !Task.isCancelled {
-            let config = ConfigStore.loadConfig(devRoot: devRoot)?.versionUpdate ?? VersionUpdateConfig()
-            let before = await service.cachedStatus
+            let config = ConfigStore.loadConfig(devRoot: devRoot)?.versionUpdate
+                ?? VersionUpdateConfig()
+            let before = service.cachedStatus
             let after = await service.checkIfDue(
                 enabled: config.enabled, intervalHours: config.intervalHours)
             if after != before {
                 await eventHub.broadcast()
             }
             let hours = max(VersionUpdateConfig.minimumIntervalHours, config.intervalHours)
-            try? await Task.sleep(nanoseconds: UInt64(hours) * 3_600 * 1_000_000_000)
+            // Wake hourly so a lowered interval takes effect without waiting out
+            // a long prior sleep.
+            var remaining = hours * 3600
+            while remaining > 0, !Task.isCancelled {
+                let chunk = min(remaining, 3600)
+                try? await Task.sleep(nanoseconds: UInt64(chunk) * 1_000_000_000)
+                remaining -= chunk
+                let refreshed = ConfigStore.loadConfig(devRoot: devRoot)?.versionUpdate
+                    ?? VersionUpdateConfig()
+                let refreshedHours = max(
+                    VersionUpdateConfig.minimumIntervalHours, refreshed.intervalHours)
+                let refreshedRemaining = refreshedHours * 3600
+                if refreshedRemaining < remaining {
+                    remaining = refreshedRemaining
+                }
+            }
         }
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/VersionUpdateService.swift
@@ -2,6 +2,9 @@ import CrowCore
 import CrowEngine
 import CrowPersistence
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Loads `version.json` from the daemon bundle or a live `--web-dir`.
 enum BuildInfoLoader {
@@ -37,6 +40,7 @@ final class VersionUpdateService {
 
     private let shell: ShellRunner
     private let updateCommand: String
+    private let transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))?
     private var buildInfo: BuildInfo
     private var lastCheckAt: Date?
     private var lastForcedCheckAt: Date?
@@ -44,9 +48,14 @@ final class VersionUpdateService {
 
     var cachedStatus: VersionUpdateStatus?
 
-    init(buildInfo: BuildInfo, shell: ShellRunner = ProcessShellRunner()) {
+    init(
+        buildInfo: BuildInfo,
+        shell: ShellRunner = ProcessShellRunner(),
+        transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil
+    ) {
         self.buildInfo = buildInfo
         self.shell = shell
+        self.transport = transport
         self.updateCommand = "git -C <clone> pull && make install"
     }
 
@@ -85,7 +94,8 @@ final class VersionUpdateService {
             let status = await VersionUpdateClient.check(
                 build: buildInfo,
                 updateCommand: updateCommand,
-                authToken: token
+                authToken: token,
+                transport: transport ?? { try await URLSession.shared.data(for: $0) }
             )
             cachedStatus = status
             lastCheckAt = Date()

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateHandlerTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+@testable import CrowDaemon
+
+@Suite struct VersionUpdateHandlerTests {
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crowd-version-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @MainActor
+    private func router(devRoot: String, service: VersionUpdateService) -> CommandRouter {
+        makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: devRoot, cockpit: nil, versionUpdateService: service)
+    }
+
+    @MainActor
+    private func call(
+        _ method: String, _ params: [String: JSONValue] = [:],
+        devRoot: String, service: VersionUpdateService
+    ) async -> JSONRPCResponse {
+        await router(devRoot: devRoot, service: service)
+            .handle(request: JSONRPCRequest(id: 1, method: method, params: params))
+    }
+
+    @Test @MainActor func getReturnsDefaultsWhenNoConfigExists() async {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let service = VersionUpdateService(
+            buildInfo: BuildInfo(version: "0.1.0", gitSha: "abc1234", buildDate: "2026-08-05"),
+            devRoot: devRoot)
+        let resp = await call("version-update-get", devRoot: devRoot, service: service)
+        #expect(resp.result?["version_update"] == .object([
+            "enabled": .bool(true), "interval_hours": .int(6),
+        ]))
+        #expect(resp.result?["status"] == .null)
+    }
+
+    @Test @MainActor func setPatchesOnlyProvidedFields() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        var seed = AppConfig()
+        seed.versionUpdate = VersionUpdateConfig(enabled: true, intervalHours: 12)
+        try ConfigStore.saveConfig(seed, devRoot: devRoot)
+        let service = VersionUpdateService(
+            buildInfo: BuildInfo(version: "0.1.0", gitSha: "abc1234", buildDate: "2026-08-05"),
+            devRoot: devRoot)
+
+        let resp = await call(
+            "version-update-set", ["enabled": .bool(false)], devRoot: devRoot, service: service)
+        #expect(resp.result?["version_update"] == .object([
+            "enabled": .bool(false), "interval_hours": .int(12),
+        ]))
+        let onDisk = try #require(ConfigStore.loadConfig(devRoot: devRoot))
+        #expect(onDisk.versionUpdate.enabled == false)
+        #expect(onDisk.versionUpdate.intervalHours == 12)
+    }
+
+    @Test @MainActor func checkReturnsCachedStatus() async {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let service = VersionUpdateService(
+            buildInfo: BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05"),
+            devRoot: devRoot)
+        let checked = await service.runCheck()
+        let resp = await call("version-update-check", devRoot: devRoot, service: service)
+        #expect(resp.result?["status"]?.objectValue?["state"]?.stringValue
+            == checked.state.rawValue)
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateHandlerTests.swift
@@ -7,6 +7,10 @@ import CrowPersistence
 @testable import CrowDaemon
 
 @Suite struct VersionUpdateHandlerTests {
+    private struct StubShell: ShellRunner {
+        func run(args: [String], env: [String: String], cwd: String?) async throws -> String { "" }
+    }
+
     private func tempDevRoot() -> String {
         let dir = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("crowd-version-\(UUID().uuidString)")
@@ -35,7 +39,7 @@ import CrowPersistence
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let service = VersionUpdateService(
             buildInfo: BuildInfo(version: "0.1.0", gitSha: "abc1234", buildDate: "2026-08-05"),
-            devRoot: devRoot)
+            shell: StubShell())
         let resp = await call("version-update-get", devRoot: devRoot, service: service)
         #expect(resp.result?["version_update"] == .object([
             "enabled": .bool(true), "interval_hours": .int(6),
@@ -51,7 +55,7 @@ import CrowPersistence
         try ConfigStore.saveConfig(seed, devRoot: devRoot)
         let service = VersionUpdateService(
             buildInfo: BuildInfo(version: "0.1.0", gitSha: "abc1234", buildDate: "2026-08-05"),
-            devRoot: devRoot)
+            shell: StubShell())
 
         let resp = await call(
             "version-update-set", ["enabled": .bool(false)], devRoot: devRoot, service: service)
@@ -68,10 +72,36 @@ import CrowPersistence
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         let service = VersionUpdateService(
             buildInfo: BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05"),
-            devRoot: devRoot)
-        let checked = await service.runCheck()
-        let resp = await call("version-update-check", devRoot: devRoot, service: service)
+            shell: StubShell())
+        let checked = await service.runCheck(force: true)
+        let resp = await call(
+            "version-update-check", ["force": .bool(true)], devRoot: devRoot, service: service)
         #expect(resp.result?["status"]?.objectValue?["state"]?.stringValue
             == checked.state.rawValue)
+    }
+
+    @Test @MainActor func disablingCheckKeepsLastKnownStatus() async {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let service = VersionUpdateService(
+            buildInfo: BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05"),
+            shell: StubShell())
+        _ = await service.runCheck(force: true)
+        let before = service.cachedStatus
+        let after = await service.checkIfDue(enabled: false, intervalHours: 6)
+        #expect(after == before)
+        #expect(service.cachedStatus == before)
+    }
+
+    @Test @MainActor func forcedChecksCoalesce() async {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let service = VersionUpdateService(
+            buildInfo: BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05"),
+            shell: StubShell())
+        async let first = service.runCheck(force: true)
+        async let second = service.runCheck(force: true)
+        let results = await [first, second]
+        #expect(results[0] == results[1])
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateHandlerTests.swift
@@ -5,6 +5,9 @@ import CrowGit
 import CrowIPC
 import CrowPersistence
 @testable import CrowDaemon
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 @Suite struct VersionUpdateHandlerTests {
     private struct StubShell: ShellRunner {
@@ -96,12 +99,42 @@ import CrowPersistence
     @Test @MainActor func forcedChecksCoalesce() async {
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let counter = CountingTransport(delayNanoseconds: 50_000_000)
         let service = VersionUpdateService(
-            buildInfo: BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05"),
-            shell: StubShell())
+            buildInfo: BuildInfo(
+                version: "0.1.0", gitSha: "abc1234",
+                gitShaFull: "abc1234567890abcdef1234567890abcdef1234",
+                buildDate: "2026-08-05"),
+            shell: StubShell(),
+            transport: counter.make())
         async let first = service.runCheck(force: true)
         async let second = service.runCheck(force: true)
         let results = await [first, second]
         #expect(results[0] == results[1])
+        #expect(counter.requestCount == 1)
+    }
+}
+
+private final class CountingTransport: @unchecked Sendable {
+    var requestCount = 0
+    let delayNanoseconds: UInt64
+
+    init(delayNanoseconds: UInt64 = 0) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func make() -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+        { [self] request in
+            self.requestCount += 1
+            if self.delayNanoseconds > 0 {
+                try await Task.sleep(nanoseconds: self.delayNanoseconds)
+            }
+            let compare: [String: Any] = [
+                "status": "identical", "ahead_by": 0, "behind_by": 0, "commits": [],
+            ]
+            let data = try JSONSerialization.data(withJSONObject: compare)
+            return (data, HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/VersionUpdateServiceTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowDaemon
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite struct VersionUpdateServiceTests {
+    private struct StubShell: ShellRunner {
+        func run(args: [String], env: [String: String], cwd: String?) async throws -> String { "" }
+    }
+
+    private final class CountingTransport: @unchecked Sendable {
+        var requestCount = 0
+        let delayNanoseconds: UInt64
+
+        init(delayNanoseconds: UInt64 = 0) {
+            self.delayNanoseconds = delayNanoseconds
+        }
+
+        func make() -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+            { [self] request in
+                self.requestCount += 1
+                if self.delayNanoseconds > 0 {
+                    try await Task.sleep(nanoseconds: self.delayNanoseconds)
+                }
+                let url = request.url?.absoluteString ?? ""
+                let compare: [String: Any] = [
+                    "status": "ahead", "ahead_by": 2, "behind_by": 0, "commits": [],
+                ]
+                let head: [String: Any] = [
+                    "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                    "commit": ["committer": ["date": "2026-08-05T12:00:00Z"]],
+                ]
+                let payload = url.contains("/commits/main") ? head : compare
+                let data = try JSONSerialization.data(withJSONObject: payload)
+                return (data, HTTPURLResponse(
+                    url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+        }
+    }
+
+    private let build = BuildInfo(
+        version: "0.1.0",
+        gitSha: "abc1234",
+        gitShaFull: "abc1234567890abcdef1234567890abcdef1234",
+        buildDate: "2026-08-05")
+
+    @Test @MainActor func forcedChecksCoalesceOntoOneTransportRound() async {
+        let counter = CountingTransport(delayNanoseconds: 50_000_000)
+        let service = VersionUpdateService(
+            buildInfo: build, shell: StubShell(), transport: counter.make())
+        async let first = service.runCheck(force: true)
+        async let second = service.runCheck(force: true)
+        _ = await [first, second]
+        // One compare + one branch-head fetch, not two of each.
+        #expect(counter.requestCount == 2)
+    }
+
+    @Test @MainActor func forcedChecksThrottleWithinMinimumSpacing() async {
+        let counter = CountingTransport()
+        let service = VersionUpdateService(
+            buildInfo: build, shell: StubShell(), transport: counter.make())
+        _ = await service.runCheck(force: true)
+        let afterFirst = counter.requestCount
+        #expect(afterFirst == 2)
+        _ = await service.runCheck(force: true)
+        #expect(counter.requestCount == afterFirst)
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
@@ -8,8 +8,9 @@ import FoundationNetworking
 /// GitHub compare call backing the version-update check (CROW-938).
 ///
 /// Compares the stamped build SHA against `corveil/crow` `main` via
-/// `GET /repos/corveil/crow/compare/{local}...main`. Injectable transport keeps
-/// the parser unit-testable without network I/O.
+/// `GET /repos/corveil/crow/compare/{local}...main`, then fetches the branch
+/// head separately so `remote_sha` stays correct when `behind_by` exceeds the
+/// compare payload's 250-commit cap.
 public enum VersionUpdateClient {
     public static let repository = "corveil/crow"
     public static let defaultBranch = "main"
@@ -51,22 +52,18 @@ public enum VersionUpdateClient {
         }
 
         let localSha = build.compareSha
-        guard let url = URL(string:
-            "https://api.github.com/repos/\(repository)/compare/\(localSha)...\(defaultBranch)"
-        ) else {
+        guard let encodedSha = localSha.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let compareURL = URL(string:
+                "https://api.github.com/repos/\(repository)/compare/\(encodedSha)...\(defaultBranch)"
+              ) else {
             return unknown(base, reason: "Invalid compare URL")
         }
 
-        var request = URLRequest(url: url)
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("Crow/\(build.version)", forHTTPHeaderField: "User-Agent")
-        if let authToken, !authToken.isEmpty {
-            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-        }
+        let compareRequest = authorizedRequest(url: compareURL, build: build, authToken: authToken)
 
         let data: Data
         do {
-            let (payload, response) = try await transport(request)
+            let (payload, response) = try await transport(compareRequest)
             guard let http = response as? HTTPURLResponse else {
                 return unknown(base, reason: "No HTTP response from GitHub")
             }
@@ -94,7 +91,8 @@ public enum VersionUpdateClient {
         let aheadBy = json["ahead_by"] as? Int ?? 0
         let status = json["status"] as? String ?? ""
 
-        let remoteCommit = remoteHeadCommit(in: json)
+        let remoteCommit = await fetchBranchHead(
+            build: build, authToken: authToken, transport: transport)
         let remoteSha = remoteCommit?.sha
         let remoteDate = remoteCommit?.date
 
@@ -140,6 +138,18 @@ public enum VersionUpdateClient {
         )
     }
 
+    private static func authorizedRequest(
+        url: URL, build: BuildInfo, authToken: String?
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("Crow/\(build.version)", forHTTPHeaderField: "User-Agent")
+        if let authToken, !authToken.isEmpty {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
     private static func unknown(_ base: VersionUpdateStatus, reason: String) -> VersionUpdateStatus {
         VersionUpdateStatus(
             state: .unknown,
@@ -160,15 +170,25 @@ public enum VersionUpdateClient {
         var date: String?
     }
 
-    /// Best-effort parse of the upstream head from a compare payload.
-    private static func remoteHeadCommit(in json: [String: Any]) -> RemoteCommit? {
-        if let commits = json["commits"] as? [[String: Any]], let last = commits.last {
-            if let parsed = parseCommitNode(last) { return parsed }
+    /// Fetch `main`'s tip — not inferred from the compare payload, which caps at
+    /// 250 commits and would give the wrong sha/date (and banner-dismiss key)
+    /// when further behind.
+    private static func fetchBranchHead(
+        build: BuildInfo,
+        authToken: String?,
+        transport: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    ) async -> RemoteCommit? {
+        guard let url = URL(string:
+            "https://api.github.com/repos/\(repository)/commits/\(defaultBranch)"
+        ) else { return nil }
+        let request = authorizedRequest(url: url, build: build, authToken: authToken)
+        guard let (data, response) = try? await transport(request),
+              let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
         }
-        if let head = json["base_commit"] as? [String: Any], let parsed = parseCommitNode(head) {
-            return parsed
-        }
-        return nil
+        return parseCommitNode(json)
     }
 
     private static func parseCommitNode(_ node: [String: Any]) -> RemoteCommit? {
@@ -201,7 +221,7 @@ public enum VersionUpdateRPC {
 
     public static func statusJSON(_ status: VersionUpdateStatus?) -> JSONValue {
         guard let status else { return .null }
-        var object: [String: JSONValue] = [
+        return .object([
             "state": .string(status.state.rawValue),
             "local_version": .string(status.localVersion),
             "local_sha": .string(status.localSha),
@@ -213,8 +233,7 @@ public enum VersionUpdateRPC {
             "update_command": status.updateCommand.map { .string($0) } ?? .null,
             "reason": status.reason.map { .string($0) } ?? .null,
             "checked_at_ms": status.checkedAtMs.map { .int(Int($0)) } ?? .null,
-        ]
-        return .object(object)
+        ])
     }
 
     public static func patchIntervalHours(

--- a/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
@@ -1,0 +1,233 @@
+import CrowCore
+import CrowIPC
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// GitHub compare call backing the version-update check (CROW-938).
+///
+/// Compares the stamped build SHA against `corveil/crow` `main` via
+/// `GET /repos/corveil/crow/compare/{local}...main`. Injectable transport keeps
+/// the parser unit-testable without network I/O.
+public enum VersionUpdateClient {
+    public static let repository = "corveil/crow"
+    public static let defaultBranch = "main"
+
+    public enum CheckError: Error, Equatable {
+        case indeterminateLocalSha
+        case http(Int)
+        case transport(String)
+        case decode
+        case rateLimited
+    }
+
+    /// Compare `build` against upstream `main`. Never throws for expected
+    /// indeterminate cases — those return `.unknown` with a reason.
+    public static func check(
+        build: BuildInfo,
+        updateCommand: String = "git -C <clone> pull && make install",
+        authToken: String? = nil,
+        transport: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = {
+            try await URLSession.shared.data(for: $0)
+        }
+    ) async -> VersionUpdateStatus {
+        let base = VersionUpdateStatus(
+            state: .unknown,
+            localVersion: build.version,
+            localSha: build.gitSha,
+            buildDate: build.buildDate,
+            checkedAtMs: currentTimeMs()
+        )
+        guard !build.isIndeterminate else {
+            return VersionUpdateStatus(
+                state: .unknown,
+                localVersion: build.version,
+                localSha: build.gitSha,
+                buildDate: build.buildDate,
+                reason: "Local build SHA is not a known git commit",
+                checkedAtMs: base.checkedAtMs
+            )
+        }
+
+        let localSha = build.compareSha
+        guard let url = URL(string:
+            "https://api.github.com/repos/\(repository)/compare/\(localSha)...\(defaultBranch)"
+        ) else {
+            return unknown(base, reason: "Invalid compare URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("Crow/\(build.version)", forHTTPHeaderField: "User-Agent")
+        if let authToken, !authToken.isEmpty {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        let data: Data
+        do {
+            let (payload, response) = try await transport(request)
+            guard let http = response as? HTTPURLResponse else {
+                return unknown(base, reason: "No HTTP response from GitHub")
+            }
+            if http.statusCode == 403,
+               let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining"),
+               remaining == "0" {
+                return unknown(base, reason: "GitHub rate limit exceeded")
+            }
+            guard (200...299).contains(http.statusCode) else {
+                if http.statusCode == 404 {
+                    return unknown(base, reason: "Local SHA is not on GitHub")
+                }
+                return unknown(base, reason: "GitHub compare failed (HTTP \(http.statusCode))")
+            }
+            data = payload
+        } catch {
+            return unknown(base, reason: "Could not reach GitHub")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return unknown(base, reason: "Unexpected GitHub response")
+        }
+
+        let behindBy = json["behind_by"] as? Int ?? 0
+        let aheadBy = json["ahead_by"] as? Int ?? 0
+        let status = json["status"] as? String ?? ""
+
+        let remoteCommit = remoteHeadCommit(in: json)
+        let remoteSha = remoteCommit?.sha
+        let remoteDate = remoteCommit?.date
+
+        if aheadBy > 0 && behindBy == 0 {
+            return VersionUpdateStatus(
+                state: .unknown,
+                localVersion: build.version,
+                localSha: build.gitSha,
+                buildDate: build.buildDate,
+                remoteSha: remoteSha,
+                remoteDate: remoteDate,
+                aheadBy: aheadBy,
+                reason: "Local build is not on upstream main",
+                checkedAtMs: base.checkedAtMs
+            )
+        }
+
+        if behindBy > 0 || status == "behind" {
+            return VersionUpdateStatus(
+                state: .behind,
+                localVersion: build.version,
+                localSha: build.gitSha,
+                buildDate: build.buildDate,
+                remoteSha: remoteSha,
+                remoteDate: remoteDate,
+                behindBy: behindBy,
+                aheadBy: aheadBy,
+                updateCommand: updateCommand,
+                checkedAtMs: base.checkedAtMs
+            )
+        }
+
+        return VersionUpdateStatus(
+            state: .upToDate,
+            localVersion: build.version,
+            localSha: build.gitSha,
+            buildDate: build.buildDate,
+            remoteSha: remoteSha,
+            remoteDate: remoteDate,
+            behindBy: 0,
+            aheadBy: aheadBy,
+            checkedAtMs: base.checkedAtMs
+        )
+    }
+
+    private static func unknown(_ base: VersionUpdateStatus, reason: String) -> VersionUpdateStatus {
+        VersionUpdateStatus(
+            state: .unknown,
+            localVersion: base.localVersion,
+            localSha: base.localSha,
+            buildDate: base.buildDate,
+            reason: reason,
+            checkedAtMs: base.checkedAtMs
+        )
+    }
+
+    private static func currentTimeMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private struct RemoteCommit {
+        var sha: String
+        var date: String?
+    }
+
+    /// Best-effort parse of the upstream head from a compare payload.
+    private static func remoteHeadCommit(in json: [String: Any]) -> RemoteCommit? {
+        if let commits = json["commits"] as? [[String: Any]], let last = commits.last {
+            if let parsed = parseCommitNode(last) { return parsed }
+        }
+        if let head = json["base_commit"] as? [String: Any], let parsed = parseCommitNode(head) {
+            return parsed
+        }
+        return nil
+    }
+
+    private static func parseCommitNode(_ node: [String: Any]) -> RemoteCommit? {
+        guard let sha = node["sha"] as? String, !sha.isEmpty else { return nil }
+        let commit = node["commit"] as? [String: Any]
+        let committer = commit?["committer"] as? [String: Any]
+        let author = commit?["author"] as? [String: Any]
+        let rawDate = (committer?["date"] as? String) ?? (author?["date"] as? String)
+        let date = rawDate.map(shortDate)
+        return RemoteCommit(sha: String(sha.prefix(7)), date: date)
+    }
+
+    /// `2026-08-05T12:34:56Z` → `2026-08-05`.
+    static func shortDate(_ iso: String) -> String {
+        if let tIndex = iso.firstIndex(of: "T") {
+            return String(iso[..<tIndex])
+        }
+        return iso
+    }
+}
+
+/// Wire encoding for `version-update-*` RPCs (CROW-938).
+public enum VersionUpdateRPC {
+    public static func configJSON(_ config: VersionUpdateConfig) -> JSONValue {
+        .object([
+            "enabled": .bool(config.enabled),
+            "interval_hours": .int(config.intervalHours),
+        ])
+    }
+
+    public static func statusJSON(_ status: VersionUpdateStatus?) -> JSONValue {
+        guard let status else { return .null }
+        var object: [String: JSONValue] = [
+            "state": .string(status.state.rawValue),
+            "local_version": .string(status.localVersion),
+            "local_sha": .string(status.localSha),
+            "build_date": .string(status.buildDate),
+            "remote_sha": status.remoteSha.map { .string($0) } ?? .null,
+            "remote_date": status.remoteDate.map { .string($0) } ?? .null,
+            "behind_by": status.behindBy.map { .int($0) } ?? .null,
+            "ahead_by": status.aheadBy.map { .int($0) } ?? .null,
+            "update_command": status.updateCommand.map { .string($0) } ?? .null,
+            "reason": status.reason.map { .string($0) } ?? .null,
+            "checked_at_ms": status.checkedAtMs.map { .int(Int($0)) } ?? .null,
+        ]
+        return .object(object)
+    }
+
+    public static func patchIntervalHours(
+        _ params: [String: JSONValue], _ key: String = "interval_hours"
+    ) throws -> Int? {
+        guard let value = params[key], value != .null else { return nil }
+        guard let hours = value.intValue else {
+            throw RPCError.invalidParams("\(key) must be an integer")
+        }
+        guard hours >= VersionUpdateConfig.minimumIntervalHours else {
+            throw RPCError.invalidParams(
+                "\(key) must be at least \(VersionUpdateConfig.minimumIntervalHours) hours")
+        }
+        return hours
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
@@ -97,7 +97,7 @@ public enum VersionUpdateClient {
         let remoteCommit: RemoteCommit?
         if status == "identical" {
             // `main`'s head is the local SHA — skip the second API call.
-            remoteCommit = RemoteCommit(sha: build.gitSha, date: build.buildDate)
+            remoteCommit = RemoteCommit(sha: build.gitSha, date: nil)
         } else {
             remoteCommit = await fetchBranchHead(
                 build: build, authToken: authToken, transport: transport)

--- a/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
@@ -91,12 +91,21 @@ public enum VersionUpdateClient {
         let aheadBy = json["ahead_by"] as? Int ?? 0
         let status = json["status"] as? String ?? ""
 
-        let remoteCommit = await fetchBranchHead(
-            build: build, authToken: authToken, transport: transport)
+        // For `compare/{local}...{main}`, GitHub's `ahead_by` is how many commits
+        // on `main` the local build lacks (i.e. how far behind we are); `behind_by`
+        // is commits the local build has that `main` lacks (feature branch / fork).
+        let remoteCommit: RemoteCommit?
+        if status == "identical" {
+            // `main`'s head is the local SHA — skip the second API call.
+            remoteCommit = RemoteCommit(sha: build.gitSha, date: build.buildDate)
+        } else {
+            remoteCommit = await fetchBranchHead(
+                build: build, authToken: authToken, transport: transport)
+        }
         let remoteSha = remoteCommit?.sha
         let remoteDate = remoteCommit?.date
 
-        if aheadBy > 0 && behindBy == 0 {
+        if behindBy > 0 || status == "behind" || status == "diverged" {
             return VersionUpdateStatus(
                 state: .unknown,
                 localVersion: build.version,
@@ -104,13 +113,14 @@ public enum VersionUpdateClient {
                 buildDate: build.buildDate,
                 remoteSha: remoteSha,
                 remoteDate: remoteDate,
+                behindBy: behindBy,
                 aheadBy: aheadBy,
                 reason: "Local build is not on upstream main",
                 checkedAtMs: base.checkedAtMs
             )
         }
 
-        if behindBy > 0 || status == "behind" {
+        if aheadBy > 0 || status == "ahead" {
             return VersionUpdateStatus(
                 state: .behind,
                 localVersion: build.version,
@@ -118,8 +128,8 @@ public enum VersionUpdateClient {
                 buildDate: build.buildDate,
                 remoteSha: remoteSha,
                 remoteDate: remoteDate,
-                behindBy: behindBy,
-                aheadBy: aheadBy,
+                behindBy: aheadBy,
+                aheadBy: behindBy,
                 updateCommand: updateCommand,
                 checkedAtMs: base.checkedAtMs
             )
@@ -133,7 +143,7 @@ public enum VersionUpdateClient {
             remoteSha: remoteSha,
             remoteDate: remoteDate,
             behindBy: 0,
-            aheadBy: aheadBy,
+            aheadBy: 0,
             checkedAtMs: base.checkedAtMs
         )
     }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
@@ -4,23 +4,42 @@ import CrowCore
 @testable import CrowEngine
 
 @Suite struct VersionUpdateClientTests {
-    private func fixture(
+    private func compareFixture(
         status: String = "behind",
         behindBy: Int = 2,
-        aheadBy: Int = 0,
-        commits: [[String: Any]] = []
+        aheadBy: Int = 0
     ) -> Data {
         let payload: [String: Any] = [
             "status": status,
             "behind_by": behindBy,
             "ahead_by": aheadBy,
-            "commits": commits,
+            "commits": [],
+        ]
+        return try! JSONSerialization.data(withJSONObject: payload)
+    }
+
+    private func headFixture(sha: String, date: String) -> Data {
+        let payload: [String: Any] = [
+            "sha": sha,
+            "commit": ["committer": ["date": date]],
         ]
         return try! JSONSerialization.data(withJSONObject: payload)
     }
 
     private let build = BuildInfo(
         version: "0.1.0", gitSha: "abc1234", gitShaFull: "abc1234567890", buildDate: "2026-08-05")
+
+    private func transport(
+        compare: Data,
+        head: Data = Data()
+    ) -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+        { request in
+            let url = request.url?.absoluteString ?? ""
+            let body = url.contains("/commits/main") ? head : compare
+            return (body, HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+    }
 
     @Test func devShaIsIndeterminate() async {
         let devBuild = BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05")
@@ -30,17 +49,12 @@ import CrowCore
     }
 
     @Test func behindByReportsUpdateCommand() async {
-        let commit: [String: Any] = [
-            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-            "commit": ["committer": ["date": "2026-08-05T12:00:00Z"]],
-        ]
-        let data = fixture(commits: [commit])
+        let head = headFixture(
+            sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", date: "2026-08-05T12:00:00Z")
         let result = await VersionUpdateClient.check(
             build: build,
             updateCommand: "git -C /tmp/crow pull && make install",
-            transport: { _ in (data, HTTPURLResponse(
-                url: URL(string: "https://api.github.com")!,
-                statusCode: 200, httpVersion: nil, headerFields: nil)!) }
+            transport: transport(compare: compareFixture(), head: head)
         )
         #expect(result.state == .behind)
         #expect(result.behindBy == 2)
@@ -49,25 +63,42 @@ import CrowCore
         #expect(result.updateCommand == "git -C /tmp/crow pull && make install")
     }
 
-    @Test func identicalIsUpToDate() async {
-        let data = fixture(status: "identical", behindBy: 0, aheadBy: 0)
+    @Test func branchHeadComesFromCommitsEndpointNotComparePayload() async {
+        let staleCommit: [String: Any] = [
+            "sha": "0000000000000000000000000000000000000001",
+            "commit": ["committer": ["date": "2020-01-01T00:00:00Z"]],
+        ]
+        let compare = try! JSONSerialization.data(withJSONObject: [
+            "status": "behind",
+            "behind_by": 300,
+            "ahead_by": 0,
+            "commits": [staleCommit],
+        ])
+        let head = headFixture(
+            sha: "cafebabecafebabecafebabecafebabecafebabe", date: "2026-08-05T15:00:00Z")
         let result = await VersionUpdateClient.check(
             build: build,
-            transport: { _ in (data, HTTPURLResponse(
-                url: URL(string: "https://api.github.com")!,
-                statusCode: 200, httpVersion: nil, headerFields: nil)!) }
+            transport: transport(compare: compare, head: head)
+        )
+        #expect(result.state == .behind)
+        #expect(result.behindBy == 300)
+        #expect(result.remoteSha == "cafebab")
+        #expect(result.remoteDate == "2026-08-05")
+    }
+
+    @Test func identicalIsUpToDate() async {
+        let result = await VersionUpdateClient.check(
+            build: build,
+            transport: transport(compare: compareFixture(status: "identical", behindBy: 0, aheadBy: 0))
         )
         #expect(result.state == .upToDate)
         #expect(result.behindBy == 0)
     }
 
     @Test func aheadOnlyIsUnknown() async {
-        let data = fixture(status: "ahead", behindBy: 0, aheadBy: 3)
         let result = await VersionUpdateClient.check(
             build: build,
-            transport: { _ in (data, HTTPURLResponse(
-                url: URL(string: "https://api.github.com")!,
-                statusCode: 200, httpVersion: nil, headerFields: nil)!) }
+            transport: transport(compare: compareFixture(status: "ahead", behindBy: 0, aheadBy: 3))
         )
         #expect(result.state == .unknown)
         #expect(result.reason?.contains("not on upstream") == true)

--- a/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowEngine
+
+@Suite struct VersionUpdateClientTests {
+    private func fixture(
+        status: String = "behind",
+        behindBy: Int = 2,
+        aheadBy: Int = 0,
+        commits: [[String: Any]] = []
+    ) -> Data {
+        let payload: [String: Any] = [
+            "status": status,
+            "behind_by": behindBy,
+            "ahead_by": aheadBy,
+            "commits": commits,
+        ]
+        return try! JSONSerialization.data(withJSONObject: payload)
+    }
+
+    private let build = BuildInfo(
+        version: "0.1.0", gitSha: "abc1234", gitShaFull: "abc1234567890", buildDate: "2026-08-05")
+
+    @Test func devShaIsIndeterminate() async {
+        let devBuild = BuildInfo(version: "0.1.0", gitSha: "dev", buildDate: "2026-08-05")
+        let result = await VersionUpdateClient.check(build: devBuild)
+        #expect(result.state == .unknown)
+        #expect(result.reason?.contains("not a known git commit") == true)
+    }
+
+    @Test func behindByReportsUpdateCommand() async {
+        let commit: [String: Any] = [
+            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "commit": ["committer": ["date": "2026-08-05T12:00:00Z"]],
+        ]
+        let data = fixture(commits: [commit])
+        let result = await VersionUpdateClient.check(
+            build: build,
+            updateCommand: "git -C /tmp/crow pull && make install",
+            transport: { _ in (data, HTTPURLResponse(
+                url: URL(string: "https://api.github.com")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!) }
+        )
+        #expect(result.state == .behind)
+        #expect(result.behindBy == 2)
+        #expect(result.remoteSha == "deadbee")
+        #expect(result.remoteDate == "2026-08-05")
+        #expect(result.updateCommand == "git -C /tmp/crow pull && make install")
+    }
+
+    @Test func identicalIsUpToDate() async {
+        let data = fixture(status: "identical", behindBy: 0, aheadBy: 0)
+        let result = await VersionUpdateClient.check(
+            build: build,
+            transport: { _ in (data, HTTPURLResponse(
+                url: URL(string: "https://api.github.com")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!) }
+        )
+        #expect(result.state == .upToDate)
+        #expect(result.behindBy == 0)
+    }
+
+    @Test func aheadOnlyIsUnknown() async {
+        let data = fixture(status: "ahead", behindBy: 0, aheadBy: 3)
+        let result = await VersionUpdateClient.check(
+            build: build,
+            transport: { _ in (data, HTTPURLResponse(
+                url: URL(string: "https://api.github.com")!,
+                statusCode: 200, httpVersion: nil, headerFields: nil)!) }
+        )
+        #expect(result.state == .unknown)
+        #expect(result.reason?.contains("not on upstream") == true)
+    }
+
+    @Test func rateLimitIsUnknown() async {
+        let result = await VersionUpdateClient.check(
+            build: build,
+            transport: { _ in
+                let response = HTTPURLResponse(
+                    url: URL(string: "https://api.github.com")!,
+                    statusCode: 403, httpVersion: nil,
+                    headerFields: ["X-RateLimit-Remaining": "0"])!
+                return (Data(), response)
+            }
+        )
+        #expect(result.state == .unknown)
+        #expect(result.reason?.contains("rate limit") == true)
+    }
+
+    @Test func shortDateTrimsTime() {
+        #expect(VersionUpdateClient.shortDate("2026-08-05T12:34:56Z") == "2026-08-05")
+    }
+}
+
+@Suite struct VersionUpdateRPCTests {
+    @Test func configJSONUsesSnakeCase() {
+        let json = VersionUpdateRPC.configJSON(VersionUpdateConfig(enabled: false, intervalHours: 12))
+        #expect(json == .object(["enabled": .bool(false), "interval_hours": .int(12)]))
+    }
+
+    @Test func patchIntervalRejectsBelowMinimum() {
+        #expect(throws: RPCError.self) {
+            _ = try VersionUpdateRPC.patchIntervalHours(["interval_hours": .int(1)])
+        }
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
@@ -123,6 +123,7 @@ import CrowCore
         #expect(result.state == .upToDate)
         #expect(result.behindBy == 0)
         #expect(result.remoteSha == build.gitSha)
+        #expect(result.remoteDate == nil)
     }
 
     @Test func localAheadOfMainIsUnknown() async {

--- a/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
@@ -5,9 +5,9 @@ import CrowCore
 
 @Suite struct VersionUpdateClientTests {
     private func compareFixture(
-        status: String = "behind",
-        behindBy: Int = 2,
-        aheadBy: Int = 0
+        status: String = "ahead",
+        behindBy: Int = 0,
+        aheadBy: Int = 2
     ) -> Data {
         let payload: [String: Any] = [
             "status": status,
@@ -48,6 +48,27 @@ import CrowCore
         #expect(result.reason?.contains("not a known git commit") == true)
     }
 
+    @Test func staleBuildReportsBehind() async {
+        // Captured from `gh api repos/corveil/crow/compare/5075fba...main`.
+        let compare = try! JSONSerialization.data(withJSONObject: [
+            "status": "ahead",
+            "ahead_by": 2,
+            "behind_by": 0,
+            "commits": [],
+        ])
+        let head = headFixture(
+            sha: "f56939ddeadbeefdeadbeefdeadbeefdeadbeef", date: "2026-08-05T12:00:00Z")
+        let result = await VersionUpdateClient.check(
+            build: build,
+            updateCommand: "git -C /tmp/crow pull && make install",
+            transport: transport(compare: compare, head: head)
+        )
+        #expect(result.state == .behind)
+        #expect(result.behindBy == 2)
+        #expect(result.remoteSha == "f56939d")
+        #expect(result.updateCommand == "git -C /tmp/crow pull && make install")
+    }
+
     @Test func behindByReportsUpdateCommand() async {
         let head = headFixture(
             sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", date: "2026-08-05T12:00:00Z")
@@ -69,9 +90,9 @@ import CrowCore
             "commit": ["committer": ["date": "2020-01-01T00:00:00Z"]],
         ]
         let compare = try! JSONSerialization.data(withJSONObject: [
-            "status": "behind",
-            "behind_by": 300,
-            "ahead_by": 0,
+            "status": "ahead",
+            "ahead_by": 300,
+            "behind_by": 0,
             "commits": [staleCommit],
         ])
         let head = headFixture(
@@ -86,19 +107,28 @@ import CrowCore
         #expect(result.remoteDate == "2026-08-05")
     }
 
-    @Test func identicalIsUpToDate() async {
+    @Test func identicalIsUpToDateAndSkipsBranchHeadFetch() async {
+        let compare = compareFixture(status: "identical", behindBy: 0, aheadBy: 0)
         let result = await VersionUpdateClient.check(
             build: build,
-            transport: transport(compare: compareFixture(status: "identical", behindBy: 0, aheadBy: 0))
+            transport: { request in
+                let url = request.url?.absoluteString ?? ""
+                if url.contains("/commits/main") {
+                    throw URLError(.cannotConnectToHost)
+                }
+                return (compare, HTTPURLResponse(
+                    url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
         )
         #expect(result.state == .upToDate)
         #expect(result.behindBy == 0)
+        #expect(result.remoteSha == build.gitSha)
     }
 
-    @Test func aheadOnlyIsUnknown() async {
+    @Test func localAheadOfMainIsUnknown() async {
         let result = await VersionUpdateClient.check(
             build: build,
-            transport: transport(compare: compareFixture(status: "ahead", behindBy: 0, aheadBy: 3))
+            transport: transport(compare: compareFixture(status: "behind", behindBy: 3, aheadBy: 0))
         )
         #expect(result.state == .unknown)
         #expect(result.reason?.contains("not on upstream") == true)

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -36,6 +36,11 @@ crow cleanup get                                                        → {"cl
 crow cleanup set [--enabled true|false] [--retention-hours N]           → patch; live within ~1 board poll. Deletes completed/archived sessions incl. worktree + branch
 crow ui get                                                             → {"ui":{"sidebar":{"hide_session_details":…}}}
 crow ui set --hide-session-details true|false                           → patch; connected browsers repaint within ~2s
+crow version                                                            → prints the stamped build version
+crow version --check                                                    → compare against corveil/crow main; human summary, exit 0/1/2
+crow version check                                                      → same as --check
+crow version get                                                        → {"version_update":{…},"status":{…}}
+crow version set [--enabled true|false] [--interval-hours N]            → patch; interval floored at 6h
 crow defaults get                                                       → {"defaults":{…9 fields…},"config_readable":bool}
 crow defaults set [--provider github|gitlab] [--cli gh|glab] [--branch-prefix 'feat/']
 crow defaults set --binary NAME=PATH                                    → merge; NAME= removes. Local-only; needs a crowd restart

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -484,6 +484,29 @@ crow ui set --hide-session-details true
 
 Settings are grouped by the config block they belong to, so `get` returns `{"ui": {"sidebar": {...}}}` and gains further blocks as more view options become configurable. Connected browsers pick the change up within a couple of seconds — no reload.
 
+### `crow version` / `crow version check` / `crow version get | set`
+
+Compare the running build against `corveil/crow` `main` (CROW-938). The daemon owns the GitHub compare call and caches the result; the CLI and Settings → About read it back.
+
+```bash
+crow version
+crow version --check
+crow version check
+crow version get
+crow version set --enabled false
+crow version set --interval-hours 12
+```
+
+| Flag / subcommand | Description |
+| ----------------- | ----------- |
+| `--check`         | Force a fresh compare and print a human summary (exit `0` up to date, `1` behind, `2` could not check) |
+| `check`           | Same as `--check` |
+| `get`             | JSON: `version_update` settings plus the cached `status` |
+| `set --enabled`   | Opt out of periodic checks (`true` or `false`) |
+| `set --interval-hours` | Hours between automatic checks (minimum 6, default 6) |
+
+`get` returns `{"version_update":{"enabled":…,"interval_hours":…},"status":{…}}` where `status.state` is `up_to_date`, `behind`, or `unknown`. A `dev` build SHA or an unrecognized commit reports `unknown` — never a false up-to-date.
+
 ### `crow defaults get | set`
 
 Workspace and automation defaults — the `defaults` block of `config.json`, behind Settings → Workspaces (provider, branch prefix), → Automation (the board filter lists) and → General (the corveil binary path).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,6 +110,10 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow ui`](#crow-ui) | View or change UI display preferences |
 | [`crow ui get`](#crow-ui-get) | Show the current UI display preferences |
 | [`crow ui set`](#crow-ui-set) | Change UI display preferences |
+| [`crow version`](#crow-version) | Show the local build and check for upstream updates |
+| [`crow version check`](#crow-version-check) | Compare this build against corveil/crow main |
+| [`crow version get`](#crow-version-get) | Show version-update settings and the cached check result |
+| [`crow version set`](#crow-version-set) | Change version-update settings |
 | [`crow web-password`](#crow-web-password) | Manage the web-access password (local-only) |
 | [`crow web-password clear`](#crow-web-password-clear) | Remove the web-access password |
 | [`crow web-password set`](#crow-web-password-set) | Set or change the web-access password |
@@ -1614,6 +1618,61 @@ Only the flags you pass change; at least one is required. Connected browsers pic
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--hide-session-details` | `<hide-session-details>` | no | Hide ticket title and repo/branch lines in sidebar rows (true or false) |
+
+---
+
+## `crow version`
+
+Show the local build and check for upstream updates.
+
+```
+crow version <check|get|set> [--check]
+```
+
+Bare `crow version` prints the stamped build version. Pass `--check` or run `crow version check` to compare against corveil/crow main via the daemon.
+
+Subcommands: [`check`](#crow-version-check), [`get`](#crow-version-get), [`set`](#crow-version-set).
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--check` | — | no | Compare this build against corveil/crow main |
+
+---
+
+## `crow version check`
+
+Compare this build against corveil/crow main.
+
+```
+crow version check
+```
+
+---
+
+## `crow version get`
+
+Show version-update settings and the cached check result.
+
+```
+crow version get
+```
+
+---
+
+## `crow version set`
+
+Change version-update settings.
+
+```
+crow version set [--enabled <enabled>] [--interval-hours <interval-hours>]
+```
+
+Only the flags you pass change; at least one is required. --interval-hours is floored at 6 so unauthenticated GitHub checks cannot exhaust the 60 req/hr limit.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--enabled` | `<enabled>` | no | Enable periodic upstream checks (true or false) |
+| `--interval-hours` | `<interval-hours>` | no | Hours between automatic checks (minimum 6, default 6) |
 
 ---
 

--- a/scripts/generate-build-info.sh
+++ b/scripts/generate-build-info.sh
@@ -22,9 +22,11 @@ fi
 
 # Capture git info (fallback to "dev" if not in a git repo)
 if git -C "$ROOT_DIR" rev-parse HEAD >/dev/null 2>&1; then
+    GIT_FULL_SHA=$(git -C "$ROOT_DIR" rev-parse HEAD)
     GIT_SHORT_SHA=$(git -C "$ROOT_DIR" rev-parse --short HEAD)
     BUILD_NUMBER=$(git -C "$ROOT_DIR" rev-list --count HEAD)
 else
+    GIT_FULL_SHA="dev"
     GIT_SHORT_SHA="dev"
     BUILD_NUMBER="1"
 fi
@@ -45,6 +47,6 @@ echo "Generated CLI version info (version: $VERSION, build: $BUILD_NUMBER, SHA: 
 WEB_DIR="$ROOT_DIR/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web"
 if [ -d "$WEB_DIR" ]; then
     cat > "$WEB_DIR/version.json" << EOF
-{"version": "$VERSION", "gitSha": "$GIT_SHORT_SHA", "buildDate": "$BUILD_DATE"}
+{"version": "$VERSION", "gitSha": "$GIT_SHORT_SHA", "gitShaFull": "$GIT_FULL_SHA", "buildDate": "$BUILD_DATE"}
 EOF
 fi


### PR DESCRIPTION
Closes #938

## Approach

**Branch-head comparison** against `corveil/crow` `main` via GitHub's compare API (`GET /repos/corveil/crow/compare/{localSha}...main`). This works today with zero release-pipeline work and matches how Crow is actually installed (build from source). Release-tag comparison can be layered on later when real GitHub Releases exist.

## Summary

- `crowd` owns the network call, caches the result, and checks once after startup plus on a configurable interval (default 6h, minimum 6h, opt-out via `versionUpdate.enabled`)
- Reuses `gh auth token` when available but does not depend on it
- `dev` / unknown / fork SHAs → `unknown` (never false up-to-date); GitHub errors fail silently
- **CLI:** `crow version`, `crow version --check` / `crow version check`, `crow version get|set`
- **Settings → About:** inline status, opt-out toggle, interval picker, Check now
- **Web UI:** dismissible banner when behind (keyed on remote SHA so new commits re-show)

## Test plan

- [x] `swift test --package-path Packages/CrowEngine --filter VersionUpdate`
- [x] `swift test --package-path Packages/CrowCLI --filter 'ParityGate|CLIDocs'`
- [x] `swift test --package-path Packages/CrowDaemon --filter 'VersionUpdate|RPCLedger'`
- [x] `scripts/check-cli-parity.sh`
- [ ] Manual: `crow version --check` on an up-to-date build → exit 0
- [ ] Manual: Settings → About shows matching status without a CLI run
- [ ] Manual: dismiss banner, confirm it stays dismissed until remote SHA changes


Made with [Cursor](https://cursor.com)