### PR TITLE
Close review rounds so a re-request starts round 2 (CROW-945)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -22,13 +22,29 @@ public struct Session: Identifiable, Codable, Sendable {
     // prompt dispatched. Gates the launchClaude prompt-vs-`--continue`
     // branch so completed reviews don't restart on app relaunch.
     public var reviewPromptDispatched: Bool
-    // Head SHA of the PR at the time the review session was created or
-    // last re-launched. Used by the kickoff guard as a fallback re-kick
-    // signal when a PR's head advances without an explicit re-request
-    // (e.g. force-push) or before the viewer-submitted-review signal is
-    // observed. Nil for non-review sessions and for legacy persisted
-    // sessions predating this field (CROW-290).
+    // Head SHA of the PR at the time the review session was created. Used by
+    // the kickoff guard as a fallback re-kick signal when a PR's head advances
+    // without an explicit re-request (e.g. force-push) or before the
+    // viewer-submitted-review signal is observed. Nil for non-review sessions
+    // and for legacy persisted sessions predating this field (CROW-290).
+    //
+    // Deliberately NOT updated when a round is re-reviewed in place. This is a
+    // *round boundary*, and the kickoff guard's whole job is to notice "the
+    // head moved and nobody opened a new round". Advancing it on re-review
+    // would disarm that fallback for the new head, so an agent that then
+    // stalled without posting a verdict would leave the PR with nothing to
+    // re-fire. For the *diff anchor* — "what should `git diff …HEAD` cover on
+    // the next pass" — use `lastReRequestedHeadSha`, which is what the two
+    // readers actually needed separately (CROW-945).
     public var lastReviewedHeadSha: String?
+    // Head SHA the last in-place re-review was scoped from (CROW-945). Written
+    // by the `reReview` quick action, which re-prompts the *existing* session
+    // rather than starting a new round, so without it every repeat pass hands
+    // the agent an ever-widening diff from round 1's head — more tokens, and
+    // findings the agent already reported. Read only for prompt scoping, never
+    // by the kickoff guard; see `lastReviewedHeadSha`. Nil until the first
+    // in-place re-review, and for every session predating this field.
+    public var lastReRequestedHeadSha: String?
     // Timestamp at which Crow enabled GitHub native auto-merge on the
     // linked PR (CROW-299). Non-nil means the one-shot enable has already
     // run; the auto-merge watcher skips this session on subsequent polls.
@@ -143,6 +159,7 @@ public struct Session: Identifiable, Codable, Sendable {
         updatedAt: Date = Date(),
         reviewPromptDispatched: Bool = false,
         lastReviewedHeadSha: String? = nil,
+        lastReRequestedHeadSha: String? = nil,
         autoMergeEnabledAt: Date? = nil,
         locked: Bool = false,
         agentSessionStartedAt: Date? = nil,
@@ -165,6 +182,7 @@ public struct Session: Identifiable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.reviewPromptDispatched = reviewPromptDispatched
         self.lastReviewedHeadSha = lastReviewedHeadSha
+        self.lastReRequestedHeadSha = lastReRequestedHeadSha
         self.autoMergeEnabledAt = autoMergeEnabledAt
         self.locked = locked
         self.agentSessionStartedAt = agentSessionStartedAt
@@ -207,6 +225,7 @@ public struct Session: Identifiable, Codable, Sendable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         reviewPromptDispatched = try container.decodeIfPresent(Bool.self, forKey: .reviewPromptDispatched) ?? true
         lastReviewedHeadSha = try container.decodeIfPresent(String.self, forKey: .lastReviewedHeadSha)
+        lastReRequestedHeadSha = try container.decodeIfPresent(String.self, forKey: .lastReRequestedHeadSha)
         autoMergeEnabledAt = try container.decodeIfPresent(Date.self, forKey: .autoMergeEnabledAt)
         agentSessionStartedAt = try container.decodeIfPresent(Date.self, forKey: .agentSessionStartedAt)
         agentSessionEndedAt = try container.decodeIfPresent(Date.self, forKey: .agentSessionEndedAt)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -784,46 +784,28 @@ public enum CrowDaemon {
         // (force-push, or round-2 commits landing before Signal A —
         // `decideReviewCompletions` rule 1 — completed round 1). The SHA-keyed
         // fingerprint makes each head its own round so B isn't blocked by A.
+        //
+        // Both decisions now live in `SessionService.createReviewSession`, which
+        // runs the same `IssueTracker.reviewKickoffAction` against the head it
+        // fetches itself (CROW-945). This hook deliberately does NOT pre-decide:
+        // it would have to use `request.headRefOid` — a board snapshot up to a
+        // poll old — and two callers deciding from two different heads is
+        // exactly the divergence that let a round go on shadowing its PR. So
+        // this stays a filter + a rate guard, and the service owns the verdict.
         var autoReviewed: Set<String> = []
         tracker.onReviewRequestsRefreshed = { requests in
             let patterns = (config()?.workspaces ?? []).flatMap { $0.autoReviewRepos }
             guard !patterns.isEmpty else { return }
             for request in requests {
                 guard repoMatchesPatterns(request.repo, patterns: patterns) else { continue }
-                let linkedSession = request.reviewSessionID.flatMap { id in
-                    appState.sessions.first(where: { $0.id == id })
-                }
-                let action = IssueTracker.reviewKickoffAction(
-                    reviewSessionID: request.reviewSessionID,
-                    headRefOid: request.headRefOid,
-                    linkedSession: linkedSession,
-                    existingByPRSessionID: appState.existingReviewSession(forPRURL: request.url)?.id
-                )
-                guard action != .skip else { continue }
                 // SHA-keyed dedup: a new head is a fresh round; an unchanged head
                 // never re-kicks (also guards the in-flight clone window before
-                // the session's link/reviewSessionID land).
+                // the session's link/reviewSessionID land). In-memory only, so a
+                // daemon restart can re-ask — `createReviewSession` still refuses
+                // to duplicate a live round, so the worst case is one redundant
+                // metadata fetch, not a duplicate session.
                 let fingerprint = "\(request.id)\n\(request.headRefOid ?? "")"
                 guard autoReviewed.insert(fingerprint).inserted else { continue }
-                // B-fallback: retire the stale round's review session before
-                // enqueuing so `reviewSessions` doesn't double up for this PR.
-                // Complete it (not delete): completing writes its end-of-round
-                // `SessionAnalyticsSnapshot` and keeps its telemetry, whereas
-                // `deleteSession` transitions no status — so no snapshot is
-                // written — and then drops the raw rows, silently erasing round
-                // 1's tokens/cost from the scorecard on Crow's own auto-review
-                // flow (CROW-877 review). Completing also makes it invisible to
-                // `existingReviewSession(forPRURL:)` (that dedup guard excludes
-                // completed/archived), so the create below starts the new round
-                // instead of reusing the stale session. The identical completed
-                // `review-<repo>-<pr>` rows that used to pile up in Completed are
-                // now folded into one by the sidebar's within-section collapse
-                // (`groupSessions` in app.js), which also cleans up pre-existing
-                // pile-ups — so the visible-duplicate half no longer needs a
-                // destructive teardown here.
-                if case let .reReview(staleID) = action {
-                    appState.onCompleteSession?(staleID)
-                }
                 let url = request.url
                 Task { _ = await reviewSerializer.enqueue { await sessionService.createReviewSession(prURL: url, selectAfterCreate: false) } }
             }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -703,31 +703,7 @@ func makeCommandRouter(
         },
         "list-reviews": { _ in
             if tracker != nil {
-                return await MainActor.run {
-                    let fmt = ISO8601DateFormatter()
-                    let reviews: [JSONValue] = appState.filteredReviewRequests.map { r in
-                        .object([
-                            "id": .string(r.id),
-                            "pr_number": .int(r.prNumber),
-                            "title": .string(r.title),
-                            "url": .string(r.url),
-                            "repo": .string(r.repo),
-                            "author": .string(r.author),
-                            "head_branch": .string(r.headBranch),
-                            "base_branch": .string(r.baseBranch),
-                            "is_draft": .bool(r.isDraft),
-                            "requested_at": r.requestedAt.map { .string(fmt.string(from: $0)) } ?? .null,
-                            "labels": .array(r.labels.map { .object(["name": .string($0.name), "color": $0.color.map { .string($0) } ?? .null]) }),
-                            "provider": .string(r.provider.rawValue),
-                            "review_session_id": r.reviewSessionID.map { .string($0.uuidString) } ?? .null,
-                        ])
-                    }
-                    return [
-                        "reviews": .array(reviews),
-                        "loading": .bool(appState.isLoadingReviews),
-                        "unseen": .int(appState.unseenReviewCount),
-                    ]
-                }
+                return await MainActor.run { ReviewsPayload.build(appState: appState) }
             }
             let empty: [String: JSONValue] = ["reviews": .array([]), "loading": .bool(false), "unseen": .int(0)]
             return empty

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -4065,10 +4065,10 @@ function renderReviewBoard(root) {
     .sort((a, b) => (b.requested_at || '').localeCompare(a.requested_at || ''));
   const q = reviewSearch.trim().toLowerCase();
   if (q) reviews = reviews.filter((r) => reviewHaystack(r).includes(q));
-  // Only reviews without a linked session can be started, so only those are
-  // selectable. Prune stale selections against the *visible* set (a refresh or
-  // the search may have removed/hidden/linked a review).
-  const selectableUrls = new Set(reviews.filter((r) => !r.review_session_id).map((r) => r.url));
+  // Only reviews the server would actually act on can be started, so only
+  // those are selectable. Prune stale selections against the *visible* set (a
+  // refresh or the search may have removed/hidden/linked a review).
+  const selectableUrls = new Set(reviews.filter(reviewIsActionable).map((r) => r.url));
   for (const url of [...selectedReviewURLs]) if (!selectableUrls.has(url)) selectedReviewURLs.delete(url);
 
   const head = el('div', 'board-head');
@@ -4129,7 +4129,7 @@ function toggleReviewSelect(url) {
 // (CROW-865). Then clear selection and exit selection mode.
 async function startReviewSelected(btn) {
   const urls = ((boardData.reviews && boardData.reviews.reviews) || [])
-    .filter((r) => !r.review_session_id && selectedReviewURLs.has(r.url))
+    .filter((r) => reviewIsActionable(r) && selectedReviewURLs.has(r.url))
     .map((r) => r.url);
   if (!urls.length) return;
   btn.disabled = true;
@@ -4154,11 +4154,27 @@ function reviewHaystack(r) {
   return [r.title, r.repo, '@' + r.author, '#' + r.pr_number].join(' ').toLowerCase();
 }
 
+// Whether pressing Start Review / Re-review on this card would actually do
+// something (CROW-945). The server computes `kickoff_action` from the same
+// decision function `createReviewSession` runs, so the button reflects the
+// real verdict rather than the much weaker "does *a* session link to this PR"
+// question — which is what left a re-requested PR showing only "Go to Session"
+// pointing at a dead round.
+//
+// The action is an estimate: it's computed from the board's head SHA, up to a
+// poll stale, while the server decides against a head it fetches itself. So it
+// picks the *label* and never suppresses the RPC — the server is the decider.
+// Falls back to the old predicate when the field is absent (older daemon).
+function reviewIsActionable(r) {
+  if (!r.kickoff_action) return !r.review_session_id;
+  return r.kickoff_action === 'create' || r.kickoff_action === 're_review';
+}
+
 function reviewCard(r) {
-  // A review that already has a session can't be started again, so it isn't
-  // selectable — it renders dimmed and checkbox-less while selecting, as the
-  // retired ReviewBoardView did, but keeps its Go to Session button.
-  const selectable = !r.review_session_id;
+  // A review the server would decline to act on can't be started again, so it
+  // isn't selectable — it renders dimmed and checkbox-less while selecting, as
+  // the retired ReviewBoardView did, but keeps its Go to Session button.
+  const selectable = reviewIsActionable(r);
   const selecting = reviewSelectionMode && selectable;
   const isSel = selectedReviewURLs.has(r.url);
   const card = el('div', 'board-card'
@@ -4194,15 +4210,23 @@ function reviewCard(r) {
   card.appendChild(sub);
   if (r.labels && r.labels.length) card.appendChild(labelPills(r.labels));
   const foot = el('div', 'card-foot');
+  // A linked session is still reachable even when a new round is offered —
+  // "Re-review" retires that round, so the user should be able to look at it
+  // first. Order: the kickoff button leads, Go to Session follows.
+  if (!selecting && reviewIsActionable(r)) {
+    // Suppressed while selecting — the batch bar owns the kickoff there.
+    const reReview = r.kickoff_action === 're_review';
+    // Both go through `start-review`: the server runs the kickoff decision and
+    // completes the stale round itself, so there is one verb and one rule.
+    const label = reReview ? 'Re-review' : 'Start Review';
+    const rev = el('button', 'action-btn action-primary', label);
+    rev.onclick = () => spawnAction(rev, 'start-review', { url: r.url }, label);
+    foot.appendChild(rev);
+  }
   if (r.review_session_id) {
     const go = el('button', 'action-btn', 'Go to Session');
     go.onclick = () => selectSession(r.review_session_id);
     foot.appendChild(go);
-  } else if (!selecting) {
-    // Suppressed while selecting — the batch bar owns the kickoff there.
-    const rev = el('button', 'action-btn action-primary', 'Start Review');
-    rev.onclick = () => spawnAction(rev, 'start-review', { url: r.url }, 'Start Review');
-    foot.appendChild(rev);
   }
   // `.card-foot` carries a top margin, so a selectable card in select mode —
   // which has no button at all — would otherwise end in 8px of dead space.

--- a/Packages/CrowDaemon/web-tests/board.test.js
+++ b/Packages/CrowDaemon/web-tests/board.test.js
@@ -17,6 +17,8 @@ const epilogue = `
   set reviewSearch(v){reviewSearch=v;},
   set reviewSelectionMode(v){reviewSelectionMode=v;},
   get selectedReviewURLs(){return selectedReviewURLs;},
+  get rpc(){return rpc;},
+  set rpc(v){rpc = v;},
   renderBoard(){ return renderBoard(); },
   ticketsCard(){ return ticketsCard(); },
   ticketsRefreshing(){ return ticketsRefreshing(); },
@@ -197,10 +199,14 @@ check('Reviews idle: no spinner, button enabled',
 // Restores the retired ReviewBoardView's batch kickoff on the web board, using
 // the ticket board's selection model. r3 already has a review session, so it is
 // the non-selectable/dimmed case.
-const review = (id, n, title, repo, author, url, hours, sessionID) => ({
+const review = (id, n, title, repo, author, url, hours, sessionID, kickoffAction) => ({
   id, pr_number: n, title, url, repo, author, head_branch: 'feat/' + id, base_branch: 'main',
   is_draft: false, requested_at: iso(hours), labels: [], provider: 'github',
   review_session_id: sessionID || null,
+  // Omitted on purpose in the fixtures below: an older daemon doesn't send it,
+  // and the client must fall back to the `review_session_id` predicate. The
+  // CROW-945 block at the end covers the field being present.
+  ...(kickoffAction ? { kickoff_action: kickoffAction } : {}),
 });
 const reviewsPayload = { unseen: 0, reviews: [
   review('r1', 900, 'Add batch review', 'corveil/crow', 'dhilgaertner', 'https://github.com/corveil/crow/pull/900', 1),
@@ -264,6 +270,53 @@ T.boardData.reviews = { unseen: 0,
 T.renderBoard();
 check('no Select button when nothing is startable', !btn('Select'));
 check('all 3 rows offer Go to Session', countBtn('Go to Session') === 3);
+
+// -- The board offers the next round (CROW-945) --
+// Before this, the card was gated purely on "does a non-completed session link
+// to this PR", which is a much weaker question than "has this review round been
+// answered". A re-requested PR therefore rendered only "Go to Session" pointing
+// at the dead round-1 session, and the sole way forward was deleting it by hand.
+// The server now sends the verdict from the same decision function
+// `createReviewSession` runs, and the card renders it.
+console.log('\nReviews board — kickoff_action drives the button (CROW-945):');
+T.reviewSelectionMode = false; T.selectedReviewURLs.clear();
+T.boardData.reviews = { unseen: 0, reviews: [
+  review('k1', 1, 'Fresh request', 'corveil/crow', 'sam', 'https://github.com/corveil/crow/pull/1', 1, null, 'create'),
+  review('k2', 2, 'Round 1 answered, author pushed', 'corveil/crow', 'sam', 'https://github.com/corveil/crow/pull/2', 2, 'sess-k2', 're_review'),
+  review('k3', 3, 'Covered at this head', 'corveil/crow', 'sam', 'https://github.com/corveil/crow/pull/3', 3, 'sess-k3', 'skip'),
+]};
+T.renderBoard();
+check('create → Start Review', countBtn('Start Review') === 1);
+check('re_review → Re-review', !!btn('Re-review'));
+check('skip → no kickoff button', countBtn('Start Review') === 1 && countBtn('Re-review') === 1);
+// The stale round is still reachable — "Re-review" retires it, so the user
+// should be able to read it first.
+check('both linked rows keep Go to Session', countBtn('Go to Session') === 2);
+check('a re-reviewable row is selectable for batch', (() => {
+  T.reviewSelectionMode = true; T.renderBoard();
+  const n = q('.row-check').length;
+  T.reviewSelectionMode = false; T.renderBoard();
+  return n === 2;   // k1 (create) + k2 (re_review); k3 (skip) is not
+})());
+check('skip row is the only dimmed one in select mode', (() => {
+  T.reviewSelectionMode = true; T.renderBoard();
+  const dim = [...q('.board-card.not-selectable')];
+  const ok = dim.length === 1 && /Covered at this head/.test(dim[0].textContent);
+  T.reviewSelectionMode = false; T.renderBoard();
+  return ok;
+})());
+// Re-review goes through `start-review` like everything else: one verb, and the
+// server owns the decision (the board's action is computed from a poll-stale
+// head, so it picks the label and must never suppress the call).
+check('Re-review dispatches start-review', (() => {
+  let sent = null;
+  const prevRpc = T.rpc;
+  T.rpc = async (method, params) => { sent = { method, params }; return {}; };
+  btn('Re-review').onclick();
+  T.rpc = prevRpc;
+  return sent && sent.method === 'start-review' && sent.params.url === 'https://github.com/corveil/crow/pull/2';
+})());
+T.boardData.reviews = reviewsPayload; T.renderBoard();
 
 // The daemon half of the flag has no `finally` to fall back on — it clears only
 // when a later `list-tickets` says so. These cover the paths where that never

--- a/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AutoRespondCoordinator.swift
@@ -107,15 +107,30 @@ public final class AutoRespondCoordinator {
         }
 
         let prNumber = QuickActionPrompts.parsePRNumber(from: prLink.url)
+        // Diff anchor, not round boundary (CROW-945): prefer the head the last
+        // in-place re-review was scoped from, so repeat passes review only what
+        // is new rather than replaying the delta from round 1 every time. Falls
+        // back to the session's creation head on the first re-review.
+        let diffAnchorSha = session?.lastReRequestedHeadSha ?? session?.lastReviewedHeadSha
         let prompt = QuickActionPrompts.build(
             action: action,
             codeBackend: resolveCodeBackend(forSessionID: sessionID),
             prURL: prLink.url,
             prNumber: prNumber,
-            lastReviewedHeadSha: session?.lastReviewedHeadSha
+            lastReviewedHeadSha: diffAnchorSha
         )
         CrowLog.info("[QuickAction] Sending \(action.rawValue) prompt to terminal \(terminal.id.uuidString) (\(prompt.count) chars)")
         TerminalRouter.send(terminal, text: prompt)
+        // Advance the anchor only once the prompt is actually out, and only for
+        // the in-place re-review — `lastReviewedHeadSha` stays where it is on
+        // purpose so the kickoff guard's head-advance fallback stays armed for
+        // this head if the agent stalls without posting a verdict.
+        if action == .reReview,
+           let headSha = appState.prStatus[sessionID]?.headSha,
+           !headSha.isEmpty,
+           let idx = appState.sessions.firstIndex(where: { $0.id == sessionID }) {
+            appState.sessions[idx].lastReRequestedHeadSha = headSha
+        }
         return .sent
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -388,31 +388,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 }
             },
             "list-reviews": { @Sendable _ in
-                await MainActor.run {
-                    let fmt = ISO8601DateFormatter()
-                    let reviews: [JSONValue] = capturedAppState.filteredReviewRequests.map { r in
-                        .object([
-                            "id": .string(r.id),
-                            "pr_number": .int(r.prNumber),
-                            "title": .string(r.title),
-                            "url": .string(r.url),
-                            "repo": .string(r.repo),
-                            "author": .string(r.author),
-                            "head_branch": .string(r.headBranch),
-                            "base_branch": .string(r.baseBranch),
-                            "is_draft": .bool(r.isDraft),
-                            "requested_at": r.requestedAt.map { .string(fmt.string(from: $0)) } ?? .null,
-                            "labels": .array(r.labels.map { .object(["name": .string($0.name), "color": $0.color.map { .string($0) } ?? .null]) }),
-                            "provider": .string(r.provider.rawValue),
-                            "review_session_id": r.reviewSessionID.map { .string($0.uuidString) } ?? .null,
-                        ])
-                    }
-                    return [
-                        "reviews": .array(reviews),
-                        "loading": .bool(capturedAppState.isLoadingReviews),
-                        "unseen": .int(capturedAppState.unseenReviewCount),
-                    ]
-                }
+                await MainActor.run { ReviewsPayload.build(appState: capturedAppState) }
             },
             "list-allowlist": { @Sendable _ in
                 await MainActor.run {

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -714,7 +714,7 @@ public final class IssueTracker {
             // can flip even if the other provider failed.
             let staleFetch = staleCandidateURLs.isEmpty
                 ? StalePRFetchResult(prs: [], complete: true)
-                : await fetchStalePRStates(urls: staleCandidateURLs)
+                : await fetchStalePRStates(urls: staleCandidateURLs, viewerLogin: ghResult.viewerLogin)
             let stalePRs = staleFetch.prs
             let prDataComplete = staleFetch.complete
             let allKnownPRs = Self.dedupedByURL(ghResult.viewerPRs + stalePRs)
@@ -918,6 +918,10 @@ public final class IssueTracker {
         let closedTotalCount: Int
         let viewerPRs: [ViewerPR]
         let reviewRequests: [ReviewRequest]
+        /// The authenticated user's login, carried so the stale-PR follow-up in
+        /// the *same* cycle can ask GitHub for the viewer's own latest verdict
+        /// (CROW-945). Empty when `listMonitoredPRs` failed or degraded.
+        let viewerLogin: String
         let rateLimit: GitHubRateLimit?
     }
 
@@ -995,6 +999,18 @@ public final class IssueTracker {
             // that doesn't select `reviewRequests` (the stale query, GitLab),
             // so a `true` from either record is the only informative value.
             hasPendingReviewRequest: winner.hasPendingReviewRequest || loser.hasPendingReviewRequest,
+            // Latest wins, nil-tolerantly — same "nil means not fetched" rule
+            // as the fields above (CROW-945). The viewer-PR query never selects
+            // this, so picking a side would drop the stale-PR query's answer
+            // (the only one there is) whenever the viewer record won the rank.
+            // Dropping it re-opens CROW-945: the round would stop closing.
+            viewerLastReviewedAt: [winner.viewerLastReviewedAt, loser.viewerLastReviewedAt]
+                .compactMap { $0 }.max(),
+            // `updatedAt` was silently dropped here until CROW-945 — the exact
+            // failure this banner warns about, in the function the banner is
+            // attached to. It tie-breaks reconcile when several non-OPEN PRs
+            // share a branch, so losing it made that choice arbitrary.
+            updatedAt: [winner.updatedAt, loser.updatedAt].compactMap { $0 }.max(),
             mergeCommitOid: winner.mergeCommitOid ?? loser.mergeCommitOid,
             // Prefer whichever record actually knows the repo's auto-merge
             // policy — the stale-PR query and the viewer fetch don't always
@@ -1089,6 +1105,7 @@ public final class IssueTracker {
             closedTotalCount: assigned.closedTotalCount,
             viewerPRs: monitored.viewerPRs,
             reviewRequests: monitored.reviewRequests,
+            viewerLogin: monitored.viewerLogin,
             rateLimit: assigned.rateLimit ?? monitored.rateLimit
         )
     }
@@ -1163,7 +1180,7 @@ public final class IssueTracker {
     /// `viewer.pullRequests(first: 50)`, or one in a SAML-restricted org (a
     /// permanent hole in that connection), reaches the UI only through here, so
     /// without `statusCheckRollup` it could never show CI state at all.
-    private func fetchStalePRStates(urls: [String]) async -> StalePRFetchResult {
+    private func fetchStalePRStates(urls: [String], viewerLogin: String) async -> StalePRFetchResult {
         // Bucket URLs by (provider, host). GitLab self-hosted needs the host so the
         // backend pins the right GITLAB_HOST env var.
         var githubRefs: [PRRef] = []
@@ -1198,7 +1215,7 @@ public final class IssueTracker {
         if !githubRefs.isEmpty {
             let backend = providerManager.codeBackend(for: .github)!
             do {
-                let states = try await backend.prStates(refs: githubRefs)
+                let states = try await backend.prStates(refs: githubRefs, viewerLogin: viewerLogin)
                 // Keying by PRRef means we don't lose records when the API
                 // returns a canonical URL different from the stored one.
                 // Fall back to the stored URL when the API didn't provide
@@ -1219,7 +1236,7 @@ public final class IssueTracker {
         for (host, refs) in gitlabByHost {
             let backend = providerManager.codeBackend(for: .gitlab, host: host)!
             do {
-                let states = try await backend.prStates(refs: refs)
+                let states = try await backend.prStates(refs: refs, viewerLogin: nil)
                 for ref in refs {
                     guard var rec = states[ref] else { continue }
                     if rec.url.isEmpty, let stored = gitlabURLByRef[ref] {
@@ -1269,6 +1286,7 @@ public final class IssueTracker {
             changesRequestedReviewerLogins: pr.changesRequestedReviewerLogins,
             pendingReviewerLogins: pr.pendingReviewerLogins,
             hasPendingReviewRequest: pr.hasPendingReviewRequest,
+            viewerLastReviewedAt: pr.viewerLastReviewedAt,
             updatedAt: pr.updatedAt,
             mergeCommitOid: pr.mergeCommitOid,
             repoAutoMergeAllowed: pr.repoAutoMergeAllowed
@@ -1303,6 +1321,15 @@ public final class IssueTracker {
             latestReviewStates: pr.latestReviewStates,
             lastChangesRequestedAt: pr.lastChangesRequestedAt,
             lastSubstantiveCommitAt: pr.lastSubstantiveCommitAt,
+            // These three were dropped here until CROW-945, contradicting the
+            // "preserves **every** field" claim above. `evaluateAutoMerge` is
+            // reached through this helper and reads them, and an empty
+            // `changesRequestedReviewerLogins` reads as `.noReviewers` — the
+            // same shape of silent blinding as #838.
+            changesRequestedReviewerLogins: pr.changesRequestedReviewerLogins,
+            pendingReviewerLogins: pr.pendingReviewerLogins,
+            hasPendingReviewRequest: pr.hasPendingReviewRequest,
+            viewerLastReviewedAt: pr.viewerLastReviewedAt,
             updatedAt: pr.updatedAt,
             mergeCommitOid: pr.mergeCommitOid,
             repoAutoMergeAllowed: pr.repoAutoMergeAllowed
@@ -3239,7 +3266,12 @@ public final class IssueTracker {
     /// it exists to survive an in-flight poll that started *before* the add
     /// (#838), and clearing it here would hand that clobber back its opening.
     private func reevaluateAutoMergeAfterLabel(session: Session, prURL: String) async {
-        let result = await fetchStalePRStates(urls: [prURL])
+        // Empty `viewerLogin` (i.e. "don't select it") — this re-reads the
+        // viewer's *own* PR to decide auto-merge, and nobody reviews their own
+        // PR, so asking for `viewerLastReviewedAt` here would spend query
+        // budget on a field that is structurally always nil. Only the
+        // review-session path needs it.
+        let result = await fetchStalePRStates(urls: [prURL], viewerLogin: "")
         var byURL = Dictionary(result.prs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
         // Read-your-write: `backend.addMergeLabel` threw on failure, so the
@@ -4245,8 +4277,24 @@ public final class IssueTracker {
     /// Rules 2 + 3 require the PR to be present in `prsByURL` with the
     /// matching state and `prDataComplete == true` so the old "missing
     /// from open review queue == done" rule isn't reintroduced under
-    /// partial fetches. Rule 1 only needs the `ReviewRequest` payload (the
-    /// PR is still open at this point so it's always present in `reviewRequestsByPRURL`).
+    /// partial fetches.
+    ///
+    /// Rule 1 reads **two** sources and fires on the later of them (CROW-945).
+    /// `reviewRequestsByPRURL` alone could not work: it is built from the
+    /// `review-requested:@me` search, and GitHub clears the pending request the
+    /// instant the viewer submits a review, so the PR leaves that search at
+    /// exactly the moment the round should close. A rule sourced only from it
+    /// could fire only by winning a race against GitHub's search index — which
+    /// is why, in practice, review rounds never closed at all. `prsByURL`
+    /// carries the same verdict read off the PR itself, which survives the
+    /// request being consumed.
+    ///
+    /// Rule 1 is deliberately **not** gated on `prDataComplete`, including its
+    /// new `prsByURL` branch. That flag exists to stop *absence* being read as
+    /// evidence; rule 1 is *presence*-based — a degraded fetch yields no entry,
+    /// hence a nil timestamp, hence no decision. Gating it would make the fix
+    /// silently miss on any cycle where an unrelated provider errored, which is
+    /// the same over-conservatism that leaves rounds open.
     nonisolated static func decideReviewCompletions(
         reviewSessions: [Session],
         linksBySessionID: [UUID: [SessionLink]],
@@ -4261,9 +4309,11 @@ public final class IssueTracker {
             guard let prLink = sessionLinks.first(where: { $0.linkType == .pr }) else { continue }
 
             // Rule 1: viewer-submitted review after the session was created.
-            if let request = reviewRequestsByPRURL[prLink.url],
-               let reviewedAt = request.viewerLastReviewedAt,
-               reviewedAt > session.createdAt {
+            let reviewedAt = [
+                reviewRequestsByPRURL[prLink.url]?.viewerLastReviewedAt,
+                prsByURL[prLink.url]?.viewerLastReviewedAt,
+            ].compactMap { $0 }.max()
+            if let reviewedAt, reviewedAt > session.createdAt {
                 decisions.append(CompletionDecision(sessionID: session.id, reason: "viewer submitted review"))
                 continue
             }
@@ -4330,13 +4380,25 @@ public final class IssueTracker {
 
     /// Auto-complete review sessions whose PR has been merged or closed.
     /// Delegates to `decideReviewCompletions` for testability.
+    ///
+    /// The candidate filter matches `AppState.reviewSessions` (which excludes
+    /// only `.completed`/`.archived`), `collectStalePRURLs`, and
+    /// `autoCompleteFinishedSessions` — deliberately, because those are the
+    /// statuses that keep a session shadowing its PR. Filtering to `.active`
+    /// alone (as this did before CROW-945) left a `.paused` or `.inReview`
+    /// review session visible to `existingReviewSession(forPRURL:)` forever
+    /// with no rule anywhere able to complete it, so the PR could never start
+    /// another round.
     private func autoCompleteFinishedReviews(
         openReviewPRURLs: Set<String>,
         prsByURL: [String: ViewerPR],
         reviewRequestsByPRURL: [String: ReviewRequest],
         prDataComplete: Bool
     ) {
-        let activeReviews = appState.sessions.filter { $0.kind == .review && $0.status == .active }
+        let activeReviews = appState.sessions.filter {
+            $0.kind == .review
+                && ($0.status == .active || $0.status == .paused || $0.status == .inReview)
+        }
         var linksBySessionID: [UUID: [SessionLink]] = [:]
         for session in activeReviews {
             linksBySessionID[session.id] = appState.links(for: session.id)

--- a/Packages/CrowEngine/Sources/CrowEngine/ReviewsPayload.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/ReviewsPayload.swift
@@ -1,0 +1,79 @@
+import Foundation
+import CrowCore
+import CrowIPC
+
+/// The `list-reviews` RPC payload, in one place.
+///
+/// Both routers — `CrowDaemon.RPCHandlers` (the Unix socket, i.e. `crow
+/// list-reviews`) and `EngineRouter` (the web `/rpc`) — answer this verb, and
+/// until CROW-945 each carried its own byte-identical copy of the mapping. The
+/// CLI and the browser therefore agreed only by accident of copy-paste, which
+/// is precisely the drift you don't want under a field that decides which
+/// button a card renders.
+public enum ReviewsPayload {
+
+    /// Build the payload from live state.
+    ///
+    /// `kickoff_action` is computed **here, at serialization time**, not stamped
+    /// onto `ReviewRequest` when the board is assembled: `appState.reviewRequests`
+    /// refreshes at most once a poll while the board re-renders far more often,
+    /// so an assembly-time verdict would be stale the moment a session was
+    /// created or completed. Reading live `sessions`/`links` on each call keeps
+    /// the label consistent with what the button will actually do.
+    ///
+    /// It is still only an **estimate**: it uses `request.headRefOid` (a board
+    /// snapshot) whereas `SessionService.createReviewSession` decides against a
+    /// head it fetches itself. The client must therefore treat this as a label
+    /// and never suppress the RPC on it — the server is the decider.
+    @MainActor
+    public static func build(appState: AppState) -> [String: JSONValue] {
+        let fmt = ISO8601DateFormatter()
+        let reviews: [JSONValue] = appState.filteredReviewRequests.map { r in
+            let existing = appState.existingReviewSession(forPRURL: r.url)
+            let linked = r.reviewSessionID.flatMap { id in
+                appState.sessions.first(where: { $0.id == id })
+            } ?? existing
+            let action = IssueTracker.reviewKickoffAction(
+                reviewSessionID: r.reviewSessionID ?? existing?.id,
+                headRefOid: r.headRefOid,
+                linkedSession: linked,
+                existingByPRSessionID: existing?.id
+            )
+            return .object([
+                "id": .string(r.id),
+                "pr_number": .int(r.prNumber),
+                "title": .string(r.title),
+                "url": .string(r.url),
+                "repo": .string(r.repo),
+                "author": .string(r.author),
+                "head_branch": .string(r.headBranch),
+                "base_branch": .string(r.baseBranch),
+                "is_draft": .bool(r.isDraft),
+                "requested_at": r.requestedAt.map { .string(fmt.string(from: $0)) } ?? .null,
+                "labels": .array(r.labels.map {
+                    .object(["name": .string($0.name), "color": $0.color.map { .string($0) } ?? .null])
+                }),
+                "provider": .string(r.provider.rawValue),
+                "review_session_id": r.reviewSessionID.map { .string($0.uuidString) } ?? .null,
+                "head_ref_oid": r.headRefOid.map { .string($0) } ?? .null,
+                "kickoff_action": .string(actionName(action)),
+            ])
+        }
+        return [
+            "reviews": .array(reviews),
+            "loading": .bool(appState.isLoadingReviews),
+            "unseen": .int(appState.unseenReviewCount),
+        ]
+    }
+
+    /// Wire names for `IssueTracker.ReviewKickoffAction`. Kept as a total switch
+    /// (no `default`) so adding a case to the enum fails the build here rather
+    /// than silently serializing as something the board doesn't handle.
+    static func actionName(_ action: IssueTracker.ReviewKickoffAction) -> String {
+        switch action {
+        case .create: return "create"
+        case .reReview: return "re_review"
+        case .skip: return "skip"
+        }
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -2844,17 +2844,8 @@ public final class SessionService {
     /// what produced the SwiftUI reentrant-layout crash in #266.
     @discardableResult
     public func createReviewSession(prURL: String, selectAfterCreate: Bool = false) async -> UUID? {
-        // Universal backstop against duplicate sessions for the same PR. The
-        // serial kickoff queue in AppDelegate guarantees that by the time a
-        // second `createReviewSession` runs, the first has already appended
-        // its row to `appState.sessions` — so this check is authoritative,
-        // not racy. Belt-and-suspenders for the auto-review watcher race
-        // (CROW-406) and any future caller that re-enters during a kickoff.
-        if let existing = appState.existingReviewSession(forPRURL: prURL) {
-            CrowLog.info("[SessionService] Skipping duplicate review session for \(prURL); reusing \(existing.id)")
-            if selectAfterCreate { appState.selectedSessionID = existing.id }
-            return existing.id
-        }
+        // The duplicate/round guard lives *below*, after `fetchPRMetadata`,
+        // because deciding it needs the PR's real head — see the note there.
 
         // Parse org/repo and PR number from URL like "https://github.com/org/repo/pull/123"
         guard let parsed = Session.parseReviewPR(url: prURL) else {
@@ -2899,6 +2890,54 @@ public final class SessionService {
         } catch {
             CrowLog.info("[SessionService] Failed to fetch PR metadata for \(prURL): \(error.localizedDescription)")
             return nil
+        }
+
+        // Duplicate/round guard — the *one* kickoff decision, run through the
+        // same pure function the daemon's auto-review hook uses so the
+        // manual/board path and the `autoReviewRepos` path can't disagree about
+        // whether a round is still open (CROW-945; before this there were two
+        // divergent dedup rules and only the auto path could ever re-review).
+        //
+        // Deliberately placed here, after the metadata fetch, for two reasons.
+        // It needs the PR's *real* head to tell "already covered" from "the
+        // author pushed and this is a new round" — `appState.reviewRequests` is
+        // up to a poll stale and is simply absent for a PR hidden by the board
+        // filters or for a voluntary `crow start-review` on a PR nobody asked
+        // you to review, which would pin the decision to `.skip` forever with
+        // no way out. And reading `existingReviewSession` *after* the awaits
+        // keeps the CROW-406 property the old top-of-function check had: a
+        // session that landed while we were fetching is still seen. (Callers
+        // are serialized on the review kickoff queue, so this is belt and
+        // braces.) The fetch is not extra work — the clone below needs it
+        // regardless.
+        if let existing = appState.existingReviewSession(forPRURL: prURL) {
+            let action = IssueTracker.reviewKickoffAction(
+                reviewSessionID: existing.id,
+                headRefOid: prMetadata.headRefOid,
+                linkedSession: existing,
+                existingByPRSessionID: existing.id
+            )
+            switch action {
+            case .skip, .create:
+                // `.create` is unreachable here (it requires no existing
+                // session) — treat it as `.skip` rather than racing the live
+                // session with a second one for the same PR.
+                CrowLog.info("[SessionService] Skipping duplicate review session for \(prURL); reusing \(existing.id)")
+                if selectAfterCreate { appState.selectedSessionID = existing.id }
+                return existing.id
+            case .reReview(let staleID):
+                // Retire the stale round before creating the new one. Called
+                // directly rather than through `appState.onCompleteSession`:
+                // that callback is optional and only CrowDaemon wires it, so a
+                // nil one would complete nothing and then leave two live
+                // sessions on one PR — the CROW-406 double-session this guard
+                // exists to prevent. Completing (not deleting) also writes the
+                // round's end-of-run analytics snapshot, and makes it invisible
+                // to `existingReviewSession`, which is what lets the create
+                // below proceed.
+                CrowLog.info("[SessionService] PR head advanced past review session \(staleID); completing it and starting a new round for \(prURL)")
+                completeSession(id: staleID)
+            }
         }
 
         let prep: ReviewClonePrep

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerCompletionTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerCompletionTests.swift
@@ -58,7 +58,8 @@ struct IssueTrackerCompletionTests {
     private func makeViewerPR(
         url: String,
         state: String,
-        number: Int = 1
+        number: Int = 1,
+        viewerLastReviewedAt: Date? = nil
     ) -> IssueTracker.ViewerPR {
         IssueTracker.ViewerPR(
             number: number,
@@ -76,7 +77,8 @@ struct IssueTrackerCompletionTests {
             linkedIssueReferences: [],
             checksState: "",
             failedCheckNames: [],
-            latestReviewStates: []
+            latestReviewStates: [],
+            viewerLastReviewedAt: viewerLastReviewedAt
         )
     }
 
@@ -419,6 +421,122 @@ struct IssueTrackerCompletionTests {
         #expect(decisions == [
             IssueTracker.CompletionDecision(sessionID: reviewSession.id, reason: "viewer submitted review")
         ])
+    }
+
+    // MARK: - Round closes from the PR, not the request search (CROW-945)
+
+    @Test
+    func viewerReviewFromPRCompletesWithoutAnyReviewRequest() {
+        // THE regression test for CROW-945. GitHub clears the pending review
+        // request the instant the viewer submits a review, so the PR leaves the
+        // `review-requested:@me` search at exactly the moment the round should
+        // close — `reviewRequestsByPRURL` is empty here for that reason, which
+        // is the normal steady state, not an edge case. The verdict read off
+        // the PR itself must still close the round; when it didn't, the session
+        // stayed active forever and the board offered only "Go to Session".
+        let reviewSession = makeSession(kind: .review, createdAt: Date().addingTimeInterval(-3600))
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let pr = makeViewerPR(url: prURL, state: "OPEN", viewerLastReviewedAt: Date())
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [],
+            prsByURL: [prURL: pr],
+            reviewRequestsByPRURL: [:],
+            prDataComplete: true
+        )
+        #expect(decisions == [
+            IssueTracker.CompletionDecision(sessionID: reviewSession.id, reason: "viewer submitted review")
+        ])
+    }
+
+    @Test
+    func viewerReviewFromPRIsNotGatedOnPRDataComplete() {
+        // The PR-sourced branch is presence-based, so a degraded cycle can only
+        // ever make it silent (no entry -> nil -> no decision) — it can never
+        // make it wrong. Gating it on `prDataComplete` would therefore buy no
+        // safety and would make rounds stay open whenever an unrelated provider
+        // errored, which is the over-conservatism CROW-945 was about.
+        let reviewSession = makeSession(kind: .review, createdAt: Date().addingTimeInterval(-3600))
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let pr = makeViewerPR(url: prURL, state: "OPEN", viewerLastReviewedAt: Date())
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [],
+            prsByURL: [prURL: pr],
+            reviewRequestsByPRURL: [:],
+            prDataComplete: false
+        )
+        #expect(decisions.count == 1)
+    }
+
+    @Test
+    func prPresentWithNoViewerVerdictDoesNotComplete() {
+        // The counterpart to `reviewMissingFromPayloadDoesNotComplete`, which
+        // covers *absence*. Now that the PR is a source for rule 1, its
+        // *presence* with a nil timestamp must stay a non-decision: nil means
+        // "not fetched" (GitLab, or a cycle where the viewer login was
+        // unknown), never "the viewer declined to review".
+        let reviewSession = makeSession(kind: .review, createdAt: Date().addingTimeInterval(-3600))
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let pr = makeViewerPR(url: prURL, state: "OPEN", viewerLastReviewedAt: nil)
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [prURL: pr],
+            reviewRequestsByPRURL: [:],
+            prDataComplete: true
+        )
+        #expect(decisions.isEmpty)
+    }
+
+    @Test
+    func prReviewPredatingSessionDoesNotCompleteTheNewRound() {
+        // Round 2's session must not be closed by round 1's verdict. This is
+        // the failure mode the PR-sourced branch could introduce that the
+        // search-sourced one could not: the search dropped the PR after a
+        // review, whereas the PR keeps reporting that old verdict on every
+        // poll, forever. Only the `> session.createdAt` compare stops a fresh
+        // round being completed the moment it starts.
+        let round1ReviewedAt = Date().addingTimeInterval(-7200)
+        let round2 = makeSession(kind: .review, createdAt: Date().addingTimeInterval(-3600))
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let pr = makeViewerPR(url: prURL, state: "OPEN", viewerLastReviewedAt: round1ReviewedAt)
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [round2],
+            linksBySessionID: [round2.id: [prLink(sessionID: round2.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [prURL: pr],
+            reviewRequestsByPRURL: [:],
+            prDataComplete: true
+        )
+        #expect(decisions.isEmpty)
+    }
+
+    @Test
+    func laterOfTheTwoViewerReviewSourcesWins() {
+        // Both sources can be populated in the same cycle (the author
+        // re-requested, so the PR is back in the search while the PR itself
+        // still reports the verdict). Take the later timestamp rather than
+        // preferring one source: a stale search row must not veto a fresh
+        // verdict, nor the reverse.
+        let sessionStart = Date().addingTimeInterval(-3600)
+        let reviewSession = makeSession(kind: .review, createdAt: sessionStart)
+        let prURL = "https://github.com/foo/bar/pull/9"
+        // Search row predates the session (round 1); the PR carries round 2's.
+        let request = makeReviewRequest(url: prURL, viewerLastReviewedAt: sessionStart.addingTimeInterval(-3600))
+        let pr = makeViewerPR(url: prURL, state: "OPEN", viewerLastReviewedAt: Date())
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [prURL: pr],
+            reviewRequestsByPRURL: [prURL: request],
+            prDataComplete: true
+        )
+        #expect(decisions.count == 1)
     }
 
     // MARK: - Auto-Cleanup

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerDedupTests.swift
@@ -28,7 +28,9 @@ struct IssueTrackerDedupTests {
         lastSubstantiveCommitAt: Date? = nil,
         changesRequestedReviewerLogins: [String] = [],
         pendingReviewerLogins: [String] = [],
-        hasPendingReviewRequest: Bool = false
+        hasPendingReviewRequest: Bool = false,
+        viewerLastReviewedAt: Date? = nil,
+        updatedAt: Date? = nil
     ) -> IssueTracker.ViewerPR {
         IssueTracker.ViewerPR(
             number: number,
@@ -51,7 +53,9 @@ struct IssueTrackerDedupTests {
             lastSubstantiveCommitAt: lastSubstantiveCommitAt,
             changesRequestedReviewerLogins: changesRequestedReviewerLogins,
             pendingReviewerLogins: pendingReviewerLogins,
-            hasPendingReviewRequest: hasPendingReviewRequest
+            hasPendingReviewRequest: hasPendingReviewRequest,
+            viewerLastReviewedAt: viewerLastReviewedAt,
+            updatedAt: updatedAt
         )
     }
 
@@ -245,12 +249,16 @@ struct IssueTrackerDedupTests {
         // this when `PRRecord` grows — the initializer defaults mean an
         // omission in `mergePRRecords` compiles silently.
         let url = "https://github.com/corveil/crow/pull/836"
+        let stamp = Date(timeIntervalSince1970: 1780740000)
         let viewer = makeViewerPR(
             url: url, state: "OPEN", labels: [Self.crowMerge],
             changesRequestedReviewerLogins: ["dgershman"],
             pendingReviewerLogins: ["someoneelse"],
-            hasPendingReviewRequest: true)
-        let stale = makeViewerPR(url: url, state: "MERGED", labels: [])
+            hasPendingReviewRequest: true,
+            updatedAt: stamp)
+        let stale = makeViewerPR(
+            url: url, state: "MERGED", labels: [],
+            viewerLastReviewedAt: stamp)
         let deduped = IssueTracker.dedupedByURL([viewer, stale])
         #expect(deduped.count == 1)
         #expect(hasCrowMerge(deduped[0]))
@@ -259,6 +267,14 @@ struct IssueTrackerDedupTests {
         #expect(deduped[0].changesRequestedReviewerLogins == ["dgershman"])
         #expect(deduped[0].pendingReviewerLogins == ["someoneelse"])
         #expect(deduped[0].hasPendingReviewRequest)
+        // CROW-945. `viewerLastReviewedAt` arrives ONLY from the stale record
+        // (the viewer-PR query never selects it) and the stale record wins the
+        // state rank here, so both merge directions have to carry it — dropping
+        // it stops review rounds closing, which is the whole bug.
+        #expect(deduped[0].viewerLastReviewedAt == stamp)
+        // `updatedAt` arrives only from the viewer record, i.e. the loser.
+        // It was silently dropped before CROW-945.
+        #expect(deduped[0].updatedAt == stamp)
     }
 
     @Test func mergePRRecordsCarriesReviewerFieldsFromEitherSide() {

--- a/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/QuickActionPromptsTests.swift
@@ -16,7 +16,7 @@ private struct FakeCodeBackend: CodeBackend {
     func listMonitoredPRs() async throws -> MonitoredPRListing {
         MonitoredPRListing(viewerPRs: [], reviewRequests: [], viewerLogin: "")
     }
-    func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] { [:] }
+    func prStates(refs: [PRRef], viewerLogin: String?) async throws -> [PRRef: PRRecord] { [:] }
     func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo] { [] }
     func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch] { [] }
     func enableAutoMerge(prURL: String) async throws {}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/ReviewsPayloadTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/ReviewsPayloadTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowIPC
+import CrowProvider
+@testable import CrowEngine
+
+/// The `list-reviews` payload (CROW-945).
+///
+/// Two things are under test here. First, that `kickoff_action` reports what
+/// `SessionService.createReviewSession` would actually do — the board used to
+/// gate its button on "does a non-completed session link to this PR", which is
+/// a much weaker question than "has this review round been answered", so a
+/// re-requested PR rendered only "Go to Session" pointing at a dead round.
+/// Second, that both routers answer from this one builder: `RPCHandlers` (the
+/// socket, i.e. `crow list-reviews`) and `EngineRouter` (the web `/rpc`) each
+/// carried a byte-identical copy before, so the CLI and the browser agreed only
+/// by accident of copy-paste.
+@Suite("list-reviews payload")
+@MainActor
+struct ReviewsPayloadTests {
+
+    private func makeRequest(
+        url: String,
+        headRefOid: String? = nil,
+        reviewSessionID: UUID? = nil
+    ) -> ReviewRequest {
+        ReviewRequest(
+            id: "github:foo/bar#9",
+            prNumber: 9,
+            title: "Review me",
+            url: url,
+            repo: "foo/bar",
+            author: "alice",
+            headBranch: "feature",
+            baseBranch: "main",
+            reviewSessionID: reviewSessionID,
+            headRefOid: headRefOid
+        )
+    }
+
+    private func makeState(
+        request: ReviewRequest,
+        session: Session? = nil
+    ) -> AppState {
+        let state = AppState()
+        state.reviewRequests = [request]
+        if let session {
+            state.sessions = [session]
+            state.links[session.id] = [
+                SessionLink(sessionID: session.id, label: "PR", url: request.url, linkType: .pr)
+            ]
+        }
+        return state
+    }
+
+    private func firstReview(_ payload: [String: JSONValue]) throws -> [String: JSONValue] {
+        guard case let .array(reviews)? = payload["reviews"],
+              case let .object(first)? = reviews.first else {
+            throw TestFailure.missingReview
+        }
+        return first
+    }
+
+    private enum TestFailure: Error { case missingReview }
+
+    private func action(_ review: [String: JSONValue]) -> String? {
+        guard case let .string(s)? = review["kickoff_action"] else { return nil }
+        return s
+    }
+
+    @Test
+    func unclaimedReviewOffersCreate() throws {
+        let request = makeRequest(url: "https://github.com/foo/bar/pull/9", headRefOid: "sha-a")
+        let payload = ReviewsPayload.build(appState: makeState(request: request))
+        #expect(action(try firstReview(payload)) == "create")
+    }
+
+    @Test
+    func liveRoundAtTheSameHeadSkips() throws {
+        let session = Session(
+            name: "review", kind: .review,
+            lastReviewedHeadSha: "sha-a"
+        )
+        let request = makeRequest(
+            url: "https://github.com/foo/bar/pull/9",
+            headRefOid: "sha-a",
+            reviewSessionID: session.id
+        )
+        let payload = ReviewsPayload.build(appState: makeState(request: request, session: session))
+        #expect(action(try firstReview(payload)) == "skip")
+    }
+
+    /// THE CROW-945 board symptom. Round 1's session is still linked and the
+    /// author has pushed + re-requested, so the head has moved past what that
+    /// session reviewed. The board must offer the next round rather than only
+    /// "Go to Session" — which was the state with no way forward short of
+    /// deleting the session by hand.
+    @Test
+    func advancedHeadOffersReReview() throws {
+        let session = Session(
+            name: "review", kind: .review,
+            lastReviewedHeadSha: "sha-a"
+        )
+        let request = makeRequest(
+            url: "https://github.com/foo/bar/pull/9",
+            headRefOid: "sha-b",
+            reviewSessionID: session.id
+        )
+        let payload = ReviewsPayload.build(appState: makeState(request: request, session: session))
+        #expect(action(try firstReview(payload)) == "re_review")
+    }
+
+    /// A completed round stops shadowing the PR: `existingReviewSession`
+    /// excludes completed/archived, so the next request reads as a fresh one.
+    /// This is what rule 1 buys once it can actually fire.
+    @Test
+    func completedRoundNoLongerShadowsThePR() throws {
+        var session = Session(
+            name: "review", kind: .review,
+            lastReviewedHeadSha: "sha-a"
+        )
+        session.status = .completed
+        // `reviewSessionID` is nil because `IssueTracker` only cross-references
+        // against `reviewSessions`, which excludes completed ones.
+        let request = makeRequest(url: "https://github.com/foo/bar/pull/9", headRefOid: "sha-a")
+        let payload = ReviewsPayload.build(appState: makeState(request: request, session: session))
+        #expect(action(try firstReview(payload)) == "create")
+    }
+
+    /// The cross-reference lags the actual session by up to a poll, so the
+    /// action must also consult the authoritative link-based lookup — otherwise
+    /// the ~10s clone window reads as "nothing covers this PR" and double-kicks
+    /// (CROW-406). Note the session carries the head it was created against:
+    /// `createReviewSession` stamps `lastReviewedHeadSha` from the PR metadata
+    /// it fetched, so a just-created round is never mistaken for a stale one.
+    @Test
+    func inFlightKickoffIsSkippedBeforeCrossRefLands() throws {
+        let session = Session(name: "review", kind: .review, lastReviewedHeadSha: "sha-a")
+        // `reviewSessionID` nil — IssueTracker hasn't re-polled yet.
+        let request = makeRequest(url: "https://github.com/foo/bar/pull/9", headRefOid: "sha-a")
+        let payload = ReviewsPayload.build(appState: makeState(request: request, session: session))
+        #expect(action(try firstReview(payload)) == "skip")
+    }
+
+    /// A linked session with no recorded head reads as re-reviewable. That's
+    /// `reviewKickoffAction`'s long-standing rule (an unknown head can't be
+    /// shown to cover the current one) and it now reaches the board and the
+    /// manual path, not just the `autoReviewRepos` watcher — so pin it. In
+    /// practice this is only legacy sessions predating CROW-290; nothing
+    /// auto-fires from it, since the board needs a click and the auto path
+    /// needs `autoReviewRepos`.
+    @Test
+    func linkedSessionWithNoRecordedHeadOffersReReview() throws {
+        let session = Session(name: "review", kind: .review, lastReviewedHeadSha: nil)
+        let request = makeRequest(
+            url: "https://github.com/foo/bar/pull/9",
+            headRefOid: "sha-a",
+            reviewSessionID: session.id
+        )
+        let payload = ReviewsPayload.build(appState: makeState(request: request, session: session))
+        #expect(action(try firstReview(payload)) == "re_review")
+    }
+
+    /// No head from the provider → never re-review on a guess. `shaAdvanced`
+    /// requires a known head, so an unfetched one leaves the round alone.
+    @Test
+    func unknownHeadNeverReReviews() throws {
+        let session = Session(name: "review", kind: .review, lastReviewedHeadSha: "sha-a")
+        let request = makeRequest(
+            url: "https://github.com/foo/bar/pull/9",
+            headRefOid: nil,
+            reviewSessionID: session.id
+        )
+        let payload = ReviewsPayload.build(appState: makeState(request: request, session: session))
+        #expect(action(try firstReview(payload)) == "skip")
+    }
+
+    /// `requested_at` was permanently nil in production (the fractional-seconds
+    /// formatter), which blanked the board's relative-time chip and collapsed
+    /// its "newest first" sort to `.distantPast` for every row.
+    @Test
+    func requestedAtAndHeadAreSerialized() throws {
+        var request = makeRequest(url: "https://github.com/foo/bar/pull/9", headRefOid: "sha-a")
+        request.requestedAt = Date(timeIntervalSince1970: 1780740000)
+        let review = try firstReview(ReviewsPayload.build(appState: makeState(request: request)))
+        guard case let .string(stamp)? = review["requested_at"] else {
+            Issue.record("requested_at missing"); return
+        }
+        #expect(stamp.hasPrefix("2026-06-06T10:00:00"))
+        #expect(review["head_ref_oid"] == .string("sha-a"))
+    }
+
+    /// Total switch over the enum — a new case must fail the build here rather
+    /// than serialize as something the board silently doesn't handle.
+    @Test
+    func actionNamesAreStable() {
+        #expect(ReviewsPayload.actionName(.create) == "create")
+        #expect(ReviewsPayload.actionName(.skip) == "skip")
+        #expect(ReviewsPayload.actionName(.reReview(staleSessionID: UUID())) == "re_review")
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -109,6 +109,22 @@ public struct PRRecord: Sendable {
     /// non-empty `changesRequestedReviewerLogins`, neither of which those paths
     /// populate either, so an unknown here can't provoke a spurious re-request.
     public let hasPendingReviewRequest: Bool
+    /// When the *viewer* last submitted a formal verdict (APPROVED /
+    /// CHANGES_REQUESTED / DISMISSED) on this PR. `nil` means "not fetched",
+    /// never "no review" — the viewer-PR query and GitLab don't select it.
+    ///
+    /// This is what closes a review round (CROW-945). It has to be read off
+    /// the PR rather than off the `review-requested:@me` search, because
+    /// GitHub clears the pending request the instant the viewer submits a
+    /// review — so the search stops carrying the PR at exactly the moment the
+    /// round should close, and a rule sourced from it could only ever fire by
+    /// winning a race against GitHub's search index.
+    ///
+    /// COMMENTED and PENDING reviews are deliberately excluded upstream (the
+    /// GraphQL `states:` filter): `crow-review-pr` mandates
+    /// `--request-changes`/`--approve` and forbids `--comment`, so a comment
+    /// carries notes, not a verdict, and must leave the round open.
+    public let viewerLastReviewedAt: Date?
     /// Used by reconcile tie-breaking when multiple non-OPEN PRs exist on the same branch.
     public let updatedAt: Date?
     /// SHA of the merge/squash commit on the base branch. Populated only by
@@ -147,6 +163,7 @@ public struct PRRecord: Sendable {
         changesRequestedReviewerLogins: [String] = [],
         pendingReviewerLogins: [String] = [],
         hasPendingReviewRequest: Bool = false,
+        viewerLastReviewedAt: Date? = nil,
         updatedAt: Date? = nil,
         mergeCommitOid: String? = nil,
         repoAutoMergeAllowed: Bool? = nil
@@ -172,6 +189,7 @@ public struct PRRecord: Sendable {
         self.changesRequestedReviewerLogins = changesRequestedReviewerLogins
         self.pendingReviewerLogins = pendingReviewerLogins
         self.hasPendingReviewRequest = hasPendingReviewRequest
+        self.viewerLastReviewedAt = viewerLastReviewedAt
         self.updatedAt = updatedAt
         self.mergeCommitOid = mergeCommitOid
         self.repoAutoMergeAllowed = repoAutoMergeAllowed
@@ -200,9 +218,20 @@ public enum IssueBody {
 /// Tolerant ISO-8601 parsing shared across backends (#751). Providers are
 /// inconsistent about fractional seconds — GitHub GraphQL emits the plain form
 /// (`2026-06-15T01:28:17Z`) while GitLab/others may include `.SSS`. A formatter
-/// pinned to one shape silently returns nil for the other (the CROW-508 trap;
-/// see `GitHubCodeBackend.parseGitHubDateTime`), which quietly disables any
-/// feature that depends on the parsed date. Try plain first, then fractional.
+/// pinned to one shape silently returns nil for the other, which quietly
+/// disables any feature that depends on the parsed date. Try plain first
+/// (matches what GitHub actually emits today), then fractional for resilience
+/// against future API drift.
+///
+/// **This is the only sanctioned way to parse a provider timestamp.** Do not
+/// hand-roll an `ISO8601DateFormatter` in a backend — the trap has now bitten
+/// three times, always the same way and always silently: CROW-508 left
+/// `needsRefine` inert (PR #509 review), and CROW-945 left
+/// `ReviewRequest.viewerLastReviewedAt` and `requestedAt` permanently nil,
+/// which meant a review round could never close and the Reviews board's
+/// "requested" chip never rendered. Nothing fails loudly when a formatter
+/// mismatches — the feature just stops existing — so the fix is to have one
+/// implementation rather than to be careful at each call site.
 public enum IssueDate {
     public static func parse(_ raw: String?) -> Date? {
         guard let raw else { return nil }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -100,8 +100,40 @@ public struct GitHubCodeBackend: CodeBackend {
     /// by a few requests of granularity. Re-add the block and a return-shape
     /// tuple if that granularity ever starts mattering.
 
-    public func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] {
+    public func prStates(refs: [PRRef], viewerLogin: String?) async throws -> [PRRef: PRRecord] {
         guard !refs.isEmpty else { return [:] }
+        // The viewer's own latest *verdict* on each PR (CROW-945). This is the
+        // signal that closes a review round, and it has to come from the PR
+        // itself: the `review-requested:@me` search that used to be its only
+        // source drops the PR the instant the viewer submits a review, i.e.
+        // exactly when the round should close. A review session's PR is
+        // authored by someone else, so it is never in `viewerPRs` and always
+        // lands here — this query already runs every poll, so the signal costs
+        // no extra API call.
+        //
+        // `states:` is load-bearing, not decoration. GraphQL's
+        // `viewerLatestReview` takes no arguments and returns the latest review
+        // of ANY state, so a follow-up `--comment` review (COMMENTED) or an
+        // unsubmitted draft (PENDING, null `submittedAt`) would mask a real
+        // CHANGES_REQUESTED verdict and reproduce CROW-945 through a new field.
+        // Filtering server-side also beats scanning `reviews(last: 20)`: one
+        // node per alias instead of twenty, and immune to the >20-review
+        // truncation that the search path's unfiltered scan still has.
+        //
+        // Omitted entirely when the login is unknown (a failed
+        // `listMonitoredPRs` earlier in the cycle), leaving the field nil —
+        // "not fetched", never "no review". See `PRRecord`.
+        let viewer = viewerLogin?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        // Sorted so the query text is stable across runs (a Set's iteration
+        // order is not) — an unstable query string would defeat any response
+        // caching and make diffing two `gh` invocations pointless.
+        let states = Self.roundClosingReviewStates.sorted().joined(separator: ", ")
+        let reviewsSelection = viewer.isEmpty ? "" : """
+
+                  reviews(last: 1, author: $viewer, states: [\(states)]) {
+                    nodes { state submittedAt }
+                  }
+            """
         var queryParts: [String] = []
         var args: [String] = ["gh", "api", "graphql"]
         for (i, ref) in refs.enumerated() {
@@ -122,7 +154,7 @@ public struct GitHubCodeBackend: CodeBackend {
                         ... on StatusContext { context state }
                       }
                     }
-                  }
+                  }\(reviewsSelection)
                 }
               }
             """)
@@ -133,6 +165,12 @@ public struct GitHubCodeBackend: CodeBackend {
         var varDecls: [String] = []
         for i in 0..<refs.count {
             varDecls.append("$owner\(i): String!, $repo\(i): String!, $num\(i): Int!")
+        }
+        if !viewer.isEmpty {
+            varDecls.append("$viewer: String!")
+            // `-f`, not `-F`: `-F` type-infers, so an all-digit login would be
+            // sent as an Int and fail the `String!` variable.
+            args.append(contentsOf: ["-f", "viewer=\(viewer)"])
         }
         let query = """
         query(\(varDecls.joined(separator: ", "))) {
@@ -293,8 +331,6 @@ public struct GitHubCodeBackend: CodeBackend {
     static func parseKeyPRMatches(_ output: String, candidate: KeyCandidate) -> [KeyPRMatch] {
         guard let data = output.data(using: .utf8),
               let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
-        let dateFmt = ISO8601DateFormatter()
-        dateFmt.formatOptions = [.withInternetDateTime]
         let needle = candidate.key.lowercased()
         var matches: [KeyPRMatch] = []
         for node in arr {
@@ -304,7 +340,7 @@ public struct GitHubCodeBackend: CodeBackend {
             let title = (node["title"] as? String ?? "").lowercased()
             let head = (node["headRefName"] as? String ?? "").lowercased()
             guard title.contains(needle) || head.contains(needle) else { continue }
-            let updatedAt = (node["updatedAt"] as? String).flatMap { dateFmt.date(from: $0) }
+            let updatedAt = IssueDate.parse(node["updatedAt"] as? String)
             matches.append(KeyPRMatch(
                 candidate: candidate, number: number, url: url, state: state, updatedAt: updatedAt
             ))
@@ -479,13 +515,10 @@ public struct GitHubCodeBackend: CodeBackend {
               let dataObj = json["data"] as? [String: Any] else {
             throw ProviderError.commandFailed("listMonitoredPRs: failed to parse GraphQL response")
         }
-        let dateFmt = ISO8601DateFormatter()
-        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let viewerLogin = (dataObj["viewer"] as? [String: Any])?["login"] as? String ?? ""
         let viewerPRs = parseViewerPRs(dataObj["viewerPRs"] as? [String: Any])
         let reviewRequests = parseReviewRequests(
             dataObj["reviewPRs"] as? [String: Any],
-            dateFormatter: dateFmt,
             viewerLogin: viewerLogin.isEmpty ? nil : viewerLogin
         )
         let rate = GitHubTaskBackend.parseRateLimit(dataObj["rateLimit"] as? [String: Any])
@@ -506,13 +539,10 @@ public struct GitHubCodeBackend: CodeBackend {
         guard let dataObj = GitHubTaskBackend.decodeGraphQLData(blob) else {
             return MonitoredPRListing(viewerPRs: [], reviewRequests: [], viewerLogin: "", samlRestricted: true)
         }
-        let dateFmt = ISO8601DateFormatter()
-        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let viewerLogin = (dataObj["viewer"] as? [String: Any])?["login"] as? String ?? ""
         let viewerPRs = parseViewerPRs(dataObj["viewerPRs"] as? [String: Any])
         let reviewRequests = parseReviewRequests(
             dataObj["reviewPRs"] as? [String: Any],
-            dateFormatter: dateFmt,
             viewerLogin: viewerLogin.isEmpty ? nil : viewerLogin
         )
         let rate = GitHubTaskBackend.parseRateLimit(dataObj["rateLimit"] as? [String: Any])
@@ -584,14 +614,14 @@ public struct GitHubCodeBackend: CodeBackend {
         // — GitHub orders that connection by reviewer, not by recency, so a
         // narrow window could omit the CR we need.
         //
-        // Parse with `parseGitHubDateTime` (tolerant of both fractional and
+        // Parse with `IssueDate.parse` (tolerant of both fractional and
         // non-fractional). GitHub's GraphQL `DateTime` scalar emits
         // non-fractional ISO-8601 (`2026-06-15T01:28:17Z`), and an
         // `ISO8601DateFormatter` configured with `.withFractionalSeconds`
         // returns nil for that shape — silently disabling the rule.
         let lastChangesRequestedAt = latestReviewNodes
             .filter { ($0["state"] as? String) == "CHANGES_REQUESTED" }
-            .compactMap { ($0["submittedAt"] as? String).flatMap(Self.parseGitHubDateTime) }
+            .compactMap { IssueDate.parse($0["submittedAt"] as? String) }
             .max()
         // Stateless "needs refine" rule (CROW-508): the latest non-merge,
         // non-rebase commit timestamp anchors "has the agent substantively
@@ -628,7 +658,7 @@ public struct GitHubCodeBackend: CodeBackend {
                 if parents >= 2 { return nil }
                 let message = (commit["messageHeadline"] as? String) ?? ""
                 if Self.isMergeCommitMessage(message) { return nil }
-                return (commit["authoredDate"] as? String).flatMap(Self.parseGitHubDateTime)
+                return IssueDate.parse(commit["authoredDate"] as? String)
             }
             .max()
         // Who is blocking the PR right now, for the CROW-921 re-request
@@ -662,6 +692,19 @@ public struct GitHubCodeBackend: CodeBackend {
             .compactMap { ($0["requestedReviewer"] as? [String: Any])?["login"] as? String }
             .filter { !$0.isEmpty }
         let hasPendingReviewRequest = ((reviewRequestsObj?["totalCount"] as? Int) ?? 0) > 0
+        // The viewer's own latest verdict, from the `reviews(author:, states:)`
+        // selection the stale-PR query adds (CROW-945). Absent on every other
+        // path, which leaves this nil — "not fetched", never "no review".
+        //
+        // The state filter is redundant against today's query (which already
+        // filters server-side) and kept anyway: it is the assertion that only a
+        // verdict closes a round, so a future selection-set edit that widened
+        // or dropped `states:` would degrade to "no timestamp" rather than
+        // silently start closing rounds on a COMMENTED review.
+        let viewerLastReviewedAt = LenientJSON.nodes(node, "reviews")
+            .filter { Self.roundClosingReviewStates.contains(($0["state"] as? String) ?? "") }
+            .compactMap { IssueDate.parse($0["submittedAt"] as? String) }
+            .max()
         return PRRecord(
             number: number,
             url: url,
@@ -684,6 +727,7 @@ public struct GitHubCodeBackend: CodeBackend {
             changesRequestedReviewerLogins: changesRequestedReviewerLogins,
             pendingReviewerLogins: pendingReviewerLogins,
             hasPendingReviewRequest: hasPendingReviewRequest,
+            viewerLastReviewedAt: viewerLastReviewedAt,
             mergeCommitOid: mergeCommitOid,
             repoAutoMergeAllowed: repoAutoMergeAllowed
         )
@@ -701,37 +745,24 @@ public struct GitHubCodeBackend: CodeBackend {
             || trimmed.hasPrefix("Merge pull request ")
     }
 
-    /// Parse a GitHub `DateTime` scalar tolerantly. GitHub's GraphQL emits
-    /// the non-fractional ISO-8601 form (`2026-06-15T01:28:17Z`), but
-    /// `ISO8601DateFormatter` configured with `.withFractionalSeconds`
-    /// returns nil for that shape, and the inverse configuration rejects
-    /// any timestamp that DOES carry a fraction. Production code must
-    /// tolerate both — a strict formatter silently disables features that
-    /// depend on parsed timestamps (CROW-508 needsRefine was inert this
-    /// way; see PR #509 review). We try the non-fractional form first
-    /// (matches what GitHub actually emits today), then fall back to
-    /// fractional for resilience against future API drift.
+    /// Review states that constitute a *verdict* and therefore close a review
+    /// round. COMMENTED and PENDING are excluded on purpose: `crow-review-pr`
+    /// mandates `--request-changes`/`--approve` and forbids `--comment`, so a
+    /// comment is notes without a decision and the round stays open. PENDING is
+    /// an unsubmitted draft and carries no `submittedAt` at all.
     ///
-    /// Other call sites in this file still use the brittle pattern (see
-    /// `parseReviewRequests`, `parseStaleMRResponse`, parseStaleStateResponse).
-    /// They're out of scope for this PR but should migrate to this helper
-    /// in a follow-up — same trap, different fields.
-    nonisolated static func parseGitHubDateTime(_ raw: String) -> Date? {
-        let plain = ISO8601DateFormatter()
-        plain.formatOptions = [.withInternetDateTime]
-        if let d = plain.date(from: raw) { return d }
-        let withFraction = ISO8601DateFormatter()
-        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return withFraction.date(from: raw)
-    }
+    /// Shared by the two paths that answer "has the viewer reviewed this?" —
+    /// `parseReviewRequests` (the `review-requested:@me` search) and
+    /// `parsePRNode` (the stale-PR query, which also passes these to GraphQL as
+    /// `states:`). One definition so the two can't drift into disagreeing about
+    /// what closes a round.
+    static let roundClosingReviewStates: Set<String> = ["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]
 
     static func parseReviewRequests(
         _ searchObj: [String: Any]?,
-        dateFormatter: ISO8601DateFormatter,
         viewerLogin: String?
     ) -> [ReviewRequest] {
         let nodes = LenientJSON.nodes(searchObj)
-        let satisfyingStates: Set<String> = ["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]
         var requests: [ReviewRequest] = []
         for node in nodes {
             guard let number = node["number"] as? Int,
@@ -743,7 +774,7 @@ public struct GitHubCodeBackend: CodeBackend {
             let headBranch = (node["headRefName"] as? String) ?? ""
             let headRefOid = node["headRefOid"] as? String
             let baseBranch = (node["baseRefName"] as? String) ?? ""
-            let updatedAt = (node["updatedAt"] as? String).flatMap { dateFormatter.date(from: $0) }
+            let updatedAt = IssueDate.parse(node["updatedAt"] as? String)
             let labels = LenientJSON.nodes(node, "labels")
                 .compactMap { labelNode -> LabelInfo? in
                     guard let name = labelNode["name"] as? String else { return nil }
@@ -755,9 +786,8 @@ public struct GitHubCodeBackend: CodeBackend {
                     guard let author = (review["author"] as? [String: Any])?["login"] as? String,
                           author == viewerLogin,
                           let state = review["state"] as? String,
-                          satisfyingStates.contains(state),
-                          let submittedAtStr = review["submittedAt"] as? String,
-                          let submittedAt = dateFormatter.date(from: submittedAtStr) else { continue }
+                          Self.roundClosingReviewStates.contains(state),
+                          let submittedAt = IssueDate.parse(review["submittedAt"] as? String) else { continue }
                     if viewerLastReviewedAt == nil || submittedAt > viewerLastReviewedAt! {
                         viewerLastReviewedAt = submittedAt
                     }
@@ -832,8 +862,6 @@ public struct GitHubCodeBackend: CodeBackend {
         guard let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = json["data"] as? [String: Any] else { return [] }
-        let dateFmt = ISO8601DateFormatter()
-        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         var matches: [BranchPRMatch] = []
         for p in parsed {
             let repoObj = dataObj["pr\(p.idx)"] as? [String: Any]
@@ -841,7 +869,7 @@ public struct GitHubCodeBackend: CodeBackend {
                 guard let number = node["number"] as? Int,
                       let url = node["url"] as? String,
                       let state = node["state"] as? String else { continue }
-                let updatedAt = (node["updatedAt"] as? String).flatMap { dateFmt.date(from: $0) }
+                let updatedAt = IssueDate.parse(node["updatedAt"] as? String)
                 matches.append(BranchPRMatch(
                     candidate: p.cand,
                     number: number,

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -595,8 +595,8 @@ public struct GitHubTaskBackend: TaskBackend {
             // Tolerant parse (#751): GitHub GraphQL emits non-fractional
             // DateTime, which a `.withFractionalSeconds` formatter rejects —
             // that silently disabled updated/created sort + "opened … ago".
-            let updatedAt = GitHubCodeBackend.parseGitHubDateTime((node["updatedAt"] as? String) ?? "")
-            let createdAt = GitHubCodeBackend.parseGitHubDateTime((node["createdAt"] as? String) ?? "")
+            let updatedAt = IssueDate.parse(node["updatedAt"] as? String)
+            let createdAt = IssueDate.parse(node["createdAt"] as? String)
             let author = (node["author"] as? [String: Any])?["login"] as? String
             let commentsCount = (node["comments"] as? [String: Any])?["totalCount"] as? Int
             let body = (node["bodyText"] as? String).flatMap(IssueBody.cap)

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
@@ -68,7 +68,10 @@ public struct GitLabCodeBackend: CodeBackend {
         return MonitoredPRListing(viewerPRs: [], reviewRequests: reviewRequests, viewerLogin: "")
     }
 
-    public func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] {
+    /// `viewerLogin` is accepted for protocol conformance and ignored: GitLab's
+    /// MR endpoint carries no per-reviewer verdict timestamp, so
+    /// `viewerLastReviewedAt` stays nil here — "not fetched", per `PRRecord`.
+    public func prStates(refs: [PRRef], viewerLogin: String?) async throws -> [PRRef: PRRecord] {
         // GitLab REST has no batching; one call per MR.
         var out: [PRRef: PRRecord] = [:]
         for ref in refs {
@@ -205,8 +208,6 @@ public struct GitLabCodeBackend: CodeBackend {
     }
 
     public func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch] {
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         var matches: [BranchPRMatch] = []
         for candidate in candidates {
             let encodedSlug = candidate.repoSlug.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? candidate.repoSlug
@@ -231,7 +232,7 @@ public struct GitLabCodeBackend: CodeBackend {
                       let url = item["web_url"] as? String else { continue }
                 let rawState = (item["state"] as? String) ?? ""
                 let normalized = Self.normalizeState(rawState)
-                let updatedAt = (item["updated_at"] as? String).flatMap { dateFormatter.date(from: $0) }
+                let updatedAt = IssueDate.parse(item["updated_at"] as? String)
                 matches.append(BranchPRMatch(
                     candidate: candidate,
                     number: number,
@@ -300,8 +301,6 @@ public struct GitLabCodeBackend: CodeBackend {
               let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
             return []
         }
-        let dateFmt = ISO8601DateFormatter()
-        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return items.compactMap { item -> ReviewRequest? in
             guard let number = item["iid"] as? Int,
                   let title = item["title"] as? String,
@@ -313,7 +312,7 @@ public struct GitLabCodeBackend: CodeBackend {
             let baseBranch = (item["target_branch"] as? String) ?? ""
             let draft = (item["draft"] as? Bool) ?? (item["work_in_progress"] as? Bool) ?? false
             let labels = (item["labels"] as? [String] ?? []).map { LabelInfo(name: $0) }
-            let updatedAt = (item["updated_at"] as? String).flatMap { dateFmt.date(from: $0) }
+            let updatedAt = IssueDate.parse(item["updated_at"] as? String)
             let headRefOid = item["sha"] as? String
             return ReviewRequest(
                 id: "gitlab:\(host):\(fullRef)",

--- a/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
@@ -44,7 +44,15 @@ public protocol CodeBackend: Sendable {
     /// issue one call; others fall back to per-PR. Returned keyed by `PRRef`
     /// (not URL) so callers don't have to round-trip through the API's
     /// canonical URL form to look up their result.
-    func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord]
+    ///
+    /// - Parameter viewerLogin: the authenticated user's login, when known.
+    ///   Lets a backend ask the host for *the viewer's own* latest verdict on
+    ///   each PR, which populates `PRRecord.viewerLastReviewedAt` (CROW-945).
+    ///   Pass nil when it isn't known — the backend then omits that selection
+    ///   and leaves the field nil, which every consumer reads as "not
+    ///   fetched" rather than "no review", per the convention documented on
+    ///   `PRRecord`.
+    func prStates(refs: [PRRef], viewerLogin: String?) async throws -> [PRRef: PRRecord]
 
     /// Fetch every commit on the PR identified by `prURL` and `repoSlug`.
     /// Returns the full commit list; the caller filters for the

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -438,6 +438,12 @@ final class BackendsTests: XCTestCase {
     /// The `reviewPRs: search(…)` connection nullifies elements the same way
     /// (#894). Covers the top-level `nodes` array and a null inside a PR's own
     /// `reviews.nodes`, which feeds `viewerLastReviewedAt`.
+    ///
+    /// Timestamps are GitHub's **actual** non-fractional shape (CROW-945). The
+    /// original fixture used `.000Z`, which no GitHub GraphQL response has ever
+    /// carried — so this test passed while the strict `.withFractionalSeconds`
+    /// formatter left both date fields permanently nil in production, and with
+    /// them `decideReviewCompletions` rule 1. See the fractional twin below.
     func testParseReviewRequestsSkipsNullNodes() throws {
         let json = """
         {"data":{
@@ -445,13 +451,13 @@ final class BackendsTests: XCTestCase {
           "reviewPRs":{"nodes":[
             null,
             {"number":21,"title":"Review me","url":"https://github.com/a/b/pull/21",
-             "state":"OPEN","isDraft":false,"updatedAt":"2026-06-07T10:00:00.000Z",
+             "state":"OPEN","isDraft":false,"updatedAt":"2026-06-07T10:00:00Z",
              "headRefName":"feat","baseRefName":"main",
              "author":{"login":"someone"},"repository":{"nameWithOwner":"a/b"},
              "labels":{"nodes":[null,{"name":"needs-review","color":"blue"}]},
              "reviews":{"nodes":[
                null,
-               {"author":{"login":"me"},"state":"APPROVED","submittedAt":"2026-06-06T10:00:00.000Z"},
+               {"author":{"login":"me"},"state":"APPROVED","submittedAt":"2026-06-06T10:00:00Z"},
                null
              ]}},
             null
@@ -464,8 +470,151 @@ final class BackendsTests: XCTestCase {
         let req = try XCTUnwrap(listing.reviewRequests.first)
         XCTAssertEqual(req.prNumber, 21)
         XCTAssertEqual(req.labels.map(\.name), ["needs-review"])
-        // The viewer's own review survived the null siblings.
-        XCTAssertNotNil(req.viewerLastReviewedAt)
+        // The viewer's own review survived the null siblings. Asserted against
+        // an absolute instant, not just non-nil: a formatter that parsed but
+        // mis-scaled would still satisfy XCTAssertNotNil.
+        XCTAssertEqual(req.viewerLastReviewedAt, Date(timeIntervalSince1970: 1780740000))
+        // `requestedAt` comes off the same formatter and was nil for the same
+        // reason — it drives the board's relative-time chip and its sort.
+        XCTAssertEqual(req.requestedAt, Date(timeIntervalSince1970: 1780826400))
+    }
+
+    /// Fractional twin of the above. GitHub emits the plain form today, but the
+    /// parser must tolerate both — otherwise fixing CROW-945 would just swap
+    /// which shape is untested, exactly how the bug survived three years.
+    func testParseReviewRequestsParsesFractionalTimestampsToo() throws {
+        let json = """
+        {"data":{
+          "viewerPRs":{"pullRequests":{"nodes":[]}},
+          "reviewPRs":{"nodes":[
+            {"number":21,"title":"Review me","url":"https://github.com/a/b/pull/21",
+             "state":"OPEN","isDraft":false,"updatedAt":"2026-06-07T10:00:00.000Z",
+             "headRefName":"feat","baseRefName":"main",
+             "author":{"login":"someone"},"repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[]},
+             "reviews":{"nodes":[
+               {"author":{"login":"me"},"state":"CHANGES_REQUESTED","submittedAt":"2026-06-06T10:00:00.500Z"}
+             ]}}
+          ]},
+          "viewer":{"login":"me"}
+        }}
+        """
+        let listing = try GitHubCodeBackend.parseMonitoredPRsResponse(json)
+        let req = try XCTUnwrap(listing.reviewRequests.first)
+        XCTAssertEqual(req.requestedAt, Date(timeIntervalSince1970: 1780826400))
+        XCTAssertEqual(req.viewerLastReviewedAt?.timeIntervalSince1970 ?? 0, 1780740000.5, accuracy: 0.01)
+    }
+
+    /// A COMMENTED review carries no verdict, so it must not close a round.
+    /// `crow-review-pr` mandates `--request-changes`/`--approve` and forbids
+    /// `--comment`; this is also why CROW-945 could not use GraphQL's
+    /// `viewerLatestReview` (no `states:` arg — a later COMMENTED review would
+    /// mask the real verdict and reintroduce the bug through a new field).
+    func testParseReviewRequestsIgnoresNonVerdictReviewStates() throws {
+        let json = """
+        {"data":{
+          "viewerPRs":{"pullRequests":{"nodes":[]}},
+          "reviewPRs":{"nodes":[
+            {"number":21,"title":"Review me","url":"https://github.com/a/b/pull/21",
+             "state":"OPEN","isDraft":false,"updatedAt":"2026-06-07T10:00:00Z",
+             "headRefName":"feat","baseRefName":"main",
+             "author":{"login":"someone"},"repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[]},
+             "reviews":{"nodes":[
+               {"author":{"login":"me"},"state":"COMMENTED","submittedAt":"2026-06-06T10:00:00Z"},
+               {"author":{"login":"other"},"state":"APPROVED","submittedAt":"2026-06-06T11:00:00Z"}
+             ]}}
+          ]},
+          "viewer":{"login":"me"}
+        }}
+        """
+        let listing = try GitHubCodeBackend.parseMonitoredPRsResponse(json)
+        let req = try XCTUnwrap(listing.reviewRequests.first)
+        // Viewer only commented; someone else's approval is not the viewer's.
+        XCTAssertNil(req.viewerLastReviewedAt)
+        // The non-verdict path must not take `requestedAt` down with it.
+        XCTAssertNotNil(req.requestedAt)
+    }
+
+    // MARK: - prStates carries the viewer's verdict (CROW-945)
+
+    /// The stale-PR query is the only source of `viewerLastReviewedAt` that
+    /// survives GitHub clearing the review request, so it has to actually ask
+    /// for it — and ask with `author:`/`states:` rather than scanning.
+    func testPRStatesQueryAsksForTheViewersOwnVerdict() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("{\"data\":{}}")]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        _ = try await backend.prStates(
+            refs: [PRRef(owner: "a", repo: "b", number: 7)],
+            viewerLogin: "me"
+        )
+        let call = try XCTUnwrap(fake.calls.first)
+        let query = try XCTUnwrap(call.args.first(where: { $0.hasPrefix("query=") }))
+        XCTAssertTrue(query.contains("reviews(last: 1, author: $viewer"), query)
+        // Server-side state filter — the whole reason this beats
+        // `viewerLatestReview`, which cannot express it.
+        XCTAssertTrue(query.contains("APPROVED, CHANGES_REQUESTED, DISMISSED"), query)
+        XCTAssertTrue(query.contains("$viewer: String!"), query)
+        // `-f`, not `-F`: `-F` type-infers, so an all-digit login would be sent
+        // as an Int and fail the `String!` variable.
+        let viewerIdx = try XCTUnwrap(call.args.firstIndex(of: "viewer=me"))
+        XCTAssertEqual(call.args[viewerIdx - 1], "-f")
+    }
+
+    /// With no known viewer login the selection is omitted rather than sent
+    /// with an empty string — an empty `author:` would match nothing and the
+    /// nil result would be indistinguishable from "the viewer hasn't reviewed",
+    /// which is precisely the ambiguity `nil == not fetched` exists to avoid.
+    func testPRStatesOmitsViewerReviewSelectionWhenLoginUnknown() async throws {
+        for login in [nil, "", "   "] as [String?] {
+            let fake = FakeShellRunner()
+            fake.responses = [.success("{\"data\":{}}")]
+            let backend = GitHubCodeBackend(shellRunner: fake)
+            _ = try await backend.prStates(
+                refs: [PRRef(owner: "a", repo: "b", number: 7)],
+                viewerLogin: login
+            )
+            let call = try XCTUnwrap(fake.calls.first)
+            let query = try XCTUnwrap(call.args.first(where: { $0.hasPrefix("query=") }))
+            XCTAssertFalse(query.contains("reviews("), "login=\(login ?? "nil"): \(query)")
+            XCTAssertFalse(query.contains("$viewer"), "login=\(login ?? "nil"): \(query)")
+        }
+    }
+
+    /// The parse half: GitHub's real non-fractional timestamp, off the
+    /// `prStates` response shape, reaches `PRRecord.viewerLastReviewedAt`.
+    func testParseStalePRResponseCarriesViewerLastReviewedAt() throws {
+        let ref = PRRef(owner: "a", repo: "b", number: 7)
+        let json = """
+        {"data":{"pr0":{"pullRequest":{
+          "number":7,"url":"https://github.com/a/b/pull/7","state":"OPEN",
+          "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"CHANGES_REQUESTED",
+          "isDraft":false,"headRefName":"feat","headRefOid":"abc123","baseRefName":"main",
+          "repository":{"nameWithOwner":"a/b"},
+          "reviews":{"nodes":[{"state":"CHANGES_REQUESTED","submittedAt":"2026-06-06T10:00:00Z"}]}
+        }}}}
+        """
+        let out = GitHubCodeBackend.parseStalePRResponse(json, refs: [ref])
+        let rec = try XCTUnwrap(out[ref])
+        XCTAssertEqual(rec.viewerLastReviewedAt, Date(timeIntervalSince1970: 1780740000))
+    }
+
+    /// A response with no `reviews` block (every path except the stale-PR
+    /// query) leaves the field nil — "not fetched", not "no review".
+    func testParseStalePRResponseLeavesViewerReviewNilWhenAbsent() throws {
+        let ref = PRRef(owner: "a", repo: "b", number: 7)
+        let json = """
+        {"data":{"pr0":{"pullRequest":{
+          "number":7,"url":"https://github.com/a/b/pull/7","state":"OPEN",
+          "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"",
+          "isDraft":false,"headRefName":"feat","headRefOid":"abc123","baseRefName":"main",
+          "repository":{"nameWithOwner":"a/b"}
+        }}}}
+        """
+        let out = GitHubCodeBackend.parseStalePRResponse(json, refs: [ref])
+        let rec = try XCTUnwrap(out[ref])
+        XCTAssertNil(rec.viewerLastReviewedAt)
     }
 
     /// #894 issue-side counterpart: one SAML-nulled assigned issue dropped the
@@ -609,7 +758,7 @@ final class BackendsTests: XCTestCase {
         fake.responses = [.success(json)]
         let backend = GitHubCodeBackend(shellRunner: fake)
         let ref = PRRef(owner: "a", repo: "b", number: 885)
-        let states = try await backend.prStates(refs: [ref])
+        let states = try await backend.prStates(refs: [ref], viewerLogin: nil)
         XCTAssertEqual(states[ref]?.checksState, "FAILURE")
         XCTAssertEqual(states[ref]?.failedCheckNames, ["Build & Test"])
         XCTAssertEqual(states[ref]?.labels.map(\.name), ["crow:merge"])
@@ -643,7 +792,7 @@ final class BackendsTests: XCTestCase {
         let blocked = PRRef(owner: "blocked", repo: "repo", number: 2)
         let alsoOK = PRRef(owner: "ok", repo: "repo", number: 3)
         // Pre-#894 this threw and the caller lost all three.
-        let states = try await backend.prStates(refs: [ok, blocked, alsoOK])
+        let states = try await backend.prStates(refs: [ok, blocked, alsoOK], viewerLogin: nil)
         XCTAssertEqual(states.count, 2)
         XCTAssertEqual(states[ok]?.state, "MERGED")
         XCTAssertEqual(states[ok]?.mergeCommitOid, "0123456789abcdef")
@@ -662,7 +811,7 @@ final class BackendsTests: XCTestCase {
         ))]
         let backend = GitHubCodeBackend(shellRunner: fake)
         do {
-            _ = try await backend.prStates(refs: [PRRef(owner: "a", repo: "b", number: 1)])
+            _ = try await backend.prStates(refs: [PRRef(owner: "a", repo: "b", number: 1)], viewerLogin: nil)
             XCTFail("expected throw")
         } catch let error as ProviderError {
             if case .samlRestricted = error {
@@ -989,7 +1138,7 @@ final class BackendsTests: XCTestCase {
         fake.responses = [.success(json)]
         let backend = GitHubCodeBackend(shellRunner: fake)
         let ref = PRRef(owner: "a", repo: "b", number: 1)
-        let states = try await backend.prStates(refs: [ref])
+        let states = try await backend.prStates(refs: [ref], viewerLogin: nil)
         XCTAssertEqual(states.count, 1)
         XCTAssertEqual(states[ref]?.state, "MERGED")
         // One batched call, not per-ref.
@@ -1037,7 +1186,7 @@ final class BackendsTests: XCTestCase {
         let backend = GitHubCodeBackend(shellRunner: fake)
         let merged = PRRef(owner: "a", repo: "b", number: 1)
         let open = PRRef(owner: "a", repo: "b", number: 2)
-        let states = try await backend.prStates(refs: [merged, open])
+        let states = try await backend.prStates(refs: [merged, open], viewerLogin: nil)
         XCTAssertEqual(states[merged]?.mergeCommitOid, "0123456789abcdef")
         XCTAssertNil(states[open]?.mergeCommitOid)
         // The query now requests the merge commit.
@@ -1359,7 +1508,7 @@ final class BackendsTests: XCTestCase {
         fake.responses = [.success(json)]
         let backend = GitLabCodeBackend(shellRunner: fake, host: "gitlab.example.com")
         let ref = PRRef(owner: "g", repo: "p", number: 3)
-        let states = try await backend.prStates(refs: [ref])
+        let states = try await backend.prStates(refs: [ref], viewerLogin: nil)
         XCTAssertEqual(states.count, 1)
         XCTAssertEqual(states[ref]?.state, "MERGED")
         XCTAssertEqual(fake.calls.count, 1)
@@ -1483,9 +1632,14 @@ final class BackendsTests: XCTestCase {
     /// and rejects this format — feature was silently inert in production.
     /// PR #509 review caught it. This test will fail loudly if a future
     /// regression re-introduces the strict formatter.
+    ///
+    /// CROW-945 collapsed `GitHubCodeBackend.parseGitHubDateTime` into
+    /// `IssueDate.parse`, which was already its byte-identical twin — two
+    /// copies of the fix meant a third call site could (and did) still get it
+    /// wrong. These tests now cover the single sanctioned entry point.
     func testParseGitHubDateTimeHandlesNonFractionalISO8601() {
         // GitHub's actual format — no fraction.
-        let nonFractional = GitHubCodeBackend.parseGitHubDateTime("2026-06-15T01:28:17Z")
+        let nonFractional = IssueDate.parse("2026-06-15T01:28:17Z")
         XCTAssertNotNil(nonFractional)
         XCTAssertEqual(nonFractional, Date(timeIntervalSince1970: 1781486897))
     }
@@ -1494,14 +1648,15 @@ final class BackendsTests: XCTestCase {
     /// fractional component must also parse. Both shapes flow through the
     /// same helper.
     func testParseGitHubDateTimeAlsoHandlesFractionalISO8601() {
-        let withFraction = GitHubCodeBackend.parseGitHubDateTime("2026-06-15T01:28:17.123Z")
+        let withFraction = IssueDate.parse("2026-06-15T01:28:17.123Z")
         XCTAssertNotNil(withFraction)
     }
 
     /// Garbage input returns nil, doesn't crash.
     func testParseGitHubDateTimeReturnsNilForGarbage() {
-        XCTAssertNil(GitHubCodeBackend.parseGitHubDateTime("not a date"))
-        XCTAssertNil(GitHubCodeBackend.parseGitHubDateTime(""))
+        XCTAssertNil(IssueDate.parse("not a date"))
+        XCTAssertNil(IssueDate.parse(""))
+        XCTAssertNil(IssueDate.parse(nil))
     }
 
     /// Merge commits (parents.totalCount >= 2) and rebase-style commits


### PR DESCRIPTION
Closes #945

A second review request on the same PR never started a second review session. Round 1 posted `CHANGES_REQUESTED`, the author pushed fixes and re-requested, and the Reviews board rendered **"Go to Session"** pointing at the dead round-1 session. Deleting that session by hand was the only way forward.

`decideReviewCompletions` rule 1 exists to close the round. It had never fired in production, for two independent reasons.

## Root cause 1 — the date never parsed

`parseMonitoredPRsResponse` built an `ISO8601DateFormatter` with `.withFractionalSeconds` and handed it to `parseReviewRequests`. GitHub's GraphQL `DateTime` scalar carries no fraction, and that formatter returns `nil` for that shape — so `viewerLastReviewedAt`, rule 1's entire input, was always nil. So was `requestedAt`, which is why the board's "requested" chip never rendered and its newest-first sort was arbitrary.

This is the trap `parseGitHubDateTime` was written to fix; its docstring named `parseReviewRequests` as an unmigrated call site. The tests missed it because the fixture used `.000Z` timestamps GitHub has never sent.

## Root cause 2 — the signal came from a search that no longer contains the PR

Rule 1 read the `review-requested:@me` payload, but GitHub clears the pending request the instant the viewer submits a review — the PR leaves that search at exactly the moment the round should close. Sourced only from there, rule 1 could fire only by winning a race against GitHub's search index.

## What changed

**One tolerant parser.** `IssueDate.parse` absorbs its byte-identical twin `parseGitHubDateTime` — two copies of the fix is how a third call site still got it wrong — and the five remaining hand-rolled formatters in the GitHub/GitLab backends migrate to it.

**Rule 1 gains a second source that survives the request being consumed.** `reviews(last: 1, author: $viewer, states: [APPROVED, CHANGES_REQUESTED, DISMISSED])` on the batched `prStates` query, which already fetches every review session's PR each poll — **zero extra API calls**.

Not `viewerLatestReview`, which the ticket suggested: schema introspection confirms it takes no arguments, so it returns the viewer's latest review of *any* state. A follow-up `--comment` review (COMMENTED) or an unsubmitted draft (PENDING, null `submittedAt`) would mask the real verdict and reproduce this exact bug through a new field. `reviews` accepts `author:` and `states:`, so the filter happens server-side: one node per alias instead of twenty, and immune to the >20-review truncation the search path has.

The new branch is presence-based and so is deliberately **not** gated on `prDataComplete` — that flag exists to stop *absence* being read as evidence, and gating presence would make the fix silently miss whenever an unrelated provider errored.

**One dedup rule.** `createReviewSession` now runs the same `IssueTracker.reviewKickoffAction` the auto-review hook used, against the head it fetches itself, so `crow start-review` starts a new round instead of returning the stale session id. The daemon hook drops its duplicate decision — two callers deciding from two different heads is the divergence that let a round keep shadowing its PR.

**The board offers the next round.** `list-reviews` gains `head_ref_oid` and a server-computed `kickoff_action`, and the two byte-identical copies of that handler collapse into one shared builder (the CLI and the web agreed only by accident of copy-paste). Cards render Start Review / Re-review / Go to Session accordingly. The action is advisory — it's computed from a poll-stale head — so the client never suppresses the RPC on it.

## Pre-existing bugs found on the same path

Fixed here because the new field would have joined them:

- `autoCompleteFinishedReviews` considered only `.active` sessions, so a `.paused` or `.inReview` review session blocked its PR forever with no rule anywhere able to complete it.
- `mergePRRecords` dropped `updatedAt`, despite its own *"Every field must be carried here"* banner and two named prior incidents.
- `withLabels` dropped the three CROW-921 reviewer fields, despite claiming to preserve every field; its caller feeds `evaluateAutoMerge`, which reads them.

## `lastReviewedHeadSha` split

It had two readers wanting opposite things. It stays the **round boundary** the kickoff guard reads; the new `lastReRequestedHeadSha` is the **diff anchor** the in-place re-review prompt scopes from. Repeat passes stop replaying round 1's delta without disarming the head-advance fallback for an agent that stalls without posting a verdict.

## Acceptance

- [x] `parseReviewRequests` parses GitHub's real non-fractional timestamps
- [x] The Reviews board shows relative "requested" times again and sorts newest-first
- [x] A review session is auto-completed once the viewer submits its verdict, without depending on the PR still being in `review-requested:@me`
- [x] Author pushes fixes + re-requests ⇒ the board offers a new review round
- [x] `crow start-review` on a PR whose previous round is closed starts a new round
- [ ] **Deferred:** re-requesting with no new commits does not spawn a duplicate round
- [x] The manual/board path and the auto-kickoff path share one decision function
- [x] Test fixtures use GitHub's actual timestamp shape; a regression test would fail if the fractional-seconds formatter came back

**On the deferred box:** the only re-kick loop is the `autoReviewRepos` auto path, which already dedups via an in-memory SHA fingerprint. That loop is self-terminating (GitHub clears the request once a verdict posts), the in-flight clone window is covered by `existingByPRSessionID`, and `autoReviewRepos` is empty for every workspace here — so the gap is a daemon restart on a path that isn't live. Making it durable means persisting the fingerprint with a pruning policy; putting the guard in the shared decision function instead would gate the *manual* Start Review button, so "I want to look at this again" would fail with an error dialog.

## Verification

- `make daemon` clean; `make parity` passes all three gates.
- CrowProvider 163, CrowEngine 655, CrowCore, CrowCLI — all green.
- Web (jsdom) suite green, including 7 new `kickoff_action` board assertions.
- CrowDaemon has 2 failing tests (`refreshTerminalsRebindsTheActiveTerminalToTheFreshRow`, `bootCatchResetsTheHistory`). **Pre-existing** — verified by swapping `HEAD`'s `app.js` back in and re-running: they fail identically. Both are source-shape assertions on `app.js` regions this PR doesn't touch, and one anchors on a string absent from `HEAD` too.
- The new query shape was run live against GitHub, returning `"submittedAt":"2026-08-05T22:22:04Z"` — exactly the non-fractional form the old formatter returned nil for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)