### PR TITLE
Launch Cursor review sessions pre-trusted (CROW-954)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -132,13 +132,19 @@ public protocol CodingAgent: Sendable {
         prompt: String
     ) async throws -> String
 
-    /// Kind-aware variant of `launchCommand`. Agents whose launch depends on the
-    /// session kind override this — e.g. Cursor withholds its workspace-trust
-    /// seed (`--trust`) from attacker-controlled `.review` handoff clones,
-    /// mirroring the `session.kind != .review` guard on `CodexTrustSeeder`. The
-    /// protocol-extension default ignores `sessionKind` and delegates to the
-    /// three-argument `launchCommand`, so agents with no kind-dependent launch
-    /// (Claude, Codex, OpenCode, Antigravity) need not implement it.
+    /// Kind-aware variant of `launchCommand`, for agents whose handoff launch
+    /// depends on the session kind. The protocol-extension default ignores
+    /// `sessionKind` and delegates to the three-argument `launchCommand`, so an
+    /// agent with no kind-dependent launch need not implement it.
+    ///
+    /// **No agent overrides this today.** Cursor was the only one — it withheld
+    /// its `--trust` workspace-trust seed from `.review` handoff clones — and
+    /// CROW-954 dropped that carve-out (review clones now launch pre-trusted,
+    /// defended by the launch-path `.cursor/` strip instead of a folder-trust
+    /// dialog). The requirement is kept because it is the seam a future harness
+    /// needs to treat a hostile review checkout differently from a `.work`
+    /// worktree; `SessionService.handoffAgent` already calls through it with the
+    /// live `session.kind`, so adding one is a single override.
     func launchCommand(
         sessionID: UUID,
         worktreePath: String,

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -75,20 +75,19 @@ public struct CursorAgent: CodingAgent {
         // unavailable kinds.
         // The `--trust` workspace-trust seed (skips the folder-trust dialog on a
         // fresh worktree — the per-launch analogue of `ClaudeTrustSeeder`,
-        // CROW-890) rides every launch path EXCEPT `.review`: a review working
-        // tree is an attacker-controlled `gh` clone at the PR author's head, so —
-        // mirroring the `session.kind != .review` guard on `CodexTrustSeeder` in
-        // `SessionService` — Crow never auto-trusts it (the intent is that review
-        // falls back to Cursor's folder-trust dialog; whether `--force` still
-        // surfaces that dialog is unverified — see `CursorLaunchArgs.launchSuffix`
-        // — but withholding `--trust` is never worse). The auto-permission
-        // flags (`--force --approve-mcps`) still apply per the caller's opt-in,
-        // including on `.review` (unchanged). See `CursorLaunchArgs` for why
-        // `--sandbox` is left unset (#829). On the non-review paths the seed also
-        // rides `--continue` resume — harmless: the first launch already recorded
-        // the saved trust decision.
+        // CROW-890) rides EVERY launch path, `.review` included as of CROW-954.
+        // The original review carve-out left unattended reviews stuck on
+        // "Workspace Trust Required" while already carrying `--force`, so the
+        // dialog gated nothing a reviewer could act on — and the clone's real
+        // defense is `stripCursorConfigFromReviewClone`, which now re-runs on
+        // every launch via `prepareWorktreeForAgentLaunch`. See
+        // `CursorLaunchArgs.trustSuffix` for the full rationale. The
+        // auto-permission flags (`--force --approve-mcps`) still apply per the
+        // caller's opt-in (unchanged). See `CursorLaunchArgs` for why `--sandbox`
+        // is left unset (#829). The seed also rides `--continue` resume —
+        // harmless: the first launch already recorded the saved trust decision.
         let launchArgs = CursorLaunchArgs.launchSuffix(
-            seedTrust: session.kind != .review,
+            seedTrust: true,
             autoPermissionMode: autoPermissionMode)
 
         switch session.kind {
@@ -162,41 +161,18 @@ public struct CursorAgent: CodingAgent {
         worktreePath: String,
         prompt: String
     ) async throws -> String {
-        // Fail closed (CROW-890 review, Yellow 2): the kindless three-argument
-        // requirement can't prove a worktree is non-`.review`, so it never seeds
-        // trust. It has no production caller — `SessionService.handoffAgent`
-        // always calls the `sessionKind:` overload below — so this can't
-        // under-trust a real launch; it just guarantees a hypothetical future
-        // caller of the bare form gets the safe default rather than reopening the
-        // review-clone hole. The kind-aware overload is the seeding path.
+        // Seeds trust for every kind (CROW-954). The CROW-890 "fail closed"
+        // default — never seed, because a kindless signature can't prove the
+        // worktree isn't `.review` — is moot now that `.review` seeds too, so
+        // Cursor no longer needs the kind-aware overload at all and the
+        // `CodingAgent` protocol default (which drops `sessionKind` and lands
+        // here) is correct for every caller.
         try await launcher.launchCommand(
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
             binary: findBinary() ?? "agent",
-            seedTrust: false
-        )
-    }
-
-    /// Kind-aware handoff launch. Overrides the `CodingAgent` default so a
-    /// `.review` handoff to Cursor does **not** carry the `--trust` seed — the
-    /// review clone is attacker-controlled (a `gh` checkout at the PR author's
-    /// head), so Crow does not auto-trust it, mirroring the `session.kind !=
-    /// .review` guard on `CodexTrustSeeder` (CROW-890 review, Red 1).
-    /// `SessionService.handoffAgent` calls this with the live `session.kind`;
-    /// every other kind seeds trust as before.
-    public func launchCommand(
-        sessionID: UUID,
-        worktreePath: String,
-        prompt: String,
-        sessionKind: SessionKind
-    ) async throws -> String {
-        try await launcher.launchCommand(
-            sessionID: sessionID,
-            worktreePath: worktreePath,
-            prompt: prompt,
-            binary: findBinary() ?? "agent",
-            seedTrust: sessionKind != .review
+            seedTrust: true
         )
     }
 

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorLaunchArgs.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorLaunchArgs.swift
@@ -10,8 +10,8 @@ public enum CursorLaunchArgs {
         "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
-    /// Workspace-trust seed appended to every Crow-launched Cursor command
-    /// **except `.review`** (auto-launch, Manager, and the handoff one-shot). A
+    /// Workspace-trust seed appended to **every** Crow-launched Cursor command
+    /// (auto-launch, Manager, and the handoff one-shot) — `.review` included. A
     /// leading-space suffix so callers concatenate it onto the shell-quoted
     /// binary path.
     ///
@@ -27,29 +27,53 @@ public enum CursorLaunchArgs {
     /// session on the folder-trust prompt (CROW-890 — closes the residual gap
     /// #829 deliberately left open).
     ///
-    /// **Withheld from `.review` sessions** (see `launchSuffix`), mirroring the
-    /// `session.kind != .review` guard on `CodexTrustSeeder`: a review working
-    /// tree is an attacker-controlled `gh` clone, so it is never auto-trusted.
+    /// **Emitted on `.review` too, as of CROW-954.** The original CROW-890 carve-out
+    /// withheld it — a review tree is a `gh` clone at the PR author's head — on the
+    /// theory that Cursor's folder-trust dialog would serve as the human gate. In
+    /// practice that theory failed on both ends:
+    ///
+    ///  - The dialog is **not** a meaningful gate. Review launches already carry
+    ///    `--force --approve-mcps` (`reviewAutoPermissionMode` defaults on), so the
+    ///    only thing a reviewer can do at the prompt is press `a` — after which
+    ///    every tool call runs unapproved anyway. It gated nothing and blocked the
+    ///    unattended dispatch that makes review sessions useful.
+    ///  - `--force` does **not** suppress it (the CROW-890 note left this
+    ///    "unverified"): observed on `agent 2026.08.04`, a Crow review session
+    ///    launched with `--force --approve-mcps` still stops on "Workspace Trust
+    ///    Required" and waits for a keypress.
+    ///
+    /// The real defense was never the dialog — it's
+    /// `SessionService.stripCursorConfigFromReviewClone`, which removes the clone's
+    /// `.cursor/` (committed `hooks.json` / `mcp.json`) before Cursor opens it. That
+    /// strip now runs on **every** launch path via `prepareWorktreeForAgentLaunch`,
+    /// not just at clone creation, so a hostile layer restored by the review skill's
+    /// `gh pr checkout` is re-stripped before the trusted launch. This is the same
+    /// **strip-not-trust** posture Grok and Antigravity reviews already rely on
+    /// (`shouldStripGrokReviewClone`, `shouldStripAntigravityReviewClone`), and it
+    /// matches Claude, whose `shouldSeedFolderTrust` has always returned `true` for
+    /// `.review`. Codex/Grok keep their `!= .review` trust guards — their trust
+    /// stores are global TOML, a different blast radius from a per-workspace marker.
     ///
     /// **Interactive as of Cursor CLI 2026.07.20**
     /// ([changelog](https://cursor.com/docs/cli/changelog): "`--trust` works in
-    /// interactive sessions"), verified empirically against `agent 2026.07.23`
-    /// whose `--help` lists `--trust` as a general flag with **no "(headless mode
+    /// interactive sessions"), verified empirically against `agent 2026.08.04`:
+    /// running `agent --trust` under a pty in a fresh repo — no `--print` — writes
+    /// `~/.cursor/projects/<slug>/.workspace-trusted` with
+    /// `"trustMethod": "cli-flag"`, the same marker the dialog writes on accept. Its
+    /// `--help` also lists `--trust` as a general flag with **no "(headless mode
     /// only)" qualifier** and **no `--print` gating** (unlike `--output-format`).
     /// The [parameter reference](https://cursor.com/docs/cli/reference/parameters)
-    /// still says headless-only, but the installed binary's own help is
-    /// authoritative and disagrees — which is why the earlier audit's
-    /// headless-only omission is now reversed.
+    /// still says headless-only; the installed binary and the observed marker
+    /// disagree, and they win.
     ///
     /// **Bounded to workspace trust — NOT `--yolo`/full-bypass.** It only
     /// suppresses the folder-trust dialog; per-tool approval still applies unless
     /// `autoPermissionSuffix` adds `--force`. Trust and auto-permission are
-    /// orthogonal, so this seed is unconditional (outside `.review`) while
-    /// `--force --approve-mcps` stays gated on the caller's opt-in (see
-    /// `launchSuffix`).
+    /// orthogonal, so this seed is unconditional while `--force --approve-mcps`
+    /// stays gated on the caller's opt-in (see `launchSuffix`).
     ///
     /// **Minimum Cursor CLI: ≥ 2026.07.20** — the build that made `--trust`
-    /// interactive. Emitted on every non-`.review` launch path, so on an older
+    /// interactive. Emitted on every launch path, so on an older
     /// binary the effect depends on that binary's handling. `--trust` has been a
     /// *recognized* flag since before 07.20 (the param reference lists it,
     /// headless-only), so an older `agent` parses it rather than erroring on an
@@ -102,17 +126,14 @@ public enum CursorLaunchArgs {
     /// the caller opted into auto-permission. Callers append it to the
     /// shell-quoted binary path.
     ///
-    /// `seedTrust` is `session.kind != .review` at the call sites. A `.review`
-    /// working tree is a `gh` clone checked out at the PR author's head
-    /// (attacker-controlled), so — mirroring the `session.kind != .review` guard
-    /// on `CodexTrustSeeder` in `SessionService` — Crow **never** auto-trusts it
-    /// (CROW-890 review, Red 1). The intent is that review falls back to Cursor's
-    /// folder-trust dialog as its human gate; note that review's default
-    /// auto-permission adds `--force`, and whether `--force` alone still surfaces
-    /// that dialog is **unverified** — but withholding `--trust` is never worse
-    /// than emitting it, so the guard holds regardless. Auto-permission is
-    /// orthogonal and unchanged on `.review`. `.work`/`.job` worktrees branch off
-    /// a trusted base and the Manager runs in the devRoot, so those seed normally.
+    /// `seedTrust` is `true` at every production call site as of CROW-954 —
+    /// including `.review`, whose clone is protected by the launch-path
+    /// `.cursor/` strip rather than by the folder-trust dialog (see
+    /// `trustSuffix` for why the dialog was never the real gate). The parameter
+    /// is kept rather than inlined so the withholding behavior stays expressible
+    /// and unit-testable: if a future harness change makes an un-stripped Cursor
+    /// worktree reachable, flipping one call site back to `false` restores the
+    /// old posture without re-deriving the flag plumbing.
     public static func launchSuffix(seedTrust: Bool, autoPermissionMode: Bool) -> String {
         (seedTrust ? trustSuffix : "") + autoPermissionSuffix(autoPermissionMode)
     }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
@@ -87,10 +87,11 @@ struct CursorAgentTests {
         #expect(cmd?.contains(".crow-review-prompt.md") == true)
         #expect(cmd?.contains(".crow-job-prompt.md") == false)
         #expect(cmd?.hasSuffix("\n") == true)
-        // CROW-890 review (Red 1): a `.review` clone is attacker-controlled, so
-        // it must NOT be auto-trusted — the `--trust` seed is withheld, leaving
-        // Cursor's folder-trust dialog as the human gate.
-        #expect(cmd?.contains("--trust") == false)
+        // CROW-954 reverses the CROW-890 carve-out: a `.review` clone launches
+        // pre-trusted so unattended dispatch isn't stranded on "Workspace Trust
+        // Required". Its defense is the launch-path `.cursor/` strip
+        // (`SessionService.shouldStripCursorReviewClone`), not the dialog.
+        #expect(cmd?.contains("--trust") == true)
     }
 
     @Test func autoLaunchCommandReviewSessionSubsequentLaunch() {
@@ -109,62 +110,61 @@ struct CursorAgentTests {
         #expect(cmd != nil)
         #expect(cmd?.contains(".crow-review-prompt.md") == false)
         #expect(cmd?.hasSuffix("--continue\n") == true)
-        // Resume of a `.review` session stays untrusted too (Red 1).
-        #expect(cmd?.contains("--trust") == false)
+        // The seed rides `--continue` resume too — harmless, since the first
+        // launch already recorded the saved trust decision (CROW-954).
+        #expect(cmd?.contains("--trust") == true)
     }
 
-    @Test func autoLaunchCommandReviewOmitsTrustSeedEvenWithAutoPermission() {
-        // CROW-890 review, Red 1 — the exact shipped-default exploit config
-        // (`reviewAutoPermissionMode == true`). A `.review` clone is
-        // attacker-controlled, so it must NEVER be auto-trusted even with review
-        // auto-permission on. Auto-permission (`--force --approve-mcps`) is
-        // unchanged; only the `--trust` seed is withheld, leaving Cursor's
-        // folder-trust dialog as the human gate — mirrors the Codex
-        // `session.kind != .review` guard.
+    @Test func autoLaunchCommandReviewSeedsTrustAndRunEverything() {
+        // CROW-954, the shipped-default review config
+        // (`reviewAutoPermissionMode == true`): a review session must come up both
+        // already-trusted (`--trust`) AND in Run Everything mode (`--force`, which
+        // `agent --help` documents `--yolo` as an alias of). Regression pin for the
+        // reported symptom — the session stopping on Cursor's "Workspace Trust
+        // Required" prompt despite carrying `--force --approve-mcps`, which does
+        // NOT suppress that dialog (observed on `agent 2026.08.04`).
         let session = Session(name: "review", kind: .review, agentKind: .cursor)
         let cmd = agent.autoLaunchCommand(
             session: session, worktreePath: "/tmp/wt",
             remoteControlEnabled: false, autoPermissionMode: true, telemetryPort: nil)
+        #expect(cmd?.contains("--trust") == true)
         #expect(cmd?.contains("--force --approve-mcps") == true)
-        #expect(cmd?.contains("--trust") == false)
+        // Trust leads, so it is in effect before the prompt argument is parsed.
+        #expect(cmd?.contains("--trust --force --approve-mcps") == true)
     }
 
-    @Test func launchCommandHandoffWithholdsTrustForReview() async throws {
-        // The kind-aware handoff launch (`SessionService.handoffAgent` passes the
-        // live `session.kind`): a `.review` handoff to Cursor omits the trust
-        // seed (attacker-controlled clone), a `.work` handoff keeps it (Red 1).
-        let review = try await agent.launchCommand(
-            sessionID: UUID(), worktreePath: "/w", prompt: "p", sessionKind: .review)
-        #expect(review.contains("--trust") == false)
-        let work = try await agent.launchCommand(
-            sessionID: UUID(), worktreePath: "/w", prompt: "p", sessionKind: .work)
-        #expect(work.contains("--trust") == true)
+    @Test func launchCommandHandoffSeedsTrustForEveryKind() async throws {
+        // `SessionService.handoffAgent` passes the live `session.kind` through the
+        // `CodingAgent` protocol default. Post-CROW-954 Cursor has no kind-dependent
+        // launch, so every kind — `.review` included — carries the trust seed.
+        for kind in [SessionKind.review, .work, .job] {
+            let cmd = try await agent.launchCommand(
+                sessionID: UUID(), worktreePath: "/w", prompt: "p", sessionKind: kind)
+            #expect(cmd.contains("--trust") == true, "\(kind) handoff should seed trust")
+        }
     }
 
-    @Test func existentialDispatchReachesCursorOverride() async throws {
-        // CROW-890 review, Yellow 1: `SessionService.handoffAgent` holds the
-        // agent as `any CodingAgent` and calls the `sessionKind:` overload
-        // through the existential. Pin that dynamic dispatch reaches CursorAgent's
-        // override — if the protocol *requirement* were dropped (leaving only the
-        // extension default), a `.review` handoff would silently start emitting
-        // `--trust` again with an otherwise-green suite (verified counterfactual).
+    @Test func existentialDispatchSeedsTrustForReviewHandoff() async throws {
+        // `handoffAgent` holds the agent as `any CodingAgent`. Pin that the
+        // existential path — protocol default → Cursor's three-arg `launchCommand`
+        // — still seeds trust for a `.review` handoff. Cursor dropped its
+        // `sessionKind:` override in CROW-954; if someone reintroduces one that
+        // forgets to seed, a Cursor review handoff would silently start blocking on
+        // the trust dialog again with an otherwise-green suite.
         let erased: any CodingAgent = CursorAgent()
         let review = try await erased.launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", sessionKind: .review)
-        #expect(review.contains("--trust") == false)
-        let work = try await erased.launchCommand(
-            sessionID: UUID(), worktreePath: "/w", prompt: "p", sessionKind: .work)
-        #expect(work.contains("--trust") == true)
+        #expect(review.contains("--trust") == true)
     }
 
-    @Test func launchCommandThreeArgFailsClosed() async throws {
-        // CROW-890 review, Yellow 2: the kindless three-argument requirement
-        // (no production caller) must NEVER seed trust — fail closed, so a future
-        // caller of the bare form can't reopen the review-clone hole. The
-        // kind-aware overload above is the only seeding path.
+    @Test func launchCommandThreeArgSeedsTrust() async throws {
+        // The kindless three-argument requirement is what the protocol default
+        // lands on, so it must seed too. The CROW-890 "fail closed, never seed"
+        // default is moot now that every kind is trusted (CROW-954) — leaving it
+        // would strand exactly the handoff path that default serves.
         let cmd = try await agent.launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p")
-        #expect(cmd.contains("--trust") == false)
+        #expect(cmd.contains("--trust") == true)
     }
 
     @Test func autoLaunchCommandManagerSessionUnsupported() {

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
@@ -45,10 +45,12 @@ struct CursorLauncherTests {
         #expect(cmd.contains("--force") == false)          // no auto-permission
     }
 
-    @Test func launchCommandWithholdsTrustSeedForReviewClone() async throws {
-        // CROW-890 review (Red 1): `seedTrust: false` (the `.review` handoff
-        // case) drops `--trust` — the binary is followed directly by the prompt,
-        // so an attacker-controlled review clone keeps the folder-trust gate.
+    @Test func launchCommandWithholdsTrustSeedWhenSeedTrustOff() async throws {
+        // The `seedTrust: false` arm has no production caller as of CROW-954 (every
+        // Cursor launch now seeds, `.review` included), but the parameter is kept
+        // so the withholding posture stays one flag flip away — see
+        // `CursorLaunchArgs.launchSuffix`. Pin the arm so it can't silently rot
+        // into a no-op that would make restoring it a lie.
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: false)
         #expect(cmd.contains("--trust") == false)

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -841,7 +841,11 @@ public final class SessionService {
     /// arm a committed `.codex`/`.grok` hook on launch. Review falls back to the
     /// agent's own trust prompt (the human-gated path), and `prepareReviewClone`
     /// strips committed agent config as defense-in-depth. Cursor/OpenCode/
-    /// Antigravity have no folder-trust store, so they never seed.
+    /// Antigravity have no folder-trust store *this seeder can write*, so they
+    /// never seed here — note that does **not** mean Cursor launches untrusted: it
+    /// trusts per-launch via the `--trust` flag (`CursorLaunchArgs.trustSuffix`),
+    /// on every kind including `.review` (CROW-954), which is why its review clones
+    /// are stripped on every launch path rather than gated by a dialog.
     nonisolated static func shouldSeedFolderTrust(
         agentKind: AgentKind, sessionKind: SessionKind) -> Bool {
         switch agentKind {
@@ -936,9 +940,13 @@ public final class SessionService {
     ///     approval gate and Antigravity seeds no trust, so the strip is the *only*
     ///     defense — it MUST re-run here, not just at creation, because the review
     ///     skill's `gh pr checkout` (or a head-advancing re-review) restores the
-    ///     attacker's hooks from the PR head.
-    ///  2. **Seed** the agent's folder trust (Claude/Codex/Grok, never `.review`),
-    ///     gated via `shouldSeedFolderTrust`.
+    ///     attacker's hooks from the PR head. Same again for a Cursor `.review`
+    ///     clone's `.cursor/` (`shouldStripCursorReviewClone`, CROW-954): now that
+    ///     Cursor seeds `--trust` on review, no folder-trust dialog stands behind
+    ///     the strip either, so it joins the every-launch set for the same reason.
+    ///  2. **Seed** the agent's folder trust (Claude and — via the per-launch
+    ///     `--trust` flag, not this step — Cursor on every kind; Codex/Grok on
+    ///     everything but `.review`), gated via `shouldSeedFolderTrust`.
     ///  3. **Reconcile the main clone's** hook block (#915). A linked worktree
     ///     loads the main clone's `.claude/settings.local.json` in addition to
     ///     its own, so a stale block there breaks hooks and telemetry for every
@@ -950,8 +958,8 @@ public final class SessionService {
     ///
     /// All are no-ops for the agents/kinds/layouts that don't need them, so this
     /// is safe to call from every launch path unconditionally. **The call sites of
-    /// this symbol ARE the answer to "how many Grok/Antigravity launch paths open a
-    /// review clone"** — `rg prepareWorktreeForAgentLaunch`, never a hand-maintained
+    /// this symbol ARE the answer to "how many Grok/Antigravity/Cursor launch paths
+    /// open a review clone"** — `rg prepareWorktreeForAgentLaunch`, never a hand-maintained
     /// count (which went stale four rounds running). Today: `pasteDeferredLaunch`,
     /// `launchAgent`, `handoffAgent`, `createManagerTerminal` (seed only — Manager
     /// is never `.review`), and the `send` RPC (`EngineRouter`). `prepareReviewClone`
@@ -969,6 +977,9 @@ public final class SessionService {
         }
         if shouldStripAntigravityReviewClone(agentKind: agentKind, sessionKind: sessionKind) {
             stripAntigravityConfigFromReviewClone(clonePath: worktreePath)
+        }
+        if shouldStripCursorReviewClone(agentKind: agentKind, sessionKind: sessionKind) {
+            stripCursorConfigFromReviewClone(clonePath: worktreePath)
         }
         seedTrustIfNeeded(
             agentKind: agentKind, sessionKind: sessionKind, worktreePath: worktreePath)
@@ -3053,6 +3064,27 @@ public final class SessionService {
     nonisolated static func shouldStripCursorReviewCloneOnHandoff(
         targetKind: AgentKind, sessionKind: SessionKind) -> Bool {
         targetKind == .cursor && sessionKind == .review
+    }
+
+    /// Whether Cursor is about to open a `.review` clone and must therefore strip
+    /// its committed `.cursor/` first — the launch-path gate, as opposed to the
+    /// creation-time (`prepareReviewClone`) and handoff
+    /// (`shouldStripCursorReviewCloneOnHandoff`) arms.
+    ///
+    /// Added with CROW-954, which made Cursor seed `--trust` on `.review`. Before
+    /// that, a review clone launched untrusted and Cursor's folder-trust dialog
+    /// stood between a restored `.cursor/hooks.json` and execution, so stripping at
+    /// creation was enough. Now the clone launches pre-trusted, so the strip is the
+    /// **only** thing between a hostile committed hook and the reviewer's machine —
+    /// exactly the position Antigravity is in (`shouldStripAntigravityReviewClone`,
+    /// #902 review Red), and for the same reason it must re-fire on every launch,
+    /// not just at creation: the review skill's `gh pr checkout` (or a
+    /// head-advancing re-review) restores the attacker's `.cursor/` from the PR
+    /// head, and a warm `crowd` restart or `crow send` reopens the clone through
+    /// neither the creation nor the handoff arm.
+    nonisolated static func shouldStripCursorReviewClone(
+        agentKind: AgentKind, sessionKind: SessionKind) -> Bool {
+        agentKind == .cursor && sessionKind == .review
     }
 
     /// Gate for refusing a review-session handoff (and `crow agents set

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1529,8 +1529,10 @@ public final class SessionService {
         // agent — a handoff flips a review created under another agent onto a clone
         // never stripped for Grok. Same for an Antigravity `.review` handoff — the
         // gate strips `.agents/` (#902 review Red), which is why this PR needs no
-        // bespoke Antigravity handoff arm. Seed is a no-op for `.review` / trustless
-        // agents.
+        // bespoke Antigravity handoff arm — and, as of CROW-954, same for a Cursor
+        // `.review` handoff, whose `.cursor/` the gate now strips too (that is what
+        // retired Cursor's own handoff arm below). Seed is a no-op for `.review` /
+        // trustless agents.
         Self.prepareWorktreeForAgentLaunch(
             agentKind: target.kind, sessionKind: session.kind,
             worktreePath: worktree.worktreePath,
@@ -1566,21 +1568,15 @@ public final class SessionService {
         }
         // Handing off to Cursor → sync its global Jira MCP (this path selects
         // Cursor without touching config, so the boot-time gate would miss it).
+        //
+        // No bespoke `.cursor/` strip arm here: the shared
+        // `prepareWorktreeForAgentLaunch` above already ran with `target.kind`, so
+        // a handoff that flips a review created under Claude/Codex/OpenCode onto
+        // Cursor is stripped before launch (#829 review round 10, Red 1 — the
+        // hazard is unchanged, only its owner moved). CROW-954 routed Cursor
+        // through that gate, which retired the duplicate arm and leaves one strip
+        // path per agent, same as Antigravity (CROW-954 review, Green 1).
         if target.kind == .cursor {
-            // Neutralize the review clone's committed `.cursor/` FIRST (#829
-            // review round 10, Red 1). `prepareReviewClone` strips it only when
-            // Cursor is the *creation-time* review agent; a handoff flips a
-            // review session created under Claude/Codex/OpenCode to Cursor in a
-            // clone that was never stripped, so without this the attacker's
-            // `.cursor/hooks.json` fires on the very first handoff launch (hooks
-            // have no approval gate) and its `.cursor/mcp.json` is auto-trusted
-            // on the next relaunch. Mirrors the Codex handoff arm's
-            // `session.kind != .review` reasoning above, applied to Cursor's
-            // config layer rather than its trust seed.
-            if Self.shouldStripCursorReviewCloneOnHandoff(
-                targetKind: target.kind, sessionKind: session.kind) {
-                Self.stripCursorConfigFromReviewClone(clonePath: worktree.worktreePath)
-            }
             syncCursorMCPBridge()
         }
 
@@ -1980,7 +1976,7 @@ public final class SessionService {
     /// build the clone directory, so gateway resolution can never disagree with
     /// what creation decided the repo was. Extracted as a pure function so the
     /// link-selection rule is unit-testable without standing up the terminal
-    /// machinery (same reasoning as `shouldStripCursorReviewCloneOnHandoff`).
+    /// machinery (same reasoning as `shouldStripCursorReviewClone`).
     ///
     /// GitLab MR URLs don't fit `parseReviewPR`'s shape and yield a slug that
     /// claims nothing — which lands on "unset", exactly today's behavior. The
@@ -3054,22 +3050,16 @@ public final class SessionService {
         let clonePath: String
     }
 
-    /// Gate for the Cursor-handoff `.cursor/` strip: fire only when handing a
-    /// *review* session off to Cursor. Extracted as a pure predicate so the
-    /// handoff gate — the dimension both the round-10 and round-11 blockers
-    /// lived in — is unit-testable without standing up the full `handoffAgent`
-    /// terminal machinery (mirrors `shouldRestartPrimaryManagerOnRecreate`).
-    /// `.work`/`.job` handoffs to Cursor, and `.review` handoffs to any other
-    /// agent, must NOT strip (#829 review round 11, Green 2).
-    nonisolated static func shouldStripCursorReviewCloneOnHandoff(
-        targetKind: AgentKind, sessionKind: SessionKind) -> Bool {
-        targetKind == .cursor && sessionKind == .review
-    }
-
     /// Whether Cursor is about to open a `.review` clone and must therefore strip
     /// its committed `.cursor/` first — the launch-path gate, as opposed to the
-    /// creation-time (`prepareReviewClone`) and handoff
-    /// (`shouldStripCursorReviewCloneOnHandoff`) arms.
+    /// creation-time (`prepareReviewClone`) arm.
+    ///
+    /// This subsumes the former `shouldStripCursorReviewCloneOnHandoff`, retired in
+    /// the CROW-954 review (Green 1): `handoffAgent` routes through
+    /// `prepareWorktreeForAgentLaunch` with the *target* kind, so the handoff case
+    /// — flipping a review created under another agent onto Cursor, in a clone
+    /// `prepareReviewClone` never stripped for Cursor (#829 review round 10, Red 1)
+    /// — is covered here, leaving one strip path per agent as with Antigravity.
     ///
     /// Added with CROW-954, which made Cursor seed `--trust` on `.review`. Before
     /// that, a review clone launched untrusted and Cursor's folder-trust dialog
@@ -3099,7 +3089,7 @@ public final class SessionService {
     /// `AgentsRPCSupport.validateRoleSupportsAgent`) so a future review-incapable
     /// harness can be gated in one place without the two drifting. Extracted as a
     /// pure predicate so the gate stays unit-testable without the full
-    /// `handoffAgent` machinery (mirrors `shouldStripCursorReviewCloneOnHandoff`).
+    /// `handoffAgent` machinery (mirrors `shouldStripCursorReviewClone`).
     nonisolated static func shouldRefuseReviewHandoff(
         targetKind: AgentKind, sessionKind: SessionKind) -> Bool {
         // Intentionally always `false`: every registered harness now supports
@@ -3177,33 +3167,36 @@ public final class SessionService {
     /// machine once Cursor loads the clone as its project root. Stripping the
     /// whole directory removes both surfaces.
     ///
-    /// Shared by two call sites so the gate can't drift (#829 review round 10):
-    /// `prepareReviewClone` (the creation-time default review agent) and the
-    /// Cursor branch of `handoffAgent` (`crow handoff-agent --agent cursor` can
-    /// flip a review session created under another agent to Cursor *after* the
-    /// clone was prepped, landing it in a never-stripped hostile checkout).
-    /// Working-tree removal only: the git index entry survives (`removeItem`
-    /// doesn't stage a deletion), so `CursorHookConfigWriter.writeHookConfig`
-    /// still correctly declines to overwrite a *committed* hooks file and the
-    /// review runs without Crow's hook-based state signals — a bounded,
-    /// pre-existing limitation for repos that commit their own `.cursor/`,
-    /// independent of this security strip. Idempotent; no-ops when the clone
-    /// ships no `.cursor/`.
+    /// Shared rather than inlined so the gate can't drift (#829 review round 10):
+    /// `prepareReviewClone` strips at creation time,
+    /// `prepareWorktreeForAgentLaunch` on every launch path (via
+    /// `shouldStripCursorReviewClone` — CROW-954), and
+    /// `stripGrokConfigFromReviewClone` reuses it for the `.cursor/` layer Grok
+    /// also discovers. `rg stripCursorConfigFromReviewClone` is the authority on
+    /// that set — never a hand-maintained count here, which is what went stale
+    /// four rounds running on the sibling helpers. Working-tree removal only: the
+    /// git index entry survives (`removeItem` doesn't stage a deletion), so
+    /// `CursorHookConfigWriter.writeHookConfig` still correctly declines to
+    /// overwrite a *committed* hooks file and the review runs without Crow's
+    /// hook-based state signals — a bounded, pre-existing limitation for repos
+    /// that commit their own `.cursor/`, independent of this security strip.
+    /// Idempotent; no-ops when the clone ships no `.cursor/`.
+    ///
+    /// Delegates to `removeReviewCloneConfig` so a genuine removal failure is
+    /// **audible** (`CrowLog.error`, not `info`). That matters as of CROW-954:
+    /// Cursor review clones now launch pre-trusted (`--trust`) with `--force
+    /// --approve-mcps`, so this strip is the *only* thing standing between a
+    /// committed `.cursor/hooks.json` and unsandboxed execution. A swallowed
+    /// failure would leave live attacker config in place with nothing to show for
+    /// it — the same rationale already spelled out on
+    /// `stripAntigravityConfigFromReviewClone` (#902 review r3, Yellow 1), which
+    /// this now matches. Before CROW-954 an `info` line was tolerable because
+    /// Cursor's folder-trust dialog stood behind the strip; this PR removed that
+    /// backstop (CROW-954 review, Yellow 1).
     nonisolated static func stripCursorConfigFromReviewClone(clonePath: String) {
-        let cursorDir = (clonePath as NSString).appendingPathComponent(".cursor")
-        do {
-            try FileManager.default.removeItem(atPath: cursorDir)
-        } catch let error as NSError
-            where error.domain == NSCocoaErrorDomain
-            && error.code == NSFileNoSuchFileError {
-            // No `.cursor/` shipped — the common, expected case. Stay quiet.
-        } catch {
-            // A real removal failure (permissions, a `.cursor` that's a busy
-            // mount, etc.) leaves the attacker's config layer in place, so this
-            // security control must be audible rather than swallowed (#829
-            // review round 11, Green 1).
-            CrowLog.info("[SessionService] Failed to strip .cursor/ from review clone \(clonePath): \(error.localizedDescription)")
-        }
+        removeReviewCloneConfig(
+            (clonePath as NSString).appendingPathComponent(".cursor"),
+            label: ".cursor/", clonePath: clonePath)
     }
 
     /// Whether Grok is about to open a `.review` clone and must therefore strip
@@ -3211,7 +3204,7 @@ public final class SessionService {
     /// anti-drift guarantee comes from routing — every launch path calls
     /// `prepareWorktreeForAgentLaunch` (grep its call sites), and creation-time
     /// `prepareReviewClone` strips directly — not from any enumeration here (#861
-    /// review, Red; mirrors `shouldStripCursorReviewCloneOnHandoff`). Only a
+    /// review, Red; mirrors `shouldStripCursorReviewClone`). Only a
     /// `.review` session on Grok strips: `.work`/`.job` branch off a trusted base,
     /// and a `.review` on any other agent must not strip a surface that agent
     /// doesn't load.
@@ -3329,7 +3322,9 @@ public final class SessionService {
     /// Remove one review-clone config path, quiet when it isn't present (the
     /// common case) but **audible** on a real removal failure — a swallowed
     /// error would leave an attacker-controlled config layer in place. Shared by
-    /// the Grok strip's several layers.
+    /// **all three** review-clone strips — Grok's several layers, Antigravity's
+    /// `.agents/`+`.gemini/`, and Cursor's `.cursor/` (CROW-954) — so every strip
+    /// reports a failure at one log level.
     private nonisolated static func removeReviewCloneConfig(
         _ path: String, label: String, clonePath: String) {
         do {

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
@@ -267,4 +267,71 @@ struct SessionServiceReviewCloneStripTests {
 
         #expect(FileManager.default.fileExists(atPath: agentsDir))
     }
+
+    // MARK: - Cursor launch-path strip (CROW-954 — the dialog is gone, so this is the gate)
+
+    /// Only a `.review` clone *on Cursor* strips on the launch path. Before
+    /// CROW-954 the creation-time strip was backstopped by Cursor's folder-trust
+    /// dialog; now that review launches carry `--trust`, this gate is the only
+    /// thing between a committed `.cursor/hooks.json` restored by the review
+    /// skill's `gh pr checkout` and unsandboxed execution.
+    @Test func cursorStripGateFiresOnlyForReview() {
+        #expect(SessionService.shouldStripCursorReviewClone(
+            agentKind: .cursor, sessionKind: .review))
+    }
+
+    /// A `.work`/`.job` Cursor session branches off a trusted base — no strip.
+    @Test func cursorStripGateSkipsNonReview() {
+        #expect(!SessionService.shouldStripCursorReviewClone(
+            agentKind: .cursor, sessionKind: .work))
+        #expect(!SessionService.shouldStripCursorReviewClone(
+            agentKind: .cursor, sessionKind: .job))
+    }
+
+    /// A `.review` on any *other* agent must not strip `.cursor/` — stripping a
+    /// surface the reviewing agent doesn't load would just hide the files a hostile
+    /// PR ships (same reasoning as the `.codex/`/`.agents/` gates). Grok is the
+    /// deliberate exception and strips `.cursor/` through its own broader helper.
+    @Test func cursorStripGateSkipsReviewForOtherAgents() {
+        for k: AgentKind in [.claudeCode, .codex, .openCode, .antigravity] {
+            #expect(!SessionService.shouldStripCursorReviewClone(
+                agentKind: k, sessionKind: .review))
+        }
+    }
+
+    /// The launch-gate wiring, not just the predicate: delete the
+    /// `shouldStripCursorReviewClone` arm of `prepareWorktreeForAgentLaunch` and
+    /// only this test fails. `.cursor` seeds no folder trust through
+    /// `seedTrustIfNeeded` (it trusts per-launch via the `--trust` flag instead),
+    /// so this call touches zero global trust state.
+    @Test func prepareStripsCursorConfigWhenGateFires() {
+        let clone = Self.makeTempDir(name: "prep-cursor-review")
+        defer { try? FileManager.default.removeItem(atPath: clone) }
+        let cursorDir = (clone as NSString).appendingPathComponent(".cursor")
+        try? FileManager.default.createDirectory(
+            atPath: cursorDir, withIntermediateDirectories: true)
+        try? "{\"hooks\":\"EVIL\"}".write(
+            toFile: (cursorDir as NSString).appendingPathComponent("hooks.json"),
+            atomically: true, encoding: .utf8)
+
+        SessionService.prepareWorktreeForAgentLaunch(
+            agentKind: .cursor, sessionKind: .review, worktreePath: clone, ownership: .empty)
+
+        #expect(!FileManager.default.fileExists(atPath: cursorDir))
+    }
+
+    /// The gate is scoped: a `.work` Cursor session is a normal working clone, so
+    /// `prepareWorktreeForAgentLaunch` leaves the user's own `.cursor/` alone.
+    @Test func prepareLeavesCursorConfigForNonReview() {
+        let clone = Self.makeTempDir(name: "prep-cursor-work")
+        defer { try? FileManager.default.removeItem(atPath: clone) }
+        let cursorDir = (clone as NSString).appendingPathComponent(".cursor")
+        try? FileManager.default.createDirectory(
+            atPath: cursorDir, withIntermediateDirectories: true)
+
+        SessionService.prepareWorktreeForAgentLaunch(
+            agentKind: .cursor, sessionKind: .work, worktreePath: clone, ownership: .empty)
+
+        #expect(FileManager.default.fileExists(atPath: cursorDir))
+    }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewCloneStripTests.swift
@@ -80,33 +80,17 @@ struct SessionServiceReviewCloneStripTests {
     }
 
     // MARK: - Handoff gate (the dimension both round-10 and round-11 blockers lived in)
-
-    /// Only a `.review` handoff *to Cursor* strips: the exact gate that, when
-    /// missing (round 10) or divergent (round 11), left Cursor running in an
-    /// unstripped hostile clone.
-    @Test func handoffGateFiresOnlyForCursorReview() {
-        #expect(SessionService.shouldStripCursorReviewCloneOnHandoff(
-            targetKind: .cursor, sessionKind: .review))
-    }
-
-    /// A `.work`/`.job` handoff to Cursor is a normal working clone, not an
-    /// attacker-controlled review head — no strip.
-    @Test func handoffGateSkipsNonReviewCursor() {
-        #expect(!SessionService.shouldStripCursorReviewCloneOnHandoff(
-            targetKind: .cursor, sessionKind: .work))
-        #expect(!SessionService.shouldStripCursorReviewCloneOnHandoff(
-            targetKind: .cursor, sessionKind: .job))
-    }
-
-    /// A `.review` handoff to any *other* agent must not strip `.cursor/` —
-    /// stripping a surface the reviewing agent doesn't load would just hide the
-    /// files a hostile PR ships (same reasoning as the `.codex/` gate).
-    @Test func handoffGateSkipsReviewForNonCursorAgents() {
-        for k: AgentKind in [.claudeCode, .codex, .openCode, .grok] {
-            #expect(!SessionService.shouldStripCursorReviewCloneOnHandoff(
-                targetKind: k, sessionKind: .review))
-        }
-    }
+    //
+    // The dedicated `shouldStripCursorReviewCloneOnHandoff` tests that lived here
+    // were retired with the predicate itself (CROW-954 review, Green 1).
+    // `handoffAgent` strips via the shared `prepareWorktreeForAgentLaunch` gate,
+    // called with the *target* kind, so the round-10 hazard (a review created under
+    // another agent flipped onto Cursor in a never-stripped clone) is now covered by
+    // the launch-gate tests below — `cursorStripGateFiresOnlyForReview`,
+    // `cursorStripGateSkipsNonReview`, `cursorStripGateSkipsReviewForOtherAgents`
+    // assert the same agent × session-kind matrix, and
+    // `prepareStripsCursorConfigWhenGateFires` pins the wiring. Duplicating them
+    // against a second predicate is what let round 11's divergence happen.
 
     // MARK: - Antigravity review support (#902 — was #862 refusal, now wired)
 

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -47,12 +47,54 @@ deliberate, documented gaps (full grid in the
 > folder-trust dialog rather than launching pre-trusted, though whether `--force`
 > (review's default auto-permission) still surfaces that dialog is unverified;
 > withholding `--trust` is never worse than emitting it (CROW-890 review, Red 1).
-> Requires **Cursor CLI ≥
+> **[Superseded by the 2026-08-10 amendment below — the `.review` carve-out is
+> removed.]** Requires **Cursor CLI ≥
 > 2026.07.20**; the seed is emitted on every non-`.review` path, so an older
 > binary is out of support. Probed 2026.07.23 that the arg parser silently
 > ignores a mode-gated flag used outside its mode (`agent --output-format json
 > --version` exits 0, no error), so a pre-floor build recognizing `--trust`
 > would no-op it and degrade to the old prompt rather than reject the launch.
+
+> **Amendment (2026-08-10, CROW-954):** the `.review` carve-out in the #890
+> amendment above is **removed** — Cursor now seeds `--trust` on every session
+> kind, review included. The carve-out rested on one load-bearing claim, that a
+> review clone would "fall back to Cursor's folder-trust dialog" as a *human gate*.
+> Both halves of that failed in practice:
+>
+> 1. **The dialog gated nothing.** Review launches already carry `--force
+>    --approve-mcps` (`reviewAutoPermissionMode` ships on), so the reviewer's only
+>    meaningful choice at the prompt is to trust — after which every tool call runs
+>    unapproved. It was a keypress, not a decision.
+> 2. **`--force` does not suppress it** — the exact question the #890 amendment
+>    left "unverified". Observed on `agent 2026.08.04`: a Crow review session
+>    launched with `--force --approve-mcps` stops on "Workspace Trust Required" and
+>    waits. So the carve-out's cost was not theoretical — it broke the unattended
+>    dispatch that makes review sessions useful, which is precisely the failure the
+>    trust seed exists to prevent.
+>
+> The security property the carve-out was reaching for is preserved, and moved to
+> where it actually holds: `SessionService.stripCursorConfigFromReviewClone` removes
+> the clone's committed `.cursor/` (`hooks.json`, `mcp.json`) and is now promoted
+> from a creation-time + handoff strip to run on **every** launch path via
+> `prepareWorktreeForAgentLaunch` (`shouldStripCursorReviewClone`). That promotion
+> is load-bearing, not cosmetic: with no dialog behind it, the strip must re-fire
+> after the review skill's `gh pr checkout` (or a head-advancing re-review) restores
+> the attacker's config, and a warm `crowd` restart or `crow send` reopens the clone
+> through neither the creation nor the handoff arm. This is the same
+> **strip-not-trust** posture Grok (#861) and Antigravity (#902) reviews already
+> rely on, and it re-converges Cursor with `ClaudeTrustSeeder`, which has always
+> trusted `.review` (`shouldSeedFolderTrust` returns `true` for Claude on every
+> kind) — so the #890 "divergence from Claude, follow the Codex precedent" framing
+> is retired for Cursor. **Codex and Grok keep their `!= .review` guards**: they
+> write durable global trust records (`~/.codex/config.toml`,
+> `~/.grok/trusted_folders.toml`) that outlive the session, a materially larger
+> blast radius than Cursor's per-workspace marker under `~/.cursor/projects/`, and
+> nothing about this change argues for touching them.
+>
+> Verified interactively (not just from `--help`) on `agent 2026.08.04`: running
+> `agent --trust` under a pty in a fresh repo, with no `--print`, writes
+> `~/.cursor/projects/<slug>/.workspace-trusted` containing `"trustMethod":
+> "cli-flag"` — the same saved decision the dialog records on accept.
 
 > **Amendment (2026-07-28, #902):** Antigravity's **review** gap — recorded as a
 > Tier-2 deferral (its `autoLaunchCommand(.review)` returned `nil`, so a review

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -36,7 +36,7 @@ capabilities, update this table in the same PR.
 | MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ✅ `jira` bridged into `~/.cursor/mcp.json` (#829) | ✅ mirrored from `~/.claude.json` into `config.toml` | ❌ falls back to `acli` | ❌ falls back to `acli` (Jira MCP bridge deferred; Grok *does* read Claude/Cursor MCP configs) | ❌ falls back to `acli` (file bridge deferred) |
 | Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body (human-gated) | ✅ inlined skill body (#902) |
 | Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `$(cat …)` job/review; handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (`$(cat …-prompt.md)`) | ✅ run-then-`--continue` | ✅ run-then-`-c` (`.job`/`.review`); `.work` bare | ✅ `-p "$(cat …-{job,review}-prompt.md)"` (`.job`/`.review`, #902); `.work` bare |
-| Gateway env / trust seed / telemetry | ✅ Claude special-case | ⚠️ trust seed only (`--trust`, per-launch, except `.review`) | ⚠️ trust seed only (`[projects."…"]` in `config.toml`) | ❌ | ⚠️ trust seed only (`[folders."…"]` in `~/.grok/trusted_folders.toml`) | ❌ |
+| Gateway env / trust seed / telemetry | ✅ Claude special-case | ⚠️ trust seed only (`--trust`, per-launch, every kind) | ⚠️ trust seed only (`[projects."…"]` in `config.toml`) | ❌ | ⚠️ trust seed only (`[folders."…"]` in `~/.grok/trusted_folders.toml`) | ❌ |
 | Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ | ✅ (alias `/title`) | ❌ unverified on v1.1.7 (opt-out `nil`) |
 | Self-host / local models | provider-dependent | provider-dependent | provider-dependent | provider-dependent | ✅ `config.toml` `[model.*]` → any OpenAI/Anthropic-compatible or local (Ollama) endpoint | ❌ **permanent** — closed-source, Google-Sign-In/GCP-locked (Gemini 3 Pro / Claude Sonnet 4.5 only) |
 
@@ -195,10 +195,13 @@ harness's sessions
   `git push`, and the Manager's `crow`-socket / `gh` / sibling `git worktree add`
   all need network the sandbox would kill; `--sandbox` is left unset so Cursor
   honors the user's own config), `--yolo`, and the undocumented `--auto-review`.
-  (`--trust` **is** emitted — but as a per-launch workspace-**trust seed**, not an
-  auto-permission flag; see "Gateway env / trust seed / telemetry" below. It went
-  interactive in Cursor CLI 2026.07.20, reversing the earlier headless-only
-  omission, #890.)
+  Note `--yolo` is skipped only because it is a pure **alias** for `--force`
+  (`agent --help`: "Alias for --force (Run Everything)"), not because Crow declines
+  Run Everything — `--force` *is* Run Everything, and it is what review sessions
+  run under. (`--trust` **is** emitted — but as a per-launch workspace-**trust
+  seed**, not an auto-permission flag; see "Gateway env / trust seed / telemetry"
+  below. It went interactive in Cursor CLI 2026.07.20, reversing the earlier
+  headless-only omission, #890, and covers `.review` too as of CROW-954.)
 - **Codex:** honored for `.job` sessions on the **interactive** launch —
   `codex -a never -s workspace-write "$(cat …-prompt.md)"` (approval off, sandbox
   still bounded; the analogue of Claude's `--permission-mode auto`, **not** the
@@ -466,22 +469,30 @@ the two Manager gateway writes noted below):
   blocks an auto-launched session (CROW-600). Runs at **four** call sites:
   `SessionService.launchAgent`, `handoffAgent`, and the two Manager paths.
 - **Trust seeding (Cursor)** — the per-launch analogue of the Claude seed:
-  `CursorLaunchArgs.trustSuffix` appends `--trust` to every Crow-driven launch
-  (auto-launch, Manager, and the handoff one-shot) **except `.review`**, so a
-  fresh `.work`/`.job` worktree doesn't block on Cursor's folder-trust dialog
-  (CROW-890). A `.review` clone is an attacker-controlled `gh` checkout at the PR
-  author's head, so — mirroring the `session.kind != .review` guard on
-  `CodexTrustSeeder` — Crow **never** auto-trusts it; the intent is that review
-  falls back to Cursor's folder-trust dialog as its human gate, though whether
-  `--force` (review's default auto-permission) still surfaces that dialog is
-  unverified — withholding `--trust` is never worse than emitting it (CROW-890
-  review, Red 1). **Interactive since Cursor
-  CLI 2026.07.20** ([changelog](https://cursor.com/docs/cli/changelog)); verified
-  against `agent 2026.07.23`, whose `--help` drops the "(headless mode only)"
-  qualifier the [param reference](https://cursor.com/docs/cli/reference/parameters)
-  still carries. **Workspace trust only** — not `--yolo`; auto-permission stays
-  in the separate `--force --approve-mcps` (which still applies on `.review`,
-  unchanged).
+  `CursorLaunchArgs.trustSuffix` appends `--trust` to **every** Crow-driven launch
+  (auto-launch, Manager, and the handoff one-shot), so no worktree blocks on
+  Cursor's folder-trust dialog (CROW-890). **`.review` included as of CROW-954**,
+  reversing the original carve-out. The carve-out assumed the dialog would act as
+  review's human gate; both halves of that assumption were wrong. Review launches
+  already carry `--force --approve-mcps` (`reviewAutoPermissionMode` defaults on),
+  so the only available answer at the prompt is "trust", after which nothing is
+  gated anyway — and `--force` does **not** suppress the prompt (the CROW-890 note
+  left this "unverified"; observed on `agent 2026.08.04`, a review session stops on
+  "Workspace Trust Required" and waits for a keypress, which is exactly the
+  unattended-dispatch failure the seed exists to prevent). The clone's real defense
+  is `stripCursorConfigFromReviewClone`, promoted to run on **every** launch path
+  via `prepareWorktreeForAgentLaunch` — the same **strip-not-trust** posture Grok
+  and Antigravity reviews already use, and consistent with Claude, whose
+  `shouldSeedFolderTrust` has always returned `true` for `.review`. **Interactive
+  since Cursor CLI 2026.07.20**
+  ([changelog](https://cursor.com/docs/cli/changelog)); verified against `agent
+  2026.08.04` — `agent --trust` under a pty with no `--print` writes
+  `~/.cursor/projects/<slug>/.workspace-trusted` with `"trustMethod": "cli-flag"`,
+  the same marker the dialog writes on accept. Its `--help` also drops the
+  "(headless mode only)" qualifier the
+  [param reference](https://cursor.com/docs/cli/reference/parameters) still
+  carries. **Workspace trust only** — not `--yolo`; auto-permission stays in the
+  separate `--force --approve-mcps`.
 - **AI-gateway env** — two mechanisms for the workspace's `ANTHROPIC_BASE_URL` /
   `ANTHROPIC_CUSTOM_HEADERS` (CROW-402): `ClaudeHookConfigWriter.writeGatewayEnv`
   writes the env block into `settings.local.json` (Claude-gated at `launchAgent`
@@ -635,7 +646,7 @@ against current upstream CLIs.
 | Codex reuses Claude's hook engine (`ClaudeHooksEngine`, byte-compatible schemas) | verified against **codex 0.123.0** | `CodexSignalSource` | 2026-07-24 |
 | Claude background-recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` | 2026-07-24 |
 | Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` | 2026-07-24 |
-| Cursor interactive `--trust` (workspace-trust seed) — reverses the earlier headless-only omission; withheld from `.review` clones | **min: Cursor CLI ≥ 2026.07.20** (changelog: interactive); verified `agent 2026.07.23` (`--help` drops "headless mode only") | `CursorLaunchArgs.trustSuffix` | 2026-07-28 — emitted on every non-`.review` path (Crow never auto-trusts review clones, mirroring the Codex `!= .review` guard; intended fallback is the folder-trust dialog, dialog-under-`--force` unverified). Pre-2026.07.20 CLI out of support; probed 2026.07.23 that the parser ignores a mode-gated flag (`--output-format json --version` exits 0), so older builds no-op `--trust` rather than reject. Re-probe if `--help` ever restores the headless-only qualifier |
+| Cursor interactive `--trust` (workspace-trust seed) — reverses the earlier headless-only omission; now emitted on **every** kind incl. `.review` | **min: Cursor CLI ≥ 2026.07.20** (changelog: interactive); verified `agent 2026.08.04` (`--help` drops "headless mode only"; pty run with no `--print` writes `.workspace-trusted` / `"trustMethod": "cli-flag"`) | `CursorLaunchArgs.trustSuffix` | 2026-08-10 (CROW-954) — emitted on every path. The `.review` carve-out is **removed**: `--force` was observed NOT to suppress the trust dialog (the CROW-890 "unverified" note, now settled), so the carve-out stranded unattended reviews on a prompt that gated nothing — review already runs `--force --approve-mcps`. Review clones are now defended by the launch-path `.cursor/` strip (`shouldStripCursorReviewClone`) instead. Pre-2026.07.20 CLI out of support; probed 2026.07.23 that the parser ignores a mode-gated flag (`--output-format json --version` exits 0), so older builds no-op `--trust` rather than reject. Re-probe if `--help` ever restores the headless-only qualifier |
 | OpenCode `session.idle` "done" semantics unconfirmed for TUI | — (CROW-545) | `OpenCodeHookConfigWriter` | 2026-07-24 |
 | Antigravity flags (`agy` hooks events, `-p` non-TTY stdout, `-c`/`--conversation` resume) | `agy` **v1.1.7 (2026-07-26)** | `AntigravityAgent` / `AntigravityHookConfigWriter` | 2026-07-26 — re-probe on upgrade |
 | Antigravity structured-stdout (would promote toward first-class parity) | upstream FRs **#119/#597** (`--output-format stream-json`), **#31** (ACP) | `AntigravitySignalSource` | 2026-07-26 — hooks are the only transport until either lands |


### PR DESCRIPTION
Closes #954.

Choosing Cursor as the review agent left review sessions parked on Cursor's "Workspace Trust Required" prompt instead of starting work, defeating unattended review dispatch.

## Cause

`CursorLaunchArgs.launchSuffix` was called with `seedTrust: session.kind != .review` — a CROW-890 carve-out (review, Red 1) justified as "review falls back to Cursor's folder-trust dialog as its human gate." Both halves of that fail in practice:

1. **The dialog gated nothing actionable.** Review launches already carry `--force --approve-mcps` (`reviewAutoPermissionMode` defaults on), so the only useful answer at the prompt is "trust" — after which every tool call runs unapproved anyway. It was a keypress, not a decision.
2. **`--force` does not suppress the prompt.** CROW-890's own comment flagged this as *"unverified"*. Now settled: on `agent 2026.08.04`, a review session launched with `--force --approve-mcps` still stops on "Workspace Trust Required" and waits.

So the carve-out bought no security while costing exactly the unattended dispatch the trust seed exists to provide. Cursor was also the outlier — `SessionService.shouldSeedFolderTrust` returns `true` for Claude on **every** kind, `.review` included, so Claude reviews have always launched pre-trusted.

## Change

- **`CursorAgent` seeds `--trust` on every session kind**, `.review` included. Reviews now launch as `'agent' --trust --force --approve-mcps \"$(cat …/.crow-review-prompt.md)\"` — already trusted, already in Run Everything mode.
- **Dropped Cursor's kind-aware `launchCommand(…sessionKind:)` override** — it existed solely to withhold the seed. Nothing else implements it, so the protocol default now serves every caller; the protocol requirement is kept as the seam a future harness would need.
- **Promoted `stripCursorConfigFromReviewClone` to every launch path** via a new `shouldStripCursorReviewClone` gate in `prepareWorktreeForAgentLaunch`.

That last one is the load-bearing part. The clone's real defense was never the dialog — it's the strip that removes committed `.cursor/hooks.json` / `mcp.json` before Cursor opens the tree. It previously ran only at clone creation and on handoff. With no dialog behind it, it must also re-fire after the review skill's `gh pr checkout` (or a head-advancing re-review) restores a hostile `.cursor/` from the PR head, and after a warm `crowd` restart or `crow send` reopens the clone through neither existing arm. This is the same **strip-not-trust** posture Grok (#861) and Antigravity (#902) reviews already rely on.

**Codex and Grok deliberately keep their `!= .review` trust guards.** They write durable *global* trust records (`~/.codex/config.toml`, `~/.grok/trusted_folders.toml`) that outlive the session — a materially larger blast radius than Cursor's per-workspace marker under `~/.cursor/projects/`. Nothing here argues for touching them.

## On the security tradeoff

This is a real reduction in defense depth, stated plainly: a hostile PR's `.cursor/` now has one mechanism standing in its way instead of two. The judgment is that the second mechanism was not actually a mechanism — a prompt whose only answer is "yes", in front of a session already running `--force`, is not a gate. The strip is now covered on every launch path and by tests that fail if the gate is removed.

## Verification

`--trust` is documented as ["headless mode only"](https://cursor.com/docs/cli/reference/parameters), which would have made this fix a silent no-op. **That doc is stale.** Verified empirically on `agent 2026.08.04` — running `agent --trust` under a pty in a fresh repo, with no `--print`, writes `~/.cursor/projects/<slug>/.workspace-trusted`:

```json
{
  "trustedAt": "2026-08-10T15:47:02.341Z",
  "workspacePath": "/private/tmp/…/repo",
  "trustMethod": "cli-flag"
}
```

That is the same saved decision the dialog records on accept. (Test artifacts were cleaned up afterward.)

Also confirmed from `agent --help` that **"Run Everything" is `--force`** — `--yolo  Alias for --force (Run Everything)` — so reviews were already in that mode; only trust was missing.

## Tests

- CrowCore **544** pass, CrowCursor **67** pass, CrowEngine **685** pass.
- Rewrote the CrowCursor assertions that pinned the old carve-out; `autoLaunchCommandReviewSeedsTrustAndRunEverything` is the regression pin for the reported symptom (asserts both `--trust` and `--force --approve-mcps` under the shipped default).
- Added 5 CrowEngine tests for the new strip gate, including `prepareStripsCursorConfigWhenGateFires` — delete the new arm of `prepareWorktreeForAgentLaunch` and only that test fails.
- CrowDaemon has 2 failures (`WebTerminalAssetTests`, `WebNotificationCenterTests`); verified identical on a clean `origin/main` worktree, so **pre-existing and unrelated**.

## Docs

`docs/agent-harness-matrix.md` (grid row, auto-permission bullet, trust-seed bullet, version re-check row) and an ADR 0015 amendment marking the #890 `.review` carve-out superseded.

## Note

The fix takes effect only after a rebuild + `crowd` restart; review sessions launched by the old binary still need one keypress.

[🐦‍⬛ Created with Crow via Claude Code](https://github.com/corveil/crow)
