### PR TITLE
Restore the visible scrollbar CROW-593 hid (CROW-1016)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -18,6 +18,16 @@
   --blue: #0A84FF;
   --purple: #BF5AF2;
   --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  /* Scrollbar (CROW-1016). Gold so the thumb reads as chrome, not content, at
+     the lowest alpha that still clears WCAG 2.2 §1.4.11's 3:1 non-text contrast
+     against every surface it can sit on — 0.50 gives 3.3:1 (--bg-card) to
+     3.6:1 (--bg-deep), where 0.30 gave a barely-there 2.0:1, which is the
+     invisibility this ticket exists to fix. Dimming this below ~0.45 re-hides
+     the bar by another name. --scroll-gutter is the track width AND the grab
+     target. */
+  --scroll-thumb: rgba(221, 196, 130, 0.50);
+  --scroll-thumb-hover: rgba(221, 196, 130, 0.72);
+  --scroll-gutter: 10px;
 }
 
 * { box-sizing: border-box; }
@@ -569,9 +579,84 @@ body.update-banner-visible #back-to-sidebar {
 #app.board-active #tabbar,
 #app.board-active #terminal-wrap { display: none; }
 
-/* Scroll, but no visible scrollbar. */
-#board, #sidebar { scrollbar-width: none; -ms-overflow-style: none; }
-#board::-webkit-scrollbar, #sidebar::-webkit-scrollbar { width: 0; height: 0; display: none; }
+/* ---- Scrollbars (CROW-1016) ----
+   CROW-593 hid the bar on #board and #sidebar for "web-UI parity". That also
+   took away the gutter people grabbed in the desktop app, leaving panes that
+   scroll with no thumb and no hint that there is more below. Restore it.
+
+   Two engines, two mechanisms, and they are not redundant:
+     * Firefox honours `scrollbar-width` / `scrollbar-color` and ignores the
+       ::-webkit- pseudo-elements.
+     * WebKit/Blink honour the pseudo-elements and ignore `scrollbar-color`.
+       Giving ::-webkit-scrollbar an explicit width ALSO opts the element out of
+       macOS overlay scrollbars, so the thumb is drawn before the wheel moves —
+       which is the whole point of the ticket, not a side effect.
+
+   Scoped to a fine pointer on purpose. This UI is driven from a phone as much
+   as a desktop, and a permanent 10px gutter is real width lost off a 350px
+   sidebar; touch platforms already draw an overlay thumb during a flick, and
+   with the hide rule gone they are free to. So: desktop gets a persistent,
+   grabbable bar, touch keeps the native overlay one. Neither gets nothing.
+
+   `.settings-body` is settings.css's pane, styled from here so the app has ONE
+   scrollbar policy rather than a copy per stylesheet (settings.css already
+   draws its palette from this file's tokens).
+
+   The selector list is spelled out per rule instead of factored into one
+   `:is(…)`. That is deliberate, not an oversight: custom-scrollbar
+   pseudo-elements resolve on an old, narrow path in WebKit/Blink, an
+   unsupported selector form drops the whole rule silently, and the failure mode
+   — a bar you cannot see — is the exact bug this ticket is fixing. Repetition
+   is the cheaper risk. */
+@media (hover: hover) and (pointer: fine) {
+  #sidebar,
+  #board,
+  .settings-body,
+  .notif-list,
+  .wizard-list {
+    scrollbar-width: thin;
+    scrollbar-color: var(--scroll-thumb) transparent;
+  }
+  #sidebar::-webkit-scrollbar,
+  #board::-webkit-scrollbar,
+  .settings-body::-webkit-scrollbar,
+  .notif-list::-webkit-scrollbar,
+  .wizard-list::-webkit-scrollbar {
+    width: var(--scroll-gutter);
+    height: var(--scroll-gutter);
+  }
+  #sidebar::-webkit-scrollbar-track,
+  #board::-webkit-scrollbar-track,
+  .settings-body::-webkit-scrollbar-track,
+  .notif-list::-webkit-scrollbar-track,
+  .wizard-list::-webkit-scrollbar-track,
+  #sidebar::-webkit-scrollbar-corner,
+  #board::-webkit-scrollbar-corner,
+  .settings-body::-webkit-scrollbar-corner,
+  .notif-list::-webkit-scrollbar-corner,
+  .wizard-list::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  /* The transparent border + content-box clip inset the *painted* thumb without
+     shrinking it: the pointer still hits the full --scroll-gutter track. */
+  #sidebar::-webkit-scrollbar-thumb,
+  #board::-webkit-scrollbar-thumb,
+  .settings-body::-webkit-scrollbar-thumb,
+  .notif-list::-webkit-scrollbar-thumb,
+  .wizard-list::-webkit-scrollbar-thumb {
+    background-color: var(--scroll-thumb);
+    background-clip: content-box;
+    border: 2px solid transparent;
+    border-radius: var(--scroll-gutter);
+  }
+  #sidebar::-webkit-scrollbar-thumb:hover,
+  #board::-webkit-scrollbar-thumb:hover,
+  .settings-body::-webkit-scrollbar-thumb:hover,
+  .notif-list::-webkit-scrollbar-thumb:hover,
+  .wizard-list::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scroll-thumb-hover);
+  }
+}
 
 .board-head { position: sticky; top: 0; z-index: 2; background: var(--bg-deep); display: flex; align-items: center; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; padding: 4px 0 8px; }
 .board-title { color: var(--gold); font-size: 18px; font-weight: 700; margin-right: auto; }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -69,6 +69,18 @@ import Testing
             .joined(separator: "\n")
     }
 
