### PR TITLE
Open the terminal context menu on long-press (CROW-1006)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -408,8 +408,13 @@ body {
 /* #777: `touch-action: none` hands the one-finger gesture to enableTouchScroll
    instead of iOS Safari's overscroll — without it Safari rubber-bands the fixed
    xterm canvas and the swipe never reaches the buffer. Costs pinch-zoom over the
-   terminal (change the font size instead); long-press selection is unaffected. */
-#terminal { width: 100%; height: 100%; touch-action: none; }
+   terminal (change the font size instead).
+   CROW-1006: `-webkit-touch-callout: none` keeps iOS from popping its own
+   long-press sheet over the canvas, so Crow's menu (attached in app.js's boot
+   block) is the only thing a long-press here produces. Nothing is lost — the
+   grid is already `user-select: none` via xterm.css, so there is no native
+   selection to call out; the menu's Select all / Copy is the way out. */
+#terminal { width: 100%; height: 100%; touch-action: none; -webkit-touch-callout: none; }
 
 /* ---- Terminal skeleton loading overlay (#677) ----
    Masks the xterm attach/reload window (blank/garbled grid, reflow flash,
@@ -948,11 +953,16 @@ body.update-banner-visible #back-to-sidebar {
    now a tinted chip inside the PR pill, so its color can distinguish "armed"
    from "Crow gave up". See PR_AUTOMERGE_GLYPH in app.js. */
 
-/* ---- Custom right-click context menu ---- */
+/* ---- Custom right-click / long-press context menu ---- */
+/* CROW-1006: the menu now also opens on touch, where a second long-press landing
+   on it would otherwise raise iOS's text-selection callout over the item labels.
+   These are actions, not copyable text — same treatment terminal.html's #ctxmenu
+   has always had. */
 .ctx-menu {
   position: fixed; z-index: 1000; min-width: 190px; padding: 4px;
   background: var(--bg-card); border: 1px solid var(--border-strong);
   border-radius: 8px; box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  user-select: none; -webkit-user-select: none; -webkit-touch-callout: none;
 }
 .ctx-item { padding: 6px 10px; border-radius: 5px; font-size: 12px; color: var(--text-primary); cursor: pointer; }
 .ctx-item:hover { background: rgba(221, 196, 130, 0.14); }
@@ -968,6 +978,15 @@ body.update-banner-visible #back-to-sidebar {
 .ctx-hint {
   padding: 6px 10px 2px; font-size: 11px; color: var(--text-secondary);
   border-top: 1px solid var(--border-subtle); margin-top: 4px; cursor: default;
+}
+/* A 12px/6px row is a comfortable mouse target and a fiddly thumb one. Now that
+   long-press makes this menu the ONLY way to copy/paste out of the terminal on a
+   phone (CROW-1006), give the rows a finger-sized hit area there. Scoped to a
+   coarse pointer, so the desktop menu is untouched. */
+@media (pointer: coarse) {
+  .ctx-menu { min-width: 220px; }
+  .ctx-item { padding: 11px 12px; font-size: 14px; }
+  .ctx-hint { padding: 10px 12px 4px; font-size: 12px; }
 }
 
 /* ---- Detail header: gold PR chip + inline PR status ---- */

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -6605,7 +6605,22 @@ document.getElementById('back-to-sidebar').onclick = () => {
 };
 // Our own terminal context menu (copy/paste/select-all/clear) replaces the
 // browser default over the coding pane.
-document.getElementById('terminal-wrap').addEventListener('contextmenu', showTerminalMenu);
+//
+// Long-press is the touch half of the same menu (CROW-1006). xterm draws into a
+// canvas under `user-select: none`, so a phone has no native selection or copy
+// callout to fall back on here — this menu IS the mobile context menu, and
+// without a touch entry point copy and paste were simply unreachable. The bridge
+// carries its own weight even where the platform has one: iOS Safari dispatches
+// no `contextmenu` for a long-press on a plain element. Android Chrome does, so
+// both paths fire ~500ms in — harmless, because showTerminalMenu closes any open
+// menu before rebuilding it at (nearly) the same point, which reads as one menu.
+{
+  const wrap = document.getElementById('terminal-wrap');
+  wrap.addEventListener('contextmenu', showTerminalMenu);
+  attachLongPress(wrap, (x, y) => {
+    showTerminalMenu({ preventDefault() {}, clientX: x, clientY: y });
+  });
+}
 
 // Paint the left pane immediately — cached last-known layout, or skeleton
 // placeholders — before the first /rpc round-trip (CROW-613). A stale-schema

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -26,16 +26,21 @@
       box-sizing: border-box;
       padding-bottom: env(safe-area-inset-bottom);
     }
