### PR TITLE
Self-heal a reload that rebuilds a one-screen terminal buffer (CROW-1027)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -5227,6 +5227,11 @@ let searchAddon = null;
 let termWs = null;
 let termSkelTimer = null; // #677: safety timeout that clears the skeleton overlay
 let termReconnectDelay = 1000; // #687: backoff between reconnect attempts (ms), reset on open
+// CROW-1027: id of the pending onclose auto-reconnect. Tracked so a manual
+// ↻ Reload (or attachWindow) can cancel it before opening its own socket —
+// otherwise the stray timer fires a SECOND attach that races the reload's on the
+// shared window/term (dead-wheel double-connect hazard).
+let termReconnectTimer = null;
 
 // In-flight state for the header's ↻ Reload button (CROW-979). Module state, not
 // DOM state: `refreshLive` repaints the whole detail header every 4s, so a busy
@@ -5923,8 +5928,19 @@ function showTerminalMenu(e) {
   armContextMenuClose();
 }
 
+// CROW-1027: cancel a queued onclose auto-reconnect. Idempotent — safe to call
+// when nothing is pending, and a no-op when the timer's own callback (which nulls
+// the id first) is what's running.
+function clearTermReconnectTimer() {
+  clearTimeout(termReconnectTimer);
+  termReconnectTimer = null;
+}
+
 function connectTerminalWs() {
   if (sessionDead) { hideTerminalSkeleton(); return; } // don't loop after an expired remote cookie (review Yellow); clear any overlay so the #679 scrim owns the screen
+  // CROW-1027: this attach supersedes any queued auto-reconnect — drop it so two
+  // sockets can't race on the shared window/term.
+  clearTermReconnectTimer();
   // #677: cover this (re)attach — initial connect, auto-reconnect, and (via
   // reloadTerminal) the #675 right-click Reload + tab/session switch — with the
   // skeleton. `painted` gates the hide to the FIRST PTY byte of THIS socket.
@@ -5954,6 +5970,9 @@ function connectTerminalWs() {
       // Keep the attach bookkeeping truthful after any (re)connect — initial
       // connect, reloadTerminal, or a dropped-socket auto-reconnect (#673).
       attachedWindow = activeTerminal.window;
+      // CROW-1027: the fit above races the replay's capture, which can rebuild a
+      // one-screen (dead-wheel) buffer. Verify shortly after and re-capture if so.
+      armScrollbackHeal();
     }
   };
   termWs.onmessage = (event) => {
@@ -5992,7 +6011,9 @@ function connectTerminalWs() {
     if (sessionDead) { hideTerminalSkeleton(); return; }
     setTerminalReconnecting(true);
     showTerminalSkeleton();
-    setTimeout(connectTerminalWs, termReconnectDelay);
+    // CROW-1027: track the id so a manual reload can cancel this before it fires
+    // (null it first inside the callback so a later clear is a harmless no-op).
+    termReconnectTimer = setTimeout(() => { termReconnectTimer = null; connectTerminalWs(); }, termReconnectDelay);
     termReconnectDelay = Math.min(termReconnectDelay * 2, 10000);
   };
   termWs.onerror = () => termWs.close(); // funnels to onclose (keeps overlay up)
@@ -6121,6 +6142,18 @@ let scrollbackFullySynced = false; // last capture returned nothing new
 let lastHydrateAt = 0;
 let lastViewportY = 0; // previous scroll position, to detect arrival at the top
 
+// CROW-1027: post-attach scrollback self-heal. The reload/attach fits (resizes)
+// the pane immediately before select-window replays it, so `capture-pane` can run
+// mid-reflow and come back ONE screen tall — the replay's ESC[3J then wipes what
+// little history the buffer had, leaving `baseY === 0` and a dead wheel. A brief
+// settle after attach, then a re-capture when the buffer really is one screen
+// tall, rebuilds it against a now-settled pane. Gated on `baseY === 0` so a
+// healthy attach (the common case) sends nothing, and bounded so it never loops.
+const SCROLLBACK_HEAL_MS = 250; // distinct from 1500 (skeleton) / 10000 (reload settle)
+const SCROLLBACK_HEAL_MAX = 2; // bounded re-captures — accept a genuine one-screen pane after this
+let scrollbackHealTimer = null;
+let scrollbackHealLeft = 0;
+
 // The flight ends this long after the last frame, but never later than the
 // arm-time deadline. There is deliberately NO viewport restore here: the replay
 // rebuilds the buffer while `isUserScrolling` is true (which the trigger's
@@ -6177,6 +6210,42 @@ function resetScrollbackSync() {
   scrollbackDirty = true;
   lastHydrateAt = 0; // the new surface gets its own budget, not the old one's
   lastViewportY = 0; // ...and its own scroll history, not the old one's position
+  // CROW-1027: drop any pending self-heal — a fresh attach arms its own.
+  clearTimeout(scrollbackHealTimer);
+  scrollbackHealTimer = null;
+  scrollbackHealLeft = 0;
+}
+
+// CROW-1027: arm the post-attach scrollback check. Called from onopen after
+// select-window, so it runs once per (re)attach; resetScrollbackSync clears it on
+// the next teardown.
+function armScrollbackHeal() {
+  clearTimeout(scrollbackHealTimer);
+  scrollbackHealLeft = SCROLLBACK_HEAL_MAX;
+  scrollbackHealTimer = setTimeout(verifyScrollbackAfterAttach, SCROLLBACK_HEAL_MS);
+}
+
+// If the attach's replay rebuilt a one-screen buffer (`baseY === 0`) on a surface
+// that owns its scrollback locally, re-issue one select-window so crowd re-captures
+// the pane — by now the resize's reflow has settled, so the capture carries the
+// full history and the wheel comes back. A healthy buffer (`baseY > 0`) sends
+// nothing. Bounded by scrollbackHealLeft so a genuinely one-screen pane is accepted
+// rather than re-captured forever.
+function verifyScrollbackAfterAttach() {
+  scrollbackHealTimer = null;
+  if (!term || !activeTerminal) return;
+  // Alt-buffer agents (Claude Code) forward the wheel by design — no local
+  // scrollback to repair (AC #3). Same gate maybeHydrateScrollback uses.
+  if (activeTerminal.agent_surface) return;
+  if (activeTerminal.window == null) return;
+  if (!termWs || termWs.readyState !== WebSocket.OPEN) return;
+  const buf = term.buffer && term.buffer.active;
+  if (!buf || buf.type === 'alternate') return;
+  if (buf.baseY > 0) return; // scrollback present → healthy, stop
+  if (scrollbackHealLeft <= 0) return; // exhausted → accept a real one-screen pane
+  scrollbackHealLeft -= 1;
+  selectWindow(activeTerminal.window); // re-capture against the now-settled pane
+  scrollbackHealTimer = setTimeout(verifyScrollbackAfterAttach, SCROLLBACK_HEAL_MS);
 }
 
 function maybeHydrateScrollback() {
@@ -6242,6 +6311,9 @@ function reloadTerminal() {
   // anyway — drop any in-flight re-sync (its restore would fight the fresh
   // attach) and treat the rebuilt buffer as needing one again.
   resetScrollbackSync();
+  // CROW-1027: cancel a queued auto-reconnect so it can't open a second socket
+  // that races the one we're about to build on the shared window/term.
+  clearTermReconnectTimer();
   if (termWs) {
     const old = termWs;
     old.onopen = old.onmessage = old.onclose = old.onerror = null;

--- a/Packages/CrowDaemon/web-tests/terminal-reload.test.js
+++ b/Packages/CrowDaemon/web-tests/terminal-reload.test.js
@@ -21,6 +21,8 @@ const epilogue = `
   showEmptyDetail(m, o){ return showEmptyDetail(m, o); },
   showTerminalMenu(e){ return showTerminalMenu(e); },
   reloadTerminalAction(){ return reloadTerminalAction(); },
+  reloadTerminal(){ return reloadTerminal(); },
+  connectTerminalWs(){ return connectTerminalWs(); },
   clearTerminalReloadPending(){ return clearTerminalReloadPending(); },
   syncTerminalReloadEnabled(){ return syncTerminalReloadEnabled(); },
   get terminalReloadPending(){ return terminalReloadPending; },
@@ -31,6 +33,8 @@ const epilogue = `
   set selectedId(v){ selectedId = v; },
   set activeTerminal(v){ activeTerminal = v; },
   TERMINAL_RELOAD_SETTLE_MS,
+  SCROLLBACK_HEAL_MS,
+  SCROLLBACK_HEAL_MAX,
 };
 `;
 const APP_JS = __dirname + '/../Sources/CrowDaemon/Resources/web/app.js';
@@ -314,6 +318,101 @@ console.log('\nthe existing right-click path is untouched:');
   check('“Reload terminal” still in the terminal menu', items.includes('Reload terminal'));
   const menu = window.document.querySelector('.ctx-menu');
   if (menu) menu.remove();
+}
+
+// --- CROW-1027: post-attach scrollback self-heal + reconnect-timer cancel -----
+// The reload attach fits (resizes) the pane immediately before select-window
+// replays it, so `capture-pane` can run mid-reflow and rebuild a ONE-screen
+// (dead-wheel) buffer. onopen arms a short settle; if the buffer really came back
+// one screen tall (`baseY === 0`) on a shell surface, it re-issues select-window
+// so crowd re-captures the now-settled pane.
+function selectWindowCount(sock) {
+  return sock.sent.filter((d) => { try { return JSON.parse(d).type === 'select-window'; } catch (_) { return false; } }).length;
+}
+
+console.log('\nCROW-1027: a reload that rebuilds a one-screen buffer self-heals:');
+{
+  mount('work'); // shell surface — activeTerminal carries no agent_surface flag
+  T.reloadTerminal();
+  const sock = sockets[sockets.length - 1];
+  sock.fireOpen(); // onopen → selectWindow (initial) + armScrollbackHeal
+  const initial = selectWindowCount(sock);
+  check('initial attach selected the window once', initial === 1);
+  lastTerm.buffer.active.baseY = 0; // daemon replay landed one screen tall
+  fireTimersAt(T.SCROLLBACK_HEAL_MS);
+  check('dead wheel triggers one re-capture', selectWindowCount(sock) === initial + 1);
+  lastTerm.buffer.active.baseY = 42; // the re-capture rebuilt real history
+  fireTimersAt(T.SCROLLBACK_HEAL_MS);
+  check('a healthy buffer stops re-capturing', selectWindowCount(sock) === initial + 1);
+  check('the wheel is live again (baseY > 0)', lastTerm.buffer.active.baseY > 0);
+}
+
+console.log('\nCROW-1027: a healthy attach never re-captures:');
+{
+  mount('work');
+  T.reloadTerminal();
+  const sock = sockets[sockets.length - 1];
+  lastTerm.buffer.active.baseY = 30; // scrollback already present when onopen fires
+  sock.fireOpen();
+  const n = selectWindowCount(sock);
+  fireTimersAt(T.SCROLLBACK_HEAL_MS);
+  check('no extra select-window on a healthy buffer', selectWindowCount(sock) === n);
+}
+
+console.log('\nCROW-1027: self-heal is bounded and never loops:');
+{
+  mount('work');
+  T.reloadTerminal();
+  const sock = sockets[sockets.length - 1];
+  sock.fireOpen();
+  const initial = selectWindowCount(sock);
+  lastTerm.buffer.active.baseY = 0; // stays dead however many times we re-capture
+  for (let i = 0; i < 5; i++) fireTimersAt(T.SCROLLBACK_HEAL_MS);
+  check('caps at SCROLLBACK_HEAL_MAX re-captures', selectWindowCount(sock) === initial + T.SCROLLBACK_HEAL_MAX);
+  check('no self-heal timer left armed', timerCountAt(T.SCROLLBACK_HEAL_MS) === 0);
+}
+
+console.log('\nCROW-1027: alt-buffer agents (Claude Code) are unaffected:');
+{
+  mount('work');
+  T.activeTerminal = { id: 't1', name: 'Claude Code', window: 3, agent_surface: true };
+  T.reloadTerminal();
+  const sock = sockets[sockets.length - 1];
+  sock.fireOpen();
+  const initial = selectWindowCount(sock);
+  lastTerm.buffer.active.baseY = 0;
+  fireTimersAt(T.SCROLLBACK_HEAL_MS);
+  check('agent surface: no self-heal re-capture', selectWindowCount(sock) === initial);
+
+  // Even a non-agent surface parked on the ALT buffer has no local scrollback to
+  // repair, so the buffer-type gate short-circuits too.
+  mount('work');
+  T.reloadTerminal();
+  const sock2 = sockets[sockets.length - 1];
+  sock2.fireOpen();
+  const initial2 = selectWindowCount(sock2);
+  lastTerm.buffer.active.baseY = 0;
+  lastTerm.buffer.active.type = 'alternate';
+  fireTimersAt(T.SCROLLBACK_HEAL_MS);
+  check('alt buffer type: no self-heal re-capture', selectWindowCount(sock2) === initial2);
+}
+
+console.log('\nCROW-1027: a reload cancels a pending auto-reconnect (no double-connect):');
+{
+  mount('work');
+  T.connectTerminalWs();
+  const s0 = sockets[sockets.length - 1];
+  s0.fireOpen(); // resets the reconnect backoff to 1000ms
+  s0.close();    // simulate a dropped socket → arms the auto-reconnect timer
+  check('auto-reconnect armed at 1000ms', timerCountAt(1000) === 1);
+  const before = sockets.length;
+  T.reloadTerminal(); // manual reload builds its own socket...
+  check('reload built exactly one new socket', sockets.length === before + 1);
+  check('reload cancelled the pending reconnect', timerCountAt(1000) === 0);
+  const after = sockets.length;
+  fireTimersAt(1000); // the stray reconnect, had it survived, would have attached here
+  check('no second attach races the reload', sockets.length === after);
+  check('termWs is the reload’s socket', T.termWs === sockets[sockets.length - 1]);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #1027

## Problem

Pressing **↻ Reload** on a shell/Manager terminal *sometimes* leaves it unable to scroll — dead wheel, no scrollbar — until another Reload. Reproduces on both the Tauri desktop app and the web UI.

**Mechanism.** `reloadTerminal()` blanks the buffer and refills it only from the CROW-606 select-window replay. On the attach, `onopen` runs `applyTermFit()` (a resize) immediately before `selectWindow()` (the replay) — deliberately, so the real pane width reaches the PTY before the capture. That resize fires a SIGWINCH; the daemon's select-window handler runs `capture-pane` right after switching the window, so the capture can land **mid-reflow** and come back one screen tall. The replay's `ESC[3J` then wipes the little history the buffer had → `baseY === 0` → `term.scrollLines` is a silent no-op → dead wheel. It's "sometimes" because the reflow-vs-capture timing, the `applyTermFit` focus gate, and multi-client `window-size latest` flap all vary.

## Fix

Kept **client-only** — the daemon `/terminal` handler needs a real PTY + tmux and can't be unit-tested, whereas the jsdom harness fully drives sockets, timers, and `baseY`.

1. **Post-attach settle-and-verify self-heal.** Keep the deliberate resize-before-replay ordering (a pure reorder would just trade a dead wheel for history captured at the fresh attach's 80×24 default, and the grouped attach perturbs window size on its own). After each attach a ~250 ms settle checks the rebuilt buffer: if a non-alt **shell** surface came back one screen tall (`baseY === 0`), re-issue **one** `select-window` so crowd re-captures the now-settled pane and the wheel returns. A healthy buffer (`baseY > 0`) sends nothing; the retry is bounded (`SCROLLBACK_HEAL_MAX`) so a genuinely one-screen pane is accepted rather than re-captured forever. Alt-buffer agents (Claude Code) are skipped — their wheel is forwarded by design.
2. **Close the double-connect race.** The `onclose` auto-reconnect `setTimeout` stored no id, so a manual Reload (or `attachWindow`) while a reconnect was pending could open a second socket racing the first on the shared window/term. Track the id and cancel it in `connectTerminalWs` and `reloadTerminal`.

Not touching the `applyTermFit` focus gate (load-bearing for #667 shared-size ownership) or ADR-0013 scroll behavior. Scoped to the reload race — #1026's holey-middle hydrate gating is separate.

## Acceptance criteria

- [x] ↻ Reload reliably rebuilds a **scrollable** buffer (self-heal re-captures when the first replay was one-screen).
- [x] Rapid Reload / Reload-during-reconnect does not spawn two racing attaches.
- [x] Alt-buffer agents (Claude Code) unaffected.

## Tests

- `Packages/CrowDaemon/web-tests/terminal-reload.test.js` (jsdom): new scenarios for self-heal, healthy-no-recapture, bounded/never-loops, alt-buffer + agent-surface skip, and no-double-connect. **65 passed, 0 failed.**
- Full web-tests CI suite: all 16 files, 0 failed.
- `swift test --package-path Packages/CrowDaemon` builds clean; `TerminalReplayTests` green (daemon unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)