### PR TITLE
Move the restored scrollbar off the sidebar and onto the xterm (CROW-1020)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -18,16 +18,21 @@
   --blue: #0A84FF;
   --purple: #BF5AF2;
   --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  /* Scrollbar (CROW-1016). Gold so the thumb reads as chrome, not content, at
-     the lowest alpha that still clears WCAG 2.2 §1.4.11's 3:1 non-text contrast
-     against every surface it can sit on — 0.50 gives 3.3:1 (--bg-card) to
-     3.6:1 (--bg-deep), where 0.30 gave a barely-there 2.0:1, which is the
-     invisibility this ticket exists to fix. Dimming this below ~0.45 re-hides
-     the bar by another name. --scroll-gutter is the track width AND the grab
-     target. */
+  /* Terminal scrollbar thumb (CROW-1016 → CROW-1020). Gold so it reads as
+     chrome, not content, at the lowest alpha that still clears WCAG 2.2
+     §1.4.11's 3:1 non-text contrast against the surface it sits on — 0.50 is
+     3.46:1 over the xterm background (#1e1e1e), where the 0.20 xterm derives by
+     default from the foreground measured 1.67:1, which is the invisibility
+     CROW-1020 exists to fix. Dimming this below ~0.45 re-hides the bar by
+     another name (0.45 is 3.06:1; 0.44 is 2.98:1).
+
+     Declared here rather than in app.js because these are theme tokens and this
+     is where the palette lives — but xterm paints its slider from JS `theme`
+     options, not from CSS, so app.js's scrollbarTheme() reads them back out.
+     One definition, two consumers; see the CROW-1020 note by #terminal. */
   --scroll-thumb: rgba(221, 196, 130, 0.50);
   --scroll-thumb-hover: rgba(221, 196, 130, 0.72);
-  --scroll-gutter: 10px;
+  --scroll-thumb-active: rgba(221, 196, 130, 0.90);
 }
 
 * { box-sizing: border-box; }