+    /* CROW-1006: iOS must not pop its own long-press sheet over the grid — the
+       #ctxmenu below is what a long-press opens here. Nothing is lost: xterm.css
+       already marks the grid `user-select: none`. */
     #terminal {
       width: 100%;
       height: 100%;
+      -webkit-touch-callout: none;
     }
-    /* Our own right-click menu — tmux's mouse menu is suppressed below. */
+    /* Our own right-click / long-press menu — tmux's mouse menu is suppressed below. */
     #ctxmenu {
       position: fixed; z-index: 50; display: none;
       background: #252526; border: 1px solid #3c3c3c; border-radius: 6px;
       padding: 4px; min-width: 140px; box-shadow: 0 4px 16px rgba(0,0,0,.4);
       font: 13px -apple-system, system-ui, sans-serif; color: #d4d4d4; user-select: none;
+      -webkit-touch-callout: none;
     }
     #ctxmenu button {
       display: block; width: 100%; text-align: left; background: none; border: 0;
@@ -43,6 +48,11 @@
     }
     #ctxmenu button:hover { background: #04395e; }
     #ctxmenu button:disabled { color: #6a6a6a; cursor: default; background: none; }
+    /* Finger-sized rows where the menu is reached by long-press (CROW-1006). */
+    @media (pointer: coarse) {
+      #ctxmenu { min-width: 200px; font-size: 15px; }
+      #ctxmenu button { padding: 11px 12px; }
+    }
   </style>
 </head>
 <body>
@@ -227,8 +237,7 @@
         b.onclick = function () { hideMenu(); fn(); };
         menu.appendChild(b);
       }
-      document.getElementById('terminal').addEventListener('contextmenu', function (e) {
-        e.preventDefault();
+      function openMenu(x, y) {
         menu.innerHTML = '';
         const hasSel = term.hasSelection();
         addItem('Copy', hasSel, copySelection);
@@ -237,9 +246,41 @@
         addItem('Clear', true, function () { term.clear(); });
         menu.style.display = 'block';
         const mw = menu.offsetWidth || 140, mh = menu.offsetHeight || 120;
-        menu.style.left = Math.min(e.clientX, window.innerWidth - mw - 4) + 'px';
-        menu.style.top = Math.min(e.clientY, window.innerHeight - mh - 4) + 'px';
+        menu.style.left = Math.min(x, window.innerWidth - mw - 4) + 'px';
+        menu.style.top = Math.min(y, window.innerHeight - mh - 4) + 'px';
+      }
+      const termEl = document.getElementById('terminal');
+      termEl.addEventListener('contextmenu', function (e) {
+        e.preventDefault();
+        openMenu(e.clientX, e.clientY);
       });
+      // Touch has no right-click, and the grid is `user-select: none`, so without
+      // this bridge copy/paste were unreachable on a phone (CROW-1006). Mirrors
+      // app.js's attachLongPress: fire at the touch point after ~500ms if the
+      // finger hasn't moved past a small threshold, then swallow the emulated
+      // click so the trailing tap doesn't immediately hideMenu().
+      (function attachLongPress(node) {
+        let timer = null, sx = 0, sy = 0, fired = false;
+        const clear = function () { if (timer) { clearTimeout(timer); timer = null; } };
+        node.addEventListener('touchstart', function (e) {
+          if (e.touches.length !== 1) { clear(); return; }
+          fired = false;
+          sx = e.touches[0].clientX;
+          sy = e.touches[0].clientY;
+          clear();
+          timer = setTimeout(function () { fired = true; timer = null; openMenu(sx, sy); }, 500);
+        }, { passive: true });
+        node.addEventListener('touchmove', function (e) {
+          if (!timer) return;
+          const t = e.touches[0];
+          if (Math.abs(t.clientX - sx) > 10 || Math.abs(t.clientY - sy) > 10) clear();
+        }, { passive: true });
+        node.addEventListener('touchend', function (e) {
+          clear();
+          if (fired) { e.preventDefault(); fired = false; }
+        });
+        node.addEventListener('touchcancel', clear, { passive: true });
+      })(termEl);
       window.addEventListener('click', hideMenu);
       window.addEventListener('blur', hideMenu);
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -340,6 +340,83 @@ import Testing
             "\(page)'s viewport meta must opt into the full-bleed safe-area layout")
     }
 
