### PR TITLE
Add a ↻ Reload button to the session top bar (CROW-979)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -1443,6 +1443,19 @@ body.update-banner-visible #back-to-sidebar {
   animation: wizard-spin 0.7s linear infinite;
 }
 
+/* The ↻ on the header's Reload button (CROW-979). Boxed to the same 12×12 as
+   `.action-spinner` so swapping one for the other while reloading doesn't shift
+   the button's width. */
+.reload-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  font-size: 12px;
+  line-height: 1;
+}
+
 /* ---- Scorecard (ADR 0008 web parity, #721) ---- */
 .score-weeklabel { color: var(--text-secondary); font-size: 12px; }
 .score-banner {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -2427,6 +2427,11 @@ function showEmptyDetail(msg, opts) {
   selectedBoard = null;
   terminals = [];
   activeTerminal = null;
+  // CROW-979: the ↻ that was spinning belonged to the session we just dropped, and
+  // its `onopen` may never come (the socket is being torn down with it). Clearing
+  // after `selectedId` is already null makes the repaint a no-op — the header is
+  // emptied below regardless — but leaves no stale flag for the next selection.
+  clearTerminalReloadPending();
   const app = document.getElementById('app');
   app.classList.remove('has-selection', 'board-active', 'mobile-show-sidebar');
   // On narrow screens `#app:not(.has-selection) #detail` is display:none, which
@@ -3159,8 +3164,30 @@ function renderHeader(s) {
                                          liveFor(s.id).auto_rebase_state));
   }
 
-  // Right-aligned action cluster: PR quick-actions, then status transitions + delete.
+  // Right-aligned action cluster: terminal reload, PR quick-actions, then status
+  // transitions + delete.
   const actions = el('div', 'actions-cluster');
+  // Terminal reload (CROW-979). `reloadTerminal()` was reachable only from the
+  // terminal's right-click menu, which a touch device has no way to open — so on a
+  // phone the cheap recovery for a corrupted surface didn't exist and the only way
+  // out was leaving the session and coming back. Deliberately OUTSIDE the
+  // `kind !== 'manager'` guard below: that guard is why a Manager session shows no
+  // buttons at all, and the Manager window is the common CROW-804 stuck-surface
+  // case (it has no tabs to hang a control off either, #680).
+  const reloadBusy = terminalReloadPending;
+  const reload = el('button', 'action-btn action-btn-reload', '');
+  // Swap the ↻ glyph for the shared spinner ring rather than spinning the button,
+  // so the chrome stays put while it turns (the CROW-797 tickets-refresh fix).
+  reload.appendChild(reloadBusy ? el('span', 'action-spinner') : el('span', 'reload-glyph', '↻'));
+  reload.appendChild(el('span', null, 'Reload'));
+  reload.disabled = reloadBusy || !activeTerminal;
+  reload.title = reloadBusy
+    ? 'Reloading terminal…'
+    : (activeTerminal
+        ? 'Reload the terminal — reset the view and reconnect'
+        : 'No terminal attached');
+  reload.onclick = () => reloadTerminalAction();
+  actions.appendChild(reload);
   if (pr && pr.has_pr && !pr.is_merged) {
     // Quick-actions dispatch a prompt into the session's managed Claude Code
     // terminal — disable them when there is none (native `canDispatchQuickAction`;
@@ -3535,6 +3562,11 @@ async function refreshTerminals() {
     }, { replace: true });
   }
   renderTabs();
+  // CROW-979: this call is what binds `activeTerminal`, and the header's ↻ Reload
+  // is disabled until there is one. selectSession renders the header *before*
+  // awaiting this, so without a nudge the button would sit disabled until the next
+  // 4s refreshLive tick.
+  syncTerminalReloadEnabled();
   // #673: session switches funnel through here too (selectSession → refreshTerminals),
   // changing which window this shared socket shows — same corruption as a terminal-tab
   // switch. attachWindow reloads only when the window actually changes, so a same-session
@@ -4932,6 +4964,63 @@ let termWs = null;
 let termSkelTimer = null; // #677: safety timeout that clears the skeleton overlay
 let termReconnectDelay = 1000; // #687: backoff between reconnect attempts (ms), reset on open
 
