### PR TITLE
Revalidate the daemon's own web assets with ETags (CROW-1024)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
@@ -1,4 +1,5 @@
 import CrowTerminal
+import Crypto
 import Foundation
 import Hummingbird
 import NIOCore
@@ -13,27 +14,27 @@ import NIOCore
 /// refresh, no rebuild.
 enum StaticAssets {
     static func mount(on router: Router<CrowHTTPContext>, webDir: String? = nil) {
-        router.get("/") { _, _ in webResponse("index.html", webDir: webDir) }
-        router.get("/index.html") { _, _ in webResponse("index.html", webDir: webDir) }
+        router.get("/") { req, _ in webResponse("index.html", webDir: webDir, request: req) }
+        router.get("/index.html") { req, _ in webResponse("index.html", webDir: webDir, request: req) }
         // Login page (CROW-593) — reachable without auth; the auth middleware
         // also serves it as the fallback for unauthenticated navigational GETs.
-        router.get("/login") { _, _ in webResponse("login.html", webDir: webDir) }
-        router.get("/app.css") { _, _ in webResponse("app.css", webDir: webDir) }
-        router.get("/app.js") { _, _ in webResponse("app.js", webDir: webDir) }
+        router.get("/login") { req, _ in webResponse("login.html", webDir: webDir, request: req) }
+        router.get("/app.css") { req, _ in webResponse("app.css", webDir: webDir, request: req) }
+        router.get("/app.js") { req, _ in webResponse("app.js", webDir: webDir, request: req) }
         // Web Settings modal assets (CROW-581) — split out of app.css/app.js.
-        router.get("/settings.css") { _, _ in webResponse("settings.css", webDir: webDir) }
-        router.get("/settings.js") { _, _ in webResponse("settings.js", webDir: webDir) }
-        router.get("/brand.svg") { _, _ in webResponse("brand.svg", webDir: webDir) }
+        router.get("/settings.css") { req, _ in webResponse("settings.css", webDir: webDir, request: req) }
+        router.get("/settings.js") { req, _ in webResponse("settings.js", webDir: webDir, request: req) }
+        router.get("/brand.svg") { req, _ in webResponse("brand.svg", webDir: webDir, request: req) }
         // Build info for the Settings → About tab, written by
         // scripts/generate-build-info.sh. 404s gracefully when absent (the daemon
         // stays buildable without it — CROW-581).
-        router.get("/version.json") { _, _ in webResponse("version.json", webDir: webDir) }
+        router.get("/version.json") { req, _ in webResponse("version.json", webDir: webDir, request: req) }
         // Session-validity probe, gated by WebAuthMiddleware: 204 when the session
         // cookie is valid (or loopback), 401 when it isn't. The web UI polls this on
         // disconnect to tell "session expired" from "crowd is down" (CROW-593).
         router.get("/auth/check") { _, _ in Response(status: .noContent) }
         // The standalone single-terminal page from M1, kept for debugging.
-        router.get("/terminal.html") { _, _ in webResponse("terminal.html", webDir: webDir) }
+        router.get("/terminal.html") { req, _ in webResponse("terminal.html", webDir: webDir, request: req) }
 
         router.get("/xterm/:file") { _, context -> Response in
             // Basename-only guard against path traversal.
@@ -56,18 +57,19 @@ enum StaticAssets {
     }
 
     /// The login page as a 200 response — used by the auth middleware as the
-    /// fallback for unauthenticated navigational GETs (CROW-593).
-    static func loginPage(webDir: String?) -> Response {
-        webResponse("login.html", webDir: webDir)
+    /// fallback for unauthenticated navigational GETs (CROW-593). The `request`,
+    /// when the caller has one, lets the response answer a conditional GET.
+    static func loginPage(webDir: String?, request: Request? = nil) -> Response {
+        webResponse("login.html", webDir: webDir, request: request)
     }
 
     /// Load a web UI file — from `webDir` on disk when set (live/hot-reload),
     /// otherwise from the daemon bundle's `web/` resource directory.
-    private static func webResponse(_ name: String, webDir: String?) -> Response {
+    private static func webResponse(_ name: String, webDir: String?, request: Request? = nil) -> Response {
         if let webDir {
             let url = URL(fileURLWithPath: webDir).appendingPathComponent(name)
             if let data = try? Data(contentsOf: url) {
-                return fileResponse(data, name: name)
+                return fileResponse(data, name: name, request: request, revalidate: true)
             }
         }
         let base = (name as NSString).deletingPathExtension
@@ -76,10 +78,12 @@ enum StaticAssets {
               let data = try? Data(contentsOf: url) else {
             return Response(status: .notFound)
         }
-        return fileResponse(data, name: name)
+        return fileResponse(data, name: name, request: request, revalidate: true)
     }
 
-    private static func fileResponse(_ data: Data, name: String) -> Response {
+    private static func fileResponse(_ data: Data, name: String,
+                                     request: Request? = nil,
+                                     revalidate: Bool = false) -> Response {
         var headers: HTTPFields = [
             .contentType: contentType(for: name),
             .xContentTypeOptions: "nosniff",
@@ -94,10 +98,46 @@ enum StaticAssets {
         if appliesCSP(to: name) {
             headers[.contentSecurityPolicy] = contentSecurityPolicy
         }
+        // The app's own HTML/JS/CSS must always be revalidated so a fresh build lands
+        // on a normal reload instead of the browser running a stale heuristically
+        // cached `app.js` (CROW-1024). `no-cache` = "may cache, but revalidate before
+        // reuse"; the strong ETag lets that revalidation return an empty 304 when the
+        // bytes are unchanged, so it stays cheap. The `/xterm/*` vendor bundle keeps
+        // its long-lived heuristic cache (revalidate == false).
+        if revalidate {
+            let tag = strongETag(for: data)
+            headers[.cacheControl] = "no-cache"
+            headers[.eTag] = tag
+            if let request, ifNoneMatch(request, matches: tag) {
+                return Response(status: .notModified, headers: headers)
+            }
+        }
         return Response(
             status: .ok,
             headers: headers,
             body: .init(byteBuffer: ByteBuffer(bytes: data)))
+    }
+
+    /// A strong ETag for `data`: the hex SHA-256 of the bytes, quoted. Content-based
+    /// (not mtime/path), so identical bytes validate identically across installs and
+    /// between the `webDir` and bundle sources (CROW-1024).
+    private static func strongETag(for data: Data) -> String {
+        let hex = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        return "\"\(hex)\""
+    }
+
+    /// Whether the request's `If-None-Match` matches `etag` (or is `*`). Handles a
+    /// comma-separated list and an optional `W/` weak-validator prefix on each
+    /// candidate, per RFC 9110 §13.1.2.
+    static func ifNoneMatch(_ request: Request, matches etag: String) -> Bool {
+        guard let header = request.headers[.ifNoneMatch] else { return false }
+        if header.trimmingCharacters(in: .whitespaces) == "*" { return true }
+        for raw in header.split(separator: ",") {
+            var candidate = raw.trimmingCharacters(in: .whitespaces)
+            if candidate.hasPrefix("W/") { candidate = String(candidate.dropFirst(2)) }
+            if candidate == etag { return true }
+        }
+        return false
     }
 
     /// Whether the Content-Security-Policy is attached to `name`. Scoped to the

--- a/Packages/CrowDaemon/Sources/CrowDaemon/WebAuthRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/WebAuthRoutes.swift
@@ -72,7 +72,7 @@ struct WebAuthMiddleware<Context: RemoteAddressRequestContext>: RouterMiddleware
             return try await next(request, context)
         }
         if Self.serveLoginPageForUnauthorized(method: request.method, accept: request.headers[.accept]) {
-            return StaticAssets.loginPage(webDir: webDir)
+            return StaticAssets.loginPage(webDir: webDir, request: request)
         }
         return Response(status: .unauthorized)
     }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/StaticAssetsCacheTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/StaticAssetsCacheTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdTesting
+import Testing
+
+@testable import CrowDaemon
+
+/// The daemon must serve its own HTML/JS/CSS with revalidation headers so an
+/// already-open browser tab picks up a new build on a normal reload instead of
+/// running a stale, heuristically cached `app.js` (CROW-1024). A strong ETag
+/// keeps that revalidation cheap by letting an unchanged asset answer with an
+/// empty 304. The `/xterm/*` vendor bundle deliberately keeps its long-lived
+/// cache and stays out of this policy.
+@Suite("Static asset cache policy")
+struct StaticAssetsCacheTests {
+
+    /// A router with just the static-asset routes mounted; assets resolve from the
+    /// compiled `Bundle.module` (`webDir` nil). No middleware and no actor state,
+    /// so `.test(.router)` is enough.
+    private func makeApp() -> some ApplicationProtocol {
+        let router = Router(context: CrowHTTPContext.self)
+        StaticAssets.mount(on: router)
+        return Application(router: router)
+    }
+
+    @Test("app.js is served with Cache-Control: no-cache and a strong ETag")
+    func appJSRevalidates() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(uri: "/app.js", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.headers[.cacheControl] == "no-cache")
+                let etag = try #require(response.headers[.eTag])
+                // A strong validator: quoted, and more than just the empty quotes.
+                #expect(etag.hasPrefix("\"") && etag.hasSuffix("\""))
+                #expect(etag.count > 2)
+                #expect(response.body.readableBytes > 0)
+            }
+        }
+    }
+
+    @Test("A conditional GET with the current ETag returns an empty 304")
+    func conditionalGETReturns304() async throws {
+        try await makeApp().test(.router) { client in
+            // Learn the ETag the server is currently advertising for app.js.
+            let etag = try await client.execute(uri: "/app.js", method: .get) { response in
+                #expect(response.status == .ok)
+                return try #require(response.headers[.eTag])
+            }
+            // Re-request it conditionally → 304 Not Modified with no body, but the
+            // validating headers are still present.
+            try await client.execute(
+                uri: "/app.js", method: .get, headers: [.ifNoneMatch: etag]
+            ) { response in
+                #expect(response.status == .notModified)
+                #expect(response.body.readableBytes == 0)
+                #expect(response.headers[.eTag] == etag)
+                #expect(response.headers[.cacheControl] == "no-cache")
+            }
+        }
+    }
+
+    @Test("A stale If-None-Match still gets the full 200 body")
+    func staleETagGetsFullBody() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/app.js", method: .get, headers: [.ifNoneMatch: "\"not-the-current-etag\""]
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.body.readableBytes > 0)
+                #expect(response.headers[.eTag] != nil)
+            }
+        }
+    }
+
+    @Test("index.html keeps its CSP alongside the new cache headers")
+    func indexHTMLKeepsCSPAndCaching() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(uri: "/", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.headers[.cacheControl] == "no-cache")
+                #expect(response.headers[.eTag] != nil)
+                #expect(response.headers[.contentSecurityPolicy] != nil)
+            }
+        }
+    }
+
+    @Test("The xterm vendor bundle stays out of the revalidation policy")
+    func xtermIsNotRevalidated() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(uri: "/xterm/xterm.js", method: .get) { response in
+                // It is served (from CrowTerminal's bundle); the point is that it
+                // carries neither the no-cache directive nor an ETag, so the long-
+                // lived vendor cache is untouched (CROW-1024).
+                #expect(response.status == .ok)
+                #expect(response.headers[.cacheControl] == nil)
+                #expect(response.headers[.eTag] == nil)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1024

## Problem

The daemon served its web UI (`index.html`, `app.js`, `app.css`, `settings.js`, …) with **no `Cache-Control` or validation headers**, and `index.html` references `/app.js` unversioned. Browsers therefore heuristically cache `app.js` and keep executing the **stale** copy after a new build — which is why the Cursor wheel-scroll fix (#1014) worked in the desktop Tauri app (fresh WebView cache) but stayed **dead in a `:8787` browser tab** until a manual hard-refresh.

## Fix (Option A — revalidation headers)

Serve the app's own HTML/JS/CSS with `Cache-Control: no-cache` plus a **strong content-hash (SHA-256) `ETag`**, and answer a matching conditional GET with an empty **`304`**. The browser now revalidates on every reload, so a new build lands immediately while unchanged assets stay cheap (empty 304, no body).

- Localized to `StaticAssets.fileResponse` — the single choke point every app asset flows through. The request is threaded into `webResponse`/`loginPage` so `If-None-Match` can be read.
- The ETag is a **content hash** (not mtime/path), so identical bytes validate identically across installs and between the `webDir` and bundle sources.
- `If-None-Match` handling covers a comma-separated list, an optional `W/` weak prefix, and `*`.

## `/xterm/*` left as-is (deliberate)

The xterm 6.0.0 vendor bundle keeps its long-lived heuristic cache (`revalidate: false`). Its URL is **unversioned**, so marking it `immutable` would re-introduce the same staleness class on a future xterm upgrade — leaving it untouched is the safest minimal choice, and it matches the ticket's scoping.

## Tests

New `StaticAssetsCacheTests` drives the real router via `HummingbirdTesting` (`.test(.router)`):
- `app.js` → `200` with `Cache-Control: no-cache` + a quoted strong `ETag`.
- Conditional GET with the current ETag → empty `304` (validating headers retained).
- A stale `If-None-Match` → full `200` body.
- `index.html` keeps its CSP **and** the new cache headers.
- `/xterm/xterm.js` carries **neither** `Cache-Control` nor `ETag` (scoping guard).

`swift build` + the new suite pass. (Two unrelated suites — `RPCLanePolicyTests` and `WebNotificationCenterTests` — fail identically on the branch **before** this change; they're pre-existing and untouched here.)

## Acceptance criteria

- [x] An already-open `:8787` tab picks up the new `app.js` on a normal reload (no empty-cache required).
- [x] Cursor terminals can wheel-scroll in the browser once the new `app.js` is fetched (the #1014 fix is no longer masked by a stale cache).
- [x] `app.js` / `app.css` / `settings.js` / `index.html` are served with `Cache-Control` + validation; a regression test asserts the header/304 policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)