+    /// CROW-1006: both terminal surfaces must reach their context menu by
+    /// long-press, not right-click alone.
+    ///
+    /// The grid is a canvas that `xterm.css` marks `user-select: none`, so a
+    /// phone has no native selection or copy callout over it — these menus *are*
+    /// the mobile context menu, and until this bridge landed copy and paste were
+    /// unreachable there. A `contextmenu` listener is not enough on its own:
+    /// iOS Safari dispatches no `contextmenu` for a long-press on a plain
+    /// element, which is the case this exists for.
+    ///
+    /// Asserted per-surface because the two carry separate implementations (the
+    /// drift this suite exists to prevent) — `app.js` reuses its shared
+    /// `attachLongPress`, the debug page inlines an equivalent.
+    ///
+    /// Deliberately NOT run through `stripComments`: every assertion here is
+    /// positive, and the shapes matched are code, not prose. `stripComments`
+    /// pairs the `/*` inside app.js's `// … #/settings/*` line comment with a
+    /// later `*after*`, swallowing the region this registration lives in — a
+    /// hazard only *negative* guards need to bear.
+    @Test func bothTerminalSurfacesOpenTheirMenuOnLongPress() throws {
+        let appJS = try Self.webAsset("app.js")
+        #expect(
+            appJS.contains("wrap.addEventListener('contextmenu', showTerminalMenu)"),
+            "app.js must keep the desktop right-click path on #terminal-wrap")
+        #expect(
+            appJS.contains("attachLongPress(wrap,"),
+            "app.js must bridge long-press to the same menu on #terminal-wrap (CROW-1006)")
+
+        let debugPage = try Self.webAsset("terminal.html")
+        // One builder, two entry points: routing both through `openMenu` is what
+        // keeps the touch menu from drifting from the right-click one *within*
+        // the page, the way the two pages once drifted from each other.
+        #expect(
+            debugPage.contains("openMenu(e.clientX, e.clientY)")
+                && debugPage.contains("openMenu(sx, sy)"),
+            "terminal.html's right-click and long-press must build the same menu (CROW-1006)")
+    }
+
+    /// The gesture contract the bridge above depends on, pinned on both
+    /// surfaces: a press must be still, single-fingered, and held — otherwise
+    /// the menu would ambush a scroll drag (the #777 touch-scroll shim owns the
+    /// same finger) or a pinch. The trailing `preventDefault` matters just as
+    /// much: without it the emulated click lands on the surface underneath and
+    /// dismisses the menu it just opened.
+    @Test(arguments: ["app.js", "terminal.html"])
+    func longPressIsStillSingleFingeredAndHeld(asset: String) throws {
+        let code = try Self.webAsset(asset)
+        #expect(
+            code.contains("}, 500)"),
+            "\(asset)'s long-press must be held, not instant")
+        #expect(
+            code.contains("touches.length !== 1"),
+            "\(asset) must ignore multi-touch — a pinch is not a long-press")
+        #expect(
+            code.contains("> 10 ||"),
+            "\(asset) must cancel on movement so a scroll drag never opens the menu")
+        #expect(
+            code.contains("if (fired) { e.preventDefault();"),
+            "\(asset) must swallow the emulated click, or the menu closes itself")
+    }
+
+    /// iOS must not pre-empt either menu with its own long-press sheet. Nothing
+    /// is given up by suppressing it: the grid carries `user-select: none`
+    /// already, so there is no native selection for the callout to act on — only
+    /// a sheet that would race Crow's menu for the same gesture (CROW-1006).
+    @Test(arguments: ["app.css", "terminal.html"])
+    func theTerminalGridSuppressesTheIOSCallout(asset: String) throws {
+        let source = try Self.webAsset(asset)
+        let block = try #require(
+            source.range(of: "#terminal {"),
+            "\(asset) must style #terminal")
+        let rule = source[block.lowerBound...].prefix(while: { $0 != "}" })
+        #expect(
+            rule.contains("-webkit-touch-callout: none"),
+            "\(asset)'s #terminal must suppress the iOS long-press callout (CROW-1006)")
+    }
+
     /// Cancelling a gesture and being able to perform it are one decision: a
     /// surface may only `preventDefault()` the copy chord if its copy always
     /// delivers. `navigator.clipboard` is absent over plain http (a

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -52,6 +52,24 @@ swallowing a non-mouse mode like `?25`), including xterm's params-object and
 sub-parameter shapes; and graceful degradation when `activeTerminal` is null or
 an older daemon omits `agent_surface`.
 
