### PR TITLE
Shift+Tab session switcher overlay (MRU, filters, live preview)

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SettingsCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SettingsCommands.swift
@@ -209,11 +209,59 @@ public struct UISet: ParsableCommand {
         help: "Hide ticket title and repo/branch lines in sidebar rows (true or false)")
     var hideSessionDetails: Bool?
 
+    @Option(
+        name: .customLong("switcher-enabled"),
+        help: "Enable the session switcher overlay (true or false)")
+    var switcherEnabled: Bool?
+
+    @Option(
+        name: .customLong("switcher-binding"),
+        help: "Session switcher key chord (default: shift+tab)")
+    var switcherBinding: String?
+
+    @Option(
+        name: .customLong("switcher-capture-in-terminal"),
+        help: "Capture the switcher binding inside focused terminals (true or false)")
+    var switcherCaptureInTerminal: Bool?
+
+    @Option(
+        name: .customLong("switcher-order"),
+        help: "Session switcher ordering: mru or sidebar")
+    var switcherOrder: String?
+
+    @Option(
+        name: .customLong("switcher-preview"),
+        help: "Fetch a tmux pane preview for the highlighted switcher card (true or false)")
+    var switcherPreview: Bool?
+
+    @Option(
+        name: .customLong("switcher-include"),
+        parsing: .upToNextOption,
+        help: "Include filter as key=value (managers, jobs, reviews, active, paused, in_review, completed, archived)")
+    var switcherIncludes: [String] = []
+
     public init() {}
 
     public func validate() throws {
-        guard hideSessionDetails != nil else {
-            throw ValidationError("Nothing to set — provide --hide-session-details.")
+        guard hideSessionDetails != nil || switcherEnabled != nil || switcherBinding != nil
+            || switcherCaptureInTerminal != nil || switcherOrder != nil || switcherPreview != nil
+            || !switcherIncludes.isEmpty else {
+            throw ValidationError(
+                "Nothing to set — provide at least one UI preference flag.")
+        }
+        if let switcherOrder, !["mru", "sidebar"].contains(switcherOrder) {
+            throw ValidationError("--switcher-order must be mru or sidebar.")
+        }
+        for item in switcherIncludes {
+            let parts = item.split(separator: "=", maxSplits: 1).map(String.init)
+            guard parts.count == 2,
+                  ["managers", "jobs", "reviews", "active", "paused", "in_review", "completed", "archived"]
+                    .contains(parts[0]),
+                  ["true", "false"].contains(parts[1].lowercased()) else {
+                throw ValidationError(
+                    "--switcher-include must be key=true|false where key is one of: "
+                    + "managers, jobs, reviews, active, paused, in_review, completed, archived")
+            }
         }
     }
 
@@ -221,6 +269,27 @@ public struct UISet: ParsableCommand {
         var params: [String: JSONValue] = [:]
         if let hideSessionDetails {
             params["hide_session_details"] = .bool(hideSessionDetails)
+        }
+        if let switcherEnabled {
+            params["switcher_enabled"] = .bool(switcherEnabled)
+        }
+        if let switcherBinding {
+            params["switcher_binding"] = .string(switcherBinding)
+        }
+        if let switcherCaptureInTerminal {
+            params["switcher_capture_in_terminal"] = .bool(switcherCaptureInTerminal)
+        }
+        if let switcherOrder {
+            params["switcher_order"] = .string(switcherOrder)
+        }
+        if let switcherPreview {
+            params["switcher_preview"] = .bool(switcherPreview)
+        }
+        for item in switcherIncludes {
+            let parts = item.split(separator: "=", maxSplits: 1).map(String.init)
+            let key = parts[0]
+            let flag = parts[1].lowercased() == "true"
+            params["switcher_include_\(key)"] = .bool(flag)
         }
         let result = try rpc("ui-set", params: params)
         printJSON(result)

--- a/Packages/CrowCLI/Tests/CrowCLITests/SettingsCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/SettingsCommandParsingTests.swift
@@ -112,6 +112,24 @@ import ArgumentParser
     #expect(try UISet.parse(["--hide-session-details", "true"]).hideSessionDetails == true)
 }
 
+@Test func uiSetParsesSwitcherFlags() throws {
+    let cmd = try UISet.parse([
+        "--switcher-enabled", "false",
+        "--switcher-binding", "ctrl+`",
+        "--switcher-capture-in-terminal", "false",
+        "--switcher-order", "sidebar",
+        "--switcher-preview", "false",
+        "--switcher-include", "managers=true",
+        "--switcher-include", "completed=true",
+    ])
+    #expect(cmd.switcherEnabled == false)
+    #expect(cmd.switcherBinding == "ctrl+`")
+    #expect(cmd.switcherCaptureInTerminal == false)
+    #expect(cmd.switcherOrder == "sidebar")
+    #expect(cmd.switcherPreview == false)
+    #expect(cmd.switcherIncludes == ["managers=true", "completed=true"])
+}
+
 @Test func uiSetParsesExplicitFalse() throws {
     #expect(try UISet.parse(["--hide-session-details", "false"]).hideSessionDetails == false)
 }

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -550,14 +550,12 @@ public final class AppState {
     /// otherwise the first terminal with a binding.
     public func terminalPreviewWindowIndex(for sessionID: UUID) -> Int? {
         let terms = terminals(for: sessionID)
-        let preferred: SessionTerminal?
-        if let activeID = activeTerminalID[sessionID] {
-            preferred = terms.first { $0.id == activeID }
-        } else {
-            preferred = nil
+        if let activeID = activeTerminalID[sessionID],
+           let active = terms.first(where: { $0.id == activeID }),
+           let binding = active.tmuxBinding {
+            return binding.windowIndex
         }
-        let terminal = preferred ?? terms.first(where: { $0.tmuxBinding != nil })
-        return terminal?.tmuxBinding?.windowIndex
+        return terms.first(where: { $0.tmuxBinding != nil })?.tmuxBinding?.windowIndex
     }
 
     /// Whether a session has a managed Claude Code terminal that quick

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -545,6 +545,21 @@ public final class AppState {
         terminals[sessionID] ?? []
     }
 
+    /// tmux window index for the session-switcher preview card (CROW-976).
+    /// Prefers the session's active terminal when it has a tmux binding,
+    /// otherwise the first terminal with a binding.
+    public func terminalPreviewWindowIndex(for sessionID: UUID) -> Int? {
+        let terms = terminals(for: sessionID)
+        let preferred: SessionTerminal?
+        if let activeID = activeTerminalID[sessionID] {
+            preferred = terms.first { $0.id == activeID }
+        } else {
+            preferred = nil
+        }
+        let terminal = preferred ?? terms.first(where: { $0.tmuxBinding != nil })
+        return terminal?.tmuxBinding?.windowIndex
+    }
+
     /// Whether a session has a managed Claude Code terminal that quick
     /// actions can be dispatched into. The dispatcher in AppDelegate
     /// re-checks the surface state before sending; this is the lighter

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -10,6 +10,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
     public var defaults: ConfigDefaults
     public var notifications: NotificationSettings
     public var sidebar: SidebarSettings
+    /// Shift+Tab (or configured binding) session switcher overlay (CROW-976).
+    public var switcher: SwitcherSettings
     public var remoteControlEnabled: Bool
     public var managerAutoPermissionMode: Bool
     /// When true, sessions launched by the Jobs scheduler start with
@@ -135,6 +137,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         defaults: ConfigDefaults = ConfigDefaults(),
         notifications: NotificationSettings = NotificationSettings(),
         sidebar: SidebarSettings = SidebarSettings(),
+        switcher: SwitcherSettings = SwitcherSettings(),
         remoteControlEnabled: Bool = false,
         managerAutoPermissionMode: Bool = true,
         jobsAutoPermissionMode: Bool = true,
@@ -159,6 +162,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.defaults = defaults
         self.notifications = notifications
         self.sidebar = sidebar
+        self.switcher = switcher
         self.remoteControlEnabled = remoteControlEnabled
         self.managerAutoPermissionMode = managerAutoPermissionMode
         self.jobsAutoPermissionMode = jobsAutoPermissionMode
@@ -186,6 +190,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         defaults = try container.decodeIfPresent(ConfigDefaults.self, forKey: .defaults) ?? ConfigDefaults()
         notifications = try container.decodeIfPresent(NotificationSettings.self, forKey: .notifications) ?? NotificationSettings()
         sidebar = try container.decodeIfPresent(SidebarSettings.self, forKey: .sidebar) ?? SidebarSettings()
+        switcher = try container.decodeIfPresent(SwitcherSettings.self, forKey: .switcher) ?? SwitcherSettings()
         remoteControlEnabled = try container.decodeIfPresent(Bool.self, forKey: .remoteControlEnabled) ?? false
         managerAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .managerAutoPermissionMode) ?? true
         jobsAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .jobsAutoPermissionMode) ?? true
@@ -252,7 +257,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
+        case workspaces, defaults, notifications, sidebar, switcher, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth
     }
 
     /// Resolve the agent that should drive a newly-created session of the
@@ -914,6 +919,104 @@ public struct SidebarSettings: Codable, Sendable, Equatable {
     }
 
     enum CodingKeys: String, CodingKey { case hideSessionDetails }
