### PR TITLE
Drop the redundant try on /rpc's task group (CROW-993)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -74,7 +74,14 @@ enum RPCWebSocketHandler {
             // "daemon died" (CROW-956).
             let readFailure = ErrorBox()
 
-            try await withThrowingTaskGroup(of: Void.self) { group in
+            // No `try`: `withThrowingTaskGroup` is `rethrows`, and this body
+            // throws nothing — the one call that could, `group.next()`, is
+            // deliberately `try?`'d below so `shutdown()` always runs. It stays a
+            // *throwing* group because the child tasks throw; their errors are
+            // simply discarded at scope exit, which is the whole reason
+            // `readFailure` exists. Re-adding `try` only restores the warning
+            // (CROW-993).
+            await withThrowingTaskGroup(of: Void.self) { group in
                 // Writer — the sole owner of `outbound`. Unchanged: responses
                 // may now arrive out of order, but they still cross the socket
                 // one frame at a time from one task, and the client correlates


### PR DESCRIPTION
Closes #993

## Problem

`swift build` (debug) emitted:

```
Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift:77:13: warning: no calls to throwing functions occur within 'try' expression
 77 |             try await withThrowingTaskGroup(of: Void.self) { group in
    |             `- warning: no calls to throwing functions occur within 'try' expression
```

## Change

Dropped the `try`. `withThrowingTaskGroup` is `rethrows`, and this body throws nothing — the only call that could, `group.next()`, is deliberately `try?`'d so the `shutdown()` whose ordering is load-bearing always runs. The `try` was therefore already a no-op at runtime: the compiler had resolved the `rethrows` call as non-throwing, which is exactly what it was warning about. **Behaviour-identical.**

The group stays a *throwing* group on purpose. Its child tasks throw (`outbound.write`, the reader's `messages(...)`), and their errors being discarded at scope exit is the whole reason `ErrorBox` exists: the reader catches its own failure and hands it out through `readFailure`, which `onUpgrade` rethrows *after* teardown so `WSCore` can turn it into the 1009 the client sees (CROW-956). Making the group rethrow instead — the ticket's other option — would skip `eventHub.unsubscribe` and break that ordering, so I took the `try`-removal route and left a comment saying why, so it isn't helpfully restored later.

## On the warning appearing twice

That's one site, not two targets. `RPCWebSocketHandler.swift` belongs to the `CrowDaemon` library target only; the root package's `crowd` and `CrowCLI` targets consume it as a product rather than recompiling the source. The duplication is the Swift driver's batched frontend jobs re-emitting the same diagnostic. Fixing the single site clears both lines — confirmed below.

## No CHANGELOG entry

Build-log hygiene with no user-visible behaviour change, matching the recent merges that skipped it for non-user-facing work. Flagging it as a decision rather than an oversight.

## Testing

- `swift build` in `Packages/CrowDaemon` — warning gone, build clean.
- `swift build` at the repo root — **0 warnings, 0 errors** across all targets (this was the ticket's acceptance bar).
- `swift build --build-tests` in `Packages/CrowDaemon` — test target still compiles.

One note for the reviewer: `--build-tests` prints 5 `variable 'state' was never mutated` warnings from `SessionTerminalPreviewHandlerTests.swift`. Those are **pre-existing**, in a file this PR doesn't touch, and don't appear in `swift build`'s output at all since it doesn't compile tests — out of scope here rather than overlooked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)