+## `long-press.test.js` — mobile terminal context menu (CROW-1006)
+
+Drives the boot-time registration on `#terminal-wrap` against a fake xterm,
+synthesised touch events, and a controllable clock. The grid is a canvas under
+`user-select: none`, so a phone has no native selection or copy callout there —
+Crow's own menu *is* the mobile context menu, and long-press is its only touch
+entry point.
+
+Coverage: a still 500ms press opens the menu at the touch point; the trailing
+emulated click is swallowed so the tap never reaches xterm (and never closes the
+menu it just opened); a drag past the 10px threshold cancels instead and leaves
+`touchend` uncancelled, so an ordinary scroll drag keeps its native tap
+semantics; a sub-threshold wobble still counts; multi-touch (pinch) arms
+nothing; `Copy` appears only with a selection; the full touch-only `Select all`
+→ `Copy` route that is the whole point of the ticket; the agent-surface
+force-select hint; the pre-attach `term === null` guard; and the desktop
+`contextmenu` path producing the same menu at the cursor.
+
 ## `key-handler.test.js` — terminal copy/paste keys (#875)
 
 Drives `handleTerminalKey` and `pasteIntoTerminal` against a fake xterm +

--- a/Packages/CrowDaemon/web-tests/long-press.test.js
+++ b/Packages/CrowDaemon/web-tests/long-press.test.js
@@ -1,0 +1,236 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// CROW-1006: long-press → terminal context menu on touch devices. xterm draws
+// into a canvas that xterm.css marks `user-select: none`, so a phone has no
+// native selection or copy callout over the grid — Crow's own menu is the mobile
+// context menu, and before this bridge it was reachable only by right-click.
+//
+// Drives the real boot-time registration in Resources/web/app.js against a fake
+// xterm, synthesised touch events, and a controllable clock. Same harness shape
+// as touch-scroll.test.js: an epilogue evaluated in app.js's own top-level
+// lexical scope exposes the module-scope bindings the menu reads.
+const epilogue = `
+;globalThis.__t = {
+  set term(v){ term = v; },
+  set activeTerminal(v){ activeTerminal = v; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body>
+     <div id="app">
+       <div id="terminal-wrap"><div id="terminal"></div></div>
+     </div>
+   </body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.WebSocket.OPEN = 1;
+window.TextEncoder = TextEncoder; // jsdom omits it; real browsers have it
+window.setInterval = () => 0;
+window.requestAnimationFrame = () => 0;
+
+// Controllable clock. attachLongPress arms a 500ms timer and cancels it with the
+// id it got back, so ids must be truthy (its `if (timer)` guard) — hence 1-based.
+// Only the 500ms timers are ever fired by hand; app.js's own boot timers stay
+// parked, which is the point of not using real ones.
+const timers = [];
+window.setTimeout = (fn, ms) => timers.push({ fn, ms, live: true });
+window.clearTimeout = (id) => { const t = timers[id - 1]; if (t) t.live = false; };
+function fireLongPressTimers() {
+  let fired = 0;
+  for (const t of timers) {
+    if (t.live && t.ms === 500) { t.live = false; t.fn(); fired++; }
+  }
+  return fired;
+}
+
+const clipboard = [];
+Object.defineProperty(window.navigator, 'clipboard', {
+  configurable: true,
+  value: { writeText: (t) => { clipboard.push(t); return Promise.resolve(); } },
+});
+
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+// ---- Fakes -----------------------------------------------------------------
+
+const wrap = realGet('terminal-wrap');
+
+// Reset to a known state: no open menu, a fake xterm with the given selection.
+// `term = null` models the pre-attach window, where the menu must stay away.
+// Returns the fake so a case can re-wire it (T.term is a write-only accessor —
+// the epilogue exposes the binding, not its value).
+function setup({ selection = '', agentSurface = false, noTerm = false } = {}) {
+  const m = window.document.querySelector('.ctx-menu');
+  if (m) m.remove();
+  clipboard.length = 0;
+  for (const t of timers) t.live = false; // park anything left armed
+  const calls = [];
+  const term = noTerm ? null : {
+    getSelection: () => selection,
+    selectAll: () => calls.push('selectAll'),
+    clear: () => calls.push('clear'),
+  };
+  T.term = term;
+  T.activeTerminal = { id: 't1', window: 1, agent_surface: agentSurface };
+  return { calls, term };
+}
+
+const touch = (type, points) => {
+  const e = new window.Event(type, { bubbles: true, cancelable: true });
+  e.touches = points.map(([clientX, clientY]) => ({ clientX, clientY }));
+  wrap.dispatchEvent(e);
+  return e;
+};
+const rightClick = (x, y) => {
+  const e = new window.Event('contextmenu', { bubbles: true, cancelable: true });
+  e.clientX = x;
+  e.clientY = y;
+  wrap.dispatchEvent(e);
+  return e;
+};
+const menu = () => window.document.querySelector('.ctx-menu');
+const labels = () => Array.from(menu() ? menu().querySelectorAll('.ctx-item') : []).map((n) => n.textContent);
+const clickItem = (label) => {
+  const item = Array.from(menu().querySelectorAll('.ctx-item')).find((n) => n.textContent === label);
+  item.dispatchEvent(new window.Event('click', { bubbles: true, cancelable: true }));
+};
+
+// ---- The regression itself -------------------------------------------------
+
+console.log('A still long-press opens the terminal menu:');
+{
+  setup();
+  touch('touchstart', [[100, 200]]);
+  check('a 500ms timer is armed on touchstart', fireLongPressTimers() === 1);
+  check('the menu opened', !!menu());
+  check('Paste / Select all / Clear / Reload offered',
+    labels().join('|') === 'Paste|Select all|Clear|Reload terminal');
+  check('positioned at the touch point', menu().style.left === '100px' && menu().style.top === '200px');
+}
+
+console.log('\nThe trailing emulated click is swallowed:');
+{
+  setup();
+  touch('touchstart', [[100, 200]]);
+  fireLongPressTimers();
+  const end = touch('touchend', []);
+  check('touchend is preventDefault\'ed so the tap never reaches xterm', end.defaultPrevented);
+  check('the menu is still open after the finger lifts', !!menu());
+}
+
+console.log('\nA scroll drag cancels instead of opening a menu (#777 stays intact):');
+{
+  setup();
+  touch('touchstart', [[100, 200]]);
+  touch('touchmove', [[100, 260]]); // past the 10px threshold
+  check('no timer left to fire', fireLongPressTimers() === 0);
+  check('no menu', !menu());
+  const end = touch('touchend', []);
+  check('touchend is NOT preventDefault\'ed, so a drag keeps its native tap semantics',
+    !end.defaultPrevented);
+}
+
+console.log('\nA sub-threshold wobble still counts as a long-press:');
+{
+  setup();
+  touch('touchstart', [[100, 200]]);
+  touch('touchmove', [[104, 206]]); // inside the 10px threshold
+  check('the timer survives', fireLongPressTimers() === 1);
+  check('the menu opened', !!menu());
+}
+
+console.log('\nMulti-touch is not a long-press:');
+{
+  setup();
+  touch('touchstart', [[100, 200], [180, 240]]); // pinch
+  check('nothing armed', fireLongPressTimers() === 0);
+  check('no menu', !menu());
+}
+
+console.log('\nCopy is offered only when there is a selection:');
+{
+  setup({ selection: '' });
+  touch('touchstart', [[10, 10]]);
+  fireLongPressTimers();
+  check('no Copy without a selection', !labels().includes('Copy'));
+
+  setup({ selection: 'hello from the pty' });
+  touch('touchstart', [[10, 10]]);
+  fireLongPressTimers();
+  check('Copy is first once something is selected', labels()[0] === 'Copy');
+  clickItem('Copy');
+  check('tapping Copy writes the selection to the clipboard', clipboard.join() === 'hello from the pty');
+  check('the menu closes behind the tap', !menu());
+}
+
+// The whole point of the ticket: on a phone this two-step (long-press → Select
+// all, long-press → Copy) is the ONLY route to the transcript's text, since
+// xterm has no touch drag-select.
+console.log('\nSelect all → Copy is reachable entirely by touch:');
+{
+  let selection = '';
+  const { calls, term } = setup({ selection: '' });
+  term.selectAll = () => { calls.push('selectAll'); selection = 'buffer contents'; };
+  term.getSelection = () => selection;
+
+  touch('touchstart', [[10, 10]]);
+  fireLongPressTimers();
+  clickItem('Select all');
+  touch('touchend', []);
+  check('Select all ran', calls.join() === 'selectAll');
+
+  touch('touchstart', [[10, 10]]);
+  fireLongPressTimers();
+  check('the second long-press now offers Copy', labels()[0] === 'Copy');
+  clickItem('Copy');
+  check('...and it copies the selected buffer', clipboard.join() === 'buffer contents');
+}
+
+console.log('\nOn an agent surface the force-select hint still rides along:');
+{
+  setup({ agentSurface: true });
+  touch('touchstart', [[10, 10]]);
+  fireLongPressTimers();
+  check('hint shown when nothing is selected', !!menu().querySelector('.ctx-hint'));
+}
+
+console.log('\nNo terminal attached yet → no menu:');
+{
+  setup({ noTerm: true });
+  touch('touchstart', [[10, 10]]);
+  check('the timer still fires', fireLongPressTimers() === 1);
+  check('but showTerminalMenu bails', !menu());
+}
+
+console.log('\nDesktop right-click is unchanged:');
+{
+  setup({ selection: 'sel' });
+  const e = rightClick(42, 84);
+  check('the browser menu is suppressed', e.defaultPrevented);
+  check('Crow\'s menu opened', !!menu());
+  check('same items as the long-press path', labels()[0] === 'Copy');
+  check('positioned at the cursor', menu().style.left === '42px' && menu().style.top === '84px');
+}
+
+console.log('\n' + (fail ? `FAIL — ${fail} failed, ${pass} passed` : `OK — ${pass} passed`));
+process.exit(fail ? 1 : 0);

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,10 +2,10 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; efficiency scorecard Manager metering; terminal touch- and wheel-scroll; terminal scrollback re-sync; terminal key handling; terminal reload button; terminal visual-viewport/software-keyboard fit; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; efficiency scorecard Manager metering; terminal touch- and wheel-scroll; terminal long-press context menu; terminal scrollback re-sync; terminal key handling; terminal reload button; terminal visual-viewport/software-keyboard fit; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board scorecard touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload visual-viewport switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board scorecard touch-scroll wheel-scroll scrollback-hydrate key-handler terminal-reload visual-viewport switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board scorecard touch-scroll wheel-scroll long-press scrollback-hydrate key-handler terminal-reload visual-viewport switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
+    "test:ci": "fail=0; for f in board scorecard touch-scroll wheel-scroll long-press scrollback-hydrate key-handler terminal-reload visual-viewport switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"


### PR DESCRIPTION
Closes #1006

## The problem

On a phone there was no way to copy or paste out of the agent transcript. The terminal is an xterm canvas that `xterm.css` marks `user-select: none`, so the browser has **no native selection or copy callout** to offer over it — Crow's own menu (Copy / Paste / Select all / Clear / Reload) *is* the context menu for that surface. Its only entry point was a right-click, and iOS Safari dispatches no `contextmenu` for a long-press on a plain element. So on the surface that needed it most, the menu was simply unreachable.

Non-terminal surfaces (sidebar, board cards, detail header) are ordinary DOM text and already long-press-select natively — nothing there was blocking them, so nothing there changed.

## The fix

Bridge long-press to the same menu on both terminal surfaces:

- **`app.js`** reuses the shared `attachLongPress` (500 ms hold, 10 px movement threshold, single-finger) that sidebar rows already use, pointed at `#terminal-wrap` → `showTerminalMenu`. A drag past the threshold cancels, so the #777 touch-scroll shim keeps the gesture; the trailing emulated click is swallowed so the menu isn't dismissed by the very tap that opened it.
- **`terminal.html`** (the standalone debug page) had the same right-click-only menu, so it gets an equivalent inline bridge. Both of its entry points now build the menu through one `openMenu`, so they can't drift *within* the page the way the two pages once drifted from each other.

