### PR TITLE
Fix review launch quoting when SKILL body contains double quotes

### DIFF
--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -129,9 +129,9 @@ public struct AntigravityAgent: CodingAgent {
                     : ".crow-job-prompt.md"
                 let promptPath = (worktreePath as NSString)
                     .appendingPathComponent(promptFile)
-                // Quote the path so a devRoot containing spaces doesn't split
-                // `cat`'s argv and resolve the prompt to empty.
-                return "\(agentPath)\(autoArgs) -p \"$(cat \(AntigravityLaunchArgs.shellQuote(promptPath)))\"\n"
+                return ShellLaunchArgs.evalPromptLaunch(
+                    prefix: "\(agentPath)\(autoArgs) -p",
+                    promptPath: promptPath)
             }
             return "\(agentPath)\(autoArgs) -c\n"
         case .manager:

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLauncher.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLauncher.swift
@@ -90,6 +90,9 @@ public actor AntigravityLauncher {
         try prompt.write(to: promptPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
-        return "cd \(AntigravityLaunchArgs.shellQuote(worktreePath)) && \(AntigravityLaunchArgs.shellQuote(binary)) -p \"$(cat \(AntigravityLaunchArgs.shellQuote(promptPath.path)))\"\n"
+        return "cd \(AntigravityLaunchArgs.shellQuote(worktreePath)) && "
+            + ShellLaunchArgs.evalPromptLaunch(
+                prefix: "\(AntigravityLaunchArgs.shellQuote(binary)) -p",
+                promptPath: promptPath.path).trimmingCharacters(in: .newlines) + "\n"
     }
 }

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentTests.swift
@@ -50,19 +50,23 @@ struct AntigravityAgentTests {
             session: session, worktreePath: "/tmp/wt",
             remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
         #expect(cmd != nil)
-        #expect(cmd?.contains(" -p \"$(cat ") == true)
+        #expect(cmd?.contains("_CROW_P=$(<") == true)
+        #expect(cmd?.contains("eval \"") == true)
+        #expect(cmd?.contains(" -p $(printf '%q'") == true)
         #expect(cmd?.contains(".crow-job-prompt.md") == true)
         #expect(cmd?.hasSuffix("\n") == true)
     }
 
     @Test func jobFirstLaunchQuotesPromptPathWithSpaces() {
-        // A worktree under `/Users/x/My Projects/…` must not split `cat`'s argv:
-        // the prompt path is single-quoted inside the `$(cat …)` substitution.
+        // A worktree under `/Users/x/My Projects/…` must not split the prompt read:
+        // the prompt path is single-quoted inside the `$(< …)` substitution.
         let session = Session(name: "job", kind: .job, agentKind: .antigravity)
         let cmd = agent.autoLaunchCommand(
             session: session, worktreePath: "/Users/x/My Projects/wt",
             remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
-        #expect(cmd?.contains("-p \"$(cat '/Users/x/My Projects/wt/.crow-job-prompt.md')\"") == true)
+        #expect(cmd?.contains("_CROW_P=$(< '/Users/x/My Projects/wt/.crow-job-prompt.md');") == true)
+        #expect(cmd?.contains("eval \"") == true)
+        #expect(cmd?.contains(" -p $(printf '%q'") == true)
     }
 
     @Test func jobSubsequentLaunchResumesWithDashC() {
@@ -76,14 +80,15 @@ struct AntigravityAgentTests {
     }
 
     @Test func reviewFirstLaunchInjectsPromptViaDashP() {
-        // #902: review now dispatches the inlined SKILL body via
-        // `-p "$(cat '…/.crow-review-prompt.md')"`, same shape as `.job`.
+        // #902: review dispatches the inlined SKILL body via `-p "$_CROW_P"`.
         let session = Session(name: "review", kind: .review, agentKind: .antigravity)
         let cmd = agent.autoLaunchCommand(
             session: session, worktreePath: "/tmp/wt",
             remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
         #expect(cmd != nil)
-        #expect(cmd?.contains(" -p \"$(cat ") == true)
+        #expect(cmd?.contains("_CROW_P=$(<") == true)
+        #expect(cmd?.contains("eval \"") == true)
+        #expect(cmd?.contains(" -p $(printf '%q'") == true)
         #expect(cmd?.contains(".crow-review-prompt.md") == true)
         // NOT the job prompt file — review reads its own.
         #expect(cmd?.contains(".crow-job-prompt.md") == false)
@@ -91,13 +96,15 @@ struct AntigravityAgentTests {
     }
 
     @Test func reviewFirstLaunchQuotesPromptPathWithSpaces() {
-        // A worktree under `/Users/x/My Projects/…` must not split `cat`'s argv:
-        // the prompt path is single-quoted inside the `$(cat …)` substitution.
+        // A worktree under `/Users/x/My Projects/…` must not split the prompt read:
+        // the prompt path is single-quoted inside the `$(< …)` substitution.
         let session = Session(name: "review", kind: .review, agentKind: .antigravity)
         let cmd = agent.autoLaunchCommand(
             session: session, worktreePath: "/Users/x/My Projects/wt",
             remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
-        #expect(cmd?.contains("-p \"$(cat '/Users/x/My Projects/wt/.crow-review-prompt.md')\"") == true)
+        #expect(cmd?.contains("_CROW_P=$(< '/Users/x/My Projects/wt/.crow-review-prompt.md');") == true)
+        #expect(cmd?.contains("eval \"") == true)
+        #expect(cmd?.contains(" -p $(printf '%q'") == true)
     }
 
     @Test func reviewSubsequentLaunchResumesWithDashC() {

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityLauncherTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityLauncherTests.swift
@@ -55,9 +55,9 @@ struct AntigravityLauncherTests {
         let cmd = try await launcher.launchCommand(
             sessionID: sid, worktreePath: "/wt/crow", prompt: "hello world", binary: "/bin/agy")
 
-        // Shape: cd '<wt>' && '<binary>' -p "$(cat '<tmp>')" — all paths quoted.
-        #expect(cmd.hasPrefix("cd '/wt/crow' && '/bin/agy' -p \"$(cat '"))
-        #expect(cmd.hasSuffix("')\"\n"))
+        // Shape: cd '<wt>' && _CROW_P=…; eval '<binary> -p …'
+        #expect(cmd.hasPrefix("cd '/wt/crow' && _CROW_P=$(< '"))
+        #expect(cmd.contains("eval \"'/bin/agy' -p $(printf '%q'"))
 
         // The temp prompt file exists, holds the prompt, and is owner-only 0600.
         let tmp = FileManager.default.temporaryDirectory

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
@@ -81,7 +81,9 @@ public struct ClaudeCodeAgent: CodingAgent {
         if let initialPromptFile, !session.reviewPromptDispatched {
             let promptPath = (worktreePath as NSString)
                 .appendingPathComponent(initialPromptFile)
-            return "\(envPrefix)\(claudePath)\(rcArgs) \"$(cat \(promptPath))\"\n"
+            return envPrefix + ShellLaunchArgs.evalPromptLaunch(
+                prefix: claudePath + rcArgs,
+                promptPath: promptPath)
         }
         return "\(envPrefix)\(claudePath)\(rcArgs) --continue\n"
     }

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
@@ -146,7 +146,10 @@ public actor ClaudeLauncher {
         // Restrict prompt file to owner-only access
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
-        return "cd \(Self.shellEscape(worktreePath)) && claude \"$(cat \(Self.shellEscape(promptPath.path)))\"\n"
+        return "cd \(Self.shellEscape(worktreePath)) && "
+            + ShellLaunchArgs.evalPromptLaunch(
+                prefix: "claude",
+                promptPath: promptPath.path).trimmingCharacters(in: .newlines) + "\n"
     }
 
     /// Escape a string for safe inclusion in a shell command by wrapping in single quotes.

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeCodeAgentLaunchTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeCodeAgentLaunchTests.swift
@@ -29,18 +29,20 @@ struct ClaudeCodeAgentLaunchTests {
             for dispatched in [false, true] {
                 let cmd = try #require(command(kind: kind, dispatched: dispatched))
                 #expect(cmd.hasSuffix(" --continue\n"))
-                #expect(!cmd.contains("$(cat"))
+                #expect(!cmd.contains("$(<"))
             }
         }
     }
 
     @Test func reviewAndJobReadPromptFileOnFirstLaunchOnly() throws {
         let review = try #require(command(kind: .review, dispatched: false))
-        #expect(review.contains("\"$(cat /tmp/wt/.crow-review-prompt.md)\""))
+        #expect(review.contains("_CROW_P=$(< '/tmp/wt/.crow-review-prompt.md')"))
+        #expect(review.contains("eval \""))
+        #expect(review.contains("claude $(printf '%q'"))
         #expect(!review.contains("--continue"))
 
         let job = try #require(command(kind: .job, dispatched: false))
-        #expect(job.contains("\"$(cat /tmp/wt/.crow-job-prompt.md)\""))
+        #expect(job.contains("_CROW_P=$(< '/tmp/wt/.crow-job-prompt.md')"))
         #expect(!job.contains("--continue"))
     }
 
@@ -48,7 +50,7 @@ struct ClaudeCodeAgentLaunchTests {
         for kind in [SessionKind.review, .job] {
             let cmd = try #require(command(kind: kind, dispatched: true))
             #expect(cmd.hasSuffix(" --continue\n"))
-            #expect(!cmd.contains("$(cat"))
+            #expect(!cmd.contains("$(<"))
         }
     }
 

--- a/Packages/CrowCodex/Sources/CrowCodex/CodexLauncher.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/CodexLauncher.swift
@@ -76,7 +76,10 @@ public actor CodexLauncher {
         try prompt.write(to: promptPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
-        return "cd \(Self.shellEscape(worktreePath)) && codex \"$(cat \(Self.shellEscape(promptPath.path)))\"\n"
+        return "cd \(Self.shellEscape(worktreePath)) && "
+            + ShellLaunchArgs.evalPromptLaunch(
+                prefix: "codex",
+                promptPath: promptPath.path).trimmingCharacters(in: .newlines) + "\n"
     }
 
     private static func shellEscape(_ str: String) -> String {

--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -198,13 +198,4 @@ public struct OpenAICodexAgent: CodingAgent {
     public func sessionRenameSlashCommand(newName: String) -> String? {
         "/rename \(newName)\n"
     }
-
-    /// Single-quote a path for safe interpolation inside `$(cat …)`. Without
-    /// this, a worktree/devRoot containing a space (`/Users/j/Dev Projects/…`)
-    /// splits into multiple `cat` args → `cat` fails → the substitution yields
-    /// `""` and Codex launches with an empty prompt and idles (#843 review
-    /// round 7). Mirrors `CodexLauncher.shellEscape` / `OpenCodeLaunchArgs`.
-    static func shellEscape(_ path: String) -> String {
-        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
 }

--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -91,7 +91,6 @@ public struct OpenAICodexAgent: CodingAgent {
                 // sandbox flags to the same interactive launch.
                 let promptPath = (worktreePath as NSString)
                     .appendingPathComponent(".crow-job-prompt.md")
-                let promptArg = "\"$(cat \(Self.shellEscape(promptPath)))\""
                 if autoPermissionMode {
                     // Approval off, workspace-write sandbox still ON — the
                     // bounded analogue of Claude's `--permission-mode auto`
@@ -100,11 +99,15 @@ public struct OpenAICodexAgent: CodingAgent {
                     // `-s danger-full-access` (those disable the sandbox; only
                     // for externally-sandboxed runners). Options precede the
                     // positional prompt.
-                    return "\(codexPath) -a never -s workspace-write \(promptArg)\n"
+                    return ShellLaunchArgs.evalPromptLaunch(
+                        prefix: "\(codexPath) -a never -s workspace-write",
+                        promptPath: promptPath)
                 }
                 // Auto-permission off: interactive TUI with the initial prompt,
                 // default approval policy so the user approves each step.
-                return "\(codexPath) \(promptArg)\n"
+                return ShellLaunchArgs.evalPromptLaunch(
+                    prefix: codexPath,
+                    promptPath: promptPath)
             }
             // Subsequent restarts resume the prior thread — interactive, so
             // plain `--last` (cwd-scoped) selects it. Carry the same bounded
@@ -138,7 +141,9 @@ public struct OpenAICodexAgent: CodingAgent {
             if !session.reviewPromptDispatched {
                 let promptPath = (worktreePath as NSString)
                     .appendingPathComponent(".crow-review-prompt.md")
-                return "\(codexPath) \"$(cat \(Self.shellEscape(promptPath)))\"\n"
+                return ShellLaunchArgs.evalPromptLaunch(
+                    prefix: codexPath,
+                    promptPath: promptPath)
             }
             return "\(codexPath) resume --last\n"
         case .manager:

--- a/Packages/CrowCodex/Tests/CrowCodexTests/OpenAICodexAgentTests.swift
+++ b/Packages/CrowCodex/Tests/CrowCodexTests/OpenAICodexAgentTests.swift
@@ -177,20 +177,19 @@ struct OpenAICodexAgentTests {
     }
 
     @Test func autoLaunchCommandQuotesPromptPathWithSpaces() {
-        // #843 review round 7: a worktree/devRoot with a space must not split
-        // `$(cat …)` into multiple args (→ empty prompt, idle session). The path
-        // inside the substitution is single-quoted.
+        // #843 review round 7 / #957: a worktree/devRoot with a space must not
+        // split the prompt read. The path inside the substitution is single-quoted.
         let job = Session(name: "job", kind: .job, agentKind: .codex)
         let jobCmd = agent.autoLaunchCommand(
             session: job, worktreePath: "/tmp/my worktree",
             remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
-        #expect(jobCmd?.contains("$(cat '/tmp/my worktree/.crow-job-prompt.md')") == true)
+        #expect(jobCmd?.contains("_CROW_P=$(< '/tmp/my worktree/.crow-job-prompt.md')") == true)
 
         let review = Session(name: "review", kind: .review, agentKind: .codex)
         let reviewCmd = agent.autoLaunchCommand(
             session: review, worktreePath: "/tmp/my worktree",
             remoteControlEnabled: false, autoPermissionMode: false, telemetryPort: nil)
-        #expect(reviewCmd?.contains("$(cat '/tmp/my worktree/.crow-review-prompt.md')") == true)
+        #expect(reviewCmd?.contains("_CROW_P=$(< '/tmp/my worktree/.crow-review-prompt.md')") == true)
     }
 
     @Test func findBinaryReturnsNilWhenAbsent() {

--- a/Packages/CrowCore/Sources/CrowCore/ShellLaunchArgs.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ShellLaunchArgs.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Helpers for building shell launch commands Crow pastes into managed tmux
+/// panes. Centralized so every `CodingAgent` shares one quoting strategy.
+public enum ShellLaunchArgs {
+    /// POSIX single-quote escape for paths interpolated into shell commands.
+    public static func shellQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Bash statements that read `promptPath`, then `eval` a command built from
+    /// `prefix` (the shell-quoted agent binary plus flags) with the prompt file
+    /// contents as the final argv.
+    ///
+    /// Avoid `"$(cat path)"`, which breaks when the file contains `"` (#957).
+    /// macOS bash's `printf %q` emits backslash escapes that must be re-parsed
+    /// via `eval` (unlike GNU bash's `$'…'` form). Crow pastes this into the
+    /// user's interactive shell (zsh/bash via `crow-shell-wrapper`).
+    public static func evalPromptLaunch(prefix: String, promptPath: String) -> String {
+        let quotedPath = shellQuote(promptPath)
+        return "_CROW_P=$(< \(quotedPath)); eval \"\(prefix) $(printf '%q' \"$_CROW_P\")\"\n"
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/ShellLaunchArgsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ShellLaunchArgsTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite("ShellLaunchArgs")
+struct ShellLaunchArgsTests {
+    @Test func shellQuoteEscapesSingleQuotes() {
+        #expect(ShellLaunchArgs.shellQuote("plain") == "'plain'")
+        #expect(ShellLaunchArgs.shellQuote("has'quote") == "'has'\\''quote'")
+    }
+
+    @Test func evalPromptLaunchAvoidsCatSubshell() {
+        let cmd = ShellLaunchArgs.evalPromptLaunch(
+            prefix: "'agent' --force",
+            promptPath: "/tmp/wt/.crow-review-prompt.md")
+        #expect(cmd.contains("_CROW_P=$(< '/tmp/wt/.crow-review-prompt.md')"))
+        #expect(cmd.contains("eval \"'agent' --force $(printf '%q'"))
+        #expect(!cmd.contains("$(cat"))
+    }
+
+    @Test func evalPromptLaunchQuotesPathsWithSpaces() {
+        let cmd = ShellLaunchArgs.evalPromptLaunch(
+            prefix: "'agent'",
+            promptPath: "/Users/x/My Projects/wt/.crow-job-prompt.md")
+        #expect(cmd.contains("'/Users/x/My Projects/wt/.crow-job-prompt.md'"))
+    }
+
+    /// #957 repro: inlined SKILL bodies contain `"` and `$` — launch must preserve them.
+    @Test func evalPromptLaunchSurvivesQuotesAndDollars() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent(
+            "shell-launch-\(UUID().uuidString)")
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tmp) }
+        let promptFile = tmp.appendingPathComponent(".crow-review-prompt.md")
+        let expected = "test \"quotes\" $HOME "
+        try expected.write(to: promptFile, atomically: true, encoding: .utf8)
+
+        let launch = ShellLaunchArgs.evalPromptLaunch(
+            prefix: "'agent' --force",
+            promptPath: promptFile.path).trimmingCharacters(in: .newlines)
+
+        let script = "agent() { printf '%s' \"$2\"; }; \(launch)"
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", script]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let out = String(
+            decoding: pipe.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self)
+        #expect(process.terminationStatus == 0)
+        #expect(out == expected)
+    }
+}

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -128,10 +128,9 @@ public struct CursorAgent: CodingAgent {
                     : ".crow-job-prompt.md"
                 let promptPath = (worktreePath as NSString)
                     .appendingPathComponent(promptFile)
-                // Quote the path so a devRoot containing spaces
-                // (`/Users/x/My Projects/…`) doesn't split `cat`'s argv and
-                // resolve the positional prompt to empty.
-                return "\(agentPath)\(launchArgs) \"$(cat \(CursorLaunchArgs.shellQuote(promptPath)))\"\n"
+                return ShellLaunchArgs.evalPromptLaunch(
+                    prefix: "\(agentPath)\(launchArgs)",
+                    promptPath: promptPath)
             }
             return "\(agentPath)\(launchArgs) --continue\n"
         case .manager:

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
@@ -101,6 +101,9 @@ public actor CursorLauncher {
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
         let trust = seedTrust ? CursorLaunchArgs.trustSuffix : ""
-        return "cd \(CursorLaunchArgs.shellQuote(worktreePath)) && \(CursorLaunchArgs.shellQuote(binary))\(trust) \"$(cat \(CursorLaunchArgs.shellQuote(promptPath.path)))\"\n"
+        return "cd \(CursorLaunchArgs.shellQuote(worktreePath)) && "
+            + ShellLaunchArgs.evalPromptLaunch(
+                prefix: "\(CursorLaunchArgs.shellQuote(binary))\(trust)",
+                promptPath: promptPath.path).trimmingCharacters(in: .newlines) + "\n"
     }
 }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
@@ -86,6 +86,8 @@ struct CursorAgentTests {
         #expect(cmd != nil)
         #expect(cmd?.contains(".crow-review-prompt.md") == true)
         #expect(cmd?.contains(".crow-job-prompt.md") == false)
+        #expect(cmd?.contains("eval \"") == true)
+        #expect(cmd?.contains("$(cat") == false)
         #expect(cmd?.hasSuffix("\n") == true)
         // CROW-890 review (Red 1): a `.review` clone is attacker-controlled, so
         // it must NOT be auto-trusted — the `--trust` seed is withheld, leaving

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
@@ -41,7 +41,8 @@ struct CursorLauncherTests {
         // to approval).
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: true)
-        #expect(cmd.contains("'agent' --trust \"$(cat "))  // seed, before the prompt
+        #expect(cmd.contains("_CROW_P=$(< "))
+        #expect(cmd.contains("eval \"'agent' --trust $(printf '%q'"))
         #expect(cmd.contains("--force") == false)          // no auto-permission
     }
 
@@ -52,6 +53,6 @@ struct CursorLauncherTests {
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: false)
         #expect(cmd.contains("--trust") == false)
-        #expect(cmd.contains("'agent' \"$(cat "))
+        #expect(cmd.contains("eval \"'agent' $(printf '%q'"))
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1278,7 +1278,6 @@ public final class SessionService {
         }
         // Preflight (CROW-439): review/job sessions inline their initial prompt
         // via `ShellLaunchArgs.evalPromptLaunch`. If that file isn't on disk when the
-        // read). If that file isn't on disk when the shell runs the substitution,
         // shell substitution runs, the agent launches with an empty string and
         // silently idles. Refuse to dispatch and surface the missing path
         // instead so the user sees why nothing happened.

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1277,7 +1277,8 @@ public final class SessionService {
             return
         }
         // Preflight (CROW-439): review/job sessions inline their initial prompt
-        // via `$(cat .crow-*-prompt.md)`. If that file isn't on disk when the
+        // via `ShellLaunchArgs.evalPromptLaunch`. If that file isn't on disk when the
+        // read). If that file isn't on disk when the shell runs the substitution,
         // shell substitution runs, the agent launches with an empty string and
         // silently idles. Refuse to dispatch and surface the missing path
         // instead so the user sees why nothing happened.
@@ -3506,7 +3507,7 @@ public final class SessionService {
         }
 
         // Write review prompt file into the clone directory. Write failures
-        // MUST surface (CROW-439): the launcher's `$(cat ...)` shell
+        // MUST surface (CROW-439): the launcher's prompt-file shell substitution
         // substitution will yield an empty string and the agent will idle if
         // the file isn't there.
         let promptPath = (clonePath as NSString).appendingPathComponent(".crow-review-prompt.md")
@@ -3636,7 +3637,7 @@ public final class SessionService {
 
         // Write the first prompt to the file launchClaude reads on first launch.
         // Write failures MUST surface (CROW-439): if the file isn't there, the
-        // launcher's `$(cat .crow-job-prompt.md)` shell substitution yields an
+        // launcher's prompt-file shell substitution yields an
         // empty string and the agent silently idles.
         let promptPath = (worktreePath as NSString).appendingPathComponent(".crow-job-prompt.md")
         do {

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CrowCore
 
 /// Helpers for building OpenCode launch commands. Centralized so
 /// `OpenCodeAgent`, `OpenCodeLauncher`, and tests share one implementation
@@ -187,7 +188,6 @@ public enum OpenCodeLaunchArgs {
         tuiSupportsAuto: Bool,
         runHelpText: String
     ) -> String {
-        let quotedPath = shellQuote(promptPath)
         let runFlags = runAutoApproveSuffix(
             autoPermissionMode: autoPermissionMode,
             runHelpText: runHelpText
@@ -196,7 +196,9 @@ public enum OpenCodeLaunchArgs {
             autoPermissionMode: autoPermissionMode,
             tuiSupportsAuto: tuiSupportsAuto
         )
-        return "\(binary) run \"$(cat \(quotedPath))\"\(runFlags)"
+        return ShellLaunchArgs.evalPromptLaunch(
+            prefix: "\(binary) run\(runFlags)",
+            promptPath: promptPath).trimmingCharacters(in: .newlines)
             + "; \(binary) --continue\(continueFlags)\n"
     }
 

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeLaunchArgsTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeLaunchArgsTests.swift
@@ -58,7 +58,7 @@ struct OpenCodeLaunchArgsTests {
             tuiSupportsAuto: true,
             runHelpText: runHelpWithDangerously
         )
-        #expect(cmd == "/opt/homebrew/bin/opencode run \"$(cat '/tmp/wt/.crow-job-prompt.md')\""
+        #expect(cmd == "_CROW_P=$(< '/tmp/wt/.crow-job-prompt.md'); eval \"/opt/homebrew/bin/opencode run $(printf '%q' \"$_CROW_P\")\""
             + "; /opt/homebrew/bin/opencode --continue\n")
         #expect(cmd.contains(" | ") == false)
     }
@@ -71,7 +71,8 @@ struct OpenCodeLaunchArgsTests {
             tuiSupportsAuto: true,
             runHelpText: runHelpWithAuto
         )
-        #expect(cmd.contains(" run \"$(cat '/tmp/p.md')\" --auto"))
+        #expect(cmd.contains(" eval \"opencode run --auto $(printf '%q'"))
+        #expect(cmd.contains("_CROW_P=$(< '/tmp/p.md');"))
         #expect(cmd.contains("; opencode --continue --auto\n"))
     }
 
@@ -83,7 +84,7 @@ struct OpenCodeLaunchArgsTests {
             tuiSupportsAuto: false,
             runHelpText: tuiHelpWithoutAuto
         )
-        #expect(cmd == "opencode run \"$(cat '/tmp/p.md')\"; opencode --continue\n")
+        #expect(cmd == "_CROW_P=$(< '/tmp/p.md'); eval \"opencode run $(printf '%q' \"$_CROW_P\")\"; opencode --continue\n")
     }
 
     @Test func firstLaunchChainedCommandShellQuotesPromptPath() {
@@ -94,7 +95,7 @@ struct OpenCodeLaunchArgsTests {
             tuiSupportsAuto: false,
             runHelpText: ""
         )
-        #expect(cmd.contains("$(cat '/tmp/my worktree/.crow-job-prompt.md')"))
+        #expect(cmd.contains("_CROW_P=$(< '/tmp/my worktree/.crow-job-prompt.md')"))
     }
 
     @Test func resumeTUICommandCarriesAutoForResumedJobs() {

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -104,6 +104,15 @@ posix_quote() {
   printf "'%s'" "$s"
 }
 
+# Bash prefix that reads a prompt file into `_CROW_P`, then evals a command
+# prefix with the prompt as the final argv — safe for quotes, $, and newlines.
+# Avoid "$(cat path)" inside double quotes (#957).
+# Mirrors Swift ShellLaunchArgs.evalPromptLaunch.
+eval_prompt_launch() {
+  printf '_CROW_P=$(< %s); eval "%s $(printf '"'"'%%q'"'"' \"$_CROW_P\")"' \
+    "$(posix_quote "$2")" "$1"
+}
+
 # Read the global remoteControlEnabled flag from {devRoot}/.claude/config.json.
 # Returns 0 if true, 1 otherwise. Missing file / malformed JSON / missing
 # key all default to 1 (off), matching AppConfig's decodeIfPresent behavior.
@@ -1305,9 +1314,9 @@ launch_claude_code() {
   # intermittently dropped the launch into a not-yet-ready shell, leaving a
   # bare zsh with no agent (#408).
   #
-  # The prompt stays in its file — `"$(cat $prompt_path)"` is expanded by the
+  # The prompt stays in its file — `eval_prompt_launch` is expanded by the
   # TARGET shell at paste time, so the command sent over the socket is small
-  # (no ARG_MAX / payload concern).
+  # (no ARG_MAX / payload concern) and survives arbitrary prompt content (#957).
   local rc_args=""
   if is_remote_control_enabled; then
     # Keep building --rc here: crow's resolveClaudeInCommand only injects
@@ -1334,7 +1343,7 @@ launch_claude_code() {
     perm_mode="auto"
     log "coderViewAutoPermissionMode enabled — launching with --permission-mode auto"
   fi
-  local launch_cmd="cd $WORKTREE_PATH && ${gw_prefix}$bin --permission-mode $perm_mode$rc_args \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $(eval_prompt_launch "${gw_prefix}$bin --permission-mode $perm_mode$rc_args" "$prompt_path")"
   create_agent_terminal "Claude Code" "$launch_cmd"
 }
 
@@ -1359,7 +1368,7 @@ launch_cursor() {
   # form (NOT the .work bare-`agent` form) so the unattended skill flow
   # feeds the prompt at launch — same divergence-from-Swift-.work
   # rationale that launch_claude_code uses for its prompt-argv form.
-  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $(eval_prompt_launch "$bin" "$prompt_path")"
   create_agent_terminal "Cursor" "$launch_cmd"
 }
 
@@ -1381,7 +1390,7 @@ launch_codex() {
   # pre-fills the TUI composer — same mechanism Cursor's `agent` uses.
   # The prompt-argv form was deferred in MVP because older Codex CLIs
   # ignored extra argv; unblocked here (#492).
-  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $(eval_prompt_launch "$bin" "$prompt_path")"
   create_agent_terminal "OpenAI Codex" "$launch_cmd"
 }
 
@@ -1403,7 +1412,7 @@ launch_opencode() {
   # OpenCode: headless `run` consumes the prompt, then `; --continue` opens
   # the interactive TUI with a fresh terminal stdin (#547). Brace group keeps
   # both commands gated on a successful `cd`.
-  local launch_cmd="cd $WORKTREE_PATH && { $bin run \"\$(cat $prompt_path)\"; $bin --continue; }"
+  local launch_cmd="cd $WORKTREE_PATH && { $(eval_prompt_launch "$bin run" "$prompt_path"); $bin --continue; }"
   create_agent_terminal "OpenCode" "$launch_cmd"
 }
 

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -104,6 +104,15 @@ posix_quote() {
   printf "'%s'" "$s"
 }
 
+# Bash prefix that reads a prompt file into `_CROW_P`, then evals a command
+# prefix with the prompt as the final argv — safe for quotes, $, and newlines.
+# Avoid "$(cat path)" inside double quotes (#957).
+# Mirrors Swift ShellLaunchArgs.evalPromptLaunch.
+eval_prompt_launch() {
+  printf '_CROW_P=$(< %s); eval "%s $(printf '"'"'%%q'"'"' \"$_CROW_P\")"' \
+    "$(posix_quote "$2")" "$1"
+}
+
 # Read the global remoteControlEnabled flag from {devRoot}/.claude/config.json.
 # Returns 0 if true, 1 otherwise. Missing file / malformed JSON / missing
 # key all default to 1 (off), matching AppConfig's decodeIfPresent behavior.
@@ -1315,9 +1324,9 @@ launch_claude_code() {
   # intermittently dropped the launch into a not-yet-ready shell, leaving a
   # bare zsh with no agent (#408).
   #
-  # The prompt stays in its file — `"$(cat $prompt_path)"` is expanded by the
+  # The prompt stays in its file — `eval_prompt_launch` is expanded by the
   # TARGET shell at paste time, so the command sent over the socket is small
-  # (no ARG_MAX / payload concern).
+  # (no ARG_MAX / payload concern) and survives arbitrary prompt content (#957).
   local rc_args=""
   if is_remote_control_enabled; then
     # Keep building --rc here: crow's resolveClaudeInCommand only injects
@@ -1344,7 +1353,7 @@ launch_claude_code() {
     perm_mode="auto"
     log "coderViewAutoPermissionMode enabled — launching with --permission-mode auto"
   fi
-  local launch_cmd="cd $WORKTREE_PATH && ${gw_prefix}$bin --permission-mode $perm_mode$rc_args \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $(eval_prompt_launch "${gw_prefix}$bin --permission-mode $perm_mode$rc_args" "$prompt_path")"
   create_agent_terminal "Claude Code" "$launch_cmd"
 }
 
@@ -1369,7 +1378,7 @@ launch_cursor() {
   # form (NOT the .work bare-`agent` form) so the unattended skill flow
   # feeds the prompt at launch — same divergence-from-Swift-.work
   # rationale that launch_claude_code uses for its prompt-argv form.
-  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $(eval_prompt_launch "$bin" "$prompt_path")"
   create_agent_terminal "Cursor" "$launch_cmd"
 }
 
@@ -1391,7 +1400,7 @@ launch_codex() {
   # pre-fills the TUI composer — same mechanism Cursor's `agent` uses.
   # The prompt-argv form was deferred in MVP because older Codex CLIs
   # ignored extra argv; unblocked here (#492).
-  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $(eval_prompt_launch "$bin" "$prompt_path")"
   create_agent_terminal "OpenAI Codex" "$launch_cmd"
 }
 
@@ -1413,7 +1422,7 @@ launch_opencode() {
   # OpenCode: headless `run` consumes the prompt, then `; --continue` opens
   # the interactive TUI with a fresh terminal stdin (#547). Brace group keeps
   # both commands gated on a successful `cd`.
-  local launch_cmd="cd $WORKTREE_PATH && { $bin run \"\$(cat $prompt_path)\"; $bin --continue; }"
+  local launch_cmd="cd $WORKTREE_PATH && { $(eval_prompt_launch "$bin run" "$prompt_path"); $bin --continue; }"
   create_agent_terminal "OpenCode" "$launch_cmd"
 }
 


### PR DESCRIPTION
Closes #957

## Summary

Review and job sessions inlined the prompt via `"$(cat .crow-*-prompt.md)"`, which breaks when the bundled `crow-review-pr` SKILL body contains literal `"` characters (e.g. `--body "YOUR_REVIEW_HERE"`). The shell terminates the outer double-quoted string early and `agent` never starts.

This adds `ShellLaunchArgs.evalPromptLaunch` in CrowCore: read the prompt file into `_CROW_P`, then `eval` the agent command with `printf '%q'` so arbitrary prompt content (quotes, backticks, `$`, newlines) survives paste into zsh/bash. All agents that used `$(cat …)` (Cursor, Claude, Codex, OpenCode, Antigravity) and the `/crow-workspace` setup script now share this helper. Grok already used `--prompt-file` and is unchanged.

## Test plan

- [x] `ShellLaunchArgsTests.evalPromptLaunchSurvivesQuotesAndDollars` executes the launch snippet in bash and verifies the full prompt is passed through
- [x] Agent package tests updated to assert `eval` form and no `$(cat`
- [ ] Rebuild/restart `crowd`, start a review on a PR whose inlined SKILL has `"` in the body, confirm `agent` launches instead of dumping markdown into scrollback

Made with [Cursor](https://cursor.com)