### PR TITLE
Correct the baseY-is-zero rationale for alt-buffer agents (CROW-1020 follow-up)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -5480,9 +5480,15 @@ function scrollbarTheme() {
 // surface allowing it: with nothing to scroll, xterm sizes the slider to the
 // whole track, so an ungated pin would paint a permanent stripe down every
 // empty terminal. `baseY` (lines that have scrolled off the top) is exactly
-// xterm's own "is the bar needed" test, and it is 0 in the alternate screen —
-// which is where alt-buffer agents like Claude Code live and where there is no
-// local scrollback to reach anyway (see applySurfaceScrollback).
+// xterm's own "is the bar needed" test.
+//
+// That also covers alt-buffer agents (Claude Code) for free — but NOT via the
+// buffer type, and the distinction matters if this is ever rewritten.
+// crow-tmux.conf strips smcup/rmcup toward the CLIENT, so the web xterm is
+// permanently in its main buffer and `buffer.active.type` is never 'alternate'
+// here (the same trap ADR-0013 calls out for the wheel routing). What actually
+// zeroes baseY on those surfaces is applySurfaceScrollback pinning
+// `options.scrollback = 0`, which caps the main buffer at `rows`.
 function updateTerminalScrollbar() {
   const wrap = document.getElementById('terminal-wrap');
   if (!wrap) return;


### PR DESCRIPTION
Comment-only follow-up to #1021. No behaviour change.

#1021's `updateTerminalScrollbar` explains its `baseY > 0` gate like this:

> `baseY` … is 0 in the alternate screen — which is where alt-buffer agents like Claude Code live

The gate is right. That reason is not, and it happens to be the exact trap `crow-tmux.conf` spends a paragraph warning about:

```
set -gas terminal-overrides ',xterm*:smcup@:rmcup@,screen*:smcup@:rmcup@'
```

> That is why `app.js` must NOT route the hybrid scroll model on `term.buffer.active.type === 'alternate'`: with this strip in place the web client is permanently in its main buffer, so that test is always false.

The strip cancels the **client** terminal's alt-screen capability, so the browser's xterm never enters its alternate buffer no matter what the tmux pane is doing. What actually zeroes `baseY` on a Claude Code surface is `applySurfaceScrollback` pinning `options.scrollback = 0`, which caps the main buffer at `rows`.

Left as-is this reads as license to rewrite the gate as `buffer.active.type === 'alternate'` — which is always false on this client, so the bar would then show on Claude Code tabs with a full-height slider and nothing to scroll. ADR-0013 already had to learn this once for the wheel routing (#824); the comment now says so rather than implying the opposite.

This missed #1021 by 27 minutes — the `crow:merge` watcher squashed the branch at 09:36 and the correction was pushed at 10:04, after the PR had already closed.

- `node --check` on app.js: clean
- `npm run test:ci` (web-tests): exit 0, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)