### PR TITLE
Gate visual-viewport refit to touch surfaces so desktop fills the pane (CROW-1045)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.html
@@ -21,10 +21,13 @@
     }
     /* Under viewport-fit=cover the page runs under the home indicator, so inset
        the grid — otherwise the prompt line sits behind it once the keyboard
-       closes (CROW-988). border-box keeps the page exactly one viewport tall. */
-    body {
-      box-sizing: border-box;
-      padding-bottom: env(safe-area-inset-bottom);
+       closes (CROW-988). border-box keeps the page exactly one viewport tall.
+       Scoped to coarse pointer (CROW-1045): only a touch surface has a home
+       indicator, and the desktop WKWebView must not carry bottom padding —
+       env() already resolves to 0 there, so this is belt-and-suspenders. */
+    body { box-sizing: border-box; }
+    @media (pointer: coarse) {
+      body { padding-bottom: env(safe-area-inset-bottom); }
     }
     /* CROW-1006: iOS must not pop its own long-press sheet over the grid — the
        #ctxmenu below is what a long-press opens here. Nothing is lost: xterm.css

--- a/Packages/CrowDaemon/web-tests/visual-viewport.test.js
+++ b/Packages/CrowDaemon/web-tests/visual-viewport.test.js
@@ -6,6 +6,8 @@ const { JSDOM } = require('jsdom');
 // xterm-addon-crow-viewport.js (served to the web UI at /xterm/…) against a fake
 // visualViewport, a fake xterm and a controllable rAF, so the geometry maths and
 // the "leave every non-phone surface alone" guards are pinned without a device.
+// CROW-1045 adds the desktop-WKWebView guard: `visualViewport` presence is not a
+// keyboard, so a non-touch surface must stay fully inert (case 1b).
 const ADDON_JS =
   __dirname + '/../../CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js';
 
@@ -17,10 +19,18 @@ const HOST_TOP = 120;      // the web app's terminal sits below header + tabbar
 
 // A fresh world per case: the addon holds module-free per-instance state, but
 // each test wants its own listener set, rAF queue and host element.
-function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP } = {}) {
+function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP, keyboardCapable = true } = {}) {
   const dom = new JSDOM('<!doctype html><html><body><div id="host"></div></body></html>',
     { runScripts: 'outside-only', url: 'http://localhost/' });
   const { window } = dom;
+
+  // CROW-1045: the addon now gates on a keyboard-capable surface (touch), not
+  // merely `visualViewport` presence — a desktop WKWebView exposes visualViewport
+  // but has no software keyboard. jsdom implements neither `matchMedia` nor a
+  // non-zero `maxTouchPoints`, so it reads as desktop by default; hand it a
+  // `matchMedia` that answers `(pointer: coarse)` to model a phone/tablet. The
+  // one desktop case flips this off to prove the addon stays wholly inert.
+  window.matchMedia = (q) => ({ media: q, matches: keyboardCapable && /coarse/.test(q) });
 
   // rAF we drive by hand. Callbacks registered DURING a flush land in the next
   // one, matching the browser — the addon relies on that to pin the prompt only
@@ -98,6 +108,27 @@ function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP } = {}) {
   check('registers no listeners', Object.keys(w.listeners).length === 0);
   check('schedules no frames', w.frames() === 0);
   check('writes no inline height', w.height() === '');
+  check('dispose is safe', (() => { try { w.addon.dispose(); return true; } catch (_) { return false; } })());
+}
+
+// ---- 1b. Desktop WKWebView (has visualViewport, no keyboard) → inert ---------
+// CROW-1045 regression: the macOS desktop app is a WKWebView that exposes
+// `visualViewport` just like a phone, and under viewport-fit=cover its layout
+// viewport can outrun the visible height enough to look like a keyboard. With no
+// software keyboard on the surface, the addon must not act on that — it has to
+// be as inert as the no-visualViewport case, or it shrinks a full-height grid
+// and strands a dead band below it.
+{
+  console.log('desktop WKWebView (no software keyboard)');
+  const w = makeWorld({ keyboardCapable: false });
+  w.activate();
+  check('registers no listeners', Object.keys(w.listeners).length === 0);
+  check('schedules no frames', w.frames() === 0);
+  // A keyboard-sized occlusion that WOULD size the host on a phone…
+  w.keyboard(300);
+  w.emit();       // no subscription, so nothing runs — asserted for intent
+  check('writes no inline height', w.height() === '');
+  check('asks for no refit', w.resizes.length === 0);
   check('dispose is safe', (() => { try { w.addon.dispose(); return true; } catch (_) { return false; } })());
 }
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js
@@ -16,12 +16,24 @@
 // the parity drift that bit reflow-debounce #661/#662 and the mouse-mode
 // swallow #776.
 //
-// Deliberately inert everywhere a keyboard can't occlude the page: absent
-// `visualViewport` (older embedded webviews) is a hard no-op, and so is any
-// occlusion below KEYBOARD_MIN_OCCLUSION — which is what desktop browsers and
-// mobile browser chrome produce. Nothing is written to the host's style until a
-// keyboard-sized inset actually appears, and it is restored verbatim when that
-// inset goes away.
+// Deliberately inert everywhere a keyboard can't occlude the page. Three
+// independent guards: absent `visualViewport` (older embedded webviews) is a
+// hard no-op; a surface with no software keyboard (the desktop WKWebView — see
+// below) never even subscribes; and past those, any occlusion below
+// KEYBOARD_MIN_OCCLUSION is ignored. Nothing is written to the host's style
+// until a keyboard-sized inset actually appears, and it is restored verbatim
+// when that inset goes away.
+//
+// CROW-1045: `visualViewport` presence alone is NOT "this surface has a
+// keyboard." The macOS desktop app is a WKWebView (Tauri), and WKWebViews
+// expose `visualViewport` just like a phone does. Under `viewport-fit=cover`
+// its layout viewport (`documentElement.clientHeight`) can outrun the visible
+// `visualViewport.height` by the window chrome / safe-area — an offset the
+// occlusion test above then mistakes for a keyboard, shrinking the terminal
+// host and stranding a dead band below the grid (the reported regression). A
+// software keyboard only exists on a touch surface, so gate the whole addon on
+// that: coarse pointer or touch points. Desktop fails both and stays inert,
+// exactly like the no-`visualViewport` case; phones and tablets are unchanged.
 //
 // Loaded via <script src> (not ES modules), so it exposes a namespaced UMD-style
 // global matching the vendored addons
@@ -42,6 +54,31 @@
   // FitAddon a 0-or-negative box, whose degenerate proposeDimensions makes a
   // junk grid — the same failure the host pages already guard against.
   var MIN_HOST_HEIGHT = 40;
+
+  // Does this surface have a software keyboard that can occlude the page? Only a
+  // touch surface does. `visualViewport` is not the test — desktop WKWebViews
+  // (the Tauri macOS app) expose it too, and CROW-1045 is exactly that surface
+  // tripping the occlusion detector on window chrome. `maxTouchPoints > 0` is
+  // the primary signal (iOS reports 5, macOS reports 0); `(pointer: coarse)` is
+  // the fallback for the rare touch device that under-reports it. Both are
+  // wrapped/typed defensively — an embedded webview may lack `matchMedia`, and a
+  // throwing/absent one must read as "not touch," i.e. desktop, i.e. inert.
+  function keyboardCapable(global) {
+    var nav = global.navigator;
+    if (nav && typeof nav.maxTouchPoints === 'number' && nav.maxTouchPoints > 0) {
+      return true;
+    }
+    var mm = global.matchMedia;
+    if (typeof mm === 'function') {
+      try {
+        var q = mm.call(global, '(pointer: coarse)');
+        if (q && q.matches) {
+          return true;
+        }
+      } catch (_) { /* no usable matchMedia → treat as non-touch */ }
+    }
+    return false;
+  }
 
   /// `options.host`    element to size; defaults to the container passed to
   ///                   `term.open()` (i.e. `term.element.parentElement`).
