### PR TITLE
Prefer cursor-agent and identity-probe the ambiguous agent token (CROW-989)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Agent/BinaryIdentityProbe.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/BinaryIdentityProbe.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Shared machinery for `CodingAgent.verifyBinaryIdentity` — running a cheap
+/// `--help` / `--version` probe against a resolved binary and matching its
+/// output for agent-specific markers.
+///
+/// Extracted from `GrokAgent` (CROW-911) when Cursor's generic `agent` token hit
+/// the same collision in the field (CROW-989: xAI's grok-build installs
+/// `~/.grok/bin/agent`, so `agent` resolved to Grok's TUI and Crow handed it
+/// Cursor's flags). Both adapters now share one implementation of the subprocess
+/// race, so the hard-timeout reasoning below is stated and tested once instead of
+/// being copied per colliding token — the generalization ADR 0014 anticipated.
+///
+/// ⚠️ **Trust-boundary note.** Probing *executes* a PATH-resolved third-party
+/// binary at daemon boot. That's inherent to identity probing: it's on the user's
+/// own PATH, the output is only substring-matched (never logged or evaluated),
+/// and the run is hard-bounded so a hanging binary can't stall startup.
+public enum BinaryIdentityProbe {
+    /// Per-leg cap for one `--help` / `--version` probe.
+    public static let defaultTimeoutNanos: UInt64 = 3 * 1_000_000_000
+
+    /// Probe `path` with each arg in `args` (in order) and return `true` as soon
+    /// as the merged stdout+stderr contains any string in `markers`.
+    ///
+    /// Matching is **OR, not AND**, and case-insensitive: one upstream flag
+    /// rename can't grey out a genuine install, while a foreign binary carrying
+    /// none of the markers is rejected. Callers order `args` so the cheapest
+    /// discriminator runs first — a match short-circuits, so a genuine install
+    /// usually costs a single spawn.
+    ///
+    /// `markers` must already be lowercased; they're compared against the
+    /// lowercased probe output.
+    public static func matches(
+        path: String,
+        args: [String],
+        markers: [String],
+        runner: any ShellRunner,
+        timeoutNanos: UInt64 = defaultTimeoutNanos
+    ) async -> Bool {
+        for arg in args {
+            let out = await run(path, arg, runner: runner, timeoutNanos: timeoutNanos).lowercased()
+            if markers.contains(where: { out.contains($0) }) { return true }
+        }
+        return false
+    }
+
+    /// Run `<binary> <arg>` and return its merged stdout+stderr, or `""` on spawn
+    /// failure **or timeout**. The cap is a *hard* bound on the awaiting task: it
+    /// races the run against a sleep behind a resume-once guard and returns
+    /// whichever finishes first — so even a runner that never completes and
+    /// ignores cancellation (a binary that reads stdin, or forks a child holding
+    /// the stdout pipe so `readDataToEndOfFile()` never sees EOF) **cannot stall
+    /// `registerAgents` at boot** (CROW-911 review — an earlier `withTaskGroup`
+    /// form awaited the losing child and so bounded nothing).
+    ///
+    /// On timeout the run `Task` is cancelled: with the cancellation-aware
+    /// `ProcessShellRunner` that `terminate()`s the child so it doesn't leak; a
+    /// genuinely uncancellable runner leaks one blocked reader but boot proceeds.
+    ///
+    /// A non-zero exit is **not** an error here — a foreign binary may print its
+    /// banner to stderr and exit 2, and that banner is exactly what identifies
+    /// it — so `nonZeroExit` output is returned rather than discarded.
+    public static func run(
+        _ binary: String,
+        _ arg: String,
+        runner: any ShellRunner,
+        timeoutNanos: UInt64 = defaultTimeoutNanos
+    ) async -> String {
+        let gate = ResumeOnceGate()
+        return await withCheckedContinuation { (cont: CheckedContinuation<String, Never>) in
+            @Sendable func finish(_ result: String) {
+                if gate.claim() { cont.resume(returning: result) }
+            }
+            let work = Task {
+                let out: String
+                do {
+                    out = try await runner.run(args: [binary, arg], env: [:], cwd: nil)
+                } catch let ShellRunnerError.nonZeroExit(_, output) {
+                    out = output
+                } catch {
+                    out = ""
+                }
+                finish(out)
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: timeoutNanos)
+                work.cancel()
+                finish("")
+            }
+        }
+    }
+}
+
+/// A cross-platform (no Darwin `os`) resume-once guard for `BinaryIdentityProbe.run`'s
+/// race: `claim()` returns `true` exactly once — for the first of the run and
+/// timeout tasks to finish — so the continuation is resumed a single time. An
+/// `NSLock`-backed `Bool` rather than `OSAllocatedUnfairLock`, which is
+/// Apple-platforms-only and breaks the Linux CI build (#912).
+private final class ResumeOnceGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+
+    func claim() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if resumed { return false }
+        resumed = true
+        return true
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -23,6 +23,33 @@ public struct ResolvedBinary: Sendable, Equatable {
     }
 }
 
+/// The PATH leg of `CodingAgent.resolveBinary()`, factored out of the protocol
+/// extension so the ordering guarantee is unit-testable — `ShellEnvironment` is
+/// a singleton that snapshots the real PATH at init, so the walk can't otherwise
+/// be exercised against a synthetic one.
+public enum BinaryTokenResolver {
+    /// Return the first `lookup` hit, trying `tokens` in order.
+    ///
+    /// **Token-major, not directory-major** — and that's the whole point. A
+    /// directory-major walk (each PATH entry checked for every token) would let
+    /// PATH *order* decide between an agent's preferred binary name and its
+    /// ambiguous alias, which is exactly how a foreign `~/.grok/bin/agent` early
+    /// in PATH beat Cursor's own CLI (CROW-989). Trying every PATH entry for
+    /// `cursor-agent` before any is tried for `agent` makes the choice depend on
+    /// the *name*, not on install order.
+    ///
+    /// Single-token agents are unaffected: one pass, identical to the old walk.
+    public static func firstOnPath(
+        tokens: [String],
+        lookup: (String) -> String?
+    ) -> String? {
+        for token in tokens {
+            if let found = lookup(token) { return found }
+        }
+        return nil
+    }
+}
+
 /// A coding agent that Crow can launch in a terminal and observe via hook
 /// events. Phase A wraps the existing Claude Code integration; later phases
 /// introduce additional conformers.