+}
+
+/// Session-switcher ordering mode (CROW-976).
+public enum SwitcherOrder: String, Codable, Sendable, Equatable {
+    case mru
+    case sidebar
+}
+
+/// Per-category / per-status filters for the session switcher overlay.
+public struct SwitcherIncludeSettings: Codable, Sendable, Equatable {
+    public var managers: Bool
+    public var jobs: Bool
+    public var reviews: Bool
+    public var active: Bool
+    public var paused: Bool
+    public var inReview: Bool
+    public var completed: Bool
+    public var archived: Bool
+
+    public init(
+        managers: Bool = false,
+        jobs: Bool = false,
+        reviews: Bool = true,
+        active: Bool = true,
+        paused: Bool = true,
+        inReview: Bool = true,
+        completed: Bool = false,
+        archived: Bool = false
+    ) {
+        self.managers = managers
+        self.jobs = jobs
+        self.reviews = reviews
+        self.active = active
+        self.paused = paused
+        self.inReview = inReview
+        self.completed = completed
+        self.archived = archived
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        managers = try c.decodeIfPresent(Bool.self, forKey: .managers) ?? false
+        jobs = try c.decodeIfPresent(Bool.self, forKey: .jobs) ?? false
+        reviews = try c.decodeIfPresent(Bool.self, forKey: .reviews) ?? true
+        active = try c.decodeIfPresent(Bool.self, forKey: .active) ?? true
+        paused = try c.decodeIfPresent(Bool.self, forKey: .paused) ?? true
+        inReview = try c.decodeIfPresent(Bool.self, forKey: .inReview) ?? true
+        completed = try c.decodeIfPresent(Bool.self, forKey: .completed) ?? false
+        archived = try c.decodeIfPresent(Bool.self, forKey: .archived) ?? false
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case managers, jobs, reviews, active, paused, inReview, completed, archived
+    }
+}
+
+/// Session switcher overlay preferences (CROW-976).
+public struct SwitcherSettings: Codable, Sendable, Equatable {
+    public var enabled: Bool
+    /// Chord string, e.g. `shift+tab`. Parsed client-side.
+    public var binding: String
+    /// When true, the binding is captured even inside a focused terminal.
+    public var captureInTerminal: Bool
+    public var order: SwitcherOrder
+    /// Fetch a cheap tmux pane preview for the highlighted card.
+    public var preview: Bool
+    public var include: SwitcherIncludeSettings
+
+    public init(
+        enabled: Bool = true,
+        binding: String = "shift+tab",
+        captureInTerminal: Bool = true,
+        order: SwitcherOrder = .mru,
+        preview: Bool = true,
+        include: SwitcherIncludeSettings = SwitcherIncludeSettings()
+    ) {
+        self.enabled = enabled
+        self.binding = binding
+        self.captureInTerminal = captureInTerminal
+        self.order = order
+        self.preview = preview
+        self.include = include
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        binding = try c.decodeIfPresent(String.self, forKey: .binding) ?? "shift+tab"
+        captureInTerminal = try c.decodeIfPresent(Bool.self, forKey: .captureInTerminal) ?? true
+        order = try c.decodeIfPresent(SwitcherOrder.self, forKey: .order) ?? .mru
+        preview = try c.decodeIfPresent(Bool.self, forKey: .preview) ?? true
+        include = try c.decodeIfPresent(SwitcherIncludeSettings.self, forKey: .include)
+            ?? SwitcherIncludeSettings()
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enabled, binding, captureInTerminal, order, preview, include
+    }
 }
 
 /// Telemetry collection settings for Claude Code OTLP metrics.

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -341,6 +341,20 @@ public enum ParityLedger {
 
         .field("sidebar.hideSessionDetails", read: "ui get", write: "ui set"),
 
+        .field("switcher.enabled", read: "ui get", write: "ui set"),
+        .field("switcher.binding", read: "ui get", write: "ui set"),
+        .field("switcher.captureInTerminal", read: "ui get", write: "ui set"),
+        .field("switcher.order", read: "ui get", write: "ui set"),
+        .field("switcher.preview", read: "ui get", write: "ui set"),
+        .field("switcher.include.managers", read: "ui get", write: "ui set"),
+        .field("switcher.include.jobs", read: "ui get", write: "ui set"),
+        .field("switcher.include.reviews", read: "ui get", write: "ui set"),
+        .field("switcher.include.active", read: "ui get", write: "ui set"),
+        .field("switcher.include.paused", read: "ui get", write: "ui set"),
+        .field("switcher.include.inReview", read: "ui get", write: "ui set"),
+        .field("switcher.include.completed", read: "ui get", write: "ui set"),
+        .field("switcher.include.archived", read: "ui get", write: "ui set"),
+
         .field("notifications.globalMute", read: "notifications get", write: "notifications set"),
         .field("notifications.soundEnabled", read: "notifications get", write: "notifications set"),
         .field(

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -190,6 +190,13 @@ public enum ParityLedger {
         .write("rebuild-scorecard", cli: "rebuild-scorecard"),
         .read("get-state", cli: "get-state"),
         .read("list-artifacts", cli: "list-artifacts"),
+        .read(
+            "get-session-terminal-preview",
+            noCLI: """
+                Web session-switcher preview: best-effort tmux pane tail for the \
+                highlighted card (CROW-976). No CLI verb — the switcher is \
+                browser-only and fetches on demand.
+                """),
 
         // Settings
         // `defaults-get` is deliberately un-gated on `/rpc`; `defaults-set` is

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -354,6 +354,29 @@ import Testing
     #expect(config.sidebar.hideSessionDetails == false)
 }
 
+@Test func switcherSettingsDecodeDefaultsWhenAbsent() throws {
+    let json = "{}".data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+
+    #expect(config.switcher.enabled == true)
+    #expect(config.switcher.binding == "shift+tab")
+    #expect(config.switcher.captureInTerminal == true)
+    #expect(config.switcher.order == .mru)
+    #expect(config.switcher.preview == true)
+    #expect(config.switcher.include.reviews == true)
+    #expect(config.switcher.include.managers == false)
+    #expect(config.switcher.include.completed == false)
+}
+
+@Test func switcherSettingsDecodesEmptyObject() throws {
+    let json = #"{"switcher": {}}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+
+    #expect(config.switcher.enabled == true)
+    #expect(config.switcher.binding == "shift+tab")
+    #expect(config.switcher.include.archived == false)
+}
+
 @Test func telemetryCleanupSidebarSurviveFullRoundTrip() throws {
     let config = AppConfig(
         sidebar: SidebarSettings(hideSessionDetails: true),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -648,7 +648,7 @@ func makeCommandRouter(
         },
         // Best-effort tmux pane tail for the session-switcher preview card
         // (CROW-976). Returns plain text or null — never errors on a missing pane.
-        "session-terminal-preview": { params in
+        "get-session-terminal-preview": { params in
             guard let sidStr = params["session_id"]?.stringValue,
                   let sid = UUID(uuidString: sidStr) else {
                 throw DaemonRPCError.invalidParams("session_id required")

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -657,15 +657,7 @@ func makeCommandRouter(
                 return ["preview": .null]
             }
             let windowIndex: Int? = await MainActor.run {
-                let terms = appState.terminals(for: sid)
-                let preferred: SessionTerminal?
-                if let activeID = appState.activeTerminalID[sid] {
-                    preferred = terms.first { $0.id == activeID }
-                } else {
-                    preferred = nil
-                }
-                let terminal = preferred ?? terms.first(where: { $0.tmuxBinding != nil })
-                return terminal?.tmuxBinding?.windowIndex
+                appState.terminalPreviewWindowIndex(for: sid)
             }
             guard let index = windowIndex,
                   let preview = cockpit.previewText(windowIndex: index) else {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -646,6 +646,27 @@ func makeCommandRouter(
             if let dir { result["dir"] = .string(dir.path) }
             return result
         },
+        // Best-effort tmux pane tail for the session-switcher preview card
+        // (CROW-976). Returns plain text or null — never errors on a missing pane.
+        "session-terminal-preview": { params in
+            guard let sidStr = params["session_id"]?.stringValue,
+                  let sid = UUID(uuidString: sidStr) else {
+                throw DaemonRPCError.invalidParams("session_id required")
+            }
+            guard let cockpit else {
+                return ["preview": .null]
+            }
+            let windowIndex: Int? = await MainActor.run {
+                appState.terminals(for: sid)
+                    .compactMap(\.tmuxBinding?.windowIndex)
+                    .first
+            }
+            guard let index = windowIndex,
+                  let preview = cockpit.previewText(windowIndex: index) else {
+                return ["preview": .null]
+            }
+            return ["preview": .string(preview)]
+        },
         // Board reads. When the daemon owns the tracker/allowList (CROW-581 M-C)
         // they answer locally off `appState` — populated by the daemon's own
         // IssueTracker/AllowListService — so the boards work with the app down.
@@ -1650,24 +1671,45 @@ func makeCommandRouter(
         },
         "ui-get": { _ in
             let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-            return ["ui": SettingsRPC.uiJSON(config.sidebar)]
+            return ["ui": SettingsRPC.uiJSON(sidebar: config.sidebar, switcher: config.switcher)]
         },
         "ui-set": { params in
             try await mapRPCError {
-                guard let hideSessionDetails =
-                        try SettingsRPC.patchBool(params, "hide_session_details") else {
+                let hideSessionDetails = try SettingsRPC.patchBool(params, "hide_session_details")
+                let switcherEnabled = try SettingsRPC.patchBool(params, "switcher_enabled")
+                let switcherBinding = try SettingsRPC.patchNonEmptyString(params, "switcher_binding")
+                let switcherCapture = try SettingsRPC.patchBool(params, "switcher_capture_in_terminal")
+                let switcherOrder = try SettingsRPC.patchSwitcherOrder(params)
+                let switcherPreview = try SettingsRPC.patchBool(params, "switcher_preview")
+                let includePatches = try SettingsRPC.patchSwitcherIncludeKey(params)
+                guard hideSessionDetails != nil || switcherEnabled != nil || switcherBinding != nil
+                    || switcherCapture != nil || switcherOrder != nil || switcherPreview != nil
+                    || !includePatches.isEmpty else {
                     throw RPCError.invalidParams(
-                        "Nothing to set — provide at least one of hide_session_details.")
+                        "Nothing to set — provide at least one UI preference flag.")
                 }
-                let sidebar = try mutateConfig(devRoot: devRoot) { config -> SidebarSettings in
-                    config.sidebar.hideSessionDetails = hideSessionDetails
-                    return config.sidebar
+                let (sidebar, switcher) = try mutateConfig(devRoot: devRoot) {
+                    config -> (SidebarSettings, SwitcherSettings) in
+                    if let hideSessionDetails {
+                        config.sidebar.hideSessionDetails = hideSessionDetails
+                    }
+                    if let switcherEnabled { config.switcher.enabled = switcherEnabled }
+                    if let switcherBinding { config.switcher.binding = switcherBinding }
+                    if let switcherCapture {
+                        config.switcher.captureInTerminal = switcherCapture
+                    }
+                    if let switcherOrder { config.switcher.order = switcherOrder }
+                    if let switcherPreview { config.switcher.preview = switcherPreview }
+                    for (path, value) in includePatches {
+                        config.switcher.include[keyPath: path] = value
+                    }
+                    return (config.sidebar, config.switcher)
                 }
                 // Connected browsers re-read the view-affecting config slice off
                 // the `configReloaded` push that `startStoreReloadPoll` fires when
                 // config.json's mtime moves — no restart, no reload.
                 return [
-                    "ui": SettingsRPC.uiJSON(sidebar),
+                    "ui": SettingsRPC.uiJSON(sidebar: sidebar, switcher: switcher),
                     "restart_required": .bool(false),
                 ]
             }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -657,9 +657,15 @@ func makeCommandRouter(
                 return ["preview": .null]
             }
             let windowIndex: Int? = await MainActor.run {
-                appState.terminals(for: sid)
-                    .compactMap(\.tmuxBinding?.windowIndex)
-                    .first
+                let terms = appState.terminals(for: sid)
+                let preferred: SessionTerminal?
+                if let activeID = appState.activeTerminalID[sid] {
+                    preferred = terms.first { $0.id == activeID }
+                } else {
+                    preferred = nil
+                }
+                let terminal = preferred ?? terms.first(where: { $0.tmuxBinding != nil })
+                return terminal?.tmuxBinding?.windowIndex
             }
             guard let index = windowIndex,
                   let preview = cockpit.previewText(windowIndex: index) else {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -1069,6 +1069,103 @@ body.update-banner-visible #back-to-sidebar {
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
 }
 
+/* Session switcher overlay (CROW-976) — macOS-style task switcher */
+.session-switcher {
+  position: fixed;
+  inset: 0;
+  z-index: 1900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(10px);
+}
+.session-switcher[hidden] { display: none; }
+.switcher-panel {
+  width: min(1100px, 96vw);
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.switcher-strip {
+  display: flex;
+  gap: 14px;
+  overflow-x: auto;
+  padding: 8px 4px 12px;
+  scroll-snap-type: x mandatory;
+}
+.switcher-card {
+  flex: 0 0 min(320px, 82vw);
+  scroll-snap-align: center;
+  background: var(--bg-surface);
+  border: 2px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+}
+.switcher-card:hover { border-color: var(--border-strong); }
+.switcher-card.highlighted {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 1px var(--gold), 0 12px 32px rgba(0, 0, 0, 0.35);
+  transform: scale(1.02);
+}
+.switcher-card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.switcher-cat {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+.switcher-name {
+  font-weight: 600;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.switcher-subtle, .switcher-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+.switcher-meta { font-family: var(--font-mono, ui-monospace, monospace); }
+.switcher-activity { font-size: 11px; font-weight: 600; }
+.switcher-preview {
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: #0d0d0d;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  line-height: 1.35;
+  color: #c8c8c8;
+  max-height: 11em;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.switcher-hint {
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 /* Single-line text prompt modal (rename, etc.) — replaces window.prompt(), which
    silently returns null over the web in several browsers (CROW-593). Sits above
    the settings modal (z 2000) so it can layer over anything. */

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2500,8 +2500,52 @@ const switcherState = {
   open: false,
   originId: null,
   index: 0,
-  shiftHeld: false,
+  chord: null,
+  modifiersHeld: null,
 };
+
+function switcherBindingModifierFromEvent(e) {
+  switch (e.key) {
+    case 'Shift': return 'shift';
+    case 'Control': return 'ctrl';
+    case 'Alt': return 'alt';
+    case 'Meta': return 'meta';
+    default: return null;
+  }
+}
+
+function switcherBindingModifiersActive() {
+  const c = switcherState.chord;
+  const h = switcherState.modifiersHeld;
+  if (!c || !h) return false;
+  if (c.shift && h.shift) return true;
+  if (c.ctrl && h.ctrl) return true;
+  if (c.alt && h.alt) return true;
+  if (c.meta && h.meta) return true;
+  return false;
+}
+
+function switcherCommitHint() {
+  const b = parseSwitcherBinding(uiConfig.switcherBinding);
+  const mods = [];
+  if (b.shift) mods.push('Shift');
+  if (b.ctrl) mods.push('Ctrl');
+  if (b.alt) mods.push('Alt');
+  if (b.meta) mods.push('Cmd');
+  const modHint = mods.length ? 'release ' + mods.join('+') : 'click a card';
+  return 'Tab / ←→ to cycle · ' + modHint + ' to switch · Esc to cancel';
+}
+
+function captureSwitcherModifiers(e) {
+  const b = parseSwitcherBinding(uiConfig.switcherBinding);
+  switcherState.chord = b;
+  switcherState.modifiersHeld = {
+    shift: b.shift && e.shiftKey,
+    ctrl: b.ctrl && e.ctrlKey,
+    alt: b.alt && e.altKey,
+    meta: b.meta && e.metaKey,
+  };
+}
 
 function touchSessionMRU(id) {
   if (!id) return;
@@ -2598,7 +2642,8 @@ function switcherAdvance(delta) {
 function closeSwitcherOverlay() {
   switcherState.open = false;
   switcherState.originId = null;
-  switcherState.shiftHeld = false;
+  switcherState.chord = null;
+  switcherState.modifiersHeld = null;
   if (switcherPreviewTimer) { clearTimeout(switcherPreviewTimer); switcherPreviewTimer = null; }
   const root = document.getElementById('session-switcher');
   if (root) {
@@ -2632,7 +2677,7 @@ function switcherOnBinding(e) {
   if (!switcherState.open) {
     switcherState.open = true;
     switcherState.originId = selectedId;
-    switcherState.shiftHeld = true;
+    captureSwitcherModifiers(e);
     const cur = entries.findIndex((s) => s.id === selectedId);
     switcherState.index = cur >= 0 ? (cur + 1) % entries.length : 0;
     renderSwitcherOverlay();
@@ -2710,7 +2755,7 @@ function renderSwitcherOverlay() {
     strip.appendChild(renderSwitcherCard(s, i === switcherState.index));
   });
   panel.appendChild(strip);
-  const hint = el('div', 'switcher-hint', 'Tab / ←→ to cycle · release Shift to switch · Esc to cancel');
+  const hint = el('div', 'switcher-hint', switcherCommitHint());
   panel.appendChild(hint);
   root.appendChild(panel);
   requestAnimationFrame(() => {
@@ -2781,7 +2826,8 @@ function onSwitcherKeyDown(e) {
       switcherAdvance(-1);
       return;
     }
-    if (e.key === 'Tab' && switcherState.shiftHeld) {
+    if (e.key === 'Tab' && switcherState.chord && switcherState.chord.shift
+        && switcherState.modifiersHeld && switcherState.modifiersHeld.shift) {
       e.preventDefault();
       e.stopPropagation();
       switcherAdvance(1);
@@ -2797,11 +2843,11 @@ function onSwitcherKeyDown(e) {
 }
 
 function onSwitcherKeyUp(e) {
-  if (!switcherState.open) return;
-  if (e.key === 'Shift') {
-    switcherState.shiftHeld = false;
-    switcherCommit();
-  }
+  if (!switcherState.open || !switcherState.chord || !switcherState.modifiersHeld) return;
+  const mod = switcherBindingModifierFromEvent(e);
+  if (!mod || !switcherState.chord[mod]) return;
+  switcherState.modifiersHeld[mod] = false;
+  if (!switcherBindingModifiersActive()) switcherCommit();
 }
 
 document.addEventListener('keydown', onSwitcherKeyDown, true);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2856,6 +2856,8 @@ function onSwitcherKeyUp(e) {
   if (!switcherState.open || !switcherState.chord || !switcherState.modifiersHeld) return;
   const mod = switcherBindingModifierFromEvent(e);
   if (!mod || !switcherState.chord[mod]) return;
+  e.preventDefault();
+  e.stopPropagation();
   switcherState.modifiersHeld[mod] = false;
   if (!switcherBindingModifiersActive()) switcherCommit();
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2527,10 +2527,39 @@ function switcherBindingModifiersActive() {
   return false;
 }
 
+function switcherBindingHasModifiers(b) {
+  return b.shift || b.ctrl || b.alt || b.meta;
+}
+
+function switcherBindingKeysForPart(keyPart) {
+  const lower = keyPart.toLowerCase();
+  const aliases = {
+    tab: ['Tab'],
+    enter: ['Enter'],
+    escape: ['Escape'],
+    esc: ['Escape'],
+    space: [' ', 'Space'],
+    '`': ['`', 'Backquote'],
+    backquote: ['`', 'Backquote'],
+    '-': ['-', 'Minus'],
+    minus: ['-', 'Minus'],
+    '=': ['=', 'Equal'],
+    equal: ['=', 'Equal'],
+    left: ['ArrowLeft'],
+    right: ['ArrowRight'],
+    up: ['ArrowUp'],
+    down: ['ArrowDown'],
+  };
+  if (aliases[lower]) return aliases[lower];
+  if (keyPart.length === 1) return [keyPart, keyPart.toUpperCase()];
+  return [keyPart.charAt(0).toUpperCase() + keyPart.slice(1)];
+}
+
 function switcherCycleKeyLabel() {
   const b = parseSwitcherBinding(uiConfig.switcherBinding);
-  if (b.key === 'Tab') return 'Tab';
-  if (b.key === ' ') return 'Space';
+  if (b.keys.includes('Tab')) return 'Tab';
+  if (b.keys.includes(' ') || b.keys.includes('Space')) return 'Space';
+  if (b.keys.includes('Backquote') || b.keys.includes('`')) return '`';
   return b.key;
 }
 
@@ -2541,8 +2570,11 @@ function switcherCommitHint() {
   if (b.ctrl) mods.push('Ctrl');
   if (b.alt) mods.push('Alt');
   if (b.meta) mods.push('Cmd');
-  const modHint = mods.length ? 'release ' + mods.join('+') : 'click a card';
-  return switcherCycleKeyLabel() + ' / ←→ to cycle · ' + modHint + ' to switch · Esc to cancel';
+  const cycle = switcherCycleKeyLabel();
+  const commitHint = switcherBindingHasModifiers(b)
+    ? 'release ' + mods.join('+')
+    : 'release ' + cycle;
+  return cycle + ' / ←→ to cycle · ' + commitHint + ' to switch · Esc to cancel';
 }
 
 function captureSwitcherModifiers(e) {
@@ -2567,9 +2599,10 @@ function touchSessionMRU(id) {
 function parseSwitcherBinding(binding) {
   const parts = String(binding || 'shift+tab').toLowerCase().split('+').map((p) => p.trim()).filter(Boolean);
   const keyPart = parts[parts.length - 1] || 'tab';
-  const named = { tab: 'Tab', enter: 'Enter', escape: 'Escape', space: ' ' };
+  const keys = switcherBindingKeysForPart(keyPart);
   return {
-    key: named[keyPart] || (keyPart.length === 1 ? keyPart.toUpperCase() : keyPart),
+    key: keys[0],
+    keys,
     shift: parts.includes('shift'),
     ctrl: parts.includes('ctrl'),
     alt: parts.includes('alt'),
@@ -2583,9 +2616,9 @@ function eventMatchesSwitcherBinding(e, binding) {
   if (!!e.ctrlKey !== b.ctrl) return false;
   if (!!e.altKey !== b.alt) return false;
   if (!!e.metaKey !== b.meta) return false;
-  if (e.key === b.key) return true;
-  if (b.key.length === 1 && e.key.toLowerCase() === b.key.toLowerCase()) return true;
-  return false;
+  if (b.keys.includes(e.key)) return true;
+  return b.keys.some((k) => k.length === 1 && e.key.length === 1
+    && e.key.toLowerCase() === k.toLowerCase());
 }
 
 function switcherIncludesSession(s, include) {
@@ -2898,11 +2931,19 @@ function onSwitcherKeyDown(e) {
 function onSwitcherKeyUp(e) {
   if (!switcherState.open || !switcherState.chord || !switcherState.modifiersHeld) return;
   const mod = switcherBindingModifierFromEvent(e);
-  if (!mod || !switcherState.chord[mod]) return;
-  e.preventDefault();
-  e.stopPropagation();
-  switcherState.modifiersHeld[mod] = false;
-  if (!switcherBindingModifiersActive()) switcherCommit();
+  if (mod && switcherState.chord[mod]) {
+    e.preventDefault();
+    e.stopPropagation();
+    switcherState.modifiersHeld[mod] = false;
+    if (!switcherBindingModifiersActive()) switcherCommit();
+    return;
+  }
+  if (!switcherBindingHasModifiers(switcherState.chord)
+      && eventMatchesSwitcherBinding(e, uiConfig.switcherBinding)) {
+    e.preventDefault();
+    e.stopPropagation();
+    switcherCommit();
+  }
 }
 
 document.addEventListener('keydown', onSwitcherKeyDown, true);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2500,8 +2500,10 @@ const switcherState = {
   open: false,
   originId: null,
   index: 0,
+  highlightedId: null,
   chord: null,
   modifiersHeld: null,
+  previousFocus: null,
 };
 
 function switcherBindingModifierFromEvent(e) {
@@ -2638,10 +2640,31 @@ function switcherCategoryLabel(s) {
   return 'Work';
 }
 
+function switcherClampIndex(entries) {
+  if (!entries.length) return 0;
+  const cur = entries[switcherState.index];
+  if (cur && switcherState.highlightedId && cur.id === switcherState.highlightedId) {
+    return switcherState.index;
+  }
+  if (switcherState.highlightedId) {
+    const hi = entries.findIndex((s) => s.id === switcherState.highlightedId);
+    if (hi >= 0) {
+      switcherState.index = hi;
+      return hi;
+    }
+  }
+  if (switcherState.index >= entries.length) {
+    switcherState.index = entries.length - 1;
+  }
+  if (switcherState.index < 0) switcherState.index = 0;
+  return switcherState.index;
+}
+
 function switcherAdvance(delta) {
   const entries = buildSwitcherEntries();
   if (!entries.length) return;
   switcherState.index = (switcherState.index + delta + entries.length) % entries.length;
+  switcherState.highlightedId = entries[switcherState.index]?.id ?? null;
   renderSwitcherOverlay();
   scheduleSwitcherPreview();
 }
@@ -2651,12 +2674,18 @@ function closeSwitcherOverlay() {
   switcherState.originId = null;
   switcherState.chord = null;
   switcherState.modifiersHeld = null;
+  switcherState.highlightedId = null;
   if (switcherPreviewTimer) { clearTimeout(switcherPreviewTimer); switcherPreviewTimer = null; }
   const root = document.getElementById('session-switcher');
   if (root) {
     root.hidden = true;
     root.setAttribute('aria-hidden', 'true');
     root.innerHTML = '';
+  }
+  const prev = switcherState.previousFocus;
+  switcherState.previousFocus = null;
+  if (prev && typeof prev.focus === 'function') {
+    try { prev.focus(); } catch (_) { /* detached node */ }
   }
 }
 
@@ -2684,9 +2713,11 @@ function switcherOnBinding(e) {
   if (!switcherState.open) {
     switcherState.open = true;
     switcherState.originId = selectedId;
+    switcherState.previousFocus = document.activeElement;
     captureSwitcherModifiers(e);
     const cur = entries.findIndex((s) => s.id === selectedId);
     switcherState.index = cur >= 0 ? (cur + 1) % entries.length : 0;
+    switcherState.highlightedId = entries[switcherState.index]?.id ?? null;
     if (isTerminalFocused()) document.activeElement.blur();
     renderSwitcherOverlay();
     scheduleSwitcherPreview();
@@ -2699,9 +2730,13 @@ function switcherOnBinding(e) {
 
 function renderSwitcherCard(s, highlighted) {
   const card = el('div', 'switcher-card' + (highlighted ? ' highlighted' : ''));
+  card.setAttribute('role', 'option');
+  card.setAttribute('aria-selected', highlighted ? 'true' : 'false');
+  if (highlighted) card.tabIndex = 0;
   card.onclick = (ev) => {
     ev.stopPropagation();
     switcherState.index = buildSwitcherEntries().findIndex((x) => x.id === s.id);
+    switcherState.highlightedId = s.id;
     switcherCommit();
   };
   const top = el('div', 'switcher-card-top');
@@ -2754,21 +2789,29 @@ function renderSwitcherOverlay() {
     closeSwitcherOverlay();
     return;
   }
+  switcherClampIndex(entries);
+  switcherState.highlightedId = entries[switcherState.index]?.id ?? null;
   root.hidden = false;
   root.setAttribute('aria-hidden', 'false');
   root.innerHTML = '';
   const panel = el('div', 'switcher-panel');
   const strip = el('div', 'switcher-strip');
+  strip.setAttribute('role', 'listbox');
+  strip.setAttribute('aria-label', 'Sessions');
+  const hi = switcherState.index;
   entries.forEach((s, i) => {
-    strip.appendChild(renderSwitcherCard(s, i === switcherState.index));
+    strip.appendChild(renderSwitcherCard(s, i === hi));
   });
   panel.appendChild(strip);
   const hint = el('div', 'switcher-hint', switcherCommitHint());
   panel.appendChild(hint);
   root.appendChild(panel);
   requestAnimationFrame(() => {
-    const hi = strip.querySelector('.switcher-card.highlighted');
-    if (hi) hi.scrollIntoView({ inline: 'center', block: 'nearest' });
+    const card = strip.querySelector('.switcher-card.highlighted');
+    if (card) {
+      card.scrollIntoView({ inline: 'center', block: 'nearest' });
+      card.focus();
+    }
   });
   fillSwitcherPreview();
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -352,6 +352,16 @@ window.refreshVersionUpdateBanner = refreshVersionUpdateBanner;
 // saves (via `window.reloadUIConfig`). Mirrors the desktop's
 // `appState.hideSessionDetails`.
 const uiConfig = { hideSessionDetails: false, notifications: null, webPasswordSet: false, vsCodeAvailable: false, isLocal: false,
+  // Session switcher overlay (CROW-976) — defaults mirror AppConfig.SwitcherSettings.
+  switcherEnabled: true,
+  switcherBinding: 'shift+tab',
+  switcherCaptureInTerminal: true,
+  switcherOrder: 'mru',
+  switcherPreview: true,
+  switcherInclude: {
+    managers: false, jobs: false, reviews: true,
+    active: true, paused: true, in_review: true, completed: false, archived: false,
+  },
   // Terminal wheel-scroll sensitivity (CROW-835), consumed by enableWheelScroll.
   // Defaults mirror AppConfig.TerminalSettings: 3 local lines/notch on plain
   // shells, 1 forwarded notch/notch on agent surfaces.
@@ -361,6 +371,23 @@ async function loadUIConfig() {
     const res = await rpc('get-config');
     const cfg = JSON.parse((res && res.config) || '{}');
     uiConfig.hideSessionDetails = !!(cfg.sidebar && cfg.sidebar.hideSessionDetails);
+    const sw = cfg.switcher || {};
+    uiConfig.switcherEnabled = sw.enabled !== false;
+    uiConfig.switcherBinding = (sw.binding && String(sw.binding)) || 'shift+tab';
+    uiConfig.switcherCaptureInTerminal = sw.captureInTerminal !== false;
+    uiConfig.switcherOrder = (sw.order === 'sidebar') ? 'sidebar' : 'mru';
+    uiConfig.switcherPreview = sw.preview !== false;
+    const inc = sw.include || {};
+    uiConfig.switcherInclude = {
+      managers: !!inc.managers,
+      jobs: !!inc.jobs,
+      reviews: inc.reviews !== false,
+      active: inc.active !== false,
+      paused: inc.paused !== false,
+      in_review: inc.inReview !== false,
+      completed: !!inc.completed,
+      archived: !!inc.archived,
+    };
     // Wheel-scroll sensitivity (CROW-835). Fall back to the defaults for a config
     // that predates the `terminal` block or omits a knob; clamp to a sane floor of
     // 1 so a stray 0 can't wedge the wheel (Math.trunc would never emit a notch).
@@ -2459,6 +2486,327 @@ function showSessionNotFound(id) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Session switcher overlay — macOS-style MRU cycling (CROW-976)
+// ---------------------------------------------------------------------------
+
+const sessionMRU = [];
+const SWITCHER_PREVIEW_CACHE_MS = 4000;
+const SWITCHER_PREVIEW_DEBOUNCE_MS = 150;
+const switcherPreviewCache = new Map();
+let switcherPreviewTimer = null;
+let switcherPreviewSeq = 0;
+const switcherState = {
+  open: false,
+  originId: null,
+  index: 0,
+  shiftHeld: false,
+};
+
+function touchSessionMRU(id) {
+  if (!id) return;
+  const i = sessionMRU.indexOf(id);
+  if (i >= 0) sessionMRU.splice(i, 1);
+  sessionMRU.unshift(id);
+  if (sessionMRU.length > 200) sessionMRU.length = 200;
+}
+
+function parseSwitcherBinding(binding) {
+  const parts = String(binding || 'shift+tab').toLowerCase().split('+').map((p) => p.trim()).filter(Boolean);
+  const keyPart = parts[parts.length - 1] || 'tab';
+  const named = { tab: 'Tab', enter: 'Enter', escape: 'Escape', space: ' ' };
+  return {
+    key: named[keyPart] || (keyPart.length === 1 ? keyPart.toUpperCase() : keyPart),
+    shift: parts.includes('shift'),
+    ctrl: parts.includes('ctrl'),
+    alt: parts.includes('alt'),
+    meta: parts.includes('meta') || parts.includes('cmd') || parts.includes('command'),
+  };
+}
+
+function eventMatchesSwitcherBinding(e, binding) {
+  const b = parseSwitcherBinding(binding);
+  if (!!e.shiftKey !== b.shift) return false;
+  if (!!e.ctrlKey !== b.ctrl) return false;
+  if (!!e.altKey !== b.alt) return false;
+  if (!!e.metaKey !== b.meta) return false;
+  if (e.key === b.key) return true;
+  if (b.key.length === 1 && e.key.toLowerCase() === b.key.toLowerCase()) return true;
+  return false;
+}
+
+function switcherIncludesSession(s, include) {
+  if (s.kind === 'manager' && !include.managers) return false;
+  if (s.kind === 'job' && !include.jobs) return false;
+  if (s.kind === 'review' && !include.reviews) return false;
+  switch (s.status) {
+    case 'active': return include.active;
+    case 'paused': return include.paused;
+    case 'inReview': return include.in_review;
+    case 'completed': return include.completed;
+    case 'archived': return include.archived;
+    default: return true;
+  }
+}
+
+function switcherSidebarOrdered(list, include) {
+  const eligible = list.filter((s) => switcherIncludesSession(s, include));
+  const out = [];
+  for (const m of eligible.filter((s) => s.kind === 'manager')) out.push(m);
+  for (const g of groupSessions(eligible)) {
+    for (const row of g.rows) out.push(row);
+  }
+  return out;
+}
+
+function switcherMruOrdered(list, include) {
+  const eligible = list.filter((s) => switcherIncludesSession(s, include));
+  const byId = new Map(eligible.map((s) => [s.id, s]));
+  const out = [];
+  for (const id of sessionMRU) {
+    const s = byId.get(id);
+    if (s) { out.push(s); byId.delete(id); }
+  }
+  for (const s of eligible) {
+    if (byId.has(s.id)) out.push(s);
+  }
+  return out;
+}
+
+function buildSwitcherEntries() {
+  const include = uiConfig.switcherInclude;
+  return uiConfig.switcherOrder === 'sidebar'
+    ? switcherSidebarOrdered(sessions, include)
+    : switcherMruOrdered(sessions, include);
+}
+
+function switcherCategoryLabel(s) {
+  if (s.kind === 'manager') return 'Manager';
+  if (s.kind === 'job') return 'Job';
+  if (s.kind === 'review') return 'Review';
+  return 'Work';
+}
+
+function switcherAdvance(delta) {
+  const entries = buildSwitcherEntries();
+  if (!entries.length) return;
+  switcherState.index = (switcherState.index + delta + entries.length) % entries.length;
+  renderSwitcherOverlay();
+  scheduleSwitcherPreview();
+}
+
+function closeSwitcherOverlay() {
+  switcherState.open = false;
+  switcherState.originId = null;
+  switcherState.shiftHeld = false;
+  if (switcherPreviewTimer) { clearTimeout(switcherPreviewTimer); switcherPreviewTimer = null; }
+  const root = document.getElementById('session-switcher');
+  if (root) {
+    root.hidden = true;
+    root.setAttribute('aria-hidden', 'true');
+    root.innerHTML = '';
+  }
+}
+
+function switcherCommit() {
+  if (!switcherState.open) return;
+  const entries = buildSwitcherEntries();
+  const target = entries[switcherState.index];
+  closeSwitcherOverlay();
+  if (target && target.id !== selectedId) selectSession(target.id);
+}
+
+function switcherCancel() {
+  if (!switcherState.open) return;
+  const origin = switcherState.originId;
+  closeSwitcherOverlay();
+  if (origin && origin !== selectedId && sessions.some((s) => s.id === origin)) {
+    selectSession(origin);
+  }
+}
+
+function switcherOnBinding(e) {
+  if (!uiConfig.switcherEnabled) return;
+  const entries = buildSwitcherEntries();
+  if (entries.length <= 1) return;
+  if (!switcherState.open) {
+    switcherState.open = true;
+    switcherState.originId = selectedId;
+    switcherState.shiftHeld = true;
+    const cur = entries.findIndex((s) => s.id === selectedId);
+    switcherState.index = cur >= 0 ? (cur + 1) % entries.length : 0;
+    renderSwitcherOverlay();
+    scheduleSwitcherPreview();
+  } else {
+    switcherAdvance(1);
+  }
+  e.preventDefault();
+  e.stopPropagation();
+}
+
+function renderSwitcherCard(s, highlighted) {
+  const card = el('div', 'switcher-card' + (highlighted ? ' highlighted' : ''));
+  card.onclick = (ev) => {
+    ev.stopPropagation();
+    switcherState.index = buildSwitcherEntries().findIndex((x) => x.id === s.id);
+    switcherCommit();
+  };
+  const top = el('div', 'switcher-card-top');
+  const cat = el('span', 'switcher-cat', switcherCategoryLabel(s));
+  top.appendChild(cat);
+  const badge = el('span', 'status-badge', s.status);
+  badge.style.color = STATUS_COLOR[s.status] || 'var(--text-muted)';
+  top.appendChild(badge);
+  if (liveFor(s.id).remote_control_active) top.appendChild(rcGlyph());
+  card.appendChild(top);
+
+  const title = el('div', 'switcher-name');
+  title.appendChild(el('span', 'agent', AGENT_GLYPH[s.agent_kind] || '•'));
+  title.appendChild(el('span', '', s.name));
+  card.appendChild(title);
+
+  const ind = activityIndicator(s);
+  if (ind.label) {
+    const act = el('span', 'switcher-activity', ind.label);
+    act.style.color = ind.color;
+    card.appendChild(act);
+  }
+
+  if (s.ticket_title) card.appendChild(el('div', 'switcher-subtle', s.ticket_title));
+  const rev = reviewForSession(s.id);
+  if (rev && rev.author) {
+    card.appendChild(el('div', 'switcher-subtle', 'PR by @' + rev.author));
+  } else if (s.review_author) {
+    card.appendChild(el('div', 'switcher-subtle', 'PR by @' + s.review_author));
+  }
+  if (s.repo) {
+    card.appendChild(el('div', 'switcher-meta', s.repo + (s.branch ? ' · ' + s.branch : '')));
+  }
+  const prLink = (s.links || []).find((l) => l.type === 'pr') || liveFor(s.id).pr_link;
+  if (prLink) card.appendChild(el('div', 'switcher-meta', prLink.label || prLink.url));
+
+  if (highlighted) {
+    const prev = el('pre', 'switcher-preview');
+    prev.textContent = '';
+    card.appendChild(prev);
+  }
+  return card;
+}
+
+function renderSwitcherOverlay() {
+  const root = document.getElementById('session-switcher');
+  if (!root) return;
+  const entries = buildSwitcherEntries();
+  if (!switcherState.open || entries.length <= 1) {
+    closeSwitcherOverlay();
+    return;
+  }
+  root.hidden = false;
+  root.setAttribute('aria-hidden', 'false');
+  root.innerHTML = '';
+  const panel = el('div', 'switcher-panel');
+  const strip = el('div', 'switcher-strip');
+  entries.forEach((s, i) => {
+    strip.appendChild(renderSwitcherCard(s, i === switcherState.index));
+  });
+  panel.appendChild(strip);
+  const hint = el('div', 'switcher-hint', 'Tab / ←→ to cycle · release Shift to switch · Esc to cancel');
+  panel.appendChild(hint);
+  root.appendChild(panel);
+  requestAnimationFrame(() => {
+    const hi = strip.querySelector('.switcher-card.highlighted');
+    if (hi) hi.scrollIntoView({ inline: 'center', block: 'nearest' });
+  });
+  fillSwitcherPreview();
+}
+
+function scheduleSwitcherPreview() {
+  if (!uiConfig.switcherPreview) return;
+  if (switcherPreviewTimer) clearTimeout(switcherPreviewTimer);
+  switcherPreviewTimer = setTimeout(() => {
+    switcherPreviewTimer = null;
+    fillSwitcherPreview();
+  }, SWITCHER_PREVIEW_DEBOUNCE_MS);
+}
+
+async function fillSwitcherPreview() {
+  if (!uiConfig.switcherPreview || !switcherState.open) return;
+  const entries = buildSwitcherEntries();
+  const s = entries[switcherState.index];
+  if (!s) return;
+  const cached = switcherPreviewCache.get(s.id);
+  const now = Date.now();
+  if (cached && (now - cached.at) < SWITCHER_PREVIEW_CACHE_MS) {
+    setSwitcherPreviewText(cached.text);
+    return;
+  }
+  const seq = ++switcherPreviewSeq;
+  try {
+    const res = await rpc('session-terminal-preview', { session_id: s.id });
+    if (seq !== switcherPreviewSeq || !switcherState.open) return;
+    const text = (res && res.preview) ? String(res.preview) : '';
+    switcherPreviewCache.set(s.id, { text, at: Date.now() });
+    setSwitcherPreviewText(text);
+  } catch (_) { /* best-effort */ }
+}
+
+function setSwitcherPreviewText(text) {
+  const pre = document.querySelector('#session-switcher .switcher-card.highlighted .switcher-preview');
+  if (pre) pre.textContent = text || '';
+}
+
+function isTerminalFocused() {
+  const node = document.getElementById('terminal');
+  return !!(node && document.activeElement && node.contains(document.activeElement));
+}
+
+function onSwitcherKeyDown(e) {
+  if (!uiConfig.switcherEnabled) return;
+  if (switcherState.open) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      switcherCancel();
+      return;
+    }
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      e.stopPropagation();
+      switcherAdvance(1);
+      return;
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      e.stopPropagation();
+      switcherAdvance(-1);
+      return;
+    }
+    if (e.key === 'Tab' && switcherState.shiftHeld) {
+      e.preventDefault();
+      e.stopPropagation();
+      switcherAdvance(1);
+      return;
+    }
+    return;
+  }
+  if (e.type !== 'keydown') return;
+  if (!eventMatchesSwitcherBinding(e, uiConfig.switcherBinding)) return;
+  if (isTerminalFocused() && !uiConfig.switcherCaptureInTerminal) return;
+  if (document.querySelector('.text-prompt-backdrop, .modal-dialog-backdrop, .settings-overlay')) return;
+  switcherOnBinding(e);
+}
+
+function onSwitcherKeyUp(e) {
+  if (!switcherState.open) return;
+  if (e.key === 'Shift') {
+    switcherState.shiftHeld = false;
+    switcherCommit();
+  }
+}
+
+document.addEventListener('keydown', onSwitcherKeyDown, true);
+document.addEventListener('keyup', onSwitcherKeyUp, true);
+
 // `opts.fromRoute` marks a call that is *applying* a URL rather than initiating
 // one. The distinction is load-bearing: when applying, the URL is authoritative,
 // and synthesizing a terminal it didn't ask for turns navigate() into a push —
@@ -2468,6 +2816,7 @@ function showSessionNotFound(id) {
 // could never move past it (review).
 async function selectSession(id, opts) {
   const fromRoute = !!(opts && opts.fromRoute);
+  touchSessionMRU(id);
   // Synchronous, before the first await: applyRoute relies on the hash being
   // settled by the time anything else can observe it. A pending terminal is
   // carried either way (it came *from* the URL). The active one is carried only
@@ -4926,6 +5275,14 @@ function handleTerminalKey(e) {
       if (q && searchAddon) { try { searchAddon.findNext(q); } catch (_) {} }
     });
     return false;
+  }
+  if (eventMatchesSwitcherBinding(e, uiConfig.switcherBinding)) {
+    if (uiConfig.switcherEnabled && uiConfig.switcherCaptureInTerminal) {
+      switcherOnBinding(e);
+      e.preventDefault();
+      e.stopPropagation();
+      return false;
+    }
   }
   return true;
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2742,7 +2742,7 @@ async function fillSwitcherPreview() {
   }
   const seq = ++switcherPreviewSeq;
   try {
-    const res = await rpc('session-terminal-preview', { session_id: s.id });
+    const res = await rpc('get-session-terminal-preview', { session_id: s.id });
     if (seq !== switcherPreviewSeq || !switcherState.open) return;
     const text = (res && res.preview) ? String(res.preview) : '';
     switcherPreviewCache.set(s.id, { text, at: Date.now() });

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2525,6 +2525,13 @@ function switcherBindingModifiersActive() {
   return false;
 }
 
+function switcherCycleKeyLabel() {
+  const b = parseSwitcherBinding(uiConfig.switcherBinding);
+  if (b.key === 'Tab') return 'Tab';
+  if (b.key === ' ') return 'Space';
+  return b.key;
+}
+
 function switcherCommitHint() {
   const b = parseSwitcherBinding(uiConfig.switcherBinding);
   const mods = [];
@@ -2533,7 +2540,7 @@ function switcherCommitHint() {
   if (b.alt) mods.push('Alt');
   if (b.meta) mods.push('Cmd');
   const modHint = mods.length ? 'release ' + mods.join('+') : 'click a card';
-  return 'Tab / ←→ to cycle · ' + modHint + ' to switch · Esc to cancel';
+  return switcherCycleKeyLabel() + ' / ←→ to cycle · ' + modHint + ' to switch · Esc to cancel';
 }
 
 function captureSwitcherModifiers(e) {
@@ -2680,6 +2687,7 @@ function switcherOnBinding(e) {
     captureSwitcherModifiers(e);
     const cur = entries.findIndex((s) => s.id === selectedId);
     switcherState.index = cur >= 0 ? (cur + 1) % entries.length : 0;
+    if (isTerminalFocused()) document.activeElement.blur();
     renderSwitcherOverlay();
     scheduleSwitcherPreview();
   } else {
@@ -2826,13 +2834,15 @@ function onSwitcherKeyDown(e) {
       switcherAdvance(-1);
       return;
     }
-    if (e.key === 'Tab' && switcherState.chord && switcherState.chord.shift
-        && switcherState.modifiersHeld && switcherState.modifiersHeld.shift) {
+    if (eventMatchesSwitcherBinding(e, uiConfig.switcherBinding)) {
       e.preventDefault();
       e.stopPropagation();
       switcherAdvance(1);
       return;
     }
+    // Swallow everything else so keystrokes don't reach the focused xterm.
+    e.preventDefault();
+    e.stopPropagation();
     return;
   }
   if (e.type !== 'keydown') return;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -68,7 +68,7 @@
     <span id="statusbar-actions"></span>
   </div>
   <div id="lightbox" hidden><img id="lightbox-img" alt=""></div>
-  <div id="session-switcher" class="session-switcher" hidden aria-hidden="true"></div>
+  <div id="session-switcher" class="session-switcher" hidden aria-hidden="true" role="dialog" aria-modal="true" aria-label="Session switcher"></div>
   <script src="/xterm/xterm.js"></script>
   <script src="/xterm/xterm-addon-fit.js"></script>
   <script src="/xterm/xterm-addon-image.js"></script>

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -68,6 +68,7 @@
     <span id="statusbar-actions"></span>
   </div>
   <div id="lightbox" hidden><img id="lightbox-img" alt=""></div>
+  <div id="session-switcher" class="session-switcher" hidden aria-hidden="true"></div>
   <script src="/xterm/xterm.js"></script>
   <script src="/xterm/xterm-addon-fit.js"></script>
   <script src="/xterm/xterm-addon-image.js"></script>

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -15,6 +15,8 @@ import Foundation
 struct TerminalCockpit: Sendable {
     static let sessionName = "crow-cockpit"
     let controller: TmuxController
+    /// When set, `previewText` delegates here instead of calling tmux (unit tests).
+    private let previewCapture: (@Sendable (Int) -> String?)?
 
     init?(devRoot: String) {
         guard let tmux = Self.resolveTmuxBinary() else { return nil }
@@ -22,7 +24,15 @@ struct TerminalCockpit: Sendable {
         // and its live session windows rather than spinning up an isolated one.
         let socketPath = Self.appTmuxSocketPath()
         controller = TmuxController(tmuxBinary: tmux, socketPath: socketPath, sessionName: Self.sessionName)
+        previewCapture = nil
         ensureSession()
+    }
+
+    /// Stub cockpit for handler tests — no tmux server required.
+    init(previewCapture: @escaping @Sendable (Int) -> String?) {
+        controller = TmuxController(
+            tmuxBinary: "/bin/false", socketPath: "/dev/null", sessionName: Self.sessionName)
+        self.previewCapture = previewCapture
     }
 
     /// Adopt the app's cockpit if it's already running; otherwise create a bare
@@ -131,6 +141,7 @@ struct TerminalCockpit: Sendable {
     /// Capture the last `previewLines` rows of a cockpit window as plain text for
     /// the session-switcher card. Best-effort — returns nil when capture fails.
     func previewText(windowIndex: Int) -> String? {
+        if let previewCapture { return previewCapture(windowIndex) }
         guard let raw = try? controller.capturePane(
             target: "\(Self.sessionName):\(windowIndex)",
             linesBack: Self.previewLines,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -114,6 +114,9 @@ struct TerminalCockpit: Sendable {
     /// drift from the policy floor (CROW-804 review).
     static let replayLines = TmuxBackend.scrollbackHistoryLimit
 
+    /// Lines captured for the session-switcher preview card (CROW-976).
+    static let previewLines = 15
+
     /// Capture window `index`'s pane scrollback (history + current screen) and
     /// package it as bytes ready to write into a reconnecting xterm.js buffer.
     /// Returns `nil` when the capture fails (best-effort — a live-only pane is
@@ -123,6 +126,29 @@ struct TerminalCockpit: Sendable {
             target: "\(group):\(index)", linesBack: Self.replayLines, escapes: true)
         else { return nil }
         return Self.replayFrame(from: raw)
+    }
+
+    /// Capture the last `previewLines` rows of a cockpit window as plain text for
+    /// the session-switcher card. Best-effort — returns nil when capture fails.
+    func previewText(windowIndex: Int) -> String? {
+        guard let raw = try? controller.capturePane(
+            target: "\(Self.sessionName):\(windowIndex)",
+            linesBack: Self.previewLines,
+            escapes: true)
+        else { return nil }
+        return Self.plainPreviewText(from: raw)
+    }
+
+    /// Strip trailing padding and ANSI escapes for a monospace preview block.
+    static func plainPreviewText(from raw: String) -> String {
+        let trimmed = raw.replacingOccurrences(of: "[\r\n]+$", with: "", options: .regularExpression)
+        let esc = "\u{1B}"
+        let noAnsi = trimmed.replacingOccurrences(
+            of: esc + "(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])",
+            with: "",
+            options: .regularExpression)
+        return noAnsi.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
     }
 
     /// Transform a `capture-pane -pe` blob into a self-contained replay frame for

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SessionTerminalPreviewHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SessionTerminalPreviewHandlerTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+@testable import CrowDaemon
+
+/// `get-session-terminal-preview` handler coverage (CROW-976).
+@Suite struct SessionTerminalPreviewHandlerTests {
+
+    @MainActor
+    private func router(
+        appState: AppState = AppState(),
+        cockpit: TerminalCockpit? = nil
+    ) -> CommandRouter {
+        makeCommandRouter(
+            appState: appState, store: JSONStore.temporary(), git: GitManager(),
+            devRoot: NSTemporaryDirectory(), cockpit: cockpit)
+    }
+
+    @MainActor
+    private func preview(
+        _ params: [String: JSONValue],
+        appState: AppState = AppState(),
+        cockpit: TerminalCockpit? = nil
+    ) async -> JSONRPCResponse {
+        await router(appState: appState, cockpit: cockpit)
+            .handle(request: JSONRPCRequest(
+                id: 1, method: "get-session-terminal-preview", params: params))
+    }
+
+    // MARK: - Param validation
+
+    @Test @MainActor func rejectsMissingSessionID() async {
+        let resp = await preview([:])
+        #expect(resp.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    @Test @MainActor func rejectsMalformedSessionID() async {
+        let resp = await preview(["session_id": .string("not-a-uuid")])
+        #expect(resp.error?.code == RPCErrorCode.invalidParams)
+    }
+
+    // MARK: - Best-effort null paths
+
+    @Test @MainActor func returnsNullWithoutCockpit() async {
+        let sid = UUID()
+        let resp = await preview(["session_id": .string(sid.uuidString)])
+        #expect(resp.error == nil)
+        #expect(resp.result?["preview"] == .null)
+    }
+
+    @Test @MainActor func returnsNullWhenNoTmuxBinding() async {
+        let sid = UUID()
+        var state = AppState()
+        state.terminals[sid] = [
+            SessionTerminal(sessionID: sid, name: "Shell", cwd: "/tmp"),
+        ]
+        let cockpit = TerminalCockpit { _ in "should not be called" }
+        let resp = await preview(
+            ["session_id": .string(sid.uuidString)], appState: state, cockpit: cockpit)
+        #expect(resp.error == nil)
+        #expect(resp.result?["preview"] == .null)
+    }
+
+    // MARK: - Happy path
+
+    @Test @MainActor func returnsPreviewForBoundPane() async {
+        let sid = UUID()
+        let tid = UUID()
+        var state = AppState()
+        state.terminals[sid] = [
+            SessionTerminal(
+                id: tid, sessionID: sid, name: "Agent", cwd: "/repo",
+                tmuxBinding: TmuxBinding(socketPath: "/tmp/sock", sessionName: "crow-cockpit", windowIndex: 3)),
+        ]
+        let cockpit = TerminalCockpit { idx in
+            #expect(idx == 3)
+            return "line one\nline two"
+        }
+        let resp = await preview(
+            ["session_id": .string(sid.uuidString)], appState: state, cockpit: cockpit)
+        #expect(resp.error == nil)
+        #expect(resp.result?["preview"] == .string("line one\nline two"))
+    }
+
+    // MARK: - Window selection
+
+    @Test @MainActor func prefersActiveTerminalWindow() async {
+        let sid = UUID()
+        let first = UUID()
+        let active = UUID()
+        var state = AppState()
+        state.terminals[sid] = [
+            SessionTerminal(
+                id: first, sessionID: sid, name: "First", cwd: "/a",
+                tmuxBinding: TmuxBinding(socketPath: "/tmp/sock", sessionName: "crow-cockpit", windowIndex: 1)),
+            SessionTerminal(
+                id: active, sessionID: sid, name: "Active", cwd: "/b",
+                tmuxBinding: TmuxBinding(socketPath: "/tmp/sock", sessionName: "crow-cockpit", windowIndex: 7)),
+        ]
+        state.activeTerminalID[sid] = active
+        #expect(state.terminalPreviewWindowIndex(for: sid) == 7)
+
+        let cockpit = TerminalCockpit { idx in
+            #expect(idx == 7)
+            return "active pane"
+        }
+        let resp = await preview(
+            ["session_id": .string(sid.uuidString)], appState: state, cockpit: cockpit)
+        #expect(resp.result?["preview"] == .string("active pane"))
+    }
+
+    @Test @MainActor func fallsBackToFirstBoundTerminal() async {
+        let sid = UUID()
+        let first = UUID()
+        var state = AppState()
+        state.terminals[sid] = [
+            SessionTerminal(sessionID: sid, name: "Shell", cwd: "/tmp"),
+            SessionTerminal(
+                id: first, sessionID: sid, name: "Agent", cwd: "/repo",
+                tmuxBinding: TmuxBinding(socketPath: "/tmp/sock", sessionName: "crow-cockpit", windowIndex: 2)),
+        ]
+        #expect(state.terminalPreviewWindowIndex(for: sid) == 2)
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SessionTerminalPreviewHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SessionTerminalPreviewHandlerTests.swift
@@ -124,4 +124,27 @@ import CrowPersistence
         ]
         #expect(state.terminalPreviewWindowIndex(for: sid) == 2)
     }
+
+    @Test @MainActor func fallsBackWhenActiveTerminalHasNoBinding() async {
+        let sid = UUID()
+        let shell = UUID()
+        let agent = UUID()
+        var state = AppState()
+        state.terminals[sid] = [
+            SessionTerminal(id: shell, sessionID: sid, name: "Shell", cwd: "/tmp"),
+            SessionTerminal(
+                id: agent, sessionID: sid, name: "Agent", cwd: "/repo",
+                tmuxBinding: TmuxBinding(socketPath: "/tmp/sock", sessionName: "crow-cockpit", windowIndex: 5)),
+        ]
+        state.activeTerminalID[sid] = shell
+        #expect(state.terminalPreviewWindowIndex(for: sid) == 5)
+
+        let cockpit = TerminalCockpit { idx in
+            #expect(idx == 5)
+            return "agent pane"
+        }
+        let resp = await preview(
+            ["session_id": .string(sid.uuidString)], appState: state, cockpit: cockpit)
+        #expect(resp.result?["preview"] == .string("agent pane"))
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SettingsHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SettingsHandlerTests.swift
@@ -121,6 +121,54 @@ import CrowEngine
         #expect(onDisk.jiraCredential?.tokenRef == "op://vault/jira/token")
     }
 
+    @Test @MainActor func uiSetPatchesSwitcherFields() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let resp = await call("ui-set", [
+            "switcher_enabled": .bool(false),
+            "switcher_binding": .string("ctrl+`"),
+            "switcher_capture_in_terminal": .bool(false),
+            "switcher_order": .string("sidebar"),
+            "switcher_preview": .bool(false),
+            "switcher_include_managers": .bool(true),
+            "switcher_include_completed": .bool(true),
+        ], devRoot: devRoot)
+
+        #expect(resp.result?["ui"] == .object([
+            "sidebar": .object(["hide_session_details": .bool(false)]),
+            "switcher": .object([
+                "enabled": .bool(false),
+                "binding": .string("ctrl+`"),
+                "capture_in_terminal": .bool(false),
+                "order": .string("sidebar"),
+                "preview": .bool(false),
+                "include": .object([
+                    "managers": .bool(true),
+                    "jobs": .bool(false),
+                    "reviews": .bool(true),
+                    "active": .bool(true),
+                    "paused": .bool(true),
+                    "in_review": .bool(true),
+                    "completed": .bool(true),
+                    "archived": .bool(false),
+                ]),
+            ]),
+        ]))
+
+        let onDisk = try #require(ConfigStore.loadConfig(devRoot: devRoot))
+        #expect(onDisk.switcher.enabled == false)
+        #expect(onDisk.switcher.binding == "ctrl+`")
+        #expect(onDisk.switcher.captureInTerminal == false)
+        #expect(onDisk.switcher.order == .sidebar)
+        #expect(onDisk.switcher.preview == false)
+        #expect(onDisk.switcher.include.managers == true)
+        #expect(onDisk.switcher.include.completed == true)
+        // Unpatched include keys keep their defaults.
+        #expect(onDisk.switcher.include.reviews == true)
+        #expect(onDisk.switcher.include.jobs == false)
+    }
+
     // MARK: - restart_required
 
     @Test @MainActor func telemetryReportsRestartOnlyForEnabledOrPort() async throws {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SettingsHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SettingsHandlerTests.swift
@@ -4,6 +4,7 @@ import CrowCore
 import CrowGit
 import CrowIPC
 import CrowPersistence
+import CrowEngine
 @testable import CrowDaemon
 
 /// End-to-end coverage of the `telemetry-*` / `cleanup-*` / `ui-*` handlers
@@ -55,6 +56,7 @@ import CrowPersistence
         let ui = await call("ui-get", devRoot: devRoot)
         #expect(ui.result?["ui"] == .object([
             "sidebar": .object(["hide_session_details": .bool(false)]),
+            "switcher": SettingsRPC.switcherJSON(SwitcherSettings()),
         ]))
     }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/TerminalReplayTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/TerminalReplayTests.swift
@@ -42,4 +42,9 @@ import Testing
         let data = TerminalCockpit.replayFrame(from: "")
         #expect(String(decoding: data, as: UTF8.self) == Self.clearPrefix)
     }
+
+    @Test func plainPreviewTextStripsAnsiAndTrailingNewlines() {
+        let text = TerminalCockpit.plainPreviewText(from: "line1\n\u{1b}[31mred\u{1b}[0m\n\n")
+        #expect(text == "line1\nred")
+    }
 }

--- a/Packages/CrowDaemon/web-tests/key-handler.test.js
+++ b/Packages/CrowDaemon/web-tests/key-handler.test.js
@@ -23,6 +23,7 @@ const epilogue = `
   set term(v){ term = v; },
   set searchAddon(v){ searchAddon = v; },
   set termWs(v){ termWs = v; },
+  set uiConfig(v){ Object.assign(uiConfig, v); },
 };
 `;
 const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
@@ -331,6 +332,28 @@ async function main() {
     const e = key('v');
     check('an unmodified keystroke passes through',
       T.handleTerminalKey(e) === true && e.prevented === 0);
+  }
+
+  // ---- Session switcher (CROW-976) -----------------------------------------
+
+  console.log('\nSession switcher binding in the terminal:');
+  {
+    withClipboard();
+    setup();
+    T.uiConfig = { switcherEnabled: true, switcherBinding: 'shift+tab', switcherCaptureInTerminal: true };
+    const e = key('Tab', { shift: true });
+    const result = T.handleTerminalKey(e);
+    check('Shift+Tab is captured when captureInTerminal is true',
+      result === false && e.prevented === 1 && sent.length === 0);
+  }
+  {
+    withClipboard();
+    setup();
+    T.uiConfig = { switcherEnabled: true, switcherBinding: 'shift+tab', switcherCaptureInTerminal: false };
+    const e = key('Tab', { shift: true });
+    const result = T.handleTerminalKey(e);
+    check('Shift+Tab passes through when captureInTerminal is false',
+      result === true && e.prevented === 0);
   }
 
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
+    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -5,7 +5,7 @@
   "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
     "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/switcher.test.js
+++ b/Packages/CrowDaemon/web-tests/switcher.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+const epilogue = `
+;globalThis.__t = {
+  switcherIncludesSession(s, include){ return switcherIncludesSession(s, include); },
+  switcherMruOrdered(list, include){ return switcherMruOrdered(list, include); },
+  switcherSidebarOrdered(list, include){ return switcherSidebarOrdered(list, include); },
+  eventMatchesSwitcherBinding(e, binding){ return eventMatchesSwitcherBinding(e, binding); },
+  touchSessionMRU(id){ return touchSessionMRU(id); },
+  set uiConfig(v){ Object.assign(uiConfig, v); },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body><div id="session-switcher" hidden></div></body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.setInterval = () => 0;
+window.setTimeout = (fn) => { fn(); return 0; };
+window.requestAnimationFrame = () => 0;
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+const DEFAULT_INCLUDE = {
+  managers: false, jobs: false, reviews: true,
+  active: true, paused: true, in_review: true, completed: false, archived: false,
+};
+
+console.log('CROW-976 session switcher helpers:');
+
+{
+  const work = { id: 'w1', kind: 'work', status: 'active' };
+  const mgr = { id: 'm1', kind: 'manager', status: 'active' };
+  const done = { id: 'd1', kind: 'work', status: 'completed' };
+  check('active work included by default', T.switcherIncludesSession(work, DEFAULT_INCLUDE));
+  check('manager excluded by default', !T.switcherIncludesSession(mgr, DEFAULT_INCLUDE));
+  check('completed excluded by default', !T.switcherIncludesSession(done, DEFAULT_INCLUDE));
+}
+
+{
+  T.touchSessionMRU('a');
+  T.touchSessionMRU('b');
+  T.touchSessionMRU('a');
+  const list = [
+    { id: 'a', kind: 'work', status: 'active' },
+    { id: 'b', kind: 'work', status: 'active' },
+    { id: 'c', kind: 'work', status: 'active' },
+  ];
+  const ordered = T.switcherMruOrdered(list, DEFAULT_INCLUDE).map((s) => s.id);
+  check('MRU puts most recent first', ordered[0] === 'a');
+  check('MRU appends unseen sessions', ordered.includes('c'));
+}
+
+{
+  const e = { key: 'Tab', shiftKey: true, ctrlKey: false, altKey: false, metaKey: false };
+  check('default binding matches Shift+Tab', T.eventMatchesSwitcherBinding(e, 'shift+tab'));
+  check('binding is case-insensitive', T.eventMatchesSwitcherBinding(e, 'Shift+Tab'));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowDaemon/web-tests/switcher.test.js
+++ b/Packages/CrowDaemon/web-tests/switcher.test.js
@@ -14,8 +14,16 @@ const epilogue = `
     return { chord: switcherState.chord, modifiersHeld: switcherState.modifiersHeld };
   },
   switcherBindingModifiersActive(){ return switcherBindingModifiersActive(); },
+  switcherBindingHasModifiers(b){ return switcherBindingHasModifiers(b); },
+  onSwitcherKeyUp(e){ return onSwitcherKeyUp(e); },
   setModifiersHeld(v){ switcherState.modifiersHeld = v; },
   setChord(v){ switcherState.chord = v; },
+  setSwitcherOpen(v){
+    switcherState.open = v;
+    switcherState.chord = parseSwitcherBinding('tab');
+    switcherState.modifiersHeld = { shift: false, ctrl: false, alt: false, meta: false };
+  },
+  getSwitcherOpen(){ return switcherState.open; },
   touchSessionMRU(id){ return touchSessionMRU(id); },
   switcherClampIndex(entries){ return switcherClampIndex(entries); },
   setIndex(i){ switcherState.index = i; },
@@ -97,6 +105,26 @@ console.log('CROW-976 session switcher helpers:');
   check('ctrl binding active while ctrl held', T.switcherBindingModifiersActive());
   T.setModifiersHeld({ shift: false, ctrl: false, alt: false, meta: false });
   check('ctrl binding inactive after release', !T.switcherBindingModifiersActive());
+}
+
+{
+  const backquote = { key: 'Backquote', shiftKey: false, ctrlKey: true, altKey: false, metaKey: false };
+  check('ctrl+` matches Backquote key event', T.eventMatchesSwitcherBinding(backquote, 'ctrl+`'));
+  const grave = { key: '`', shiftKey: false, ctrlKey: true, altKey: false, metaKey: false };
+  check('ctrl+` matches grave accent key event', T.eventMatchesSwitcherBinding(grave, 'ctrl+`'));
+  const parsed = T.parseSwitcherBinding('ctrl+`');
+  check('ctrl+` parses Backquote aliases', parsed.keys.includes('Backquote') && parsed.keys.includes('`'));
+}
+
+{
+  T.uiConfig = { switcherBinding: 'tab' };
+  T.setSwitcherOpen(true);
+  const noop = () => {};
+  T.onSwitcherKeyUp({
+    key: 'Tab', shiftKey: false, ctrlKey: false, altKey: false, metaKey: false,
+    preventDefault: noop, stopPropagation: noop,
+  });
+  check('modifier-less binding commits on key release', !T.getSwitcherOpen());
 }
 
 {

--- a/Packages/CrowDaemon/web-tests/switcher.test.js
+++ b/Packages/CrowDaemon/web-tests/switcher.test.js
@@ -17,6 +17,10 @@ const epilogue = `
   setModifiersHeld(v){ switcherState.modifiersHeld = v; },
   setChord(v){ switcherState.chord = v; },
   touchSessionMRU(id){ return touchSessionMRU(id); },
+  switcherClampIndex(entries){ return switcherClampIndex(entries); },
+  setIndex(i){ switcherState.index = i; },
+  setHighlightedId(id){ switcherState.highlightedId = id; },
+  getIndex(){ return switcherState.index; },
   set uiConfig(v){ Object.assign(uiConfig, v); },
 };
 `;
@@ -93,6 +97,26 @@ console.log('CROW-976 session switcher helpers:');
   check('ctrl binding active while ctrl held', T.switcherBindingModifiersActive());
   T.setModifiersHeld({ shift: false, ctrl: false, alt: false, meta: false });
   check('ctrl binding inactive after release', !T.switcherBindingModifiersActive());
+}
+
+{
+  const entries = [
+    { id: 'a', kind: 'work', status: 'active' },
+    { id: 'b', kind: 'work', status: 'active' },
+    { id: 'd', kind: 'work', status: 'active' },
+  ];
+  T.setIndex(4);
+  T.setHighlightedId('d');
+  T.switcherClampIndex(entries);
+  check('index clamps when list shrinks', T.getIndex() === 2);
+  T.setIndex(1);
+  T.setHighlightedId('a');
+  T.switcherClampIndex([{ id: 'b', kind: 'work', status: 'active' }]);
+  check('index falls back when highlighted session filtered out', T.getIndex() === 0);
+  T.setIndex(3);
+  T.setHighlightedId('d');
+  T.switcherClampIndex(entries);
+  check('index tracks highlighted session after shrink', T.getIndex() === 2);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowDaemon/web-tests/switcher.test.js
+++ b/Packages/CrowDaemon/web-tests/switcher.test.js
@@ -8,6 +8,14 @@ const epilogue = `
   switcherMruOrdered(list, include){ return switcherMruOrdered(list, include); },
   switcherSidebarOrdered(list, include){ return switcherSidebarOrdered(list, include); },
   eventMatchesSwitcherBinding(e, binding){ return eventMatchesSwitcherBinding(e, binding); },
+  parseSwitcherBinding(binding){ return parseSwitcherBinding(binding); },
+  captureSwitcherModifiers(e){
+    captureSwitcherModifiers(e);
+    return { chord: switcherState.chord, modifiersHeld: switcherState.modifiersHeld };
+  },
+  switcherBindingModifiersActive(){ return switcherBindingModifiersActive(); },
+  setModifiersHeld(v){ switcherState.modifiersHeld = v; },
+  setChord(v){ switcherState.chord = v; },
   touchSessionMRU(id){ return touchSessionMRU(id); },
   set uiConfig(v){ Object.assign(uiConfig, v); },
 };
@@ -73,6 +81,18 @@ console.log('CROW-976 session switcher helpers:');
   const e = { key: 'Tab', shiftKey: true, ctrlKey: false, altKey: false, metaKey: false };
   check('default binding matches Shift+Tab', T.eventMatchesSwitcherBinding(e, 'shift+tab'));
   check('binding is case-insensitive', T.eventMatchesSwitcherBinding(e, 'Shift+Tab'));
+}
+
+{
+  const cap = T.captureSwitcherModifiers({
+    key: 'Tab', shiftKey: true, ctrlKey: false, altKey: false, metaKey: false,
+  });
+  check('capture records shift from binding', cap.chord.shift && cap.modifiersHeld.shift);
+  T.setChord(T.parseSwitcherBinding('ctrl+`'));
+  T.setModifiersHeld({ shift: false, ctrl: true, alt: false, meta: false });
+  check('ctrl binding active while ctrl held', T.switcherBindingModifiersActive());
+  T.setModifiersHeld({ shift: false, ctrl: false, alt: false, meta: false });
+  check('ctrl binding inactive after release', !T.switcherBindingModifiersActive());
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
@@ -166,16 +166,86 @@ public enum SettingsRPC {
     }
 
     /// The `ui` group is a *view* namespace, not a single `AppConfig` block:
-    /// today only `sidebar`, later `terminal` and anything else purely
+    /// today `sidebar` and `switcher`, later `terminal` and anything else purely
     /// presentational. Nesting by config-block name mirrors `config.json` and
     /// keeps a future `sidebar.width` from colliding with `terminal.width`;
     /// growing the group stays purely additive.
-    public static func uiJSON(_ sidebar: SidebarSettings) -> JSONValue {
+    public static func uiJSON(sidebar: SidebarSettings, switcher: SwitcherSettings) -> JSONValue {
         .object([
             "sidebar": .object([
                 "hide_session_details": .bool(sidebar.hideSessionDetails),
             ]),
+            "switcher": switcherJSON(switcher),
         ])
+    }
+
+    public static func switcherJSON(_ switcher: SwitcherSettings) -> JSONValue {
+        .object([
+            "enabled": .bool(switcher.enabled),
+            "binding": .string(switcher.binding),
+            "capture_in_terminal": .bool(switcher.captureInTerminal),
+            "order": .string(switcher.order.rawValue),
+            "preview": .bool(switcher.preview),
+            "include": .object([
+                "managers": .bool(switcher.include.managers),
+                "jobs": .bool(switcher.include.jobs),
+                "reviews": .bool(switcher.include.reviews),
+                "active": .bool(switcher.include.active),
+                "paused": .bool(switcher.include.paused),
+                "in_review": .bool(switcher.include.inReview),
+                "completed": .bool(switcher.include.completed),
+                "archived": .bool(switcher.include.archived),
+            ]),
+        ])
+    }
+
+    /// Patch one `switcher.include` key. `key` is snake_case on the wire
+    /// (`in_review` → `inReview`).
+    public static func patchSwitcherIncludeKey(
+        _ params: [String: JSONValue], prefix: String = "switcher_include_"
+    ) throws -> [(WritableKeyPath<SwitcherIncludeSettings, Bool>, Bool)] {
+        let keys: [(String, WritableKeyPath<SwitcherIncludeSettings, Bool>)] = [
+            ("managers", \.managers),
+            ("jobs", \.jobs),
+            ("reviews", \.reviews),
+            ("active", \.active),
+            ("paused", \.paused),
+            ("in_review", \.inReview),
+            ("completed", \.completed),
+            ("archived", \.archived),
+        ]
+        var patches: [(WritableKeyPath<SwitcherIncludeSettings, Bool>, Bool)] = []
+        for (wire, path) in keys {
+            guard let value = params[prefix + wire], value != .null else { continue }
+            guard let flag = value.boolValue else {
+                throw RPCError.invalidParams("\(prefix)\(wire) must be a boolean (true or false)")
+            }
+            patches.append((path, flag))
+        }
+        return patches
+    }
+
+    public static func patchSwitcherOrder(
+        _ params: [String: JSONValue], _ key: String = "switcher_order"
+    ) throws -> SwitcherOrder? {
+        guard let value = params[key], value != .null else { return nil }
+        guard let raw = value.stringValue else {
+            throw RPCError.invalidParams("\(key) must be \"mru\" or \"sidebar\"")
+        }
+        guard let order = SwitcherOrder(rawValue: raw) else {
+            throw RPCError.invalidParams("\(key) must be \"mru\" or \"sidebar\"")
+        }
+        return order
+    }
+
+    public static func patchNonEmptyString(
+        _ params: [String: JSONValue], _ key: String
+    ) throws -> String? {
+        guard let value = params[key], value != .null else { return nil }
+        guard let text = value.stringValue, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw RPCError.invalidParams("\(key) must be a non-empty string")
+        }
+        return text
     }
 
     /// Whether a telemetry change needs a daemon restart to take effect.

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SettingsRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SettingsRPCSupportTests.swift
@@ -111,9 +111,12 @@ struct SettingsRPCSupportTests {
     /// Locks the nesting by config block, so flattening it later is a conscious
     /// break rather than an accident — `ui` grows to hold more blocks.
     @Test func uiJSONNestsUnderSidebar() throws {
-        let json = SettingsRPC.uiJSON(SidebarSettings(hideSessionDetails: true))
+        let json = SettingsRPC.uiJSON(
+            sidebar: SidebarSettings(hideSessionDetails: true),
+            switcher: SwitcherSettings())
         #expect(json == .object([
             "sidebar": .object(["hide_session_details": .bool(true)]),
+            "switcher": SettingsRPC.switcherJSON(SwitcherSettings()),
         ]))
     }
 
@@ -134,7 +137,7 @@ struct SettingsRPCSupportTests {
         let responses = [
             SettingsRPC.telemetryJSON(TelemetryConfig()),
             SettingsRPC.cleanupJSON(CleanupConfig()),
-            SettingsRPC.uiJSON(SidebarSettings()),
+            SettingsRPC.uiJSON(sidebar: SidebarSettings(), switcher: SwitcherSettings()),
             SettingsRPC.automationJSON(AppConfig()),
             SettingsRPC.automationJSON(loaded),
         ]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1610,7 +1610,7 @@ crow ui get
 Change UI display preferences.
 
 ```
-crow ui set [--hide-session-details <hide-session-details>]
+crow ui set [--hide-session-details <hide-session-details>] [--switcher-enabled <switcher-enabled>] [--switcher-binding <switcher-binding>] [--switcher-capture-in-terminal <switcher-capture-in-terminal>] [--switcher-order <switcher-order>] [--switcher-preview <switcher-preview>] [--switcher-include <switcher-include> ...]
 ```
 
 Only the flags you pass change; at least one is required. Connected browsers pick the change up within a couple of seconds — no reload.
@@ -1618,6 +1618,12 @@ Only the flags you pass change; at least one is required. Connected browsers pic
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--hide-session-details` | `<hide-session-details>` | no | Hide ticket title and repo/branch lines in sidebar rows (true or false) |
+| `--switcher-enabled` | `<switcher-enabled>` | no | Enable the session switcher overlay (true or false) |
+| `--switcher-binding` | `<switcher-binding>` | no | Session switcher key chord (default: shift+tab) |
+| `--switcher-capture-in-terminal` | `<switcher-capture-in-terminal>` | no | Capture the switcher binding inside focused terminals (true or false) |
+| `--switcher-order` | `<switcher-order>` | no | Session switcher ordering: mru or sidebar |
+| `--switcher-preview` | `<switcher-preview>` | no | Fetch a tmux pane preview for the highlighted switcher card (true or false) |
+| `--switcher-include` | `<switcher-include>` _(repeatable)_ | no | Include filter as key=value (managers, jobs, reviews, active, paused, in_review, completed, archived) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a macOS-style session switcher overlay to the web UI: **Shift+Tab** opens it, hold Shift + Tab/arrow keys cycle, release Shift commits, Escape cancels.
- Cards compose existing session metadata (status, activity, ticket/PR/repo, review author) and optionally show a debounced tmux pane preview (`session-terminal-preview` RPC, last ~15 lines).
- New `AppConfig.switcher` block with `binding`, `captureInTerminal`, `order` (mru|sidebar), `preview`, and per-category/status `include` filters — exposed via `crow ui get|set`.

Closes #976

## Test plan

- [ ] Shift+Tab from anywhere in the web UI opens the overlay; holding Shift + repeated Tab advances; releasing Shift switches to the highlighted session; Escape returns to the origin session.
- [ ] With `captureInTerminal: false`, Shift+Tab inside a focused terminal reaches the PTY (Claude Code permission-mode cycling).
- [ ] With `captureInTerminal: true`, Shift+Tab does not reach the PTY.
- [ ] Include-filter round trip via `crow ui set --switcher-include …` changes overlay membership without reload.
- [ ] MRU order flips between the two most recent sessions on a single Shift+Tab tap; `order: sidebar` matches sidebar order.
- [ ] Preview: only the highlighted card fetches; cycling fast does not fan out; sessions without a pane render without preview/error.
- [ ] One session and zero eligible sessions: overlay no-ops gracefully.
- [ ] Config compatibility: missing `switcher` key and `"switcher": {}` both decode to defaults.


Made with [Cursor](https://cursor.com)