### PR TITLE
Auto-heal scrollback holes on inline agents and mid-buffer (CROW-1026)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -6083,14 +6083,15 @@ function selectWindow(win) {
   }
 }
 
-// CROW-934: re-sync a plain-shell surface's scrollback from tmux's history.
+// CROW-934: re-sync a scrollback surface's history from tmux's pane.
 //
 // tmux collapses pane redraws when the attached client can't drain them fast
 // enough, and the browser IS that slow client. Measured against the bundled
 // config: `seq 1 20000` leaves all 19 989 lines in the pane's own history, but
 // a browser-paced reader receives only ~337 of them (a raw reader gets 19 768).
 // So the local xterm buffer is NOT a faithful copy of the pane — scroll-up hits
-// its top after a few screens while tmux still holds the rest.
+// its top after a few screens while tmux still holds the rest, and the middle
+// grows holes as thinned live output accumulates (CROW-1026).
 //
 // crowd's `select-window` reply carries the authoritative copy
 // (`capture-pane -pe -S -50000`, CROW-606) and REBUILDS the buffer in place, so
@@ -6098,11 +6099,13 @@ function selectWindow(win) {
 // (attachWindow → reloadTerminal), which is why switching away and back
 // "fixed" the history — but the tab you sit on never re-synced.
 //
-// Trigger on reaching the top of the local buffer: that is exactly when the
-// user is asking for older lines. Shell surfaces only — an agent keeps its
-// transcript in the scrollback-less alt buffer and repaints it itself
-// (ADR-0013), so a capture there returns just the viewport and would buy
-// nothing.
+// Two triggers: reaching the top of the local buffer (asking for older lines)
+// and, since CROW-1026, going idle parked on a hole mid-buffer. Any surface that
+// keeps the unified 50k scrollback is eligible — plain shells AND inline agents
+// (Cursor, and the Manager, which runs one). Only a true alt-buffer agent (Claude
+// Code) is excluded: it keeps its transcript in the scrollback-less alt buffer
+// and repaints it itself (ADR-0013 #1010), so a capture there returns just the
+// viewport and would buy nothing. Same axis as applySurfaceScrollback.
 //
 // Two independent brakes, because `onScroll` is NOT a user-scroll event: xterm's
 // BufferService.scroll ends in an unconditional `this._onScroll.fire(ydisp)`, so
@@ -6154,6 +6157,16 @@ const SCROLLBACK_HEAL_MAX = 2; // bounded re-captures — accept a genuine one-s
 let scrollbackHealTimer = null;
 let scrollbackHealLeft = 0;
 
+// CROW-1026: arrival-at-top is not the only place a hole appears — the thinned
+// live stream drops lines anywhere in the middle, and the user may be parked on
+// one. Debounce off `onScroll` (which also fires for every line pushed at the
+// bottom): the timer re-arms on each scroll AND each output frame, so it fires
+// exactly once, only after scrolling AND output have both gone quiet. During a
+// streaming build it never fires; when the user stops on a mid-buffer hole it
+// re-captures once, subject to every brake the arrival path uses.
+const HYDRATE_SCROLL_IDLE_MS = 400;
+let hydrateIdleTimer = null;
+
 // The flight ends this long after the last frame, but never later than the
 // arm-time deadline. There is deliberately NO viewport restore here: the replay
 // rebuilds the buffer while `isUserScrolling` is true (which the trigger's
@@ -6204,6 +6217,8 @@ function noteTerminalFrame() {
 function resetScrollbackSync() {
   clearTimeout(hydrateSettleTimer);
   hydrateSettleTimer = null;
+  clearTimeout(hydrateIdleTimer); // CROW-1026: drop a pending mid-buffer re-sync too
+  hydrateIdleTimer = null;
   hydratingScrollback = false;
   hydrateSawReplay = false;
   scrollbackFullySynced = false;
@@ -6248,8 +6263,59 @@ function verifyScrollbackAfterAttach() {
   scrollbackHealTimer = setTimeout(verifyScrollbackAfterAttach, SCROLLBACK_HEAL_MS);
 }
 
+// Shared arm tail for both hydrate triggers (arrival-at-top and the CROW-1026
+// scroll-idle mid-buffer heal). The caller has already decided this surface has a
+// hole worth re-fetching; here we apply the surface/socket/cooldown brakes and, if
+// they pass, arm exactly one authoritative re-capture.
+function fireScrollbackCapture(buf) {
+  if (!activeTerminal || activeTerminal.window == null) return;
+  // Only a true alt-buffer agent (Claude Code) has no scrollback to fetch — a
+  // capture there returns just the viewport. Inline agents (Cursor, and the
+  // Manager, which runs one) keep the unified 50k buffer and CAN thin, so they
+  // stay eligible. Same axis as applySurfaceScrollback (ADR-0013 #1010).
+  if (activeSurfaceIsAgent() && activeSurfaceUsesAltScreen()) return;
+  if (!termWs || termWs.readyState !== WebSocket.OPEN) return;
+  const now = Date.now();
+  if (now - lastHydrateAt < HYDRATE_MIN_INTERVAL_MS) return;
+  lastHydrateAt = now;
+  hydratingScrollback = true;
+  scrollbackDirty = false;
+  hydrateArmedAt = now;
+  hydrateBaseY = buf.baseY;
+  hydrateSawReplay = false;
+  scheduleHydrateSettle(2000);
+  selectWindow(activeTerminal.window);
+}
+
+// CROW-1026: (re)arm the scroll-idle mid-buffer heal. Debounced off `onScroll`,
+// which also fires for every line pushed at the bottom — so a streaming build
+// keeps pushing the deadline out and this never fires mid-stream; it fires once
+// when scrolling AND output have both gone quiet.
+function scheduleHydrateIdle() {
+  clearTimeout(hydrateIdleTimer);
+  hydrateIdleTimer = setTimeout(hydrateWhenIdle, HYDRATE_SCROLL_IDLE_MS);
+}
+
+// Heal a hole the user parked on mid-buffer, without a trip to line 1. The arrival
+// path owns viewportY 0; this owns everything below it. Every brake the arrival
+// path uses still applies (in-flight, latch, dirty, cooldown, settle), so #935's
+// extend-forever cannot return: a heal that finds new lines leaves scrollbackDirty
+// false until fresh output dirties it, and one that finds nothing new latches via
+// the unchanged settle. As on the arrival path there is no viewport restore, so
+// the rebuild (isUserScrolling) leaves the user at the top of the healed history.
+function hydrateWhenIdle() {
+  if (!term) return;
+  const buf = term.buffer.active;
+  if (buf.viewportY === 0) return; // the top is the arrival path's job
+  if (hydratingScrollback) return;
+  if (scrollbackFullySynced || !scrollbackDirty) return;
+  if (buf.baseY === 0) return;
+  fireScrollbackCapture(buf);
+}
+
 function maybeHydrateScrollback() {
   if (!term) return;
+  scheduleHydrateIdle(); // CROW-1026: any scroll/frame re-arms the mid-buffer heal
   const buf = term.buffer.active;
   const arrivedAtTop = buf.viewportY === 0 && lastViewportY !== 0;
   lastViewportY = buf.viewportY;
@@ -6263,19 +6329,7 @@ function maybeHydrateScrollback() {
   // `baseY > 0` is load-bearing: on a tab that has printed less than one screen
   // viewportY is permanently 0, so there is no scrollback to go fetch.
   if (buf.baseY === 0) return;
-  if (!activeTerminal || activeTerminal.agent_surface) return;
-  if (activeTerminal.window == null) return;
-  if (!termWs || termWs.readyState !== WebSocket.OPEN) return;
-  const now = Date.now();
-  if (now - lastHydrateAt < HYDRATE_MIN_INTERVAL_MS) return;
-  lastHydrateAt = now;
-  hydratingScrollback = true;
-  scrollbackDirty = false;
-  hydrateArmedAt = now;
-  hydrateBaseY = buf.baseY;
-  hydrateSawReplay = false;
-  scheduleHydrateSettle(2000);
-  selectWindow(activeTerminal.window);
+  fireScrollbackCapture(buf);
 }
 
 // #673: which tmux window this shared surface shows changes on both a terminal-tab

--- a/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
+++ b/Packages/CrowDaemon/web-tests/scrollback-hydrate.test.js
@@ -80,7 +80,7 @@ const check = (name, cond) => { if (cond) { pass++; console.log('  ✓ ' + name)
 // at all); `viewportY` is where the user is looking, 0 == the very top. The fake
 // records any attempt to move the viewport: the settle must never make one.
 let sends, fake;
-function setup({ agentSurface = false, baseY = 500, viewportY = 0, from = 400,
+function setup({ agentSurface = false, usesAltScreen = false, baseY = 500, viewportY = 0, from = 400,
                  readyState = 1, window: win = 7, dirty = true } = {}) {
   sends = [];
   timers.clear();
@@ -93,7 +93,8 @@ function setup({ agentSurface = false, baseY = 500, viewportY = 0, from = 400,
   };
   T.term = fake;
   T.termWs = { readyState, send(s) { sends.push(JSON.parse(s)); } };
-  T.activeTerminal = win === null ? null : { id: 't1', window: win, agent_surface: agentSurface };
+  T.activeTerminal = win === null ? null
+    : { id: 't1', window: win, agent_surface: agentSurface, uses_alternate_screen: usesAltScreen };
   T.resetScrollbackSync();
   T.scrollbackDirty = dirty;
   T.lastViewportY = from; // where the user scrolled FROM (0 == already parked)
@@ -115,9 +116,24 @@ console.log('scrollback hydrate (CROW-934)');
   check('  ... and clears the dirty flag', T.scrollbackDirty === false);
 }
 {
-  setup({ agentSurface: true });
+  setup({ agentSurface: true, usesAltScreen: true });
   T.maybeHydrateScrollback();
-  check('agent surface never re-syncs', selects().length === 0);
+  check('alt-buffer agent (Claude Code) never re-syncs', selects().length === 0);
+}
+{
+  // CROW-1026: an inline agent (Cursor, and every Manager tab) is agent_surface
+  // but keeps the unified 50k buffer, so it CAN thin and must stay eligible —
+  // same axis as applySurfaceScrollback (agent_surface && uses_alternate_screen).
+  setup({ agentSurface: true, usesAltScreen: false });
+  T.maybeHydrateScrollback();
+  check('inline agent (Cursor/Manager) re-syncs like a shell', selects().length === 1);
+}
+{
+  // A plain shell inside a Claude session is uses_alternate_screen (kind-scoped)
+  // yet NOT agent_surface — it has a real 50k buffer, so it stays eligible.
+  setup({ agentSurface: false, usesAltScreen: true });
+  T.maybeHydrateScrollback();
+  check('plain shell in a Claude session still re-syncs', selects().length === 1);
 }
 {
   setup({ baseY: 0, viewportY: 0 });
@@ -127,7 +143,7 @@ console.log('scrollback hydrate (CROW-934)');
 {
   setup({ baseY: 500, viewportY: 120 });
   T.maybeHydrateScrollback();
-  check('mid-buffer scroll does not re-sync', selects().length === 0);
+  check('mid-buffer scroll does not re-sync synchronously', selects().length === 0);
 }
 {
   setup({ dirty: false });
@@ -278,6 +294,64 @@ console.log('\n  teardown');
   T.maybeHydrateScrollback();
   check('reset clears the cooldown so a new surface can sync immediately',
     selects().length === 2);
+}
+
+// ---- CROW-1026: mid-buffer scroll-idle heal --------------------------------
+
+console.log('\n  mid-buffer scroll-idle heal');
+{
+  // A hole the user parked on mid-buffer heals once scrolling AND output go
+  // quiet — no trip to line 1, no manual Reload. The debounce is 400ms; advance
+  // past it to fire the pending re-capture.
+  setup({ baseY: 500, viewportY: 120 });
+  T.maybeHydrateScrollback();
+  check('the scroll itself issues no synchronous capture', selects().length === 0);
+  advance(500);
+  check('going idle mid-buffer heals the hole',
+    selects().length === 1 && selects()[0].window === 7);
+}
+{
+  // The debounce re-arms on every scroll AND every bottom-pushed line (onScroll
+  // is not a user event), so a streaming build never trips it mid-stream.
+  setup({ baseY: 500, viewportY: 120 });
+  for (let i = 0; i < 50; i++) { T.maybeHydrateScrollback(); advance(100); } // 100 < 400
+  check('a streaming build never fires the idle heal', selects().length === 0);
+  advance(500);
+  check('  ... but one settle after it stops heals once', selects().length === 1);
+}
+{
+  // Alt-buffer agents (Claude Code) have no scrollback to fetch — excluded on the
+  // idle path too, not only the arrival path.
+  setup({ agentSurface: true, usesAltScreen: true, baseY: 500, viewportY: 120 });
+  T.maybeHydrateScrollback();
+  advance(500);
+  check('alt-buffer agent is excluded from the idle heal', selects().length === 0);
+}
+{
+  // The dirty flag is the idle path's primary brake: an already-synced buffer
+  // (nothing thinned since the last sync) does not re-capture.
+  setup({ baseY: 500, viewportY: 120, dirty: false });
+  T.maybeHydrateScrollback();
+  advance(500);
+  check('a clean buffer does not idle-heal', selects().length === 0);
+}
+{
+  // After an idle heal that returns new lines, scrollbackDirty stays false, so
+  // fiddling the scroll again does not re-capture until fresh output dirties it.
+  setup({ baseY: 500, viewportY: 120 });
+  T.maybeHydrateScrollback();
+  advance(500);                       // heal #1
+  fake.buffer.active.baseY = 19949;   // the replay brought the full history...
+  T.noteTerminalFrame();              // ...landing during the flight
+  advance(3000);                      // settle: saw replay, baseY grew → not latched, dirty stays false
+  check('the idle heal issued exactly one capture', selects().length === 1);
+  check('  ... and consumed the dirty flag', T.scrollbackDirty === false);
+  fake.buffer.active.viewportY = 90;  // user nudges the scroll again
+  T.maybeHydrateScrollback();
+  advance(500);
+  check('  ... so a clean buffer does not heal again', selects().length === 1);
+  T.noteTerminalFrame();              // fresh live output (not in flight) re-dirties
+  check('  ... until fresh output marks it dirty', T.scrollbackDirty === true);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #1026

## Problem

In a long-running terminal, the **middle of the scrollback develops holes** as output accumulates (beginning and current screen stay intact). Root cause (verified against source): tmux thins pane redraws for a slow-draining client — the browser is that client — so live output between CROW-606 replays arrives incomplete. `app.js`'s own measurement: `seq 1 20000` leaves ~19,989 lines in the pane but a browser-paced xterm receives only ~337.

The CROW-934 healer `maybeHydrateScrollback` couldn't fix this:

1. **It excluded every `agent_surface` terminal.** That guard was written for **alt-buffer** agents (Claude Code), which legitimately have no scrollback — but post-ADR-0013 it also silenced **inline** agents (Cursor, and every **Manager** tab), which keep a real unified 50k buffer that *does* thin. They never auto-healed; the only recovery was ↻ Reload.
2. **It only fired on arrival at the very top.** A hole the user was looking at mid-buffer never healed unless they scrolled all the way to line 1.

## Fix

**Fix 1 — narrow the exclusion.** From `agent_surface` to `agent_surface && uses_alternate_screen`, reusing the existing `activeSurfaceIsAgent()` / `activeSurfaceUsesAltScreen()` helpers so it stays in lockstep with `applySurfaceScrollback` (the same axis ADR-0013 #1010 uses to cap xterm scrollback). Inline agents and plain shells — including a plain shell inside a Claude session, which is `uses_alternate_screen` but **not** `agent_surface` — become eligible; only true alt-buffer agents stay excluded.

**Fix 2 — scroll-idle mid-buffer heal.** A debounce armed off `onScroll` (which also fires per bottom-pushed line) re-captures **once**, only after scrolling *and* output have both gone quiet — never during a streaming build. It reuses every existing brake (in-flight guard, `scrollbackFullySynced` latch, dirty flag, `HYDRATE_MIN_INTERVAL_MS` cooldown, unchanged settle), so the #935 extend-forever bug cannot return. As on the arrival path there is deliberately no viewport restore, so the `isUserScrolling` rebuild leaves the user at the top of the now-complete history.

The arm tail is factored into a shared `fireScrollbackCapture(buf)`; the arrival-at-top path is otherwise unchanged. **JS-only** — no daemon behavior change, and the ADR-0013 scroll model / reload path (sibling #1027) are untouched.

## Acceptance criteria

- [x] A Cursor/Manager terminal shows a complete, hole-free scrollback without a manual Reload (inline agents now eligible).
- [x] A hole in the middle of the buffer heals automatically, not only at the very top (scroll-idle trigger).
- [x] Alt-buffer agents (Claude Code) are unaffected — still no spurious captures.

## Tests

- `web-tests/scrollback-hydrate.test.js`: split the agent-surface case into **alt-buffer (still excluded)** + **inline agent (now hydrates)**, added a **plain-shell-in-Claude-session** case, and a **mid-buffer scroll-idle** group (heals once; a streaming build never fires it; alt-buffer excluded; dirty/cooldown/latch respected). **44 pass, 0 fail.**
- `WebTerminalAssetTests` (CrowDaemon, 20) and `ScrollbackHealthTests` (CrowTerminal, 9) stay green.
- Full CI-gated web suite: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)