### PR TITLE
Swap crow-runner sample name in CrowEngine skill-install test fixtures (CROW-1041)

### DIFF
--- a/Packages/CrowEngine/Tests/CrowEngineTests/CorveilCLITests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/CorveilCLITests.swift
@@ -140,7 +140,7 @@ struct CorveilCLITests {
         let script = try makeScript(
             #"""
             if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
-              printf 'query-corveil\ncrow-runner\n'
+              printf 'query-corveil\nsample-skill\n'
               exit 0
             fi
             if [ "$1" = "skill" ] && [ "$2" = "install" ]; then
@@ -164,7 +164,7 @@ struct CorveilCLITests {
         #expect(outcome.ok)
         #expect(outcome.message == "Skills reinstalled")
 
-        for skill in ["query-corveil", "crow-runner"] {
+        for skill in ["query-corveil", "sample-skill"] {
             let installed = try String(
                 contentsOfFile: CorveilCLI.skillPath(devRoot: devRoot, skill: skill), encoding: .utf8)
             #expect(installed == "body:\(skill)")
@@ -202,7 +202,7 @@ struct CorveilCLITests {
         #expect(CorveilCLI.commandsDir(devRoot: "/dev/root") == "/dev/root/.claude/commands")
         #expect(CorveilCLI.skillPath(devRoot: "/dev/root", skill: "query-corveil")
             == "/dev/root/.claude/commands/query-corveil.md")
-        #expect(CorveilCLI.skillPath(devRoot: "/dev/root", skill: "crow-runner")
-            == "/dev/root/.claude/commands/crow-runner.md")
+        #expect(CorveilCLI.skillPath(devRoot: "/dev/root", skill: "sample-skill")
+            == "/dev/root/.claude/commands/sample-skill.md")
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/ScaffolderCorveilSkillInstallTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/ScaffolderCorveilSkillInstallTests.swift
@@ -66,7 +66,7 @@ struct ScaffolderCorveilSkillInstallTests {
     @Test func installsEveryEnumeratedSkill() throws {
         let (dir, devRoot) = try makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: dir) }
-        let names = ["query-corveil", "crow-runner", "worker-runner", "create-corveil-workflow"]
+        let names = ["query-corveil", "sample-skill", "worker-runner", "create-corveil-workflow"]
         let binary = try makeEnumeratingCorveil(in: dir, skills: names)
 
         let warning = Scaffolder(devRoot: devRoot).installCorveilSkill(binary)
@@ -135,13 +135,13 @@ struct ScaffolderCorveilSkillInstallTests {
     @Test func aggregatesPerSkillFailuresButInstallsTheRest() throws {
         let (dir, devRoot) = try makeTempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: dir) }
-        // `crow-runner` fails to install; the other two succeed. One bad skill
+        // `sample-skill` fails to install; the other two succeed. One bad skill
         // must not abort the others, and the single returned warning must name
         // the failure with corveil's own diagnostic.
         let binary = try makeScript(
             #"""
             if [ "$1" = "skill" ] && [ "$2" = "list" ]; then
-              printf 'query-corveil\ncrow-runner\nworker-runner\n'
+              printf 'query-corveil\nsample-skill\nworker-runner\n'
               exit 0
             fi
             if [ "$1" = "skill" ] && [ "$2" = "install" ]; then
@@ -154,8 +154,8 @@ struct ScaffolderCorveilSkillInstallTests {
                   *) shift;;
                 esac
               done
-              if [ "$name" = "crow-runner" ]; then
-                echo 'embed missing for crow-runner' >&2
+              if [ "$name" = "sample-skill" ]; then
+                echo 'embed missing for sample-skill' >&2
                 exit 7
               fi
               printf 'ok' > "$target"
@@ -173,11 +173,11 @@ struct ScaffolderCorveilSkillInstallTests {
         #expect(FileManager.default.fileExists(
             atPath: CorveilCLI.skillPath(devRoot: devRoot, skill: "worker-runner")))
         #expect(!FileManager.default.fileExists(
-            atPath: CorveilCLI.skillPath(devRoot: devRoot, skill: "crow-runner")))
+            atPath: CorveilCLI.skillPath(devRoot: devRoot, skill: "sample-skill")))
 
         let text = try #require(warning)
