### PR TITLE
Migrate OpenCode done-detection to session.status (CROW-1000)

### DIFF
--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
@@ -42,12 +42,56 @@ import CrowCore
 /// the `@opencode-ai/sdk` `Event` union and the `Hooks` interface in
 /// `@opencode-ai/plugin` (CROW-545 review):
 ///
-///   session.created           → SessionStart     (event bus)
+///   session.created           → SessionStart      (event bus)
 ///   tool.execute.before       → PreToolUse        (hook)
 ///   tool.execute.after        → PostToolUse       (hook)
-///   session.idle              → Stop              (event bus; "agent finished")
+///   session.status {idle}     → Stop              (event bus; "agent finished")
+///   session.status {busy}     → UserPromptSubmit  (event bus; "turn started")
+///   session.status {retry}    → (none — still busy; see below)
+///   session.idle              → Stop              (deprecated fallback only)
 ///   permission.ask            → PermissionRequest (hook — see below)
 ///   session.error             → Notification      (event bus)
+///
+/// **`session.status`, not `session.idle` (CROW-1000).** Upstream deprecated
+/// `session.idle` in favor of `session.status`, whose payload is
+/// `{ sessionID, status: { type: "idle" | "busy" | "retry" } }`
+/// (`packages/schema/src/session-status-event.ts` — `Idle` is literally marked
+/// `// deprecated`). Two properties of the upstream publisher
+/// (`packages/opencode/src/session/status.ts`) drive the plugin's shape, both
+/// confirmed empirically against **opencode 1.18.5** (headless `opencode run`;
+/// the events come off the same server bus the TUI uses, but the *interactive
+/// TUI* pass is still the human re-check in CROW-1000):
+///
+///  1. **Both events fire, status first.** `SessionStatus.set` publishes
+///     `session.status` and then, only when the type is `idle`, `session.idle`
+///     — 246 µs apart in the probe. So a plugin that handles both naively emits
+///     `Stop` twice per turn. The plugin therefore latches: once *any*
+///     `session.status` arrives, this build speaks the modern event and the
+///     deprecated `session.idle` is ignored. Older builds that never emit
+///     `session.status` keep the `session.idle` path, so one plugin body works
+///     across both eras with no version probe.
+///  2. **`session.status` is published on every set, not only on changes** —
+///     the probe recorded three consecutive `busy` events in a single turn. The
+///     plugin tracks the last status per `sessionID` and acts only on
+///     transitions, so one turn costs one `UserPromptSubmit` and one `Stop`
+///     rather than a subprocess per internal status write.
+///
+/// `busy` earns its own mapping: it is the "turn started" edge OpenCode
+/// otherwise never gave us. Before this, a session left `.done` only when its
+/// first tool ran, so a turn that answered without calling a tool (or thought
+/// for a while first) showed a stale `.done` card. `retry` is a *busy*
+/// sub-state (a provider retry mid-turn), so it is normalized to `busy` for
+/// transition bookkeeping and never mapped to `Stop` — treating it as "done"
+/// would park the card on a turn that is still running.
+///
+/// **Known gap (pre-existing, not CROW-1000).** OpenCode's bus is per-*server*
+/// and `session.status` carries no parent link, so a **subagent's** child
+/// session is mapped onto this plugin's one Crow session UUID: the child going
+/// idle emits a `Stop` while the parent is still working (measured 1.9 s early
+/// on 1.18.5). The deprecated `session.idle` behaved identically, so nothing
+/// here regresses it; closing it means correlating `session.created`'s
+/// `info.parentID` and ignoring non-root sessions. See
+/// `docs/agent-harness-matrix.md` → Hook async delivery.
 ///
 /// Permission detection uses the **first-class `permission.ask` hook**, not a
 /// bus `event.type`: the SDK `Event` union has no `permission.asked` literal
@@ -200,6 +244,21 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
         const CROW = \(crow);
         const SESSION = \(session);
 
