### PR TITLE
Drop update instructions from version-update banner

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -316,8 +316,7 @@ function renderVersionUpdateBanner(status) {
   dismissArmedWithoutSha = !remoteSha;
   banner.hidden = false;
   const msg = 'A newer Crow build is available — '
-    + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.'
-    + (status.update_command ? (' Update: ' + status.update_command) : '');
+    + n + ' commit' + (n === 1 ? '' : 's') + ' behind origin/main.';
   if (text.textContent !== msg) text.textContent = msg;
   if (compareLink) {
     if (status.compare_url && n > 0) {

--- a/Packages/CrowDaemon/web-tests/version-banner.test.js
+++ b/Packages/CrowDaemon/web-tests/version-banner.test.js
@@ -17,6 +17,7 @@ const epilogue = `
   },
   dismiss() { document.querySelector('.update-banner-dismiss').click(); },
   compareLink() { return document.querySelector('.update-banner-compare-link'); },
+  bannerText() { return document.querySelector('.update-banner-text').textContent; },
 };
 `;
 
@@ -104,6 +105,21 @@ const check = (name, cond) => {
     check('shown when behind', T.visible());
     T.render({ state: 'up_to_date' });
     check('hidden again', !T.visible());
+  }
+
+  console.log('\nbanner text omits update command:');
+  {
+    const { T } = load(makeStorage());
+    T.render({
+      state: 'behind',
+      behind_by: 7,
+      remote_sha: 'aaa',
+      update_command: 'git -C <clone> pull && make install',
+    });
+    check(
+      'message is behind count only',
+      T.bannerText() === 'A newer Crow build is available — 7 commits behind origin/main.'
+    );
   }
 
   console.log('\ndismiss survives a re-render for the same sha:');


### PR DESCRIPTION
Closes #972

## Summary

- Remove the `Update: git -C <clone> pull && make install` tail from the dismissible web banner; it now reports only that a newer build is available and how many commits behind `origin/main`.
- Keep `update_command` on the RPC/model (unchanged wire format).
- Add a web test asserting banner text omits the update command even when `update_command` is present in the status payload.

**Intentionally unchanged:** `crow version --check` still prints `Update:` on opt-in query; Settings → About still shows it as a hover tooltip.

## Test plan

- [x] `node Packages/CrowDaemon/web-tests/version-banner.test.js` — banner text is behind-count only
- [x] `make test` green


Made with [Cursor](https://cursor.com)