+    /// The declarations of the first CSS rule opened by `opener` — a selector's
+    /// trailing text plus ` {` — up to that rule's closing brace. Lets a pin say
+    /// WHICH rule it expects a declaration in without also freezing the
+    /// selector's line breaks and indentation (CROW-1016).
+    private static func ruleBody(openedBy opener: String, in css: String) throws -> Substring {
+        let start = try #require(css.range(of: opener), "no rule opened by \(opener)")
+        let end = try #require(
+            css.range(of: "}", range: start.upperBound..<css.endIndex),
+            "unterminated rule opened by \(opener)")
+        return css[start.upperBound..<end.lowerBound]
+    }
+
     /// The body of a top-level `function <name>(` … `\n}` block, for asserting on
     /// one handler rather than the whole file.
     private static func functionBody(_ name: String, in source: String) throws -> Substring {
@@ -619,5 +631,80 @@ import Testing
         #expect(
             css.contains("--tk-refresh:"),
             "the --tk-refresh token both the head's spacer track and the button derive from must be defined, or the var() references resolve to `none`/`auto` (CROW-924)")
+    }
+
+    /// CROW-1016: the sidebar and the board scroll with a VISIBLE bar again.
+    /// CROW-593 hid it (`scrollbar-width: none` + a zero-width
+    /// `::-webkit-scrollbar`) for "web-UI parity", which took away the gutter
+    /// people grabbed in the desktop app — nothing else regressed, so the hide
+    /// survived every suite. Pin both halves: the hide must stay gone, and each
+    /// engine's mechanism must stay present.
+    ///
+    /// Both mechanisms are load-bearing and neither substitutes for the other:
+    /// Firefox reads `scrollbar-width`/`scrollbar-color` and ignores the
+    /// pseudo-elements; WebKit/Blink read the pseudo-elements and ignore
+    /// `scrollbar-color`. The explicit `::-webkit-scrollbar` width is what opts
+    /// the element out of macOS overlay scrollbars, so losing it is exactly the
+    /// "bar you can't see until you already scrolled" the ticket rejects.
+    @Test func sidebarAndBoardKeepAVisibleScrollbar() throws {
+        // stripComments throughout: the rules' own doc comment names
+        // `scrollbar-width`, `::-webkit-scrollbar` and both engines, so a
+        // raw-file `contains` would false-pass off the prose once a declaration
+        // is deleted (mutation-checked, like the CROW-924 pins above).
+        let css = Self.stripComments(try Self.webAsset("app.css"))
+        let settingsCSS = Self.stripComments(try Self.webAsset("settings.css"))
+
+        // 1. The CROW-593 hide, in either stylesheet, is the regression itself.
+        for (name, sheet) in [("app.css", css), ("settings.css", settingsCSS)] {
+            #expect(
+                !sheet.contains("scrollbar-width: none"),
+                "\(name) must not hide the scrollbar again for overlay-chrome parity (CROW-1016)")
+            #expect(
+                !sheet.contains("-ms-overflow-style: none"),
+                "\(name) must not hide the scrollbar again via the legacy Edge/IE property (CROW-1016)")
+        }
+
+        // 2. Firefox's mechanism.
+        #expect(
+            css.contains("scrollbar-width: thin"),
+            "Firefox draws the thumb from scrollbar-width/scrollbar-color, which it needs stated (CROW-1016)")
+        #expect(
+            css.contains("scrollbar-color: var(--scroll-thumb) transparent"),
+            "the Firefox thumb must be themed off --scroll-thumb, not left as the platform default (CROW-1016)")
+
+        // 3. WebKit/Blink's — and specifically that ::-webkit-scrollbar carries
+        // an explicit width, since that (not the thumb colour) is what makes the
+        // bar persistent rather than overlay-on-scroll. Scoped to each rule's
+        // body via `ruleBody`, so moving the width onto the thumb — which sizes
+        // nothing and leaves the element on overlay — fails here.
+        #expect(
+            try Self.ruleBody(openedBy: "::-webkit-scrollbar {", in: css)
+                .contains("width: var(--scroll-gutter)"),
+            "::-webkit-scrollbar needs an explicit width or WebKit keeps the element on overlay scrollbars (CROW-1016)")
+        #expect(
+            try Self.ruleBody(openedBy: "::-webkit-scrollbar-thumb {", in: css)
+                .contains("background-color: var(--scroll-thumb)"),
+            "the WebKit thumb must be painted, or the sized track shows as an empty gutter (CROW-1016)")
+
+        // 4. Both tokens must exist: an unresolvable var() computes to the
+        // property's unset value — `width: auto` drops WebKit straight back to
+        // overlay, undoing (3) with every suite still green. `var(--scroll-…)`
+        // has no colon, so the trailing colon matches only the declarations.
+        #expect(
+            css.contains("--scroll-thumb:") && css.contains("--scroll-gutter:"),
+            "the --scroll-thumb / --scroll-gutter tokens the rules read must be defined (CROW-1016)")
+
+        // 5. The two panes the ticket names are actually covered. Scanning the
+        // scrollbar selectors (rather than pinning the whole `:is(…)` list)
+        // keeps this green when a later pane joins the list, while still failing
+        // if the sidebar or the board is dropped from it.
+        let scrollbarSelectors = css.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { $0.contains("::-webkit-scrollbar") }
+        #expect(
+            scrollbarSelectors.contains { $0.contains("#sidebar") },
+            "the sidebar session list must keep its scrollbar styling (CROW-1016)")
+        #expect(
+            scrollbarSelectors.contains { $0.contains("#board") },
+            "the ticket/reviews board must keep its scrollbar styling (CROW-1016)")
     }
 }