+// In-flight state for the header's ↻ Reload button (CROW-979). Module state, not
+// DOM state: `refreshLive` repaints the whole detail header every 4s, so a busy
+// flag parked on the button node would be wiped mid-reload — the same reason
+// `ticketRefreshPending` lives out here rather than on `.tickets-refresh`.
+let terminalReloadPending = false;
+let terminalReloadSettleTimer = null;
+// A reattach is sub-second; this only has to be long enough not to cut a slow one
+// short. It exists for the case where `onopen` never comes at all (see below).
+const TERMINAL_RELOAD_SETTLE_MS = 10000;
+
+function paintTerminalReloadState() {
+  if (!selectedId) return;
+  const s = sessions.find((x) => x.id === selectedId);
+  if (s) renderHeader(s);
+}
+
+// Repaint only when the button is actually out of date. `refreshTerminals` runs on
+// paths where nothing about the button changed (add/close terminal, a background
+// "terminals changed" push), and an unconditional renderHeader there would also
+// throw away an in-flight `markInReviewAction`, which parks its spinner on the
+// button node rather than in module state.
+function syncTerminalReloadEnabled() {
+  const btn = document.querySelector('#detail-header .action-btn-reload');
+  if (!btn) return;
+  if (btn.disabled !== (terminalReloadPending || !activeTerminal)) paintTerminalReloadState();
+}
+
+// Header ↻ Reload. `reloadTerminal()` is synchronous and returns before the new
+// socket is up, so "done" is the socket opening — cleared from connectTerminalWs's
+// `onopen`, which fires for this reload and for the auto-reconnect that follows a
+// failed one. `onclose` retries forever with backoff, though, so a daemon that
+// never comes back would leave this spinning: the settle timer is the floor under
+// that. Deliberately NOT routed through attachWindow(), whose
+// `win === attachedWindow` guard would make an explicit reload a no-op.
+function reloadTerminalAction() {
+  if (terminalReloadPending) return; // coalesce a double-tap
+  // Read `activeTerminal` here rather than at render time: renderHeader runs in
+  // selectSession *before* the awaited refreshTerminals that rebinds it, so the
+  // value captured during a paint can be the previous session's row.
+  if (!term || !activeTerminal) return; // nothing attached — the button is disabled anyway
+  terminalReloadPending = true;
+  clearTimeout(terminalReloadSettleTimer);
+  terminalReloadSettleTimer = setTimeout(clearTerminalReloadPending, TERMINAL_RELOAD_SETTLE_MS);
+  paintTerminalReloadState();
+  reloadTerminal();
+}
+
+// Idempotent: `onopen` also fires for reconnects nobody asked for, and repainting
+// the header on each of those would be needless churn.
+function clearTerminalReloadPending() {
+  if (!terminalReloadPending) return;
+  clearTimeout(terminalReloadSettleTimer);
+  terminalReloadSettleTimer = null;
+  terminalReloadPending = false;
+  paintTerminalReloadState();
+}
+
 // Skeleton loading overlay (#677): mask the artifact-prone xterm (re)attach
 // window (blank/garbled grid, reflow flash, mid-paint scrollback replay) with
 // the CROW-613 shimmer. Toggled via a `.loading` class on #terminal-wrap.