@@ -426,6 +431,42 @@ body {
    selection to call out; the menu's Select all / Copy is the way out. */
 #terminal { width: 100%; height: 100%; touch-action: none; -webkit-touch-callout: none; }
 
+/* ---- Terminal scrollbar (CROW-1020) ----
+   The bar people reach for to scroll back history is xterm's, and it was not
+   there when they went looking. Two separate reasons, both fixed here:
+
+   1. COLOUR (app.js). xterm paints its slider from JS `theme` options, and the
+      default is the foreground at 0.20 alpha — #d4d4d4 over #1e1e1e measures
+      1.67:1, well under WCAG 2.2 §1.4.11's 3:1. app.js's scrollbarTheme() hands
+      it the --scroll-thumb tokens instead (3.46:1). That applies on every
+      device, including touch.
+   2. PERSISTENCE (here). xterm 6 scrolls through a VS Code scrollable element
+      constructed with `vertical: ScrollbarVisibility.Auto`, so the thumb fades
+      out whenever the pointer is not over the grid — the class flips between
+      `visible` and `invisible`, and `invisible` is `opacity: 0; pointer-events:
+      none` in xterm.css. Overriding both pins it on.
+
+   `.has-scrollback` is set by app.js's updateTerminalScrollbar() and is NOT
+   decoration: with nothing to scroll, xterm sizes the slider to the FULL track
+   (its ScrollbarState returns the whole representable size when the bar is not
+   needed), so pinning it unconditionally would draw a permanent gold stripe
+   down the right of every alt-buffer agent session. Gated on real history, the
+   bar appears exactly when there is something to reach.
+
+   Scoped to a fine pointer, unlike the colour half. Not for width — FitAddon
+   already subtracts the 14px scrollbar from the column count on every device
+   whenever scrollback is non-zero, so the gutter is paid for regardless — but
+   for hit-testing: restoring `pointer-events` on touch would let a flick that
+   starts in that gutter drive the slider AND enableTouchScroll's one-finger
+   shim from the same gesture. Touch keeps xterm's own reveal-on-scroll, which
+   is now actually visible thanks to (1). */
+@media (hover: hover) and (pointer: fine) {
+  #terminal-wrap.has-scrollback .xterm-scrollable-element > .scrollbar.vertical {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 /* ---- Terminal skeleton loading overlay (#677) ----
    Masks the xterm attach/reload window (blank/garbled grid, reflow flash,
    mid-paint scrollback replay) with the CROW-613 .skel shimmer, restyled as
@@ -579,84 +620,15 @@ body.update-banner-visible #back-to-sidebar {
 #app.board-active #tabbar,
 #app.board-active #terminal-wrap { display: none; }
 
-/* ---- Scrollbars (CROW-1016) ----
-   CROW-593 hid the bar on #board and #sidebar for "web-UI parity". That also
-   took away the gutter people grabbed in the desktop app, leaving panes that
-   scroll with no thumb and no hint that there is more below. Restore it.
-
-   Two engines, two mechanisms, and they are not redundant:
-     * Firefox honours `scrollbar-width` / `scrollbar-color` and ignores the
-       ::-webkit- pseudo-elements.
-     * WebKit/Blink honour the pseudo-elements and ignore `scrollbar-color`.
-       Giving ::-webkit-scrollbar an explicit width ALSO opts the element out of
-       macOS overlay scrollbars, so the thumb is drawn before the wheel moves —
-       which is the whole point of the ticket, not a side effect.
-
-   Scoped to a fine pointer on purpose. This UI is driven from a phone as much
-   as a desktop, and a permanent 10px gutter is real width lost off a 350px
-   sidebar; touch platforms already draw an overlay thumb during a flick, and
-   with the hide rule gone they are free to. So: desktop gets a persistent,
-   grabbable bar, touch keeps the native overlay one. Neither gets nothing.
-
-   `.settings-body` is settings.css's pane, styled from here so the app has ONE
-   scrollbar policy rather than a copy per stylesheet (settings.css already
-   draws its palette from this file's tokens).
-
-   The selector list is spelled out per rule instead of factored into one
-   `:is(…)`. That is deliberate, not an oversight: custom-scrollbar
-   pseudo-elements resolve on an old, narrow path in WebKit/Blink, an
-   unsupported selector form drops the whole rule silently, and the failure mode
-   — a bar you cannot see — is the exact bug this ticket is fixing. Repetition
-   is the cheaper risk. */
-@media (hover: hover) and (pointer: fine) {
-  #sidebar,
-  #board,
-  .settings-body,
-  .notif-list,
-  .wizard-list {
-    scrollbar-width: thin;
-    scrollbar-color: var(--scroll-thumb) transparent;
-  }
-  #sidebar::-webkit-scrollbar,
-  #board::-webkit-scrollbar,
-  .settings-body::-webkit-scrollbar,
-  .notif-list::-webkit-scrollbar,
-  .wizard-list::-webkit-scrollbar {
-    width: var(--scroll-gutter);
-    height: var(--scroll-gutter);
-  }
-  #sidebar::-webkit-scrollbar-track,
-  #board::-webkit-scrollbar-track,
-  .settings-body::-webkit-scrollbar-track,
-  .notif-list::-webkit-scrollbar-track,
-  .wizard-list::-webkit-scrollbar-track,
-  #sidebar::-webkit-scrollbar-corner,
-  #board::-webkit-scrollbar-corner,
-  .settings-body::-webkit-scrollbar-corner,
-  .notif-list::-webkit-scrollbar-corner,
-  .wizard-list::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-  /* The transparent border + content-box clip inset the *painted* thumb without
-     shrinking it: the pointer still hits the full --scroll-gutter track. */
-  #sidebar::-webkit-scrollbar-thumb,
-  #board::-webkit-scrollbar-thumb,
-  .settings-body::-webkit-scrollbar-thumb,
-  .notif-list::-webkit-scrollbar-thumb,
-  .wizard-list::-webkit-scrollbar-thumb {
-    background-color: var(--scroll-thumb);
-    background-clip: content-box;
-    border: 2px solid transparent;
-    border-radius: var(--scroll-gutter);
-  }
-  #sidebar::-webkit-scrollbar-thumb:hover,
-  #board::-webkit-scrollbar-thumb:hover,
-  .settings-body::-webkit-scrollbar-thumb:hover,
-  .notif-list::-webkit-scrollbar-thumb:hover,
-  .wizard-list::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scroll-thumb-hover);
-  }
-}
+/* Scroll, but no visible scrollbar.
+   CROW-1016 briefly gave these two panes a permanent styled gutter; CROW-1020
+   took it back out. The bar people actually reach for is the TERMINAL's history
+   thumb (see the CROW-1020 note by #terminal) — the session list and the board
+   are overlay chrome, and a permanent 10px gutter is real width lost off a
+   350px sidebar on a UI that is driven from a phone as much as a desktop.
+   Restoring the terminal bar is not a reason to keep this one. */
+#board, #sidebar { scrollbar-width: none; -ms-overflow-style: none; }
+#board::-webkit-scrollbar, #sidebar::-webkit-scrollbar { width: 0; height: 0; display: none; }
 
 .board-head { position: sticky; top: 0; z-index: 2; background: var(--bg-deep); display: flex; align-items: center; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; padding: 4px 0 8px; }
 .board-title { color: var(--gold); font-size: 18px; font-weight: 700; margin-right: auto; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -5443,6 +5443,53 @@ function appOwnsScroll() {
   return !!(buf && buf.type === 'alternate');
 }
 
+// CROW-1020: xterm paints its scrollbar slider from the JS `theme` object, not
+// from CSS, so the gold thumb has to be handed across from app.css's --scroll-*
+// tokens rather than styled in place. Left alone, xterm derives the slider from
+// the FOREGROUND at 0.20 alpha — #d4d4d4 over #1e1e1e is 1.67:1, under WCAG 2.2
+// §1.4.11's 3:1 floor, which is why the bar read as "gone" even while it was
+// technically being drawn.
+//
+// A missing token yields an omitted key, so xterm falls back to its own default
+// instead of us duplicating the literal here — app.css stays the one place the
+// palette is written down. `rgba(r, g, b, a)` is one of the forms xterm's
+// css.toColor parses (alongside #rgb/#rrggbb/#rrggbbaa), so the token text goes
+// over verbatim.
+const TERM_SCROLLBAR_TOKENS = {
+  scrollbarSliderBackground: '--scroll-thumb',
+  scrollbarSliderHoverBackground: '--scroll-thumb-hover',
+  scrollbarSliderActiveBackground: '--scroll-thumb-active',
+};
+function scrollbarTheme() {
+  const theme = {};
+  if (typeof getComputedStyle !== 'function' || !document.documentElement) return theme;
+  const css = getComputedStyle(document.documentElement);
+  for (const key of Object.keys(TERM_SCROLLBAR_TOKENS)) {
+    const value = (css.getPropertyValue(TERM_SCROLLBAR_TOKENS[key]) || '').trim();
+    if (value) theme[key] = value;
+  }
+  return theme;
+}
+
+// CROW-1020: xterm 6 scrolls through a VS Code scrollable element built with
+// `vertical: ScrollbarVisibility.Auto`, so the thumb fades out whenever the
+// pointer is off the grid — you cannot grab what is not drawn. app.css pins it
+// visible while this class is on.
+//
+// The class is gated on the buffer actually HAVING history, not just on the
+// surface allowing it: with nothing to scroll, xterm sizes the slider to the
+// whole track, so an ungated pin would paint a permanent stripe down every
+// empty terminal. `baseY` (lines that have scrolled off the top) is exactly
+// xterm's own "is the bar needed" test, and it is 0 in the alternate screen —
+// which is where alt-buffer agents like Claude Code live and where there is no
+// local scrollback to reach anyway (see applySurfaceScrollback).
+function updateTerminalScrollbar() {
+  const wrap = document.getElementById('terminal-wrap');
+  if (!wrap) return;
+  const buf = term && term.buffer && term.buffer.active;
+  wrap.classList.toggle('has-scrollback', !!buf && buf.baseY > 0);
+}
+
 function ensureTerminal() {
   if (term) return;
   fitAddon = new FitAddon.FitAddon();
@@ -5457,7 +5504,7 @@ function ensureTerminal() {
     cursorBlink: true,
     fontSize: 14,
     fontFamily: DEFAULT_TERM_FONT,
-    theme: { background: '#1e1e1e', foreground: '#d4d4d4' },
+    theme: { background: '#1e1e1e', foreground: '#d4d4d4', ...scrollbarTheme() },
     scrollback: UNIFIED_SCROLLBACK,
     allowTransparency: true,
     // Escape hatch for agent surfaces, where we stop swallowing mouse modes so
@@ -5506,6 +5553,14 @@ function ensureTerminal() {
   // CROW-934: hydrate the shell scrollback from tmux when the user reaches the
   // top of what the live stream actually delivered.
   term.onScroll(maybeHydrateScrollback);
+  // CROW-1020: keep the "there is history to grab" class in step with the
+  // buffer. Same pair of triggers as the #668 jump-to-bottom pill, for the same
+  // reason — onScroll is what fires when the user moves, onRender is what fires
+  // when output (or a tab bind, or a reload) changes what there is to move
+  // through. classList.toggle with an unchanged value is a no-op, so the
+  // per-frame call costs nothing.
+  term.onScroll(updateTerminalScrollbar);
+  term.onRender(updateTerminalScrollbar);
   term.attachCustomKeyEventHandler(handleTerminalKey);
   enableTouchScroll(document.getElementById('terminal'));
   enableWheelScroll(document.getElementById('terminal'));

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -633,78 +633,90 @@ import Testing
             "the --tk-refresh token both the head's spacer track and the button derive from must be defined, or the var() references resolve to `none`/`auto` (CROW-924)")
     }
 
-    /// CROW-1016: the sidebar and the board scroll with a VISIBLE bar again.
-    /// CROW-593 hid it (`scrollbar-width: none` + a zero-width
-    /// `::-webkit-scrollbar`) for "web-UI parity", which took away the gutter
-    /// people grabbed in the desktop app — nothing else regressed, so the hide
-    /// survived every suite. Pin both halves: the hide must stay gone, and each
-    /// engine's mechanism must stay present.
+    /// CROW-1020: the scrollbar policy, both halves of it.
     ///
-    /// Both mechanisms are load-bearing and neither substitutes for the other:
-    /// Firefox reads `scrollbar-width`/`scrollbar-color` and ignores the
-    /// pseudo-elements; WebKit/Blink read the pseudo-elements and ignore
-    /// `scrollbar-color`. The explicit `::-webkit-scrollbar` width is what opts
-    /// the element out of macOS overlay scrollbars, so losing it is exactly the
-    /// "bar you can't see until you already scrolled" the ticket rejects.
-    @Test func sidebarAndBoardKeepAVisibleScrollbar() throws {
-        // stripComments throughout: the rules' own doc comment names
-        // `scrollbar-width`, `::-webkit-scrollbar` and both engines, so a
+    /// CROW-1016 read "the scrollbar is gone" as being about `#sidebar`/`#board`
+    /// — those were the panes carrying CROW-593's hide rule — and #1019 gave
+    /// them a permanent styled gutter. Wrong surface: what people grab is the
+    /// TERMINAL's history thumb. So this pins the corrected split, in one test
+    /// because the two halves are one decision and must not drift apart:
+    ///
+    ///   * the sidebar and board stay overlay chrome (hide rule restored);
+    ///   * the terminal gets a bar you can see and grab.
+    ///
+    /// The terminal half needs BOTH of its pieces, and neither substitutes for
+    /// the other. xterm 6 paints its slider from JS `theme` options (so the
+    /// colour has to come from app.js, not CSS) and builds its scrollable
+    /// element with `ScrollbarVisibility.Auto` (so the thumb fades out unless
+    /// CSS pins it). Half of that leaves either an invisible bar or a
+    /// disappearing one — which is the bug, twice over.
+    @Test func sidebarStaysOverlayAndTerminalGetsAVisibleScrollbar() throws {
+        // stripComments throughout: these rules' own doc comments name
+        // `scrollbar-width: none`, `.has-scrollback` and both engines, so a
         // raw-file `contains` would false-pass off the prose once a declaration
         // is deleted (mutation-checked, like the CROW-924 pins above).
         let css = Self.stripComments(try Self.webAsset("app.css"))
-        let settingsCSS = Self.stripComments(try Self.webAsset("settings.css"))
+        let appJS = Self.stripComments(try Self.webAsset("app.js"))
 
-        // 1. The CROW-593 hide, in either stylesheet, is the regression itself.
-        for (name, sheet) in [("app.css", css), ("settings.css", settingsCSS)] {
+        // 1. Sidebar and board are back to scrolling without a gutter. Scoped to
+        // the rule body so this fails if the hide migrates to some other pane
+        // and leaves these two pinned open.
+        let hide = try Self.ruleBody(openedBy: "#board, #sidebar {", in: css)
+        #expect(
+            hide.contains("scrollbar-width: none"),
+            "the sidebar/board hide must stay: they are overlay chrome, and a permanent gutter is real width off a 350px sidebar (CROW-1020)")
+        #expect(
+            hide.contains("-ms-overflow-style: none"),
+            "the legacy Edge/IE half of the hide belongs with it (CROW-1020)")
+        #expect(
+            try Self.ruleBody(openedBy: "#board::-webkit-scrollbar, #sidebar::-webkit-scrollbar {", in: css)
+                .contains("width: 0"),
+            "WebKit/Blink ignore scrollbar-width, so the pseudo-element half of the hide is not optional (CROW-1020)")
+
+        // 2. The terminal's bar is pinned visible. `opacity` alone is not
+        // enough — xterm.css's `.invisible` sets `pointer-events: none` too, so
+        // dropping that line leaves a thumb you can see and cannot grab, which
+        // is a subtler version of the same complaint.
+        let termBar = try Self.ruleBody(
+            openedBy: "#terminal-wrap.has-scrollback .xterm-scrollable-element > .scrollbar.vertical {",
+            in: css)
+        #expect(
+            termBar.contains("opacity: 1"),
+            "the terminal thumb must be pinned opaque, or xterm's Auto visibility fades it out whenever the pointer leaves (CROW-1020)")
+        #expect(
+            termBar.contains("pointer-events: auto"),
+            "xterm.css's .invisible also kills pointer-events, so the thumb must be made grabbable and not merely visible (CROW-1020)")
+
+        // 3. …and only while there is history. Ungated, the pin would paint a
+        // permanent stripe down every empty terminal: xterm sizes the slider to
+        // the FULL track when the bar is not needed. The class is toggled from
+        // app.js off the buffer's baseY (behaviour covered by
+        // web-tests/terminal-scrollbar.test.js); what this pins is that the CSS
+        // still asks for it rather than matching #terminal-wrap outright.
+        #expect(
+            appJS.contains("classList.toggle('has-scrollback'"),
+            "app.css gates the terminal thumb on .has-scrollback, so app.js must still be the thing that sets it (CROW-1020)")
+
+        // 4. The colour handoff. xterm derives the slider from the FOREGROUND at
+        // 0.20 alpha — 1.67:1 on #1e1e1e, under WCAG 2.2 §1.4.11's 3:1 — so
+        // without an explicit theme the pinned bar is pinned invisible, and
+        // every assertion above still passes.
+        #expect(
+            appJS.contains("scrollbarSliderBackground: '--scroll-thumb'"),
+            "xterm paints its slider from JS theme options, so the thumb colour must be handed over there (CROW-1020)")
+        #expect(
+            appJS.contains("...scrollbarTheme()"),
+            "scrollbarTheme() must actually reach the Terminal's theme, not just be defined (CROW-1020)")
+
+        // 5. The tokens it reads must exist: a missing one is dropped rather
+        // than sent as an empty string (xterm's css.toColor THROWS on that, at
+        // construction), so this failing means a silently default-coloured bar.
+        // `var(--scroll-…)` has no colon, so the trailing colon matches only the
+        // declarations.
+        for token in ["--scroll-thumb:", "--scroll-thumb-hover:", "--scroll-thumb-active:"] {
             #expect(
-                !sheet.contains("scrollbar-width: none"),
-                "\(name) must not hide the scrollbar again for overlay-chrome parity (CROW-1016)")
-            #expect(
-                !sheet.contains("-ms-overflow-style: none"),
-                "\(name) must not hide the scrollbar again via the legacy Edge/IE property (CROW-1016)")
+                css.contains(token),
+                "the \(token.dropLast()) token app.js reads for xterm's slider must be defined (CROW-1020)")
         }
