### PR TITLE
Install all embedded corveil skills, not just query-corveil (CROW-1039)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ crow corveil reinstall-skill [--path PATH]     → {"ok":bool,"message":"Skill r
 ```
 
 - **Branch on `ok`, not the exit code.** A corveil that is missing, non-executable, exits non-zero, or hangs past 5s is a successful *report* of a broken binary. A non-zero `crow` exit means the request never ran (no daemon, or no path configured anywhere).
-- `reinstall-skill` re-runs the launch-time `corveil skill install`, writing `{devRoot}/.claude/commands/query-corveil.md` — the "I just rebuilt corveil, pick up its new embedded skill" loop, no `crowd` restart. It is idempotent.
+- `reinstall-skill` re-runs the launch-time `corveil skill install` for **every** embedded skill (enumerated via `corveil skill list`), writing each into `{devRoot}/.claude/commands/<name>.md` — the "I just rebuilt corveil, pick up its new embedded skills" loop, no `crowd` restart. `skill_path` names that directory. It is idempotent; one skill failing doesn't abort the rest (the warning names any that didn't install).
 - A reinstall also updates the launch-time corveil warning: succeeding clears it, failing replaces it.
 - Both are **local-only** on `/rpc` (they execute a path on the daemon host), like `gateway`/`web-password`/`mcp token`. The CLI is unaffected — it goes over the Unix socket.
 

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/CorveilCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/CorveilCommands.swift
@@ -67,16 +67,17 @@ public struct CorveilVerify: ParsableCommand {
 public struct CorveilReinstallSkill: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "reinstall-skill",
-        abstract: "Reinstall the /query-corveil slash command from the corveil binary",
+        abstract: "Reinstall every embedded slash command from the corveil binary",
         discussion: """
         Re-runs the `corveil skill install` that `crowd` runs at launch, writing \
-        `{devRoot}/.claude/commands/query-corveil.md`. Use it after rebuilding \
-        corveil locally to pick up its new embedded skill without restarting \
-        the daemon.
+        every embedded skill the binary ships (`corveil skill list`) into \
+        `{devRoot}/.claude/commands/` — one `<skill>.md` per skill. Use it after \
+        rebuilding corveil locally to pick up its new embedded skills without \
+        restarting the daemon. `skill_path` in the response is that directory.
 
         A run also updates the launch-time corveil warning: succeeding clears \
-        it, failing replaces it, so there is one answer to "is corveil broken?" \
-        rather than a startup one and a button one.
+        it, a per-skill failure replaces it, so there is one answer to "is \
+        corveil broken?" rather than a startup one and a button one.
         """
     )
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilRoutes.swift
@@ -80,7 +80,7 @@ enum CorveilRoutes {
                     appState.corveilSkillInstallWarning = outcome.ok ? nil : outcome.message
                 }
                 var payload = outcomeJSON(outcome)
-                payload["skill_path"] = CorveilCLI.skillPath(devRoot: devRoot)
+                payload["skill_path"] = CorveilCLI.commandsDir(devRoot: devRoot)
                 return json(payload)
 
             default:

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2181,8 +2181,8 @@ private func makeMCPTokenHandlers(devRoot: String) -> [String: CommandRouter.Han
 /// `open-in-vscode` / `open-terminal` are gated on the same argument.
 ///
 /// Neither writes config: `corveil-verify` runs `--version`, and
-/// `corveil-reinstall-skill` writes one file inside the devRoot. What the
-/// reinstall *does* update is `AppState.corveilSkillInstallWarning` — the
+/// `corveil-reinstall-skill` writes the embedded skill files inside the devRoot.
+/// What the reinstall *does* update is `AppState.corveilSkillInstallWarning` —
 /// launch-time diagnostic — so a manual reinstall that succeeds clears the
 /// stale warning and one that fails replaces it. That was the retired desktop
 /// app's behaviour and it is the point: "is corveil broken?" stays
@@ -2212,7 +2212,7 @@ private func makeCorveilHandlers(
                 "ok": .bool(outcome.ok),
                 "message": .string(outcome.message),
                 "path": .string(outcome.path),
-                "skill_path": .string(CorveilCLI.skillPath(devRoot: devRoot)),
+                "skill_path": .string(CorveilCLI.commandsDir(devRoot: devRoot)),
             ]
         },
     ]

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilRouteGatingTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilRouteGatingTests.swift
@@ -44,7 +44,19 @@ import Testing
         try """
         #!/bin/sh
         : > "\(marker)"
-        if [ "$1" = "skill" ]; then printf 'stub skill' > "$4"; fi
+        if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
+          echo query-corveil
+          exit 0
+        fi
+        if [ "$1" = "skill" ] && [ "$2" = "install" ]; then
+          target=""
+          shift 2
+          while [ $# -gt 0 ]; do
+            case "$1" in --path) target="$2"; shift 2;; *) shift;; esac
+          done
+          printf 'stub skill' > "$target"
+          exit 0
+        fi
         echo 'corveil 0.0.1-stub'
         """.write(toFile: binary, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary)
@@ -105,13 +117,14 @@ import Testing
                     try JSONSerialization.jsonObject(with: Data(buffer: response.body))
                         as? [String: Any])
                 #expect(json["ok"] as? Bool == true)
-                // The response names the file it wrote, so the UI can say where.
+                // The response names the directory it wrote into, so the UI can
+                // say where the skills landed.
                 #expect(json["skill_path"] as? String
-                    == CorveilCLI.skillPath(devRoot: fixture.devRoot))
+                    == CorveilCLI.commandsDir(devRoot: fixture.devRoot))
             }
         }
         #expect(FileManager.default.fileExists(
-            atPath: CorveilCLI.skillPath(devRoot: fixture.devRoot)))
+            atPath: CorveilCLI.skillPath(devRoot: fixture.devRoot, skill: "query-corveil")))
     }
 
     /// A broken binary is a successful *report* of a broken binary. 200 with

--- a/Packages/CrowEngine/Sources/CrowEngine/CorveilCLI.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/CorveilCLI.swift
@@ -120,26 +120,39 @@ public enum CorveilCLI {
         return Outcome(ok: false, message: detail, path: path)
     }
 
-    /// Re-run `corveil skill install --path {devRoot}/.claude/commands/query-corveil.md`
-    /// on demand — the same flow the daemon runs at launch, without a restart.
+    /// Re-run `corveil skill install` for **every** embedded skill on demand —
+    /// the same flow the daemon runs at launch, without a restart (CROW-1039,
+    /// generalizing the single-skill CROW-482 install).
     ///
     /// Thin over ``Scaffolder/installCorveilSkill(_:)`` rather than a second
     /// implementation: the button must install exactly what launch installs, or
     /// "reinstall and see if that fixes it" stops being a diagnosis. The
     /// `String?` warning it returns is the daemon's `corveilSkillInstallWarning`
-    /// text, so a failure here reads the same as a failure at startup.
+    /// text — a per-skill failure summary when some skills don't install — so a
+    /// failure here reads the same as a failure at startup.
     public static func reinstallSkill(path: String, devRoot: String) -> Outcome {
         let path = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let warning = Scaffolder(devRoot: devRoot).installCorveilSkill(path) else {
-            return Outcome(ok: true, message: "Skill reinstalled", path: path)
+            return Outcome(ok: true, message: "Skills reinstalled", path: path)
         }
         return Outcome(ok: false, message: warning, path: path)
     }
 
-    /// Where ``reinstallSkill(path:devRoot:)`` writes, for surfaces that want to
-    /// name the file. Kept next to the install so the two cannot disagree.
-    public static func skillPath(devRoot: String) -> String {
-        (devRoot as NSString).appendingPathComponent(".claude/commands/query-corveil.md")
+    /// The `.claude/commands` directory every embedded skill installs into, for
+    /// surfaces that want to name the destination (the Reinstall button's
+    /// `skill_path`). One directory rather than one file now that the install is
+    /// multi-skill (CROW-1039). Kept next to the install so the two cannot
+    /// disagree.
+    public static func commandsDir(devRoot: String) -> String {
+        (devRoot as NSString).appendingPathComponent(".claude/commands")
+    }
+
+    /// The install target for a single embedded skill: `<commandsDir>/<skill>.md`,
+    /// mirroring `corveil skill install`'s own `~/.claude/commands/<skill>.md`
+    /// default. Kept next to the install so the destination and any reported path
+    /// cannot disagree.
+    public static func skillPath(devRoot: String, skill: String) -> String {
+        (commandsDir(devRoot: devRoot) as NSString).appendingPathComponent("\(skill).md")
     }
 
     /// Read a pipe to EOF after the child has exited, so this returns at once.

--- a/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/Scaffolder.swift
@@ -22,11 +22,12 @@ public struct Scaffolder {
     /// these files, so its agent kind is the right one to bake in.
     ///
     /// `corveilBinaryPath`, when set and executable, triggers a post-scaffold
-    /// `corveil skill install --path {devRoot}/.claude/commands/query-corveil.md`
-    /// so the embedded `/query-corveil` slash command stays in sync with the
-    /// user's locally-built corveil binary (CROW-482). Failures here are
-    /// non-fatal: they are returned as `ScaffoldResult.warning` and never
-    /// throw — the rest of the scaffold has already succeeded by that point.
+    /// install of *every* embedded corveil skill into
+    /// `{devRoot}/.claude/commands/` (CROW-1039, generalizing CROW-482), so each
+    /// `/slash-command` the binary ships stays in sync with the user's
+    /// locally-built corveil. Failures here are non-fatal: they are returned as
+    /// `ScaffoldResult.warning` and never throw — the rest of the scaffold has
+    /// already succeeded by that point.
     ///
     /// `binaryOverrides` is the full `defaults.binaries` map. Every entry
     /// whose target is executable becomes a symlink at
@@ -209,8 +210,8 @@ public struct Scaffolder {
         ClaudeHookConfigWriter.ensureCrowCLISymlink(
             devRoot: devRoot, appCrowPath: appCrowBinaryPath)
 
-        // Re-install the embedded /query-corveil slash command from the
-        // user-configured corveil binary on every launch (CROW-482). Failure
+        // Re-install every embedded corveil slash command from the
+        // user-configured corveil binary on every launch (CROW-1039). Failure
         // here is intentionally non-fatal — the rest of the scaffold is done.
         let warning = installCorveilSkill(corveilBinaryPath)
         return ScaffoldResult(warning: warning)
@@ -278,18 +279,31 @@ public struct Scaffolder {
         }
     }
 
-    /// Runs `<corveilBinaryPath> skill install --path {devRoot}/.claude/commands/query-corveil.md`
-    /// when the path is set and points at an executable. Returns a short
-    /// user-facing warning string on failure; `nil` on success or when the
-    /// feature is unconfigured (empty/nil path).
+    /// Installs **every** embedded corveil skill as a `/slash-command` under
+    /// `{devRoot}/.claude/commands/` when `corveilBinaryPath` is set and points
+    /// at an executable (CROW-1039). Returns a short user-facing warning string
+    /// summarizing any per-skill failures; `nil` on success or when the feature
+    /// is unconfigured (empty/nil path).
+    ///
+    /// The set is *enumerated* from the binary (`corveil skill list`), not
+    /// hardcoded, so a corveil that ships a new embedded skill gets it installed
+    /// without a Crow change. Each skill is installed independently
+    /// (`corveil skill install --skill <name> --path .../<name>.md`); one skill
+    /// failing does not abort the rest — failures are aggregated into the single
+    /// returned warning (→ `AppState.corveilSkillInstallWarning`). If the binary
+    /// can't enumerate (older build, no `list` subcommand, empty output) the
+    /// install falls back to the historical single default, ``defaultCorveilSkill``,
+    /// so a launch never regresses to installing *fewer* skills than before.
     ///
     /// `Scaffolder.scaffold(...)` runs synchronously on the daemon's launch
     /// path (`CrowDaemon.run` → `LaunchScaffold.run`, before the Manager
-    /// session is ensured), so a hung corveil binary (wrong executable, stdin
-    /// prompt, etc.) would stall startup before the Manager comes up. The hard
-    /// wall-clock timeout bounds the worst case: after `corveilInstallTimeout`
-    /// seconds the process is sent SIGTERM and the install reports a warning
-    /// rather than blocking forever.
+    /// session is ensured), so a hung corveil binary would stall startup before
+    /// the Manager comes up. Two guards bound the worst case: each subprocess is
+    /// SIGTERM'd after ``corveilInstallTimeout`` seconds, and the whole
+    /// enumerate-then-install sequence shares one ``corveilInstallBudget``
+    /// wall-clock deadline — once it is spent, no further subprocess is launched.
+    /// A binary that hangs on `list` (the common wedged case) still costs only a
+    /// single ``corveilInstallTimeout``, exactly as the one-skill install did.
     ///
     /// Public, not private — it is also the "reinstall without restarting Crow"
     /// entry point for a corveil binary the user just picked (CROW-490) or
@@ -308,12 +322,10 @@ public struct Scaffolder {
         }
 
         // Via `CorveilCLI`, not a second literal: the Settings "Reinstall skill"
-        // button names this file to the user, and a target that drifts from the
-        // name shown would make the button's own report wrong (CROW-1011). The
-        // directory is derived from the target for the same reason — creating
-        // one path and writing to another is how that drift would show up.
-        let target = CorveilCLI.skillPath(devRoot: devRoot)
-        let commandsDir = (target as NSString).deletingLastPathComponent
+        // button names this directory to the user, and a target that drifts from
+        // the name shown would make the button's own report wrong (CROW-1011).
+        // Every skill lands in this one dir, so it is created once up front.
+        let commandsDir = CorveilCLI.commandsDir(devRoot: devRoot)
         do {
             try fm.createDirectory(atPath: commandsDir, withIntermediateDirectories: true)
         } catch {
@@ -321,57 +333,192 @@ public struct Scaffolder {
             return "Corveil skill install failed — could not create .claude/commands directory."
         }
 
+        // One wall-clock deadline shared by enumeration + every install, so N
+        // skills can't stall startup for N × the per-process timeout.
+        let deadline = Date().addingTimeInterval(Self.corveilInstallBudget)
+
+        // 1. Enumerate the embedded skills from the binary itself. A hung `list`
+        //    is the common wedged case — bail with the timeout warning rather
+        //    than spending the rest of the budget on installs that will also
+        //    hang. Any other `list` failure (older binary, no `list`
+        //    subcommand, empty output) falls back to the historical single
+        //    default so we never install *fewer* skills than before CROW-1039.
+        var didFallBack = false
+        let skills: [String]
+        switch runCorveil(binary: path, args: ["skill", "list", "--format", "json"], deadline: deadline) {
+        case .timedOut:
+            CrowLog.info("[Scaffolder] corveil skill list timed out")
+            return Self.timeoutWarning
+        case .launchFailed(let message):
+            CrowLog.info("[Scaffolder] corveil skill list launch failed: \(message)")
+            return "Corveil skill install failed — \(message). Check path in Settings."
+        case .failed(let stderr, let code):
+            CrowLog.info("[Scaffolder] corveil skill list exit=\(code) stderr=\(stderr) — falling back to \(Self.defaultCorveilSkill)")
+            skills = [Self.defaultCorveilSkill]
+            didFallBack = true
+        case .succeeded(let stdout, _):
+            let parsed = Self.parseSkillNames(from: stdout)
+            if parsed.isEmpty {
+                CrowLog.info("[Scaffolder] corveil skill list returned no skills — falling back to \(Self.defaultCorveilSkill)")
+                skills = [Self.defaultCorveilSkill]
+                didFallBack = true
+            } else {
+                skills = parsed
+            }
+        }
+
+        // 2. Install each skill independently. Best-effort: collect per-skill
+        //    failures and keep going, so one broken skill doesn't cost the
+        //    others. A timeout means the binary is now hung, so stop.
+        var failures: [(skill: String, reason: String)] = []
+        installLoop: for skill in skills {
+            guard deadline.timeIntervalSinceNow > 0 else {
+                CrowLog.info("[Scaffolder] corveil install budget spent before \(skill)")
+                failures.append((skill, "timed out"))
+                break
+            }
+            let target = CorveilCLI.skillPath(devRoot: devRoot, skill: skill)
+            // Fallback installs the historical default with no `--skill`, exactly
+            // matching corveil's own default — so an old binary that predates the
+            // `--skill` flag still installs query-corveil.
+            let args = didFallBack
+                ? ["skill", "install", "--path", target]
+                : ["skill", "install", "--skill", skill, "--path", target]
+            switch runCorveil(binary: path, args: args, deadline: deadline) {
+            case .succeeded:
+                CrowLog.info("[Scaffolder] corveil skill '\(skill)' installed at \(target)")
+            case .timedOut:
+                CrowLog.info("[Scaffolder] corveil skill '\(skill)' install timed out")
+                failures.append((skill, "timed out"))
+                break installLoop  // hung binary — don't burn the rest of the budget
+            case .launchFailed(let message):
+                CrowLog.info("[Scaffolder] corveil skill '\(skill)' launch failed: \(message)")
+                failures.append((skill, message))
+            case .failed(let stderr, let code):
+                let detail = stderr.isEmpty ? "exit code \(code)" : stderr
+                CrowLog.info("[Scaffolder] corveil skill '\(skill)' install exit=\(code) stderr=\(stderr)")
+                failures.append((skill, detail))
+            }
+        }
+
+        guard !failures.isEmpty else { return nil }
+        let detail = failures.map { "\($0.skill) (\($0.reason))" }.joined(separator: ", ")
+        let noun = failures.count == 1 ? "skill" : "skills"
+        return "Corveil skill install failed for \(failures.count) \(noun): \(detail). Check path in Settings."
+    }
+
+    /// Outcome of one bounded corveil subprocess run by ``runCorveil(binary:args:deadline:)``.
+    private enum CorveilRun {
+        case succeeded(stdout: String, stderr: String)
+        case failed(stderr: String, code: Int32)
+        case timedOut
+        case launchFailed(String)
+    }
+
+    /// Run `<binary> <args>` bounded by both the per-process
+    /// ``corveilInstallTimeout`` and the caller's shared `deadline`, capturing
+    /// stdout/stderr. Reads the pipes after `waitUntilExit` (the same proven
+    /// pattern as ``CorveilCLI/verify(path:)``): corveil's `list`/`install`
+    /// output is a few short lines, well under the pipe buffer, so a post-exit
+    /// read is deadlock-free and picks up EOF immediately once both writers
+    /// (child + Foundation) have closed.
+    private func runCorveil(binary: String, args: [String], deadline: Date) -> CorveilRun {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { return .timedOut }
+
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: path)
-        proc.arguments = ["skill", "install", "--path", target]
-        let stderrPipe = Pipe()
-        proc.standardError = stderrPipe
-        // Discard stdout explicitly. We don't surface corveil's diagnostic
-        // line, and routing to /dev/null is deadlock-proof — an undrained
-        // `Pipe()` would block the child if it ever wrote >64KB before exit.
-        proc.standardOutput = FileHandle.nullDevice
+        proc.executableURL = URL(fileURLWithPath: binary)
+        proc.arguments = args
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
 
         do {
             try proc.run()
         } catch {
-            CrowLog.info("[Scaffolder] corveil launch failed: \(error.localizedDescription)")
-            return "Corveil skill install failed — \(error.localizedDescription). Check path in Settings."
+            return .launchFailed(error.localizedDescription)
         }
 
-        // Watchdog: SIGTERM after `corveilInstallTimeout` so a hung binary
-        // unblocks `waitUntilExit`. The watchdog records the timeout so we
-        // can distinguish exit-N from wall-clock kill below. `waitUntilExit`
-        // (not a polling loop) is what triggers Foundation's pipe-write-FD
-        // cleanup, which is the only way the post-exit `readToEnd()` below
-        // reliably sees EOF.
-        let watchdog = ScaffolderTimeoutWatchdog(deadline: Self.corveilInstallTimeout, proc: proc)
+        // Cap this process at whichever comes first: the per-process ceiling or
+        // whatever remains of the shared budget.
+        let watchdog = ScaffolderTimeoutWatchdog(
+            deadline: min(Self.corveilInstallTimeout, remaining), proc: proc)
         watchdog.start()
         proc.waitUntilExit()
         let timedOut = watchdog.cancel()
 
-        if timedOut {
-            CrowLog.info("[Scaffolder] corveil skill install timed out after \(String(format: "%.1f", Self.corveilInstallTimeout))s")
-            return "Corveil skill install timed out after \(Int(Self.corveilInstallTimeout))s — binary may be hung. Check path in Settings."
-        }
-        if proc.terminationStatus != 0 {
-            let stderr = (try? stderrPipe.fileHandleForReading.readToEnd())
-                .flatMap { String(data: $0, encoding: .utf8) }?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            CrowLog.info("[Scaffolder] corveil skill install exit=\(proc.terminationStatus) stderr=\(stderr)")
-            let detail = stderr.isEmpty ? "exit code \(proc.terminationStatus)" : stderr
-            return "Corveil skill install failed — \(detail). Check path in Settings."
-        }
-        CrowLog.info("[Scaffolder] corveil skill installed at \(target)")
-        return nil
+        let stdout = Self.readTrimmed(outPipe)
+        let stderr = Self.readTrimmed(errPipe)
+        if timedOut { return .timedOut }
+        if proc.terminationStatus != 0 { return .failed(stderr: stderr, code: proc.terminationStatus) }
+        return .succeeded(stdout: stdout, stderr: stderr)
     }
 
-    /// Wall-clock budget for the per-launch `corveil skill install` run. Tight
-    /// because `Scaffolder.scaffold(...)` runs synchronously on the daemon
-    /// launch path (`CrowDaemon.run` → `LaunchScaffold.run`) before the Manager
-    /// session is ensured — a hung corveil binary delays the Manager's spawn by
-    /// this many seconds. 5s is generous for a local subprocess that only writes
-    /// one ~10KB file.
+    /// Read a pipe to EOF after the child has exited, trimmed. Returns at once
+    /// because `waitUntilExit` has already closed both writer FDs.
+    private static func readTrimmed(_ pipe: Pipe) -> String {
+        let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    /// Parse `corveil skill list` output into embedded-skill names. Current
+    /// corveil builds print one name per line even under `--format json`; a
+    /// future build may emit a JSON array (of strings, or of `{name}` objects).
+    /// Accept all three, and keep only well-formed slugs so a stray banner or
+    /// log line can't become a bogus install target or `<name>.md` filename.
+    static func parseSkillNames(from output: String) -> [String] {
+        if let data = output.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) {
+            if let names = json as? [String] {
+                return names.compactMap(sanitizedSkillName)
+            }
+            if let objects = json as? [[String: Any]] {
+                return objects.compactMap { ($0["name"] as? String).flatMap(sanitizedSkillName) }
+            }
+        }
+        return output.split(whereSeparator: { $0.isNewline })
+            .compactMap { sanitizedSkillName(String($0)) }
+    }
+
+    /// A skill name is a lowercase kebab/underscore slug. Anything else — a
+    /// banner line, a path, a blank line — is rejected, which both filters
+    /// non-skill output and blocks path traversal via the `<name>.md` target
+    /// (a name with `/` or `.` never survives).
+    private static func sanitizedSkillName(_ raw: String) -> String? {
+        let name = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty,
+              name.allSatisfy({
+                  ("a"..."z").contains($0) || ("0"..."9").contains($0) || $0 == "-" || $0 == "_"
+              })
+        else { return nil }
+        return name
+    }
+
+    /// The single skill corveil installs by default, and the historical Crow
+    /// behaviour before CROW-1039. The fallback when the binary can't enumerate
+    /// its embedded skills, so a launch never regresses to installing nothing.
+    static let defaultCorveilSkill = "query-corveil"
+
+    /// Wall-clock budget for a *single* `corveil skill list`/`install`
+    /// subprocess. Tight because `Scaffolder.scaffold(...)` runs synchronously on
+    /// the daemon launch path (`CrowDaemon.run` → `LaunchScaffold.run`) before
+    /// the Manager session is ensured — a hung corveil binary delays the
+    /// Manager's spawn by this many seconds. 5s is generous for a local
+    /// subprocess that only writes one ~10KB file.
     static let corveilInstallTimeout: TimeInterval = 5.0
+
+    /// Overall wall-clock budget across enumeration + *all* installs on the
+    /// launch path (CROW-1039). Bounds the worst case when several installs are
+    /// each slow-but-not-hung: once it is spent, no further subprocess starts. A
+    /// single hung subprocess is bounded tighter, by ``corveilInstallTimeout``.
+    static let corveilInstallBudget: TimeInterval = 10.0
+
+    /// Shared warning text for a corveil binary that hangs during install —
+    /// reused by the `list` bail-out and any per-skill timeout.
+    static let timeoutWarning =
+        "Corveil skill install timed out after \(Int(corveilInstallTimeout))s — binary may be hung. Check path in Settings."
 
     // MARK: - Bundled Templates
 

--- a/Packages/CrowEngine/Tests/CrowEngineTests/CorveilCLITests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/CorveilCLITests.swift
@@ -128,18 +128,32 @@ struct CorveilCLITests {
 
     // MARK: - reinstallSkill
 
-    @Test func reinstallWritesTheSkillFromTheBinary() throws {
+    @Test func reinstallWritesEverySkillFromTheBinary() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(atPath: dir) }
         let devRoot = (dir as NSString).appendingPathComponent("devRoot")
         try FileManager.default.createDirectory(atPath: devRoot, withIntermediateDirectories: true)
 
-        // Stand in for `corveil skill install --path <target>`: write the body
-        // the real CLI would write to whatever `--path` names.
+        // Stand in for a real corveil: enumerate two embedded skills, then on
+        // `skill install --skill <name> --path <target>` write a per-skill body
+        // to `<target>` so the test can prove each one landed (CROW-1039).
         let script = try makeScript(
             #"""
-            if [ "$1" = "skill" ] && [ "$2" = "install" ] && [ "$3" = "--path" ]; then
-              printf 'installed body' > "$4"
+            if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
+              printf 'query-corveil\ncrow-runner\n'
+              exit 0
+            fi
+            if [ "$1" = "skill" ] && [ "$2" = "install" ]; then
+              name=""; target=""
+              shift 2
+              while [ $# -gt 0 ]; do
+                case "$1" in
+                  --skill) name="$2"; shift 2;;
+                  --path) target="$2"; shift 2;;
+                  *) shift;;
+                esac
+              done
+              printf 'body:%s' "$name" > "$target"
               exit 0
             fi
             exit 1
@@ -148,10 +162,13 @@ struct CorveilCLITests {
 
         let outcome = CorveilCLI.reinstallSkill(path: script, devRoot: devRoot)
         #expect(outcome.ok)
-        #expect(outcome.message == "Skill reinstalled")
+        #expect(outcome.message == "Skills reinstalled")
 
-        let installed = try String(contentsOfFile: CorveilCLI.skillPath(devRoot: devRoot), encoding: .utf8)
-        #expect(installed == "installed body")
+        for skill in ["query-corveil", "crow-runner"] {
+            let installed = try String(
+                contentsOfFile: CorveilCLI.skillPath(devRoot: devRoot, skill: skill), encoding: .utf8)
+            #expect(installed == "body:\(skill)")
+        }
     }
 
     @Test func reinstallSurfacesTheLaunchTimeWarningOnFailure() throws {
@@ -176,12 +193,16 @@ struct CorveilCLITests {
         #expect(outcome.message.contains("not executable"))
     }
 
-    // MARK: - skillPath
+    // MARK: - commandsDir / skillPath
 
-    @Test func skillPathIsTheFileScaffoldInstalls() {
-        // Pinned because Settings names this file to the user; `Scaffolder`
-        // installs to exactly this path via the same function.
-        #expect(CorveilCLI.skillPath(devRoot: "/dev/root")
+    @Test func commandsDirAndSkillPathAreWhereScaffoldInstalls() {
+        // Pinned because Settings names the commands dir to the user, and
+        // `Scaffolder` installs each skill to exactly `<dir>/<name>.md` via the
+        // same helpers (CROW-1039).
+        #expect(CorveilCLI.commandsDir(devRoot: "/dev/root") == "/dev/root/.claude/commands")
+        #expect(CorveilCLI.skillPath(devRoot: "/dev/root", skill: "query-corveil")
             == "/dev/root/.claude/commands/query-corveil.md")
+        #expect(CorveilCLI.skillPath(devRoot: "/dev/root", skill: "crow-runner")
+            == "/dev/root/.claude/commands/crow-runner.md")
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/ScaffolderCorveilSkillInstallTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/ScaffolderCorveilSkillInstallTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import Testing
+
+@testable import CrowEngine
+
+/// The multi-skill corveil install `Scaffolder` runs at launch and behind the
+/// Settings "Reinstall skill" button (CROW-1039): enumerate the binary's
+/// embedded skills, install each one independently, aggregate per-skill
+/// failures, and never regress below the historical single default when the
+/// binary can't be enumerated.
+@Suite("Scaffolder — corveil embedded-skill install")
+struct ScaffolderCorveilSkillInstallTests {
+
+    // MARK: - Fixtures
+
+    private func makeTempDevRoot() throws -> (dir: String, devRoot: String) {
+        let dir = NSTemporaryDirectory().appending("scaffolder-corveil-\(UUID().uuidString)")
+        let devRoot = (dir as NSString).appendingPathComponent("devRoot")
+        try FileManager.default.createDirectory(atPath: devRoot, withIntermediateDirectories: true)
+        return (dir, devRoot)
+    }
+
+    @discardableResult
+    private func makeScript(_ body: String, in dir: String, named: String = "corveil") throws -> String {
+        let path = (dir as NSString).appendingPathComponent(named)
+        try "#!/bin/sh\n\(body)\n".write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
+    }
+
+    /// A stub `corveil` that enumerates `skills` (one name per line) and, on
+    /// `skill install --skill <name> --path <target>`, writes `installed:<name>`
+    /// to `<target>` — so a test can prove exactly which skills landed.
+    private func makeEnumeratingCorveil(in dir: String, skills: [String]) throws -> String {
+        let listing = skills.joined(separator: "\\n")
+        return try makeScript(
+            #"""
+            if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
+              printf '\#(listing)\n'
+              exit 0
+            fi
+            if [ "$1" = "skill" ] && [ "$2" = "install" ]; then
+              name=default; target=""
+              shift 2
+              while [ $# -gt 0 ]; do
+                case "$1" in
+                  --skill) name="$2"; shift 2;;
+                  --path) target="$2"; shift 2;;
+                  *) shift;;
+                esac
+              done
+              printf 'installed:%s' "$name" > "$target"
+              exit 0
+            fi
+            exit 1
+            """#,
+            in: dir)
+    }
+
+    private func body(ofSkill skill: String, devRoot: String) throws -> String {
+        try String(contentsOfFile: CorveilCLI.skillPath(devRoot: devRoot, skill: skill), encoding: .utf8)
+    }
+
+    // MARK: - Enumerate + install-each
+
+    @Test func installsEveryEnumeratedSkill() throws {
+        let (dir, devRoot) = try makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let names = ["query-corveil", "crow-runner", "worker-runner", "create-corveil-workflow"]
+        let binary = try makeEnumeratingCorveil(in: dir, skills: names)
+
+        let warning = Scaffolder(devRoot: devRoot).installCorveilSkill(binary)
+
+        #expect(warning == nil)
+        // Every enumerated skill lands as its own `<name>.md`, installed with
+        // `--skill <name>` (the stub echoes the name back into the file body).
+        for name in names {
+            #expect(try body(ofSkill: name, devRoot: devRoot) == "installed:\(name)")
+        }
+    }
+
+    // MARK: - Fallback when enumeration fails
+
+    @Test func fallsBackToDefaultWhenListFails() throws {
+        let (dir, devRoot) = try makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        // An older binary with no `skill list` subcommand. Its `skill install`
+        // matches ONLY when there is no `--skill` flag (i.e. corveil's own
+        // default) — so this both proves the fallback installs query-corveil and
+        // that it omits `--skill`, which an ancient binary wouldn't understand.
+        let binary = try makeScript(
+            #"""
+            if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
+              echo 'unknown command "list"' >&2
+              exit 1
+            fi
+            if [ "$1" = "skill" ] && [ "$2" = "install" ] && [ "$3" = "--path" ]; then
+              printf 'default-install' > "$4"
+              exit 0
+            fi
+            exit 1
+            """#,
+            in: dir)
+
+        let warning = Scaffolder(devRoot: devRoot).installCorveilSkill(binary)
+
+        #expect(warning == nil)
+        #expect(try body(ofSkill: "query-corveil", devRoot: devRoot) == "default-install")
+    }
+
+    @Test func fallsBackToDefaultWhenListIsEmpty() throws {
+        let (dir, devRoot) = try makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        // `skill list` succeeds but prints nothing parseable — still install the
+        // default rather than silently installing nothing.
+        let binary = try makeScript(
+            #"""
+            if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
+              exit 0
+            fi
+            if [ "$1" = "skill" ] && [ "$2" = "install" ] && [ "$3" = "--path" ]; then
+              printf 'default-install' > "$4"
+              exit 0
+            fi
+            exit 1
+            """#,
+            in: dir)
+
+        #expect(Scaffolder(devRoot: devRoot).installCorveilSkill(binary) == nil)
+        #expect(try body(ofSkill: "query-corveil", devRoot: devRoot) == "default-install")
+    }
+
+    // MARK: - Per-skill failure aggregation
+
+    @Test func aggregatesPerSkillFailuresButInstallsTheRest() throws {
+        let (dir, devRoot) = try makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        // `crow-runner` fails to install; the other two succeed. One bad skill
+        // must not abort the others, and the single returned warning must name
+        // the failure with corveil's own diagnostic.
+        let binary = try makeScript(
+            #"""
+            if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
+              printf 'query-corveil\ncrow-runner\nworker-runner\n'
+              exit 0
+            fi
+            if [ "$1" = "skill" ] && [ "$2" = "install" ]; then
+              name=""; target=""
+              shift 2
+              while [ $# -gt 0 ]; do
+                case "$1" in
+                  --skill) name="$2"; shift 2;;
+                  --path) target="$2"; shift 2;;
+                  *) shift;;
+                esac
+              done
+              if [ "$name" = "crow-runner" ]; then
+                echo 'embed missing for crow-runner' >&2
+                exit 7
+              fi
+              printf 'ok' > "$target"
+              exit 0
+            fi
+            exit 1
+            """#,
+            in: dir)
+
+        let warning = Scaffolder(devRoot: devRoot).installCorveilSkill(binary)
+
+        // The two good skills landed; the bad one did not.
+        #expect(FileManager.default.fileExists(
+            atPath: CorveilCLI.skillPath(devRoot: devRoot, skill: "query-corveil")))
+        #expect(FileManager.default.fileExists(
+            atPath: CorveilCLI.skillPath(devRoot: devRoot, skill: "worker-runner")))
+        #expect(!FileManager.default.fileExists(
+            atPath: CorveilCLI.skillPath(devRoot: devRoot, skill: "crow-runner")))
+
+        let text = try #require(warning)
+        #expect(text.contains("crow-runner"))
+        #expect(text.contains("embed missing for crow-runner"))
+        #expect(text.contains("1 skill"))
+    }
+
+    // MARK: - Unconfigured / broken binary
+
+    @Test func unconfiguredBinaryIsANoOp() throws {
+        let (dir, devRoot) = try makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        #expect(Scaffolder(devRoot: devRoot).installCorveilSkill(nil) == nil)
+        #expect(Scaffolder(devRoot: devRoot).installCorveilSkill("   ") == nil)
+        // Nothing was created under .claude/commands.
+        #expect(!FileManager.default.fileExists(
+            atPath: CorveilCLI.commandsDir(devRoot: devRoot)))
+    }
+
+    @Test func nonExecutableBinaryWarnsWithoutRunning() throws {
+        let (dir, devRoot) = try makeTempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let warning = Scaffolder(devRoot: devRoot).installCorveilSkill("/nonexistent/corveil")
+        #expect(warning?.contains("not executable") == true)
+    }
+
+    // MARK: - parseSkillNames
+
+    @Test func parsesOneNamePerLine() {
+        #expect(Scaffolder.parseSkillNames(from: "query-corveil\ncrow-runner\nworker-runner\n")
+            == ["query-corveil", "crow-runner", "worker-runner"])
+    }
+
+    @Test func parsesAJSONArrayOfStrings() {
+        // A future corveil build may honour `--format json` with a real array.
+        #expect(Scaffolder.parseSkillNames(from: #"["query-corveil","crow-runner"]"#)
+            == ["query-corveil", "crow-runner"])
+    }
+
+    @Test func parsesAJSONArrayOfObjects() {
+        let json = #"[{"name":"query-corveil","description":"x"},{"name":"crow-runner"}]"#
+        #expect(Scaffolder.parseSkillNames(from: json) == ["query-corveil", "crow-runner"])
+    }
+
+    @Test func dropsBannerAndBlankLines() {
+        // Only clean slugs survive — a header line, an indented blurb, and blank
+        // lines are all rejected so they can't become bogus install targets.
+        let chatty = """
+        Available skills:
+          query-corveil   Walk a Corveil ontology.
+
+        crow-runner
+        """
+        #expect(Scaffolder.parseSkillNames(from: chatty) == ["crow-runner"])
+    }
+
+    @Test func rejectsPathTraversalNames() {
+        // A name with a slash or a dot never becomes a `<name>.md` target.
+        #expect(Scaffolder.parseSkillNames(from: "../evil\n/etc/passwd\nok-skill")
+            == ["ok-skill"])
+    }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -788,7 +788,7 @@ crow corveil verify --path /opt/homebrew/bin/corveil
 
 ### `crow corveil reinstall-skill`
 
-Reinstall the `/query-corveil` slash command from the corveil binary — the same `corveil skill install` the daemon runs at launch, without restarting it.
+Reinstall **every** embedded slash command from the corveil binary — the same `corveil skill install` the daemon runs at launch, without restarting it. The set is enumerated from the binary (`corveil skill list`), so a corveil that ships a new embedded skill gets it installed without a Crow change.
 
 ```bash
 crow corveil reinstall-skill
@@ -798,14 +798,15 @@ crow corveil reinstall-skill --path ~/src/corveil/bin/corveil
 ```json
 {
   "ok": true,
-  "message": "Skill reinstalled",
+  "message": "Skills reinstalled",
   "path": "/opt/homebrew/bin/corveil",
-  "skill_path": "/Users/you/Dev/.claude/commands/query-corveil.md"
+  "skill_path": "/Users/you/Dev/.claude/commands"
 }
 ```
 
-- The loop this serves is "I just rebuilt corveil locally; install its new embedded skill." The install is idempotent, so running it repeatedly is safe.
-- A run also updates the launch-time corveil warning: succeeding clears it, failing replaces it. There is one answer to "is corveil broken?", not a startup one and a button one.
+- Each skill lands as `{devRoot}/.claude/commands/<name>.md`; `skill_path` names that directory. The install is idempotent, so running it repeatedly is safe.
+- The loop this serves is "I just rebuilt corveil locally; install its new embedded skills." Each skill installs independently — one that fails doesn't abort the rest, and `message` names the ones that didn't install (`ok` is then `false`).
+- A run also updates the launch-time corveil warning: succeeding clears it, a per-skill failure replaces it. There is one answer to "is corveil broken?", not a startup one and a button one.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow codex-notify`](#crow-codex-notify) | Bridge Codex's notify command into Crow's hook-event pipeline |
 | [`crow complete-session`](#crow-complete-session) | Mark a session completed |
 | [`crow corveil`](#crow-corveil) | Verify the configured Corveil CLI binary, and reinstall its skill |
-| [`crow corveil reinstall-skill`](#crow-corveil-reinstall-skill) | Reinstall the /query-corveil slash command from the corveil binary |
+| [`crow corveil reinstall-skill`](#crow-corveil-reinstall-skill) | Reinstall every embedded slash command from the corveil binary |
 | [`crow corveil verify`](#crow-corveil-verify) | Run `corveil --version` and report what came back |
 | [`crow create-manager`](#crow-create-manager) | Create an additional Manager session |
 | [`crow defaults`](#crow-defaults) | View or change workspace and automation defaults |
@@ -491,15 +491,15 @@ Subcommands: [`verify`](#crow-corveil-verify), [`reinstall-skill`](#crow-corveil
 
 ## `crow corveil reinstall-skill`
 
-Reinstall the /query-corveil slash command from the corveil binary.
+Reinstall every embedded slash command from the corveil binary.
 
 ```
 crow corveil reinstall-skill [--path <path>]
 ```
 
-Re-runs the `corveil skill install` that `crowd` runs at launch, writing `{devRoot}/.claude/commands/query-corveil.md`. Use it after rebuilding corveil locally to pick up its new embedded skill without restarting the daemon.
+Re-runs the `corveil skill install` that `crowd` runs at launch, writing every embedded skill the binary ships (`corveil skill list`) into `{devRoot}/.claude/commands/` — one `<skill>.md` per skill. Use it after rebuilding corveil locally to pick up its new embedded skills without restarting the daemon. `skill_path` in the response is that directory.
 
-A run also updates the launch-time corveil warning: succeeding clears it, failing replaces it, so there is one answer to "is corveil broken?" rather than a startup one and a button one.
+A run also updates the launch-time corveil warning: succeeding clears it, a per-skill failure replaces it, so there is one answer to "is corveil broken?" rather than a startup one and a button one.
 
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #1039

## Problem

`Scaffolder.installCorveilSkill` hardcoded a single skill (`query-corveil`) in two places — it built `["skill", "install", "--path", target]` with **no `--skill` flag** (so `corveil skill install` fell back to its own `query-corveil` default), and `target` came from `CorveilCLI.skillPath(devRoot:)`, literally `.../query-corveil.md`. So the other embedded skills the binary ships — `create-corveil-workflow`, `crow-runner`, `worker-runner` — never reached `.claude/commands/` and never became `/slash-commands`, even though `corveil skill list` shows all four. `crow corveil reinstall-skill` shared the same function and the same limitation.

## Change

Generalize the installer to **enumerate** the binary's embedded skills (`corveil skill list`) and install each to `{devRoot}/.claude/commands/<name>.md` independently. This covers the ticket's five concerns:

- **Enumerate, don't hardcode** — `parseSkillNames` accepts one-name-per-line (what current corveil builds print, even under `--format json`) and a JSON array of strings/objects (a future build), keeping only well-formed slugs so a banner line or a path-traversal name can't become an install target or filename.
- **Warning aggregation** — per-skill best-effort: one skill failing doesn't abort the rest; failures aggregate into the single `String?` warning (→ `AppState.corveilSkillInstallWarning`), naming each failed skill with corveil's own diagnostic.
- **Timeout budget** — keeps the per-process 5s cap **and** adds a 10s overall `corveilInstallBudget` shared across enumerate + all installs, so N installs can't stall the synchronous launch path (`CrowDaemon.run` → `LaunchScaffold.run`). A hang on `list` (the common wedged case) still costs just one 5s cap.
- **Fallback** — if the binary can't enumerate (older build, no `list` subcommand, empty output), install the historical `query-corveil` default with **no `--skill`**, so a launch never regresses to installing fewer skills than before.
- **Path surface** — `CorveilCLI.skillPath(devRoot:)` (a single `query-corveil` file) is replaced by `commandsDir(devRoot:)` + `skillPath(devRoot:skill:)`. The Reinstall button / `corveil-reinstall-skill` RPC now report the commands **directory** as `skill_path`.

Default-install-all (no config allowlist) — simplest, and matches "the binary ships what it wants installed."

## Acceptance

- On daemon launch and on `crow corveil reinstall-skill`, every embedded skill lands in `{devRoot}/.claude/commands/` — verified by a test installing `create-corveil-workflow`, `crow-runner`, `worker-runner` alongside `query-corveil`.
- A missing / hung / non-executable / non-enumerable binary still can't stall startup (per-process cap + overall budget + `list`-timeout bail + fallback).
- The Reinstall report reflects the multi-skill result (directory `skill_path`, per-skill failure summary).

## Docs

Updated the `reinstall-skill` CLI abstract/discussion (regenerated `docs/cli.md`), the hand-written `docs/cli-reference.md`, and `CLAUDE.md`.

## Tests

- New `ScaffolderCorveilSkillInstallTests`: enumerate-and-install-each, fallback (list fails / empty output), per-skill failure aggregation, unconfigured/non-executable no-op, and `parseSkillNames` (plain lines, JSON array of strings, JSON array of objects, banner/blank filtering, path-traversal rejection).
- Updated `CorveilCLITests` and `CorveilRouteGatingTests` for the new multi-skill shape and `commandsDir`/`skillPath(devRoot:skill:)` surface.
- CrowEngine (49), CrowDaemon corveil/launch (11), and CrowCLI corveil/docs (11) suites pass; CLI parity + docs-freshness gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)