@@ -68,6 +105,13 @@
     // No signal → leave the page exactly as it was. This is the whole
     // "non-visualViewport webviews are unchanged" guarantee.
     if (!vv) {
+      return;
+    }
+    // No software keyboard on this surface → same hard no-op (CROW-1045). The
+    // desktop WKWebView has `visualViewport` but no keyboard, so acting on its
+    // occlusion would shrink a full-height terminal for nothing. Bail before
+    // subscribing so this surface never even schedules a measurement.
+    if (!keyboardCapable(global)) {
       return;
     }
     var host = this._host || (term.element && term.element.parentElement);


### PR DESCRIPTION
Closes #1045

## Problem

Agent-session terminals (Claude Code and every agent surface) stopped filling the full pane height in the **macOS desktop app**: the grid renders from the top and leaves a large blank band (~a quarter to a third of the pane) below the prompt. Regression from CROW-988 (#996), which refit the web terminal to the visual viewport for the phone software-keyboard case on the explicit assumption that "desktop is untouched."

## Root cause (mechanism a)

`CrowViewportAddon.activate()` gated only on `window.visualViewport` *existing*. But the macOS desktop app is a **WKWebView (Tauri)**, and WKWebViews expose `visualViewport` just like a phone. Under `viewport-fit=cover`, the layout viewport (`documentElement.clientHeight`) can outrun the visible `visualViewport.height` by the window chrome / safe-area, so the occlusion detector (`occluded > KEYBOARD_MIN_OCCLUSION` = 120) mistakes that offset for a software keyboard and writes a short inline `height` on the terminal host (`term.element.parentElement` = `#terminal`). xterm refits to the short box → dead band. The in-place session switch (#1036) and `applyTermFit`'s `!document.hasFocus()` early-return (#667) then keep the wrong size pinned.

## Fix

A software keyboard only exists on a **touch surface**, so gate the whole addon on that (`(pointer: coarse)` or `navigator.maxTouchPoints > 0`) — not merely on `visualViewport` presence. Desktop fails the check and stays **fully inert**: no listeners, no measurement, no host resize — exactly like the existing no-`visualViewport` guarantee. Phones and tablets are unchanged; they still get the CROW-988 keyboard fix.

Defensively (mechanism b), `terminal.html`'s `padding-bottom: env(safe-area-inset-bottom)` is scoped to `@media (pointer: coarse)`. The `viewport-fit=cover` / `interactive-widget=resizes-content` meta tags are **left in place** — they are provably inert on desktop (no notch, no virtual keyboard) and the Swift asset tests (`viewportMetaHandlesTheSoftwareKeyboard`) require them.

## Tests

- **`web-tests/visual-viewport.test.js`**: new "desktop WKWebView (no software keyboard)" case — has `visualViewport` but is not keyboard-capable — proving the addon registers no listeners, schedules no frames, and writes no inline height even under a keyboard-sized occlusion. Existing phone-keyboard cases keep passing (harness now models a keyboard-capable world by default). 36/36 pass (was 31).
- Web CI subset (`npm run test:ci`): all green.
- Swift asset tests: CrowTerminal `BundledResourcesTests` 9/9, CrowDaemon `WebTerminalAssetTests` 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)