@@ -5496,6 +5585,7 @@ function connectTerminalWs() {
     // sends no immediate output. #687: this timer must NOT live in
     // showTerminalSkeleton, or it re-fires during the disconnect loop → strobe.
     setTerminalReconnecting(false);
+    clearTerminalReloadPending(); // CROW-979: the header ↻ settles when we're attached again
     termReconnectDelay = 1000;
     clearTimeout(termSkelTimer);
     termSkelTimer = setTimeout(hideTerminalSkeleton, 1500);

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -49,6 +49,25 @@ the selection and cancelling the browser default, while Ctrl+C with no
 selection still falls through as SIGINT; Cmd+F cancelling the browser find bar
 and opening ours; and non-keydown / unmodified keys passing through untouched.
 
+## `terminal-reload.test.js` — header ↻ Reload button (CROW-979)
+
+Drives `renderHeader` and `reloadTerminalAction` against a fake xterm + a fake
+`/terminal` socket whose `onopen` fires on demand. Coverage: the button renders
+for work / review / job **and manager** sessions (managers previously got no
+action cluster at all, since every other button sits inside the
+`kind !== 'manager'` guard, and they have no tabs to hang a control off either);
+disabled with nothing attached and enabled once `activeTerminal` binds; a click
+resetting the xterm buffer, detaching the old socket's handlers *before* closing
+it, and opening a fresh one; the `↻`-swapped-for-`.action-spinner` in-flight
+treatment, both nodes boxed to the same 12×12 so the swap can't shift the button
+(the CROW-797 tickets-refresh fix); the spinner settling when the socket opens,
+and — because `onclose` retries with backoff forever — also settling via the
+`TERMINAL_RELOAD_SETTLE_MS` timer when the socket never opens at all; the timer
+being disarmed when `onopen` wins the race; double-tap coalescing; clicking with
+no terminal (or no xterm) being a no-op rather than a throw; `showEmptyDetail`
+dropping a pending reload with the session; and the pre-existing right-click
+"Reload terminal" menu item still being present.
+
 ## `row.test.js` — sidebar session rows (CROW-773)
 
 Drives `sessionRow`. Coverage: the PR pill's status glyphs for every

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,10 +2,10 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; terminal reload button; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
+    "test:ci": "fail=0; for f in board touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/terminal-reload.test.js
+++ b/Packages/CrowDaemon/web-tests/terminal-reload.test.js
@@ -1,0 +1,320 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// CROW-979 regression tests for the header's ↻ Reload button. Before it, the only
+// route to `reloadTerminal()` was the terminal's right-click menu — which a touch
+// device cannot open, so on a phone the cheap recovery for a corrupted surface did
+// not exist at all.
+//
+// Same loader shape as the other files here (the REAL app.js in a jsdom VM plus an
+// epilogue exposing module-scope internals), with two deviations this file needs:
+//   • the fake /terminal socket STORES its handlers instead of discarding them, so
+//     a test can fire `onopen` on demand — that transition is what settles the
+//     spinner, and firing it on assignment (rpc-timeout.test.js's shape) would make
+//     the in-flight state unobservable;
+//   • setTimeout/clearTimeout are a controllable queue selectable by delay, so the
+//     10s settle timer can be fired without also firing the 1500s skeleton timer.
+const epilogue = `
+;globalThis.__t = {
+  renderHeader(s){ return renderHeader(s); },
+  showEmptyDetail(m, o){ return showEmptyDetail(m, o); },
+  showTerminalMenu(e){ return showTerminalMenu(e); },
+  reloadTerminalAction(){ return reloadTerminalAction(); },
+  clearTerminalReloadPending(){ return clearTerminalReloadPending(); },
+  syncTerminalReloadEnabled(){ return syncTerminalReloadEnabled(); },
+  get terminalReloadPending(){ return terminalReloadPending; },
+  get termWs(){ return termWs; },
+  set termWs(v){ termWs = v; },
+  set term(v){ term = v; },
+  set sessions(v){ sessions = v; },
+  set selectedId(v){ selectedId = v; },
+  set activeTerminal(v){ activeTerminal = v; },
+  TERMINAL_RELOAD_SETTLE_MS,
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const APP_CSS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.css';
+
+const dom = new JSDOM(
+  `<!doctype html><html><head>
+     <style>${fs.readFileSync(APP_CSS, 'utf8')}</style>
+   </head><body>
+     <div id="app"><header id="detail-header"></header><div id="tabbar"></div>
+       <div id="terminal-wrap"><div id="terminal"></div></div><div id="board"></div>
+       <div id="sidebar"></div></div>
+   </body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+
+// --- controllable timers ----------------------------------------------------
+let timerSeq = 0;
+const timers = [];
+window.setTimeout = (fn, ms) => { timers.push({ id: ++timerSeq, fn, ms: ms || 0 }); return timerSeq; };
+window.clearTimeout = (id) => { const i = timers.findIndex((t) => t.id === id); if (i >= 0) timers.splice(i, 1); };
+window.setInterval = () => 0;
+window.requestAnimationFrame = () => 0;
+function fireTimersAt(ms) {
+  const hits = timers.filter((t) => t.ms === ms);
+  hits.forEach((t) => { timers.splice(timers.indexOf(t), 1); t.fn(); });
+  return hits.length;
+}
+function timerCountAt(ms) { return timers.filter((t) => t.ms === ms).length; }
+
+// --- fake sockets -----------------------------------------------------------
+// Every `new WebSocket(...)` lands here; `sockets` is append-only so a test can
+// assert that reloadTerminal really tore one down and built another.
+const sockets = [];
+window.WebSocket = function (url) {
+  const s = {
+    url, readyState: 0, closed: false, sent: [],
+    send(d) { this.sent.push(d); },
+    close() { this.closed = true; this.readyState = 3; if (this._onclose) this._onclose({}); },
+    fireOpen() { this.readyState = 1; if (this._onopen) this._onopen(); },
+  };
+  Object.defineProperty(s, 'onopen', { set(fn) { s._onopen = fn; }, get() { return s._onopen; } });
+  Object.defineProperty(s, 'onmessage', { set(fn) { s._onmessage = fn; }, get() { return s._onmessage; } });
+  Object.defineProperty(s, 'onclose', { set(fn) { s._onclose = fn; }, get() { return s._onclose; } });
+  Object.defineProperty(s, 'onerror', { set(fn) { s._onerror = fn; }, get() { return s._onerror; } });
+  sockets.push(s);
+  return s;
+};
+window.WebSocket.OPEN = 1;
+
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try {
+  vm.runInContext(fs.readFileSync(APP_JS, 'utf8') + epilogue, ctx, { filename: 'app.js' });
+} catch (e) {
+  console.log('[load warn]', e.message);
+}
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0;
+let fail = 0;
+const check = (name, cond) => {
+  if (cond) { pass++; console.log('  ✓ ' + name); }
+  else { fail++; console.log('  ✗ ' + name); }
+};
+
+// --- helpers ----------------------------------------------------------------
+const SESSION_ID = 's1';
+let lastTerm = null;
+function fakeTerm() {
+  return {
+    resets: 0,
+    reset() { this.resets++; },
+    buffer: { active: { viewportY: 0, baseY: 0 } },
+    getSelection() { return ''; },
+    selectAll() {}, clear() {}, write() {}, focus() {},
+  };
+}
+// Put the app in "session <kind> selected, one terminal attached" and paint.
+function mount(kind, opts) {
+  const o = opts || {};
+  const s = { id: SESSION_ID, name: 'sess', status: 'active', kind };
+  T.sessions = [s];
+  T.selectedId = SESSION_ID;
+  T.activeTerminal = o.noTerminal ? null : { id: 't1', name: 'Claude Code', window: 3 };
+  lastTerm = o.noTerm ? null : fakeTerm();
+  T.term = lastTerm;
+  T.termWs = null;
+  T.clearTerminalReloadPending();
+  T.renderHeader(s);
+  return s;
+}
+function reloadBtn() {
+  return [...window.document.querySelectorAll('#detail-header .actions-cluster .action-btn')]
+    .find((b) => b.textContent.includes('Reload')) || null;
+}
+
+console.log('the ↻ Reload button renders for every session kind:');
+for (const kind of ['work', 'review', 'job', 'manager']) {
+  mount(kind);
+  const b = reloadBtn();
+  check(kind + ': button present', !!b);
+  check(kind + ': shows the ↻ glyph', !!(b && b.querySelector('.reload-glyph')));
+}
+
+console.log('\nmanager sessions get an action cluster at all (the #680 gap):');
+{
+  // Every other header button sits inside `if (s.kind !== 'manager')`, so before
+  // CROW-979 a Manager with no links rendered no header row whatsoever — which is
+  // exactly the surface with no tabs to hang a control off either.
+  mount('manager');
+  const cluster = window.document.querySelector('#detail-header .actions-cluster');
+  check('cluster exists for a manager', !!cluster);
+  check('and holds only Reload', !!cluster && cluster.children.length === 1);
+}
+
+console.log('\nrefreshTerminals only repaints the header when the button is stale:');
+{
+  // selectSession paints the header BEFORE awaiting refreshTerminals, so the
+  // button starts disabled and must flip once activeTerminal binds — but the same
+  // sync runs on add/close-terminal and background pushes, where an unconditional
+  // renderHeader would also throw away an in-flight In Review spinner (that one
+  // keeps its state on the node, not in module state).
+  mount('work', { noTerminal: true });
+  check('starts disabled with nothing bound', reloadBtn().disabled === true);
+  const stale = reloadBtn();
+  T.activeTerminal = { id: 't1', name: 'Claude Code', window: 3 };
+  T.syncTerminalReloadEnabled();
+  check('flips to enabled once bound', reloadBtn().disabled === false);
+  check('header was rebuilt', reloadBtn() !== stale);
+
+  // Nothing changed this time — the node must survive untouched.
+  const fresh = reloadBtn();
+  fresh.dataset.marker = 'kept';
+  T.syncTerminalReloadEnabled();
+  check('no repaint when already correct', reloadBtn().dataset.marker === 'kept');
+}
+
+console.log('\nglyph and spinner share one box, so the swap causes no layout shift:');
+{
+  // The CROW-797 fix for the tickets ↻: spin an inner node inside stationary
+  // chrome. That only holds if the two nodes are the same size.
+  mount('work');
+  const glyph = reloadBtn().querySelector('.reload-glyph');
+  const gs = glyph && window.getComputedStyle(glyph);
+  check('↻ glyph is 12×12', !!gs && gs.width === '12px' && gs.height === '12px');
+}
+
+console.log('\ndisabled when nothing is attached, enabled when something is:');
+{
+  mount('work', { noTerminal: true });
+  const b = reloadBtn();
+  check('present but disabled', !!b && b.disabled === true);
+  check('title explains why', !!b && b.title === 'No terminal attached');
+
+  mount('work');
+  const b2 = reloadBtn();
+  check('enabled with a terminal attached', !!b2 && b2.disabled === false);
+  check('title describes the action', !!b2 && /Reload the terminal/.test(b2.title));
+}
+
+console.log('\nclick reloads: buffer reset, old socket dropped, new socket opened:');
+{
+  mount('work');
+  // Stand an already-open socket up so reloadTerminal has one to tear down. The
+  // fake's close() fires onclose, so leaving this handler attached would make the
+  // reconnect loop re-enter — which is precisely what reloadTerminal detaches to
+  // prevent, and what this asserts.
+  const old = new window.WebSocket('ws://localhost/terminal');
+  old.readyState = 1;
+  let staleOnCloseFired = false;
+  old.onclose = () => { staleOnCloseFired = true; };
+  T.termWs = old;
+  const before = sockets.length;
+
+  reloadBtn().click();
+
+  check('xterm buffer reset', lastTerm.resets === 1);
+  check('old socket closed', old.closed === true);
+  check('old handlers detached first', old.onclose === null);
+  check('stale onclose never ran', staleOnCloseFired === false);
+  check('a fresh socket was opened', sockets.length === before + 1);
+  check('…and it is the live one', T.termWs === sockets[sockets.length - 1]);
+  check('pending flag set', T.terminalReloadPending === true);
+}
+
+console.log('\n…and the button spins in place while it reconnects:');
+{
+  const b = reloadBtn();
+  check('button disabled', !!b && b.disabled === true);
+  check('spinner swapped in', !!b && !!b.querySelector('.action-spinner'));
+  check('↻ glyph swapped out', !!b && b.querySelector('.reload-glyph') === null);
+  check('title says reloading', !!b && b.title === 'Reloading terminal…');
+  // The spinner and the glyph occupy the same 12×12 box, so the swap can't shift
+  // the button's width (the CROW-797 fix, applied to this button).
+  const spinNode = b && b.querySelector('.action-spinner');
+  const spin = spinNode && window.getComputedStyle(spinNode);
+  check('spinner is 12×12', !!spin && spin.width === '12px' && spin.height === '12px');
+}
+
+console.log('\nthe socket opening settles it:');
+{
+  sockets[sockets.length - 1].fireOpen();
+  check('pending flag cleared', T.terminalReloadPending === false);
+  const b = reloadBtn();
+  check('↻ glyph restored', !!b && !!b.querySelector('.reload-glyph'));
+  check('no spinner left', !!b && b.querySelector('.action-spinner') === null);
+  check('button re-enabled', !!b && b.disabled === false);
+}
+
+console.log('\na reconnect that never opens still settles (no forever-spinner):');
+{
+  // onclose retries with backoff indefinitely, so "wait for onopen" alone would
+  // spin until the daemon came back — which for a dead daemon is never.
+  mount('work');
+  reloadBtn().click();
+  check('pending while in flight', T.terminalReloadPending === true);
+  check('settle timer armed', timerCountAt(T.TERMINAL_RELOAD_SETTLE_MS) === 1);
+  fireTimersAt(T.TERMINAL_RELOAD_SETTLE_MS);
+  check('pending cleared by the settle timer', T.terminalReloadPending === false);
+  check('↻ glyph restored', !!reloadBtn().querySelector('.reload-glyph'));
+}
+
+console.log('\nsettle timer is disarmed when the socket opens first:');
+{
+  mount('work');
+  reloadBtn().click();
+  check('armed on click', timerCountAt(T.TERMINAL_RELOAD_SETTLE_MS) === 1);
+  sockets[sockets.length - 1].fireOpen();
+  check('disarmed on open', timerCountAt(T.TERMINAL_RELOAD_SETTLE_MS) === 0);
+}
+
+console.log('\na double-tap coalesces into one reload:');
+{
+  mount('work');
+  const before = sockets.length;
+  const b = reloadBtn();
+  b.click();
+  // The re-render replaces the node, but the stale one still carries the handler —
+  // the closest a test gets to a real double-tap landing before the repaint.
+  b.click();
+  check('only one socket opened', sockets.length === before + 1);
+}
+
+console.log('\nclicking with nothing attached is a no-op, not a throw:');
+{
+  mount('work', { noTerminal: true });
+  const before = sockets.length;
+  let threw = false;
+  try { T.reloadTerminalAction(); } catch (_) { threw = true; }
+  check('did not throw', threw === false);
+  check('no socket opened', sockets.length === before);
+  check('no pending flag stranded', T.terminalReloadPending === false);
+
+  mount('work', { noTerm: true });
+  let threw2 = false;
+  try { T.reloadTerminalAction(); } catch (_) { threw2 = true; }
+  check('no xterm instance: did not throw', threw2 === false);
+  check('no xterm instance: no pending flag', T.terminalReloadPending === false);
+}
+
+console.log('\ndeselecting the session drops a pending reload:');
+{
+  mount('work');
+  reloadBtn().click();
+  check('pending before deselect', T.terminalReloadPending === true);
+  T.showEmptyDetail('Select a session');
+  check('cleared by showEmptyDetail', T.terminalReloadPending === false);
+  check('settle timer disarmed too', timerCountAt(T.TERMINAL_RELOAD_SETTLE_MS) === 0);
+}
+
+console.log('\nthe existing right-click path is untouched:');
+{
+  mount('work');
+  T.showTerminalMenu({ preventDefault() {}, clientX: 10, clientY: 10 });
+  const items = [...window.document.querySelectorAll('.ctx-menu .ctx-item')].map((n) => n.textContent);
+  check('“Reload terminal” still in the terminal menu', items.includes('Reload terminal'));
+  const menu = window.document.querySelector('.ctx-menu');
+  if (menu) menu.remove();
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #979.

## The problem

`reloadTerminal()` (`app.js`) — reset the xterm buffer, drop the socket, reconnect so `crowd` replays the pane's tmux scrollback — was reachable from exactly one place: the terminal's **right-click menu**. A touch device has no way to open that menu, so on a phone the cheap recovery for a corrupted surface didn't exist at all. The only way out was leaving the session and coming back.

Meanwhile the session top bar already carries *In Review*, *Mark as Completed* and *Delete*, and the `max-width: 720px` block leaves `#detail-header` and `.actions-cluster` visible — there was simply no reload button among them.

## The change

A `↻ Reload` button in that cluster, leading position so it's never adjacent to `Delete`.

| | before | after |
|---|---|---|
| work session | `Mark as Completed` · `Delete` | **`↻ Reload`** · `Mark as Completed` · `Delete` |
| manager session | *(no action cluster at all)* | **`↻ Reload`** |

It sits **outside** `renderHeader`'s `kind !== 'manager'` guard on purpose. That guard is why a Manager renders no action cluster, and the Manager window is the common CROW-804 stuck-surface case — it also has no tabs (#680, `#tabbar:empty { display: none }`) to hang a control off, which is why the tab bar was the wrong home for this.

**In-flight state is module-scoped, not on the node.** `refreshLive` repaints the whole header every 4s and would wipe a DOM-held flag mid-reload — the same reason `ticketRefreshPending` lives outside `.tickets-refresh`. While reloading, the `↻` swaps for the shared `.action-spinner`, both boxed to 12×12 so the chrome stays put (the CROW-797 tickets-refresh fix).

**Settling is on the socket opening** — the honest "attached again" signal. But `onclose` retries with backoff *forever*, so a daemon that never comes back would spin indefinitely; a 10s settle timer is the floor under that, plus a clear from `showEmptyDetail` when the session is dropped out from under it.

`refreshTerminals` is what binds `activeTerminal` (the button is disabled until there is one), and `selectSession` paints the header *before* awaiting it — so it nudges the button. That nudge is guarded to repaint only when the enablement actually changed: an unconditional `renderHeader` there would also throw away an in-flight `markInReviewAction`, which does keep its spinner on the node.

## Ambiguity resolved (per the ticket)

The ticket asked for this to be called out rather than silently swapped. **This ships reload only.** The proposed secondary gesture routing to `recreateTerminal()` is not here — the ask is reload, and recreate restarts the agent, so it stays deliberate and stays exactly where it is (the `⚠` tab badge and the Manager degraded strip, both untouched). The existing right-click *Reload terminal* item is untouched too: this adds a discoverable path, it doesn't move the old one.

## Corrections to the ticket's premises

- The class is `.action-btn`, not `.action-button`.
- There's no refresh glyph in the `ICONS` map — this uses the literal `↻`, as `.tickets-refresh` does.
- `reloadTerminal()` takes **no argument** and is synchronous; it acts on the shared surface and `connectTerminalWs`'s `onopen` re-selects `activeTerminal.window`. So there's no promise to await, and the handler reads `activeTerminal` at click time rather than capturing it at paint time.
- It must **not** route through `attachWindow(activeTerminal.window)` — the `win === attachedWindow` guard would make an explicit reload a no-op.

## Tests

New `web-tests/terminal-reload.test.js` — 51 assertions, registered in **both** `test` and `test:ci`, documented in `web-tests/README.md`. Covers the ticket's test plan: renders for work/review/job **and manager**; disabled with nothing attached; click resets the buffer, detaches the old socket's handlers *before* closing it, opens a fresh one; the spinner swap and its 12×12 no-layout-shift box; settling on `onopen`; settling via the timer when `onopen` never comes; timer disarmed when open wins the race; double-tap coalescing; no-op (not a throw) with no terminal; `showEmptyDetail` dropping a pending reload; and the right-click menu item still present.

Mutation-checked rather than assumed — dropping the `onopen` clear (5 fail), the disabled gate (5 fail), the busy read, the repaint guard (2 fail), or the `.reload-glyph` CSS rule (1 fail) each turns it red.

`npm run test:ci` is green. `row.test.js` is 57 passed / 10 failed both with and without this change — pre-existing CROW-802 drift, which is why `test:ci` omits it.

## Verify

```bash
cd Packages/CrowDaemon/web-tests && npm ci && npm test
```

Then in the browser with `crowd` running:
- `↻ Reload` shows in the top bar on a **work** session and on the **Manager**.
- Click: buffer resets, socket reconnects, tmux scrollback replays, scroll-up history intact.
- Spinner turns while reconnecting and settles on open, with no width jump.
- Stop `crowd` and click: settles within ~10s instead of spinning forever.
- Switch tabs, then click ↻ — the *currently attached* window reloads.
- Under 720px (or on a phone): present and tappable — the case this is for.
- Right-click *Reload terminal* still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)