-
-        // 2. Firefox's mechanism.
-        #expect(
-            css.contains("scrollbar-width: thin"),
-            "Firefox draws the thumb from scrollbar-width/scrollbar-color, which it needs stated (CROW-1016)")
-        #expect(
-            css.contains("scrollbar-color: var(--scroll-thumb) transparent"),
-            "the Firefox thumb must be themed off --scroll-thumb, not left as the platform default (CROW-1016)")
-
-        // 3. WebKit/Blink's — and specifically that ::-webkit-scrollbar carries
-        // an explicit width, since that (not the thumb colour) is what makes the
-        // bar persistent rather than overlay-on-scroll. Scoped to each rule's
-        // body via `ruleBody`, so moving the width onto the thumb — which sizes
-        // nothing and leaves the element on overlay — fails here.
-        #expect(
-            try Self.ruleBody(openedBy: "::-webkit-scrollbar {", in: css)
-                .contains("width: var(--scroll-gutter)"),
-            "::-webkit-scrollbar needs an explicit width or WebKit keeps the element on overlay scrollbars (CROW-1016)")
-        #expect(
-            try Self.ruleBody(openedBy: "::-webkit-scrollbar-thumb {", in: css)
-                .contains("background-color: var(--scroll-thumb)"),
-            "the WebKit thumb must be painted, or the sized track shows as an empty gutter (CROW-1016)")
-
-        // 4. Both tokens must exist: an unresolvable var() computes to the
-        // property's unset value — `width: auto` drops WebKit straight back to
-        // overlay, undoing (3) with every suite still green. `var(--scroll-…)`
-        // has no colon, so the trailing colon matches only the declarations.
-        #expect(
-            css.contains("--scroll-thumb:") && css.contains("--scroll-gutter:"),
-            "the --scroll-thumb / --scroll-gutter tokens the rules read must be defined (CROW-1016)")
-
-        // 5. The two panes the ticket names are actually covered. Scanning the
-        // scrollbar selectors (rather than pinning the whole `:is(…)` list)
-        // keeps this green when a later pane joins the list, while still failing
-        // if the sidebar or the board is dropped from it.
-        let scrollbarSelectors = css.split(separator: "\n", omittingEmptySubsequences: false)
-            .filter { $0.contains("::-webkit-scrollbar") }
-        #expect(
-            scrollbarSelectors.contains { $0.contains("#sidebar") },
-            "the sidebar session list must keep its scrollbar styling (CROW-1016)")
-        #expect(
-            scrollbarSelectors.contains { $0.contains("#board") },
-            "the ticket/reviews board must keep its scrollbar styling (CROW-1016)")
     }
 }

