### PR TITLE
Strip SKILL frontmatter from inlined review prompts (CROW-968)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/MarkdownFrontmatter.swift
+++ b/Packages/CrowCore/Sources/CrowCore/MarkdownFrontmatter.swift
@@ -23,8 +23,6 @@ import Foundation
 /// checked-in `skills/crow-review-pr/SKILL.md` and its bundled `.template`
 /// (`scripts/check-workspace-custom-instructions.sh` enforces that).
 public enum MarkdownFrontmatter {
-    private static let delimiter = "---"
-
     /// Drop a leading YAML frontmatter block, returning the body that follows.
     ///
     /// Deliberately conservative — the inputs include bodies that legitimately
@@ -43,25 +41,70 @@ public enum MarkdownFrontmatter {
     /// document that opens with a markdown horizontal rule and contains a second
     /// one — indistinguishable from frontmatter by any line-based parser, and not
     /// a shape a SKILL body takes.
+    ///
+    /// Scans the UTF-8 view rather than `components(separatedBy: "\n")`. Swift
+    /// treats `"\r\n"` as a **single** grapheme cluster, and Foundation's
+    /// grapheme-aware search differs by platform: Darwin splits a CRLF document
+    /// on the embedded `\n`, swift-corelibs-foundation does not, so on Linux the
+    /// whole file came back as one "line" and nothing was ever stripped. Bytes
+    /// behave identically everywhere.
     public static func stripped(_ body: String) -> String {
-        let lines = body.components(separatedBy: "\n")
-        guard let first = lines.first, isDelimiter(first) else { return body }
+        let bytes = Array(body.utf8)
+
+        guard let opening = line(in: bytes, at: 0), isDelimiter(bytes, opening.content) else {
+            return body
+        }
+
         // Search from line 2: the opening delimiter must not close itself.
-        // `dropFirst()` yields a slice sharing `lines`' indices, so the returned
-        // index addresses `lines` directly.
-        guard let closing = lines.dropFirst().firstIndex(where: isDelimiter) else { return body }
+        var cursor = opening.next
+        while let current = line(in: bytes, at: cursor) {
+            guard isDelimiter(bytes, current.content) else {
+                cursor = current.next
+                continue
+            }
+            // Skip blank lines after the closing delimiter so the result starts
+            // at the body's first real character.
+            var start = current.next
+            while let following = line(in: bytes, at: start), isBlank(bytes, following.content) {
+                start = following.next
+            }
+            // `start` is always a line boundary, so the slice is valid UTF-8.
+            return String(decoding: bytes[start...], as: UTF8.self)
+        }
 
-        return lines[lines.index(after: closing)...]
-            // `.whitespacesAndNewlines`, not `.whitespaces`: splitting a CRLF
-            // document on `\n` makes a blank line the single character `\r`,
-            // which `.whitespaces` (space + tab) does not match.
-            .drop { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            .joined(separator: "\n")
+        return body
     }
 
-    /// A line that is exactly `---`, tolerating a CRLF carriage return. Splitting
-    /// on `\n` leaves the `\r` attached to every line of a CRLF document.
-    private static func isDelimiter(_ line: String) -> Bool {
-        (line.hasSuffix("\r") ? String(line.dropLast()) : line) == delimiter
+    /// The line beginning at `offset`: its content without the line terminator,
+    /// and the offset the next line starts at. `nil` once `offset` is past the end.
+    private static func line(
+        in bytes: [UInt8], at offset: Int
+    ) -> (content: Range<Int>, next: Int)? {
+        guard offset < bytes.count else { return nil }
+
+        var end = offset
+        while end < bytes.count, bytes[end] != Self.lineFeed { end += 1 }
+
+        // Drop a CRLF's carriage return from the content, not from the offsets.
+        var contentEnd = end
+        if contentEnd > offset, bytes[contentEnd - 1] == Self.carriageReturn { contentEnd -= 1 }
+
+        return (offset..<contentEnd, end < bytes.count ? end + 1 : bytes.count)
     }
+
+    /// A line whose content is exactly `---`.
+    private static func isDelimiter(_ bytes: [UInt8], _ content: Range<Int>) -> Bool {
+        content.count == 3 && bytes[content].allSatisfy { $0 == Self.hyphen }
+    }
+
+    /// A line with nothing but horizontal whitespace on it.
+    private static func isBlank(_ bytes: [UInt8], _ content: Range<Int>) -> Bool {
+        bytes[content].allSatisfy { $0 == Self.space || $0 == Self.tab }
+    }
+
+    private static let lineFeed: UInt8 = 0x0A
+    private static let carriageReturn: UInt8 = 0x0D
+    private static let hyphen: UInt8 = 0x2D
+    private static let space: UInt8 = 0x20
+    private static let tab: UInt8 = 0x09
 }

--- a/Packages/CrowCore/Sources/CrowCore/MarkdownFrontmatter.swift
+++ b/Packages/CrowCore/Sources/CrowCore/MarkdownFrontmatter.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Leading YAML frontmatter (`---` … `---`) handling for markdown bodies Crow
+/// inlines into agent prompts.
+///
+/// Crow ships the `crow-review-pr` instructions as a SKILL file, which carries
+/// `name`/`description` frontmatter because Claude Code's skill engine requires
+/// it. Agents without a slash-command engine (Cursor, OpenCode, Codex, Grok,
+/// Antigravity) get that body **inlined** into `.crow-review-prompt.md` instead,
+/// where the frontmatter is worse than useless:
+///
+/// - It is skill-engine metadata the inlined brief has no reader for, and it
+///   costs tokens on every review.
+/// - It makes the prompt's first byte a `-`, so a CLI that parses its positional
+///   prompt with an option parser reads it as a flag and exits. Cursor's
+///   commander-based `agent` did exactly that — `error: unknown option '---`
+///   (CROW-968). Shell quoting does not save you here: `printf %q` protects the
+///   string from the *shell*, but a leading hyphen is not shell-special, so it
+///   reaches the binary's argv intact.
+///
+/// Only the **inlined** copy is stripped. The `.claude/skills/crow-review-pr/
+/// SKILL.md` Crow writes into a review clone keeps its frontmatter, as do the
+/// checked-in `skills/crow-review-pr/SKILL.md` and its bundled `.template`
+/// (`scripts/check-workspace-custom-instructions.sh` enforces that).
+public enum MarkdownFrontmatter {
+    private static let delimiter = "---"
+
+    /// Drop a leading YAML frontmatter block, returning the body that follows.
+    ///
+    /// Deliberately conservative — the inputs include bodies that legitimately
+    /// have no frontmatter (`Scaffolder.bundledReviewSkill()`'s built-in fallback,
+    /// every test fixture), so the no-op path is the common one and must never
+    /// damage its input:
+    ///
+    /// - The **first** line must be exactly `---`. Frontmatter is column-1 only,
+    ///   so an indented `---` is left alone.
+    /// - A closing `---` line must exist. Without one this is not a frontmatter
+    ///   block, and the input is returned unchanged rather than consumed whole.
+    /// - Leading blank lines after the closing delimiter are dropped, so the
+    ///   result starts at the body's first real character.
+    ///
+    /// CRLF-terminated lines are recognized. The one accepted false positive is a
+    /// document that opens with a markdown horizontal rule and contains a second
+    /// one — indistinguishable from frontmatter by any line-based parser, and not
+    /// a shape a SKILL body takes.
+    public static func stripped(_ body: String) -> String {
+        let lines = body.components(separatedBy: "\n")
+        guard let first = lines.first, isDelimiter(first) else { return body }
+        // Search from line 2: the opening delimiter must not close itself.
+        // `dropFirst()` yields a slice sharing `lines`' indices, so the returned
+        // index addresses `lines` directly.
+        guard let closing = lines.dropFirst().firstIndex(where: isDelimiter) else { return body }
+
+        return lines[lines.index(after: closing)...]
+            // `.whitespacesAndNewlines`, not `.whitespaces`: splitting a CRLF
+            // document on `\n` makes a blank line the single character `\r`,
+            // which `.whitespaces` (space + tab) does not match.
+            .drop { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .joined(separator: "\n")
+    }
+
+    /// A line that is exactly `---`, tolerating a CRLF carriage return. Splitting
+    /// on `\n` leaves the `\r` attached to every line of a CRLF document.
+    private static func isDelimiter(_ line: String) -> Bool {
+        (line.hasSuffix("\r") ? String(line.dropLast()) : line) == delimiter
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/ShellLaunchArgs.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ShellLaunchArgs.swift
@@ -16,8 +16,29 @@ public enum ShellLaunchArgs {
     /// macOS bash's `printf %q` emits backslash escapes that must be re-parsed
     /// via `eval` (unlike GNU bash's `$'…'` form). Crow pastes this into the
     /// user's interactive shell (zsh/bash via `crow-shell-wrapper`).
-    public static func evalPromptLaunch(prefix: String, promptPath: String) -> String {
+    ///
+    /// `endOfOptions` emits a literal `--` before the prompt, so a prompt whose
+    /// first character is `-` reaches the binary as an operand instead of being
+    /// parsed as a flag. Quoting does **not** cover this: `printf %q` protects the
+    /// string from the *shell*, but a leading hyphen is not shell-special and
+    /// survives into argv, where an option parser claims it (CROW-968).
+    ///
+    /// It is **opt-in per agent, not a global default**, because `--` is a
+    /// convention rather than a guarantee — this helper is shared by Claude,
+    /// Codex, OpenCode and Antigravity, and a parser that treats a bare `--` as a
+    /// literal prompt word would silently corrupt every launch. Enable it only for
+    /// a CLI whose behaviour has been checked. Verified so far:
+    ///
+    /// - **Cursor** (`agent`, commander): `agent --list-models --bogus` →
+    ///   `error: unknown option '--bogus'`; `agent --list-models -- --bogus`
+    ///   parses clean. Enabled at both Cursor call sites.
+    public static func evalPromptLaunch(
+        prefix: String,
+        promptPath: String,
+        endOfOptions: Bool = false
+    ) -> String {
         let quotedPath = shellQuote(promptPath)
-        return "_CROW_P=$(< \(quotedPath)); eval \"\(prefix) $(printf '%q' \"$_CROW_P\")\"\n"
+        let separator = endOfOptions ? "-- " : ""
+        return "_CROW_P=$(< \(quotedPath)); eval \"\(prefix) \(separator)$(printf '%q' \"$_CROW_P\")\"\n"
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/MarkdownFrontmatterTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/MarkdownFrontmatterTests.swift
@@ -96,9 +96,12 @@ struct MarkdownFrontmatterTests {
         #expect(MarkdownFrontmatter.stripped("") == "")
     }
 
-    /// Splitting on `\n` leaves `\r` attached to every line of a CRLF document, so
-    /// the delimiter check has to tolerate it — otherwise a CRLF SKILL body would
-    /// silently keep its frontmatter and reintroduce CROW-968.
+    /// Splitting a CRLF document is where this first broke: Swift treats `"\r\n"`
+    /// as a **single** grapheme cluster, and Foundation's grapheme-aware
+    /// `components(separatedBy: "\n")` differs by platform — Darwin splits on the
+    /// embedded `\n`, swift-corelibs-foundation does not. The first implementation
+    /// passed on macOS and stripped nothing on Linux. The scan runs over UTF-8
+    /// bytes now, so this must hold identically on both.
     @Test func handlesCRLFLineEndings() {
         let body = "---\r\nname: crow-review-pr\r\n---\r\n\r\n# Crow Review PR\r\nBody."
 
@@ -108,6 +111,30 @@ struct MarkdownFrontmatterTests {
         #expect(!stripped.contains("name: crow-review-pr"))
         // The body's own CRLF endings survive — only the frontmatter is removed.
         #expect(stripped == "# Crow Review PR\r\nBody.")
+    }
+
+    /// The same document in both line-ending conventions must strip to the same
+    /// body modulo its terminators. Guards the whole class of "works on one
+    /// platform / one file's line endings" bugs, not just the one that shipped.
+    @Test func crlfAndLFStripEquivalently() {
+        let lf = "---\nname: x\ndescription: y\n---\n\n# Body\n\nMore."
+        let crlf = lf.replacingOccurrences(of: "\n", with: "\r\n")
+
+        let strippedLF = MarkdownFrontmatter.stripped(lf)
+        let strippedCRLF = MarkdownFrontmatter.stripped(crlf)
+
+        #expect(strippedLF == "# Body\n\nMore.")
+        #expect(strippedCRLF.replacingOccurrences(of: "\r\n", with: "\n") == strippedLF)
+    }
+
+    /// A trailing-whitespace `---` is not a delimiter. Being strict here is what
+    /// keeps the scan from mistaking loosely-formatted body content for a block.
+    @Test func requiresAnExactDelimiter() {
+        let padded = "--- \nname: x\n---\nbody"
+        #expect(MarkdownFrontmatter.stripped(padded) == padded)
+
+        let tooLong = "----\nname: x\n----\nbody"
+        #expect(MarkdownFrontmatter.stripped(tooLong) == tooLong)
     }
 
     /// An empty frontmatter block still strips, and must not leave the result

--- a/Packages/CrowCore/Tests/CrowCoreTests/MarkdownFrontmatterTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/MarkdownFrontmatterTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// Tests for the frontmatter strip applied to inlined review prompts (CROW-968).
+///
+/// The bug this guards: the `crow-review-pr` SKILL body was inlined verbatim into
+/// `.crow-review-prompt.md`, so the prompt's first byte was `-` and Cursor's
+/// commander-based `agent` parsed it as a flag — `error: unknown option '---`.
+/// The review session died before it started.
+///
+/// The no-op cases matter just as much as the stripping one: this helper runs on
+/// every inlined review body, including bodies that legitimately have no
+/// frontmatter (`Scaffolder.bundledReviewSkill()`'s built-in fallback, the engine
+/// test fixtures). Damaging those would trade one dead-review mode for another.
+@Suite("MarkdownFrontmatter")
+struct MarkdownFrontmatterTests {
+
+    /// The real `skills/crow-review-pr/SKILL.md` shape, including the `description:
+    /// >-` folded block scalar that spans three lines — a naive "find the next
+    /// line containing `---`" scan would still work here, but a body-aware one
+    /// would need to understand YAML. Pinning the actual shape keeps the simple
+    /// parser honest.
+    private static let skillShaped = """
+    ---
+    name: crow-review-pr
+    description: >-
+      Perform a comprehensive code and security review on a GitHub pull request,
+      then post the findings as a PR review. Use when the user invokes
+      /crow-review-pr or asks to review a pull request through Crow.
+    ---
+
+    # Crow Review PR
+
+    Review PR $ARGUMENTS.
+    """
+
+    @Test func stripsTheSkillFrontmatterBlock() {
+        let stripped = MarkdownFrontmatter.stripped(Self.skillShaped)
+
+        // The defect itself: a leading `-` is what `agent` read as a flag.
+        #expect(!stripped.hasPrefix("-"))
+        #expect(!stripped.hasPrefix("---"))
+        // Metadata gone — including the folded-scalar continuation lines, which a
+        // parser that stopped at the first `---` after line 1 would leave behind.
+        #expect(!stripped.contains("name: crow-review-pr"))
+        #expect(!stripped.contains("description:"))
+        #expect(!stripped.contains("Use when the user invokes"))
+        // Body intact and starting at its first real character (the blank line
+        // between the closing delimiter and the heading is dropped).
+        #expect(stripped == """
+        # Crow Review PR
+
+        Review PR $ARGUMENTS.
+        """)
+    }
+
+    /// `Scaffolder.bundledReviewSkill()` returns a frontmatter-free stub whenever
+    /// the repo root can't be resolved (every test process), and the engine's
+    /// prompt fixtures have none either. Those bodies must come back byte-identical.
+    @Test func isANoOpWithoutFrontmatter() {
+        let body = """
+        # Crow Review PR
+        Review PR $ARGUMENTS — checkout via `gh pr checkout $ARGUMENTS`.
+        """
+
+        #expect(MarkdownFrontmatter.stripped(body) == body)
+    }
+
+    /// An opening `---` with no closing one is not a frontmatter block. Returning
+    /// the input unchanged is the safe reading — the alternative (consume to EOF)
+    /// would hand the agent an empty prompt and leave it idling, the exact silent
+    /// failure CROW-439's preflight exists to prevent.
+    @Test func isANoOpWhenTheBlockIsNeverClosed() {
+        let body = """
+        ---
+        name: crow-review-pr
+
+        # Crow Review PR
+        """
+
+        #expect(MarkdownFrontmatter.stripped(body) == body)
+    }
+
+    /// Frontmatter is column-1-only, so an indented `---` is body content (a YAML
+    /// snippet inside a fenced block, say), not a delimiter.
+    @Test func isANoOpWhenTheDelimiterIsNotOnTheFirstLine() {
+        let indented = "  ---\nname: x\n---\nbody"
+        #expect(MarkdownFrontmatter.stripped(indented) == indented)
+
+        let laterBlock = "# Heading\n\n---\nname: x\n---\nbody"
+        #expect(MarkdownFrontmatter.stripped(laterBlock) == laterBlock)
+    }
+
+    @Test func isANoOpOnAnEmptyBody() {
+        #expect(MarkdownFrontmatter.stripped("") == "")
+    }
+
+    /// Splitting on `\n` leaves `\r` attached to every line of a CRLF document, so
+    /// the delimiter check has to tolerate it — otherwise a CRLF SKILL body would
+    /// silently keep its frontmatter and reintroduce CROW-968.
+    @Test func handlesCRLFLineEndings() {
+        let body = "---\r\nname: crow-review-pr\r\n---\r\n\r\n# Crow Review PR\r\nBody."
+
+        let stripped = MarkdownFrontmatter.stripped(body)
+
+        #expect(!stripped.hasPrefix("-"))
+        #expect(!stripped.contains("name: crow-review-pr"))
+        // The body's own CRLF endings survive — only the frontmatter is removed.
+        #expect(stripped == "# Crow Review PR\r\nBody.")
+    }
+
+    /// An empty frontmatter block still strips, and must not leave the result
+    /// starting on a delimiter or a blank line.
+    @Test func stripsAnEmptyFrontmatterBlock() {
+        #expect(MarkdownFrontmatter.stripped("---\n---\n\n# Body") == "# Body")
+    }
+
+    /// Only the FIRST block goes. A `---` horizontal rule later in the body is
+    /// content and must survive — the strip is not a global delete.
+    @Test func leavesLaterHorizontalRulesAlone() {
+        let stripped = MarkdownFrontmatter.stripped("""
+        ---
+        name: x
+        ---
+
+        # Body
+
+        ---
+
+        ## Section
+        """)
+
+        #expect(stripped == """
+        # Body
+
+        ---
+
+        ## Section
+        """)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/ShellLaunchArgsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ShellLaunchArgsTests.swift
@@ -55,4 +55,68 @@ struct ShellLaunchArgsTests {
         #expect(process.terminationStatus == 0)
         #expect(out == expected)
     }
+
+    // MARK: - End-of-options separator (CROW-968)
+
+    @Test func evalPromptLaunchEmitsSeparatorWhenAsked() {
+        let cmd = ShellLaunchArgs.evalPromptLaunch(
+            prefix: "'agent' --trust --force",
+            promptPath: "/tmp/wt/.crow-review-prompt.md",
+            endOfOptions: true)
+
+        // The `--` must sit immediately before the prompt substitution, after the
+        // agent's own flags — anywhere earlier and `--trust`/`--force` would
+        // themselves become operands.
+        #expect(cmd.contains("eval \"'agent' --trust --force -- $(printf '%q'"))
+    }
+
+    /// The separator is opt-in per agent (Claude/Codex/OpenCode/Antigravity share
+    /// this helper and their parsers are unverified), so omitting it must produce
+    /// byte-identical output to the pre-CROW-968 form.
+    @Test func evalPromptLaunchWithoutSeparatorIsUnchanged() {
+        let cmd = ShellLaunchArgs.evalPromptLaunch(
+            prefix: "'agent' --force",
+            promptPath: "/tmp/wt/.crow-review-prompt.md")
+
+        #expect(cmd == "_CROW_P=$(< '/tmp/wt/.crow-review-prompt.md'); "
+            + "eval \"'agent' --force $(printf '%q' \"$_CROW_P\")\"\n")
+        #expect(!cmd.contains(" -- "))
+    }
+
+    /// CROW-968 repro at the shell layer: the review prompt began with `---`, and
+    /// Cursor's `agent` read it as a flag. Proves `--` lands as its own argv
+    /// element and the hyphen-leading body still arrives intact — quoting alone
+    /// never fixed this, since a leading `-` is not shell-special.
+    @Test func evalPromptLaunchSeparatorSurvivesAHyphenLeadingPrompt() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent(
+            "shell-launch-\(UUID().uuidString)")
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tmp) }
+        let promptFile = tmp.appendingPathComponent(".crow-review-prompt.md")
+        let expected = "---\nname: crow-review-pr\n---\n\n# Crow Review PR"
+        try expected.write(to: promptFile, atomically: true, encoding: .utf8)
+
+        let launch = ShellLaunchArgs.evalPromptLaunch(
+            prefix: "'agent' --force",
+            promptPath: promptFile.path,
+            endOfOptions: true).trimmingCharacters(in: .newlines)
+
+        // `$1` is `--` and `$2` is the prompt: the separator must be a distinct
+        // argv element, not glued onto the body.
+        let script = "agent() { printf '%s|%s' \"$2\" \"$3\"; }; \(launch)"
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", script]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let out = String(
+            decoding: pipe.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self)
+        #expect(process.terminationStatus == 0)
+        #expect(out == "--|\(expected)")
+    }
 }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -121,6 +121,16 @@ public struct CursorAgent: CodingAgent {
             // inlines the crow-review-pr SKILL body for Cursor so the `agent`
             // CLI gets a self-contained brief — no slash-command engine
             // needed (#431). `reviewPromptDispatched` gates both kinds.
+            //
+            // `endOfOptions: true` puts a literal `--` before the prompt (CROW-968).
+            // `agent` is commander-based (`Usage: agent [options] [command]
+            // [prompt...]`) and claims any argv element starting with `-` as an
+            // option, so a prompt whose first character is a hyphen kills the
+            // launch — which is exactly what the review SKILL's `---` frontmatter
+            // did. Stripping that frontmatter is the fix; this is the belt to its
+            // braces, and covers a user's job prompt that happens to start with
+            // `-`. Verified against the installed binary: `agent --list-models
+            // --bogus` errors, `agent --list-models -- --bogus` parses clean.
             if !session.reviewPromptDispatched {
                 let promptFile = session.kind == .review
                     ? ".crow-review-prompt.md"
@@ -129,7 +139,8 @@ public struct CursorAgent: CodingAgent {
                     .appendingPathComponent(promptFile)
                 return ShellLaunchArgs.evalPromptLaunch(
                     prefix: "\(agentPath)\(launchArgs)",
-                    promptPath: promptPath)
+                    promptPath: promptPath,
+                    endOfOptions: true)
             }
             return "\(agentPath)\(launchArgs) --continue\n"
         case .manager:

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
@@ -101,9 +101,13 @@ public actor CursorLauncher {
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
         let trust = seedTrust ? CursorLaunchArgs.trustSuffix : ""
+        // `endOfOptions: true` — same commander parser as `CursorAgent`, so a
+        // handoff note beginning with `-` would be read as a flag and abort the
+        // launch (CROW-968). See `ShellLaunchArgs.evalPromptLaunch`.
         return "cd \(CursorLaunchArgs.shellQuote(worktreePath)) && "
             + ShellLaunchArgs.evalPromptLaunch(
                 prefix: "\(CursorLaunchArgs.shellQuote(binary))\(trust)",
-                promptPath: promptPath.path).trimmingCharacters(in: .newlines) + "\n"
+                promptPath: promptPath.path,
+                endOfOptions: true).trimmingCharacters(in: .newlines) + "\n"
     }
 }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
@@ -89,6 +89,10 @@ struct CursorAgentTests {
         #expect(cmd?.contains("eval \"") == true)
         #expect(cmd?.contains("$(cat") == false)
         #expect(cmd?.hasSuffix("\n") == true)
+        // CROW-968: the inlined review brief must reach `agent` as an operand.
+        // Without the `--`, a prompt starting with `-` (the SKILL's `---`
+        // frontmatter) is claimed by commander as an option and the launch dies.
+        #expect(cmd?.contains(" -- $(printf") == true)
         // CROW-954 reverses the CROW-890 carve-out: a `.review` clone launches
         // pre-trusted so unattended dispatch isn't stranded on "Workspace Trust
         // Required". Its defense is the launch-path `.cursor/` strip
@@ -200,6 +204,33 @@ struct CursorAgentTests {
         #expect(cmd != nil)
         #expect(cmd?.contains(".crow-job-prompt.md") == true)
         #expect(cmd?.hasSuffix("\n") == true)
+        // CROW-968: job prompts are user-authored, so one can legitimately begin
+        // with `-`. The separator covers that as well as the review path.
+        #expect(cmd?.contains(" -- $(printf") == true)
+    }
+
+    /// CROW-968: the `--` belongs to the prompt-dispatch path only. A resume or a
+    /// bare `.work` TUI passes no positional prompt, so an end-of-options marker
+    /// there would be a stray argv element with nothing to protect.
+    @Test func endOfOptionsSeparatorOnlyRidesThePromptDispatch() {
+        var resumed = Session(name: "review", kind: .review, agentKind: .cursor)
+        resumed.reviewPromptDispatched = true
+
+        for session in [
+            Session(name: "work", kind: .work, agentKind: .cursor),
+            resumed,
+        ] {
+            let cmd = agent.autoLaunchCommand(
+                session: session,
+                worktreePath: "/tmp/wt",
+                remoteControlEnabled: false,
+                autoPermissionMode: true,
+                telemetryPort: nil
+            )
+            // ` -- ` specifically: `--trust`/`--force`/`--continue` all contain
+            // a double hyphen, so a bare `contains("--")` would pass vacuously.
+            #expect(cmd?.contains(" -- ") == false, "\(session.kind) carried a stray separator")
+        }
     }
 
     @Test func autoLaunchCommandJobSessionSubsequentLaunch() {

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
@@ -42,7 +42,7 @@ struct CursorLauncherTests {
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: true)
         #expect(cmd.contains("_CROW_P=$(< "))
-        #expect(cmd.contains("eval \"'agent' --trust $(printf '%q'"))
+        #expect(cmd.contains("eval \"'agent' --trust -- $(printf '%q'"))
         #expect(cmd.contains("--force") == false)          // no auto-permission
     }
 
@@ -55,6 +55,20 @@ struct CursorLauncherTests {
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: false)
         #expect(cmd.contains("--trust") == false)
-        #expect(cmd.contains("eval \"'agent' $(printf '%q'"))
+        #expect(cmd.contains("eval \"'agent' -- $(printf '%q'"))
+    }
+
+    /// CROW-968: the handoff prompt runs through the same commander parser as
+    /// `CursorAgent.autoLaunchCommand`, so it needs the same `--` guard — a note
+    /// or brief beginning with `-` would otherwise be read as an option and abort
+    /// the handoff before the agent starts.
+    @Test func launchCommandSeparatesOptionsFromTheHandoffPrompt() async throws {
+        let cmd = try await CursorLauncher().launchCommand(
+            sessionID: UUID(),
+            worktreePath: "/w",
+            prompt: "--- not a flag",
+            seedTrust: true)
+
+        #expect(cmd.contains(" -- $(printf '%q'"))
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -3578,6 +3578,11 @@ public final class SessionService {
         // literal string regardless of how the agent quotes the body (issue #447 — single-quoted
         // heredocs in gh/glab calls don't expand shell variables). The verdict policy is already
         // rendered into `policySkillBody` above (CROW-963).
+        //
+        // This copy keeps its YAML frontmatter — Claude Code's skill engine needs the
+        // `name`/`description` block to load it at all. Only the *inlined* prompt written
+        // above is frontmatter-stripped (`cursorReviewPrompt`, CROW-968); don't be tempted
+        // to hoist that strip up to `policySkillBody`, which would break this file.
         let cloneSkillsDir = (clonePath as NSString).appendingPathComponent(".claude/skills/crow-review-pr")
         try? fm.createDirectory(atPath: cloneSkillsDir, withIntermediateDirectories: true)
         let resolvedSkillContent = CrowAttribution.expandSkillBody(policySkillBody, agentKind: reviewAgentKind)
@@ -3902,9 +3907,27 @@ public final class SessionService {
 
     /// Apply the inlined-SKILL substitutions to a raw `crow-review-pr` SKILL
     /// body for agents without a slash-command engine (Cursor, OpenCode):
-    /// replace `$ARGUMENTS` with the PR URL, and expand
-    /// `${CROW_AGENT_DISPLAY_NAME:-…}` / legacy "via Claude Code" wording so the
-    /// posted GitHub review identifies the reviewing agent correctly.
+    /// strip the YAML frontmatter, replace `$ARGUMENTS` with the PR URL, and
+    /// expand `${CROW_AGENT_DISPLAY_NAME:-…}` / legacy "via Claude Code" wording
+    /// so the posted GitHub review identifies the reviewing agent correctly.
+    ///
+    /// The frontmatter strip (CROW-968) is what makes the inlined body safe to
+    /// pass as a positional argument. The SKILL file opens with a `---` block
+    /// because Claude Code's skill engine requires `name`/`description`; inlined,
+    /// that block made the prompt's first byte a `-`, which Cursor's commander-
+    /// based `agent` parsed as a flag — `error: unknown option '---` — killing the
+    /// session before it started. Shell quoting never covered this: `printf %q`
+    /// protects the string from the shell, but a leading hyphen is not
+    /// shell-special and survives into argv. Stripping is right on its own merits
+    /// too — the metadata has no reader in an inlined brief and costs tokens on
+    /// every review.
+    ///
+    /// It belongs **here**, not upstream, and not in
+    /// `CrowAttribution.expandSkillBody`: `prepareReviewClone` renders the
+    /// workspace policy into one `policySkillBody` and forks it two ways, and the
+    /// other consumer — the `.claude/skills/crow-review-pr/SKILL.md` copy written
+    /// into the review clone — **must keep** its frontmatter or Claude Code won't
+    /// load the skill. Only the inlined side is stripped.
     ///
     /// `agentKind` defaults to `.cursor` for backward compatibility with the
     /// original single-agent call site (and its unit test); pass the actual
@@ -3915,7 +3938,8 @@ public final class SessionService {
     /// scaffolder's file-resolution fallback.
     nonisolated static func cursorReviewPrompt(skillBody: String, prURL: String, agentKind: AgentKind = .cursor) -> String {
         CrowAttribution.expandSkillBody(
-            skillBody.replacingOccurrences(of: "$ARGUMENTS", with: prURL),
+            MarkdownFrontmatter.stripped(skillBody)
+                .replacingOccurrences(of: "$ARGUMENTS", with: prURL),
             agentKind: agentKind
         )
     }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
@@ -47,6 +47,21 @@ struct SessionServiceReviewPromptTests {
     \(ReviewVerdictPolicy.notesPlaceholder)
     """
 
+    /// `fixtureSkillBody` with the real skill's YAML frontmatter prepended — the
+    /// shape `Scaffolder.bundledReviewSkill()` actually returns in production, and
+    /// the one that killed every Cursor review (CROW-968).
+    private static let frontmatterSkillBody = """
+    ---
+    name: crow-review-pr
+    description: >-
+      Perform a comprehensive code and security review on a GitHub pull request,
+      then post the findings as a PR review. Use when the user invokes
+      /crow-review-pr or asks to review a pull request through Crow.
+    ---
+
+    \(fixtureSkillBody)
+    """
+
     @Test func cursorPromptSubstitutesPRURLForArguments() {
         let prompt = SessionService.cursorReviewPrompt(
             skillBody: Self.fixtureSkillBody,
@@ -163,6 +178,69 @@ struct SessionServiceReviewPromptTests {
             skillBody: Scaffolder.bundledReviewSkill(),
             prURL: Self.prURL,
             agentKind: .antigravity))
+    }
+
+    // MARK: - Frontmatter strip (CROW-968)
+
+    /// The inlined prompt is handed to the agent CLI as a bare positional
+    /// argument. With the SKILL's `---` frontmatter still attached, its first byte
+    /// was `-`, so Cursor's commander-based `agent` parsed it as a flag and exited
+    /// with `error: unknown option '---` before the review ever began. Shell
+    /// quoting does not cover this — `printf %q` protects the string from the
+    /// shell, but a leading hyphen is not shell-special and survives into argv.
+    @Test func cursorPromptStripsTheSkillFrontmatter() {
+        let prompt = SessionService.cursorReviewPrompt(
+            skillBody: Self.frontmatterSkillBody,
+            prURL: Self.prURL
+        )
+
+        // The defect, stated directly.
+        #expect(!prompt.hasPrefix("-"))
+        #expect(!prompt.hasPrefix("---"))
+        // Skill-engine metadata has no reader in an inlined brief and costs
+        // tokens on every review — including the folded-scalar continuation lines.
+        #expect(!prompt.contains("name: crow-review-pr"))
+        #expect(!prompt.contains("description:"))
+        #expect(!prompt.contains("Use when the user invokes"))
+        // The strip must not cost us the body or the other substitutions.
+        #expect(prompt.contains("Review PR \(Self.prURL)"))
+        #expect(prompt.contains("gh pr checkout \(Self.prURL)"))
+        #expect(prompt.contains("via Cursor"))
+    }
+
+    /// Stripping runs on every inlined body, and most of them have no frontmatter
+    /// — `Scaffolder.bundledReviewSkill()`'s built-in fallback (returned whenever
+    /// the repo root can't be resolved, i.e. in every test process) and the
+    /// fixtures here. Those must pass through untouched, or the fix would trade
+    /// one dead-review mode for another.
+    @Test func cursorPromptIsUnchangedForABodyWithoutFrontmatter() {
+        let withFrontmatter = SessionService.cursorReviewPrompt(
+            skillBody: Self.frontmatterSkillBody, prURL: Self.prURL)
+        let without = SessionService.cursorReviewPrompt(
+            skillBody: Self.fixtureSkillBody, prURL: Self.prURL)
+
+        // Same body in, same prompt out — the frontmatter is the only difference
+        // between the two fixtures, so stripping must collapse them exactly.
+        #expect(withFrontmatter == without)
+    }
+
+    /// Every inlining harness reaches the agent CLI's argument parser the same
+    /// way, so none of them may emit a leading `-`. Mirrors the agent loop in
+    /// `buildReviewPromptInlineBranchesCarryTheWorkspacePolicy`.
+    @Test func noInlineBranchEmitsALeadingHyphen() {
+        for agentKind: AgentKind in [.cursor, .openCode, .codex, .grok, .antigravity] {
+            let prompt = SessionService.buildReviewPrompt(
+                prURL: Self.prURL,
+                prTitle: Self.prTitle,
+                repoSlug: Self.repoSlug,
+                prNumber: Self.prNumber,
+                agentKind: agentKind,
+                skillBody: Self.frontmatterSkillBody
+            )
+
+            #expect(!prompt.hasPrefix("-"), "\(agentKind.rawValue) would be parsed as a flag")
+            #expect(!prompt.contains("name: crow-review-pr"), "\(agentKind.rawValue) kept its frontmatter")
+        }
     }
 
     // MARK: - Per-workspace verdict policy (CROW-963)

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -35,7 +35,7 @@ capabilities, update this table in the same PR.
 | Hook async delivery | ✅ `PostToolUse*` async | ⚠️ declared, timing unverified | ❌ sync-only (v0.141.0) | ⚠️ names verified, timing unverified | ❌ sync-only (async support unverified) | ❌ no `async` in Antigravity's schema — all sync |
 | MCP (e.g. Jira) | ✅ `jira` MCP server via `~/.claude.json` | ✅ `jira` bridged into `~/.cursor/mcp.json` (#829) | ✅ mirrored from `~/.claude.json` into `config.toml` | ❌ falls back to `acli` | ❌ falls back to `acli` (Jira MCP bridge deferred; Grok *does* read Claude/Cursor MCP configs) | ❌ falls back to `acli` (file bridge deferred) |
 | Review (`/crow-review-pr`) | ✅ slash-command | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body | ✅ inlined skill body (human-gated) | ✅ inlined skill body (#902) |
-| Initial-prompt injection | ✅ `$(cat …-prompt.md)` + deferred paste | ✅ `$(cat …)` job/review; handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (`$(cat …-prompt.md)`) | ✅ run-then-`--continue` | ✅ run-then-`-c` (`.job`/`.review`); `.work` bare | ✅ `-p "$(cat …-{job,review}-prompt.md)"` (`.job`/`.review`, #902); `.work` bare |
+| Initial-prompt injection | ✅ prompt-file contents as argv + deferred paste | ✅ job/review, `--`-separated (CROW-968); handoff launcher auto-wired (#829); `.work` bare | ✅ `.job` + `.review` (prompt-file contents as argv) | ✅ run-then-`--continue` | ✅ run-then-`-c` (`.job`/`.review`); `.work` bare | ✅ `-p "$prompt"` (`.job`/`.review`, #902); `.work` bare |
 | Gateway env / trust seed / telemetry | ✅ Claude special-case | ⚠️ trust seed only (`--trust`, per-launch, every kind) | ⚠️ trust seed only (`[projects."…"]` in `config.toml`) | ❌ | ⚠️ trust seed only (`[folders."…"]` in `~/.grok/trusted_folders.toml`) | ❌ |
 | Rename passthrough (`/rename`) | ✅ | ✅ | ✅ | ✅ | ✅ (alias `/title`) | ❌ unverified on v1.1.7 (opt-out `nil`) |
 | Self-host / local models | provider-dependent | provider-dependent | provider-dependent | provider-dependent | ✅ `config.toml` `[model.*]` → any OpenAI/Anthropic-compatible or local (Ollama) endpoint | ❌ **permanent** — closed-source, Google-Sign-In/GCP-locked (Gemini 3 Pro / Claude Sonnet 4.5 only) |
@@ -203,7 +203,7 @@ harness's sessions
   below. It went interactive in Cursor CLI 2026.07.20, reversing the earlier
   headless-only omission, #890, and covers `.review` too as of CROW-954.)
 - **Codex:** honored for `.job` sessions on the **interactive** launch —
-  `codex -a never -s workspace-write "$(cat …-prompt.md)"` (approval off, sandbox
+  `codex -a never -s workspace-write "$prompt"` (approval off, sandbox
   still bounded; the analogue of Claude's `--permission-mode auto`, **not** the
   full-bypass `--dangerously-bypass-approvals-and-sandbox` / `-s danger-full-access`,
   #830). It is deliberately **not** headless `codex exec`: `exec` is one-shot, so
@@ -430,6 +430,17 @@ share the host's global config and are disambiguated by `cwd`. See
   → never post `gh pr review` → never satisfy `decideReviewCompletions`
   (`buildReviewPromptGrokBranchInlinesSkillBody` guards the regression).
 
+The inlined body is **frontmatter-stripped** (`MarkdownFrontmatter.stripped`,
+CROW-968). The SKILL file opens with a `---` YAML block because Claude Code's
+skill engine requires `name`/`description`; inlined, that made the prompt's first
+byte a `-`, which Cursor's commander-based `agent` parsed as a flag —
+`error: unknown option '---` — killing every review before it started. The strip
+applies **only** to the inlined prompt: the `.claude/skills/crow-review-pr/SKILL.md`
+copy written into the review clone keeps its frontmatter, or Claude wouldn't load
+the skill at all. `prepareReviewClone` renders the workspace verdict policy into
+one body and forks it two ways, so the strip has to sit on the inlined side of
+that fork (in `cursorReviewPrompt`), not upstream of it.
+
 ### Initial-prompt injection
 
 Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
@@ -437,24 +448,36 @@ Review/job sessions get a pre-written prompt file (`.crow-review-prompt.md` /
 in `launchAgent` refuses to dispatch if that file is missing, for **every**
 harness (CROW-439) — it's gated on the prompt-file convention, not on agent kind.
 
-- **Claude:** `$(cat …-prompt.md)`, dispatched through the deferred `#408`
-  paste path (stash in `pendingLaunchCommands`, paste on `.shellReady`).
-- **Cursor:** `agent "$(cat …)"` for job/review (path shell-quoted). The
+- **Claude:** the prompt file's contents as the final argv, dispatched through the
+  deferred `#408` paste path (stash in `pendingLaunchCommands`, paste on
+  `.shellReady`).
+- **Cursor:** `agent … -- "$prompt"` for job/review (path shell-quoted). The
   interactive TUI takes the positional prompt directly, so no headless `-p` leg
   is needed; `CursorLauncher.launchCommand` feeds the prompt on agent handoff
   (#829). `.work` launches `agent` bare (the user types into the TUI).
 - **Codex:** job only; review returns `nil`.
-- **OpenCode:** **run-then-`--continue`** — headless `opencode run "$(cat …)"`
+- **OpenCode:** **run-then-`--continue`** — headless `opencode run "$prompt"`
   consumes the prompt reliably, then `; opencode --continue` opens the TUI with a
   fresh stdin so `crow send` keeps working (#547).
 - **Grok:** **run-then-`-c`** — headless `grok --prompt-file <path>` consumes the
   prompt (any prompt arg forces headless), then `; grok -c` resumes the same
-  session in the TUI with a fresh stdin. Uses `--prompt-file` (not `-p "$(cat …)"`)
+  session in the TUI with a fresh stdin. Uses `--prompt-file` (not `-p "$prompt"`)
   so a large inlined review-skill body never becomes a giant argv or rides a
   subshell (#861). `.job`/`.review` only; `.work` launches `grok` bare.
-- **Antigravity:** `agy -p "$(cat …)"` for job/review (path shell-quoted); the
+- **Antigravity:** `agy -p "$prompt"` for job/review (path shell-quoted); the
   tmux PTY means the non-TTY `-p` stdout-drop doesn't bite. Restart resumes with
   `-c`. `.work` launches `agy` bare (#902).
+
+`ShellLaunchArgs.evalPromptLaunch` builds every one of these except Grok's, whose
+prompt is read from a path and so never becomes argv. Its `endOfOptions` flag adds
+a literal `--` before the prompt so a body starting with `-` arrives as an operand
+instead of an option (CROW-968). It is **opt-in per harness, deliberately not a
+global default** — `--` is a convention, not a guarantee, and a parser that treated
+a bare `--` as a prompt word would corrupt every launch on that harness. Enabled
+today for **Cursor only** (both `CursorAgent.autoLaunchCommand` and
+`CursorLauncher.launchCommand`), verified against the installed binary:
+`agent --list-models --bogus` errors, `agent --list-models -- --bogus` parses
+clean. Check the CLI before enabling it anywhere else.
 
 ### Gateway env / trust seed / telemetry
 


### PR DESCRIPTION
Closes #968

## The bug

Cursor review sessions never started — `agent` exited during argument parsing:

```
error: unknown option '---
name: crow-review-pr
…
```

`SessionService.cursorReviewPrompt` inlined the **entire** `crow-review-pr` SKILL body — YAML frontmatter included — into `.crow-review-prompt.md`, so the file's first bytes were `---\n`. `CursorAgent.autoLaunchCommand` hands those contents to `agent` as a bare positional argument, and `agent` is commander-based (`Usage: agent [options] [command] [prompt...]`), so it claimed the leading hyphens as a flag.

Shell quoting never covered this: `printf %q` protects the string from the *shell*, but a leading `-` is not shell-special and survives into argv.

Affected every harness that receives the inlined body — `cursor`, `openCode`, `codex`, `grok`, `antigravity`. Claude Code was unaffected (terse `/crow-review-pr <URL>` form, no leading hyphen).

As the ticket notes, the defect predates CROW-954 and #958 — `evalPromptLaunch` has never emitted a `--`, and the frontmatter has been in SKILL.md far longer. Those two commits only removed the earlier failures that were masking this one.

## The fix

**1. Strip the frontmatter when inlining** — new `MarkdownFrontmatter.stripped` in CrowCore. Conservative: strips only when line 1 is exactly `---` and a closing `---` exists, returns its input untouched otherwise. The no-op path is the common one (`Scaffolder.bundledReviewSkill()`'s built-in fallback and the test fixtures carry no frontmatter), so it must never damage its input.

Two placement decisions worth reviewing:

- **In `cursorReviewPrompt`, below the fork in `prepareReviewClone`.** That function renders the workspace verdict policy into one body and forks it two ways; the other consumer is the clone's `.claude/skills/crow-review-pr/SKILL.md`, which **must keep** its frontmatter or Claude Code won't load the skill. Hoisting the strip up to `policySkillBody` would fix Cursor and break Claude. There's a comment at that call site saying so.
- **In CrowCore, not CrowEngine** — CrowEngine isn't in the Linux PR-CI package list (`.github/workflows/ci.yml`), so engine tests don't run on PRs. CrowCore's do.

The strip is right independent of the parsing bug: the metadata has no reader in an inlined brief and costs tokens on every review.

**2. Opt-in `--` end-of-options separator** — `ShellLaunchArgs.evalPromptLaunch` gains an `endOfOptions` flag, enabled at Cursor's two call sites only (`CursorAgent.autoLaunchCommand`, `CursorLauncher.launchCommand`).

Opt-in per harness on purpose, per the ticket: `--` is a convention, not a guarantee, and this helper is shared by Claude, Codex, OpenCode and Antigravity. Only Cursor's parser was verifiable here, so only Cursor opts in; everyone else keeps the `false` default and is source-compatible. Grok is unaffected either way — it passes `--prompt-file`, so its prompt never becomes argv.

## The second commit is worth a look

The first push went green on macOS and **failed on Linux CI**, on a test in this PR. It was a real bug, not a flaky test.

Swift treats `"\r\n"` as a single grapheme cluster, and Foundation's grapheme-aware `components(separatedBy: "\n")` differs by platform: Darwin splits on the embedded `\n`, swift-corelibs-foundation does not. On Linux the whole file came back as one "line", `lines.first` was never `---`, and the guard returned the body untouched — meaning **every Cursor review on a CRLF checkout would have kept its frontmatter and reproduced this exact bug**, on the platform the daemon isn't developed on.

`5d8859f` replaces the line split with a scan over `body.utf8`: walk to each `\n`, drop a trailing `\r` from the line's content but not from the offsets, slice the original bytes at a line boundary. Byte comparisons behave identically everywhere. Behaviour is otherwise unchanged.

## Verification

The ticket's one unverified checkbox, settled against the installed `cursor-agent 2026.08.04`:

| Invocation | Result |
|---|---|
| `agent --list-models --bogus-flag-xyz` | `error: unknown option '--bogus-flag-xyz'` |
| `agent --list-models -- --bogus-flag-xyz` | parses clean |

Against the real `skills/crow-review-pr/SKILL.md`: first bytes go from `2d 2d 2d 0a` (`---\n`, the exact signature in the ticket) to `23 20 43 72` (`# Cr`), 162 → 154 lines, with `$ARGUMENTS`, the attribution footer and the body tail all intact.

Run in the `swift:6.1` container CI uses, not just on macOS: **CrowCore 582** and **CrowCursor 69** green, CrowEngine builds clean.

New tests: 10 in `MarkdownFrontmatterTests` (strip, five no-op shapes, CRLF, LF/CRLF equivalence, delimiter strictness, later-horizontal-rules-survive), 3 in `ShellLaunchArgsTests` (separator placement, default output byte-identical to before, and a real `/bin/bash` round-trip proving `--` lands as its own argv element ahead of a `---`-leading body), 3 in `SessionServiceReviewPromptTests` (including a loop asserting no inlining harness emits a leading `-`), 1 in `CursorAgentTests` (the separator rides prompt dispatch only, not resume or `.work`) and 1 in `CursorLauncherTests`.

## Pre-existing failures, not from this PR

`make test` is red on three tests that reproduce identically on clean `main` with these changes stashed: `bootCatchResetsTheHistory` and `refreshTerminalsRebindsTheActiveTerminalToTheFreshRow` (CrowDaemon), and `retryReadinessEmitsTimedOutWhenSentinelMissing` (CrowTerminal, a real-tmux integration test). None are touched here. Worth noting separately that `make test`'s `for` loop doesn't abort on failure, so its exit code masks mid-loop failures — these have to be found by grepping the log.

## Not in this PR

- **End-to-end confirmation.** Steps 5–6 of the ticket's test plan (rebuild/restart `crowd`, run a review to a posted verdict) need a daemon restart, so they're left to the maintainer.
- **The two stuck sessions.** `review-corveil-2170` (`53D18B11-…`) and `review-corveil-cloud-terraform-378` (`B7E9B52E-…`) still hold the bad prompt file and need relaunching — or deleting and re-kicking from the Reviews board — once this is built and `crowd` restarted. Left alone deliberately, since `crow delete-session` is destructive.

## Incidental

The `docs/agent-harness-matrix.md` bullets in the section I edited still showed the pre-#957 `$(cat …)` launch notation, which `evalPromptLaunch` stopped emitting when it moved to `$(< path)` + `printf %q` — and which `CursorAgentTests` explicitly asserts is absent. Refreshed so the section doesn't contradict the paragraph this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)