`-webkit-touch-callout: none` over each grid keeps iOS from racing the menu with its own long-press sheet. Nothing is given up: there is no native selection there for a callout to act on. Menu rows get a finger-sized hit area under `@media (pointer: coarse)`.

**Android Chrome** fires `contextmenu` for the same press, so both paths run ~500 ms in. That's harmless — `showTerminalMenu` closes any open menu before rebuilding it at the same point, so it reads as one menu.

## Desktop is unchanged

Right-click still goes through the identical `contextmenu` → `showTerminalMenu` path, with the same items at the same cursor position (pinned by a test). The coarse-pointer sizing is scoped to `pointer: coarse`, so a mouse — including on a hybrid touchscreen laptop, which reports `pointer: fine` — sees the old menu exactly.

## Test plan

`Packages/CrowDaemon/web-tests/long-press.test.js` (new, wired into `test` + `test:ci`, so it runs on the PR lane) drives the **real** boot-time registration against a fake xterm, synthesised touch events and a controllable clock — 27 assertions:

- a still 500 ms press opens the menu at the touch point
- the trailing emulated click is swallowed (menu survives the finger lifting)
- a drag past 10 px cancels instead, leaving `touchend` uncancelled
- a sub-threshold wobble still counts; multi-touch (pinch) arms nothing
- `Copy` appears only with a selection
- **the full touch-only `Select all` → `Copy` route** — the thing the ticket is actually asking for, since xterm has no touch drag-select
- the agent-surface force-select hint, the pre-attach `term === null` guard
- the desktop `contextmenu` path producing the same menu at the cursor

