### PR TITLE
Launch the Cursor binary discovery verified, not a fresh PATH walk (CROW-1058)

### DIFF
--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -73,7 +73,7 @@ public struct AntigravityAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let agentPath = AntigravityLaunchArgs.shellQuote(findBinary() ?? "agy")
+        let agentPath = AntigravityLaunchArgs.shellQuote(launchBinary() ?? "agy")
         // Bounded auto-permission — a no-op suffix on the pinned version (see
         // `AntigravityLaunchArgs.autoPermissionSuffix`); kept for call-site
         // uniformity so a future bounded flag lands once for every path.
@@ -166,7 +166,7 @@ public struct AntigravityAgent: CodingAgent {
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
-            binary: findBinary() ?? "agy"
+            binary: launchBinary() ?? "agy"
         )
     }
 
@@ -181,7 +181,7 @@ public struct AntigravityAgent: CodingAgent {
         // control doesn't apply. Terminal backend appends the submitting Enter,
         // so return the command without a trailing newline (cross-agent
         // convention).
-        let agentPath = AntigravityLaunchArgs.shellQuote(findBinary() ?? "agy")
+        let agentPath = AntigravityLaunchArgs.shellQuote(launchBinary() ?? "agy")
         return agentPath + AntigravityLaunchArgs.autoPermissionSuffix(autoPermissionMode)
     }
 

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
@@ -51,7 +51,7 @@ public struct ClaudeCodeAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let claudePath = findBinary() ?? "claude"
+        let claudePath = launchBinary() ?? "claude"
         let rcArgs = ClaudeLaunchArgs.argsSuffix(
             remoteControl: remoteControlEnabled,
             sessionName: session.name,
@@ -130,7 +130,7 @@ public struct ClaudeCodeAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String {
-        let claudePath = findBinary() ?? "claude"
+        let claudePath = launchBinary() ?? "claude"
         return claudePath + ClaudeLaunchArgs.argsSuffix(
             remoteControl: remoteControlEnabled,
             sessionName: sessionName,

--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -79,7 +79,7 @@ public struct OpenAICodexAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let codexPath = findBinary() ?? "codex"
+        let codexPath = launchBinary() ?? "codex"
 
         switch session.kind {
         case .work:
@@ -225,7 +225,7 @@ public struct OpenAICodexAgent: CodingAgent {
         // command rather than on `supportsRemoteControl`
         // (`SessionService.ensureManagerSession`), so the CROW-1001 flip
         // leaves this path exactly as it was — same as Cursor's Manager.
-        return findBinary() ?? "codex"
+        return launchBinary() ?? "codex"
     }
 
     /// Codex TUI exposes `/rename` for the current thread (CROW-629).

--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentDiscovery.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentDiscovery.swift
@@ -22,19 +22,61 @@ public enum AgentAvailability: Sendable, Equatable {
 /// decision lived inside a `private static` local function).
 public enum AgentDiscovery {
     /// Resolve `agent`'s binary and decide availability. An explicit
-    /// `.override` pin is trusted without probing; a PATH/`.fallback` match on a
-    /// collision-prone token is identity-probed (`verifyBinaryIdentity`) so a
+    /// `.override` pin is trusted without probing; PATH/`.fallback` matches on a
+    /// collision-prone token are identity-probed (`verifyBinaryIdentity`) so a
     /// foreign same-named binary is reported unavailable rather than launchable.
+    ///
+    /// Also **pins the verified path** in `VerifiedBinaries` so launch execs the
+    /// binary discovery identified, rather than re-resolving and possibly
+    /// landing elsewhere (CROW-1058). That side effect is why this is the one
+    /// entry point registration should call; `decide` below is the pure half.
     public static func evaluate(_ agent: any CodingAgent) async -> AgentAvailability {
-        guard let resolved = agent.resolveBinary() else {
+        let outcome = await decide(agent)
+        // Pin the winner so `launchBinary()` execs the binary we identified
+        // rather than re-walking PATH and possibly landing on a different one
+        // (CROW-1058). Clearing on failure matters as much as recording on
+        // success: a re-registration that now fails must not leave the previous
+        // pin behind for launch to keep using.
+        switch outcome {
+        case .available(let path, _):
+            VerifiedBinaries.shared.record(kind: agent.kind, path: path)
+        case .unavailableNotFound, .unavailableFailedProbe:
+            VerifiedBinaries.shared.clear(kind: agent.kind)
+        }
+        return outcome
+    }
+
+    /// The availability decision itself, with no side effects.
+    ///
+    /// Probes **every** candidate rather than only the first. A single sample is
+    /// enough to judge an unambiguous token, but not one that collides: with
+    /// grok-build's `agent` ahead of Cursor's on PATH, first-sample-only reports
+    /// Cursor unavailable while a genuine `cursor-agent` sits further down the
+    /// list (CROW-989's documented residual, CROW-1058). Candidates are already
+    /// in preference order, so the first that verifies is also the most
+    /// preferred one that verifies.
+    ///
+    /// Cost is unchanged for a healthy install: candidates are ordered
+    /// preferred-name-first, so the genuine binary is normally sampled first and
+    /// the loop exits after one spawn. Extra probes happen only when an earlier
+    /// candidate is an impostor — exactly the case worth paying for — and each
+    /// is hard-bounded by `BinaryIdentityProbe`.
+    private static func decide(_ agent: any CodingAgent) async -> AgentAvailability {
+        let candidates = agent.resolveBinaryCandidates()
+        guard let first = candidates.first else {
             return .unavailableNotFound
         }
-        if resolved.source == .override {
-            return .available(path: resolved.path, viaOverride: true)
+        if first.source == .override {
+            return .available(path: first.path, viaOverride: true)
         }
-        if await agent.verifyBinaryIdentity(atPath: resolved.path) {
-            return .available(path: resolved.path, viaOverride: false)
+        for candidate in candidates {
+            if await agent.verifyBinaryIdentity(atPath: candidate.path) {
+                return .available(path: candidate.path, viaOverride: false)
+            }
         }
-        return .unavailableFailedProbe(path: resolved.path)
+        // Report the most-preferred candidate as the impostor: it's the one the
+        // pre-CROW-1058 walk would have launched, so it's the path the operator
+        // needs named in the boot log.
+        return .unavailableFailedProbe(path: first.path)
     }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -48,6 +48,35 @@ public enum BinaryTokenResolver {
         }
         return nil
     }
+
+    /// Every PATH hit for `tokens`, token-major and de-duplicated — the plural
+    /// form of `firstOnPath`, with the same ordering guarantee.
+    ///
+    /// `firstOnPath` answers "which binary do we launch?" with one sample per
+    /// token, which is only sound when a token names exactly one tool. It does
+    /// not for Cursor's legacy `agent`: with grok-build's `~/.grok/bin/agent`
+    /// earlier on PATH than Cursor's own, the single sample *is* the foreign
+    /// binary and Cursor is written off as unavailable even though a genuine
+    /// install is sitting further down PATH (CROW-989's documented residual).
+    /// Returning the whole list lets `AgentDiscovery.evaluate` keep probing past
+    /// an impostor instead of stopping at it (CROW-1058).
+    ///
+    /// Preference order is preserved end-to-end: every hit for the preferred
+    /// token comes before any hit for an alias, so a verified `cursor-agent`
+    /// still wins over a verified `agent` regardless of PATH order.
+    public static func allOnPath(
+        tokens: [String],
+        lookup: (String) -> [String]
+    ) -> [String] {
+        var found: [String] = []
+        var seen = Set<String>()
+        for token in tokens {
+            for path in lookup(token) where seen.insert(path).inserted {
+                found.append(path)
+            }
+        }
+        return found
+    }
 }
 
 /// A coding agent that Crow can launch in a terminal and observe via hook
@@ -143,10 +172,42 @@ public protocol CodingAgent: Sendable {
     /// per-session picker and the launch-command builder below.
     func resolveBinary() -> ResolvedBinary?
 
+    /// Every binary this agent could plausibly launch, most-preferred first:
+    /// an explicit `defaults.binaries.<kind>` pin alone (authoritative), else
+    /// **all** PATH hits across `binaryTokens` (token-major) followed by every
+    /// executable `fallbackCandidates` entry.
+    ///
+    /// `resolveBinary()` is the head of this list. The tail exists for
+    /// `AgentDiscovery.evaluate`, which identity-probes down the list rather
+    /// than judging the agent on its first sample — the difference between
+    /// "the first `agent` on PATH is grok-build, so Cursor is unavailable" and
+    /// "keep looking; Cursor's own `agent` is two entries further along"
+    /// (CROW-1058).
+    func resolveBinaryCandidates() -> [ResolvedBinary]
+
     /// Resolve this agent's binary on disk, or return `nil` if it isn't
     /// installed. Convenience over `resolveBinary()` for the many callers that
     /// only need the path.
+    ///
+    /// ⚠️ **Presence check, not a launch target.** This is a fresh walk every
+    /// call, and since discovery may now probe *past* a candidate that failed
+    /// identity, the head of the walk is no longer necessarily the binary
+    /// discovery approved. Use `launchBinary()` for anything that will be
+    /// exec'd; keep this for "is it installed?" questions.
     func findBinary() -> String?
+
+    /// The binary to actually **exec**, or `nil` when none can be trusted.
+    ///
+    /// `findBinary()` answers "is this agent installed?"; this answers "what do
+    /// we put in the pane command?", and the two are deliberately not the same
+    /// function. Launch prefers the path that passed the identity probe at
+    /// registration over a fresh walk, because a fresh walk is free to land on
+    /// a *different* binary than the one Crow verified — which is exactly how a
+    /// Cursor session came up running grok-build (CROW-1058).
+    ///
+    /// Returning `nil` means **do not launch**. For a colliding token that is
+    /// the required outcome: running the foreign binary is not a success.
+    func launchBinary() -> String?
 
     /// Confirm the binary resolved at `path` is genuinely *this* agent and not
     /// a different tool that happens to share the launch token (CROW-911).
@@ -287,10 +348,11 @@ public extension CodingAgent {
             sessionID: sessionID, worktreePath: worktreePath, prompt: prompt)
     }
 
-    /// Default binary discovery with provenance: explicit `BinaryOverrides`
-    /// (`.override`) → PATH walk over `binaryTokens` (`.path`) → hardcoded
-    /// `fallbackCandidates` (`.fallback`). Returns the first resolved absolute
-    /// path + how it was found, or `nil` if nothing matches.
+    /// Default binary discovery with provenance: the head of
+    /// `resolveBinaryCandidates()` — explicit `BinaryOverrides` (`.override`) →
+    /// PATH walk over `binaryTokens` (`.path`) → hardcoded `fallbackCandidates`
+    /// (`.fallback`). Returns the first resolved absolute path + how it was
+    /// found, or `nil` if nothing matches.
     ///
     /// This replaces the per-agent hardcoded-list-only impl that left
     /// nvm/Volta/pnpm/asdf installs invisible to Crow (CROW-484).
@@ -301,32 +363,88 @@ public extension CodingAgent {
     /// an unambiguous `cursor-agent` late in PATH still beats a foreign `agent`
     /// early in it (CROW-989). Agents with no aliases are unaffected: one token,
     /// one walk, byte-identical behavior.
-    func resolveBinary() -> ResolvedBinary? {
+    func resolveBinary() -> ResolvedBinary? { resolveBinaryCandidates().first }
+
+    /// Default candidate enumeration, in the precedence `resolveBinary()`
+    /// documents: `.override` (alone, and authoritative) → every PATH hit across
+    /// `binaryTokens`, token-major (`.path`) → every executable
+    /// `fallbackCandidates` entry (`.fallback`).
+    ///
+    /// The head of this list is byte-identical to the pre-CROW-1058
+    /// `resolveBinary()`, so nothing about which binary Crow *picks* changes
+    /// here. What changes is that the runners-up survive: discovery can probe
+    /// past an impostor sitting in front of a genuine install instead of
+    /// judging the whole token by its first sample.
+    func resolveBinaryCandidates() -> [ResolvedBinary] {
         let fm = FileManager.default
         // 1. Explicit user override from `defaults.binaries.<kind>`. Verify
         //    the path is still executable so a stale override falls through
-        //    to discovery rather than breaking registration outright.
+        //    to discovery rather than breaking registration outright. When it
+        //    holds it is the *only* candidate — the user named the exact
+        //    binary, so there is nothing to fall back to and nothing to probe.
         if let configured = BinaryOverrides.shared.path(for: kind),
            fm.isExecutableFile(atPath: configured) {
-            return ResolvedBinary(path: configured, source: .override)
+            return [ResolvedBinary(path: configured, source: .override)]
         }
+        var candidates: [ResolvedBinary] = []
+        // `allOnPath` already de-duplicates within itself; `seen` carries that
+        // across the two legs, so a `fallbackCandidates` entry that PATH also
+        // resolves isn't probed twice.
+        var seen = Set<String>()
         // 2. Walk the user's resolved PATH the same way `command -v` does, once
-        //    per token in preference order.
-        if let found = BinaryTokenResolver.firstOnPath(
+        //    per token in preference order — but keeping every hit, not just
+        //    the first (CROW-1058).
+        for path in BinaryTokenResolver.allOnPath(
             tokens: binaryTokens,
-            lookup: { ShellEnvironment.shared.findExecutable($0) }
-        ) {
-            return ResolvedBinary(path: found, source: .path)
+            lookup: { ShellEnvironment.shared.findExecutables($0) }
+        ) where seen.insert(path).inserted {
+            candidates.append(ResolvedBinary(path: path, source: .path))
         }
         // 3. Hardcoded last-resort fallback covers the exotic-PATH case.
-        if let fb = fallbackCandidates.first(where: { fm.isExecutableFile(atPath: $0) }) {
-            return ResolvedBinary(path: fb, source: .fallback)
+        for fb in fallbackCandidates
+        where fm.isExecutableFile(atPath: fb) && seen.insert(fb).inserted {
+            candidates.append(ResolvedBinary(path: fb, source: .fallback))
         }
-        return nil
+        return candidates
     }
 
     /// Default `findBinary()`: the resolved path from `resolveBinary()`, or `nil`.
     func findBinary() -> String? { resolveBinary()?.path }
+
+    /// Default launch binary: the user's pin, else the path that passed the
+    /// identity probe at registration, else — only for an agent whose token
+    /// cannot collide — a fresh resolution.
+    ///
+    /// The last leg is where CROW-1058 is closed. An agent that declares an
+    /// alias in `alternateLaunchCommandTokens` has, by that declaration, said
+    /// its binary answers to an ambiguous name; handing back an *unverified*
+    /// path whose basename is that alias is how Crow came to exec grok-build's
+    /// `~/.grok/bin/agent` for a session configured as Cursor. So for those
+    /// agents the unverified fallback is narrowed to the unambiguous preferred
+    /// name, and anything else resolves to `nil` — refuse to launch rather than
+    /// "succeed" by running the colliding binary.
+    ///
+    /// Agents with no aliases (every conformer but Cursor) skip that narrowing
+    /// entirely and behave exactly as before: pin → verified → resolved.
+    ///
+    /// Executability is re-checked on both cached legs so an uninstall between
+    /// boot and launch degrades to "not installed" rather than to a dead path
+    /// interpolated into the pane.
+    func launchBinary() -> String? {
+        let fm = FileManager.default
+        if let pinned = BinaryOverrides.shared.path(for: kind),
+           fm.isExecutableFile(atPath: pinned) {
+            return pinned
+        }
+        if let verified = VerifiedBinaries.shared.path(for: kind),
+           fm.isExecutableFile(atPath: verified) {
+            return verified
+        }
+        guard let resolved = findBinary() else { return nil }
+        guard !alternateLaunchCommandTokens.isEmpty else { return resolved }
+        guard (resolved as NSString).lastPathComponent == launchCommandToken else { return nil }
+        return resolved
+    }
 
     /// Default identity check: trust a bare match. Agents with an unambiguous
     /// launch token don't need to probe — overridden only by collision-prone

--- a/Packages/CrowCore/Sources/CrowCore/Agent/VerifiedBinaries.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/VerifiedBinaries.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The absolute path that passed `CodingAgent.verifyBinaryIdentity` at
+/// registration, per `AgentKind` — written once by `AgentDiscovery.evaluate`
+/// and read by `CodingAgent.launchBinary()` at exec time.
+///
+/// **Why a cache and not a re-walk.** Registration and launch used to resolve
+/// independently: boot probed whatever `resolveBinary()` returned, and every
+/// later launch ran a *fresh* PATH walk whose result was interpolated into the
+/// tmux command unprobed. Those two walks can disagree — a colliding token
+/// (Cursor's legacy `agent`, which xAI's grok-build also installs) can resolve
+/// to a different binary the second time if PATH, the override map, or the
+/// on-disk install changed in between. That is how a session configured as
+/// Cursor exec'd grok-build even though `cursor-agent` was installed and the
+/// probe had passed at boot (CROW-1058). Pinning the *verified* path makes
+/// "the binary we identified" and "the binary we launch" the same string by
+/// construction, instead of two walks that happen to agree.
+///
+/// Deliberately **not** persisted to disk: the pin must not outlive the
+/// process that verified it, or an upgrade/uninstall would leave Crow launching
+/// a path that no longer holds this agent. `launchBinary()` re-checks
+/// executability on every read for the same reason.
+public final class VerifiedBinaries: @unchecked Sendable {
+    public static let shared = VerifiedBinaries()
+
+    private let lock = NSLock()
+    private var paths: [AgentKind: String] = [:]
+
+    public init() {}
+
+    /// Pin `path` as the identity-verified binary for `kind`.
+    public func record(kind: AgentKind, path: String) {
+        lock.lock(); defer { lock.unlock() }
+        paths[kind] = path
+    }
+
+    /// Drop any pin for `kind`. Called when discovery reports the agent
+    /// unavailable, so a re-registration that now fails cannot leave a stale
+    /// path behind for `launchBinary()` to hand back.
+    public func clear(kind: AgentKind) {
+        lock.lock(); defer { lock.unlock() }
+        paths[kind] = nil
+    }
+
+    /// The verified path for `kind`, or `nil` if discovery never confirmed one.
+    public func path(for kind: AgentKind) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return paths[kind]
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/ShellEnvironment.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ShellEnvironment.swift
@@ -46,6 +46,29 @@ public final class ShellEnvironment: Sendable {
         return nil
     }
 
+    /// Returns **every** absolute path at which `name` resolves to an executable
+    /// on the user's PATH, in PATH order and de-duplicated. `findExecutable`
+    /// returns only the first of these.
+    ///
+    /// The plural form exists because "first hit wins" is the wrong rule for a
+    /// launch token that collides: when two different tools are both installed
+    /// as `agent`, stopping at the earlier one hands Cursor whichever of them
+    /// PATH happens to list first (CROW-989's documented residual). Callers that
+    /// can tell the two apart — `AgentDiscovery.evaluate`, via
+    /// `verifyBinaryIdentity` — walk this list until one binary verifies instead
+    /// of accepting or rejecting the whole token on a single sample (CROW-1058).
+    public func findExecutables(_ name: String) -> [String] {
+        let fm = FileManager.default
+        var found: [String] = []
+        var seen = Set<String>()
+        for dir in resolvedPATH.split(separator: ":") {
+            let path = "\(dir)/\(name)"
+            guard fm.isExecutableFile(atPath: path), seen.insert(path).inserted else { continue }
+            found.append(path)
+        }
+        return found
+    }
+
     /// Returns `true` if `name` is an executable found in the resolved PATH.
     public func hasCommand(_ name: String) -> Bool {
         findExecutable(name) != nil

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentDiscoveryTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentDiscoveryTests.swift
@@ -2,7 +2,10 @@ import Foundation
 import Testing
 @testable import CrowCore
 
-@Suite("AgentDiscovery")
+// Serialized: these share the process-wide `VerifiedBinaries` /
+// `BinaryOverrides` singletons, so running them in parallel would have
+// each test tearing down the next one's fixture.
+@Suite("AgentDiscovery", .serialized)
 struct AgentDiscoveryTests {
     private final class NoopHookConfigWriter: HookConfigWriter, @unchecked Sendable {
         func writeHookConfig(worktreePath: String, sessionID: UUID, crowPath: String) throws {}
@@ -31,11 +34,35 @@ struct AgentDiscoveryTests {
         let hookConfigWriter: any HookConfigWriter = NoopHookConfigWriter()
         let stateSignalSource: any StateSignalSource = NoopStateSignalSource()
 
-        var resolved: ResolvedBinary?
-        var identity: Bool
+        /// The full candidate list, most-preferred first — what
+        /// `AgentDiscovery.evaluate` walks. Modelled as a list rather than a
+        /// single value because the CROW-1058 behavior under test *is* the
+        /// walk: a first candidate that fails the probe must not condemn the
+        /// ones behind it.
+        var candidates: [ResolvedBinary]
+        /// Paths the probe accepts. Everything else is rejected, so a fixture
+        /// can plant an impostor and a genuine install in the same list.
+        var verified: Set<String>
+        /// Every path the probe was actually run against, in order — lets a
+        /// test assert the walk short-circuits instead of probing everything.
+        let probed = Recorder()
 
-        func resolveBinary() -> ResolvedBinary? { resolved }
-        func verifyBinaryIdentity(atPath path: String) async -> Bool { identity }
+        init(candidates: [ResolvedBinary], verified: Set<String>) {
+            self.candidates = candidates
+            self.verified = verified
+        }
+
+        /// Single-candidate convenience for the cases that predate the walk.
+        init(resolved: ResolvedBinary?, identity: Bool) {
+            self.candidates = resolved.map { [$0] } ?? []
+            self.verified = (identity ? resolved.map { Set([$0.path]) } : nil) ?? []
+        }
+
+        func resolveBinaryCandidates() -> [ResolvedBinary] { candidates }
+        func verifyBinaryIdentity(atPath path: String) async -> Bool {
+            probed.record(path)
+            return verified.contains(path)
+        }
 
         func autoLaunchCommand(
             session: Session, worktreePath: String, remoteControlEnabled: Bool,
@@ -85,6 +112,111 @@ struct AgentDiscoveryTests {
         #expect(await AgentDiscovery.evaluate(agent) == .unavailableFailedProbe(path: "/usr/bin/grok"))
     }
 
+    // MARK: - Walking past an impostor (CROW-1058)
+
+    /// The residual CROW-989 documented and left open: grok-build's `agent` sits
+    /// earlier on PATH than Cursor's own, so the first candidate is a foreign
+    /// binary. Judging the token on that one sample reports Cursor unavailable
+    /// even though a genuine install is right behind it. The walk keeps going.
+    @Test func probesPastAnImpostorToAGenuineInstallFurtherDownPath() async {
+        let agent = StubAgent(
+            candidates: [
+                ResolvedBinary(path: "/Users/x/.grok/bin/agent", source: .path),
+                ResolvedBinary(path: "/Users/x/.local/bin/agent", source: .path),
+            ],
+            verified: ["/Users/x/.local/bin/agent"]
+        )
+        #expect(await AgentDiscovery.evaluate(agent)
+                == .available(path: "/Users/x/.local/bin/agent", viaOverride: false))
+    }
+
+    /// …and the fallback leg is walked the same way, so a hardcoded
+    /// `~/.local/bin/agent` (grok-build's mirror) can't strand a genuine
+    /// `cursor-agent` listed after it.
+    @Test func walkContinuesAcrossPathAndFallbackCandidates() async {
+        let agent = StubAgent(
+            candidates: [
+                ResolvedBinary(path: "/Users/x/.local/bin/agent", source: .path),
+                ResolvedBinary(path: "/opt/homebrew/bin/cursor-agent", source: .fallback),
+            ],
+            verified: ["/opt/homebrew/bin/cursor-agent"]
+        )
+        #expect(await AgentDiscovery.evaluate(agent)
+                == .available(path: "/opt/homebrew/bin/cursor-agent", viaOverride: false))
+    }
+
+    /// When nothing verifies, the *most-preferred* candidate is named — it's the
+    /// one the pre-CROW-1058 walk would have launched, so it's the path the
+    /// operator needs in the boot log.
+    @Test func failedProbeReportsTheMostPreferredCandidate() async {
+        let agent = StubAgent(
+            candidates: [
+                ResolvedBinary(path: "/Users/x/.grok/bin/agent", source: .path),
+                ResolvedBinary(path: "/usr/local/bin/agent", source: .path),
+            ],
+            verified: []
+        )
+        #expect(await AgentDiscovery.evaluate(agent)
+                == .unavailableFailedProbe(path: "/Users/x/.grok/bin/agent"))
+    }
+
+    /// A healthy install still costs one probe: candidates are ordered
+    /// preferred-name-first, so the loop exits on the first spawn and the extra
+    /// candidates are never sampled.
+    @Test func healthyInstallProbesOnlyTheFirstCandidate() async {
+        let agent = StubAgent(
+            candidates: [
+                ResolvedBinary(path: "/opt/homebrew/bin/cursor-agent", source: .path),
+                ResolvedBinary(path: "/Users/x/.grok/bin/agent", source: .path),
+            ],
+            verified: ["/opt/homebrew/bin/cursor-agent"]
+        )
+        _ = await AgentDiscovery.evaluate(agent)
+        #expect(agent.probed.value == ["/opt/homebrew/bin/cursor-agent"])
+    }
+
+    // MARK: - Verified-path pin (CROW-1058)
+
+    /// The pin is what makes launch exec the binary discovery identified — the
+    /// half of CROW-1058 that a fresh PATH walk at launch time got wrong.
+    @Test func availabilityPinsTheVerifiedPath() async {
+        VerifiedBinaries.shared.clear(kind: .grok)
+        defer { VerifiedBinaries.shared.clear(kind: .grok) }
+        let agent = StubAgent(
+            candidates: [
+                ResolvedBinary(path: "/Users/x/.grok/bin/agent", source: .path),
+                ResolvedBinary(path: "/Users/x/.local/bin/cursor-agent", source: .path),
+            ],
+            verified: ["/Users/x/.local/bin/cursor-agent"]
+        )
+        _ = await AgentDiscovery.evaluate(agent)
+        // The impostor was first in line; the *verified* path is what's pinned.
+        #expect(VerifiedBinaries.shared.path(for: agent.kind) == "/Users/x/.local/bin/cursor-agent")
+    }
+
+    /// A re-registration that now fails must not leave the old pin behind for
+    /// `launchBinary()` to keep handing out — an uninstall would otherwise keep
+    /// launching a path that no longer holds this agent.
+    @Test func failedEvaluationClearsAStalePin() async {
+        VerifiedBinaries.shared.clear(kind: .grok)
+        defer { VerifiedBinaries.shared.clear(kind: .grok) }
+        VerifiedBinaries.shared.record(kind: .grok, path: "/stale/grok")
+        let agent = StubAgent(resolved: nil, identity: true)
+        #expect(await AgentDiscovery.evaluate(agent) == .unavailableNotFound)
+        #expect(VerifiedBinaries.shared.path(for: .grok) == nil)
+    }
+
+    /// An override pin is authoritative *and* pinned, so launch uses the exact
+    /// binary the user named without re-walking.
+    @Test func overridePinIsAlsoRecordedForLaunch() async {
+        VerifiedBinaries.shared.clear(kind: .grok)
+        defer { VerifiedBinaries.shared.clear(kind: .grok) }
+        let agent = StubAgent(
+            resolved: ResolvedBinary(path: "/pin/grok", source: .override), identity: false)
+        _ = await AgentDiscovery.evaluate(agent)
+        #expect(VerifiedBinaries.shared.path(for: .grok) == "/pin/grok")
+    }
+
     @Test func fallbackMatchIsProbedNotTrusted() async {
         // A `.fallback` match is treated like `.path` — probed, not trusted like
         // an override.
@@ -94,4 +226,13 @@ struct AgentDiscoveryTests {
         )
         #expect(await AgentDiscovery.evaluate(agent) == .unavailableFailedProbe(path: "/opt/grok"))
     }
+}
+
+/// Records probe calls in order. A class so the `struct` agent can mutate it
+/// from a non-mutating protocol method.
+private final class Recorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: [String] = []
+    var value: [String] { lock.lock(); defer { lock.unlock() }; return paths }
+    func record(_ p: String) { lock.lock(); defer { lock.unlock() }; paths.append(p) }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/BinaryResolutionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BinaryResolutionTests.swift
@@ -153,6 +153,132 @@ struct BinaryResolutionTests {
     }
 }
 
+// MARK: - Multi-candidate walk (CROW-1058)
+
+// Serialized: these share the process-wide `VerifiedBinaries` /
+// `BinaryOverrides` singletons, so running them in parallel would have
+// each test tearing down the next one's fixture.
+@Suite("Binary candidates and launch selection", .serialized)
+struct LaunchBinarySelectionTests {
+
+    /// `allOnPath` keeps the token-major preference order of `firstOnPath` while
+    /// surfacing the runners-up — every `cursor-agent` hit precedes every
+    /// `agent` hit, regardless of where each sits in PATH.
+    @Test func allOnPathIsTokenMajorAndKeepsEveryHit() {
+        let path: [String: [String]] = [
+            "cursor-agent": ["/opt/homebrew/bin/cursor-agent", "/Users/x/.local/bin/cursor-agent"],
+            "agent": ["/Users/x/.grok/bin/agent", "/Users/x/.local/bin/agent"],
+        ]
+        #expect(BinaryTokenResolver.allOnPath(
+            tokens: ["cursor-agent", "agent"], lookup: { path[$0] ?? [] }) == [
+                "/opt/homebrew/bin/cursor-agent",
+                "/Users/x/.local/bin/cursor-agent",
+                "/Users/x/.grok/bin/agent",
+                "/Users/x/.local/bin/agent",
+            ])
+    }
+
+    /// The same absolute path reached under two token names (Cursor symlinks
+    /// both into one directory) is probed once, not twice.
+    @Test func allOnPathDeDuplicatesSharedPaths() {
+        let shared = ["/usr/local/bin/agent"]
+        #expect(BinaryTokenResolver.allOnPath(
+            tokens: ["cursor-agent", "agent"],
+            lookup: { $0 == "agent" ? shared : shared }) == shared)
+    }
+
+    @Test func allOnPathReturnsEmptyWhenNothingResolves() {
+        #expect(BinaryTokenResolver.allOnPath(
+            tokens: ["cursor-agent", "agent"], lookup: { _ in [] }).isEmpty)
+    }
+
+    // MARK: - launchBinary()
+
+    /// **The CROW-1058 assertion.** Launch must exec the binary discovery
+    /// verified, not whatever a fresh walk turns up — those can differ, and when
+    /// they did, a Cursor session came up running grok-build.
+    @Test func launchPrefersTheVerifiedPathOverAFreshResolution() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        VerifiedBinaries.shared.record(kind: .cursor, path: "/bin/sh")
+        var agent = StubAgent()
+        agent.aliases = ["agent"]
+        agent.candidates = [ResolvedBinary(path: "/Users/x/.grok/bin/agent", source: .path)]
+        #expect(agent.launchBinary() == "/bin/sh")
+    }
+
+    // NB: "an explicit `defaults.binaries.cursor` pin still outranks the verified
+    // path" is asserted in `CursorAgentTests`, not here. `BinaryOverrides.shared`
+    // is process-wide and `BinaryOverridesTests` — a sibling suite that runs in
+    // parallel with this one — resets it, so a fixture built on it would flake
+    // in this package. There it is also the stronger assertion: it reads the
+    // real Cursor launch text rather than a stub's resolution.
+
+    /// A pin that no longer points at an executable (upgrade, uninstall) is
+    /// dropped rather than interpolated into the pane as a dead path.
+    @Test func launchIgnoresAVerifiedPathThatIsGone() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        VerifiedBinaries.shared.record(kind: .cursor, path: "/tmp/crow1058-does-not-exist")
+        var agent = StubAgent()
+        agent.candidates = [ResolvedBinary(path: "/usr/bin/true", source: .path)]
+        #expect(agent.launchBinary() == "/usr/bin/true")
+    }
+
+    /// With nothing verified, an agent that declares an alias will not launch a
+    /// path named after that alias — `…/bin/agent` is precisely the colliding
+    /// name, and "no launch" is the required outcome, not "launch it anyway".
+    @Test func launchRefusesAnUnverifiedAliasNamedBinary() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        var agent = StubAgent()
+        agent.aliases = ["agent"]
+        agent.candidates = [ResolvedBinary(path: "/Users/x/.grok/bin/agent", source: .path)]
+        #expect(agent.launchBinary() == nil)
+    }
+
+    /// …but the unambiguous preferred name is still launchable unverified, so a
+    /// genuine install on a host where the probe never ran (a unit test, a
+    /// registration-free embedding) isn't grounded.
+    @Test func launchAcceptsAnUnverifiedPreferredNameBinary() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        var agent = StubAgent()
+        agent.aliases = ["agent"]
+        agent.candidates = [ResolvedBinary(path: "/usr/local/bin/stub", source: .path)]
+        #expect(agent.launchBinary() == "/usr/local/bin/stub")
+    }
+
+    /// An agent with no alias declares its token unambiguous, so the narrowing
+    /// never applies — every conformer but Cursor keeps the old behavior byte
+    /// for byte, whatever its binary is named.
+    @Test func launchLeavesAliasFreeAgentsAlone() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        var agent = StubAgent()  // no aliases
+        agent.candidates = [ResolvedBinary(path: "/opt/weird/place/renamed", source: .fallback)]
+        #expect(agent.launchBinary() == "/opt/weird/place/renamed")
+    }
+
+    @Test func launchReturnsNilWhenNothingResolvesAtAll() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        #expect(StubAgent().launchBinary() == nil)
+    }
+
+    /// `resolveBinary()` is still the head of the candidate list — the selection
+    /// CROW-1058 preserves while widening what discovery may probe.
+    @Test func resolveBinaryIsTheHeadOfTheCandidateList() {
+        var agent = StubAgent()
+        agent.candidates = [
+            ResolvedBinary(path: "/first", source: .path),
+            ResolvedBinary(path: "/second", source: .path),
+        ]
+        #expect(agent.resolveBinary() == ResolvedBinary(path: "/first", source: .path))
+        #expect(agent.findBinary() == "/first")
+    }
+}
+
 // MARK: - Fixtures
 
 /// Canned probe responder keyed by the probe arg, recording which args were