--- a/Packages/CrowDaemon/web-tests/package.json
+++ b/Packages/CrowDaemon/web-tests/package.json
@@ -2,10 +2,10 @@
   "name": "crow-web-tests",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless jsdom regression tests for the web UI (Ticket Board; efficiency scorecard Manager metering; terminal touch- and wheel-scroll; terminal long-press context menu; terminal scrollback re-sync; terminal key handling; terminal reload button; terminal visual-viewport/software-keyboard fit; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
+  "description": "Headless jsdom regression tests for the web UI (Ticket Board; efficiency scorecard Manager metering; terminal touch- and wheel-scroll; terminal long-press context menu; terminal scrollback re-sync; terminal history scrollbar; terminal key handling; terminal reload button; terminal visual-viewport/software-keyboard fit; session switcher overlay; sidebar session rows; sidebar grouping/collapse; sidebar select toggle; JSON-RPC deadlines and late responses; JSON-RPC close codes; hash URL routing; version-update banner). Drives the real app.js from Resources/web against mocks.",
   "scripts": {
-    "test": "fail=0; for f in board scorecard touch-scroll wheel-scroll long-press scrollback-hydrate key-handler terminal-reload visual-viewport switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
-    "test:ci": "fail=0; for f in board scorecard touch-scroll wheel-scroll long-press scrollback-hydrate key-handler terminal-reload visual-viewport switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
+    "test": "fail=0; for f in board scorecard touch-scroll wheel-scroll long-press scrollback-hydrate terminal-scrollbar key-handler terminal-reload visual-viewport switcher row sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail",
+    "test:ci": "fail=0; for f in board scorecard touch-scroll wheel-scroll long-press scrollback-hydrate terminal-scrollbar key-handler terminal-reload visual-viewport switcher sidebar-groups sidebar-select rpc-timeout rpc-close-code router version-banner; do node \"$f.test.js\" || fail=1; done; exit $fail"
   },
   "devDependencies": {
     "jsdom": "^24.0.0"

--- a/Packages/CrowDaemon/web-tests/terminal-scrollbar.test.js
+++ b/Packages/CrowDaemon/web-tests/terminal-scrollbar.test.js
@@ -1,0 +1,166 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// CROW-1020: the terminal's history scrollbar. xterm 6 scrolls through a VS Code
+// scrollable element built with `vertical: ScrollbarVisibility.Auto`, so its
+// thumb fades out whenever the pointer leaves the grid; app.css pins it visible
+// while `#terminal-wrap` carries `.has-scrollback`, and `updateTerminalScrollbar`
+// is what puts that class on and takes it off.
+//
+// The gate is the load-bearing part, so that is what this drives. With nothing
+// to scroll xterm sizes the slider to the WHOLE track, so a class that stuck on
+// would paint a permanent stripe down every empty terminal — "off when there is
+// no history" is as much of a requirement as "on when there is".
+//
+// `scrollbarTheme` is driven too: xterm paints its slider from JS theme options,
+// so a token that never reaches them is a bar that is pinned visible in exactly
+// the colour that made it invisible.
+const epilogue = `
+;globalThis.__t = {
+  updateTerminalScrollbar(){ return updateTerminalScrollbar(); },
+  scrollbarTheme(){ return scrollbarTheme(); },
+  set term(v){ term = v; },
+};
+`;
+const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
+const appjs = fs.readFileSync(APP_JS, 'utf8') + epilogue;
+
+const dom = new JSDOM(
+  `<!doctype html><html><body><div id="terminal-wrap"><div id="terminal"></div></div></body></html>`,
+  { runScripts: 'outside-only', pretendToBeVisual: true, url: 'http://localhost/' }
+);
+const { window } = dom;
+window.WebSocket = function () {
+  return { send() {}, close() {},
+    set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
+};
+window.WebSocket.OPEN = 1;
+window.TextEncoder = TextEncoder;
+window.setInterval = () => 0;
+window.setTimeout = () => 0;
+window.requestAnimationFrame = () => 0;
+
+// Unlike the other harnesses this one does NOT stub getElementById away, because
+// the class lands on a real `#terminal-wrap` and the assertions read it back. Any
+// other id app.js reaches for during load still has to resolve, though.
+const realGet = window.document.getElementById.bind(window.document);
+window.document.getElementById = (id) =>
+  realGet(id) || window.document.createElement('div');
+
+const ctx = dom.getInternalVMContext();
+try { vm.runInContext(appjs, ctx, { filename: 'app.js' }); }
+catch (e) { console.log('[load warn]', e.message); }
+const T = ctx.__t;
+if (!T) { console.log('FATAL: epilogue did not run (app.js threw before it)'); process.exit(2); }
+
+let pass = 0, fail = 0;
+const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name); } else { fail++; console.log('  ✗ ' + name); } };
+
+const wrap = window.document.getElementById('terminal-wrap');
+const shown = () => wrap.classList.contains('has-scrollback');
+
+// `baseY` is how many lines have scrolled off the top — xterm's own test for
+// whether the bar is needed, and 0 in the alternate screen.
+function setTerm(baseY) {
+  T.term = baseY === null ? null : { buffer: { active: { baseY, viewportY: 0 } } };
+}
+
+console.log('terminal scrollbar (CROW-1020)');
+
+{
+  setTerm(0);
+  T.updateTerminalScrollbar();
+  check('an empty buffer gets no bar', !shown());
+}
+{
+  setTerm(1);
+  T.updateTerminalScrollbar();
+  check('one line of history is enough to show it', shown());
+}
+{
+  setTerm(19949);
+  T.updateTerminalScrollbar();
+  check('a deep buffer keeps it shown', shown());
+}
+{
+  // Switching to an alt-buffer agent (Claude Code) or clearing the screen drops
+  // baseY back to 0. The class has to come off, or the pinned slider — sized to
+  // the full track when it is not needed — becomes a permanent stripe.
+  setTerm(500);
+  T.updateTerminalScrollbar();
+  setTerm(0);
+  T.updateTerminalScrollbar();
+  check('dropping back to no history hides it again', !shown());
+}
+{
+  // Belt and braces: `has-scrollback` is not the only class on this element
+  // (#677's `.loading`, #687's `.reconnecting`), so the toggle must not clobber
+  // its neighbours.
+  wrap.classList.add('loading');
+  setTerm(300);
+  T.updateTerminalScrollbar();
+  check('toggling it leaves the skeleton/reconnect classes alone',
+    shown() && wrap.classList.contains('loading'));
+  wrap.classList.remove('loading');
+}
+
+console.log('\n  before a terminal exists');
+{
+  setTerm(400);
+  T.updateTerminalScrollbar();
+  setTerm(null);
+  T.updateTerminalScrollbar();
+  check('no terminal hides the bar rather than throwing', !shown());
+}
+{
+  // A Terminal that has been constructed but not opened has no buffer yet; the
+  // #668 pill reads the same fields and this path runs on the same events.
+  T.term = {};
+  T.updateTerminalScrollbar();
+  check('a terminal with no buffer yet does not throw', !shown());
+}
+
+console.log('\n  theme handoff');
+{
+  // No tokens in this document yet, so every one reads empty — and an empty
+  // token must OMIT its key rather than send xterm an empty colour string, which
+  // css.toColor rejects by THROWING ("Unsupported css format") and would take
+  // the whole terminal down at construction.
+  const theme = T.scrollbarTheme();
+  check('missing tokens yield no keys at all (xterm keeps its own default)',
+    theme && Object.keys(theme).length === 0);
+  check('  ... and never an empty colour string xterm would throw on',
+    !Object.values(theme).some((v) => !v));
+}
+{
+  // Now with the tokens defined, as app.css defines them. Distinct values per
+  // token on purpose: equal ones would let the three keys be transposed — hover
+  // wired to the resting colour, say — with every assertion still green.
+  const style = window.document.createElement('style');
+  style.textContent = ':root {'
+    + ' --scroll-thumb: rgba(221, 196, 130, 0.50);'
+    + ' --scroll-thumb-hover: rgba(221, 196, 130, 0.72);'
+    + ' --scroll-thumb-active: rgba(221, 196, 130, 0.90);'
+    + ' }';
+  window.document.head.appendChild(style);
+
+  const theme = T.scrollbarTheme();
+  check('the resting thumb comes from --scroll-thumb',
+    theme.scrollbarSliderBackground === 'rgba(221, 196, 130, 0.50)');
+  check('the hover thumb comes from --scroll-thumb-hover',
+    theme.scrollbarSliderHoverBackground === 'rgba(221, 196, 130, 0.72)');
+  check('the drag thumb comes from --scroll-thumb-active',
+    theme.scrollbarSliderActiveBackground === 'rgba(221, 196, 130, 0.90)');
+  check('and nothing else is smuggled into the theme', Object.keys(theme).length === 3);
+
+  // `rgba(r, g, b, a)` is one of the forms xterm's css.toColor parses, so the
+  // token text can go over verbatim. Guard the shape here rather than trusting
+  // it: an unparseable colour throws at Terminal construction.
+  const rgba = /^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*(,\s*(0|1|\d?\.\d+)\s*)?\)$/;
+  check('  ... in a form xterm can parse',
+    Object.values(theme).every((v) => rgba.test(v)));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #1020

