### PR TITLE
Add grading-discipline rules to crow-review-pr verdict gate (CROW-986)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/ReviewVerdictPolicy.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ReviewVerdictPolicy.swift
@@ -43,9 +43,10 @@ public enum ReviewSeverity: String, Codable, Sendable, CaseIterable {
 /// Renders a workspace's review-verdict policy into the bundled `crow-review-pr`
 /// SKILL body (CROW-963).
 ///
-/// The skill carries three placeholders — the Step 5 verdict rule, the summary
+/// The skill carries four placeholders — the Step 5 verdict rule, the grading
+/// guidance that bounds the severity a finding may be assigned, the summary
 /// table's data rows, and the two reinforcing bullets under Important Notes. All
-/// three must agree, or the agent is handed a brief that contradicts itself.
+/// must agree, or the agent is handed a brief that contradicts itself.
 ///
 /// **Advisory, not enforcement.** The review agent invokes `gh pr review` itself;
 /// Crow never sees the call and cannot check the posted verdict against the
@@ -59,22 +60,26 @@ public enum ReviewVerdictPolicy {
     // MARK: - Placeholders
 
     public static let rulePlaceholder = "{{CROW_REVIEW_VERDICT_RULE}}"
+    public static let gradingGuidancePlaceholder = "{{CROW_REVIEW_GRADING_GUIDANCE}}"
     public static let tablePlaceholder = "{{CROW_REVIEW_VERDICT_TABLE}}"
     public static let notesPlaceholder = "{{CROW_REVIEW_VERDICT_NOTES}}"
 
     // MARK: - Expansion
 
-    /// Substitute the three verdict placeholders for `blocking`.
+    /// Substitute the four verdict placeholders for `blocking`.
     ///
     /// Idempotent: a body with no placeholders left (already expanded, or the
     /// test-environment stub from `Scaffolder.bundledReviewSkill()`) passes
     /// through unchanged. That is what lets the review path pre-expand once
     /// before its launch paths diverge and still route through
     /// `CrowAttribution.expandSkillBody`, which expands again with the default.
+    /// The grading-guidance block is policy-independent, so its second pass is a
+    /// no-op regardless of which set the re-expansion uses.
     public static func expand(_ body: String, blocking: [ReviewSeverity]) -> String {
         let canonical = ReviewSeverity.canonicalize(blocking)
         return body
             .replacingOccurrences(of: rulePlaceholder, with: ruleBlock(blocking: canonical))
+            .replacingOccurrences(of: gradingGuidancePlaceholder, with: gradingGuidanceBlock)
             .replacingOccurrences(of: tablePlaceholder, with: tableRows(blocking: canonical))
             .replacingOccurrences(of: notesPlaceholder, with: notesBullets(blocking: canonical))
     }
@@ -162,6 +167,24 @@ public enum ReviewVerdictPolicy {
     - **Request Changes** (`--request-changes`): any Red **or** any Yellow finding.
 
     Yellow findings are "should fix" — the implementing agent will address them as soon as it sees the request-changes verdict, so rejecting on Yellow lands them in the same round trip instead of a follow-up. Comment-only reviews remain forbidden; if uncertain, request changes.
+    """
+
+    /// Grading discipline (CROW-986). Bounds the *severity a finding may be
+    /// assigned* — a separate axis from which severities gate the verdict, so this
+    /// text is constant and renders identically for every workspace policy.
+    ///
+    /// Without it, the verdict gate has no terminating condition when a Yellow
+    /// finding is a risk the author has consciously accepted: one judgment call is
+    /// enough to reject, and a competent review of a non-trivial diff almost always
+    /// surfaces one. These three rules give the reviewer a way to say "your call,
+    /// approved" by capping such findings at Green, which the default and red-only
+    /// policies treat as non-blocking.
+    public static let gradingGuidanceBlock = """
+    Grading discipline — the rules below bound the **severity you may assign** to a finding. They hold no matter which severities gate the verdict above, because they are about how to grade, not about what blocks:
+
+    - **An accepted risk is not a blocker.** A hazard the PR explicitly documents and consciously accepts is at most **Green**. When the diff is correct and the only disagreement is whether to accept a risk the author has already called out, that acceptance is the author's decision to make — state your view in the body and let the verdict follow the grade, rather than blocking on it.
+    - **Do not re-block a declined finding.** A finding you raised in an earlier round that the author has answered with a rationale — rather than a code change — may be restated at most as **Green**. Re-raising the same point at a blocking severity round after round is not permitted; if you remain unconvinced, leave it Green and, if it is worth tracking, file a follow-up issue instead of holding up the PR.
+    - **Grade against the diff, not the roadmap.** Severity measures a defect in what is written. "The code is correct, but a hazard it identifies is left unenforced" is **Green** — not Yellow or Red. A future improvement you would like to see is not a defect in this change.
     """
 
     // MARK: - Helpers

--- a/Packages/CrowCore/Tests/CrowCoreTests/ReviewVerdictPolicyTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ReviewVerdictPolicyTests.swift
@@ -118,12 +118,13 @@ struct ReviewVerdictPolicyTests {
     @Test func expandLeavesNoPlaceholderBehindForAnyPolicy() {
         let body = [
             ReviewVerdictPolicy.rulePlaceholder,
+            ReviewVerdictPolicy.gradingGuidancePlaceholder,
             ReviewVerdictPolicy.tablePlaceholder,
             ReviewVerdictPolicy.notesPlaceholder,
         ].joined(separator: "\n\n")
         for blocking in [[ReviewSeverity.red], ReviewSeverity.defaultBlocking, ReviewSeverity.allCases] {
             let expanded = ReviewVerdictPolicy.expand(body, blocking: blocking)
-            #expect(!expanded.contains("{{CROW_REVIEW_VERDICT_"))
+            #expect(!expanded.contains("{{CROW_REVIEW_"))
         }
     }
 
@@ -182,6 +183,7 @@ struct ReviewVerdictPolicyTests {
         #expect(skill == template, "the two halves of crow-review-pr must stay byte-identical")
         for placeholder in [
             ReviewVerdictPolicy.rulePlaceholder,
+            ReviewVerdictPolicy.gradingGuidancePlaceholder,
             ReviewVerdictPolicy.tablePlaceholder,
             ReviewVerdictPolicy.notesPlaceholder,
         ] {
@@ -208,6 +210,8 @@ struct ReviewVerdictPolicyTests {
         #expect(asDefault.contains(Self.goldenRule))
         #expect(asDefault.contains(Self.goldenTable))
         #expect(asDefault.contains(Self.goldenNotes))
+        // CROW-986: the real skill carries the grading placeholder and expands it.
+        #expect(asDefault.contains("An accepted risk is not a blocker."))
 
         let asRedOnly = ReviewVerdictPolicy.expand(skill, blocking: [.red])
         #expect(!asRedOnly.contains(Self.goldenRule))
@@ -224,5 +228,32 @@ struct ReviewVerdictPolicyTests {
 
     @Test func defaultBlockingIsRedAndYellow() {
         #expect(ReviewSeverity.defaultBlocking == [.red, .yellow])
+    }
+
+    // MARK: - Grading guidance (CROW-986)
+
+    /// The grading block carries all three loop-breaking rules that let a review
+    /// of a documented, accepted risk terminate in an approval.
+    @Test func gradingGuidanceCarriesTheThreeLoopBreakingRules() {
+        let guidance = ReviewVerdictPolicy.gradingGuidanceBlock
+        #expect(guidance.contains("An accepted risk is not a blocker."))
+        #expect(guidance.contains("Do not re-block a declined finding."))
+        #expect(guidance.contains("Grade against the diff, not the roadmap."))
+        // Each rule caps the finding at Green rather than dropping it.
+        #expect(guidance.contains("at most **Green**"))
+    }
+
+    /// The guidance bounds the *grade*, not the *gate*: it must render identically
+    /// no matter which severities a workspace blocks on. Expanding a body that
+    /// carries only the grading placeholder proves the substituted text does not
+    /// vary with `blocking`.
+    @Test func gradingGuidanceIsIndependentOfTheBlockingPolicy() {
+        let body = ReviewVerdictPolicy.gradingGuidancePlaceholder
+        let redOnly = ReviewVerdictPolicy.expand(body, blocking: [.red])
+        let byDefault = ReviewVerdictPolicy.expand(body, blocking: ReviewSeverity.defaultBlocking)
+        let everything = ReviewVerdictPolicy.expand(body, blocking: ReviewSeverity.allCases)
+        #expect(redOnly == byDefault)
+        #expect(byDefault == everything)
+        #expect(redOnly == ReviewVerdictPolicy.gradingGuidanceBlock)
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
@@ -40,6 +40,8 @@ struct SessionServiceReviewPromptTests {
 
     \(ReviewVerdictPolicy.rulePlaceholder)
 
+    \(ReviewVerdictPolicy.gradingGuidancePlaceholder)
+
     | Color  | Meaning      | Verdict effect            |
     |--------|--------------|---------------------------|
     \(ReviewVerdictPolicy.tablePlaceholder)
@@ -277,6 +279,36 @@ struct SessionServiceReviewPromptTests {
             #expect(prompt.contains(Self.prURL))
             #expect(!prompt.contains("$ARGUMENTS"))
             #expect(!prompt.contains("{{CROW_REVIEW_VERDICT_"))
+        }
+    }
+
+    /// CROW-986: the grading-guidance rules bound the *grade*, not the *gate*, so
+    /// they must reach the agent through every inline branch and read identically
+    /// under any workspace policy. Assert the built prompt carries all three rules
+    /// for both the default (Red+Yellow) and a relaxed (Red-only) workspace.
+    @Test func buildReviewPromptCarriesTheGradingGuidanceForEveryPolicy() {
+        for blocking in [ReviewSeverity.defaultBlocking, [.red]] {
+            let body = ReviewVerdictPolicy.expand(Self.policyFixtureSkillBody, blocking: blocking)
+
+            for agentKind: AgentKind in [.cursor, .openCode, .codex, .grok, .antigravity] {
+                let prompt = SessionService.buildReviewPrompt(
+                    prURL: Self.prURL,
+                    prTitle: Self.prTitle,
+                    repoSlug: Self.repoSlug,
+                    prNumber: Self.prNumber,
+                    agentKind: agentKind,
+                    skillBody: body
+                )
+
+                #expect(prompt.contains("An accepted risk is not a blocker."),
+                        "\(agentKind.rawValue)/\(blocking) lost the accepted-risk rule")
+                #expect(prompt.contains("Do not re-block a declined finding."),
+                        "\(agentKind.rawValue)/\(blocking) lost the declined-finding rule")
+                #expect(prompt.contains("Grade against the diff, not the roadmap."),
+                        "\(agentKind.rawValue)/\(blocking) lost the grade-against-the-diff rule")
+                // No verdict-family placeholder may survive expansion.
+                #expect(!prompt.contains("{{CROW_REVIEW_"))
+            }
         }
     }
 

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -95,6 +95,8 @@ Every Crow review must end with a verdict — **exactly one** of the two actions
 
 {{CROW_REVIEW_VERDICT_RULE}}
 
+{{CROW_REVIEW_GRADING_GUIDANCE}}
+
 Draft the review using this format:
 
 ```markdown

--- a/scripts/check-workspace-custom-instructions.sh
+++ b/scripts/check-workspace-custom-instructions.sh
@@ -111,6 +111,7 @@ fi
 # replaced it — and the per-workspace setting stops reaching the agent.
 for placeholder in \
     "{{CROW_REVIEW_VERDICT_RULE}}" \
+    "{{CROW_REVIEW_GRADING_GUIDANCE}}" \
     "{{CROW_REVIEW_VERDICT_TABLE}}" \
     "{{CROW_REVIEW_VERDICT_NOTES}}"; do
     require "skills/crow-review-pr/SKILL.md" "$placeholder"

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -95,6 +95,8 @@ Every Crow review must end with a verdict — **exactly one** of the two actions
 
 {{CROW_REVIEW_VERDICT_RULE}}
 
+{{CROW_REVIEW_GRADING_GUIDANCE}}
+
 Draft the review using this format:
 
 ```markdown


### PR DESCRIPTION
Closes #986

## Problem

The `crow-review-pr` verdict gate has no terminating condition when a Yellow finding is a risk the author has **consciously accepted**. Under the default policy, any Yellow or Red forces `--request-changes`, and a competent review of a non-trivial diff almost always surfaces at least one judgment call — one Yellow is enough to reject, with no way for the reviewer to say "noted, your call, approved."

CROW-963 made *which* severities gate configurable (`reviewBlockingSeverities` → `{{CROW_REVIEW_VERDICT_RULE}}`), but that only moves the threshold. It does not stop severity inflation or give the reviewer a terminating move — a reviewer who believes a finding matters can still label it Red and force the same outcome.

## Change (ticket items 1–3)

Adds a fourth, **severity-independent** placeholder `{{CROW_REVIEW_GRADING_GUIDANCE}}`, rendered in Step 5 alongside `{{CROW_REVIEW_VERDICT_RULE}}` from a constant. It carries three grading rules that bound the *severity a finding may be assigned* — a separate axis from which severities gate the verdict:

1. **An accepted risk is not a blocker** — a hazard the PR documents and consciously accepts is at most Green.
2. **Don't re-block a declined finding** — a prior-round finding the author answered with a rationale (not a code change) may be restated at most as Green; re-raising it at blocking severity across rounds is prohibited.
3. **Grade against the diff, not the roadmap** — severity measures a defect in what is written; "correct but the hazard is unenforced" is Green, not Yellow/Red.

Because the guidance bounds the **grade**, not the **gate**, it renders identically for every workspace policy and leaves the byte-pinned `defaultRuleBlock` (and its golden tests) untouched. Genuine Red defects are unaffected.

### Files

- `ReviewVerdictPolicy.swift` — new `gradingGuidancePlaceholder` constant, `gradingGuidanceBlock` constant, and one substitution in `expand`. `ruleBlock`/`tableRows`/`notesBullets`/`defaultRuleBlock` unchanged.
- `skills/crow-review-pr/SKILL.md` + `Resources/crow-review-pr-SKILL.md.template` — the placeholder after the verdict rule (kept byte-identical).
- `scripts/check-workspace-custom-instructions.sh` — drift guard extended to require the new placeholder in both halves.
- `ReviewVerdictPolicyTests` — new render + policy-independence tests; placeholder-coverage guards extended.
- `SessionServiceReviewPromptTests` (named in acceptance) — end-to-end coverage that the three rules reach every inline agent branch under both the default and a red-only policy.

## Acceptance mapping

- *PR whose only findings are accepted risks → `--approve`*: rule 1 grades them Green (non-blocking under default/red-only).
- *Declined finding in round N doesn't force changes in N+1*: rule 2 caps a rationale-answered finding at Green and forbids re-raising at blocking severity.
- *Existing behavior unchanged for genuine Red defects*: gating logic untouched; guidance only bounds grades upward toward Green.
- *Coverage in `SessionServiceReviewPromptTests`*: added.

## Deferred: item 4 (round cap)

Item 4 (approve after N zero-Red rounds and file a follow-up instead of blocking again) is **out of scope here**. It needs daemon support to know the review round count — the review skill has no round awareness today, and Crow doesn't see the reviewer's `gh pr review` call — so a round cap is a separate, larger change spanning the daemon and review-dispatch path. Per the ticket's guidance to prefer landing 1–3 cleanly, it is left for a follow-up.

## Testing

- `scripts/check-workspace-custom-instructions.sh` — passes (drift + placeholder guard).
- `swift test --package-path Packages/CrowCore --filter ReviewVerdictPolicyTests` — 19 passed.
- `swift test --package-path Packages/CrowEngine --filter SessionServiceReviewPromptTests` — 18 passed.
- `make test` — full suite green (two pre-existing flaky web tests in CrowDaemon, `bootCatchResetsTheHistory` / `refreshTerminalsRebindsTheActiveTerminalToTheFreshRow`, passed on re-run; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)