Plus three drift guards in `WebTerminalAssetTests` pinning the bridge, the gesture contract (held / single-fingered / still / click-swallowing) and the callout suppression into **both** surfaces — that suite exists precisely to stop these two files diverging.

Verified locally: `npm run test:ci` in `web-tests` is green (16 files), and `swift build --build-tests --package-path Packages/CrowDaemon` compiles and links. I did **not** run CrowDaemon's `swift test` — it boots `crowd` and would kill the live environment on this host; that suite runs on `release.yml`'s macOS lane. The three new assertions are pure string checks, and I verified each one byte-exactly against the shipped assets before committing.

Manual check worth doing on a phone: long-press the terminal → menu appears → **Select all** → long-press again → **Copy**, then long-press → **Paste**. And confirm a one-finger swipe still scrolls the buffer rather than opening the menu.

## Unrelated finding, not fixed here

`WebTerminalAssetTests.stripComments` pairs the `/*` inside `app.js`'s `// … #/settings/*` line comment with a later `*after*`, swallowing ~105 lines (6556–6661). No current assertion breaks — the only whole-file use is negative, so it just passes vacuously over that region — but it means a future negative guard could silently stop guarding. Flagging rather than fixing: a correct JS comment stripper (strings, regexes) is its own change. My new assertions are all positive and deliberately read the raw source, so they're immune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