## What went wrong in #1019

#1016 named `#sidebar` / `#board` in its acceptance criteria because those were the panes carrying CROW-593's hide rule. But the report was "the scrollbar is gone", and the bar people actually reach for is the **terminal's history thumb**. #1019 gave the sidebar a permanent styled gutter and left the terminal exactly as invisible as it was.

This puts the hide back and fixes the pane that was meant.

## Sidebar / board: reverted

The CROW-593 rule goes back verbatim:

```css
#board, #sidebar { scrollbar-width: none; -ms-overflow-style: none; }
#board::-webkit-scrollbar, #sidebar::-webkit-scrollbar { width: 0; height: 0; display: none; }
```

#1019's block also reached `.settings-body`, `.notif-list` and `.wizard-list` — panes that never had a hide rule and weren't in scope for either ticket. It comes out whole rather than leaving half a policy behind. `--scroll-gutter` went with it (no consumer left).

## Terminal: two independent bugs, both fixed

The bar was missing for two reasons, and fixing either alone leaves you with an invisible bar or a disappearing one.

**1. Colour — app.js.** xterm paints its slider from the JS `theme` object, not from CSS. Left alone it derives the slider from the *foreground* at 0.20 alpha:

```js
scrollbarSliderBackground: color.opacity(foreground, .2)   // xterm.js 6.0.0
```