-        #expect(text.contains("crow-runner"))
-        #expect(text.contains("embed missing for crow-runner"))
+        #expect(text.contains("sample-skill"))
+        #expect(text.contains("embed missing for sample-skill"))
         #expect(text.contains("1 skill"))
     }
 
@@ -203,19 +203,19 @@ struct ScaffolderCorveilSkillInstallTests {
     // MARK: - parseSkillNames
 
     @Test func parsesOneNamePerLine() {
-        #expect(Scaffolder.parseSkillNames(from: "query-corveil\ncrow-runner\nworker-runner\n")
-            == ["query-corveil", "crow-runner", "worker-runner"])
+        #expect(Scaffolder.parseSkillNames(from: "query-corveil\nsample-skill\nworker-runner\n")
+            == ["query-corveil", "sample-skill", "worker-runner"])
     }
 
     @Test func parsesAJSONArrayOfStrings() {
         // A future corveil build may honour `--format json` with a real array.
-        #expect(Scaffolder.parseSkillNames(from: #"["query-corveil","crow-runner"]"#)
-            == ["query-corveil", "crow-runner"])
+        #expect(Scaffolder.parseSkillNames(from: #"["query-corveil","sample-skill"]"#)
+            == ["query-corveil", "sample-skill"])
     }
 
     @Test func parsesAJSONArrayOfObjects() {
-        let json = #"[{"name":"query-corveil","description":"x"},{"name":"crow-runner"}]"#
-        #expect(Scaffolder.parseSkillNames(from: json) == ["query-corveil", "crow-runner"])
+        let json = #"[{"name":"query-corveil","description":"x"},{"name":"sample-skill"}]"#
+        #expect(Scaffolder.parseSkillNames(from: json) == ["query-corveil", "sample-skill"])
     }
 
     @Test func dropsBannerAndBlankLines() {
@@ -225,9 +225,9 @@ struct ScaffolderCorveilSkillInstallTests {
         Available skills:
           query-corveil   Walk a Corveil ontology.
 
-        crow-runner
+        sample-skill
         """
-        #expect(Scaffolder.parseSkillNames(from: chatty) == ["crow-runner"])
+        #expect(Scaffolder.parseSkillNames(from: chatty) == ["sample-skill"])
     }
 
     @Test func rejectsPathTraversalNames() {


### PR DESCRIPTION
Closes #1041

Follow-up to corveil/corveil#2301 (removal of the `crow-runner` corveil skill).

## What

The `crow-runner` skill is being fully removed. Crow has **no production dependency** on it — the only references were a handful of CrowEngine test fixtures using `"crow-runner"` as a *sample* skill name feeding a stubbed `corveil skill list` / `skill install`. Once the real skill is gone, those fixtures named a skill that no longer exists.

Swapped `crow-runner` → `sample-skill` (an obviously-synthetic placeholder) in:

- `Packages/CrowEngine/Tests/CrowEngineTests/ScaffolderCorveilSkillInstallTests.swift` — the enumerate/install list, the per-skill-failure aggregation test, and the `parseSkillNames` cases.
- `Packages/CrowEngine/Tests/CrowEngineTests/CorveilCLITests.swift` — the stub `skill list` output, the install loop, and the `skillPath(devRoot:skill:)` case.

`sample-skill` was chosen over the ticket's `worker-runner`/`create-corveil-workflow` suggestions because those names already appear alongside `crow-runner` in some lists — a synthetic name avoids collisions and makes clear it's just test data.

## Why it's cosmetic

The fixtures drive a **stub** corveil binary; the sample names are arbitrary strings feeding a fake `corveil skill list`. They exercise the generic enumerate-and-install-each logic from #1039, not `crow-runner` specifically. No behavior change; assertions updated to match the new sample.

## Verification

- No `crow-runner` reference remains under `Packages/CrowEngine/Tests/**`.
- `swift test --package-path Packages/CrowEngine --filter Corveil` → **26 tests, 2 suites, all green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)