### PR TITLE
fix(web): hide update banner when [hidden] is set

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -49,6 +49,7 @@ body {
   color: var(--gold);
   font-size: 13px;
 }
+.update-banner[hidden] { display: none; }
 .update-banner-text { flex: 1 1 auto; }
 .update-banner-dismiss {
   flex: 0 0 auto;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -220,6 +220,15 @@ function onServerChanged() {
 
 const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
 let versionBannerDismissedWithoutSha = false;
+let versionBannerDismissedSha = '';
+
+function readDismissedSha() {
+  try {
+    return localStorage.getItem(VERSION_BANNER_DISMISS_KEY) || '';
+  } catch (_) {
+    return versionBannerDismissedSha;
+  }
+}
 
 function syncUpdateBannerLayout(banner) {
   if (!banner || banner.hidden) {
@@ -252,10 +261,17 @@ function renderVersionUpdateBanner(status) {
     try {
       if (dismissRemoteSha) {
         localStorage.setItem(VERSION_BANNER_DISMISS_KEY, dismissRemoteSha);
+        versionBannerDismissedSha = dismissRemoteSha;
       } else if (dismissArmed) {
         versionBannerDismissedWithoutSha = true;
       }
-    } catch (_) { /* session-only when storage is unavailable */ }
+    } catch (_) {
+      if (dismissRemoteSha) {
+        versionBannerDismissedSha = dismissRemoteSha;
+      } else if (dismissArmed) {
+        versionBannerDismissedWithoutSha = true;
+      }
+    }
   };
 
   if (!status || status.state !== 'behind') {
@@ -264,7 +280,7 @@ function renderVersionUpdateBanner(status) {
   }
   const remoteSha = status.remote_sha || '';
   if (remoteSha) versionBannerDismissedWithoutSha = false;
-  if (remoteSha && localStorage.getItem(VERSION_BANNER_DISMISS_KEY) === remoteSha) {
+  if (remoteSha && readDismissedSha() === remoteSha) {
     hideVersionUpdateBanner(banner, text);
     return;
   }
@@ -276,9 +292,10 @@ function renderVersionUpdateBanner(status) {
   dismissRemoteSha = remoteSha;
   dismissArmed = !remoteSha;
   banner.hidden = false;
-  text.textContent = 'A newer Crow build is available — '
+  const msg = 'A newer Crow build is available — '
     + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
     + (status.update_command ? (' Update: ' + status.update_command) : '');
+  if (text.textContent !== msg) text.textContent = msg;
   syncUpdateBannerLayout(banner);
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -222,11 +222,13 @@ const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
 let versionBannerDismissedWithoutSha = false;
 let versionBannerDismissedSha = '';
 
-function readDismissedSha() {
+function isDismissedSha(sha) {
+  if (!sha) return false;
+  if (versionBannerDismissedSha === sha) return true;
   try {
-    return localStorage.getItem(VERSION_BANNER_DISMISS_KEY) || versionBannerDismissedSha;
+    return localStorage.getItem(VERSION_BANNER_DISMISS_KEY) === sha;
   } catch (_) {
-    return versionBannerDismissedSha;
+    return false;
   }
 }
 
@@ -275,7 +277,7 @@ function renderVersionUpdateBanner(status) {
   }
   const remoteSha = status.remote_sha || '';
   if (remoteSha) versionBannerDismissedWithoutSha = false;
-  if (remoteSha && readDismissedSha() === remoteSha) {
+  if (remoteSha && isDismissedSha(remoteSha)) {
     hideVersionUpdateBanner(banner, text);
     return;
   }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -232,6 +232,12 @@ function syncUpdateBannerLayout(banner) {
     '--update-banner-height', banner.offsetHeight + 'px');
 }
 
+function hideVersionUpdateBanner(banner, text) {
+  if (text) text.textContent = '';
+  banner.hidden = true;
+  syncUpdateBannerLayout(banner);
+}
+
 function renderVersionUpdateBanner(status) {
   const banner = document.getElementById('update-banner');
   if (!banner) return;
@@ -239,38 +245,39 @@ function renderVersionUpdateBanner(status) {
   const dismiss = banner.querySelector('.update-banner-dismiss');
   if (!text || !dismiss) return;
 
+  let dismissRemoteSha = '';
+  let dismissWithoutSha = false;
+  dismiss.onclick = () => {
+    if (dismissRemoteSha) {
+      localStorage.setItem(VERSION_BANNER_DISMISS_KEY, dismissRemoteSha);
+    } else if (dismissWithoutSha) {
+      versionBannerDismissedWithoutSha = true;
+    }
+    hideVersionUpdateBanner(banner, text);
+  };
+
   if (!status || status.state !== 'behind') {
-    banner.hidden = true;
-    syncUpdateBannerLayout(banner);
+    hideVersionUpdateBanner(banner, text);
     return;
   }
   const remoteSha = status.remote_sha || '';
   if (remoteSha) versionBannerDismissedWithoutSha = false;
   if (remoteSha && localStorage.getItem(VERSION_BANNER_DISMISS_KEY) === remoteSha) {
-    banner.hidden = true;
-    syncUpdateBannerLayout(banner);
+    hideVersionUpdateBanner(banner, text);
     return;
   }
   if (!remoteSha && versionBannerDismissedWithoutSha) {
-    banner.hidden = true;
-    syncUpdateBannerLayout(banner);
+    hideVersionUpdateBanner(banner, text);
     return;
   }
   const n = status.behind_by || 0;
   text.textContent = 'A newer Crow build is available — '
     + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
     + (status.update_command ? (' Update: ' + status.update_command) : '');
+  dismissRemoteSha = remoteSha;
+  dismissWithoutSha = !remoteSha;
   banner.hidden = false;
   syncUpdateBannerLayout(banner);
-  dismiss.onclick = () => {
-    if (remoteSha) {
-      localStorage.setItem(VERSION_BANNER_DISMISS_KEY, remoteSha);
-    } else {
-      versionBannerDismissedWithoutSha = true;
-    }
-    banner.hidden = true;
-    syncUpdateBannerLayout(banner);
-  };
 }
 
 async function refreshVersionUpdateBanner(cachedStatus) {
@@ -283,7 +290,9 @@ async function refreshVersionUpdateBanner(cachedStatus) {
     renderVersionUpdateBanner(res && res.status);
   } catch (_) {
     const banner = document.getElementById('update-banner');
-    if (banner) banner.hidden = true;
+    if (banner) {
+      hideVersionUpdateBanner(banner, banner.querySelector('.update-banner-text'));
+    }
   }
 }
 window.refreshVersionUpdateBanner = refreshVersionUpdateBanner;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -246,14 +246,16 @@ function renderVersionUpdateBanner(status) {
   if (!text || !dismiss) return;
 
   let dismissRemoteSha = '';
-  let dismissWithoutSha = false;
+  let dismissArmed = false;
   dismiss.onclick = () => {
-    if (dismissRemoteSha) {
-      localStorage.setItem(VERSION_BANNER_DISMISS_KEY, dismissRemoteSha);
-    } else if (dismissWithoutSha) {
-      versionBannerDismissedWithoutSha = true;
-    }
     hideVersionUpdateBanner(banner, text);
+    try {
+      if (dismissRemoteSha) {
+        localStorage.setItem(VERSION_BANNER_DISMISS_KEY, dismissRemoteSha);
+      } else if (dismissArmed) {
+        versionBannerDismissedWithoutSha = true;
+      }
+    } catch (_) { /* session-only when storage is unavailable */ }
   };
 
   if (!status || status.state !== 'behind') {
@@ -271,12 +273,12 @@ function renderVersionUpdateBanner(status) {
     return;
   }
   const n = status.behind_by || 0;
+  dismissRemoteSha = remoteSha;
+  dismissArmed = !remoteSha;
+  banner.hidden = false;
   text.textContent = 'A newer Crow build is available — '
     + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
     + (status.update_command ? (' Update: ' + status.update_command) : '');
-  dismissRemoteSha = remoteSha;
-  dismissWithoutSha = !remoteSha;
-  banner.hidden = false;
   syncUpdateBannerLayout(banner);
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -224,7 +224,7 @@ let versionBannerDismissedSha = '';
 
 function readDismissedSha() {
   try {
-    return localStorage.getItem(VERSION_BANNER_DISMISS_KEY) || '';
+    return localStorage.getItem(VERSION_BANNER_DISMISS_KEY) || versionBannerDismissedSha;
   } catch (_) {
     return versionBannerDismissedSha;
   }
@@ -242,6 +242,7 @@ function syncUpdateBannerLayout(banner) {
 }
 
 function hideVersionUpdateBanner(banner, text) {
+  if (!banner) return;
   if (text) text.textContent = '';
   banner.hidden = true;
   syncUpdateBannerLayout(banner);
@@ -255,22 +256,16 @@ function renderVersionUpdateBanner(status) {
   if (!text || !dismiss) return;
 
   let dismissRemoteSha = '';
-  let dismissArmed = false;
+  let dismissArmedWithoutSha = false;
   dismiss.onclick = () => {
     hideVersionUpdateBanner(banner, text);
-    try {
-      if (dismissRemoteSha) {
+    if (dismissRemoteSha) {
+      versionBannerDismissedSha = dismissRemoteSha;
+      try {
         localStorage.setItem(VERSION_BANNER_DISMISS_KEY, dismissRemoteSha);
-        versionBannerDismissedSha = dismissRemoteSha;
-      } else if (dismissArmed) {
-        versionBannerDismissedWithoutSha = true;
-      }
-    } catch (_) {
-      if (dismissRemoteSha) {
-        versionBannerDismissedSha = dismissRemoteSha;
-      } else if (dismissArmed) {
-        versionBannerDismissedWithoutSha = true;
-      }
+      } catch (_) {}
+    } else if (dismissArmedWithoutSha) {
+      versionBannerDismissedWithoutSha = true;
     }
   };
 
@@ -290,7 +285,7 @@ function renderVersionUpdateBanner(status) {
   }
   const n = status.behind_by || 0;
   dismissRemoteSha = remoteSha;
-  dismissArmed = !remoteSha;
+  dismissArmedWithoutSha = !remoteSha;
   banner.hidden = false;
   const msg = 'A newer Crow build is available — '
     + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -109,6 +109,16 @@ way `index.html` does, so `openSettings` / `setSettingsTab` are the shipped
 implementations rather than stubs — the tab-routing bug they guard (a re-entry
 that silently reset `dirty`) is invisible to a stub.
 
+## `version-banner.test.js` — version-update banner (#942)
+
+Drives `renderVersionUpdateBanner` / `refreshVersionUpdateBanner` against
+mock `localStorage` and `rpc`, with the real `app.css` injected so assertions
+use computed style (not just the `hidden` property). Coverage: `[hidden]`
+genuinely hides the flex banner, behind/up-to-date toggling, SHA dismiss
+surviving a poll, a new SHA re-showing, the `setItem`-throws path with stale
+storage, no-SHA session dismiss resetting when a SHA arrives, `getItem` throws
+not blocking render or in-memory dismiss, and RPC failure hiding the banner.
+
 ## Run
 
 ```sh

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; hash URL routing). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler row sidebar-groups sidebar-select rpc-timeout router; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler sidebar-groups sidebar-select rpc-timeout router; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler row sidebar-groups sidebar-select rpc-timeout router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
+    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler sidebar-groups sidebar-select rpc-timeout router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,7 +2,7 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; hash URL routing). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
     "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler row sidebar-groups sidebar-select rpc-timeout router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
     "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler sidebar-groups sidebar-select rpc-timeout router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"

--- a/Packages/CrowDaemon/web-tests/version-banner.test.js
+++ b/Packages/CrowDaemon/web-tests/version-banner.test.js
@@ -9,6 +9,8 @@ const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
 const epilogue = `
 ;globalThis.__t = {
   render(status) { renderVersionUpdateBanner(status); },
+  refresh() { return refreshVersionUpdateBanner(); },
+  setRpc(fn) { rpc = fn; },
   visible() {
     const b = document.getElementById('update-banner');
     return b && window.getComputedStyle(b).display !== 'none';
@@ -20,9 +22,13 @@ const epilogue = `
 function makeStorage(initial = {}) {
   const data = { ...initial };
   let setItemThrows = false;
+  let getItemThrows = false;
   return {
     storage: {
-      getItem(k) { return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null; },
+      getItem(k) {
+        if (getItemThrows) throw new DOMException('SecurityError');
+        return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null;
+      },
       setItem(k, v) {
         if (setItemThrows) throw new DOMException('QuotaExceededError');
         data[k] = String(v);
@@ -33,6 +39,7 @@ function makeStorage(initial = {}) {
       key() { return null; },
     },
     setSetItemThrows(v) { setItemThrows = v; },
+    setGetItemThrows(v) { getItemThrows = v; },
     get(k) { return data[k]; },
   };
 }
@@ -81,55 +88,100 @@ const check = (name, cond) => {
   else { fail++; console.log('  ✗ ' + name); }
 };
 
-console.log('[hidden] hides via computed style on first paint:');
-{
-  const { T } = load(makeStorage());
-  check('banner starts hidden', !T.visible());
-}
+(async () => {
+  console.log('[hidden] hides via computed style on first paint:');
+  {
+    const { T } = load(makeStorage());
+    check('banner starts hidden', !T.visible());
+  }
 
-console.log('\nbehind → shown, up_to_date → hidden:');
-{
-  const { T } = load(makeStorage());
-  T.render({ state: 'behind', behind_by: 3, remote_sha: 'aaa' });
-  check('shown when behind', T.visible());
-  T.render({ state: 'up_to_date' });
-  check('hidden again', !T.visible());
-}
+  console.log('\nbehind → shown, up_to_date → hidden:');
+  {
+    const { T } = load(makeStorage());
+    T.render({ state: 'behind', behind_by: 3, remote_sha: 'aaa' });
+    check('shown when behind', T.visible());
+    T.render({ state: 'up_to_date' });
+    check('hidden again', !T.visible());
+  }
 
-console.log('\ndismiss survives a re-render for the same sha:');
-{
-  const { T } = load(makeStorage());
-  T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
-  check('shown for aaa', T.visible());
-  T.dismiss();
-  check('dismiss hid it', !T.visible());
-  T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
-  check('stays hidden on re-render', !T.visible());
-}
+  console.log('\ndismiss survives a re-render for the same sha:');
+  {
+    const { T } = load(makeStorage());
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    check('shown for aaa', T.visible());
+    T.dismiss();
+    check('dismiss hid it', !T.visible());
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    check('stays hidden on re-render', !T.visible());
+  }
 
-console.log('\na new sha re-shows after dismiss:');
-{
-  const { T } = load(makeStorage());
-  T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
-  T.dismiss();
-  T.render({ state: 'behind', behind_by: 2, remote_sha: 'bbb' });
-  check('bbb shown after aaa dismissed', T.visible());
-}
+  console.log('\na new sha re-shows after dismiss:');
+  {
+    const { T } = load(makeStorage());
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    T.dismiss();
+    T.render({ state: 'behind', behind_by: 2, remote_sha: 'bbb' });
+    check('bbb shown after aaa dismissed', T.visible());
+  }
 
-console.log('\nsetItem throws but in-memory dismiss sticks across poll:');
-{
-  const storage = makeStorage({ [VERSION_BANNER_DISMISS_KEY]: 'aaa' });
-  const { T } = load(storage);
-  check('stale aaa persisted', storage.get(VERSION_BANNER_DISMISS_KEY) === 'aaa');
-  T.render({ state: 'behind', behind_by: 1, remote_sha: 'bbb' });
-  check('banner shown for bbb', T.visible());
-  storage.setSetItemThrows(true);
-  T.dismiss();
-  check('dismiss hid it', !T.visible());
-  check('storage still holds stale aaa', storage.get(VERSION_BANNER_DISMISS_KEY) === 'aaa');
-  T.render({ state: 'behind', behind_by: 1, remote_sha: 'bbb' });
-  check('stays hidden on re-render', !T.visible());
-}
+  console.log('\nsetItem throws but in-memory dismiss sticks across poll:');
+  {
+    const storage = makeStorage({ [VERSION_BANNER_DISMISS_KEY]: 'aaa' });
+    const { T } = load(storage);
+    check('stale aaa persisted', storage.get(VERSION_BANNER_DISMISS_KEY) === 'aaa');
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'bbb' });
+    check('banner shown for bbb', T.visible());
+    storage.setSetItemThrows(true);
+    T.dismiss();
+    check('dismiss hid it', !T.visible());
+    check('storage still holds stale aaa', storage.get(VERSION_BANNER_DISMISS_KEY) === 'aaa');
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'bbb' });
+    check('stays hidden on re-render', !T.visible());
+  }
 
-console.log(`\n${pass} passed, ${fail} failed`);
-process.exit(fail ? 1 : 0);
+  console.log('\nno-sha dismiss is session-only until a sha arrives:');
+  {
+    const { T } = load(makeStorage());
+    T.render({ state: 'behind', behind_by: 2 });
+    check('shown without remote_sha', T.visible());
+    T.dismiss();
+    check('dismiss hid it', !T.visible());
+    T.render({ state: 'behind', behind_by: 2 });
+    check('stays hidden on re-render', !T.visible());
+    T.render({ state: 'behind', behind_by: 2, remote_sha: 'aaa' });
+    check('reshown when remote_sha arrives', T.visible());
+  }
+
+  console.log('\ngetItem throws but banner still renders when behind:');
+  {
+    const storage = makeStorage();
+    const { T } = load(storage);
+    storage.setGetItemThrows(true);
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    check('shown when getItem throws', T.visible());
+  }
+
+  console.log('\ngetItem throws but in-memory dismiss still sticks:');
+  {
+    const storage = makeStorage();
+    const { T } = load(storage);
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    T.dismiss();
+    storage.setGetItemThrows(true);
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    check('stays hidden on re-render', !T.visible());
+  }
+
+  console.log('\nrefreshVersionUpdateBanner hides banner on RPC failure:');
+  {
+    const { T } = load(makeStorage());
+    T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+    check('shown before RPC failure', T.visible());
+    T.setRpc(() => Promise.reject(new Error('rpc failed')));
+    await T.refresh();
+    check('hidden after RPC failure', !T.visible());
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(2); });

--- a/Packages/CrowDaemon/web-tests/version-banner.test.js
+++ b/Packages/CrowDaemon/web-tests/version-banner.test.js
@@ -1,0 +1,135 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const APP_CSS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.css';
+const VERSION_BANNER_DISMISS_KEY = 'crow.updateBannerDismissedSha';
+
+const epilogue = `
+;globalThis.__t = {
+  render(status) { renderVersionUpdateBanner(status); },
+  visible() {
+    const b = document.getElementById('update-banner');
+    return b && window.getComputedStyle(b).display !== 'none';
+  },
+  dismiss() { document.querySelector('.update-banner-dismiss').click(); },
+};
+`;
+
+function makeStorage(initial = {}) {
+  const data = { ...initial };
+  let setItemThrows = false;
+  return {
+    storage: {
+      getItem(k) { return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null; },
+      setItem(k, v) {
+        if (setItemThrows) throw new DOMException('QuotaExceededError');
+        data[k] = String(v);
+      },
+      removeItem(k) { delete data[k]; },
+      clear() { for (const k of Object.keys(data)) delete data[k]; },
+      get length() { return Object.keys(data).length; },
+      key() { return null; },
+    },
+    setSetItemThrows(v) { setItemThrows = v; },
+    get(k) { return data[k]; },
+  };
+}
+
+function load(storageWrap) {
+  const dom = new JSDOM(
+    `<!doctype html><html><head>
+       <style>${fs.readFileSync(APP_CSS, 'utf8')}</style>
+     </head><body>
+       <div id="update-banner" class="update-banner" hidden role="status">
+         <span class="update-banner-text"></span>
+         <button type="button" class="update-banner-dismiss" aria-label="Dismiss update notice">×</button>
+       </div>
+     </body></html>`,
+    { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+  );
+  const { window } = dom;
+  Object.defineProperty(window, 'localStorage', {
+    value: storageWrap.storage, configurable: true, writable: true,
+  });
+  window.WebSocket = function () {
+    return { send() {}, close() {},
+      set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+  };
+  window.setInterval = () => 0;
+  window.setTimeout = () => 0;
+  window.requestAnimationFrame = () => 0;
+  const realGet = window.document.getElementById.bind(window.document);
+  window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+  const ctx = dom.getInternalVMContext();
+  try {
+    vm.runInContext(fs.readFileSync(APP_JS, 'utf8') + epilogue, ctx, { filename: 'app.js' });
+  } catch (e) {
+    console.log('[load warn]', e.message);
+  }
+  const T = ctx.__t;
+  if (!T) throw new Error('epilogue did not run');
+  return { T, storage: storageWrap, window };
+}
+
+let pass = 0;
+let fail = 0;
+const check = (name, cond) => {
+  if (cond) { pass++; console.log('  ✓ ' + name); }
+  else { fail++; console.log('  ✗ ' + name); }
+};
+
+console.log('[hidden] hides via computed style on first paint:');
+{
+  const { T } = load(makeStorage());
+  check('banner starts hidden', !T.visible());
+}
+
+console.log('\nbehind → shown, up_to_date → hidden:');
+{
+  const { T } = load(makeStorage());
+  T.render({ state: 'behind', behind_by: 3, remote_sha: 'aaa' });
+  check('shown when behind', T.visible());
+  T.render({ state: 'up_to_date' });
+  check('hidden again', !T.visible());
+}
+
+console.log('\ndismiss survives a re-render for the same sha:');
+{
+  const { T } = load(makeStorage());
+  T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+  check('shown for aaa', T.visible());
+  T.dismiss();
+  check('dismiss hid it', !T.visible());
+  T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+  check('stays hidden on re-render', !T.visible());
+}
+
+console.log('\na new sha re-shows after dismiss:');
+{
+  const { T } = load(makeStorage());
+  T.render({ state: 'behind', behind_by: 1, remote_sha: 'aaa' });
+  T.dismiss();
+  T.render({ state: 'behind', behind_by: 2, remote_sha: 'bbb' });
+  check('bbb shown after aaa dismissed', T.visible());
+}
+
+console.log('\nsetItem throws but in-memory dismiss sticks across poll:');
+{
+  const storage = makeStorage({ [VERSION_BANNER_DISMISS_KEY]: 'aaa' });
+  const { T } = load(storage);
+  check('stale aaa persisted', storage.get(VERSION_BANNER_DISMISS_KEY) === 'aaa');
+  T.render({ state: 'behind', behind_by: 1, remote_sha: 'bbb' });
+  check('banner shown for bbb', T.visible());
+  storage.setSetItemThrows(true);
+  T.dismiss();
+  check('dismiss hid it', !T.visible());
+  check('storage still holds stale aaa', storage.get(VERSION_BANNER_DISMISS_KEY) === 'aaa');
+  T.render({ state: 'behind', behind_by: 1, remote_sha: 'bbb' });
+  check('stays hidden on re-render', !T.visible());
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #942

## Summary

- Add `.update-banner[hidden] { display: none; }` so the flex layout no longer overrides the `hidden` attribute (matching `#session-scrim` and `#lightbox`).
- Bind the dismiss handler unconditionally and clear banner text on all hide paths so a stale/empty bar is never both visible and inert.

## Test plan

- [ ] With `crow version --check` reporting **Up to date**, no banner is visible on first paint or after the check completes.
- [ ] With the build behind, the banner appears with text and a working dismiss button.
- [ ] Dismissing hides the banner until the remote SHA changes.
- [ ] `version-update-get` failing or returning `unknown` leaves no visible banner.


Made with [Cursor](https://cursor.com)