+        // Does this OpenCode build speak `session.status`? Upstream publishes
+        // BOTH `session.status {idle}` and the deprecated `session.idle` on the
+        // same turn end (status first, ~246µs earlier on 1.18.5), so handling
+        // both unconditionally would emit Stop twice. Latch on the first
+        // `session.status` we see and ignore `session.idle` from then on; a
+        // build old enough to never emit `session.status` keeps the fallback.
+        let sawSessionStatus = false;
+
+        // Last status type per sessionID. `session.status` is published on
+        // every internal status write, not only on changes (three consecutive
+        // `busy` events in one observed turn), so we act on transitions only.
+        // Absent means idle — matching upstream, which deletes the entry when a
+        // session goes idle.
+        const lastStatus = new Map();
+
         async function emit($, cwd, event, extra) {
           try {
             const payload = JSON.stringify(Object.assign({ cwd }, extra || {}));
@@ -236,9 +295,40 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
                 case "session.created":
                   await emit($, cwd, "SessionStart", { source: "startup" });
                   break;
+                case "session.status": {
+                  // Canonical idle/busy signal (`session.idle` is deprecated).
+                  sawSessionStatus = true;
+                  const props = event.properties || {};
+                  const id = props.sessionID || "";
+                  const raw = (props.status && props.status.type) || "";
+                  // `retry` is a busy sub-state (provider retry mid-turn), NOT a
+                  // finished turn — fold it into `busy` so a busy→retry→busy
+                  // round trip stays one working stretch and never reads as done.
+                  const state = raw === "retry" ? "busy" : raw;
+                  // Absent = idle, so the first `busy` of a turn is a transition.
+                  const prev = lastStatus.get(id) || "idle";
+                  if (prev === state) break;
+                  if (state === "idle") {
+                    lastStatus.delete(id);
+                    // OpenCode has finished the turn and is waiting on the user.
+                    await emit($, cwd, "Stop");
+                  } else {
+                    lastStatus.set(id, state);
+                    if (state === "busy") {
+                      // Turn started — the only "agent began working" edge
+                      // OpenCode gives us. Without it a session stays `.done`
+                      // until its first tool call. An unrecognized future state
+                      // is recorded but emits nothing.
+                      await emit($, cwd, "UserPromptSubmit");
+                    }
+                  }
+                  break;
+                }
                 case "session.idle":
-                  // OpenCode has finished the turn and is waiting on the user.
-                  await emit($, cwd, "Stop");
+                  // Deprecated upstream, and emitted alongside
+                  // `session.status {idle}` on builds that have it — so only
+                  // act on it when this build never spoke `session.status`.
+                  if (!sawSessionStatus) await emit($, cwd, "Stop");
                   break;
                 case "session.error":
                   await emit($, cwd, "Notification", { message: "Session error" });

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeSignalSource.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeSignalSource.swift
@@ -7,9 +7,11 @@ import CrowCore
 /// Crow-canonical PascalCase name in the `--event` argument, so this source
 /// shares Claude/Codex/Cursor's vocabulary verbatim: `SessionStart`,
 /// `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, `Notification`,
-/// `PermissionRequest`. The MVP plugin only emits a subset (no
-/// `UserPromptSubmit`); the extra cases are kept for cross-agent parity and
-/// to absorb events a future plugin revision may add without code changes.
+/// `PermissionRequest`. `UserPromptSubmit` and `Stop` are the two edges of
+/// OpenCode's `session.status` event (`busy` and `idle` respectively, CROW-1000);
+/// the plugin emits no other canonical names today, and the extra cases are kept
+/// for cross-agent parity and to absorb events a future plugin revision adds
+/// without code changes.
 ///
 /// The mapping is intentionally identical to `CursorSignalSource` — OpenCode
 /// and Cursor are both TUI agents whose state model (idle ⇄ working ⇄ waiting)
@@ -68,7 +70,7 @@ public struct OpenCodeSignalSource: StateSignalSource {
             }
 
         case "PermissionRequest":
-            // OpenCode's `permission.asked` maps here — the agent is blocked
+            // OpenCode's `permission.ask` hook maps here — the agent is blocked
             // waiting on a user decision.
             if currentNotificationType != "question" {
                 transition.notification = .set(HookNotification(

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
@@ -25,6 +25,9 @@ struct OpenCodeHookConfigWriterTests {
         // OpenCode event.type → Crow-canonical PascalCase.
         #expect(js.contains("case \"session.created\":"))
         #expect(js.contains("\"SessionStart\""))
+        // Done detection rides `session.status` (CROW-1000), with the
+        // deprecated `session.idle` kept only as an older-build fallback.
+        #expect(js.contains("case \"session.status\":"))
         #expect(js.contains("case \"session.idle\":"))
         #expect(js.contains("\"Stop\""))
         // Permission detection uses the first-class `permission.ask` hook, not
@@ -36,6 +39,37 @@ struct OpenCodeHookConfigWriterTests {
         #expect(js.contains("\"PostToolUse\""))
         // Prefers the git worktree path for cwd resolution.
         #expect(js.contains("worktree || directory"))
+    }
+
+    @Test func pluginSourceLatchesSessionStatusSoIdleDoesNotDoubleEmit() {
+        // Upstream publishes BOTH `session.status {idle}` and the deprecated
+        // `session.idle` at turn end (status first), so the plugin must ignore
+        // the compat event once it has seen a `session.status`.
+        let js = OpenCodeHookConfigWriter.pluginSource(crowPath: "/bin/crow")
+        #expect(js.contains("let sawSessionStatus = false;"))
+        #expect(js.contains("sawSessionStatus = true;"))
+        #expect(js.contains("if (!sawSessionStatus) await emit($, cwd, \"Stop\");"))
+    }
+
+    @Test func pluginSourceActsOnStatusTransitionsOnly() {
+        // `session.status` is published on every internal status write, not
+        // only on changes, so the plugin dedups per sessionID.
+        let js = OpenCodeHookConfigWriter.pluginSource(crowPath: "/bin/crow")
+        #expect(js.contains("const lastStatus = new Map();"))
+        #expect(js.contains("const prev = lastStatus.get(id) || \"idle\";"))
+        #expect(js.contains("if (prev === state) break;"))
+    }
+
+    @Test func pluginSourceMapsBusyToWorkingAndNeverTreatsRetryAsDone() {
+        let js = OpenCodeHookConfigWriter.pluginSource(crowPath: "/bin/crow")
+        // `busy` is the "turn started" edge — the card must leave `.done`
+        // before the first tool call.
+        #expect(js.contains("\"UserPromptSubmit\""))
+        // `retry` is a busy sub-state: folded into busy, never mapped to Stop.
+        #expect(js.contains("raw === \"retry\" ? \"busy\" : raw"))
+        // Only these two normalized states produce an emit.
+        #expect(js.contains("if (state === \"idle\") {"))
+        #expect(js.contains("if (state === \"busy\") {"))
     }
 
     @Test func globalPluginSourceSelfSuppressesWhenPerProjectExists() {

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeSignalSourceTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeSignalSourceTests.swift
@@ -61,8 +61,9 @@ struct OpenCodeSignalSourceTests {
         }
     }
 
-    @Test func sessionIdleMappedToStopMarksDone() {
-        // OpenCode's `session.idle` → canonical `Stop` in the plugin; the
+    @Test func sessionStatusIdleMappedToStopMarksDone() {
+        // OpenCode's `session.status {idle}` → canonical `Stop` in the plugin
+        // (with the deprecated `session.idle` as an older-build fallback); the
         // signal source drives `.done` + records the top-level stop.
         let t = source.transition(
             for: event("Stop"),
@@ -73,6 +74,22 @@ struct OpenCodeSignalSourceTests {
         #expect(t.newActivityState == .done)
         if case .set = t.lastTopLevelStopAt {} else {
             Issue.record("Stop should set lastTopLevelStopAt")
+        }
+    }
+
+    @Test func sessionStatusBusyMappedToUserPromptSubmitResumesWorking() {
+        // `session.status {busy}` → canonical `UserPromptSubmit`: the turn
+        // started, so a `.done` card must go back to `.working` *before* the
+        // first tool call, and the stale top-level stop must be cleared.
+        let t = source.transition(
+            for: event("UserPromptSubmit"),
+            currentActivityState: .done,
+            currentNotificationType: nil,
+            currentLastTopLevelStopAt: Date()
+        )
+        #expect(t.newActivityState == .working)
+        if case .clear = t.lastTopLevelStopAt {} else {
+            Issue.record("UserPromptSubmit should clear the stale lastTopLevelStopAt")
         }
     }
 

--- a/docs/adr/0015-harness-capability-tiers.md
+++ b/docs/adr/0015-harness-capability-tiers.md
@@ -267,8 +267,10 @@ that will close them (Cursor/Codex/OpenCode launchers are written but
   table (kept in one place so the two docs can't go stale asymmetrically);
   today it covers Codex sync-only (**v0.139.0**), the `codex_hooks`→`hooks`
   rename (**v0.139.0+**), the `ClaudeHooksEngine` reuse (**codex 0.123.0**),
-  Claude's recap subagent (**≥ 2.1.108**), and the two unpinned empirical
-  timings (Cursor async, OpenCode `session.idle` / CROW-545).
+  Claude's recap subagent (**≥ 2.1.108**), OpenCode's `session.status` done
+  signal (**opencode 1.18.5**, CROW-1000 — replaces the formerly unpinned
+  `session.idle` question), and the one still-unpinned empirical timing
+  (Cursor async).
 
 - The gating rule (8) means a partially-installed environment produces a smaller,
   correct picker rather than broken entries — but "why can't I hand off to X?"

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -376,7 +376,9 @@ All harnesses report lifecycle events by shelling out to `crow hook-event`, but
   dropping the global writer (#830).
 - **OpenCode** — no command-hook file at all; Crow installs a global **JS
   plugin** `crow-hooks.js` under `~/.config/opencode/plugins/` that subscribes to
-  OpenCode's event bus + `tool.execute.*` / `permission.ask` hooks and pipes a
+  OpenCode's event bus (`session.status` for the busy/idle edges — see
+  [Hook async delivery](#hook-async-delivery)) + `tool.execute.*` /
+  `permission.ask` hooks and pipes a
   `{cwd, …}` JSON payload to `crow hook-event --agent opencode`. `cwd`-resolved
   (`OpenCodeHookConfigWriter`).
 - **Grok** — per-worktree `.grok/hooks/crow.json`, written per session with
@@ -444,9 +446,33 @@ share the host's global config and are disambiguated by `cwd`. See
   re-check target — see below.)*
 - **Cursor:** declares `PostToolUse` / `Notification` async, but the timing is
   "one of the three things to confirm empirically" (`CursorSignalSource`).
-- **OpenCode:** event *names* are verified; the *timing/semantics* (esp. whether
-  `session.idle` is the right "done" signal for interactive TUI sessions) are an
-  open empirical question (CROW-545, `OpenCodeHookConfigWriter`).
+- **OpenCode:** event *names* are verified, and the "done" signal is now the
+  **canonical `session.status`** rather than the deprecated `session.idle`
+  (CROW-1000). Timing measured on **opencode 1.18.5** via headless
+  `opencode run`: upstream's `SessionStatus.set` publishes
+  `session.status {idle}` and then `session.idle` from the same call — 246 µs
+  apart — so the plugin latches on the first `session.status` and ignores the
+  compat event, keeping one `Stop` per turn. `session.status` is published on
+  *every* status write (three consecutive `busy` events in one observed turn),
+  so the plugin acts on transitions only. `busy` now maps to `UserPromptSubmit`,
+  which is what closed the real gap: in a live end-to-end run the turn-start
+  edge landed **6.65 s before** the first `PreToolUse`, a window the card
+  previously spent on a stale `.done`. `retry` is folded into `busy` and never
+  reads as done. ⚠️ **Still open:** the probe was headless, so the *interactive
+  TUI* claim CROW-545 originally asked about is inferred (same server bus), not
+  measured — a TUI job session is the remaining human re-check.
+- **OpenCode child sessions leak into the parent's card** (confirmed 2026-08-13,
+  opencode 1.18.5; **pre-existing**, not introduced by CROW-1000). The bus is
+  per-server, and `session.status` / `session.idle` carry only a `sessionID` —
+  no parent link — so a **subagent's** status is mapped onto the one Crow
+  session UUID like the parent's. A run that delegated to a subagent emitted
+  `SessionStart` (child `session.created`), then `Stop` when the **child** went
+  idle **1.9 s before the parent finished**, leaving the card `.done` mid-turn.
+  The deprecated `session.idle` had the identical failure, so this is a
+  standing gap rather than a regression. Fixing it means correlating
+  `session.created`'s `info.parentID` and dropping non-root sessions — a
+  distinct behavior change (it also re-opens what `SessionStart`/`PreToolUse`
+  should mean for subagents), so it is **not** in CROW-1000.
 
 > **Apply-order caveat (#903).** Since `crow hook-event` became fire-and-forget,
 > `PreToolUse` being non-async only guarantees the daemon *accepts* it ahead of
@@ -773,7 +799,7 @@ against current upstream CLIs.
 | Claude background-recap subagent must not elevate state | Claude Code **≥ 2.1.108** (`awaySummaryEnabled`) | `ClaudeHookSignalSource` | 2026-07-24 |
 | Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` | 2026-07-24 |
 | Cursor interactive `--trust` (workspace-trust seed) — reverses the earlier headless-only omission; now emitted on **every** kind incl. `.review` | **min: Cursor CLI ≥ 2026.07.20** (changelog: interactive); verified `agent 2026.08.04` (`--help` drops "headless mode only"; pty run with no `--print` writes `.workspace-trusted` / `"trustMethod": "cli-flag"`) | `CursorLaunchArgs.trustSuffix` | 2026-08-10 (CROW-954) — emitted on every path. The `.review` carve-out is **removed**: `--force` was observed NOT to suppress the trust dialog (the CROW-890 "unverified" note, now settled), so the carve-out stranded unattended reviews on a prompt that gated nothing — review already runs `--force --approve-mcps`. Review clones are now defended by the launch-path `.cursor/` strip (`shouldStripCursorReviewClone`) instead. Pre-2026.07.20 CLI out of support; probed 2026.07.23 that the parser ignores a mode-gated flag (`--output-format json --version` exits 0), so older builds no-op `--trust` rather than reject. Re-probe if `--help` ever restores the headless-only qualifier |
-| OpenCode `session.idle` "done" semantics unconfirmed for TUI | — (CROW-545) | `OpenCodeHookConfigWriter` | 2026-07-24 |
+| OpenCode "done" signal is `session.status {idle}`, not the deprecated `session.idle` | opencode **1.18.5** (probed; `session.status` present) | `OpenCodeHookConfigWriter` | 2026-08-13 (CROW-1000) — upstream publishes **both** at turn end (`session/status.ts` `set` → Status then Idle, 246 µs apart), so the plugin latches on the first `session.status` and drops the compat event; older builds keep the `session.idle` fallback. `session.status` fires on every status write, not only on changes, so transitions are deduped per `sessionID`. ⚠️ Probed via headless `opencode run`, **not** the interactive TUI — the TUI pass is the open human re-check, as is a build ≥ **1.18.16** (the version the ticket cites for the deprecation docs). Re-probe if upstream stops emitting `session.idle` (fallback becomes dead code) or adds a fourth `SessionStatus` type |
 | Antigravity flags (`agy` hooks events, `-p` non-TTY stdout, `-c`/`--conversation` resume) | `agy` **v1.1.7 (2026-07-26)** | `AntigravityAgent` / `AntigravityHookConfigWriter` | 2026-07-26 — re-probe on upgrade |
 | Antigravity structured-stdout (would promote toward first-class parity) | upstream FRs **#119/#597** (`--output-format stream-json`), **#31** (ACP) | `AntigravitySignalSource` | 2026-07-26 — hooks are the only transport until either lands |
 | Antigravity bounded auto-permission has no verified interactive launch flag | `agy` **v1.1.7**; headless `-p` ignores `permissions.allow` (issue #548) | `AntigravityLaunchArgs.autoPermissionSuffix` | 2026-07-26 |


### PR DESCRIPTION
Closes #1000

OpenCode deprecated `session.idle` in favor of `session.status`; Crow's `crow-hooks.js` still keyed done-detection off the compat event. This migrates it, and turns CROW-545's open empirical question into a measured, version-pinned answer.

## What upstream actually does

From `packages/opencode/src/session/status.ts` (and `packages/schema/src/session-status-event.ts`, where `Idle` is literally marked `// deprecated`):

```ts
const set = (sessionID, status) => {
  publish(Event.Status, { sessionID, status })
  if (status.type === "idle") publish(Event.Idle, { sessionID })   // ← both fire
}
```

Two consequences drove the implementation — both **measured on opencode 1.18.5**, not assumed:

1. **Both events fire at turn end, status first — 246 µs apart.** Handling both naively emits `Stop` twice per turn. The plugin **latches** on the first `session.status` it sees and ignores `session.idle` from then on. One body serves both eras with no version probe; a build too old to emit `session.status` keeps the fallback.
2. **`session.status` is published on every status write, not only on changes** — the probe recorded *three consecutive* `busy` events in one turn. The plugin tracks the last state per `sessionID` and acts on transitions only, so a turn costs one `UserPromptSubmit` + one `Stop` instead of a subprocess per internal write.

## Why `busy` is mapped too

This is where the user-visible win is. OpenCode gave Crow no "turn started" edge, so a session left `.done` only when its **first tool ran** — a turn that thought for a while, or answered without calling a tool, showed a stale `.done` card. `busy` → `UserPromptSubmit` closes that.

`retry` is folded into `busy`: it's a provider retry *mid-turn*, so it must never read as done, and a `busy→retry→busy` round trip stays one working stretch.

## Empirical validation

**Live end-to-end** — the actual generated plugin, real `opencode run` on 1.18.5, with a logging stand-in for `crow`:

```
SessionStart      t+0.00s
UserPromptSubmit  t+2.74s   ← new edge, 6.65s BEFORE the first tool call
PreToolUse        t+9.39s
PostToolUse       t+9.54s
Stop              t+11.42s
```

Exactly one of each — no double `Stop`, i.e. the latch suppressed the deprecated event. That 6.65 s is precisely the window the card previously spent on a stale `.done`.

The generated plugin was also driven through the **exact captured 1.18.5 event sequence** plus legacy-build, retry-folding, two-concurrent-sessions and multi-turn cases; all produce one `UserPromptSubmit` and one `Stop` per turn.

## Honest limits (recorded in the matrix, not just here)

- The probe was **headless `opencode run`, not the interactive TUI**. The events come off the same server bus, so the mapping carries — but the TUI claim CROW-545 originally asked about is *inferred*, not measured. A TUI job session is the remaining human re-check (ticket item 4).
- Verified on **1.18.5**, not the ≥ 1.18.16 the ticket cites. `session.status` is already present and fully functional at 1.18.5; re-pin after a TUI pass on a newer build.

## Gap found while probing — pre-existing, deliberately not fixed here

A subagent's **child session** publishes its own status, and `session.status` carries no parent link, so it maps onto the one Crow session UUID:

```
PreToolUse        ← parent's task tool starts
SessionStart      ← child session.created
UserPromptSubmit  ← child busy
Stop              ← CHILD idle — parent still working, card reads .done 1.9s early
PostToolUse / Stop ← parent actually finishes
```

The deprecated `session.idle` had the **identical** failure, so this is a standing gap, not a regression from this PR. Closing it means correlating `session.created`'s `info.parentID` and dropping non-root sessions — a distinct behavior change (it re-opens what `SessionStart`/`PreToolUse` should mean for subagents), so it's out of scope here and documented in the matrix. Happy to file a follow-up.

## Files

- `OpenCodeHookConfigWriter` — plugin template: `session.status` handling, latch, per-session transition dedup; `session.idle` demoted to fallback.
- `OpenCodeSignalSource` — no logic change (it already handled `UserPromptSubmit`/`Stop`); doc corrected — it no longer claims the plugin never emits `UserPromptSubmit`, and the `permission.asked` typo is now `permission.ask`.
- `docs/agent-harness-matrix.md` — Hook async delivery bullet rewritten with measured timings; the CROW-545 pin row replaced with a pinned, dated one; child-session gap documented.
- `docs/adr/0015` — OpenCode moved out of "unpinned empirical timings" (Cursor async is now the only one left).

## Test plan

- `swift test --package-path Packages/CrowOpenCode` — 58 tests pass (4 new/updated).
- Behavioral: generated plugin syntax-checked (`node --check`, `bun build`) and driven through the 5 scenarios above.
- Live: real opencode 1.18.5 run, trace above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