### PR DESCRIPTION
Closes #1016

## What

CROW-593 hid the scrollbar on `#board` and `#sidebar` for "web-UI parity" with overlay chrome:

```css
/* Scroll, but no visible scrollbar. */
#board, #sidebar { scrollbar-width: none; -ms-overflow-style: none; }
#board::-webkit-scrollbar, #sidebar::-webkit-scrollbar { width: 0; height: 0; display: none; }
```

Scroll itself kept working, so nothing ever failed — but the gutter people grabbed in the desktop app was gone, along with any hint that a pane has more content below. This deletes that rule and styles the bar instead.

## Why it takes two mechanisms

Neither reaches the other engine, so both are stated:

| Engine | Reads | Ignores |
|---|---|---|
| Firefox | `scrollbar-width` / `scrollbar-color` | `::-webkit-*` |
| WebKit / Blink | `::-webkit-scrollbar*` | `scrollbar-color` |

The explicit `::-webkit-scrollbar` **width** is the load-bearing part on WebKit: it opts the element out of macOS overlay scrollbars, so the thumb is drawn *before* the wheel moves. Dropping it silently returns the bar to "visible only once you already scrolled" — the thing the ticket rejects.

## Scoping and contrast

- **Gated to `(hover: hover) and (pointer: fine)`.** A permanent 10px gutter is real width off a 350px sidebar, and this UI is driven from a phone as much as a desktop. Touch platforms already draw an overlay thumb during a flick and — with the hide rule gone — are now free to. Desktop gets a persistent grabbable bar, touch keeps the native one, neither gets nothing.
- **Thumb is gold at 0.50 alpha**, the lowest that clears WCAG 2.2 §1.4.11's 3:1 non-text contrast on every surface it can sit on (3.3:1 on `--bg-card`, 3.6:1 on `--bg-deep`). The 0.30 I first tried measured 2.0:1 — the same invisibility by another name. Painted thumb is inset with a transparent border + `background-clip: content-box`, so the *hit* area stays the full 10px track.
- Applied to the sidebar and board (the panes the ticket names) plus the settings body and the two popover lists, so the app has one scrollbar policy rather than a per-pane accident.

The selector list is spelled out per rule rather than factored into one `:is(…)`. Deliberate: custom-scrollbar pseudo-elements resolve on a narrow path in WebKit/Blink, an unsupported selector form drops the whole rule silently, and that failure mode is exactly the bug being fixed. Repetition is the cheaper risk.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Sidebar + board show a usable vertical scrollbar on overflow | ✅ hide rule deleted, both panes styled |
| Wheel / trackpad / touch scroll still works | ✅ no `overflow` values changed; only bar *appearance* |
| Settings stays visible if it overflows | ✅ `.settings-body` never had a hide rule, and now matches the theme |
| Not hidden again for "parity" | ✅ pinned by test (below) |

## Tests

New `WebTerminalAssetTests.sidebarAndBoardKeepAVisibleScrollbar` pins both halves — the hide must stay gone from **both** stylesheets, and each engine's mechanism, the two tokens, and the two named panes must stay present. Declaration pins are scoped to their own rule via a new `ruleBody` helper, so they catch the width migrating off `::-webkit-scrollbar` without also freezing the selector's indentation. Pane coverage is checked by scanning the scrollbar selectors rather than pinning the whole list, so adding a sixth pane later doesn't turn this red.

- `swift build --build-tests` for CrowDaemon: **Build complete** (compiles clean; not run here — `swift test` boots `crowd` on this host)
- `npm run test:ci` in `web-tests`: **24 passed, 0 failed**
- app.css re-parsed through jsdom's CSSOM: all five rules land with their declarations intact, and no `scrollbar-width: none` remains
- Contrast ratios computed against all three surface tokens (see table above)

**Not verified here:** the rendered bar itself. Headless Chrome would not start in this sandbox, so the visual check — thumb visible in sidebar/board/settings on desktop, native overlay preserved on a phone — is the one step left for review.