### PR TITLE
Refit the web terminal to the visual viewport (CROW-988)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -5416,6 +5416,16 @@ function ensureTerminal() {
   // Jump-to-bottom pill (#668), shared with the desktop surface. Must load after
   // open() so the addon can anchor its button to the terminal's container.
   term.loadAddon(new CrowJumpBottomAddon.CrowJumpBottomAddon());
+  // CROW-988: keep the grid inside the *visual* viewport so a phone's software
+  // keyboard can't sit on top of the prompt line. Inert without
+  // window.visualViewport and while nothing keyboard-sized occludes the page, so
+  // desktop is untouched. Feeds the same coalesced fitTerminal every other
+  // resize route uses. Guarded like the WebGL load below — a failed asset fetch
+  // must not take ensureTerminal (and with it the whole terminal) down.
+  if (typeof CrowViewportAddon === 'object' && CrowViewportAddon
+      && typeof CrowViewportAddon.CrowViewportAddon === 'function') {
+    term.loadAddon(new CrowViewportAddon.CrowViewportAddon({ onResize: fitTerminal }));
+  }
   // WebGL renderer for throughput; must load after open(). Falls back to the
   // default renderer if the GL context is unavailable or gets lost.
   try {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <!-- CROW-988: `interactive-widget=resizes-content` makes Chrome/Android shrink
+       the LAYOUT viewport for the software keyboard, so `100dvh` below and the
+       existing window-`resize` fit path self-correct there. iOS ignores it and
+       only shrinks the visual viewport, which is what xterm-addon-crow-viewport
+       handles. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
   <title>Crow</title>
   <link rel="icon" type="image/svg+xml" href="/brand.svg">
   <link rel="stylesheet" href="/xterm/xterm.css">
@@ -76,6 +81,7 @@
   <script src="/xterm/xterm-addon-web-links.js"></script>
   <script src="/xterm/xterm-addon-webgl.js"></script>
   <script src="/xterm/xterm-addon-crow-jumpbottom.js"></script>
+  <script src="/xterm/xterm-addon-crow-viewport.js"></script>
   <script src="/app.js"></script>
   <script src="/settings.js"></script>
 </body>

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -2,7 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- CROW-988: parity with index.html. `viewport-fit=cover` lets the #1e1e1e
+       background go full-bleed (the safe-area inset on body below keeps the last
+       row off the home indicator), and `interactive-widget=resizes-content`
+       makes Chrome/Android shrink the layout viewport for the software keyboard
+       so the plain `resize` fit below self-corrects there. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
   <title>Crow Terminal</title>
   <link rel="stylesheet" href="/xterm/xterm.css">
   <style>
@@ -13,6 +18,13 @@
       height: 100%;
       overflow: hidden;
       background: #1e1e1e;
+    }
+    /* Under viewport-fit=cover the page runs under the home indicator, so inset
+       the grid — otherwise the prompt line sits behind it once the keyboard
+       closes (CROW-988). border-box keeps the page exactly one viewport tall. */
+    body {
+      box-sizing: border-box;
+      padding-bottom: env(safe-area-inset-bottom);
     }
     #terminal {
       width: 100%;
@@ -40,6 +52,7 @@
   <script src="/xterm/xterm-addon-fit.js"></script>
   <script src="/xterm/xterm-addon-image.js"></script>
   <script src="/xterm/xterm-addon-crow-jumpbottom.js"></script>
+  <script src="/xterm/xterm-addon-crow-viewport.js"></script>
   <script>
     // WebSocket transport variant of CrowTerminal's terminal.html. The xterm.js
     // config block is copied verbatim so font/scrollback/inline-image behavior
@@ -103,6 +116,15 @@
       // Jump-to-bottom pill (#668) — load after open() so it can anchor its
       // button to the terminal container.
       term.loadAddon(new CrowJumpBottomAddon.CrowJumpBottomAddon());
+      // CROW-988: keep the grid inside the visual viewport so a phone's software
+      // keyboard can't cover the prompt line. Inert without visualViewport and
+      // until something keyboard-sized occludes the page. `sendResize` is a
+      // hoisted function declaration, so passing it before its definition below
+      // is fine.
+      if (typeof CrowViewportAddon === 'object' && CrowViewportAddon
+          && typeof CrowViewportAddon.CrowViewportAddon === 'function') {
+        term.loadAddon(new CrowViewportAddon.CrowViewportAddon({ onResize: sendResize }));
+      }
 
       const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
       const ws = new WebSocket(proto + '://' + window.location.host + '/terminal');

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -284,6 +284,62 @@ import Testing
             "\(asset)'s Shift+Enter branch must cancel the event — returning false leaves xterm's own cancel unreached, so the keypress phase writes a second \\r (#875)")
     }
 