`#d4d4d4` at 0.20 over `#1e1e1e` is **1.67:1** — under WCAG 2.2 §1.4.11's 3:1 floor. That is why it read as "gone" while technically being drawn. `scrollbarTheme()` reads app.css's `--scroll-*` tokens back out and hands them over, so the tokens keep one definition and gain a second consumer rather than the gold being written down twice. A missing token yields an *omitted key* (xterm's own default), never an empty string — `css.toColor` throws on that, at Terminal construction.

| Slider state | Token | Contrast on `#1e1e1e` |
|---|---|---|
| xterm default | fg @ 0.20 | 1.67:1 ❌ |
| resting | `--scroll-thumb` (gold @ 0.50) | **3.46:1** ✅ |
| hover | `--scroll-thumb-hover` (0.72) | 5.70:1 ✅ |
| drag | `--scroll-thumb-active` (0.90) | 8.14:1 ✅ |

0.50 is the floor, not a preference: 0.45 measures 3.06:1 and 0.44 measures 2.98:1.

**2. Persistence — app.css.** xterm 6 scrolls through a VS Code scrollable element constructed with `vertical: ScrollbarVisibility.Auto`, so the thumb fades out whenever the pointer isn't over the grid. The override pins **both** declarations xterm.css's `.invisible` sets:

```css
#terminal-wrap.has-scrollback .xterm-scrollable-element > .scrollbar.vertical {
  opacity: 1;
  pointer-events: auto;
}
```

`pointer-events` is not incidental — a thumb you can see and cannot grab is the same complaint one step later.

## Why `.has-scrollback` is load-bearing

When the bar isn't needed, xterm's `ScrollbarState` sizes the slider to the **whole** track. Pinning it unconditionally would draw a permanent gold stripe down the right of every alt-buffer agent session. The class is set from `buffer.active.baseY` — the same quantity as xterm's own "is the bar needed" test. That covers alt-buffer agents (Claude Code) for free, though **not** via the buffer type: crow-tmux.conf strips `smcup`/`rmcup` toward the client, so the web xterm is permanently in its main buffer and `buffer.active.type` is never `'alternate'` there (the trap ADR-0013 calls out for the wheel routing). What zeroes `baseY` on those surfaces is `applySurfaceScrollback` pinning `options.scrollback = 0`, capping the main buffer at `rows`. Updated on `onScroll` + `onRender`, the same pair the #668 jump-to-bottom pill uses, for the same reason.

## Why only the persistence half is gated to a fine pointer

Not for width. FitAddon already subtracts the 14px scrollbar from the column count on *every* device whenever `scrollback !== 0`, so the gutter is paid for regardless — unlike the sidebar, showing the bar here costs no layout.

It's for hit-testing: restoring `pointer-events` on touch would let a flick starting in that gutter drive the slider **and** `enableTouchScroll`'s one-finger shim from the same gesture. Touch keeps xterm's own reveal-on-scroll, which is now actually visible thanks to the colour fix.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Left sidebar has no persistent scrollbar gutter | ✅ CROW-593 hide restored verbatim |
| xterm shows a usable vertical scrollbar when there is history | ✅ themed + pinned, gated on `baseY > 0` |
| Wheel / trackpad / hydrate-on-top (CROW-934) still work | ✅ no scroll handler or `overflow` value changed — appearance and hit-testing only |
| #1019's test rewritten, not deleted without a pin | ✅ see below |

## Tests

`sidebarAndBoardKeepAVisibleScrollbar` → **`sidebarStaysOverlayAndTerminalGetsAVisibleScrollbar`**, same file. Both halves in one test on purpose: they're one decision and must not drift apart. It pins the hide (scoped to its own rule body, so it fails if the hide migrates to another pane), both terminal declarations, the `.has-scrollback` gate still being asked for, the token→theme-key handoff, and that the three tokens exist.

New **`web-tests/terminal-scrollbar.test.js`** drives the real `updateTerminalScrollbar` and `scrollbarTheme` against jsdom — the gate in both directions, teardown paths, and the token mapping with three distinct values so a transposition can't pass.

Both were mutation-checked:
- forcing the class on → **4 failures**
- dropping the empty-token guard → **2 failures**
- swapping `--scroll-thumb-hover` for `--scroll-thumb-active` → **1 failure**

- `swift build --build-tests` (CrowDaemon): **Build complete** — not run here, `swift test` boots `crowd` on this host
- `npm run test:ci` (web-tests): **exit 0, 0 failures** across all 16 files, including the new one (14 assertions)
- The Swift pins were additionally replayed against the real assets with the test's own `stripComments`/`ruleBody` logic: all 11 hold
- Contrast figures above computed from the WCAG relative-luminance formula

**Not verified here:** the rendered bar. Headless Chrome won't start in this sandbox, so the visual check is the one step left for review — thumb visible and draggable in a shell tab with history, absent in an empty tab and in a Claude Code session, sidebar showing no gutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
