### PR TITLE
Add compare link to version update banner and CLI

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/VersionCommands.swift
@@ -98,6 +98,9 @@ enum VersionCheck {
             if let behind = obj["behind_by"]?.intValue {
                 print("→ \(behind) commit\(behind == 1 ? "" : "s") behind")
             }
+            if let compareUrl = obj["compare_url"]?.stringValue {
+                print("See changes:  \(compareUrl)")
+            }
             if let cmd = obj["update_command"]?.stringValue {
                 print("")
                 print("Update:  \(cmd)")

--- a/Packages/CrowCore/Sources/CrowCore/Models/VersionUpdate.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/VersionUpdate.swift
@@ -80,6 +80,8 @@ public struct VersionUpdateStatus: Codable, Sendable, Equatable {
     public var behindBy: Int?
     public var aheadBy: Int?
     public var updateCommand: String?
+    /// GitHub compare URL between the installed build and upstream `main`.
+    public var compareUrl: String?
     /// Human-readable reason when `state == .unknown`.
     public var reason: String?
     /// Epoch milliseconds when this result was produced.
@@ -95,6 +97,7 @@ public struct VersionUpdateStatus: Codable, Sendable, Equatable {
         behindBy: Int? = nil,
         aheadBy: Int? = nil,
         updateCommand: String? = nil,
+        compareUrl: String? = nil,
         reason: String? = nil,
         checkedAtMs: Int64? = nil
     ) {
@@ -107,6 +110,7 @@ public struct VersionUpdateStatus: Codable, Sendable, Equatable {
         self.behindBy = behindBy
         self.aheadBy = aheadBy
         self.updateCommand = updateCommand
+        self.compareUrl = compareUrl
         self.reason = reason
         self.checkedAtMs = checkedAtMs
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -51,6 +51,14 @@ body {
 }
 .update-banner[hidden] { display: none; }
 .update-banner-text { flex: 1 1 auto; }
+.update-banner-compare-link {
+  flex: 0 0 auto;
+  color: var(--gold);
+  text-decoration: underline;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.update-banner-compare-link[hidden] { display: none; }
 .update-banner-dismiss {
   flex: 0 0 auto;
   border: none;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -266,6 +266,11 @@ function syncUpdateBannerLayout(banner) {
 function hideVersionUpdateBanner(banner, text) {
   if (!banner) return;
   if (text) text.textContent = '';
+  const compareLink = banner.querySelector('.update-banner-compare-link');
+  if (compareLink) {
+    compareLink.hidden = true;
+    compareLink.removeAttribute('href');
+  }
   banner.hidden = true;
   syncUpdateBannerLayout(banner);
 }
@@ -274,6 +279,7 @@ function renderVersionUpdateBanner(status) {
   const banner = document.getElementById('update-banner');
   if (!banner) return;
   const text = banner.querySelector('.update-banner-text');
+  const compareLink = banner.querySelector('.update-banner-compare-link');
   const dismiss = banner.querySelector('.update-banner-dismiss');
   if (!text || !dismiss) return;
 
@@ -313,6 +319,15 @@ function renderVersionUpdateBanner(status) {
     + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
     + (status.update_command ? (' Update: ' + status.update_command) : '');
   if (text.textContent !== msg) text.textContent = msg;
+  if (compareLink) {
+    if (status.compare_url && n > 0) {
+      compareLink.href = status.compare_url;
+      compareLink.hidden = false;
+    } else {
+      compareLink.hidden = true;
+      compareLink.removeAttribute('href');
+    }
+  }
   syncUpdateBannerLayout(banner);
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -12,6 +12,7 @@
 <body>
   <div id="update-banner" class="update-banner" hidden role="status">
     <span class="update-banner-text"></span>
+    <a class="update-banner-compare-link" hidden href="#" target="_blank" rel="noopener noreferrer">See changes</a>
     <button type="button" class="update-banner-dismiss" aria-label="Dismiss update notice">×</button>
   </div>
   <div id="app">

--- a/Packages/CrowDaemon/web-tests/version-banner.test.js
+++ b/Packages/CrowDaemon/web-tests/version-banner.test.js
@@ -16,6 +16,7 @@ const epilogue = `
     return b && window.getComputedStyle(b).display !== 'none';
   },
   dismiss() { document.querySelector('.update-banner-dismiss').click(); },
+  compareLink() { return document.querySelector('.update-banner-compare-link'); },
 };
 `;
 
@@ -51,6 +52,7 @@ function load(storageWrap) {
      </head><body>
        <div id="update-banner" class="update-banner" hidden role="status">
          <span class="update-banner-text"></span>
+         <a class="update-banner-compare-link" hidden href="#" target="_blank" rel="noopener noreferrer">See changes</a>
          <button type="button" class="update-banner-dismiss" aria-label="Dismiss update notice">×</button>
        </div>
      </body></html>`,
@@ -180,6 +182,18 @@ const check = (name, cond) => {
     T.setRpc(() => Promise.reject(new Error('rpc failed')));
     await T.refresh();
     check('hidden after RPC failure', !T.visible());
+  }
+
+  console.log('\ncompare link shown when compare_url present:');
+  {
+    const { T } = load(makeStorage());
+    const url = 'https://github.com/corveil/crow/compare/abc...def';
+    T.render({ state: 'behind', behind_by: 2, remote_sha: 'def5678', compare_url: url });
+    const link = T.compareLink();
+    check('compare link visible', link && !link.hidden);
+    check('compare link href', link && link.getAttribute('href') === url);
+    T.render({ state: 'behind', behind_by: 2, remote_sha: 'def5678' });
+    check('compare link hidden without url', link && link.hidden);
   }
 
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/VersionUpdateRPCSupport.swift
@@ -102,7 +102,7 @@ public enum VersionUpdateClient {
             remoteCommit = await fetchBranchHead(
                 build: build, authToken: authToken, transport: transport)
         }
-        let remoteSha = remoteCommit?.sha
+        let remoteSha = remoteCommit.map { displaySha($0.sha) }
         let remoteDate = remoteCommit?.date
 
         if behindBy > 0 || status == "behind" || status == "diverged" {
@@ -131,6 +131,8 @@ public enum VersionUpdateClient {
                 behindBy: aheadBy,
                 aheadBy: behindBy,
                 updateCommand: updateCommand,
+                compareUrl: githubCompareURL(
+                    localSha: localSha, remoteSha: remoteCommit?.sha, behindBy: aheadBy),
                 checkedAtMs: base.checkedAtMs
             )
         }
@@ -160,6 +162,20 @@ public enum VersionUpdateClient {
         return request
     }
 
+    /// `https://github.com/corveil/crow/compare/{local}...{remote}` when both SHAs
+    /// are known and the build is behind upstream.
+    static func githubCompareURL(localSha: String, remoteSha: String?, behindBy: Int) -> String? {
+        guard behindBy > 0 else { return nil }
+        let local = localSha.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let remoteRaw = remoteSha else { return nil }
+        let remote = remoteRaw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !local.isEmpty, local != "dev", !remote.isEmpty else { return nil }
+        let hex = #"^[0-9a-f]{7,40}$"#
+        guard local.range(of: hex, options: .regularExpression) != nil,
+              remote.range(of: hex, options: .regularExpression) != nil else { return nil }
+        return "https://github.com/\(repository)/compare/\(local)...\(remote)"
+    }
+
     private static func unknown(_ base: VersionUpdateStatus, reason: String) -> VersionUpdateStatus {
         VersionUpdateStatus(
             state: .unknown,
@@ -173,6 +189,10 @@ public enum VersionUpdateClient {
 
     private static func currentTimeMs() -> Int64 {
         Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private static func displaySha(_ fullSha: String) -> String {
+        String(fullSha.prefix(7))
     }
 
     private struct RemoteCommit {
@@ -208,7 +228,7 @@ public enum VersionUpdateClient {
         let author = commit?["author"] as? [String: Any]
         let rawDate = (committer?["date"] as? String) ?? (author?["date"] as? String)
         let date = rawDate.map(shortDate)
-        return RemoteCommit(sha: String(sha.prefix(7)), date: date)
+        return RemoteCommit(sha: sha, date: date)
     }
 
     /// `2026-08-05T12:34:56Z` → `2026-08-05`.
@@ -241,6 +261,7 @@ public enum VersionUpdateRPC {
             "behind_by": status.behindBy.map { .int($0) } ?? .null,
             "ahead_by": status.aheadBy.map { .int($0) } ?? .null,
             "update_command": status.updateCommand.map { .string($0) } ?? .null,
+            "compare_url": status.compareUrl.map { .string($0) } ?? .null,
             "reason": status.reason.map { .string($0) } ?? .null,
             "checked_at_ms": status.checkedAtMs.map { .int(Int($0)) } ?? .null,
         ])

--- a/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/VersionUpdateTests.swift
@@ -67,6 +67,8 @@ import CrowCore
         #expect(result.behindBy == 2)
         #expect(result.remoteSha == "f56939d")
         #expect(result.updateCommand == "git -C /tmp/crow pull && make install")
+        #expect(result.compareUrl ==
+            "https://github.com/corveil/crow/compare/abc1234567890...f56939ddeadbeefdeadbeefdeadbeefdeadbeef")
     }
 
     @Test func behindByReportsUpdateCommand() async {
@@ -153,6 +155,26 @@ import CrowCore
     @Test func shortDateTrimsTime() {
         #expect(VersionUpdateClient.shortDate("2026-08-05T12:34:56Z") == "2026-08-05")
     }
+
+    @Test func githubCompareURLBuildsLink() {
+        let url = VersionUpdateClient.githubCompareURL(
+            localSha: "abc1234567890",
+            remoteSha: "f56939ddeadbeefdeadbeefdeadbeefdeadbeef",
+            behindBy: 2)
+        #expect(url == "https://github.com/corveil/crow/compare/abc1234567890...f56939ddeadbeefdeadbeefdeadbeefdeadbeef")
+    }
+
+    @Test func githubCompareURLNilWhenNotBehind() {
+        #expect(VersionUpdateClient.githubCompareURL(
+            localSha: "abc1234", remoteSha: "def5678", behindBy: 0) == nil)
+    }
+
+    @Test func githubCompareURLNilForInvalidSha() {
+        #expect(VersionUpdateClient.githubCompareURL(
+            localSha: "dev", remoteSha: "abc1234", behindBy: 1) == nil)
+        #expect(VersionUpdateClient.githubCompareURL(
+            localSha: "abc1234", remoteSha: nil, behindBy: 1) == nil)
+    }
 }
 
 @Suite struct VersionUpdateRPCTests {
@@ -165,5 +187,19 @@ import CrowCore
         #expect(throws: RPCError.self) {
             _ = try VersionUpdateRPC.patchIntervalHours(["interval_hours": .int(0)])
         }
+    }
+
+    @Test func statusJSONIncludesCompareURL() {
+        let status = VersionUpdateStatus(
+            state: .behind,
+            localVersion: "0.1.0",
+            localSha: "abc1234",
+            buildDate: "2026-08-05",
+            remoteSha: "def5678",
+            behindBy: 2,
+            compareUrl: "https://github.com/corveil/crow/compare/abc...def")
+        let json = VersionUpdateRPC.statusJSON(status)
+        #expect(json.objectValue?["compare_url"]?.stringValue ==
+            "https://github.com/corveil/crow/compare/abc...def")
     }
 }


### PR DESCRIPTION
Closes #964

## Summary
- Compute a `compare_url` (`https://github.com/corveil/crow/compare/{local}...{remote}`) from SHAs already resolved during the version check — no extra network round-trip
- Show a "See changes" link in the update banner when `behind_by > 0` and SHAs are available
- Include `compare_url` in version-update RPC JSON (`crow version get`) and human `crow version check` output
- Omit the link when SHAs are unavailable (dev builds, missing remote SHA)

## Test plan
- [x] `swift test --package-path Packages/CrowEngine --filter VersionUpdate`
- [x] `node Packages/CrowDaemon/web-tests/version-banner.test.js`
- [ ] Manual: trigger update banner with a stale build and confirm "See changes" opens GitHub compare view
- [ ] Manual: `crow version check` prints compare URL when behind


Made with [Cursor](https://cursor.com)