+    /// CROW-988: a software keyboard shrinks only the VISUAL viewport on iOS, so
+    /// the grid must be refit against `visualViewport` or the prompt line ends up
+    /// under the keyboard with no way to scroll it back. The logic lives in the
+    /// shared `xterm-addon-crow-viewport.js` (pinned separately by
+    /// `BundledResourcesTests.viewportAddonIsBundled`) — but an addon nobody
+    /// loads fixes nothing, and the two live pages wire their xterm setups
+    /// independently, which is exactly how the mouse-mode swallow (#776) shipped
+    /// on one surface and not the other. Pin the script tag AND the load on both.
+    ///
+    /// Also pin that the addon is handed a refit callback: the addon
+    /// deliberately doesn't call `fitAddon.fit()` itself (each page wraps the fit
+    /// in its own dedup/ownership rules), so an omitted `onResize` resizes the
+    /// host element and leaves the xterm grid at its old row count — the
+    /// clipped-rows half of the bug, silently.
+    @Test(arguments: ["app.js", "terminal.html"])
+    func terminalSurfacesRefitAgainstTheVisualViewport(asset: String) throws {
+        let code = Self.stripComments(try Self.webAsset(asset))
+        #expect(
+            code.contains("CrowViewportAddon.CrowViewportAddon("),
+            "\(asset) must construct the visual-viewport addon (CROW-988)")
+        #expect(
+            code.contains("onResize:"),
+            "\(asset) must hand the addon its own refit — the addon never calls fit() itself")
+    }
+
+    /// The `<script src>` half of the above, on the pages that own the tag.
+    /// `app.js` is loaded by `index.html`, so that's where its tag lives.
+    @Test(arguments: ["index.html", "terminal.html"])
+    func terminalPagesShipTheViewportAddon(page: String) throws {
+        let source = try Self.webAsset(page)
+        #expect(
+            source.contains("xterm-addon-crow-viewport.js"),
+            "\(page) must load the visual-viewport addon (CROW-988)")
+    }
+
+    /// `interactive-widget=resizes-content` makes Chrome/Android shrink the
+    /// LAYOUT viewport for the keyboard, which puts that platform back on the
+    /// ordinary `100dvh` + window-`resize` path the pages already handle; without
+    /// it Android overlays the keyboard and depends entirely on the addon.
+    /// `viewport-fit=cover` is what lets the terminal background go full-bleed —
+    /// `terminal.html` was the one page missing it (CROW-988).
+    @Test(arguments: ["index.html", "terminal.html"])
+    func viewportMetaHandlesTheSoftwareKeyboard(page: String) throws {
+        let source = try Self.webAsset(page)
+        let meta = try #require(
+            source.split(separator: "\n", omittingEmptySubsequences: false)
+                .first { $0.contains("name=\"viewport\"") },
+            "\(page) must declare a viewport meta")
+        #expect(
+            meta.contains("interactive-widget=resizes-content"),
+            "\(page)'s viewport meta must let Android resize the layout viewport (CROW-988)")
+        #expect(
+            meta.contains("viewport-fit=cover"),
+            "\(page)'s viewport meta must opt into the full-bleed safe-area layout")
+    }
+
     /// Cancelling a gesture and being able to perform it are one decision: a
     /// surface may only `preventDefault()` the copy chord if its copy always
     /// delivers. `navigator.clipboard` is absent over plain http (a

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,10 +2,10 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; efficiency scorecard Manager metering; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; terminal reload button; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; efficiency scorecard Manager metering; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; terminal reload button; terminal visual-viewport/software-keyboard fit; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board scorecard touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board scorecard touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board scorecard touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload visual-viewport switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
+    "test:ci": "fail=0; for f in board scorecard touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload visual-viewport switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/visual-viewport.test.js
+++ b/Packages/CrowDaemon/web-tests/visual-viewport.test.js
@@ -1,0 +1,238 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// CROW-988 regression: the visual-viewport fit addon. Drives the real
+// xterm-addon-crow-viewport.js (served to the web UI at /xterm/…) against a fake
+// visualViewport, a fake xterm and a controllable rAF, so the geometry maths and
+// the "leave every non-phone surface alone" guards are pinned without a device.
+const ADDON_JS =
+  __dirname + '/../../CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js';
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+const LAYOUT_HEIGHT = 800; // layout viewport — unchanged by an iOS keyboard
+const HOST_TOP = 120;      // the web app's terminal sits below header + tabbar
+
+// A fresh world per case: the addon holds module-free per-instance state, but
+// each test wants its own listener set, rAF queue and host element.
+function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP } = {}) {
+  const dom = new JSDOM('<!doctype html><html><body><div id="host"></div></body></html>',
+    { runScripts: 'outside-only', url: 'http://localhost/' });
+  const { window } = dom;
+
+  // rAF we drive by hand. Callbacks registered DURING a flush land in the next
+  // one, matching the browser — the addon relies on that to pin the prompt only
+  // after the page's own (frame-coalesced) refit has landed.
+  let queue = [];
+  window.requestAnimationFrame = (fn) => { queue.push(fn); return queue.length; };
+  const flush = () => { const due = queue; queue = []; due.forEach((fn) => fn()); };
+  const frames = () => queue.length;
+
+  const listeners = {};
+  const vv = {
+    height: LAYOUT_HEIGHT,
+    offsetTop: 0,
+    addEventListener: (t, fn) => { (listeners[t] = listeners[t] || []).push(fn); },
+    removeEventListener: (t, fn) => {
+      listeners[t] = (listeners[t] || []).filter((f) => f !== fn);
+    },
+  };
+  if (hasVisualViewport) window.visualViewport = vv;
+
+  Object.defineProperty(window.document.documentElement, 'clientHeight',
+    { value: LAYOUT_HEIGHT, configurable: true });
+
+  const host = window.document.getElementById('host');
+  host.getBoundingClientRect = () => ({ top: hostTop, bottom: LAYOUT_HEIGHT, height: 0 });
+  // jsdom has no layout, so clientHeight is 0 for everything — the addon reads it
+  // to tell "hidden" from "laid out", so give it a real box by default.
+  let clientHeight = LAYOUT_HEIGHT - hostTop;
+  Object.defineProperty(host, 'clientHeight', {
+    get: () => clientHeight, configurable: true,
+  });
+
+  const ctx = dom.getInternalVMContext();
+  vm.runInContext(fs.readFileSync(ADDON_JS, 'utf8'), ctx, { filename: 'crow-viewport.js' });
+
+  // Fake terminal: `term.element.parentElement` is the container passed to
+  // term.open(), which is what the addon defaults its host to.
+  const element = window.document.createElement('div');
+  host.appendChild(element);
+  const scrolls = [];
+  const resizes = [];
+  const term = {
+    element,
+    buffer: { active: { viewportY: 10, baseY: 10 } }, // at the live edge
+    scrollToBottom: () => scrolls.push(1),
+  };
+
+  const addon = new ctx.CrowViewportAddon.CrowViewportAddon({
+    onResize: () => resizes.push(1),
+  });
+
+  // Fire what iOS fires, then settle the frame(s) the addon schedules.
+  const emit = (type = 'resize') => {
+    (listeners[type] || []).forEach((fn) => fn());
+    flush();
+  };
+
+  return {
+    window, vv, host, term, addon, scrolls, resizes, listeners, flush, frames, emit,
+    activate: () => addon.activate(term),
+    height: () => host.style.height,
+    // A keyboard of `px`, iOS-style: visual viewport shrinks, layout does not.
+    keyboard: (px) => { vv.height = LAYOUT_HEIGHT - px; },
+    // `display: none` — the web app hides the terminal while a board is open.
+    hide: () => { clientHeight = 0; },
+    show: () => { clientHeight = LAYOUT_HEIGHT - hostTop; },
+  };
+}
+
+// ---- 1. No visualViewport → the page is left exactly as it was --------------
+{
+  console.log('no visualViewport');
+  const w = makeWorld({ hasVisualViewport: false });
+  w.activate();
+  check('registers no listeners', Object.keys(w.listeners).length === 0);
+  check('schedules no frames', w.frames() === 0);
+  check('writes no inline height', w.height() === '');
+  check('dispose is safe', (() => { try { w.addon.dispose(); return true; } catch (_) { return false; } })());
+}
+
+// ---- 2. Browser chrome only → still inert ----------------------------------
+{
+  console.log('browser chrome (sub-threshold occlusion)');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(60); // iOS Safari's collapsing toolbars, not a keyboard
+  w.emit();
+  check('subscribes to resize and scroll',
+    (w.listeners.resize || []).length === 1 && (w.listeners.scroll || []).length === 1);
+  check('writes no inline height', w.height() === '');
+  check('asks for no refit', w.resizes.length === 0);
+}
+
+// ---- 3. Keyboard opens → host reaches the visible bottom, prompt pinned -----
+{
+  console.log('keyboard opens');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(300);
+  w.emit();
+  // Visible bottom is 800-300 = 500 in layout coords; the host starts at 120.
+  check('host sized to the visible bottom', w.height() === '380px');
+  check('asks the page to refit', w.resizes.length === 1);
+  check('does not pin before the refit lands', w.scrolls.length === 0);
+  w.flush(); // the frame the addon deferred the pin to
+  check('pins the prompt one frame later', w.scrolls.length === 1);
+
+  // A repeat event with identical geometry must not storm the PTY with a
+  // same-size SIGWINCH.
+  w.emit();
+  check('no-ops an unchanged geometry', w.resizes.length === 1);
+}
+
+// ---- 4. Rotation with the keyboard open → recomputed ------------------------
+{
+  console.log('rotation with the keyboard open');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(300);
+  w.emit();
+  w.flush();
+  w.keyboard(200); // landscape keyboard is shorter
+  w.emit();
+  check('host resized to the new visible bottom', w.height() === '480px');
+  check('refit again', w.resizes.length === 2);
+  w.flush();
+  check('re-pins (user was at the live edge)', w.scrolls.length === 2);
+}
+
+// ---- 5. Scrolled-up user keeps their place ---------------------------------
+{
+  console.log('scrolled-up user, keyboard already open');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(300);
+  w.emit();
+  w.flush();
+  check('opening pinned once', w.scrolls.length === 1);
+  w.term.buffer.active.viewportY = 3; // scrolled back through history
+  w.keyboard(260);
+  w.emit();
+  w.flush();
+  check('refit happened', w.resizes.length === 2);
+  check('but the viewport was left alone', w.scrolls.length === 1);
+}
+
+// ---- 6. Keyboard closes → CSS takes back over -------------------------------
+{
+  console.log('keyboard closes');
+  const w = makeWorld();
+  w.host.style.height = '55%'; // a pre-existing inline height must survive
+  w.activate();
+  w.keyboard(300);
+  w.emit();
+  check('overrides while open', w.height() === '380px');
+  w.keyboard(0);
+  w.emit();
+  check('restores the height it found', w.height() === '55%');
+  check('refits on the way back', w.resizes.length === 2);
+  w.emit();
+  check('stays quiet once restored', w.resizes.length === 2);
+}
+
+// ---- 7. offsetTop is added, not subtracted ---------------------------------
+{
+  console.log('shifted visual viewport');
+  const w = makeWorld();
+  w.activate();
+  w.vv.height = 400;
+  w.vv.offsetTop = 50; // visible band is [50, 450) inside an 800px layout
+  w.emit();
+  check('host reaches offsetTop + height', w.height() === '330px'); // 450 - 120
+}
+
+// ---- 8. A host with no layout box is never sized ---------------------------
+{
+  console.log('hidden host (board open over the terminal)');
+  const w = makeWorld();
+  w.activate();
+  w.hide();
+  w.keyboard(300);
+  w.emit();
+  check('no height stranded on a hidden host', w.height() === '');
+  check('no refit asked for', w.resizes.length === 0);
+
+  // Releasing stays unconditional: hiding the terminal mid-keyboard must not
+  // strand the override, so the restore path has to run on a hidden host too.
+  w.show();
+  w.emit();
+  check('sizes once it has a box again', w.height() === '380px');
+  w.hide();
+  w.keyboard(0);
+  w.emit();
+  check('released even though the host is hidden', w.height() === '');
+}
+
+// ---- 9. dispose unwinds everything -----------------------------------------
+{
+  console.log('dispose');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(300);
+  w.emit();
+  check('applied before dispose', w.height() === '380px');
+  w.addon.dispose();
+  check('inline height released', w.height() === '');
+  check('listeners removed',
+    (w.listeners.resize || []).length === 0 && (w.listeners.scroll || []).length === 0);
+  // A frame already in flight must not touch a disposed terminal.
+  w.flush();
+  check('no pin after dispose', w.scrolls.length === 0);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js
@@ -1,0 +1,220 @@
+// Crow visual-viewport fit (CROW-988), as a shared xterm.js addon.
+//
+// On a phone, opening the software keyboard hides the agent's prompt line. iOS
+// Safari (and Chrome/Android by default) shrink the *visual* viewport and leave
+// the *layout* viewport alone, so `window.innerHeight`, `height: 100%` and even
+// `100dvh` all still report the full pre-keyboard height and `window.resize`
+// never fires. The grid keeps rendering at its old size and its bottom rows —
+// where the prompt sits — end up underneath the keyboard, unreachable (the
+// terminal surfaces are `overflow: hidden`, so they can't be scrolled into view
+// either). `window.visualViewport` is the only signal that anything changed.
+//
+// This subscribes to it and sizes the terminal's host element so its bottom
+// edge lands on the bottom of the *visible* area, then asks the page to refit
+// and pins the prompt. Written once here, as an addon, so every surface that
+// loads it stays in sync instead of hand-mirroring the logic per front-end —
+// the parity drift that bit reflow-debounce #661/#662 and the mouse-mode
+// swallow #776.
+//
+// Deliberately inert everywhere a keyboard can't occlude the page: absent
+// `visualViewport` (older embedded webviews) is a hard no-op, and so is any
+// occlusion below KEYBOARD_MIN_OCCLUSION — which is what desktop browsers and
+// mobile browser chrome produce. Nothing is written to the host's style until a
+// keyboard-sized inset actually appears, and it is restored verbatim when that
+// inset goes away.
+//
+// Loaded via <script src> (not ES modules), so it exposes a namespaced UMD-style
+// global matching the vendored addons
+// (window.FitAddon.FitAddon → window.CrowViewportAddon.CrowViewportAddon).
+(function (global) {
+  'use strict';
+
+  // How much of the layout viewport must be occluded before we treat it as a
+  // software keyboard. Mobile browser chrome (iOS Safari's collapsing toolbars)
+  // routinely puts `visualViewport.height` 40-60px below the layout viewport
+  // with no keyboard in sight, and desktop pinch-zoom is smaller still; the
+  // shortest phone keyboard — landscape, on a small device — is comfortably
+  // north of 150px. 120 separates the two without straddling either.
+  var KEYBOARD_MIN_OCCLUSION = 120;
+
+  // Never size the host below this. A pathological measurement (a mid-rotation
+  // frame, a host scrolled off the visible area) would otherwise hand
+  // FitAddon a 0-or-negative box, whose degenerate proposeDimensions makes a
+  // junk grid — the same failure the host pages already guard against.
+  var MIN_HOST_HEIGHT = 40;
+
+  /// `options.host`    element to size; defaults to the container passed to
+  ///                   `term.open()` (i.e. `term.element.parentElement`).
+  /// `options.onResize` called after the host is resized — the page's own
+  ///                   coalesced fit + PTY resize. The addon deliberately does
+  ///                   NOT call `fitAddon.fit()` itself: each surface wraps the
+  ///                   fit in its own dedup/ownership rules (app.js gates on
+  ///                   focus so a background tab can't steal tmux's shared
+  ///                   window size, #667) and reaching past that would
+  ///                   reintroduce exactly what those guards exist to stop.
+  function CrowViewportAddon(options) {
+    options = options || {};
+    this._onResize = typeof options.onResize === 'function' ? options.onResize : null;
+    this._host = options.host || null;
+    this._applied = false;      // have we written to host.style.height?
+    this._savedHeight = '';     // the inline height we found there, restored on undo
+    this._keyboardOpen = false;
+    this._pending = false;      // a frame is already scheduled
+  }
+
+  // ITerminalAddon.activate — must run after term.open() so term.element exists.
+  CrowViewportAddon.prototype.activate = function (term) {
+    var vv = global.visualViewport;
+    // No signal → leave the page exactly as it was. This is the whole
+    // "non-visualViewport webviews are unchanged" guarantee.
+    if (!vv) {
+      return;
+    }
+    var host = this._host || (term.element && term.element.parentElement);
+    if (!host) {
+      return;
+    }
+    this._term = term;
+    this._host = host;
+    this._vv = vv;
+
+    var self = this;
+    this._onChange = function () { self._schedule(); };
+    // `scroll` matters as much as `resize`: iOS reports a keyboard that shifts
+    // the visual viewport within an unchanged layout viewport as a scroll.
+    vv.addEventListener('resize', this._onChange);
+    vv.addEventListener('scroll', this._onChange);
+
+    // Evaluate once up front — a terminal can be attached with the keyboard
+    // already open (switching sessions/tabs mid-typing).
+    this._schedule();
+  };
+
+  // Coalesce a burst of viewport events into one measurement per frame. iOS
+  // emits a stream of them while the keyboard animates in.
+  CrowViewportAddon.prototype._schedule = function () {
+    if (this._pending) {
+      return;
+    }
+    this._pending = true;
+    var self = this;
+    global.requestAnimationFrame(function () {
+      self._pending = false;
+      self._apply();
+    });
+  };
+
+  CrowViewportAddon.prototype._apply = function () {
+    var term = this._term;
+    var host = this._host;
+    var vv = this._vv;
+    if (!term || !host || !vv || !host.isConnected) {
+      return; // disposed or detached between the event and the frame
+    }
+
+    var root = global.document && global.document.documentElement;
+    var layoutHeight = root ? root.clientHeight : 0;
+    // Bottom edge of the visible area in LAYOUT-viewport coordinates — the same
+    // space getBoundingClientRect() reports in, which is what makes this work
+    // for a terminal that isn't full-page (the web app's is below a header and
+    // a tab bar). `offsetTop` is how far the visual viewport has been pushed
+    // down inside the layout viewport, so it must be added, not subtracted.
+    var visibleBottom = vv.offsetTop + vv.height;
+    var occluded = layoutHeight - visibleBottom;
+
+    if (occluded <= KEYBOARD_MIN_OCCLUSION) {
+      this._restore();
+      return;
+    }
+
+    // A host with no layout box measures as a zero-rect at the document origin,
+    // which would compute a full-viewport height and strand it there for
+    // whenever the element comes back. The web app hides the whole terminal
+    // while a board is open, and a board has its own focusable inputs — so this
+    // is reachable, not theoretical. Skip only the *apply* path: releasing a
+    // height (above) is safe on a hidden element and must stay unconditional, or
+    // hiding the terminal mid-keyboard would strand the override for good.
+    if (host.clientHeight < 1) {
+      return;
+    }
+
+    var available = Math.round(visibleBottom - host.getBoundingClientRect().top);
+    var next = Math.max(available, MIN_HOST_HEIGHT) + 'px';
+    var opening = !this._keyboardOpen;
+    if (!opening && host.style.height === next) {
+      return; // geometry unchanged — a same-size refit is a needless SIGWINCH
+    }
+    if (!this._applied) {
+      this._savedHeight = host.style.height;
+      this._applied = true;
+    }
+    // Pin the prompt when the keyboard opens (revealing it is the point), and
+    // otherwise only when the user was already at the live edge — a shrinking
+    // grid can push a pinned viewport off the bottom, but someone who scrolled
+    // up with the keyboard open kept their place on purpose.
+    var pin = opening || this._atBottom();
+    this._keyboardOpen = true;
+    host.style.height = next;
+    this._refit(pin);
+  };
+
+  // Undo everything we wrote and hand sizing back to the stylesheet. Idempotent:
+  // the common case (no keyboard, ever) never took the branch that sets
+  // `_applied`, so this returns without touching the DOM.
+  CrowViewportAddon.prototype._restore = function () {
+    this._keyboardOpen = false;
+    if (!this._applied) {
+      return;
+    }
+    this._applied = false;
+    this._host.style.height = this._savedHeight;
+    this._savedHeight = '';
+    this._refit(false);
+  };
+
+  CrowViewportAddon.prototype._atBottom = function () {
+    var b = this._term.buffer && this._term.buffer.active;
+    return !b || b.viewportY >= b.baseY;
+  };
+
+  CrowViewportAddon.prototype._refit = function (pin) {
+    if (this._onResize) {
+      try { this._onResize(); } catch (_) { /* the page's fit is its own problem */ }
+    }
+    if (!pin) {
+      return;
+    }
+    // The host pages coalesce their fit to the NEXT frame, so the grid still has
+    // its pre-resize row count right now. Scrolling to the bottom here would
+    // land on the old geometry and the fit would drop the prompt back out of
+    // view — so pin one frame later, after the refit has landed.
+    var self = this;
+    global.requestAnimationFrame(function () {
+      if (!self._term) {
+        return;
+      }
+      try { self._term.scrollToBottom(); } catch (_) { /* disposed mid-frame */ }
+    });
+  };
+
+  // ITerminalAddon.dispose — the web UI creates/switches/closes terminals, so
+  // this must leave no stacked visualViewport listeners and no inline height
+  // stranded on a recycled host element.
+  CrowViewportAddon.prototype.dispose = function () {
+    if (this._vv && this._onChange) {
+      this._vv.removeEventListener('resize', this._onChange);
+      this._vv.removeEventListener('scroll', this._onChange);
+    }
+    if (this._applied && this._host) {
+      this._host.style.height = this._savedHeight;
+    }
+    this._applied = false;
+    this._keyboardOpen = false;
+    this._onChange = null;
+    this._vv = null;
+    this._host = null;
+    this._term = null;
+  };
+
+  global.CrowViewportAddon = { CrowViewportAddon: CrowViewportAddon };
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -92,6 +92,27 @@ struct BundledResourcesTests {
         #expect(body.contains("CrowJumpBottomAddon"))
     }
 
+    @Test func viewportAddonIsBundled() throws {
+        // CROW-988: the software-keyboard fit lives in this shared addon, and the
+        // daemon serves this exact file to the web UI at /xterm/…. It only ships
+        // because `Resources/xterm` is `.copy`d wholesale, so pin its presence —
+        // a missing file is a silent 404 and a keyboard-blind terminal, not a
+        // build error. Also pin the load-bearing API surface.
+        let dir = try #require(BundledResources.xtermDirectoryURL)
+        let url = dir.appendingPathComponent("xterm-addon-crow-viewport.js")
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        let body = try String(contentsOf: url, encoding: .utf8)
+        // The signal the whole fix hangs on — nothing else in the web resources
+        // subscribes to it.
+        #expect(body.contains("visualViewport"))
+        #expect(body.contains("addEventListener('resize'"))
+        #expect(body.contains("addEventListener('scroll'"))
+        // The prompt has to be pinned after the refit, or revealing it is moot.
+        #expect(body.contains("scrollToBottom"))
+        // Namespaced UMD global matching the vendored addons.
+        #expect(body.contains("CrowViewportAddon"))
+    }
+
     @Test func tmuxConfHasNoBarePrefixUnbind() throws {
         // #473: a bare `unbind-key -a` (no `-T`) defaults to the prefix
         // table, which is empty/non-existent after the first clear on


### PR DESCRIPTION
Closes #988

## Problem

On a phone, opening the software keyboard hid the agent's prompt line. iOS Safari (and Chrome/Android by default) shrink the **visual** viewport and leave the **layout** viewport alone, so `window.innerHeight`, `height: 100%` and even `100dvh` all still reported the full pre-keyboard height and `window.resize` never fired. The grid kept rendering at its old size, its bottom rows ended up under the keyboard, and `overflow: hidden` meant they couldn't be scrolled back into view either.

Nothing in `Resources/web/` subscribed to `window.visualViewport` — the only signal that anything had changed.

## Fix

New shared addon `xterm-addon-crow-viewport.js`. On `visualViewport` resize/scroll it sizes the terminal's host element so its bottom edge lands on the bottom of the *visible* area, asks the page to refit, and pins the prompt.

Written as an addon rather than inline script so the surfaces that load it stay in sync instead of hand-mirroring the logic per front-end — the parity drift that bit reflow-debounce #661/#662 and the mouse-mode swallow #776.

A few decisions worth calling out:

- **Measures from `getBoundingClientRect().top`**, not from `visualViewport.height` alone. `visibleBottom = offsetTop + height` is in layout-viewport coordinates — the same space `getBoundingClientRect()` reports in — so the same maths works for the app's grid (which sits below a header and a tab bar) and the full-page debug terminal, and a shifted visual viewport is handled rather than assumed away.
- **Pins one frame after the refit, not before.** Both pages coalesce their fit to the next frame, so a `scrollToBottom()` issued immediately would land on the pre-fit geometry and the fit would drop the prompt straight back out of view.
- **Never calls `fitAddon.fit()` itself.** Each page wraps its fit in its own dedup/ownership rules — `app.js` gates on focus so a background tab can't steal tmux's shared window size (#667) — so the addon hands back through an `onResize` callback instead of reaching past them.
- **A scrolled-up viewport is left alone.** Opening the keyboard pins (revealing the prompt is the point), and so does a refit while already at the live edge (a shrinking grid can push a pinned viewport off the bottom); someone who scrolled up with the keyboard open keeps their place.
- **A host with no layout box is never sized.** The app hides the whole terminal while a board is open, and a board has its own focusable inputs, so a zero-rect measurement would strand a full-viewport height on it. Releasing a height stays unconditional, so hiding the terminal mid-keyboard can't strand the override for good.

### Staying out of the way

The acceptance criterion "desktop and non-`visualViewport` webviews are unchanged" is enforced structurally, not by hoping:

- absent `visualViewport` → `activate()` returns before registering anything;
- occlusion ≤ 120px → no-op. That threshold sits above what mobile browser chrome (iOS Safari's collapsing toolbars, ~40-60px) and desktop pinch-zoom produce, and below the shortest phone keyboard (landscape, small device, comfortably >150px);
- nothing is written to `host.style` until a keyboard-sized inset actually appears, and the inline height found there is restored verbatim when it goes.

### Also

- `interactive-widget=resizes-content` on both viewport metas — Chrome/Android then shrinks the *layout* viewport, which puts it back on the ordinary `100dvh` + window-`resize` path the pages already handle (and makes the addon correctly no-op there, since occlusion reads ~0). iOS ignores the hint, which is what the addon is for.
- `viewport-fit=cover` on `terminal.html` for parity with `index.html`, paired with `env(safe-area-inset-bottom)` so its prompt clears the home indicator once the keyboard closes. The two go together: `cover` is what creates the inset that the padding then clears.

**`app.css` is deliberately untouched.** The ticket's safe-area point is scoped to `terminal.html` here: the app shell already handles its own safe area (`100dvh` plus the existing `env()` insets on the statusbar and hamburger), and adding padding under `#terminal-wrap` would put a permanent black band above the home indicator — a visible regression on the surface this is being fixed for, not a fix.

`CrowTerminal/Resources/xterm/terminal.html` is also untouched: that page is the **retired** WKWebView surface (its own header says fixes belong in the daemon's web resources, and it's never served). The addon file lives in that directory only because `/xterm/:file` serves the library assets out of it.

## Tests

- `web-tests/visual-viewport.test.js` — 31 checks driving the real addon against a fake `visualViewport`, fake xterm and a hand-driven rAF: geometry (including `offsetTop`), the no-`visualViewport` and sub-threshold no-ops, keyboard open/close/rotate, same-geometry dedup, scrolled-up users, hidden hosts, and `dispose` unwinding listeners + inline height. Wired into both `test` and `test:ci`.
- `BundledResourcesTests.viewportAddonIsBundled` — the file ships (it only does so because `Resources/xterm` is `.copy`d wholesale; a missing file would be a silent 404 and a keyboard-blind terminal, not a build error).
- `WebTerminalAssetTests` — three new drift guards: both live pages construct the addon, both hand it an `onResize` (an omitted one would resize the host and leave the grid at its old row count — the clipped-rows half of the bug, silently), both ship the `<script src>`, and both viewport metas carry the keyboard-aware keywords.

Full `npm run test:ci` green (15 suites), `BundledResourcesTests` green (9/9), `WebTerminalAssetTests` 15/16 — the one failure, `refreshTerminalsRebindsTheActiveTerminalToTheFreshRow`, is pre-existing on `main` (it asserts a string `|| terminals[0] || null` that doesn't appear in `origin/main`'s `app.js` either) and is untouched by this diff.

## Test plan

On a phone (iOS Safari and Chrome/Android):

1. Open a session, tap the terminal to raise the keyboard → the agent's prompt line sits fully visible directly above it.
2. Type and submit → output flows, prompt stays above the keyboard.
3. Dismiss the keyboard → full-height grid returns, no leftover gap, no clipped rows.
4. Rotate with the keyboard open → refits to the new geometry, prompt still visible.
5. Scroll up through history with the keyboard open → the viewport stays where you put it.

On desktop: resize the window, drag the splitter, open the board and come back — all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)