@@ -193,6 +319,11 @@ private struct NeverRunner: ShellRunner {
 /// Minimal conformer for exercising the `binaryTokens` default composition.
 private struct StubAgent: CodingAgent {
     var aliases: [String] = []
+    /// Overrides the PATH walk so `launchBinary()`'s fallback leg is
+    /// exercisable without a real install.
+    var candidates: [ResolvedBinary] = []
+
+    func resolveBinaryCandidates() -> [ResolvedBinary] { candidates }
 
     let kind: AgentKind = .cursor
     var displayName: String { "Stub" }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -84,6 +84,34 @@ public struct CursorAgent: CodingAgent {
         self.launcher = CursorLauncher()
     }
 
+    /// The binary text every Cursor launch path interpolates — the one place
+    /// this adapter decides what to exec (CROW-1058).
+    ///
+    /// `launchBinary()`, never `findBinary()`. `findBinary()` re-walks PATH at
+    /// exec time and may land on a *different* `agent` than the one
+    /// registration identity-probed: grok-build mirrors its own into
+    /// `~/.grok/bin` and `~/.local/bin`, and that second walk is how a session
+    /// configured as Cursor came up running grok even though `cursor-agent` was
+    /// installed and the boot probe had passed. `launchBinary()` returns the
+    /// path discovery verified, and — because Cursor declares an alias — `nil`
+    /// rather than an unverified `…/bin/agent`.
+    ///
+    /// The `nil` fallback is `launchCommandToken`: `cursor-agent`, the
+    /// *unambiguous* name. Never the `agent` alias, so no Cursor launch text can
+    /// name grok-build's binary under any resolution outcome — the required
+    /// outcome, since running the colliding tool is not a success. A bare token
+    /// is still worth emitting rather than refusing outright: the pane runs a
+    /// login shell whose PATH is richer than `crowd`'s, so a `cursor-agent` the
+    /// daemon couldn't see may well resolve there — and if it doesn't, the
+    /// failure is an honest `command not found: cursor-agent`.
+    ///
+    /// Reaching the fallback at all is off the normal path: Cursor only enters
+    /// the launchable `agents` map once discovery verified a binary (CROW-989),
+    /// and that verified path is exactly what gets pinned.
+    private var resolvedLaunchBinary: String {
+        launchBinary() ?? launchCommandToken
+    }
+
     public func autoLaunchCommand(
         session: Session,
         worktreePath: String,
@@ -91,16 +119,7 @@ public struct CursorAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let agentPath = CursorLaunchArgs.shellQuote(findBinary() ?? launchCommandToken)
-        // NB: `findBinary()` resolves to an absolute path here — Cursor is
-        // registered as *known* regardless of PATH (#879), but only enters the
-        // launchable `agents` map when it resolves **and passes the identity
-        // probe** (CROW-989), and `autoLaunchCommand` only runs for a launchable
-        // agent. So the quoted form is `'/…/cursor-agent'` and
-        // `AgentLaunch.commandLaunchesToken` still matches it via its `/` prefix
-        // alternative. A bare `'cursor-agent'` (findBinary→nil) would NOT match
-        // that regex — but that path is unreachable while the launch gate
-        // excludes unavailable kinds.
+        let agentPath = CursorLaunchArgs.shellQuote(resolvedLaunchBinary)
         // The `--trust` workspace-trust seed (skips the folder-trust dialog on a
         // fresh worktree — the per-launch analogue of `ClaudeTrustSeeder`,
         // CROW-890) rides EVERY launch path, `.review` included as of CROW-954.
@@ -209,7 +228,7 @@ public struct CursorAgent: CodingAgent {
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
-            binary: findBinary() ?? launchCommandToken,
+            binary: resolvedLaunchBinary,
             seedTrust: true
         )
     }
@@ -232,7 +251,7 @@ public struct CursorAgent: CodingAgent {
         // network/filesystem-blocked — see `CursorLaunchArgs`). Terminal backend
         // appends the submitting Enter, so we return the command without a
         // trailing newline to match the cross-agent convention.
-        let agentPath = CursorLaunchArgs.shellQuote(findBinary() ?? launchCommandToken)
+        let agentPath = CursorLaunchArgs.shellQuote(resolvedLaunchBinary)
         return agentPath + CursorLaunchArgs.launchSuffix(
             seedTrust: true, autoPermissionMode: autoPermissionMode)
     }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
@@ -3,7 +3,10 @@ import Testing
 @testable import CrowCursor
 @testable import CrowCore
 
-@Suite("CursorAgent")
+// Serialized: the CROW-1058 cases write the process-wide `VerifiedBinaries` /
+// `BinaryOverrides` singletons, which the other launch-text tests read through
+// `launchBinary()`. In parallel they would tear down each other's fixtures.
+@Suite("CursorAgent", .serialized)
 struct CursorAgentTests {
     private let agent = CursorAgent()
 
@@ -339,6 +342,98 @@ struct CursorAgentTests {
         // path may or may not exist depending on the developer machine,
         // so we accept either outcome and just verify the result type.
         _ = agent.findBinary()  // smoke test: must not crash
+    }
+
+    // MARK: - Launch binary selection (CROW-1058)
+
+    /// The reported machine, as a launch-text assertion: `cursor-agent` is
+    /// installed and discovery verified it, while grok-build's `agent` is
+    /// earlier on PATH. The pane must run Cursor.
+    ///
+    /// Serialized + pinned rather than PATH-driven because the bug was never
+    /// about the *first* walk — registration already got that right. It was
+    /// about launch re-resolving and disagreeing, so the fixture pins what
+    /// discovery decided and asserts the launch text honors it.
+    @Test func launchUsesTheVerifiedCursorBinary() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        VerifiedBinaries.shared.record(kind: .cursor, path: "/bin/sh")  // stand-in: any real executable
+
+        let cmd = agent.autoLaunchCommand(
+            session: Session(name: "test", agentKind: .cursor),
+            worktreePath: "/tmp/wt",
+            remoteControlEnabled: false,
+            autoPermissionMode: false,
+            telemetryPort: nil)
+        #expect(cmd?.hasPrefix("'/bin/sh' --trust") == true)
+        #expect(cmd?.contains("grok") == false)
+    }
+
+    /// The Manager terminal and the handoff path build their command text
+    /// separately, so each is asserted against the same pin — a fix that only
+    /// covered auto-launch would leave two live routes to the wrong binary.
+    @Test func managerAndHandoffLaunchUseTheVerifiedCursorBinary() async throws {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+        VerifiedBinaries.shared.record(kind: .cursor, path: "/bin/sh")
+
+        let manager = agent.managerLaunchCommand(
+            sessionName: "Manager", remoteControlEnabled: false,
+            autoPermissionMode: false, telemetryPort: nil)
+        #expect(manager.hasPrefix("'/bin/sh' --trust"))
+
+        let handoff = try await agent.launchCommand(
+            sessionID: UUID(), worktreePath: "/tmp/wt", prompt: "hello")
+        #expect(handoff.contains("'/bin/sh'"))
+        #expect(handoff.contains("grok") == false)
+    }
+
+    /// Ticket verify #2, at the launch layer: when the only `agent` Crow can
+    /// resolve is grok-build's, no Cursor launch path may name it. Registration
+    /// already greys Cursor out (the probe rejects it); this is the belt to that
+    /// brace, because the residual CROW-989 documented is precisely a resolution
+    /// that reaches launch without a passing probe.
+    ///
+    /// The fallback is the unambiguous `cursor-agent` token — never the `agent`
+    /// alias — so the worst case is `command not found`, not the wrong agent.
+    @Test func launchNeverNamesAnUnverifiedAgentAliasBinary() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        defer { VerifiedBinaries.shared.clear(kind: .cursor) }
+
+        // No pin and no override: whatever this host resolves, the emitted
+        // binary is either an absolute `…/cursor-agent` or the bare preferred
+        // token. A path ending in `/agent` would be the CROW-1058 regression.
+        let cmd = agent.autoLaunchCommand(
+            session: Session(name: "test", agentKind: .cursor),
+            worktreePath: "/tmp/wt",
+            remoteControlEnabled: false,
+            autoPermissionMode: false,
+            telemetryPort: nil)
+        let binary = String(cmd?.prefix(while: { $0 != " " }) ?? "").trimmingCharacters(
+            in: CharacterSet(charactersIn: "'"))
+        #expect(binary == "cursor-agent" || binary.hasSuffix("/cursor-agent"))
+        #expect(binary.hasSuffix("/agent") == false)
+        #expect(binary.contains("grok") == false)
+    }
+
+    /// Ticket verify #3: an explicit `defaults.binaries.cursor` pin still wins
+    /// over the probe's pick, so the user's escape hatch survives the change.
+    @Test func explicitOverrideStillOutranksTheVerifiedPath() {
+        VerifiedBinaries.shared.clear(kind: .cursor)
+        BinaryOverrides.shared.set(["cursor": "/usr/bin/true"])
+        defer {
+            VerifiedBinaries.shared.clear(kind: .cursor)
+            BinaryOverrides.shared.set([:])
+        }
+        VerifiedBinaries.shared.record(kind: .cursor, path: "/bin/sh")
+
+        let cmd = agent.autoLaunchCommand(
+            session: Session(name: "test", agentKind: .cursor),
+            worktreePath: "/tmp/wt",
+            remoteControlEnabled: false,
+            autoPermissionMode: false,
+            telemetryPort: nil)
+        #expect(cmd?.hasPrefix("'/usr/bin/true' --trust") == true)
     }
 
     // MARK: - Identity probe (CROW-989)

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionService.swift
@@ -1482,7 +1482,14 @@ public final class SessionService {
         guard let target = AgentRegistry.shared.agent(for: targetKind) else {
             throw AgentHandoffError.agentNotRegistered(targetKind.rawValue)
         }
-        guard target.findBinary() != nil else {
+        // `launchBinary()`, not `findBinary()` — the gate must ask the same
+        // question the launch will. `findBinary()` says "some binary by that
+        // name exists", which for a colliding token can be a foreign tool; the
+        // handoff would then pass here and fail (or worse, exec the impostor)
+        // one step later. `launchBinary()` returns the identity-verified path or
+        // nothing, so a Cursor handoff on a box where the only `agent` is
+        // grok-build is refused here with a named error (CROW-1058).
+        guard target.launchBinary() != nil else {
             throw AgentHandoffError.agentBinaryMissing(targetKind.rawValue)
         }
         // Review-handoff gate. `shouldRefuseReviewHandoff` is now `false` for

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -76,7 +76,13 @@ public struct GrokAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let grokPath = findBinary() ?? "grok"
+        // `launchBinary()`, not `findBinary()`: Grok identity-probes (its `grok`
+        // collides with `superagent-ai/grok-cli`, CROW-911), and since CROW-1058
+        // discovery may probe *past* a failing candidate to a genuine one
+        // further down PATH. A fresh walk here would still return the impostor
+        // at the head of the list, so launch reads the path discovery actually
+        // verified. Behavior for a single-`grok` box is unchanged.
+        let grokPath = launchBinary() ?? "grok"
 
         switch session.kind {
         case .work:
@@ -154,7 +160,7 @@ public struct GrokAgent: CodingAgent {
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
-            binary: findBinary() ?? "grok"
+            binary: launchBinary() ?? "grok"
         )
     }
 
@@ -172,7 +178,7 @@ public struct GrokAgent: CodingAgent {
         // `grok` collides with `superagent-ai/grok-cli`, so `defaults.binaries.grok`
         // is the *expected* config here, and an override path with a space would
         // otherwise word-split when the terminal backend runs it (#861 review r8).
-        return GrokLaunchArgs.shellQuote(findBinary() ?? "grok")
+        return GrokLaunchArgs.shellQuote(launchBinary() ?? "grok")
     }
 
     /// Grok's TUI exposes `/rename` (alias `/title`) for the current session

--- a/Packages/CrowMuse/Sources/CrowMuse/MuseAgent.swift
+++ b/Packages/CrowMuse/Sources/CrowMuse/MuseAgent.swift
@@ -79,7 +79,11 @@ public struct MuseAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let musePath = findBinary() ?? "muse"
+        // `launchBinary()`, not `findBinary()`: Muse identity-probes (`muse`
+        // collides with the Muse Sequencer), and since CROW-1058 discovery may
+        // probe past a failing candidate — so launch must read the verified
+        // path rather than re-walking to the impostor at the head of the list.
+        let musePath = launchBinary() ?? "muse"
 
         switch session.kind {
         case .work:
@@ -157,7 +161,7 @@ public struct MuseAgent: CodingAgent {
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
-            binary: findBinary() ?? "muse",
+            binary: launchBinary() ?? "muse",
             trustWorkspace: false
         )
     }
@@ -175,7 +179,7 @@ public struct MuseAgent: CodingAgent {
             sessionID: sessionID,
             worktreePath: worktreePath,
             prompt: prompt,
-            binary: findBinary() ?? "muse",
+            binary: launchBinary() ?? "muse",
             trustWorkspace: sessionKind != .review
         )
     }
@@ -191,7 +195,7 @@ public struct MuseAgent: CodingAgent {
         // Terminal backend appends Enter, so no trailing newline. Quoted
         // so a spaced `defaults.binaries.muse` pin can't word-split.
         MuseLaunchArgs.managerCommand(
-            binary: findBinary() ?? "muse",
+            binary: launchBinary() ?? "muse",
             autoPermissionMode: autoPermissionMode,
             trustWorkspace: true
         )

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
@@ -70,7 +70,7 @@ public struct OpenCodeAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let opencodePath = findBinary() ?? "opencode"
+        let opencodePath = launchBinary() ?? "opencode"
 
         switch session.kind {
         case .work:
@@ -171,7 +171,7 @@ public struct OpenCodeAgent: CodingAgent {
         // apply (parity with `CursorAgent`). Terminal backend appends the
         // submitting Enter, so we return the bare command without a trailing
         // newline to match the cross-agent convention.
-        return findBinary() ?? "opencode"
+        return launchBinary() ?? "opencode"
     }
 
     /// OpenCode TUI exposes `/rename` for the current session (CROW-629).

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -116,7 +116,7 @@ managed-terminal command needs hook/env prep.
   on PATH, `agent` resolved to grok-build, so Crow built a Cursor command and ran
   Grok's binary, which died on the first flag it lacks
   (`error: unexpected argument '--force' found`) — CROW-989, the risk CROW-484
-  accepted actually firing. Two defenses now:
+  accepted actually firing. Four defenses now:
   - **Preferred-name-first PATH walk.** `resolveBinary()` is *token-major*: every
     PATH entry is searched for `cursor-agent` before any is searched for `agent`
     (`BinaryTokenResolver.firstOnPath`), so resolution depends on the name rather
@@ -129,13 +129,29 @@ managed-terminal command needs hook/env prep.
     reported unavailable, naming the resolved path, instead of launching and
     failing on flag parsing. `defaults.binaries.cursor` still pins and bypasses
     the probe.
-  - ⚠️ **Residual gap:** a machine with *only* the legacy `agent` name (no
-    `cursor-agent`) **and** grok-build earlier on PATH reports Cursor
-    unavailable — the walk stops at the first `agent` it finds rather than
-    continuing to a later, genuine one. A multi-candidate walk (probe each `agent`
-    on PATH until one verifies) would close it, but needs the verified path cached
-    for launch, since `findBinary()` re-resolves per launch. Workaround is the
-    `defaults.binaries.cursor` pin.
+  - **Multi-candidate walk** (CROW-1058, closing the residual CROW-989 left
+    open). Discovery no longer judges a token by its first sample:
+    `resolveBinaryCandidates()` returns **every** PATH hit across
+    `binaryTokens` (still token-major) plus every executable
+    `fallbackCandidates` entry, and `AgentDiscovery.evaluate` probes down that
+    list until one verifies. A machine whose *only* `cursor-agent` sits behind
+    grok-build's `agent` on PATH now registers Cursor instead of greying it out.
+    Cost is unchanged for a healthy install — the preferred name is sampled
+    first, so the loop exits after one spawn.
+  - **Verified-path pin at launch** (CROW-1058). Registration records the path
+    that passed the probe in `VerifiedBinaries`, and every launch path reads
+    `launchBinary()` rather than `findBinary()`. This is the half of the field
+    report that discovery alone could not explain: `findBinary()` re-walked PATH
+    on *every* launch and could return a different `agent` than the one boot had
+    identified, so a session configured as Cursor exec'd grok-build even with
+    `cursor-agent` installed and the boot probe passing. `launchBinary()` is
+    pin → verified path → (for an agent that declares an alias) the unambiguous
+    preferred name only — so no Cursor launch text can name a `…/bin/agent`
+    under any resolution outcome. Its last-resort fallback is the bare
+    `cursor-agent` token, which cannot be grok-build: worst case is an honest
+    `command not found`, never the wrong agent. Alias-free agents (every other
+    harness) are unaffected by the narrowing but still get the pin, which matters
+    now that discovery may probe past a first candidate.
 - **Grok's token is `grok`, which collides** with the community
   `superagent-ai/grok-cli` (also installs `grok`). Registration **identity-probes**
   a bare PATH/fallback match — `grok --help` (then `--version`), matched against
@@ -924,7 +940,7 @@ against current upstream CLIs.
 | Antigravity hook re-read timing: does `agy` read `.agents/hooks.json` **once at process start**, or per-event? | `agy` **v1.1.7** — unverified; assumed start-only | `prepareWorktreeForAgentLaunch` (launch-time strip) | 2026-07-28 (#902) — the launch-time strip mitigates a hook restored *between* launches. If `agy` re-reads per-event, a mid-session restore (SKILL's `gh pr checkout` fast-forwards → silently restores `.agents/`) would fire unmitigated, since no strip re-runs mid-session and there is no trust gate behind it. Confirm on the manual pass before promoting out of Tier-2 |
 | **Entire Grok flag set** — hooks event names, `-p`/`--single`, `-c`/`-r`, `--allow`/`--deny`, `--permission-mode`, `--trust`, `/rename` | `xai-org/grok-build` **@ 2026-07-25** (periodic mirror of xAI's monorepo, **PRs closed** → churn likely) | `GrokAgent` / `GrokLaunchArgs` / `GrokHookConfigWriter` / `GrokSignalSource` | 2026-07-26 — verified against repo source (`crates/codegen/xai-grok-*`), not blog posts |
 | Grok `grok` binary collides with community `superagent-ai/grok-cli` | **Identity probe** at registration (`grok --help`/`--version` vs grok-build flag markers) greys out the foreign `grok`; explicit `defaults.binaries.grok` pin bypasses it. Decision is pure `AgentDiscovery.evaluate`; probe markers (`--prompt-file`, `--prompt-json`, `--permission-mode`, `--always-approve`) are the same upstream flag set as the row above — re-verify together | `GrokAgent.identityMarkers` / `verifyBinaryIdentity` · `AgentDiscovery.evaluate` | 2026-07-26 (CROW-911) |
-| Cursor's legacy `agent` alias collides with grok-build's `~/.grok/bin/agent` (fired in the field) | Prefer the unambiguous **`cursor-agent`** via a token-major PATH walk (order-independent), plus the same **identity probe** on a bare `agent` match. Markers (`--approve-mcps`, `--trust`, `CURSOR_API_KEY`, `CURSOR_API_ENDPOINT`) are the flags this adapter passes — re-verify with `CursorLaunchArgs` on each Cursor CLI baseline bump. ⚠️ Residual: legacy-only install + grok-build earlier on PATH ⇒ reported unavailable; pin `defaults.binaries.cursor` | `CursorAgent.identityMarkers` / `verifyBinaryIdentity` · `BinaryTokenResolver` · `BinaryIdentityProbe` | 2026-08-11 (CROW-989) — Cursor CLI baseline `2026.08.04-aaa8809` |
+| Cursor's legacy `agent` alias collides with grok-build's `~/.grok/bin/agent` (fired in the field) | Prefer the unambiguous **`cursor-agent`** via a token-major PATH walk (order-independent), plus the same **identity probe** on a bare `agent` match. Markers (`--approve-mcps`, `--trust`, `CURSOR_API_KEY`, `CURSOR_API_ENDPOINT`) are the flags this adapter passes — re-verify with `CursorLaunchArgs` on each Cursor CLI baseline bump. CROW-1058 then closed the two gaps that let it fire again: discovery **probes every** candidate instead of stopping at the first (so a genuine `cursor-agent` behind grok-build's `agent` still registers), and launch reads the **verified path** (`launchBinary()` / `VerifiedBinaries`) instead of re-walking PATH — with the unverified fallback narrowed to the unambiguous `cursor-agent`, never the alias | `CursorAgent.identityMarkers` / `verifyBinaryIdentity` · `BinaryTokenResolver` · `BinaryIdentityProbe` · `VerifiedBinaries` / `launchBinary()` | 2026-08-19 (CROW-1058) — Cursor CLI baseline `2026.08.04-aaa8809` |
 | Grok **`--permission-mode auto` now exists** — the #859 probe reported it absent; current docs show it *and* `--always-approve`. Crow Auto maps to `--always-approve` + `--deny` on `.work`/`.job` (CROW-1037): Grok's classifier `auto` still gates `gh pr create`, which is not Claude-equivalent. Reviews stay human-gated. Re-probe `--always-approve`/`--yolo` with the rest of the flag set | Grok mirror **@ 2026-07-25** | `GrokLaunchArgs.autoPermissionSuffix` | 2026-08-15 (CROW-1037; was 2026-07-26) |
 | Grok `Stop` / `Notification` fire on the transitions Crow's state machine needs — **confirm empirically** | — (empirical, #859) | `GrokSignalSource` | 2026-07-26 |
 | Grok double-fire: only the **global** `~/.claude`/`~/.cursor` hook configs Grok also discovers (its compat scanning) firing alongside `.grok/hooks/crow.json` — dedup deferred (genuinely user-controlled config, no Crow session UUID, not RCE; cf. Codex §3b). *Project* compat sources are handled: stripped on `.review` clones (`stripGrokConfigFromReviewClone`, RCE) and neutralized on `.work`/`.job` handoff + warm-adopt (`stripPriorCompatHooksForGrokHandoff` + session-own adopt write, #861 r9-r10). The Grok-**Manager** devRoot case stays a documented limitation (`writeManagerHookConfig`). | — (empirical, #859) | `GrokHookConfigWriter` / `SessionService` | 2026-07-27 |


### PR DESCRIPTION
Closes #1058

A session configured as Cursor came up running xAI's grok-build, on a machine where `cursor-agent` was installed and the boot identity probe had passed. Both CROW-989 defenses were in place — they just didn't cover the launch.

## The two holes

**Discovery and launch resolved independently.** Registration probed whatever `resolveBinary()` returned; every later launch ran a *fresh* PATH walk via `findBinary()` and interpolated the result into the tmux command unprobed. For a colliding token those two walks can disagree — grok-build mirrors its own `agent` into `~/.grok/bin` and `~/.local/bin` — so "the binary we identified" and "the binary we launch" were two strings that happened to agree, not one.

**The walk stopped at the first sample.** The residual CROW-989 documented: with grok-build's `agent` earlier on PATH, the single sample *is* the impostor, and Cursor was written off as unavailable even when a genuine install sat further down PATH.

## The fix

| | |
|---|---|
| `VerifiedBinaries` (new) | `AgentDiscovery.evaluate` pins the path that passed the probe; cleared when an agent goes unavailable, so a stale pin can't survive an uninstall. Not persisted — a pin must not outlive the process that verified it. |
| `resolveBinaryCandidates()` | Every PATH hit across `binaryTokens` (still token-major) plus every executable fallback. `resolveBinary()` is its head, so **which binary Crow picks is unchanged** — the runners-up just survive for discovery to probe. |
| `AgentDiscovery.evaluate` | Probes down that list until one verifies, instead of judging the token by its first sample. A healthy install still costs one spawn: the preferred name is sampled first. |
| `launchBinary()` (new) | pin → verified path → *(for an agent that declares an alias)* the unambiguous preferred name only. Every launch path reads this instead of `findBinary()`. |

So **no Cursor launch text can name a `.../bin/agent` under any resolution outcome.** The last-resort fallback is the bare `cursor-agent` token, which cannot be grok-build — worst case is an honest `command not found`, never the wrong agent. (Bare rather than a hard refusal on purpose: the pane runs a login shell whose PATH is richer than `crowd`'s, one of the ticket's own hypothesized holes.)

`defaults.binaries.cursor` still outranks everything and still skips the probe.

## Why every adapter changed, not just Cursor

Widening the walk means discovery may now probe *past* a failing candidate for **any** agent that overrides `verifyBinaryIdentity` — Grok and Muse do — so a launch-time re-walk would return the impostor at the head of the list for them too. Leaving them on `findBinary()` would have introduced the same bug I was fixing. For the alias-free agents it's a no-op: their verified path *is* the head of the walk, and the preferred-name narrowing only applies to an agent with `alternateLaunchCommandTokens` (Cursor alone today). **Grok launch behavior is unchanged on a single-`grok` box**, per the ticket.

`handoffAgent`'s binary gate moves to `launchBinary()` as well, so it asks the same question the launch will rather than "some binary by that name exists".

## Ticket verify list

| | Covered by |
|---|---|
| 1. `cursor-agent` on PATH, grok's `agent` earlier → runs Cursor | `launchUsesTheVerifiedCursorBinary`, `managerAndHandoffLaunchUseTheVerifiedCursorBinary` |
| 2. Only grok's `agent` → Cursor disabled, never spawns grok | `launchNeverNamesAnUnverifiedAgentAliasBinary` + `failedProbeReportsTheMostPreferredCandidate` |
| 3. `defaults.binaries.cursor` pin wins, skips the probe | `explicitOverrideStillOutranksTheVerifiedPath`, `overridePinIsAlsoRecordedForLaunch` |
| 4. Grok still launches `grok` | CrowGrok suite unchanged and green |

Manager, auto-launch, and handoff are asserted **separately** — each builds its command text on its own, so a fix covering only auto-launch would leave two live routes to the wrong binary.

Both new suites are `.serialized`: they write the process-wide `VerifiedBinaries` / `BinaryOverrides` singletons. The CrowCore override case is deliberately *not* duplicated there — `BinaryOverridesTests` is a parallel sibling suite that resets the same map, and the CrowCursor version is the stronger assertion anyway (real launch text, not a stub's resolution).

## Testing

Per-package (never `make test` on this host). All green, run repeatedly for flakes:

`CrowCore` 672 · `CrowCursor` 80 · `CrowEngine` 784 · `CrowClaude` 93 · `CrowCodex` 84 · `CrowGrok` 58 · `CrowMuse` 58 · `CrowOpenCode` 58 · `CrowAntigravity` 41 · `swift build --product crowd` links.

Docs: `docs/agent-harness-matrix.md` — the ⚠️ residual-gap bullet is replaced by the two defenses that close it, and the risk-register row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