@@ -49,7 +76,29 @@ public protocol CodingAgent: Sendable {
     /// Used by the `send` RPC handler to decide whether a managed-terminal
     /// command needs hook-config + env-var prep before being forwarded.
     /// Examples: `"claude"`, `"codex"`.
+    ///
+    /// Also the **preferred** binary name for the PATH walk in
+    /// `resolveBinary()`. When a harness ships more than one name for the same
+    /// executable, this is the unambiguous one; see
+    /// `alternateLaunchCommandTokens` for the legacy/ambiguous aliases.
     var launchCommandToken: String { get }
+
+    /// Additional binary names this agent may be installed under, in descending
+    /// preference order after `launchCommandToken`.
+    ///
+    /// Two uses, deliberately one list (search order *is* preference order):
+    ///  - `resolveBinary()` walks PATH for `launchCommandToken` first, then each
+    ///    of these — so an unambiguous name always wins over an ambiguous alias
+    ///    regardless of PATH ordering.
+    ///  - `AgentLaunch.commandLaunchesAgent` matches a command against **any** of
+    ///    them, so a legacy install invoked under its old name still gets
+    ///    hook-config + env prep.
+    ///
+    /// Empty for every agent whose CLI ships a single name. Cursor is the one
+    /// conformer today: it prefers `cursor-agent` and keeps the generic `agent`
+    /// as an alias, because xAI's grok-build installs its own `~/.grok/bin/agent`
+    /// and won the PATH walk (CROW-989).
+    var alternateLaunchCommandTokens: [String] { get }
 
     /// Writer for the per-worktree hook configuration file.
     var hookConfigWriter: any HookConfigWriter { get }
@@ -89,9 +138,11 @@ public protocol CodingAgent: Sendable {
     /// The default returns `true`: an unambiguous launch token is trusted on a
     /// bare match, preserving today's behavior for every agent. Only agents
     /// whose token is known to collide override this to run a cheap
-    /// `--version` / `--help` identity probe — today just Grok Build (`grok`
-    /// collides with the community `superagent-ai/grok-cli`); Cursor's generic
-    /// `agent` token has the same shape and can adopt this seam later.
+    /// `--version` / `--help` identity probe — Grok Build (`grok` collides with
+    /// the community `superagent-ai/grok-cli`) and Cursor (whose legacy `agent`
+    /// alias collides with xAI's `~/.grok/bin/agent`, CROW-989). Both share
+    /// `BinaryIdentityProbe` rather than reimplementing the bounded subprocess
+    /// race.
     func verifyBinaryIdentity(atPath path: String) async -> Bool
 
     /// Build the full shell command (ending with `\n`) that auto-launches
@@ -184,6 +235,14 @@ public extension CodingAgent {
     /// override this.
     var fallbackCandidates: [String] { [] }
 
+    /// Default: no aliases — the agent's CLI ships exactly one binary name.
+    var alternateLaunchCommandTokens: [String] { [] }
+
+    /// Every binary name this agent answers to, most-preferred first. The single
+    /// ordering used by both the PATH walk and command-token matching, so those
+    /// two can't disagree about which names count as "this agent".
+    var binaryTokens: [String] { [launchCommandToken] + alternateLaunchCommandTokens }
+
     /// Default kind-aware launch: ignore `sessionKind` and delegate to the
     /// three-argument `launchCommand`. Overridden only by agents whose launch
     /// varies by kind (today just Cursor's trust seed). A protocol *requirement*
@@ -200,12 +259,19 @@ public extension CodingAgent {
     }
 
     /// Default binary discovery with provenance: explicit `BinaryOverrides`
-    /// (`.override`) → PATH walk on `launchCommandToken` (`.path`) → hardcoded
+    /// (`.override`) → PATH walk over `binaryTokens` (`.path`) → hardcoded
     /// `fallbackCandidates` (`.fallback`). Returns the first resolved absolute
     /// path + how it was found, or `nil` if nothing matches.
     ///
     /// This replaces the per-agent hardcoded-list-only impl that left
     /// nvm/Volta/pnpm/asdf installs invisible to Crow (CROW-484).
+    ///
+    /// The PATH walk is **token-major, not directory-major**: every PATH entry is
+    /// searched for the preferred token before any is searched for an alias. That
+    /// ordering is the point — it makes resolution independent of PATH order, so
+    /// an unambiguous `cursor-agent` late in PATH still beats a foreign `agent`
+    /// early in it (CROW-989). Agents with no aliases are unaffected: one token,
+    /// one walk, byte-identical behavior.
     func resolveBinary() -> ResolvedBinary? {
         let fm = FileManager.default
         // 1. Explicit user override from `defaults.binaries.<kind>`. Verify
@@ -215,8 +281,12 @@ public extension CodingAgent {
            fm.isExecutableFile(atPath: configured) {
             return ResolvedBinary(path: configured, source: .override)
         }
-        // 2. Walk the user's resolved PATH the same way `command -v` does.
-        if let found = ShellEnvironment.shared.findExecutable(launchCommandToken) {
+        // 2. Walk the user's resolved PATH the same way `command -v` does, once
+        //    per token in preference order.
+        if let found = BinaryTokenResolver.firstOnPath(
+            tokens: binaryTokens,
+            lookup: { ShellEnvironment.shared.findExecutable($0) }
+        ) {
             return ResolvedBinary(path: found, source: .path)
         }
         // 3. Hardcoded last-resort fallback covers the exotic-PATH case.
@@ -231,8 +301,8 @@ public extension CodingAgent {
 
     /// Default identity check: trust a bare match. Agents with an unambiguous
     /// launch token don't need to probe — overridden only by collision-prone
-    /// tokens (Grok Build today) so a foreign same-named binary is shown
-    /// disabled instead of falsely active (CROW-911).
+    /// tokens (Grok Build, Cursor) so a foreign same-named binary is shown
+    /// disabled instead of falsely active (CROW-911, CROW-989).
     func verifyBinaryIdentity(atPath path: String) async -> Bool { true }
 
     /// Default Manager launch command: invoke the agent's CLI binary by

--- a/Packages/CrowCore/Tests/CrowCoreTests/BinaryResolutionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BinaryResolutionTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// The resolution + identity machinery shared by every colliding-token adapter
+/// (CROW-989). `AgentDiscoveryTests` covers the availability *decision*; this
+/// covers the two pieces that decision is built from — which binary name wins,
+/// and how a probe reads a binary's output.
+@Suite("Binary resolution and identity")
+struct BinaryResolutionTests {
+
+    // MARK: - Token preference
+
+    /// The acceptance criterion from CROW-989: with a foreign binary occupying
+    /// the ambiguous alias *earlier* on PATH, the preferred name still wins.
+    /// Token-major means PATH order can't decide this.
+    @Test func preferredTokenWinsOverAnEarlierForeignAlias() {
+        // Simulates the reported machine: grok-build owns `~/.grok/bin/agent`
+        // ahead of Cursor's `~/.local/bin/{agent,cursor-agent}` on PATH.
+        let path: [String: String] = [
+            "agent": "/Users/x/.grok/bin/agent",
+            "cursor-agent": "/Users/x/.local/bin/cursor-agent",
+        ]
+        let resolved = BinaryTokenResolver.firstOnPath(
+            tokens: ["cursor-agent", "agent"], lookup: { path[$0] })
+        #expect(resolved == "/Users/x/.local/bin/cursor-agent")
+    }
+
+    /// …and reordering PATH so the foreign binary comes later doesn't change the
+    /// answer either. The lookup closure *is* the PATH walk, so swapping which
+    /// absolute path each name maps to is the same experiment as reordering PATH:
+    /// the result depends on the name, never on install order.
+    @Test func reorderingPathDoesNotChangeTheSelection() {
+        let grokFirst: [String: String] = [
+            "agent": "/Users/x/.grok/bin/agent",
+            "cursor-agent": "/opt/homebrew/bin/cursor-agent",
+        ]
+        let cursorFirst: [String: String] = [
+            "agent": "/Users/x/.local/bin/agent",
+            "cursor-agent": "/opt/homebrew/bin/cursor-agent",
+        ]
+        let tokens = ["cursor-agent", "agent"]
+        #expect(BinaryTokenResolver.firstOnPath(tokens: tokens, lookup: { grokFirst[$0] })
+                == BinaryTokenResolver.firstOnPath(tokens: tokens, lookup: { cursorFirst[$0] }))
+    }
+
+    /// A legacy install that only ships the alias still resolves — the fallback
+    /// leg of the same walk (CROW-989 acceptance: "an install with only the
+    /// legacy `agent` name still works").
+    @Test func aliasResolvesWhenPreferredNameIsAbsent() {
+        let path = ["agent": "/usr/local/bin/agent"]
+        let resolved = BinaryTokenResolver.firstOnPath(
+            tokens: ["cursor-agent", "agent"], lookup: { path[$0] })
+        #expect(resolved == "/usr/local/bin/agent")
+    }
+
+    @Test func noTokenResolvesToNil() {
+        #expect(BinaryTokenResolver.firstOnPath(
+            tokens: ["cursor-agent", "agent"], lookup: { _ in nil }) == nil)
+    }
+
+    /// A single-token agent walks exactly once — the pre-CROW-989 behavior every
+    /// non-colliding adapter still gets.
+    @Test func singleTokenWalksOnce() {
+        var probed: [String] = []
+        _ = BinaryTokenResolver.firstOnPath(tokens: ["claude"], lookup: {
+            probed.append($0); return nil
+        })
+        #expect(probed == ["claude"])
+    }
+
+    // MARK: - binaryTokens composition
+
+    @Test func binaryTokensDefaultsToTheLoneLaunchToken() {
+        #expect(StubAgent().binaryTokens == ["stub"])
+    }
+
+    @Test func binaryTokensPutsAliasesAfterThePreferredToken() {
+        var a = StubAgent()
+        a.aliases = ["legacy", "older"]
+        #expect(a.binaryTokens == ["stub", "legacy", "older"])
+    }
+
+    // MARK: - Identity probe
+
+    @Test func probeMatchesOnAnySingleMarker() async {
+        let runner = FakeProbeRunner(outputs: ["--help": "Options:\n  --approve-mcps  Approve MCPs"])
+        #expect(await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help"],
+            markers: ["--approve-mcps", "--trust"], runner: runner))
+    }
+
+    /// Markers are matched case-insensitively (the probe lowercases the output),
+    /// so a binary that shouts its env-var names still identifies.
+    @Test func probeIsCaseInsensitive() async {
+        let runner = FakeProbeRunner(outputs: ["--help": "Set CURSOR_API_KEY to authenticate"])
+        #expect(await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help"],
+            markers: ["cursor_api_key"], runner: runner))
+    }
+
+    @Test func probeRejectsOutputWithNoMarker() async {
+        let runner = FakeProbeRunner(outputs: ["--help": "Usage: something-else [OPTIONS]"])
+        #expect(await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help"],
+            markers: ["--approve-mcps"], runner: runner) == false)
+    }
+
+    /// A binary that prints nothing (or a spawn failure that yields `""`) can't
+    /// be identified, so it's rejected.
+    @Test func probeRejectsEmptyOutput() async {
+        #expect(await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help", "--version"],
+            markers: ["--approve-mcps"], runner: FakeProbeRunner(outputs: [:])) == false)
+    }
+
+    /// A foreign binary may exit non-zero yet still print the text that
+    /// identifies it; the probe merges stdout+stderr and matches regardless of
+    /// exit status.
+    @Test func probeToleratesNonZeroExit() async {
+        let runner = FakeProbeRunner(
+            outputs: ["--help": "supports --approve-mcps"], failing: ["--help"])
+        #expect(await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help"],
+            markers: ["--approve-mcps"], runner: runner))
+    }
+
+    /// Later args are only spawned when earlier ones don't match — a genuine
+    /// install costs one subprocess, not one per arg.
+    @Test func probeShortCircuitsOnTheFirstMatchingArg() async {
+        let runner = FakeProbeRunner(outputs: ["--help": "--approve-mcps", "--version": "1.0"])
+        _ = await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help", "--version"],
+            markers: ["--approve-mcps"], runner: runner)
+        #expect(runner.probed.value == ["--help"])
+    }
+
+    /// The #912 Red, at the shared layer: a binary that never exits and ignores
+    /// cancellation must not stall boot. The timeout is a *hard* bound on the
+    /// awaiting task, so this returns at the cap rather than hanging. A tiny
+    /// injected timeout keeps the test instant.
+    @Test func probeHardBoundsAgainstNeverCompletingRunner() async {
+        let out = await BinaryIdentityProbe.run(
+            "/bin/x", "--help", runner: NeverRunner(), timeoutNanos: 50_000_000)
+        #expect(out == "")
+    }
+
+    /// …and a timed-out leg yields no marker rather than a false positive.
+    @Test func timedOutProbeDoesNotMatch() async {
+        #expect(await BinaryIdentityProbe.matches(
+            path: "/bin/x", args: ["--help"], markers: ["--approve-mcps"],
+            runner: NeverRunner(), timeoutNanos: 50_000_000) == false)
+    }
+}
+
+// MARK: - Fixtures
+
+/// Canned probe responder keyed by the probe arg, recording which args were
+/// actually spawned so short-circuiting is observable. Args listed in `failing`
+/// throw `.nonZeroExit` carrying their output (a binary that exits non-zero but
+/// still prints).
+private struct FakeProbeRunner: ShellRunner {
+    let outputs: [String: String]
+    var failing: Set<String> = []
+    let probed = Recorder()
+
+    final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var args: [String] = []
+        var value: [String] { lock.lock(); defer { lock.unlock() }; return args }
+        func record(_ a: String) { lock.lock(); defer { lock.unlock() }; args.append(a) }
+    }
+
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        let arg = args.dropFirst().first ?? ""
+        probed.record(arg)
+        let out = outputs[arg] ?? ""
+        if failing.contains(arg) { throw ShellRunnerError.nonZeroExit(exitCode: 2, output: out) }
+        return out
+    }
+}
+
+/// A `ShellRunner` that never completes and ignores cancellation. Uses an
+/// *unsafe* continuation deliberately: the leak (never resumed) is the intended
+/// scenario, so a checked continuation would only emit a misuse diagnostic.
+private struct NeverRunner: ShellRunner {
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        await withUnsafeContinuation { (_: UnsafeContinuation<Void, Never>) in }
+        return ""  // unreachable
+    }
+}
+
+/// Minimal conformer for exercising the `binaryTokens` default composition.
+private struct StubAgent: CodingAgent {
+    var aliases: [String] = []
+
+    let kind: AgentKind = .cursor
+    var displayName: String { "Stub" }
+    var iconSystemName: String { "sparkles" }
+    var supportsRemoteControl: Bool { false }
+    var launchCommandToken: String { "stub" }
+    var alternateLaunchCommandTokens: [String] { aliases }
+    let hookConfigWriter: any HookConfigWriter = NoopHookConfigWriter()
+    let stateSignalSource: any StateSignalSource = NoopStateSignalSource()
+
+    func autoLaunchCommand(
+        session: Session, worktreePath: String, remoteControlEnabled: Bool,
+        autoPermissionMode: Bool, telemetryPort: UInt16?
+    ) -> String? { nil }
+    func generatePrompt(
+        session: Session, worktrees: [SessionWorktree], ticketURL: String?,
+        provider: Provider?, codeProvider: Provider?
+    ) async -> String { "" }
+    func launchCommand(sessionID: UUID, worktreePath: String, prompt: String) async throws -> String { "" }
+}
+
+private final class NoopHookConfigWriter: HookConfigWriter, @unchecked Sendable {
+    func writeHookConfig(worktreePath: String, sessionID: UUID, crowPath: String) throws {}
+    func removeHookConfig(worktreePath: String) {}
+}
+
+private struct NoopStateSignalSource: StateSignalSource {
+    func transition(
+        for event: AgentHookEvent,
+        currentActivityState: AgentActivityState,
+        currentNotificationType: String?,
+        currentLastTopLevelStopAt: Date?
+    ) -> AgentStateTransition { AgentStateTransition() }
+}

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -19,30 +19,47 @@ public struct CursorAgent: CodingAgent {
     /// `"terminal.fill"`. Easy to swap once branding firms up.
     public let iconSystemName: String = "cursorarrow.rays"
     public let supportsRemoteControl: Bool = true
-    /// Cursor's CLI binary is named `agent`, not `cursor`.
+    /// Cursor's CLI installs under **two** names for the same executable —
+    /// `cursor-agent` and the generic `agent` — both symlinked into PATH from
+    /// `~/.local/share/cursor-agent/versions/<v>/cursor-agent`. Crow prefers
+    /// `cursor-agent`, which has no known collision.
     ///
-    /// `agent` is a generic name — CI runner installs (Azure DevOps, TeamCity)
-    /// also ship a binary called `agent`, so the PATH-walk discovery in
-    /// `CodingAgent.findBinary()` can in principle resolve a non-Cursor
-    /// executable on a build machine. If that happens, set
-    /// `defaults.binaries.cursor` to the absolute path of Cursor's CLI in
-    /// `{devRoot}/.claude/config.json` — the explicit override is consulted
-    /// before the PATH walk and pins the resolution. We accept the false-
-    /// positive risk here (CROW-484) because real workstations don't usually
-    /// have a competing `agent` on PATH, and the override knob exists for
-    /// the exotic case.
-    public let launchCommandToken: String = "agent"
+    /// `agent` demonstrably does collide: **xAI's grok-build installs its own
+    /// `~/.grok/bin/agent`**, and on a box with both, that one won the PATH walk.
+    /// Crow then built a Cursor command and ran Grok's binary, which died on the
+    /// first flag it doesn't have (`error: unexpected argument '--force' found`)
+    /// — CROW-989, the collision CROW-484 accepted as a theoretical risk actually
+    /// firing. CI runners (Azure DevOps, TeamCity) ship an `agent` too.
+    ///
+    /// Preferring the unambiguous name makes resolution independent of PATH
+    /// order (`resolveBinary` is token-major: every PATH entry is searched for
+    /// `cursor-agent` before any is searched for `agent`). The legacy name stays
+    /// as an alias so an older install still resolves — and, if *that* is what
+    /// resolves, `verifyBinaryIdentity` confirms it's really Cursor before
+    /// registration marks the agent available. An explicit
+    /// `defaults.binaries.cursor` pin still overrides everything and skips the
+    /// probe.
+    public let launchCommandToken: String = "cursor-agent"
+    public let alternateLaunchCommandTokens: [String] = ["agent"]
     public let hookConfigWriter: any HookConfigWriter
     public let stateSignalSource: any StateSignalSource
 
     private let launcher: CursorLauncher
 
-    /// Last-resort search paths for the `agent` binary (Cursor's CLI), used
-    /// only when the configured `BinaryOverrides` and a PATH walk both miss.
-    /// The Cursor app bundle's embedded CLI is usually symlinked into PATH or
-    /// installed via the Cursor app's "Install 'cursor' command" action; this
-    /// list is the historical hardcoded set we used to check first (CROW-484).
+    /// Runs the `--help` identity probe. Injectable so tests can stub the
+    /// binary's output without spawning a real subprocess; production uses
+    /// `ProcessShellRunner` (the same runner provider backends use).
+    private let probeRunner: any ShellRunner
+
+    /// Last-resort search paths for Cursor's CLI, used only when the configured
+    /// `BinaryOverrides` and a PATH walk both miss. `cursor-agent` entries come
+    /// first for the same reason the token does — a hardcoded `…/bin/agent` is
+    /// just as capable of being grok-build's as a PATH one, and the identity
+    /// probe covers a `.fallback` match exactly like a `.path` one.
     public let fallbackCandidates: [String] = [
+        "/opt/homebrew/bin/cursor-agent",
+        "/usr/local/bin/cursor-agent",
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin/cursor-agent").path,
         "/opt/homebrew/bin/agent",
         "/usr/local/bin/agent",
         FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin/agent").path,
@@ -50,10 +67,12 @@ public struct CursorAgent: CodingAgent {
 
     public init(
         hookConfigWriter: any HookConfigWriter = CursorHookConfigWriter(),
-        stateSignalSource: any StateSignalSource = CursorSignalSource()
+        stateSignalSource: any StateSignalSource = CursorSignalSource(),
+        probeRunner: any ShellRunner = ProcessShellRunner()
     ) {
         self.hookConfigWriter = hookConfigWriter
         self.stateSignalSource = stateSignalSource
+        self.probeRunner = probeRunner
         self.launcher = CursorLauncher()
     }
 
@@ -64,15 +83,16 @@ public struct CursorAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let agentPath = CursorLaunchArgs.shellQuote(findBinary() ?? "agent")
+        let agentPath = CursorLaunchArgs.shellQuote(findBinary() ?? launchCommandToken)
         // NB: `findBinary()` resolves to an absolute path here — Cursor is
         // registered as *known* regardless of PATH (#879), but only enters the
-        // launchable `agents` map when it resolves, and `autoLaunchCommand` only
-        // runs for a launchable agent. So the quoted form is `'/…/agent'` and
+        // launchable `agents` map when it resolves **and passes the identity
+        // probe** (CROW-989), and `autoLaunchCommand` only runs for a launchable
+        // agent. So the quoted form is `'/…/cursor-agent'` and
         // `AgentLaunch.commandLaunchesToken` still matches it via its `/` prefix
-        // alternative. A bare `'agent'` (findBinary→nil) would NOT match that
-        // regex — but that path is unreachable while the launch gate excludes
-        // unavailable kinds.
+        // alternative. A bare `'cursor-agent'` (findBinary→nil) would NOT match
+        // that regex — but that path is unreachable while the launch gate
+        // excludes unavailable kinds.
         // The `--trust` workspace-trust seed (skips the folder-trust dialog on a
         // fresh worktree — the per-launch analogue of `ClaudeTrustSeeder`,
         // CROW-890) rides EVERY launch path, `.review` included as of CROW-954.
@@ -181,7 +201,7 @@ public struct CursorAgent: CodingAgent {
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
-            binary: findBinary() ?? "agent",
+            binary: findBinary() ?? launchCommandToken,
             seedTrust: true
         )
     }
@@ -204,7 +224,7 @@ public struct CursorAgent: CodingAgent {
         // network/filesystem-blocked — see `CursorLaunchArgs`). Terminal backend
         // appends the submitting Enter, so we return the command without a
         // trailing newline to match the cross-agent convention.
-        let agentPath = CursorLaunchArgs.shellQuote(findBinary() ?? "agent")
+        let agentPath = CursorLaunchArgs.shellQuote(findBinary() ?? launchCommandToken)
         return agentPath + CursorLaunchArgs.launchSuffix(
             seedTrust: true, autoPermissionMode: autoPermissionMode)
     }
@@ -212,5 +232,50 @@ public struct CursorAgent: CodingAgent {
     /// Cursor CLI exposes `/rename` for naming sessions (CROW-629).
     public func sessionRenameSlashCommand(newName: String) -> String? {
         "/rename \(newName)\n"
+    }
+
+    /// Substrings that identify a resolved binary as Cursor's CLI rather than
+    /// another tool installed under the same name. Matched case-insensitively
+    /// against `--help` output; **any** one match confirms identity (OR, not
+    /// AND), so a single upstream flag rename can't grey out a genuine install.
+    ///
+    /// These are the flags this adapter actually hands the binary
+    /// (`CursorLaunchArgs`: `--trust`, `--force --approve-mcps`) plus Cursor's
+    /// two env-var names. That choice is deliberate: the probe then answers the
+    /// question the launch actually depends on — *does this binary understand the
+    /// flags we're about to pass it?* — which is precisely what CROW-989 got
+    /// wrong. `--force` alone is excluded as too generic to discriminate.
+    ///
+    /// Deliberately **not** the `Usage:` line: `cursor-agent --help` prints
+    /// `Usage: agent [options] …` (the binary reports its generic argv[0] name),
+    /// so matching on "cursor-agent" there would reject every genuine install.
+    ///
+    /// Verified against the installed `cursor-agent 2026.08.04-aaa8809`, and
+    /// checked negative against `grok 1.0.0` (grok-build's `agent`), whose help
+    /// carries none of them — it offers `--always-approve` / `--allow` / `--deny`
+    /// instead. ⚠️ Re-verify on each Cursor CLI baseline bump, alongside the
+    /// launch flags in `CursorLaunchArgs` (they're the same upstream surface).
+    /// If a rewrite ever drops all of them, the user's escape hatch is an
+    /// explicit `defaults.binaries.cursor` pin, which bypasses this probe.
+    static let identityMarkers = [
+        "--approve-mcps", "--trust", "cursor_api_key", "cursor_api_endpoint",
+    ]
+
+    /// Identity-probe the resolved binary before registration marks Cursor
+    /// available (CROW-989). Only reached for a PATH/`fallbackCandidates` match:
+    /// an explicit `defaults.binaries.cursor` pin is trusted without probing
+    /// (`AgentDiscovery.evaluate`).
+    ///
+    /// `--help` only — every marker is a `--help` string, and Cursor's
+    /// `--version` prints a bare build stamp (`2026.08.04-aaa8809`) with no
+    /// vendor text, so a second spawn could never match and would only slow boot.
+    /// An empty result (a binary that prints nothing, or a probe timeout) matches
+    /// no marker and returns false.
+    public func verifyBinaryIdentity(atPath path: String) async -> Bool {
+        await BinaryIdentityProbe.matches(
+            path: path,
+            args: ["--help"],
+            markers: Self.identityMarkers,
+            runner: probeRunner)
     }
 }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
@@ -77,7 +77,7 @@ public actor CursorLauncher {
     /// agent-handoff path (`crow handoff-agent --agent cursor`) to start
     /// `agent` on that prompt instead of a bare TUI (#829).
     ///
-    /// `binary` is the resolved `agent` path (`CursorAgent.findBinary()`), so a
+    /// `binary` is the resolved Cursor CLI path (`CursorAgent.findBinary()`), so a
     /// `defaults.binaries.cursor` override is honored and a narrow PATH still
     /// launches — `agent` is a collision-prone token, so we don't hardcode it.
     ///
@@ -94,7 +94,7 @@ public actor CursorLauncher {
     /// is the one place this guard could silently regress, so every call site
     /// must state its intent. `CursorAgent` passes `sessionKind != .review`
     /// (attacker-controlled review clones are never auto-trusted, Red 1).
-    public func launchCommand(sessionID: UUID, worktreePath: String, prompt: String, binary: String = "agent", seedTrust: Bool) throws -> String {
+    public func launchCommand(sessionID: UUID, worktreePath: String, prompt: String, binary: String = "cursor-agent", seedTrust: Bool) throws -> String {
         let tmpDir = FileManager.default.temporaryDirectory
         let promptPath = tmpDir.appendingPathComponent("crow-cursor-\(sessionID.uuidString)-prompt.md")
         try prompt.write(to: promptPath, atomically: true, encoding: .utf8)

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
@@ -12,8 +12,31 @@ struct CursorAgentTests {
         #expect(agent.displayName == "Cursor")
         #expect(agent.iconSystemName == "cursorarrow.rays")
         #expect(agent.supportsRemoteControl == true)
-        #expect(agent.launchCommandToken == "agent")
+        #expect(agent.launchCommandToken == "cursor-agent")
+        #expect(agent.alternateLaunchCommandTokens == ["agent"])
         #expect(agent.sessionRenameSlashCommand(newName: "my-session") == "/rename my-session\n")
+    }
+
+    // MARK: - Binary token collision (CROW-989)
+
+    /// Cursor ships the same executable under two names. Crow prefers the
+    /// unambiguous `cursor-agent`; the generic `agent` is kept only as an alias
+    /// because xAI's grok-build installs `~/.grok/bin/agent` and won the PATH
+    /// walk, so Crow built a Cursor command and ran Grok's binary — which died
+    /// on `--force`.
+    @Test func prefersTheUnambiguousNameAndKeepsTheLegacyAlias() {
+        #expect(agent.binaryTokens == ["cursor-agent", "agent"])
+    }
+
+    /// Hardcoded fallbacks follow the same preference: a `…/bin/agent` on disk is
+    /// just as likely to be grok-build's as a PATH one, so every `cursor-agent`
+    /// candidate is tried before any bare `agent`.
+    @Test func fallbackCandidatesPreferCursorAgent() {
+        let names = agent.fallbackCandidates.map { ($0 as NSString).lastPathComponent }
+        let lastPreferred = names.lastIndex(of: "cursor-agent")
+        let firstLegacy = names.firstIndex(of: "agent")
+        #expect(lastPreferred != nil && firstLegacy != nil)
+        #expect(lastPreferred! < firstLegacy!)
     }
 
     @Test func autoLaunchCommandWorkSession() {
@@ -315,5 +338,105 @@ struct CursorAgentTests {
         // path may or may not exist depending on the developer machine,
         // so we accept either outcome and just verify the result type.
         _ = agent.findBinary()  // smoke test: must not crash
+    }
+
+    // MARK: - Identity probe (CROW-989)
+
+    /// Real `cursor-agent 2026.08.04-aaa8809 --help`, trimmed to the option lines
+    /// the markers key on. Note the `Usage:` line says **`agent`** — the binary
+    /// reports its generic argv[0] name even when invoked as `cursor-agent` —
+    /// which is exactly why the markers are flags and env vars, not the program
+    /// name.
+    private static let cursorHelp = """
+        Usage: agent [options] [command] [prompt...]
+
+        Start the Cursor Agent
+
+        Options:
+          -v, --version              Output the version number
+          --api-key <key>            API key for authentication (can also use
+                                     CURSOR_API_KEY env var)
+          -e, --endpoint <url>       Target API endpoint URL (can also use
+                                     CURSOR_API_ENDPOINT env var)
+          -f, --force                Force allow commands unless explicitly denied
+          --approve-mcps             Automatically approve all MCP servers
+          --trust                    Trust the current workspace without prompting
+        """
+
+    /// Real `grok 1.0.0 --help` (grok-build, installed as `~/.grok/bin/agent`),
+    /// trimmed. This is the binary Crow actually launched in the CROW-989 repro:
+    /// it has a `--force`-adjacent vocabulary but none of Cursor's flags, so
+    /// Cursor's `--force --approve-mcps` died on parse.
+    private static let grokBuildHelp = """
+        Grok Build TUI
+
+        Usage: agent [OPTIONS] [PROMPT] [COMMAND]
+
+        Options:
+              --allow <RULE>       Permission allow rule (compat alias: --allowedTools)
+              --always-approve     Auto-approve all tool executions
+          -c, --continue           Continue the most recent session
+              --deny <RULE>        Permission deny rule
+        """
+
+    @Test func identityProbeAcceptsCursorHelp() async {
+        let agent = CursorAgent(probeRunner: FakeProbeRunner(
+            outputs: ["--help": Self.cursorHelp]))
+        #expect(await agent.verifyBinaryIdentity(atPath: "/Users/x/.local/bin/cursor-agent"))
+    }
+
+    /// The exact CROW-989 false positive: `agent` resolved to grok-build. The
+    /// probe rejects it, so registration reports Cursor unavailable (naming the
+    /// resolved path) instead of launching and failing on flag parsing.
+    @Test func identityProbeRejectsGrokBuildUnderTheAgentName() async {
+        let agent = CursorAgent(probeRunner: FakeProbeRunner(
+            outputs: ["--help": Self.grokBuildHelp]))
+        #expect(await agent.verifyBinaryIdentity(atPath: "/Users/x/.grok/bin/agent") == false)
+    }
+
+    /// A binary that prints nothing — or a probe that times out — can't be
+    /// identified, so it's rejected rather than optimistically launched.
+    @Test func identityProbeRejectsEmptyOutput() async {
+        let agent = CursorAgent(probeRunner: FakeProbeRunner(outputs: [:]))
+        #expect(await agent.verifyBinaryIdentity(atPath: "/usr/local/bin/agent") == false)
+    }
+
+    /// Cursor's `--version` is a bare build stamp with no vendor text, so it
+    /// could never match a marker; probing it would only cost a second spawn per
+    /// boot. `--help` is the only leg.
+    @Test func identityProbeOnlySpawnsHelp() async {
+        let runner = FakeProbeRunner(outputs: ["--version": "2026.08.04-aaa8809"])
+        _ = await CursorAgent(probeRunner: runner).verifyBinaryIdentity(atPath: "/bin/x")
+        #expect(runner.probed.value == ["--help"])
+    }
+
+    /// Every marker must be present in the real Cursor help — a marker that
+    /// matches nothing is dead weight that silently narrows the probe.
+    @Test func everyMarkerAppearsInRealCursorHelp() {
+        let help = Self.cursorHelp.lowercased()
+        for marker in CursorAgent.identityMarkers {
+            #expect(help.contains(marker), "marker \(marker) no longer appears in Cursor's --help")
+        }
+    }
+}
+
+/// Canned `--help` responder for the identity probe, recording which args were
+/// spawned. Lets a test hand `verifyBinaryIdentity` real Cursor vs grok-build
+/// output without spawning a subprocess.
+private struct FakeProbeRunner: ShellRunner {
+    let outputs: [String: String]
+    let probed = Recorder()
+
+    final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var args: [String] = []
+        var value: [String] { lock.lock(); defer { lock.unlock() }; return args }
+        func record(_ a: String) { lock.lock(); defer { lock.unlock() }; args.append(a) }
+    }
+
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        let arg = args.dropFirst().first ?? ""
+        probed.record(arg)
+        return outputs[arg] ?? ""
     }
 }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorLauncherTests.swift
@@ -42,7 +42,7 @@ struct CursorLauncherTests {
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: true)
         #expect(cmd.contains("_CROW_P=$(< "))
-        #expect(cmd.contains("eval \"'agent' --trust -- $(printf '%q'"))
+        #expect(cmd.contains("eval \"'cursor-agent' --trust -- $(printf '%q'"))
         #expect(cmd.contains("--force") == false)          // no auto-permission
     }
 
@@ -55,7 +55,7 @@ struct CursorLauncherTests {
         let cmd = try await CursorLauncher().launchCommand(
             sessionID: UUID(), worktreePath: "/w", prompt: "p", seedTrust: false)
         #expect(cmd.contains("--trust") == false)
-        #expect(cmd.contains("eval \"'agent' -- $(printf '%q'"))
+        #expect(cmd.contains("eval \"'cursor-agent' -- $(printf '%q'"))
     }
 
     /// CROW-968: the handoff prompt runs through the same commander parser as

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -995,10 +995,12 @@ public enum CrowDaemon {
         //
         // A resolved binary is identity-probed for collision-prone launch tokens
         // so a foreign same-named binary is shown disabled rather than falsely
-        // active — today only Grok Build, whose `grok` token collides with
-        // `superagent-ai/grok-cli` (CROW-911). The probe is skipped for an
-        // explicit `defaults.binaries.<kind>` pin (`.available(viaOverride:)`):
-        // the user has named the exact binary, so it's authoritative.
+        // active: Grok Build, whose `grok` token collides with
+        // `superagent-ai/grok-cli` (CROW-911), and Cursor, whose legacy `agent`
+        // alias collides with grok-build's own `~/.grok/bin/agent` (CROW-989).
+        // The probe is skipped for an explicit `defaults.binaries.<kind>` pin
+        // (`.available(viaOverride:)`): the user has named the exact binary, so
+        // it's authoritative.
         func registerDiscovered(_ agent: any CodingAgent) async {
             switch await AgentDiscovery.evaluate(agent) {
             case .unavailableNotFound:

--- a/Packages/CrowEngine/Sources/CrowEngine/AgentLaunch.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AgentLaunch.swift
@@ -21,7 +21,7 @@ public enum AgentLaunch {
         crowPath: String?,
         telemetryPort: UInt16?
     ) -> (text: String, didLaunch: Bool) {
-        guard commandLaunchesToken(command, token: agent.launchCommandToken) else { return (command, false) }
+        guard commandLaunchesAgent(command, agent: agent) else { return (command, false) }
         if let worktreePath, let crowPath {
             do {
                 try agent.hookConfigWriter.writeHookConfig(
@@ -57,11 +57,26 @@ public enum AgentLaunch {
         return ("export \(vars) && \(command)", true)
     }
 
+    /// Whether `command` launches `agent` under **any** of its binary names.
+    ///
+    /// The alias-aware form of `commandLaunchesToken`, and the one every caller
+    /// should use: an agent that ships more than one name for the same executable
+    /// can be invoked under either, and both must get hook-config + env prep.
+    /// Cursor is the case in point — Crow now prefers `cursor-agent`, but a
+    /// legacy install (or an operator recovering a pane by hand) still says
+    /// `agent` (CROW-989).
+    public static func commandLaunchesAgent(_ command: String, agent: any CodingAgent) -> Bool {
+        agent.binaryTokens.contains { commandLaunchesToken(command, token: $0) }
+    }
+
     /// Whether `command` invokes `token` as a shell command rather than an
     /// incidental substring. Anchored at start-of-string, after a shell command
     /// separator (`;`, `&&`, `||`, `|`), or at a path separator (`/`). Prevents
     /// flipping readiness on prose that merely contains an agent token like
     /// Cursor's `"agent"`.
+    ///
+    /// Single-token; prefer `commandLaunchesAgent` when you have the agent, so
+    /// aliases aren't silently missed.
     public static func commandLaunchesToken(_ command: String, token: String) -> Bool {
         let escaped = NSRegularExpression.escapedPattern(for: token)
         let pattern = "(?:^|[;&|]\\s*|/)\(escaped)(?=\\s|$|[\"'])"

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -1057,7 +1057,7 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         // write, so a plain `crow send "yes"` doesn't re-strip. Strip is
                         // a no-op unless this is a Grok `.review` clone.
                         if let wtPath,
-                           AgentLaunch.commandLaunchesToken(text, token: agent.launchCommandToken) {
+                           AgentLaunch.commandLaunchesAgent(text, agent: agent) {
                             SessionService.prepareWorktreeForAgentLaunch(
                                 agentKind: session.agentKind,
                                 sessionKind: session.kind,

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AgentLaunchTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AgentLaunchTests.swift
@@ -83,6 +83,7 @@ private struct MockAgent: CodingAgent {
     var kind: AgentKind
     let spy: SpyHookConfigWriter
     var launchCommandToken: String = "claude"
+    var alternateLaunchCommandTokens: [String] = []
 
     var displayName: String { "Mock" }
     var iconSystemName: String { "sparkles" }
@@ -158,6 +159,45 @@ private struct MockAgent: CodingAgent {
             worktreePath: nil, crowPath: nil, telemetryPort: 4318)
         #expect(didLaunch)
         #expect(text == "cursor-agent chat")
+    }
+
+    /// A legacy install invoked under the alias still counts as a launch, so it
+    /// gets hook config written. Crow prefers `cursor-agent` since CROW-989, but
+    /// an older install — or an operator recovering a pane by hand with
+    /// `crow send "agent --continue"` — still says `agent`, and a miss here would
+    /// silently leave that session without hooks.
+    @Test func alternateTokenAlsoCountsAsALaunch() {
+        var a = agent(.cursor)
+        a.launchCommandToken = "cursor-agent"
+        a.alternateLaunchCommandTokens = ["agent"]
+        let sid = UUID()
+        let (_, didLaunch) = AgentLaunch.prepareAgentLaunchText(
+            command: "'/Users/x/.local/bin/agent' --trust", agent: a, sessionID: sid,
+            worktreePath: "/tmp/wt", crowPath: "/usr/local/bin/crow", telemetryPort: nil)
+        #expect(didLaunch)
+        #expect(a.spy.calls == [.init(worktreePath: "/tmp/wt", sessionID: sid, crowPath: "/usr/local/bin/crow")])
+    }
+
+    /// The alias must not widen matching into prose. `commandLaunchesToken` is
+    /// already anchored, and adding `agent` as an alias doesn't relax that —
+    /// otherwise a `crow send` of ordinary text mentioning the word would flip
+    /// readiness and rewrite hook config.
+    @Test func aliasDoesNotMatchIncidentalProse() {
+        var a = agent(.cursor)
+        a.launchCommandToken = "cursor-agent"
+        a.alternateLaunchCommandTokens = ["agent"]
+        #expect(!AgentLaunch.commandLaunchesAgent("ask the agent to retry", agent: a))
+        #expect(!AgentLaunch.commandLaunchesAgent("./my-agent run", agent: a))
+        #expect(AgentLaunch.commandLaunchesAgent("agent --continue", agent: a))
+        #expect(AgentLaunch.commandLaunchesAgent("cd /tmp && cursor-agent", agent: a))
+    }
+
+    /// An agent with no aliases matches exactly as before — the CROW-989
+    /// plumbing is inert for every single-name harness.
+    @Test func singleTokenAgentMatchingIsUnchanged() {
+        let a = agent(.claudeCode)
+        #expect(AgentLaunch.commandLaunchesAgent("claude --continue", agent: a))
+        #expect(!AgentLaunch.commandLaunchesAgent("agent --continue", agent: a))
     }
 
     /// #897 end-to-end on the wiring: the launch path resolves its crow binary

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AgentsRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AgentsRPCSupportTests.swift
@@ -22,7 +22,7 @@ struct AgentsRPCSupportTests {
     private let withUnavailable: [AgentsRPC.KnownAgent] = [
         .init(kind: .claudeCode, name: "Claude Code", binary: "claude", available: true),
         .init(kind: .codex, name: "OpenAI Codex", binary: "codex", available: true),
-        .init(kind: .cursor, name: "Cursor", binary: "agent", available: false),
+        .init(kind: .cursor, name: "Cursor", binary: "cursor-agent", available: false),
     ]
 
     // MARK: - decodeAgentKind (the registry gate)
@@ -350,7 +350,7 @@ struct AgentsRPCSupportTests {
         #expect(entries.count == 3)
         let cursor = entries.first { $0.objectValue?["kind"] == .string("cursor") }
         #expect(cursor?.objectValue?["available"] == .bool(false))
-        #expect(cursor?.objectValue?["binary"] == .string("agent"))
+        #expect(cursor?.objectValue?["binary"] == .string("cursor-agent"))
     }
 
     /// …and listing it must not make it selectable — the launch gate is the
@@ -377,7 +377,7 @@ struct AgentsRPCSupportTests {
         } catch {
             let message = String(describing: error)
             #expect(message.contains("known but not installed"))
-            #expect(message.contains("agent"))  // the PATH token
+            #expect(message.contains("cursor-agent"))  // the PATH token
             #expect(!message.contains("Expected one of"))
         }
     }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/ManagerMigrationTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/ManagerMigrationTests.swift
@@ -95,8 +95,11 @@ struct ManagerMigrationTests {
 
         // Claude path keeps producing a `claude` invocation.
         #expect(claudeCmd.contains("claude"))
-        // Cursor path emits the `agent` binary (Cursor's CLI name), not claude.
-        #expect(cursorCmd.contains("agent"))
+        // Cursor path emits Cursor's own CLI, not claude. Asserted on the
+        // unambiguous `cursor-agent` name rather than a bare `agent` substring —
+        // that substring also matches grok-build's `agent`, which is the exact
+        // mix-up CROW-989 fixed, so a loose assertion here would pass on it.
+        #expect(cursorCmd.contains("cursor-agent"))
         #expect(!cursorCmd.contains("claude"))
     }
 
@@ -183,6 +186,14 @@ struct ManagerMigrationTests {
 
         let appState = AppState()
         appState.remoteControlEnabled = true  // so the rebuilt command carries --rc/--name
+        // The command rebuild resolves the Manager's agent through the
+        // process-wide `AgentRegistry.shared`, which is NOT scoped per test (see
+        // the note in `managerCommandIsIdempotent`). Register Claude Code here
+        // rather than relying on a sibling test having done so first — under
+        // `--parallel` the ordering isn't guaranteed, and without it the rebuild
+        // falls back to a command carrying neither `--name` nor remote control.
+        // Registration is idempotent, so this is safe to repeat.
+        AgentRegistry.shared.register(ClaudeCodeAgent())
         let service = SessionService(store: store, appState: appState)
         service.hydrateState()
 

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -214,73 +214,10 @@ public struct GrokAgent: CodingAgent {
         // foreign binary that prints its banner there instead. An empty result
         // (a binary that prints nothing, or a probe timeout) simply matches no
         // marker and returns false — no separate empty-string branch needed.
-        for arg in ["--help", "--version"] {
-            let out = await Self.probeArg(path, arg, runner: probeRunner).lowercased()
-            if Self.identityMarkers.contains(where: { out.contains($0) }) { return true }
-        }
-        return false
-    }
-
-    /// Per-leg cap for the `--help` / `--version` probe. Injectable via
-    /// `probeArg` so tests exercise the timeout without a real 3s wait.
-    static let probeTimeoutNanos: UInt64 = 3 * 1_000_000_000
-
-    /// Run `<binary> <arg>` and return its merged stdout+stderr, or `""` on spawn
-    /// failure **or timeout**. The cap is a *hard* bound on the awaiting task: it
-    /// races the run against a sleep behind a resume-once guard and returns
-    /// whichever finishes first — so even a runner that never completes and
-    /// ignores cancellation (a `grok` that reads stdin, or forks a child holding
-    /// the stdout pipe so `readDataToEndOfFile()` never sees EOF) **cannot stall
-    /// `registerAgents` at boot** (CROW-911 review — the earlier `withTaskGroup`
-    /// form awaited the losing child and so bounded nothing).
-    ///
-    /// On timeout the run `Task` is cancelled: with the cancellation-aware
-    /// `ProcessShellRunner` that `terminate()`s the child so it doesn't leak; a
-    /// genuinely uncancellable runner leaks one blocked reader but boot proceeds.
-    static func probeArg(
-        _ binary: String,
-        _ arg: String,
-        runner: any ShellRunner,
-        timeoutNanos: UInt64 = probeTimeoutNanos
-    ) async -> String {
-        let gate = ResumeOnceGate()
-        return await withCheckedContinuation { (cont: CheckedContinuation<String, Never>) in
-            @Sendable func finish(_ result: String) {
-                if gate.claim() { cont.resume(returning: result) }
-            }
-            let work = Task {
-                let out: String
-                do {
-                    out = try await runner.run(args: [binary, arg], env: [:], cwd: nil)
-                } catch let ShellRunnerError.nonZeroExit(_, output) {
-                    out = output
-                } catch {
-                    out = ""
-                }
-                finish(out)
-            }
-            Task {
-                try? await Task.sleep(nanoseconds: timeoutNanos)
-                work.cancel()
-                finish("")
-            }
-        }
-    }
-}
-
-/// A cross-platform (no Darwin `os`) resume-once guard for `probeArg`'s
-/// race: `claim()` returns `true` exactly once — for the first of the run and
-/// timeout tasks to finish — so the continuation is resumed a single time. An
-/// `NSLock`-backed `Bool` rather than `OSAllocatedUnfairLock`, which is
-/// Apple-platforms-only and breaks the Linux CI build (#912).
-private final class ResumeOnceGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private var resumed = false
-
-    func claim() -> Bool {
-        lock.lock(); defer { lock.unlock() }
-        if resumed { return false }
-        resumed = true
-        return true
+        await BinaryIdentityProbe.matches(
+            path: path,
+            args: ["--help", "--version"],
+            markers: Self.identityMarkers,
+            runner: probeRunner)
     }
 }

--- a/Packages/CrowGrok/Tests/CrowGrokTests/GrokAgentTests.swift
+++ b/Packages/CrowGrok/Tests/CrowGrokTests/GrokAgentTests.swift
@@ -262,11 +262,13 @@ struct GrokAgentTests {
     }
 
     /// The Red from #912 review: a `grok` that never exits and ignores
-    /// cancellation must not stall boot. `probeArg`'s timeout is a *hard* bound
-    /// on the awaiting task — it returns `""` at the cap even against a runner
-    /// that never completes. Uses a tiny injected timeout so the test is instant.
-    @Test func probeArgHardBoundsAgainstNeverCompletingRunner() async {
-        let out = await GrokAgent.probeArg(
+    /// cancellation must not stall boot. The shared probe's timeout is a *hard*
+    /// bound on the awaiting task — it returns `""` at the cap even against a
+    /// runner that never completes. Uses a tiny injected timeout so the test is
+    /// instant. (Lives here as well as in `CrowCore` because Grok's
+    /// `verifyBinaryIdentity` is the original caller this bound was written for.)
+    @Test func probeHardBoundsAgainstNeverCompletingRunner() async {
+        let out = await BinaryIdentityProbe.run(
             "/opt/homebrew/bin/grok",
             "--help",
             runner: NeverRunner(),
@@ -296,7 +298,7 @@ private struct FakeProbeRunner: ShellRunner {
 }
 
 /// A `ShellRunner` that never completes and ignores cancellation — the exact
-/// shape from the #912 review repro. Proves `probeArg`'s timeout bounds the
+/// shape from the #912 review repro. Proves the shared probe's timeout bounds the
 /// awaiting task rather than relying on the runner cooperating. Uses an *unsafe*
 /// continuation deliberately: the leak (never resumed) is the intended scenario,
 /// so a checked continuation would only emit a spurious misuse diagnostic.

--- a/docs/adr/0014-pluggable-coding-agent-adapter.md
+++ b/docs/adr/0014-pluggable-coding-agent-adapter.md
@@ -53,7 +53,13 @@ protocol. Capabilities are **members of the protocol**, not a central switch:
   ignore.
 - **Binary discovery:** `findBinary()` with a default three-tier impl
   (explicit `defaults.binaries.<kind>` override → `PATH` walk →
-  hardcoded `fallbackCandidates`; CROW-484).
+  hardcoded `fallbackCandidates`; CROW-484). The `PATH` walk is *token-major*
+  over `binaryTokens` (`launchCommandToken` then any
+  `alternateLaunchCommandTokens`), so a harness shipping several names for one
+  executable resolves by preferred name rather than by install order — and a
+  `PATH`/fallback match on a collision-prone name is confirmed by
+  `verifyBinaryIdentity` before registration marks the agent available
+  (CROW-911 for Grok, CROW-989 for Cursor; shared `BinaryIdentityProbe`).
 
 Harnesses are keyed by
 [`AgentKind`](../../Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift),

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -25,7 +25,7 @@ capabilities, update this table in the same PR.
 
 | Dimension | Claude Code | Cursor | Codex | OpenCode | Grok Build | Antigravity (Tier-2) |
 |---|---|---|---|---|---|---|
-| Binary token (`launchCommandToken`) | `claude` | `agent` ⚠️ collision risk | `codex` | `opencode` | `grok` ⚠️ collision (`grok-cli`) — identity-probed | `agy` ✅ low collision |
+| Binary token (`launchCommandToken`) | `claude` | `cursor-agent` ✅ (alias `agent` ⚠️ collides with grok-build) — identity-probed | `codex` | `opencode` | `grok` ⚠️ collision (`grok-cli`) — identity-probed | `agy` ✅ low collision |
 | Registered at boot | **always** (default out of the box) | only if binary found | only if binary found | only if binary found | only if binary found | only if binary found |
 | Resume / continue | ✅ `--continue` | ✅ `--continue` (job/review restart, #829) | ✅ `resume --last` | ⚠️ `--continue` re-enters TUI, no history | ✅ `-c`/`-r` (run-then-`-c`; job/review restart) | ⚠️ `-c` (machine-global most-recent; no per-run id, FR #7) |
 | Remote control | ✅ native `--rc --name` | ⚠️ faked via `crow send` stdin | ❌ `supportsRemoteControl=false` (experimental `--remote` unwired) | ⚠️ faked via `crow send` stdin | ⚠️ faked via `crow send` stdin (native ACP `grok agent serve` deferred) | ⚠️ faked via `crow send` stdin (no native RC) |
@@ -92,36 +92,55 @@ Each harness declares a `launchCommandToken` — the binary name Crow resolves o
 `PATH` and the token the `send` RPC watches for to decide whether a
 managed-terminal command needs hook/env prep.
 
-- Tokens: `claude`, `agent`, `codex`, `opencode`, `grok`, `agy`
+- Tokens: `claude`, `cursor-agent`, `codex`, `opencode`, `grok`, `agy`
   (`ClaudeCodeAgent`, `CursorAgent`, `OpenAICodexAgent`, `OpenCodeAgent`,
   `GrokAgent`, `AntigravityAgent`).
-- **Cursor's token is `agent`, a generic name.** CI runners (Azure DevOps,
-  TeamCity) also ship a binary called `agent` — and, confirmed in the field,
-  **xAI's grok-build installer symlinks `agent → grok`** (`~/.grok/bin/agent`,
-  mirrored into `~/.local/bin/agent`), so on a box with grok-build ahead of
-  Cursor on PATH the `agent` token resolves to grok-build, not Cursor. Crow
-  still only accepts the false-positive risk here and lets users pin the real
-  path via `defaults.binaries.cursor` (`CursorAgent.swift` launch-token comment,
-  CROW-484). The durable fix is to adopt the CROW-911 identity-probe seam for
-  Cursor — with a PATH-walk-that-verifies (take the first `agent` on PATH that
-  passes the probe, since the wrong one can be first) — tracked as a follow-up.
+- **Cursor ships two names for one executable**, and Crow prefers the
+  unambiguous `cursor-agent`; the generic `agent` is kept as an
+  `alternateLaunchCommandTokens` alias for older installs. The generic name
+  genuinely collides: CI runners (Azure DevOps, TeamCity) ship an `agent`, and —
+  observed in the field — **xAI's grok-build installs `~/.grok/bin/agent`**
+  (mirrored into `~/.local/bin/agent`). On a box with grok-build ahead of Cursor
+  on PATH, `agent` resolved to grok-build, so Crow built a Cursor command and ran
+  Grok's binary, which died on the first flag it lacks
+  (`error: unexpected argument '--force' found`) — CROW-989, the risk CROW-484
+  accepted actually firing. Two defenses now:
+  - **Preferred-name-first PATH walk.** `resolveBinary()` is *token-major*: every
+    PATH entry is searched for `cursor-agent` before any is searched for `agent`
+    (`BinaryTokenResolver.firstOnPath`), so resolution depends on the name rather
+    than on install order. Reordering PATH cannot change the selection.
+  - **Identity probe** on a bare `agent` match, the CROW-911 seam Grok already
+    used. `cursor-agent --help` is matched against `CursorAgent.identityMarkers`
+    (`--approve-mcps`, `--trust`, `CURSOR_API_KEY`, `CURSOR_API_ENDPOINT` — the
+    flags this adapter actually passes, so the probe answers exactly the question
+    the launch depends on). A grok-build `agent` carries none of them and is
+    reported unavailable, naming the resolved path, instead of launching and
+    failing on flag parsing. `defaults.binaries.cursor` still pins and bypasses
+    the probe.
+  - ⚠️ **Residual gap:** a machine with *only* the legacy `agent` name (no
+    `cursor-agent`) **and** grok-build earlier on PATH reports Cursor
+    unavailable — the walk stops at the first `agent` it finds rather than
+    continuing to a later, genuine one. A multi-candidate walk (probe each `agent`
+    on PATH until one verifies) would close it, but needs the verified path cached
+    for launch, since `findBinary()` re-resolves per launch. Workaround is the
+    `defaults.binaries.cursor` pin.
 - **Grok's token is `grok`, which collides** with the community
-  `superagent-ai/grok-cli` (also installs `grok`). Unlike Cursor, Crow does
-  **not** just accept the false positive: registration **identity-probes** a
-  bare PATH/fallback match — `grok --help` (then `--version`), matched against
+  `superagent-ai/grok-cli` (also installs `grok`). Registration **identity-probes**
+  a bare PATH/fallback match — `grok --help` (then `--version`), matched against
   grok-build-specific flag markers in `GrokAgent.identityMarkers` — and shows
   Grok Build **disabled** when the resolved binary is the foreign `grok-cli`
   (`GrokAgent.verifyBinaryIdentity`, CROW-911). The decision is the pure
   `AgentDiscovery.evaluate` (resolve → probe a non-override match), which
   `CrowDaemon.registerAgents` wraps with registry writes + logging. An explicit
   `defaults.binaries.grok` pin is authoritative and **skips the probe**;
-  `BinaryOverrides` keys on `AgentKind.rawValue` = `"grok"`. The probe is a
-  reusable `CodingAgent` seam Cursor's `agent` token can adopt (see above).
-  ⚠️ **Trust-boundary delta:** `crowd` now *executes* the PATH-resolved `grok`
-  (an unvetted third-party binary) at boot to probe it — inherent to identity
+  `BinaryOverrides` keys on `AgentKind.rawValue` = `"grok"`. Cursor and Grok share
+  one implementation of the bounded subprocess race (`BinaryIdentityProbe`,
+  CROW-989) rather than each carrying a copy.
+  ⚠️ **Trust-boundary delta:** `crowd` now *executes* the PATH-resolved binary
+  (an unvetted third-party one) at boot to probe it — inherent to identity
   probing, on the user's own PATH, output only substring-matched (never logged
   or evaluated); the probe is hard-bounded so a hanging binary can't stall boot
-  (`GrokAgent.probeArg`).
+  (`BinaryIdentityProbe.run`).
 - **Registration order = default.** `AgentRegistry.register` sets the default to
   the *first* kind registered
   ([`AgentRegistry.swift`](../Packages/CrowCore/Sources/CrowCore/Agent/AgentRegistry.swift)).
@@ -399,7 +418,8 @@ share the host's global config and are disambiguated by `cwd`. See
   handoff, and the brand-new-terminal deferred paste / `crow send` via
   `AgentLaunch`), not at boot — so it fires for Cursor selected via config *or*
   per-session (`handoff-agent`, the Manager picker), and never copies the token
-  onto a box that merely has a binary named `agent`.
+  onto a box that merely has a binary named `agent` — doubly so since CROW-989,
+  where such a binary must also pass the identity probe to register as Cursor.
   The bridged entry is Crow-marked (a top-level `x-crow-managed` list, so the
   server def stays byte-identical to Claude's): a user's own `jira` is never
   clobbered, and the copy is withdrawn only when `~/.claude.json` parses cleanly
@@ -679,6 +699,7 @@ against current upstream CLIs.
 | Antigravity hook re-read timing: does `agy` read `.agents/hooks.json` **once at process start**, or per-event? | `agy` **v1.1.7** — unverified; assumed start-only | `prepareWorktreeForAgentLaunch` (launch-time strip) | 2026-07-28 (#902) — the launch-time strip mitigates a hook restored *between* launches. If `agy` re-reads per-event, a mid-session restore (SKILL's `gh pr checkout` fast-forwards → silently restores `.agents/`) would fire unmitigated, since no strip re-runs mid-session and there is no trust gate behind it. Confirm on the manual pass before promoting out of Tier-2 |
 | **Entire Grok flag set** — hooks event names, `-p`/`--single`, `-c`/`-r`, `--allow`/`--deny`, `--permission-mode`, `--trust`, `/rename` | `xai-org/grok-build` **@ 2026-07-25** (periodic mirror of xAI's monorepo, **PRs closed** → churn likely) | `GrokAgent` / `GrokLaunchArgs` / `GrokHookConfigWriter` / `GrokSignalSource` | 2026-07-26 — verified against repo source (`crates/codegen/xai-grok-*`), not blog posts |
 | Grok `grok` binary collides with community `superagent-ai/grok-cli` | **Identity probe** at registration (`grok --help`/`--version` vs grok-build flag markers) greys out the foreign `grok`; explicit `defaults.binaries.grok` pin bypasses it. Decision is pure `AgentDiscovery.evaluate`; probe markers (`--prompt-file`, `--prompt-json`, `--permission-mode`, `--always-approve`) are the same upstream flag set as the row above — re-verify together | `GrokAgent.identityMarkers` / `verifyBinaryIdentity` · `AgentDiscovery.evaluate` | 2026-07-26 (CROW-911) |
+| Cursor's legacy `agent` alias collides with grok-build's `~/.grok/bin/agent` (fired in the field) | Prefer the unambiguous **`cursor-agent`** via a token-major PATH walk (order-independent), plus the same **identity probe** on a bare `agent` match. Markers (`--approve-mcps`, `--trust`, `CURSOR_API_KEY`, `CURSOR_API_ENDPOINT`) are the flags this adapter passes — re-verify with `CursorLaunchArgs` on each Cursor CLI baseline bump. ⚠️ Residual: legacy-only install + grok-build earlier on PATH ⇒ reported unavailable; pin `defaults.binaries.cursor` | `CursorAgent.identityMarkers` / `verifyBinaryIdentity` · `BinaryTokenResolver` · `BinaryIdentityProbe` | 2026-08-11 (CROW-989) — Cursor CLI baseline `2026.08.04-aaa8809` |
 | Grok **`--permission-mode auto` now exists** — the ticket's pinned probe (#859) reported it absent; current docs show `grok --permission-mode auto`. Bounded `.job` posture stays `--permission-mode auto` + a minimal `--deny` backstop (never `--yolo`) regardless | Grok mirror **@ 2026-07-25** | `GrokLaunchArgs.autoPermissionSuffix` | 2026-07-26 |
 | Grok `Stop` / `Notification` fire on the transitions Crow's state machine needs — **confirm empirically** | — (empirical, #859) | `GrokSignalSource` | 2026-07-26 |
 | Grok double-fire: only the **global** `~/.claude`/`~/.cursor` hook configs Grok also discovers (its compat scanning) firing alongside `.grok/hooks/crow.json` — dedup deferred (genuinely user-controlled config, no Crow session UUID, not RCE; cf. Codex §3b). *Project* compat sources are handled: stripped on `.review` clones (`stripGrokConfigFromReviewClone`, RCE) and neutralized on `.work`/`.job` handoff + warm-adopt (`stripPriorCompatHooksForGrokHandoff` + session-own adopt write, #861 r9-r10). The Grok-**Manager** devRoot case stays a documented limitation (`writeManagerHookConfig`). | — (empirical, #859) | `GrokHookConfigWriter` / `SessionService` | 2026-07-27 |


### PR DESCRIPTION
Closes #989

## Problem

Cursor review sessions launched **Grok's** binary. `CursorAgent` identified Cursor's CLI by the bare token `agent`, and xAI's grok-build installs its own `~/.grok/bin/agent`, which won the PATH walk:

```
$ which -a agent
/Users/danny/.grok/bin/agent      ← Grok, resolved first
/Users/danny/.local/bin/agent     ← Cursor
```

Crow built a Cursor command and handed it to Grok's parser, which died on the first flag it lacks — `error: unexpected argument '--force' found`. CROW-484 recorded this collision as a theoretical risk; this is it firing.

## Fix

Two defenses, both reusing the CROW-911 seam Grok already had:

**1. Prefer the unambiguous name.** Cursor ships one executable under two names, so `launchCommandToken` becomes `cursor-agent` and `agent` moves to a new `alternateLaunchCommandTokens`. `resolveBinary()` walks PATH **token-major** — every PATH entry is searched for `cursor-agent` before any is searched for `agent` — so the selection depends on the *name*, not on install order.

**2. Verify identity before launching.** A bare `agent` match is probed against `cursor-agent --help` for the flags this adapter actually passes (`--approve-mcps`, `--trust`) plus Cursor's env-var names. That choice is deliberate: the probe answers the question the launch depends on — *does this binary understand the flags we're about to give it?* grok-build's help carries none of them, so registration reports Cursor unavailable (naming the resolved path) rather than launching and failing on flag parsing. `defaults.binaries.cursor` still pins and bypasses the probe.

Generalized rather than copied (ticket item 4): `GrokAgent.probeArg` and its resume-once guard move to `CrowCore` as `BinaryIdentityProbe`, so the hard-timeout race that keeps a hanging binary from stalling boot is stated and tested once. Command matching moves to `AgentLaunch.commandLaunchesAgent`, which matches **any** of an agent's names — a legacy `agent` install (or `crow send "agent --continue"` recovering a pane) still gets hook config written.

Agents with a single name are unaffected: `alternateLaunchCommandTokens` defaults to `[]`, one PATH pass, `verifyBinaryIdentity` still defaults to `true`.

## Acceptance

| Criterion | Status |
|---|---|
| With both `agent`s on PATH, Cursor launches against Cursor's binary | ✅ `cursor-agent` is searched first; only Cursor provides it |
| Reordering PATH so Grok precedes Cursor doesn't change the selection | ✅ token-major walk — `reorderingPathDoesNotChangeTheSelection` |
| Legacy-only `agent` install (no `cursor-agent`) still works | ✅ `aliasResolvesWhenPreferredNameIsAbsent` + probe accepts real Cursor help |
| `agent` resolves to a non-Cursor binary, `cursor-agent` absent ⇒ Cursor reported unavailable | ✅ `identityProbeRejectsGrokBuildUnderTheAgentName` → `unavailableFailedProbe(path:)`, which already logs the resolved path and the `defaults.binaries.cursor` fix |

**Residual gap** (documented in the matrix, not silently dropped): a machine with *only* the legacy name **and** grok-build earlier on PATH reports Cursor unavailable rather than walking on to a later, genuine `agent`. Closing it needs the verified path cached for launch, since `findBinary()` re-resolves per launch. Acceptance asks for "report unavailable" here, and the pin is the workaround.

## Verification

Probe markers verified against the **installed** `cursor-agent 2026.08.04-aaa8809` and checked negative against `grok 1.0.0` (grok-build's `agent`); the tests use that captured help text verbatim. Note `cursor-agent --help` prints `Usage: agent …` — the binary reports its generic argv[0] — which is why the markers are flags and env vars, not the program name. A test asserts every marker still appears in that help, so a dead marker can't silently narrow the probe.

Both `--help` probes return in <0.5s, well inside the 3s cap.

## Tests

```
CrowCore     608 → 621 ✔     CrowCursor   76 ✔      CrowGrok     56 ✔
CrowEngine   720 → 723 ✔     CrowClaude   92 ✔      CrowCodex    70 ✔
CrowOpenCode  54 ✔           CrowAntigravity 41 ✔   CrowCLI     354 ✔
```

⚠️ **CrowDaemon was not run** — `swift test` there boots a real daemon, which would take this host's live environment down. The change there is comment-only.

Also fixes a **pre-existing** order-dependent flake: `hydratePreservesManagerTmuxBinding` relied on a sibling test having populated the process-wide `AgentRegistry` (a hazard the file itself documents). The three added `AgentLaunch` tests shifted parallel scheduling enough to expose it, failing ~1 run in 3; it now registers Claude Code itself and is green 5/5.

## Docs

`docs/agent-harness-matrix.md` (token row, collision bullets, risk table — the matrix had already predicted this exact fix as a follow-up) and ADR 0014's binary-discovery bullet. The harness-audit job's watch item — *"Cursor: binary token 'agent' (collision risk)"* — is now resolved; that prompt lives in machine-local config, so it isn't touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)