### PR TITLE
Multi-harness session-log collector + opt-in Corveil upload (CROW-1056)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,22 @@ crow web-password clear                                                 → {"sa
 
 `gateway get` blanks header values unless `--reveal`. A `--header` with a blank value (`--header "X-Api-Key:"`) keeps the stored secret — that's how to change a base URL without restating credentials. A header value must not be wrapped in literal quotes (`--header 'X-Api-Key: "Bearer sk-…"'`) — they'd be sent as part of the credential and the gateway would reject the request; quote the whole `Name: Value` pair in your shell, not inside it. `web-password set` prompts twice with echo off; pipe with `--stdin` for scripts. There is no `--password` flag on purpose (shell history / `ps`).
 
+### Session-Log Sync
+
+Local-only (CROW-1056) — the multi-harness session-log collector's opt-in controls. Uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, authed by your own Corveil API key (no AWS creds on the laptop). **Default OFF**; nothing uploads until enabled *and* a workspace is opted in. Best-effort — never blocks or fails a session.
+
+```
+crow logsync get [--reveal]                                             → {"logsync":{enabled,base_url,api_key_ref,api_key_set,enabled_workspaces,retention_days,quiet_period_minutes,max_upload_bytes,configured}}
+crow logsync set [--enabled true|false] [--base-url URL] [--api-key-ref REF]
+                 [--add-workspace NAME ...] [--remove-workspace NAME ...] [--clear-workspaces]
+                 [--retention-days N] [--quiet-period-minutes N] [--max-upload-bytes N]   → {"logsync":{...},"saved":true}
+```
+
+- Local-only on `/rpc` (like `gateway`/`web-password`): the RPCs are refused for non-loopback peers, so the opt-in can't be flipped remotely.
+- `--api-key-ref` takes an `op://…` 1Password reference (resolved at upload, never at rest in `config.json`) or a plaintext key. `logsync get` masks a plaintext key unless `--reveal`; an `op://…` reference is always shown (it's a pointer, not the secret).
+- `set` is a PATCH (only the flags you pass change; at least one required). Workspace list edits compose: clear → remove → add. Empty `--base-url ''`/`--api-key-ref ''` clears that field.
+- Only Claude Code transcripts are collected today (its logs are the one harness partitioned by working directory); other harnesses are wired as their log paths are confirmed. Live within ~1 collector tick (~5 min); no restart.
+
 ### MCP
 
 Crow's read-only MCP surface (CROW-1004) — six tools over five read RPCs, so an MCP client can read the board without a Crow-launched session. No prompt-send, no writes. See `docs/mcp.md` and ADR 0019.

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
@@ -1,0 +1,146 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+// `crow logsync` (CROW-1056): opt-in controls for the multi-harness session-log
+// collector. Like `crow gateway` / `crow web-password`, these verbs are
+// LOCAL-ONLY — the `logsync-get`/`logsync-set` RPCs are refused on the remote
+// `/rpc` path (RPCWebSocketHandler.localOnlyDenial) because they configure
+// transcript uploads off the daemon host and carry a Corveil API-key reference.
+//
+// `set` is a PATCH: only the flags you pass change; passing none is an error.
+// Booleans are `@Option ... Bool?` (three states: true / false / absent).
+
+/// Parent command: `crow logsync <subcommand>`.
+public struct Logsync: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "logsync",
+        abstract: "View or change session-log upload (opt-in, local-only)",
+        discussion: """
+        The session-log collector uploads each opted-in workspace's coding-session \
+        transcripts to Corveil as session artifacts, attributed to your own Corveil \
+        API key (no AWS credentials are stored on this machine). It is OFF by \
+        default and uploads nothing until you both enable it and opt a workspace in.
+
+        Uploads are best-effort and never block or fail a session. Only Claude Code \
+        transcripts are collected today; other harnesses are wired as their on-disk \
+        log locations are confirmed.
+        """,
+        subcommands: [LogsyncGet.self, LogsyncSet.self]
+    )
+
+    public init() {}
+}
+
+public struct LogsyncGet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "get", abstract: "Show the session-log collector settings")
+
+    @Flag(name: .long, help: "Reveal a plaintext API key (op:// references are always shown)")
+    var reveal = false
+
+    public init() {}
+
+    public func run() throws {
+        let params: [String: JSONValue] = reveal ? ["reveal": .bool(true)] : [:]
+        printJSON(try rpc("logsync-get", params: params))
+    }
+}
+
+public struct LogsyncSet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Change session-log upload settings",
+        discussion: """
+        Only the flags you pass change; at least one is required.
+
+        Turn the feature on with --enabled true, point it at your Corveil API with \
+        --base-url and --api-key-ref (an op://… 1Password reference is resolved at \
+        upload so the key never lands in config.json), then opt workspaces in with \
+        --add-workspace. Nothing uploads until a workspace is opted in.
+
+        Live: the collector re-reads config each tick, so changes apply within a \
+        few minutes with no restart. Pass an empty string to --base-url/--api-key-ref \
+        to clear it.
+        """
+    )
+
+    @Option(name: .long, help: "Enable session-log upload (true or false)")
+    var enabled: Bool?
+
+    @Option(name: .customLong("base-url"), help: "Corveil API base URL (e.g. https://api.corveil.io)")
+    var baseURL: String?
+
+    @Option(
+        name: .customLong("api-key-ref"),
+        help: "Corveil API key: an op://… reference (preferred) or a plaintext key")
+    var apiKeyRef: String?
+
+    @Option(
+        name: .customLong("add-workspace"),
+        help: "Opt a workspace in (repeatable)")
+    var addWorkspace: [String] = []
+
+    @Option(
+        name: .customLong("remove-workspace"),
+        help: "Opt a workspace out (repeatable)")
+    var removeWorkspace: [String] = []
+
+    @Flag(name: .customLong("clear-workspaces"), help: "Opt every workspace out")
+    var clearWorkspaces = false
+
+    @Option(
+        name: .customLong("retention-days"),
+        help: "Days to keep the local upload ledger (0 = forever, default 30)")
+    var retentionDays: Int?
+
+    @Option(
+        name: .customLong("quiet-period-minutes"),
+        help: "Wait this long after a session's last activity before uploading (default 30)")
+    var quietPeriodMinutes: Int?
+
+    @Option(
+        name: .customLong("max-upload-bytes"),
+        help: "Per-transcript upload cap in bytes (default 8000000)")
+    var maxUploadBytes: Int?
+
+    public init() {}
+
+    public func validate() throws {
+        let anySet = enabled != nil || baseURL != nil || apiKeyRef != nil
+            || retentionDays != nil || quietPeriodMinutes != nil || maxUploadBytes != nil
+            || !addWorkspace.isEmpty || !removeWorkspace.isEmpty || clearWorkspaces
+        guard anySet else {
+            throw ValidationError(
+                "Nothing to set — provide at least one flag (e.g. --enabled, --base-url, "
+                + "--api-key-ref, --add-workspace).")
+        }
+        if let retentionDays, retentionDays < 0 {
+            throw ValidationError("--retention-days must be 0 or greater (0 = forever).")
+        }
+        if let quietPeriodMinutes, quietPeriodMinutes < 0 {
+            throw ValidationError("--quiet-period-minutes must be 0 or greater.")
+        }
+        if let maxUploadBytes, maxUploadBytes < 1 {
+            throw ValidationError("--max-upload-bytes must be at least 1.")
+        }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = [:]
+        if let enabled { params["enabled"] = .bool(enabled) }
+        if let baseURL { params["base_url"] = .string(baseURL) }
+        if let apiKeyRef { params["api_key_ref"] = .string(apiKeyRef) }
+        if let retentionDays { params["retention_days"] = .int(retentionDays) }
+        if let quietPeriodMinutes { params["quiet_period_minutes"] = .int(quietPeriodMinutes) }
+        if let maxUploadBytes { params["max_upload_bytes"] = .int(maxUploadBytes) }
+        if !addWorkspace.isEmpty {
+            params["add_workspaces"] = .array(addWorkspace.map { .string($0) })
+        }
+        if !removeWorkspace.isEmpty {
+            params["remove_workspaces"] = .array(removeWorkspace.map { .string($0) })
+        }
+        if clearWorkspaces { params["clear_workspaces"] = .bool(true) }
+        printJSON(try rpc("logsync-set", params: params))
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -49,6 +49,7 @@ public struct CrowCommand: ParsableCommand {
             Corveil.self,
             Gateway.self,
             WebPassword.self,
+            Logsync.self,
             MCP.self,
             AddWorktree.self,
             ListWorktrees.self,

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -197,7 +197,15 @@ struct ParityGateTests {
                     hashB64: "aGFzaA==",
                     scopes: [.sessionsRead, .boardRead],
                     expiresAt: Date())
-            ]
+            ],
+            logSync: LogSyncConfig(
+                enabled: true,
+                baseURL: "https://api.corveil.example",
+                apiKeyRef: "op://probe/corveil/key",
+                enabledWorkspaces: ["probe"],
+                retentionDays: 30,
+                quietPeriodMinutes: 30,
+                maxUploadBytes: 8_000_000)
         )
     }
 

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeCodeAgent.swift
@@ -44,6 +44,28 @@ public struct ClaudeCodeAgent: CodingAgent {
         self.launcher = ClaudeLauncher()
     }
 
+    /// Claude Code writes one NDJSON transcript per session under a per-project
+    /// directory named by slugifying the working directory:
+    /// `~/.claude/projects/<slug>/<claude-session-uuid>.jsonl`, where the slug
+    /// replaces every non-alphanumeric character of the absolute worktree path
+    /// with `-` (CROW-1056; verified against a live `~/.claude/projects`).
+    ///
+    /// That slug makes Claude the one harness whose durable logs are partitioned
+    /// by working directory, so a Crow worktree path maps directly to its
+    /// transcripts. When the Claude session id is known (`harnessSessionID`,
+    /// resolved from telemetry) the exact file is returned; otherwise the whole
+    /// project-slug directory — every Claude session that ran in this worktree —
+    /// is returned and the collector concatenates it into one transcript.
+    public func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] {
+        let projectDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+            .appendingPathComponent(AgentLogSource.posixPathSlug(worktreePath), isDirectory: true)
+        if let sid = harnessSessionID?.trimmingCharacters(in: .whitespaces), !sid.isEmpty {
+            return [.file(projectDir.appendingPathComponent("\(sid).jsonl").path, format: .jsonl)]
+        }
+        return [.directory(projectDir.path, format: .jsonl, fileExtension: "jsonl")]
+    }
+
     public func autoLaunchCommand(
         session: Session,
         worktreePath: String,

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeCodeAgentLogSourcesTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeCodeAgentLogSourcesTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowClaude
+
+@Suite struct ClaudeCodeAgentLogSourcesTests {
+    private var home: String { FileManager.default.homeDirectoryForCurrentUser.path }
+
+    @Test func directorySourceWhenNoSessionID() {
+        let sources = ClaudeCodeAgent().logSources(
+            worktreePath: "/Users/j/Dev/acme-1", harnessSessionID: nil)
+        #expect(sources.count == 1)
+        let s = sources[0]
+        #expect(s.selector == .directory)
+        #expect(s.format == .jsonl)
+        #expect(s.fileExtension == "jsonl")
+        #expect(s.path == home + "/.claude/projects/-Users-j-Dev-acme-1")
+    }
+
+    @Test func exactFileWhenSessionIDKnown() {
+        let sources = ClaudeCodeAgent().logSources(
+            worktreePath: "/a/b", harnessSessionID: "UUID-123")
+        #expect(sources.count == 1)
+        #expect(sources[0].selector == .file)
+        #expect(sources[0].format == .jsonl)
+        #expect(sources[0].path == home + "/.claude/projects/-a-b/UUID-123.jsonl")
+    }
+
+    @Test func blankSessionIDFallsBackToDirectory() {
+        let sources = ClaudeCodeAgent().logSources(worktreePath: "/a/b", harnessSessionID: "   ")
+        #expect(sources[0].selector == .directory)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// The on-the-wire shape of a harness's durable session log, stamped onto the
+/// uploaded artifact so the server-side derivation normalizer (corveil#2427)
+/// knows how to read it. Matches the `format` column on `crow_session_artifacts`
+/// (free text there; this enum is Crow's closed set).
+public enum AgentLogFormat: String, Sendable, Codable, Equatable, CaseIterable {
+    /// Newline-delimited JSON — one event per line. Claude Code writes exactly
+    /// this (`~/.claude/projects/<slug>/<uuid>.jsonl`), so it needs no
+    /// transformation before upload.
+    case jsonl
+    /// A SQLite database (Cursor stores chat rows inside a per-workspace
+    /// `state.vscdb`). Requires row extraction before it becomes NDJSON — not
+    /// yet wired (see `CursorAgent.logSources`).
+    case sqlite
+    /// A directory (or set) of per-session log files the collector concatenates
+    /// into one NDJSON artifact (Codex rollout files, OpenCode storage).
+    case logDir
+}
+
+/// Where a single coding-agent harness writes a durable session log on disk, and
+/// in what format. Adapters return these from `CodingAgent.logSources(...)`; the
+/// daemon's `LogSyncCollector` resolves them to concrete files, normalizes the
+/// contents to NDJSON, and uploads them as session-transcript artifacts
+/// (CROW-1056).
+///
+/// The adapter is a stateless value struct, so the session context it needs to
+/// locate its logs (the worktree path, and optionally the harness's own session
+/// id) is passed as arguments rather than read off `self` — the same reason
+/// `autoLaunchCommand` takes a `Session`.
+public struct AgentLogSource: Sendable, Equatable {
+    /// Whether `path` names a single file or a directory to enumerate.
+    public enum Selector: Sendable, Equatable {
+        /// One concrete file — used when the exact per-session log path is known
+        /// (e.g. Claude's `<uuid>.jsonl` when the harness session id is known).
+        case file
+        /// A directory whose (optionally extension-filtered) files all belong to
+        /// this session — used when a harness writes one file per run into a
+        /// per-worktree directory (e.g. Claude's project-slug directory).
+        case directory
+    }
+
+    /// Absolute path to the file or directory. `~` is NOT expanded here — callers
+    /// build absolute paths (adapters use `FileManager`/`NSHomeDirectory`).
+    public let path: String
+    /// Whether `path` is a file or a directory.
+    public let selector: Selector
+    /// The log's format, stamped onto the artifact.
+    public let format: AgentLogFormat
+    /// When `selector == .directory`, only files with this extension are
+    /// collected (e.g. `"jsonl"`); `nil` collects every regular file. Ignored
+    /// for `.file`.
+    public let fileExtension: String?
+    /// When `selector == .directory`, whether to descend into subdirectories.
+    /// Defaults to `false` (Claude's slug directory is flat).
+    public let recursive: Bool
+
+    public init(
+        path: String,
+        selector: Selector,
+        format: AgentLogFormat,
+        fileExtension: String? = nil,
+        recursive: Bool = false
+    ) {
+        self.path = path
+        self.selector = selector
+        self.format = format
+        self.fileExtension = fileExtension
+        self.recursive = recursive
+    }
+
+    /// A single-file source.
+    public static func file(_ path: String, format: AgentLogFormat) -> AgentLogSource {
+        AgentLogSource(path: path, selector: .file, format: format)
+    }
+
+    /// A directory source, optionally filtered by file extension.
+    public static func directory(
+        _ path: String,
+        format: AgentLogFormat,
+        fileExtension: String? = nil,
+        recursive: Bool = false
+    ) -> AgentLogSource {
+        AgentLogSource(
+            path: path, selector: .directory, format: format,
+            fileExtension: fileExtension, recursive: recursive)
+    }
+
+    /// Slugify a POSIX path the way Claude Code names its per-project log
+    /// directory: every character that is not an ASCII letter or digit becomes
+    /// `-`. So `/Users/j/Dev/acme-12` → `-Users-j-Dev-acme-12`.
+    ///
+    /// Verified against a live `~/.claude/projects` on macOS. Kept generic (not
+    /// "Claude") because it is a pure path transform and is unit-tested here in
+    /// CrowCore without importing the adapter.
+    public static func posixPathSlug(_ path: String) -> String {
+        String(path.unicodeScalars.map { scalar -> Character in
+            let isDigit = scalar >= "0" && scalar <= "9"
+            let isUpper = scalar >= "A" && scalar <= "Z"
+            let isLower = scalar >= "a" && scalar <= "z"
+            return (isDigit || isUpper || isLower) ? Character(scalar) : "-"
+        })
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -312,6 +312,29 @@ public protocol CodingAgent: Sendable {
     /// the protocol default returns `nil` so future agents cannot inherit a
     /// spurious `/rename` paste; Claude/Cursor/Codex/OpenCode override.
     func sessionRenameSlashCommand(newName: String) -> String?
+
+    /// Where this harness writes durable session logs on disk for a session
+    /// running in `worktreePath` (CROW-1056). The daemon's `LogSyncCollector`
+    /// resolves these to concrete files, normalizes them to NDJSON, and uploads
+    /// them as session-transcript artifacts for opted-in workspaces.
+    ///
+    /// Crow persists no transcript of its own — terminal scrollback is
+    /// tmux-memory-only — but every harness writes its own durable logs in its
+    /// own place and format. The adapter already knows how to launch each
+    /// harness; this is where it declares where that harness's logs live.
+    ///
+    /// `harnessSessionID` is the harness's OWN session identifier when known
+    /// (e.g. the Claude `.jsonl` filename UUID resolved from telemetry), letting
+    /// an adapter point at the exact file; pass `nil` to have the adapter return
+    /// the broadest per-worktree source it can (e.g. Claude's whole project-slug
+    /// directory).
+    ///
+    /// Opt-in: the protocol default returns `[]`, so a harness whose on-disk log
+    /// location is unconfirmed contributes nothing rather than uploading the
+    /// wrong bytes. Only Claude Code is fully wired today (its logs are the only
+    /// ones partitioned by working directory); the globally-stored harnesses
+    /// (Codex/Cursor/OpenCode) return `[]` pending per-harness cwd matching.
+    func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource]
 }
 
 public extension CodingAgent {
@@ -470,4 +493,10 @@ public extension CodingAgent {
     /// here prevents a future agent from silently inheriting a paste that
     /// would be sent to the model as a stray prompt (CROW-629 review).
     func sessionRenameSlashCommand(newName: String) -> String? { nil }
+
+    /// Opt-in default: no known log sources (CROW-1056). A harness whose
+    /// durable-log location is unconfirmed — or whose logs are not partitioned
+    /// by working directory — contributes nothing until its adapter overrides
+    /// this. Only `ClaudeCodeAgent` overrides it today.
+    func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] { [] }
 }

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncLedger.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// A small on-disk record of which session transcripts have already been
+/// uploaded, so a repeated sweep (including the one-time backfill of existing
+/// on-disk history) never re-uploads the same artifact (CROW-1056).
+///
+/// Idempotency is belt-and-suspenders: the server also rejects a duplicate
+/// `(session, harness, kind)` with 409, but the ledger avoids paying for the
+/// round trip (and re-reading the log files) on every tick for every
+/// already-uploaded session. Persisted at `{devRoot}/.claude/logsync-ledger.json`.
+///
+/// Written only by the single collector poll loop, so — unlike `config.json` —
+/// it needs no cross-writer lock.
+public struct LogSyncLedger: Codable, Sendable, Equatable {
+    /// What happened last for a `(session, harness, kind)` key.
+    public enum Status: String, Codable, Sendable, Equatable {
+        /// Stored (201) or already present (409). Never re-attempted.
+        case uploaded
+        /// Rejected in a way retrying can't fix (too large / auth / validation).
+        /// Never re-attempted.
+        case skippedPermanent
+        /// Transient failure (5xx / network). Re-attempted after a backoff.
+        case failedTransient
+    }
+
+    public struct Entry: Codable, Sendable, Equatable {
+        public var status: Status
+        public var sha256: String
+        public var sizeBytes: Int
+        /// Epoch seconds of the last attempt.
+        public var at: Double
+        public var reason: String?
+
+        public init(status: Status, sha256: String, sizeBytes: Int, at: Double, reason: String? = nil) {
+            self.status = status
+            self.sha256 = sha256
+            self.sizeBytes = sizeBytes
+            self.at = at
+            self.reason = reason
+        }
+    }
+
+    /// Keyed by `"<sessionUID>:<harness>:<kind>"`.
+    public var entries: [String: Entry]
+
+    public init(entries: [String: Entry] = [:]) {
+        self.entries = entries
+    }
+
+    /// The stable ledger key for one artifact slot.
+    public static func key(sessionUID: String, harness: LogSyncHarness, kind: LogSyncArtifactKind) -> String {
+        "\(sessionUID):\(harness.rawValue):\(kind.rawValue)"
+    }
+
+    /// Whether this slot should be uploaded now, given the last recorded outcome.
+    /// - `uploaded` / `skippedPermanent` → never again.
+    /// - `failedTransient` → only after `retryBackoff` seconds have passed.
+    /// - unknown → yes.
+    public func shouldUpload(key: String, now: Double, retryBackoff: Double) -> Bool {
+        guard let entry = entries[key] else { return true }
+        switch entry.status {
+        case .uploaded, .skippedPermanent: return false
+        case .failedTransient: return (now - entry.at) >= retryBackoff
+        }
+    }
+
+    public mutating func record(key: String, entry: Entry) {
+        entries[key] = entry
+    }
+
+    /// Drop entries older than `retentionDays` (housekeeping so the ledger can't
+    /// grow without bound). 0 keeps everything. A pruned-then-revisited live
+    /// session simply re-converges via the server's 409.
+    public mutating func prune(retentionDays: Int, now: Double) {
+        guard retentionDays > 0 else { return }
+        let cutoff = now - Double(retentionDays) * 86_400
+        entries = entries.filter { $0.value.at >= cutoff }
+    }
+
+    // MARK: - Persistence
+
+    /// Ledger file path under the dev root's `.claude` directory.
+    public static func ledgerURL(devRoot: String) -> URL {
+        URL(fileURLWithPath: devRoot)
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("logsync-ledger.json")
+    }
+
+    /// Load the ledger, or an empty one if absent/unreadable/corrupt (a corrupt
+    /// ledger is not fatal — worst case is a few duplicate uploads the server
+    /// 409s).
+    public static func load(devRoot: String) -> LogSyncLedger {
+        let url = ledgerURL(devRoot: devRoot)
+        guard let data = try? Data(contentsOf: url),
+              let ledger = try? JSONDecoder().decode(LogSyncLedger.self, from: data)
+        else { return LogSyncLedger() }
+        return ledger
+    }
+
+    /// Persist the ledger (pretty-printed, atomic). Best-effort — a write failure
+    /// is logged by the caller and otherwise ignored.
+    public func save(devRoot: String) throws {
+        let url = Self.ledgerURL(devRoot: devRoot)
+        let dir = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncSupport.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncSupport.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// The harness identifiers the Corveil session-artifact contract accepts on the
+/// `harness` column / query param (corveil#2426). Mirrors the server-side DB
+/// CHECK exactly, so an out-of-set value never reaches the endpoint (it would
+/// 400). Crow's own harness roster is larger than this set; anything without a
+/// first-class value maps to `.unknown`.
+public enum LogSyncHarness: String, Sendable, Equatable, CaseIterable {
+    case claude
+    case cursor
+    case codex
+    case opencode
+    case unknown
+
+    /// Map a Crow `AgentKind` to the artifact contract's harness value. The four
+    /// harnesses the server enumerates map directly; every other kind (Grok,
+    /// Antigravity, Muse, or a future one) maps to `.unknown` so the upload is
+    /// still accepted and attributed, just not harness-typed.
+    public init(agentKind: AgentKind) {
+        switch agentKind {
+        case .claudeCode: self = .claude
+        case .cursor: self = .cursor
+        case .codex: self = .codex
+        case .openCode: self = .opencode
+        default: self = .unknown
+        }
+    }
+}
+
+/// The single artifact kind the contract defines today
+/// (`crow_session_artifacts.kind`). A second value arrives with the feature that
+/// needs it.
+public enum LogSyncArtifactKind: String, Sendable, Equatable {
+    case sessionTranscript = "session_transcript"
+}
+
+/// The untrusted "sidecar hints" attached to an upload as query parameters
+/// (corveil#2426). These are *hints* for the server-side derivation's REFERENCES
+/// edges — the server derives attribution from the API key, never from these.
+/// Every field is optional; a best-effort uploader may omit any of them.
+public struct LogSyncSessionMetadata: Sendable, Equatable {
+    public var name: String?
+    public var status: String?
+    public var agentKind: String?
+    public var ticketURL: String?
+    public var ticketNumber: Int?
+    public var repo: String?
+    public var orgGoal: String?
+
+    public init(
+        name: String? = nil,
+        status: String? = nil,
+        agentKind: String? = nil,
+        ticketURL: String? = nil,
+        ticketNumber: Int? = nil,
+        repo: String? = nil,
+        orgGoal: String? = nil
+    ) {
+        self.name = name
+        self.status = status
+        self.agentKind = agentKind
+        self.ticketURL = ticketURL
+        self.ticketNumber = ticketNumber
+        self.repo = repo
+        self.orgGoal = orgGoal
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptNormalizer.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptNormalizer.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// A harness log normalized to the NDJSON bytes the upload endpoint stores, plus
+/// the cheap hint counts the server-side derivation can use (corveil#2426).
+public struct NormalizedTranscript: Sendable, Equatable {
+    /// The artifact body — NDJSON, uploaded verbatim (uncompressed; the server
+    /// sniffs the content encoding from magic bytes, so plain NDJSON is stored
+    /// with an empty `content_encoding`).
+    public let data: Data
+    /// Number of NDJSON events (non-empty lines). A hint; the server treats it as
+    /// optional.
+    public let eventCount: Int
+    /// Number of tool-use events seen (best-effort substring count). A hint.
+    public let toolCallCount: Int
+    /// Whether the transcript was cut to fit `maxBytes`.
+    public let truncated: Bool
+
+    public init(data: Data, eventCount: Int, toolCallCount: Int, truncated: Bool) {
+        self.data = data
+        self.eventCount = eventCount
+        self.toolCallCount = toolCallCount
+        self.truncated = truncated
+    }
+}
+
+/// Turns a harness's resolved on-disk log files into one NDJSON artifact body,
+/// bounded by a byte cap (CROW-1056). Pure and dependency-free so it is unit
+/// tested in CrowCore.
+public enum TranscriptNormalizer {
+    /// Normalize `files` (already resolved to concrete regular files, in the
+    /// order they should be concatenated) into a single NDJSON body.
+    ///
+    /// Returns `nil` when there is nothing to upload (no files, all empty) or the
+    /// format cannot be normalized yet (`.sqlite` — Cursor row extraction is not
+    /// wired).
+    public static func normalize(
+        files: [URL],
+        format: AgentLogFormat,
+        maxBytes: Int
+    ) -> NormalizedTranscript? {
+        switch format {
+        case .jsonl, .logDir:
+            return concatenateNDJSON(files: files, maxBytes: maxBytes)
+        case .sqlite:
+            // Chat-row extraction out of Cursor's state.vscdb is not implemented
+            // yet; declaring the source without a normalizer would upload the raw
+            // database, which is the wrong shape. Skip until extraction lands.
+            return nil
+        }
+    }
+
+    /// Concatenate NDJSON files, inserting a newline between files that don't end
+    /// in one, and cutting at the last newline within `maxBytes` if the total
+    /// would exceed the cap (marking the result truncated). Reads incrementally so
+    /// a pathologically large file can't blow past the budget in memory.
+    private static func concatenateNDJSON(files: [URL], maxBytes: Int) -> NormalizedTranscript? {
+        guard maxBytes > 0 else { return nil }
+        var out = Data()
+        out.reserveCapacity(min(maxBytes, 1 << 20))
+        let newline: UInt8 = 0x0A
+        var truncated = false
+
+        outer: for url in files {
+            guard let handle = try? FileHandle(forReadingFrom: url) else { continue }
+            defer { try? handle.close() }
+            // Separate files with a newline so a file missing its trailing
+            // newline can't glue two events into one line.
+            if let last = out.last, last != newline, !out.isEmpty {
+                if out.count + 1 > maxBytes { truncated = true; break }
+                out.append(newline)
+            }
+            while out.count < maxBytes {
+                let remaining = maxBytes - out.count
+                guard let chunk = try? handle.read(upToCount: min(65_536, remaining + 1)),
+                      !chunk.isEmpty
+                else { break }
+                if out.count + chunk.count <= maxBytes {
+                    out.append(chunk)
+                } else {
+                    out.append(chunk.prefix(maxBytes - out.count))
+                    truncated = true
+                    break outer
+                }
+            }
+            if out.count >= maxBytes {
+                // Reached the cap; if more files/bytes remain they're dropped.
+                truncated = truncated || url != files.last
+                break
+            }
+        }
+
+        if truncated {
+            out = trimToLastNewline(out)
+        }
+        guard !out.isEmpty else { return nil }
+
+        let (events, toolCalls) = countEvents(out)
+        return NormalizedTranscript(
+            data: out, eventCount: events, toolCallCount: toolCalls, truncated: truncated)
+    }
+
+    /// Drop a trailing partial line so a truncated artifact still parses as clean
+    /// NDJSON. If there is no newline at all, the data is returned unchanged.
+    private static func trimToLastNewline(_ data: Data) -> Data {
+        let newline: UInt8 = 0x0A
+        guard let idx = data.lastIndex(of: newline) else { return data }
+        return data.prefix(through: idx)
+    }
+
+    /// Count NDJSON events (non-empty lines) and tool-use events (lines carrying
+    /// the `"type":"tool_use"` marker). Best-effort hints; a single pass over the
+    /// bytes, no JSON parsing.
+    private static func countEvents(_ data: Data) -> (events: Int, toolCalls: Int) {
+        let newline: UInt8 = 0x0A
+        var events = 0
+        var lineHadBytes = false
+        for byte in data {
+            if byte == newline {
+                if lineHadBytes { events += 1 }
+                lineHadBytes = false
+            } else if byte != 0x0D { // ignore CR
+                lineHadBytes = true
+            }
+        }
+        if lineHadBytes { events += 1 } // last line with no trailing newline
+
+        // Tool-use marker count over the whole body (cheap substring scan).
+        let toolCalls: Int
+        if let marker = "\"type\":\"tool_use\"".data(using: .utf8) {
+            toolCalls = data.ranges(of: marker).count
+        } else {
+            toolCalls = 0
+        }
+        return (events, toolCalls)
+    }
+}
+
+private extension Data {
+    /// Non-overlapping occurrences of `pattern` in this data.
+    func ranges(of pattern: Data) -> [Range<Data.Index>] {
+        guard !pattern.isEmpty, count >= pattern.count else { return [] }
+        var result: [Range<Data.Index>] = []
+        var searchStart = startIndex
+        while searchStart < endIndex,
+              let found = self.range(of: pattern, in: searchStart..<endIndex) {
+            result.append(found)
+            searchStart = found.upperBound
+        }
+        return result
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptUploader.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptUploader.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Outcome of one transcript upload attempt, categorized so the collector knows
+/// whether to record it done, skip it permanently, or retry later (CROW-1056).
+public enum TranscriptUploadResult: Sendable, Equatable {
+    /// 201 — stored.
+    case created
+    /// 409 — a transcript of this `(session, harness, kind)` already exists.
+    /// Write-once is by design (corveil#2426); treat as an idempotent success so
+    /// backfill re-runs converge.
+    case alreadyExists
+    /// 413 — over the server's size cap. Permanent for this body; don't retry.
+    case tooLarge
+    /// Any other non-retryable response (400/401/403/404/other 4xx). Permanent —
+    /// retrying an auth/tenancy/validation error just hammers the endpoint.
+    case rejected(status: Int)
+    /// 5xx or a transport error. Transient — retry on a later sweep.
+    case transient
+
+    /// Whether the artifact is now stored (or already was).
+    public var isSuccess: Bool { self == .created || self == .alreadyExists }
+
+    /// Whether re-attempting can never succeed with the same body, so the
+    /// collector should stop trying (records it and moves on).
+    public var isPermanentFailure: Bool {
+        switch self {
+        case .tooLarge, .rejected: return true
+        case .created, .alreadyExists, .transient: return false
+        }
+    }
+}
+
+/// Performs one HTTP request and returns its status code, or throws on a
+/// transport error. Injected so the uploader is testable without a live server.
+public protocol TranscriptUploadTransport: Sendable {
+    func perform(_ request: URLRequest) async throws -> Int
+}
+
+/// The default transport, backed by `URLSession`.
+public struct URLSessionUploadTransport: TranscriptUploadTransport {
+    private let session: URLSession
+    public init(session: URLSession = .shared) { self.session = session }
+
+    public func perform(_ request: URLRequest) async throws -> Int {
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        return http.statusCode
+    }
+}
+
+/// Uploads a normalized session transcript to the Corveil session-artifact
+/// endpoint (corveil#2426): `POST {baseURL}/api/crow-sessions/{sessionUID}/artifacts`.
+///
+/// Authenticated with the developer's own Corveil API key
+/// (`Authorization: Bearer …`) — the server derives attribution from the key and
+/// uploads to object storage itself, so **no AWS credential is on the laptop**.
+/// Best-effort: one retry on a transient failure, then the caller records and
+/// drops it. Never blocks or fails a session.
+public struct TranscriptUploader: Sendable {
+    private let transport: any TranscriptUploadTransport
+
+    public init(transport: any TranscriptUploadTransport = URLSessionUploadTransport()) {
+        self.transport = transport
+    }
+
+    /// Build the upload request. Pure and side-effect-free so the URL, query
+    /// params, headers and body are unit-testable. Returns `nil` when `baseURL`
+    /// is blank or unparseable, or the API key is blank.
+    public static func makeRequest(
+        baseURL: String,
+        apiKey: String,
+        sessionUID: String,
+        harness: LogSyncHarness,
+        kind: LogSyncArtifactKind,
+        format: AgentLogFormat,
+        transcript: NormalizedTranscript,
+        metadata: LogSyncSessionMetadata,
+        agentSessionID: String?
+    ) -> URLRequest? {
+        let trimmedBase = baseURL.trimmingCharacters(in: .whitespaces)
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBase.isEmpty, !trimmedKey.isEmpty else { return nil }
+        // Strip a trailing slash so `…/api/…` isn't doubled.
+        let base = trimmedBase.hasSuffix("/") ? String(trimmedBase.dropLast()) : trimmedBase
+        let encodedUID = sessionUID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionUID
+        guard var components = URLComponents(string: "\(base)/api/crow-sessions/\(encodedUID)/artifacts") else {
+            return nil
+        }
+
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "harness", value: harness.rawValue),
+            URLQueryItem(name: "kind", value: kind.rawValue),
+            URLQueryItem(name: "format", value: format.rawValue),
+            URLQueryItem(name: "truncated", value: transcript.truncated ? "true" : "false"),
+            URLQueryItem(name: "event_count", value: String(transcript.eventCount)),
+            URLQueryItem(name: "tool_call_count", value: String(transcript.toolCallCount)),
+        ]
+        func add(_ name: String, _ value: String?) {
+            guard let value, !value.isEmpty else { return }
+            items.append(URLQueryItem(name: name, value: value))
+        }
+        add("agent_session_id", agentSessionID)
+        add("name", metadata.name)
+        add("status", metadata.status)
+        add("agent_kind", metadata.agentKind)
+        add("ticket_url", metadata.ticketURL)
+        if let n = metadata.ticketNumber { add("ticket_number", String(n)) }
+        add("repo", metadata.repo)
+        add("org_goal", metadata.orgGoal)
+        components.queryItems = items
+
+        guard let url = components.url else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/x-ndjson", forHTTPHeaderField: "Content-Type")
+        request.httpBody = transcript.data
+        return request
+    }
+
+    /// Categorize an HTTP status into an upload result.
+    public static func classify(status: Int) -> TranscriptUploadResult {
+        switch status {
+        case 200...299: return .created
+        case 409: return .alreadyExists
+        case 413: return .tooLarge
+        case 500...599: return .transient
+        default: return .rejected(status: status)
+        }
+    }
+
+    /// Upload the transcript. One retry on a transient failure, then give up
+    /// (returns `.transient` for the caller to record and re-attempt later).
+    public func upload(
+        baseURL: String,
+        apiKey: String,
+        sessionUID: String,
+        harness: LogSyncHarness,
+        kind: LogSyncArtifactKind,
+        format: AgentLogFormat,
+        transcript: NormalizedTranscript,
+        metadata: LogSyncSessionMetadata,
+        agentSessionID: String?
+    ) async -> TranscriptUploadResult {
+        guard let request = Self.makeRequest(
+            baseURL: baseURL, apiKey: apiKey, sessionUID: sessionUID,
+            harness: harness, kind: kind, format: format,
+            transcript: transcript, metadata: metadata, agentSessionID: agentSessionID
+        ) else {
+            return .rejected(status: 0) // misconfigured — permanent, not retried
+        }
+
+        for attempt in 0..<2 {
+            do {
+                let status = try await transport.perform(request)
+                let result = Self.classify(status: status)
+                if result == .transient, attempt == 0 { continue } // one retry
+                return result
+            } catch {
+                if attempt == 0 { continue } // one retry on transport error
+                return .transient
+            }
+        }
+        return .transient
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptUploader.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptUploader.swift
@@ -130,6 +130,10 @@ public struct TranscriptUploader: Sendable {
         case 200...299: return .created
         case 409: return .alreadyExists
         case 413: return .tooLarge
+        // Rate limiting (429) and request timeout (408) are temporary: retrying
+        // later can succeed, so they take the backoff path rather than being
+        // recorded as a permanent skip that never retries.
+        case 408, 429: return .transient
         case 500...599: return .transient
         default: return .rejected(status: status)
         }

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -102,6 +102,14 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// one. Minted/revoked via the local-only `mcp-token-*` RPCs.
     public var mcpTokens: [MCPTokenRecord]
 
+    /// Session-log collector settings (CROW-1056). Opt-in, local-only, default
+    /// OFF. When enabled, the daemon uploads opted-in workspaces' harness session
+    /// transcripts to Corveil as session-artifacts. `nil`/absent means never
+    /// configured — the collector is inert. Like `managerGateway`/`webAuth`, its
+    /// API-key value is stripped before the config reaches a browser and it is
+    /// writable only through the local-only `logsync-set` RPC (`SettingsSecrets`).
+    public var logSync: LogSyncConfig?
+
     /// Effective review-exclude patterns: the global `defaults.excludeReviewRepos`
     /// unioned with every workspace's per-workspace `excludeReviewRepos`. A repo
     /// excluded by any workspace (or the global default) is hidden from the review
@@ -165,7 +173,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
         managerGateway: WorkspaceGateway? = nil,
         jiraCredential: JiraCredential? = nil,
         webAuth: WebAuthConfig? = nil,
-        mcpTokens: [MCPTokenRecord] = []
+        mcpTokens: [MCPTokenRecord] = [],
+        logSync: LogSyncConfig? = nil
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
@@ -192,6 +201,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.jiraCredential = jiraCredential
         self.webAuth = webAuth
         self.mcpTokens = mcpTokens
+        self.logSync = logSync
     }
 
     public init(from decoder: Decoder) throws {
@@ -245,6 +255,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         }
         webAuth = try container.decodeIfPresent(WebAuthConfig.self, forKey: .webAuth)
         mcpTokens = try container.decodeIfPresent([MCPTokenRecord].self, forKey: .mcpTokens) ?? []
+        logSync = try container.decodeIfPresent(LogSyncConfig.self, forKey: .logSync)
     }
 
     /// Pre-CROW-528 shape of the now-removed `atlassianMCP` config, decoded only
@@ -268,7 +279,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, switcher, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth, mcpTokens
+        case workspaces, defaults, notifications, sidebar, switcher, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth, mcpTokens, logSync
     }
 
     /// Resolve the agent that should drive a newly-created session of the
@@ -1155,4 +1166,91 @@ public struct CleanupConfig: Codable, Sendable, Equatable {
     }
 
     enum CodingKeys: String, CodingKey { case enabled, retentionHours }
+}
+
+/// Session-log upload settings (CROW-1056) — the opt-in, local-only control
+/// block for the multi-harness session-log collector.
+///
+/// **Local-only, default OFF.** This block configures uploads *from the daemon
+/// host* and carries a Corveil API-key reference, so — like `managerGateway` /
+/// `webAuth` / `mcpTokens` — it is stripped before the config reaches a browser
+/// (`SettingsSecrets`) and is writable only through the local-only `logsync-set`
+/// RPC, never `set-config`. Nothing uploads unless a local operator turns it on.
+///
+/// The collector uploads a session's transcript only when **both** `enabled` is
+/// true **and** the session's workspace name is listed in `enabledWorkspaces`
+/// (the per-workspace opt-in — matched case-insensitively). Uploads are
+/// best-effort and never block or fail a session.
+public struct LogSyncConfig: Codable, Sendable, Equatable {
+    /// Master switch. `false` (the default) means the collector does nothing.
+    public var enabled: Bool
+    /// Corveil API base URL that hosts `POST /api/crow-sessions/{id}/artifacts`
+    /// (e.g. `https://api.corveil.io`). Empty disables uploads even when
+    /// `enabled` is true.
+    public var baseURL: String
+    /// The developer's own Corveil API key, as an `op://…` 1Password reference
+    /// (resolved at upload via `GatewayResolver.opRead`, so the secret never
+    /// lands at rest in `config.json`) or a plaintext key. Sent as
+    /// `Authorization: Bearer <key>`. The upload is authenticated as — and
+    /// attributed to — this principal, server-side; there are no AWS credentials
+    /// on the laptop.
+    public var apiKeyRef: String
+    /// Names of the workspaces opted in to transcript upload. A session uploads
+    /// only if its workspace name appears here (case-insensitive). Empty = no
+    /// workspace uploads, which is the default even when `enabled` is true.
+    public var enabledWorkspaces: [String]
+    /// Days to retain entries in the local upload ledger before pruning
+    /// (housekeeping only — mirrors `TelemetryConfig.retentionDays`; the server
+    /// enforces its own artifact retention). 0 keeps entries forever.
+    public var retentionDays: Int
+    /// A session whose newest log file changed within this window is treated as
+    /// still active and is NOT uploaded yet — the server rejects a second upload
+    /// of the same `(session, harness, kind)` with 409, so the collector waits
+    /// for the transcript to go quiescent before capturing it once. Terminal
+    /// sessions (completed/archived) bypass this. Default 30 minutes.
+    public var quietPeriodMinutes: Int
+    /// Per-artifact upload cap in bytes. A larger transcript is truncated and
+    /// flagged. Kept at/under the server's own limit. Default 8,000,000.
+    public var maxUploadBytes: Int
+
+    public init(
+        enabled: Bool = false,
+        baseURL: String = "",
+        apiKeyRef: String = "",
+        enabledWorkspaces: [String] = [],
+        retentionDays: Int = 30,
+        quietPeriodMinutes: Int = 30,
+        maxUploadBytes: Int = 8_000_000
+    ) {
+        self.enabled = enabled
+        self.baseURL = baseURL
+        self.apiKeyRef = apiKeyRef
+        self.enabledWorkspaces = enabledWorkspaces
+        self.retentionDays = retentionDays
+        self.quietPeriodMinutes = quietPeriodMinutes
+        self.maxUploadBytes = maxUploadBytes
+    }
+
+    /// Per-key tolerant decode — an older `config.json` lacking any field (or the
+    /// whole block) still decodes (CROW-814 idiom).
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        baseURL = try c.decodeIfPresent(String.self, forKey: .baseURL) ?? ""
+        apiKeyRef = try c.decodeIfPresent(String.self, forKey: .apiKeyRef) ?? ""
+        enabledWorkspaces = try c.decodeIfPresent([String].self, forKey: .enabledWorkspaces) ?? []
+        retentionDays = try c.decodeIfPresent(Int.self, forKey: .retentionDays) ?? 30
+        quietPeriodMinutes = try c.decodeIfPresent(Int.self, forKey: .quietPeriodMinutes) ?? 30
+        maxUploadBytes = try c.decodeIfPresent(Int.self, forKey: .maxUploadBytes) ?? 8_000_000
+    }
+
+    /// Whether this workspace name is opted in (case-insensitive).
+    public func uploadsWorkspace(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return enabledWorkspaces.contains { $0.lowercased() == lower }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enabled, baseURL, apiKeyRef, enabledWorkspaces, retentionDays, quietPeriodMinutes, maxUploadBytes
+    }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -147,6 +147,8 @@ public enum ParityLedger {
         "mcp-token-revoke",
         "corveil-verify",
         "corveil-reinstall-skill",
+        "logsync-get",
+        "logsync-set",
     ]
 
     /// Every method reachable through the live router pair — the daemon's
@@ -292,6 +294,8 @@ public enum ParityLedger {
         .write("telemetry-set", cli: "telemetry set"),
         .read("cleanup-get", cli: "cleanup get"),
         .write("cleanup-set", cli: "cleanup set"),
+        .read("logsync-get", cli: "logsync get"),
+        .write("logsync-set", cli: "logsync set"),
         .read("ui-get", cli: "ui get"),
         .write("ui-set", cli: "ui set"),
         .read("version-update-get", cli: "version get"),
@@ -478,6 +482,16 @@ public enum ParityLedger {
         .field("managerGateway.customHeaders", read: "gateway get", write: "gateway set"),
         .field("workspaces[].gateway.baseURL", read: "gateway get", write: "gateway set"),
         .field("workspaces[].gateway.customHeaders", read: "gateway get", write: "gateway set"),
+
+        // Session-log collector (CROW-1056). Local-socket only, like the gateway
+        // block: `logsync get`/`logsync set` are refused on the remote /rpc path.
+        .field("logSync.enabled", read: "logsync get", write: "logsync set"),
+        .field("logSync.baseURL", read: "logsync get", write: "logsync set"),
+        .field("logSync.apiKeyRef", read: "logsync get", write: "logsync set"),
+        .field("logSync.enabledWorkspaces", read: "logsync get", write: "logsync set"),
+        .field("logSync.retentionDays", read: "logsync get", write: "logsync set"),
+        .field("logSync.quietPeriodMinutes", read: "logsync get", write: "logsync set"),
+        .field("logSync.maxUploadBytes", read: "logsync get", write: "logsync set"),
 
         .field("webAuth.iterations", read: "web-password status", write: "web-password set"),
         .field(

--- a/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
+++ b/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
@@ -48,6 +48,11 @@ public enum SettingsSecrets {
             if let gateway = w.gateway { w.gateway = stripHeaderValues(gateway) }
             return w
         }
+        // Session-log collector (CROW-1056): blank the Corveil API-key reference
+        // but keep the rest of the block so the read-only web view can show what
+        // is configured. Like the gateway/token secrets, it is authored only via
+        // the local-only `logsync-set` RPC.
+        if c.logSync != nil { c.logSync?.apiKeyRef = "" }
         return c
     }
 
@@ -80,6 +85,11 @@ public enum SettingsSecrets {
         // `current` means a round-trip is a no-op regardless of what came back.
         result.mcpTokens = current?.mcpTokens ?? []
         result.managerGateway = current?.managerGateway
+        // Session-log collector (CROW-1056): the whole block is authored only via
+        // the local-only `logsync-set` RPC, so a `set-config` round-trip always
+        // restores the stored value — a browser can neither enable uploads,
+        // opt a workspace in, nor introduce a plaintext API key here.
+        result.logSync = current?.logSync
         if let current {
             let currentGatewaysByID = Dictionary(
                 current.workspaces.map { ($0.id, $0.gateway) },

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+import CrowCore
+
+@Suite struct AgentLogSourceTests {
+    @Test func posixPathSlugReplacesNonAlphanumericWithDash() {
+        // Verified rule: every non-[A-Za-z0-9] char → '-' (leading slash → '-').
+        #expect(AgentLogSource.posixPathSlug("/Users/j/Dev2/RadiusMethod/crow-1056-x")
+            == "-Users-j-Dev2-RadiusMethod-crow-1056-x")
+    }
+
+    @Test func posixPathSlugReplacesDotsAndUnderscores() {
+        #expect(AgentLogSource.posixPathSlug("/a/head_lamp-0.39.0/b")
+            == "-a-head-lamp-0-39-0-b")
+    }
+
+    @Test func posixPathSlugKeepsExistingHyphens() {
+        #expect(AgentLogSource.posixPathSlug("already-hyphenated") == "already-hyphenated")
+    }
+
+    @Test func fileFactory() {
+        let s = AgentLogSource.file("/tmp/x.jsonl", format: .jsonl)
+        #expect(s.selector == .file)
+        #expect(s.format == .jsonl)
+        #expect(s.path == "/tmp/x.jsonl")
+        #expect(s.fileExtension == nil)
+    }
+
+    @Test func directoryFactory() {
+        let s = AgentLogSource.directory("/tmp/dir", format: .jsonl, fileExtension: "jsonl")
+        #expect(s.selector == .directory)
+        #expect(s.fileExtension == "jsonl")
+        #expect(s.recursive == false)
+    }
+}
+
+@Suite struct LogSyncHarnessTests {
+    @Test func mapsKnownHarnesses() {
+        #expect(LogSyncHarness(agentKind: .claudeCode) == .claude)
+        #expect(LogSyncHarness(agentKind: .cursor) == .cursor)
+        #expect(LogSyncHarness(agentKind: .codex) == .codex)
+        #expect(LogSyncHarness(agentKind: .openCode) == .opencode)
+    }
+
+    @Test func mapsEverythingElseToUnknown() {
+        #expect(LogSyncHarness(agentKind: .grok) == .unknown)
+        #expect(LogSyncHarness(agentKind: .antigravity) == .unknown)
+        #expect(LogSyncHarness(agentKind: .muse) == .unknown)
+    }
+
+    @Test func rawValuesMatchServerContract() {
+        // These strings are the DB CHECK on crow_session_artifacts.harness.
+        #expect(LogSyncHarness.claude.rawValue == "claude")
+        #expect(LogSyncHarness.cursor.rawValue == "cursor")
+        #expect(LogSyncHarness.codex.rawValue == "codex")
+        #expect(LogSyncHarness.opencode.rawValue == "opencode")
+        #expect(LogSyncHarness.unknown.rawValue == "unknown")
+        #expect(LogSyncArtifactKind.sessionTranscript.rawValue == "session_transcript")
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/LogSyncConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/LogSyncConfigTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+import CrowCore
+
+@Suite struct LogSyncConfigTests {
+    @Test func defaultsAreOff() {
+        let c = LogSyncConfig()
+        #expect(c.enabled == false)
+        #expect(c.baseURL.isEmpty)
+        #expect(c.apiKeyRef.isEmpty)
+        #expect(c.enabledWorkspaces.isEmpty)
+        #expect(c.retentionDays == 30)
+        #expect(c.quietPeriodMinutes == 30)
+        #expect(c.maxUploadBytes == 8_000_000)
+    }
+
+    @Test func uploadsWorkspaceIsCaseInsensitive() {
+        let c = LogSyncConfig(enabledWorkspaces: ["Acme", "Corveil"])
+        #expect(c.uploadsWorkspace("acme"))
+        #expect(c.uploadsWorkspace("CORVEIL"))
+        #expect(!c.uploadsWorkspace("other"))
+    }
+
+    @Test func codableRoundTrip() throws {
+        let c = LogSyncConfig(
+            enabled: true, baseURL: "https://api.corveil.io",
+            apiKeyRef: "op://vault/corveil/key", enabledWorkspaces: ["ws1"],
+            retentionDays: 14, quietPeriodMinutes: 10, maxUploadBytes: 1_000_000)
+        let data = try JSONEncoder().encode(c)
+        let decoded = try JSONDecoder().decode(LogSyncConfig.self, from: data)
+        #expect(decoded == c)
+    }
+
+    @Test func tolerantDecodeOfPartialBlock() throws {
+        // An older config.json with only some keys still decodes to defaults.
+        let json = #"{"enabled": true, "baseURL": "https://x"}"#
+        let decoded = try JSONDecoder().decode(LogSyncConfig.self, from: Data(json.utf8))
+        #expect(decoded.enabled)
+        #expect(decoded.baseURL == "https://x")
+        #expect(decoded.retentionDays == 30) // defaulted
+        #expect(decoded.maxUploadBytes == 8_000_000)
+    }
+
+    @Test func appConfigRoundTripsLogSyncAndDefaultsToNil() throws {
+        // Absent block decodes to nil (collector inert) and re-encodes without it.
+        let bare = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+        #expect(bare.logSync == nil)
+
+        var c = AppConfig()
+        c.logSync = LogSyncConfig(enabled: true, baseURL: "https://api", apiKeyRef: "op://v/k")
+        let data = try JSONEncoder().encode(c)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.logSync == c.logSync)
+    }
+}
+
+/// The log-sync block is local-only: its API key is stripped for the browser and
+/// the whole block is restored from the stored config on a set-config round-trip.
+@Suite struct LogSyncSecretsTests {
+    @Test func apiKeyStrippedForTransport() {
+        var c = AppConfig()
+        c.logSync = LogSyncConfig(enabled: true, baseURL: "https://api", apiKeyRef: "op://v/k",
+                                  enabledWorkspaces: ["ws1"])
+        let stripped = SettingsSecrets.strippedForTransport(c)
+        #expect(stripped.logSync?.apiKeyRef == "")
+        // Non-secret fields still visible read-only.
+        #expect(stripped.logSync?.enabled == true)
+        #expect(stripped.logSync?.baseURL == "https://api")
+        #expect(stripped.logSync?.enabledWorkspaces == ["ws1"])
+    }
+
+    @Test func setConfigCannotChangeLogSync() {
+        var stored = AppConfig()
+        stored.logSync = LogSyncConfig(enabled: true, baseURL: "https://api",
+                                       apiKeyRef: "op://v/k", enabledWorkspaces: ["ws1"])
+        // A hostile/edited browser config trying to enable an extra workspace and
+        // plant a plaintext key.
+        var incoming = AppConfig()
+        incoming.logSync = LogSyncConfig(enabled: true, baseURL: "https://evil",
+                                         apiKeyRef: "plaintext-stolen",
+                                         enabledWorkspaces: ["ws1", "ws2"])
+        let result = SettingsSecrets.preservingSecrets(incoming: incoming, current: stored)
+        #expect(result.logSync == stored.logSync) // stored wins entirely
+    }
+
+    @Test func roundTripIsNoOp() {
+        var c = AppConfig()
+        c.logSync = LogSyncConfig(enabled: true, baseURL: "https://api", apiKeyRef: "op://v/k")
+        let restored = SettingsSecrets.preservingSecrets(
+            incoming: SettingsSecrets.strippedForTransport(c), current: c)
+        #expect(restored.logSync == c.logSync)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/LogSyncLedgerTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/LogSyncLedgerTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+import CrowCore
+
+@Suite struct LogSyncLedgerTests {
+    @Test func keyFormat() {
+        #expect(LogSyncLedger.key(sessionUID: "SID", harness: .claude, kind: .sessionTranscript)
+            == "SID:claude:session_transcript")
+    }
+
+    @Test func shouldUploadUnknownKey() {
+        let ledger = LogSyncLedger()
+        #expect(ledger.shouldUpload(key: "x", now: 100, retryBackoff: 60))
+    }
+
+    @Test func uploadedAndPermanentAreNeverRetried() {
+        var ledger = LogSyncLedger()
+        ledger.record(key: "u", entry: .init(status: .uploaded, sha256: "a", sizeBytes: 1, at: 0))
+        ledger.record(key: "p", entry: .init(status: .skippedPermanent, sha256: "b", sizeBytes: 1, at: 0))
+        #expect(!ledger.shouldUpload(key: "u", now: 1_000_000, retryBackoff: 60))
+        #expect(!ledger.shouldUpload(key: "p", now: 1_000_000, retryBackoff: 60))
+    }
+
+    @Test func transientRetriesOnlyAfterBackoff() {
+        var ledger = LogSyncLedger()
+        ledger.record(key: "t", entry: .init(status: .failedTransient, sha256: "c", sizeBytes: 1, at: 100))
+        #expect(!ledger.shouldUpload(key: "t", now: 150, retryBackoff: 100)) // 50s < 100s
+        #expect(ledger.shouldUpload(key: "t", now: 250, retryBackoff: 100))  // 150s >= 100s
+    }
+
+    @Test func pruneDropsOldEntries() {
+        var ledger = LogSyncLedger()
+        let now = 1_000_000.0
+        ledger.record(key: "old", entry: .init(status: .uploaded, sha256: "a", sizeBytes: 1,
+                                                at: now - 40 * 86_400))
+        ledger.record(key: "new", entry: .init(status: .uploaded, sha256: "b", sizeBytes: 1,
+                                                at: now - 1 * 86_400))
+        ledger.prune(retentionDays: 30, now: now)
+        #expect(ledger.entries["old"] == nil)
+        #expect(ledger.entries["new"] != nil)
+    }
+
+    @Test func pruneWithZeroRetentionKeepsEverything() {
+        var ledger = LogSyncLedger()
+        ledger.record(key: "old", entry: .init(status: .uploaded, sha256: "a", sizeBytes: 1, at: 0))
+        ledger.prune(retentionDays: 0, now: 1_000_000_000)
+        #expect(ledger.entries["old"] != nil)
+    }
+
+    @Test func persistenceRoundTrip() throws {
+        let devRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logsync-ledger-\(UUID().uuidString)", isDirectory: true).path
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        var ledger = LogSyncLedger()
+        ledger.record(key: "k", entry: .init(status: .uploaded, sha256: "sha", sizeBytes: 42, at: 7))
+        try ledger.save(devRoot: devRoot)
+
+        let loaded = LogSyncLedger.load(devRoot: devRoot)
+        #expect(loaded == ledger)
+        #expect(loaded.entries["k"]?.sizeBytes == 42)
+    }
+
+    @Test func loadMissingReturnsEmpty() {
+        let devRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logsync-ledger-missing-\(UUID().uuidString)", isDirectory: true).path
+        #expect(LogSyncLedger.load(devRoot: devRoot).entries.isEmpty)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/TranscriptNormalizerTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TranscriptNormalizerTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+import CrowCore
+
+@Suite struct TranscriptNormalizerTests {
+    /// Make a unique temp directory for a test's fixture files.
+    private func tempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logsync-normalizer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func concatenatesJSONLFilesInOrder() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let a = dir.appendingPathComponent("a.jsonl")
+        let b = dir.appendingPathComponent("b.jsonl")
+        try #"{"i":1}"#.write(to: a, atomically: true, encoding: .utf8) // no trailing newline
+        try "{\"i\":2}\n".write(to: b, atomically: true, encoding: .utf8)
+
+        let result = TranscriptNormalizer.normalize(files: [a, b], format: .jsonl, maxBytes: 10_000)
+        let text = String(data: result!.data, encoding: .utf8)!
+        #expect(text == "{\"i\":1}\n{\"i\":2}\n") // newline inserted between files
+        #expect(result!.eventCount == 2)
+        #expect(result!.truncated == false)
+    }
+
+    @Test func countsToolUseEvents() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let f = dir.appendingPathComponent("t.jsonl")
+        let body = """
+        {"type":"user"}
+        {"type":"assistant","content":[{"type":"tool_use","name":"Bash"}]}
+        {"type":"assistant","content":[{"type":"tool_use","name":"Read"}]}
+        """
+        try body.write(to: f, atomically: true, encoding: .utf8)
+        let result = TranscriptNormalizer.normalize(files: [f], format: .jsonl, maxBytes: 10_000)
+        #expect(result!.eventCount == 3)
+        #expect(result!.toolCallCount == 2)
+    }
+
+    @Test func truncatesAtLineBoundaryAndFlagsIt() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let f = dir.appendingPathComponent("big.jsonl")
+        let body = "{\"line\":1}\n{\"line\":2}\n{\"line\":3}\n"
+        try body.write(to: f, atomically: true, encoding: .utf8)
+        // Cap between the first and second newline → should keep only line 1.
+        let result = TranscriptNormalizer.normalize(files: [f], format: .jsonl, maxBytes: 15)
+        #expect(result!.truncated == true)
+        let text = String(data: result!.data, encoding: .utf8)!
+        #expect(text == "{\"line\":1}\n") // trimmed to last complete line
+    }
+
+    @Test func sqliteFormatIsNotNormalized() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let f = dir.appendingPathComponent("state.vscdb")
+        try Data([0x1, 0x2, 0x3]).write(to: f)
+        #expect(TranscriptNormalizer.normalize(files: [f], format: .sqlite, maxBytes: 10_000) == nil)
+    }
+
+    @Test func emptyInputsYieldNil() {
+        #expect(TranscriptNormalizer.normalize(files: [], format: .jsonl, maxBytes: 10_000) == nil)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/TranscriptUploaderTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TranscriptUploaderTests.swift
@@ -102,8 +102,20 @@ final class MockUploadTransport: TranscriptUploadTransport, @unchecked Sendable 
         #expect(TranscriptUploader.classify(status: 409) == .alreadyExists)
         #expect(TranscriptUploader.classify(status: 413) == .tooLarge)
         #expect(TranscriptUploader.classify(status: 500) == .transient)
+        // Rate limit / request timeout are retryable, not permanent skips.
+        #expect(TranscriptUploader.classify(status: 429) == .transient)
+        #expect(TranscriptUploader.classify(status: 408) == .transient)
         #expect(TranscriptUploader.classify(status: 404) == .rejected(status: 404))
         #expect(TranscriptUploader.classify(status: 401) == .rejected(status: 401))
+    }
+
+    @Test func rateLimitedUploadRetriesThenBacksOff() async {
+        // 429 must reach the backoff path, not be recorded permanently.
+        let t = MockUploadTransport(outcomes: [.success(429), .success(429)])
+        let r = await doUpload(t)
+        #expect(r == .transient)
+        #expect(!r.isPermanentFailure)
+        #expect(t.callCount == 2)
     }
 
     private func doUpload(_ transport: MockUploadTransport) async -> TranscriptUploadResult {

--- a/Packages/CrowCore/Tests/CrowCoreTests/TranscriptUploaderTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TranscriptUploaderTests.swift
@@ -2,6 +2,10 @@ import Foundation
 import Testing
 import CrowCore
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking  // URLRequest / URLError live here on Linux
+#endif
+
 /// Records requests and replays scripted outcomes so the uploader is testable
 /// without a live server.
 final class MockUploadTransport: TranscriptUploadTransport, @unchecked Sendable {

--- a/Packages/CrowCore/Tests/CrowCoreTests/TranscriptUploaderTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TranscriptUploaderTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+import CrowCore
+
+/// Records requests and replays scripted outcomes so the uploader is testable
+/// without a live server.
+final class MockUploadTransport: TranscriptUploadTransport, @unchecked Sendable {
+    private let outcomes: [Result<Int, Error>]
+    private let lock = NSLock()
+    private(set) var requests: [URLRequest] = []
+    private var callIndex = 0
+
+    init(outcomes: [Result<Int, Error>]) { self.outcomes = outcomes }
+
+    var callCount: Int { lock.withLock { callIndex } }
+
+    func perform(_ request: URLRequest) async throws -> Int {
+        let outcome: Result<Int, Error> = lock.withLock {
+            requests.append(request)
+            let o = outcomes[min(callIndex, outcomes.count - 1)]
+            callIndex += 1
+            return o
+        }
+        switch outcome {
+        case .success(let status): return status
+        case .failure(let error): throw error
+        }
+    }
+}
+
+@Suite struct TranscriptUploaderTests {
+    private let transcript = NormalizedTranscript(
+        data: Data("{\"a\":1}\n".utf8), eventCount: 1, toolCallCount: 0, truncated: false)
+
+    private func meta() -> LogSyncSessionMetadata {
+        LogSyncSessionMetadata(
+            name: "Fix thing", status: "completed", agentKind: "claude-code",
+            ticketURL: "https://github.com/o/r/issues/5", ticketNumber: 5,
+            repo: "o/r", orgGoal: "ship")
+    }
+
+    @Test func makeRequestBuildsContractURLAndHeaders() throws {
+        let req = TranscriptUploader.makeRequest(
+            baseURL: "https://api.corveil.io/", apiKey: "sk-citadel-abc",
+            sessionUID: "SID-1", harness: .claude, kind: .sessionTranscript, format: .jsonl,
+            transcript: transcript, metadata: meta(), agentSessionID: "claude-uuid")!
+
+        let comps = URLComponents(url: req.url!, resolvingAgainstBaseURL: false)!
+        #expect(comps.scheme == "https")
+        #expect(comps.host == "api.corveil.io")
+        // Trailing slash on baseURL is trimmed (no doubled slash).
+        #expect(comps.path == "/api/crow-sessions/SID-1/artifacts")
+
+        let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        #expect(items["harness"] == "claude")
+        #expect(items["kind"] == "session_transcript")
+        #expect(items["format"] == "jsonl")
+        #expect(items["truncated"] == "false")
+        #expect(items["event_count"] == "1")
+        #expect(items["agent_session_id"] == "claude-uuid")
+        #expect(items["ticket_url"] == "https://github.com/o/r/issues/5")
+        #expect(items["ticket_number"] == "5")
+        #expect(items["repo"] == "o/r")
+        #expect(items["org_goal"] == "ship")
+
+        #expect(req.httpMethod == "POST")
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer sk-citadel-abc")
+        #expect(req.value(forHTTPHeaderField: "Content-Type") == "application/x-ndjson")
+        #expect(req.httpBody == transcript.data)
+    }
+
+    @Test func makeRequestOmitsEmptySidecarHints() throws {
+        let req = TranscriptUploader.makeRequest(
+            baseURL: "https://api.x", apiKey: "k", sessionUID: "S", harness: .unknown,
+            kind: .sessionTranscript, format: .jsonl, transcript: transcript,
+            metadata: LogSyncSessionMetadata(), agentSessionID: nil)!
+        let comps = URLComponents(url: req.url!, resolvingAgainstBaseURL: false)!
+        let names = Set((comps.queryItems ?? []).map(\.name))
+        #expect(!names.contains("name"))
+        #expect(!names.contains("ticket_url"))
+        #expect(!names.contains("agent_session_id"))
+        #expect(names.contains("harness")) // required ones stay
+    }
+
+    @Test func makeRequestNilWhenMisconfigured() {
+        #expect(TranscriptUploader.makeRequest(
+            baseURL: "", apiKey: "k", sessionUID: "S", harness: .claude, kind: .sessionTranscript,
+            format: .jsonl, transcript: transcript, metadata: meta(), agentSessionID: nil) == nil)
+        #expect(TranscriptUploader.makeRequest(
+            baseURL: "https://api.x", apiKey: "  ", sessionUID: "S", harness: .claude,
+            kind: .sessionTranscript, format: .jsonl, transcript: transcript,
+            metadata: meta(), agentSessionID: nil) == nil)
+    }
+
+    @Test func classifyMapsStatuses() {
+        #expect(TranscriptUploader.classify(status: 201) == .created)
+        #expect(TranscriptUploader.classify(status: 200) == .created)
+        #expect(TranscriptUploader.classify(status: 409) == .alreadyExists)
+        #expect(TranscriptUploader.classify(status: 413) == .tooLarge)
+        #expect(TranscriptUploader.classify(status: 500) == .transient)
+        #expect(TranscriptUploader.classify(status: 404) == .rejected(status: 404))
+        #expect(TranscriptUploader.classify(status: 401) == .rejected(status: 401))
+    }
+
+    private func doUpload(_ transport: MockUploadTransport) async -> TranscriptUploadResult {
+        await TranscriptUploader(transport: transport).upload(
+            baseURL: "https://api.x", apiKey: "k", sessionUID: "S", harness: .claude,
+            kind: .sessionTranscript, format: .jsonl, transcript: transcript,
+            metadata: meta(), agentSessionID: nil)
+    }
+
+    @Test func createdOnFirstTry() async {
+        let t = MockUploadTransport(outcomes: [.success(201)])
+        #expect(await doUpload(t) == .created)
+        #expect(t.callCount == 1)
+    }
+
+    @Test func conflictTreatedAsSuccess() async {
+        let t = MockUploadTransport(outcomes: [.success(409)])
+        let r = await doUpload(t)
+        #expect(r == .alreadyExists)
+        #expect(r.isSuccess)
+    }
+
+    @Test func retriesOnceOnTransientThenSucceeds() async {
+        let t = MockUploadTransport(outcomes: [.success(503), .success(201)])
+        #expect(await doUpload(t) == .created)
+        #expect(t.callCount == 2)
+    }
+
+    @Test func twoTransientsGiveUp() async {
+        let t = MockUploadTransport(outcomes: [.success(503), .success(500)])
+        let r = await doUpload(t)
+        #expect(r == .transient)
+        #expect(t.callCount == 2)
+    }
+
+    @Test func retriesOnceOnThrownTransportError() async {
+        let t = MockUploadTransport(outcomes: [.failure(URLError(.timedOut)), .success(201)])
+        #expect(await doUpload(t) == .created)
+        #expect(t.callCount == 2)
+    }
+
+    @Test func tooLargeAndRejectedArePermanentAndNotRetried() async {
+        let big = MockUploadTransport(outcomes: [.success(413)])
+        let r1 = await doUpload(big)
+        #expect(r1 == .tooLarge)
+        #expect(r1.isPermanentFailure)
+        #expect(big.callCount == 1) // no retry on a permanent failure
+
+        let bad = MockUploadTransport(outcomes: [.success(404)])
+        let r2 = await doUpload(bad)
+        #expect(r2 == .rejected(status: 404))
+        #expect(bad.callCount == 1)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -380,6 +380,12 @@ public enum CrowDaemon {
             tracker: tracker, eventHub: eventHub, sessionService: sessionService,
             appState: appState, devRoot: options.devRoot)
 
+        // Drive the session-log collector (CROW-1056). Opt-in and default OFF —
+        // the tick is a cheap no-op until `logSync` is enabled with an opted-in
+        // workspace. Terminal-independent (it reads harness log files off disk),
+        // so it runs whenever `crowd` runs.
+        startLogSyncPoll(appState: appState, devRoot: options.devRoot)
+
         // Wire the IssueTracker's config-flag providers and its notification-only
         // outcome hooks. Terminal-INDEPENDENT, so this runs whenever `crowd` runs —
         // enabling GitHub native auto-merge is a pure gh/GraphQL call and
@@ -1005,6 +1011,22 @@ public enum CrowDaemon {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 3600 * 1_000_000_000)
                 await rebuild()
+            }
+        }
+    }
+
+    /// Drive the multi-harness session-log collector on a 5-minute cadence
+    /// (CROW-1056). Delay-first so boot isn't slowed; config is read fresh each
+    /// tick (via `ConfigStore` inside `sweep`), so enabling `logSync` in Settings
+    /// takes effect within one tick. The whole pass is a cheap no-op while the
+    /// feature is off (the default), and every upload is best-effort — a failure
+    /// never touches session state.
+    private static func startLogSyncPoll(appState: AppState, devRoot: String) {
+        let collector = LogSyncCollector(devRoot: devRoot)
+        Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 300 * 1_000_000_000)
+                await collector.sweep(appState: appState)
             }
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Crypto
+import CrowCore
+import CrowEngine
+import CrowPersistence
+
+/// The daemon-side collector that drives the multi-harness session-log upload
+/// (CROW-1056). One `sweep()` per poll tick: for every Crow session whose
+/// workspace is opted in, it finds that session's harness log files, normalizes
+/// them to NDJSON, and uploads them to Corveil as a session-transcript artifact
+/// with the session's metadata attached.
+///
+/// Design guarantees:
+/// - **Opt-in, default OFF.** Nothing uploads unless `logSync.enabled` is true
+///   *and* the session's workspace is listed in `logSync.enabledWorkspaces`.
+/// - **Non-blocking / best-effort.** This runs entirely off the session
+///   lifecycle; a failed or slow upload never delays or fails a session. One
+///   retry inside the uploader, then the ledger records and (for transient
+///   failures) backs off.
+/// - **Idempotent backfill.** A ledger + the server's write-once 409 make a
+///   repeated sweep converge without re-uploading.
+/// - **No AWS credentials on the laptop.** The client only POSTs bytes with the
+///   user's Corveil API key; the server uploads to object storage itself.
+struct LogSyncCollector {
+    let devRoot: String
+    let uploader: TranscriptUploader
+    /// Resolves an `op://…` reference to a secret (defaults to 1Password `op read`).
+    let resolveSecret: (String) -> String?
+    /// Injected clock for testability.
+    let now: () -> Date
+
+    /// Don't re-attempt a transiently-failed upload for this long.
+    private let retryBackoff: TimeInterval = 30 * 60
+
+    init(
+        devRoot: String,
+        uploader: TranscriptUploader = TranscriptUploader(),
+        resolveSecret: @escaping (String) -> String? = { GatewayResolver.opRead($0) },
+        now: @escaping () -> Date = { Date() }
+    ) {
+        self.devRoot = devRoot
+        self.uploader = uploader
+        self.resolveSecret = resolveSecret
+        self.now = now
+    }
+
+    /// One collection pass. Reads config fresh so a Settings edit applies within
+    /// one tick.
+    func sweep(appState: AppState) async {
+        guard let config = ConfigStore.loadConfig(devRoot: devRoot)?.logSync,
+              config.enabled,
+              !config.baseURL.trimmingCharacters(in: .whitespaces).isEmpty
+        else { return }
+        guard let apiKey = resolveAPIKey(config.apiKeyRef) else {
+            LogSyncLog.warnOnce("log-sync enabled but the Corveil API key could not be resolved; nothing will upload")
+            return
+        }
+        // Nothing opted in — cheap exit before touching the store or disk.
+        guard !config.enabledWorkspaces.isEmpty else { return }
+
+        // Snapshot the live sessions + their worktrees on the main actor, then do
+        // all filesystem/network work off it.
+        let snapshot: [(session: Session, worktrees: [SessionWorktree])] = await MainActor.run {
+            appState.sessions.map { ($0, appState.worktrees(for: $0.id)) }
+        }
+
+        var ledger = LogSyncLedger.load(devRoot: devRoot)
+        let nowDate = now()
+        let nowEpoch = nowDate.timeIntervalSince1970
+        let quietPeriod = TimeInterval(max(0, config.quietPeriodMinutes) * 60)
+
+        for (session, worktrees) in snapshot {
+            // Manager sessions run at the dev root, not in a workspace worktree.
+            if session.isManager { continue }
+            guard let worktree = primaryWorktree(worktrees) else { continue }
+
+            // Per-workspace opt-in.
+            guard let workspaceName = SessionService.workspaceName(
+                    forWorktreePath: worktree.worktreePath, devRoot: devRoot),
+                  config.uploadsWorkspace(workspaceName)
+            else { continue }
+
+            let harness = LogSyncHarness(agentKind: session.agentKind)
+            let kind = LogSyncArtifactKind.sessionTranscript
+            let ledgerKey = LogSyncLedger.key(sessionUID: session.id.uuidString, harness: harness, kind: kind)
+            guard ledger.shouldUpload(key: ledgerKey, now: nowEpoch, retryBackoff: retryBackoff) else { continue }
+
+            // Where does this harness write its logs? Empty for harnesses whose
+            // on-disk logs are not yet wired (everything but Claude today).
+            guard let agent = AgentRegistry.shared.agent(for: session.agentKind) else { continue }
+            let sources = agent.logSources(worktreePath: worktree.worktreePath, harnessSessionID: nil)
+            guard !sources.isEmpty else { continue }
+
+            let files = sources.flatMap { Self.resolveFiles($0) }
+            guard !files.isEmpty else { continue }
+
+            // Only upload a quiescent transcript: a session still being written
+            // to can grow, and the server's write-once 409 forbids replacing it.
+            let newest = Self.newestModification(files)
+            let terminal = session.status == .completed || session.status == .archived
+            if !terminal {
+                if let newest, nowDate.timeIntervalSince(newest) < quietPeriod { continue }
+            }
+
+            // Pick the single format (all Claude sources are .jsonl; a mixed set
+            // would be unusual — take the first source's format).
+            let format = sources.first?.format ?? .jsonl
+            guard let transcript = TranscriptNormalizer.normalize(
+                files: files, format: format, maxBytes: max(1, config.maxUploadBytes))
+            else { continue }
+
+            let sha = Self.sha256Hex(transcript.data)
+            let agentSessionID = Self.agentSessionID(from: files)
+            let metadata = LogSyncSessionMetadata(
+                name: session.name,
+                status: session.status.rawValue,
+                agentKind: session.agentKind.rawValue,
+                ticketURL: session.ticketURL,
+                ticketNumber: session.ticketNumber,
+                repo: worktree.repoName,
+                orgGoal: session.orgGoal)
+
+            let result = await uploader.upload(
+                baseURL: config.baseURL, apiKey: apiKey,
+                sessionUID: session.id.uuidString,
+                harness: harness, kind: kind, format: format,
+                transcript: transcript, metadata: metadata, agentSessionID: agentSessionID)
+
+            let entry = Self.ledgerEntry(for: result, sha: sha, size: transcript.data.count, at: nowEpoch)
+            ledger.record(key: ledgerKey, entry: entry)
+            if result.isSuccess {
+                LogSyncLog.info("uploaded transcript for session \(session.id.uuidString) (\(harness.rawValue), \(transcript.data.count) bytes)")
+            }
+        }
+
+        ledger.prune(retentionDays: config.retentionDays, now: nowEpoch)
+        do {
+            try ledger.save(devRoot: devRoot)
+        } catch {
+            LogSyncLog.info("failed to persist log-sync ledger: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Pure helpers (unit-tested)
+
+    /// Resolve an API key reference: `op://…` via `resolveSecret`, otherwise the
+    /// literal value. Returns nil for a blank ref or a failed `op` read.
+    func resolveAPIKey(_ ref: String) -> String? {
+        let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasPrefix("op://") {
+            guard let secret = resolveSecret(trimmed), !secret.isEmpty else { return nil }
+            return secret
+        }
+        return trimmed
+    }
+
+    /// The worktree the agent runs in — the primary if flagged, else the first.
+    private func primaryWorktree(_ worktrees: [SessionWorktree]) -> SessionWorktree? {
+        worktrees.first(where: { $0.isPrimary }) ?? worktrees.first
+    }
+
+    /// Expand a log source to concrete regular files, oldest-modified first so a
+    /// concatenated transcript reads chronologically.
+    static func resolveFiles(_ source: AgentLogSource) -> [URL] {
+        let fm = FileManager.default
+        switch source.selector {
+        case .file:
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: source.path, isDirectory: &isDir), !isDir.boolValue else { return [] }
+            return [URL(fileURLWithPath: source.path)]
+        case .directory:
+            let dir = URL(fileURLWithPath: source.path)
+            let keys: [URLResourceKey] = [.isRegularFileKey, .contentModificationDateKey]
+            var files: [URL] = []
+            if source.recursive {
+                guard let en = fm.enumerator(at: dir, includingPropertiesForKeys: keys) else { return [] }
+                for case let url as URL in en { files.append(url) }
+            } else {
+                guard let contents = try? fm.contentsOfDirectory(
+                    at: dir, includingPropertiesForKeys: keys) else { return [] }
+                files = contents
+            }
+            let filtered = files.filter { url in
+                guard (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
+                else { return false }
+                if let ext = source.fileExtension { return url.pathExtension == ext }
+                return true
+            }
+            return filtered.sorted { a, b in
+                (Self.modificationDate(a) ?? .distantPast) < (Self.modificationDate(b) ?? .distantPast)
+            }
+        }
+    }
+
+    static func modificationDate(_ url: URL) -> Date? {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+    }
+
+    static func newestModification(_ files: [URL]) -> Date? {
+        files.compactMap { modificationDate($0) }.max()
+    }
+
+    /// The harness's own session id when exactly one file backs the transcript
+    /// (its filename stem, e.g. the Claude `.jsonl` UUID); nil when several files
+    /// were concatenated.
+    static func agentSessionID(from files: [URL]) -> String? {
+        guard files.count == 1 else { return nil }
+        return files[0].deletingPathExtension().lastPathComponent
+    }
+
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func ledgerEntry(
+        for result: TranscriptUploadResult, sha: String, size: Int, at: Double
+    ) -> LogSyncLedger.Entry {
+        if result.isSuccess {
+            return LogSyncLedger.Entry(status: .uploaded, sha256: sha, sizeBytes: size, at: at)
+        }
+        if result.isPermanentFailure {
+            let reason: String
+            switch result {
+            case .tooLarge: reason = "too_large"
+            case .rejected(let s): reason = "rejected_\(s)"
+            default: reason = "permanent"
+            }
+            return LogSyncLedger.Entry(status: .skippedPermanent, sha256: sha, sizeBytes: size, at: at, reason: reason)
+        }
+        return LogSyncLedger.Entry(status: .failedTransient, sha256: sha, sizeBytes: size, at: at, reason: "transient")
+    }
+}
+
+/// Rate-limited logging for the collector so a persistent misconfiguration
+/// (e.g. an unresolvable API key) is stated once, not every tick.
+enum LogSyncLog {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var warned: Set<String> = []
+
+    static func info(_ message: String) {
+        CrowLog.info("[LogSync] \(message)")
+    }
+
+    static func warnOnce(_ message: String) {
+        lock.lock()
+        let firstTime = warned.insert(message).inserted
+        lock.unlock()
+        if firstTime { CrowLog.info("[LogSync] \(message)") }
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -1680,6 +1680,8 @@ func makeCommandRouter(
                 ]
             }
         },
+        "logsync-get": { params in logsyncGetHandler(params: params, devRoot: devRoot) },
+        "logsync-set": { params in try await logsyncSetHandler(params: params, devRoot: devRoot) },
         "ui-get": { _ in
             let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
             return ["ui": SettingsRPC.uiJSON(sidebar: config.sidebar, switcher: config.switcher)]
@@ -2500,6 +2502,85 @@ private func mutateConfig<T>(devRoot: String, _ transform: (inout AppConfig) thr
         }
         return result
     }
+}
+
+/// `logsync-get` (CROW-1056): echo the session-log collector block. `reveal`
+/// unmasks a plaintext API key (an `op://…` reference is always shown — it is a
+/// pointer, not the secret).
+private func logsyncGetHandler(params: [String: JSONValue], devRoot: String) -> [String: JSONValue] {
+    let reveal = params["reveal"]?.boolValue ?? false
+    let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+    return ["logsync": SettingsRPC.logsyncJSON(config.logSync, reveal: reveal)]
+}
+
+/// `logsync-set` (CROW-1056): PATCH the session-log collector block. Extracted
+/// from the handler dictionary so the big literal stays inside the type-checker's
+/// budget. Local-only (gated in `RPCWebSocketHandler.localOnlyDenial`).
+private func logsyncSetHandler(params: [String: JSONValue], devRoot: String) async throws -> [String: JSONValue] {
+    try await mapRPCError {
+        let enabled = try SettingsRPC.patchBool(params, "enabled")
+        let baseURL = try SettingsRPC.patchStringAllowingEmpty(params, "base_url")
+        let apiKeyRef = try SettingsRPC.patchStringAllowingEmpty(params, "api_key_ref")
+        let retentionDays = try SettingsRPC.patchBoundedInt(params, "retention_days", min: 0)
+        let quietPeriod = try SettingsRPC.patchBoundedInt(params, "quiet_period_minutes", min: 0)
+        let maxUploadBytes = try SettingsRPC.patchBoundedInt(params, "max_upload_bytes", min: 1)
+        let addWorkspaces = try SettingsRPC.patchStringList(params, "add_workspaces")
+        let removeWorkspaces = try SettingsRPC.patchStringList(params, "remove_workspaces")
+        let clearWorkspaces = try SettingsRPC.patchBool(params, "clear_workspaces") ?? false
+
+        let anySet = enabled != nil || baseURL != nil || apiKeyRef != nil
+            || retentionDays != nil || quietPeriod != nil || maxUploadBytes != nil
+            || addWorkspaces != nil || removeWorkspaces != nil || clearWorkspaces
+        guard anySet else {
+            throw RPCError.invalidParams(
+                "Nothing to set — provide at least one of enabled, base_url, api_key_ref, "
+                + "retention_days, quiet_period_minutes, max_upload_bytes, "
+                + "add_workspaces, remove_workspaces, clear_workspaces.")
+        }
+
+        let logSync: LogSyncConfig = try mutateConfig(devRoot: devRoot) { config in
+            var block = config.logSync ?? LogSyncConfig()
+            if let enabled { block.enabled = enabled }
+            if let baseURL { block.baseURL = baseURL }
+            if let apiKeyRef { block.apiKeyRef = apiKeyRef }
+            if let retentionDays { block.retentionDays = retentionDays }
+            if let quietPeriod { block.quietPeriodMinutes = quietPeriod }
+            if let maxUploadBytes { block.maxUploadBytes = maxUploadBytes }
+            block.enabledWorkspaces = editedWorkspaceList(
+                current: block.enabledWorkspaces,
+                clear: clearWorkspaces, remove: removeWorkspaces, add: addWorkspaces)
+            config.logSync = block
+            return block
+        }
+        // The collector re-reads config from disk every tick, so this takes
+        // effect within ~5 min — no restart.
+        return [
+            "logsync": SettingsRPC.logsyncJSON(logSync, reveal: true),
+            "saved": .bool(true),
+        ]
+    }
+}
+
+/// Apply clear/remove/add to a workspace opt-in list, case-insensitively and
+/// de-duplicated (clear first, then remove, then add — `defaults set` semantics).
+private func editedWorkspaceList(
+    current: [String], clear: Bool, remove: [String]?, add: [String]?
+) -> [String] {
+    var list = clear ? [] : current
+    if let remove, !remove.isEmpty {
+        let drop = Set(remove.map { $0.lowercased() })
+        list = list.filter { !drop.contains($0.lowercased()) }
+    }
+    if let add {
+        for name in add {
+            let trimmed = name.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty,
+                  !list.contains(where: { $0.lowercased() == trimmed.lowercased() })
+            else { continue }
+            list.append(trimmed)
+        }
+    }
+    return list
 }
 
 /// Like ``mutateConfig(devRoot:_:)`` but skips the disk write when `transform`

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -125,6 +125,7 @@ enum RPCLanePolicy {
         "workspace-remove": .fixed(.config),
         "gateway-set": .fixed(.config),
         "web-password-set": .fixed(.config),
+        "logsync-set": .fixed(.config),
         // MCP tokens live in config.json, so they share its lane — two concurrent
         // mints would otherwise read the same token array and one would lose its
         // append (CROW-1004).

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -336,6 +336,13 @@ enum RPCWebSocketHandler {
         case "gateway-get", "gateway-set", "web-password-get", "web-password-set":
             // Secret reads *and* writes (CROW-815) — see the doc comment above.
             return "gateway and web-password management is local-only"
+        case "logsync-get", "logsync-set":
+            // Session-log collector (CROW-1056). `logsync-set` enables uploading
+            // developers' session transcripts off the daemon host and carries a
+            // Corveil API-key reference; `logsync-get` can reveal it. Both configure
+            // an upload capability from the host, so — like `gateway-*` — they are
+            // loopback-only. The opt-in must never be flippable by a remote peer.
+            return "session-log sync management is local-only"
         case "mcp-token-list", "mcp-token-mint", "mcp-token-revoke":
             // MCP bearer tokens (CROW-1004). `mcp-token-mint` returns the plaintext
             // token exactly once, so a remote peer that could call it would be

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -974,6 +974,22 @@ import CrowPersistence
                 == "MCP token management is local-only")
         }
     }
+    @Test func logsyncMethodsAreLocalOnly() {
+        // `logsync-set` enables uploading developers' session transcripts off the
+        // host and carries a Corveil API-key reference; `logsync-get` can reveal
+        // it. A remote peer must not be able to flip the opt-in or read the key,
+        // so both are gated like the gateway/MCP-token surfaces (CROW-1056). This
+        // regression test is what stops a refactor silently dropping either method
+        // from the `localOnlyDenial` switch.
+        for method in ["logsync-get", "logsync-set"] {
+            let req = JSONRPCRequest(id: 1, method: method, params: [
+                "enabled": .bool(true),
+                "api_key_ref": .string("plaintext-would-be-stolen"),
+            ])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
+                == "session-log sync management is local-only")
+        }
+    }
 
     @Test func mcpExportedMethodsAreReachableRemotely() {
         // The mirror image, and the reason the MCP endpoint can share the daemon's

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowDaemon
+
+@Suite struct LogSyncCollectorTests {
+    private func collector(resolveSecret: @escaping (String) -> String? = { _ in nil }) -> LogSyncCollector {
+        LogSyncCollector(devRoot: "/tmp/does-not-matter", resolveSecret: resolveSecret)
+    }
+
+    private func tempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logsync-collector-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: API key resolution
+
+    @Test func resolvesPlaintextKeyLiterally() {
+        #expect(collector().resolveAPIKey("sk-citadel-abc") == "sk-citadel-abc")
+    }
+
+    @Test func resolvesOpReference() {
+        let c = collector { $0 == "op://vault/corveil/key" ? "RESOLVED" : nil }
+        #expect(c.resolveAPIKey("op://vault/corveil/key") == "RESOLVED")
+    }
+
+    @Test func blankOrUnresolvableKeyIsNil() {
+        #expect(collector().resolveAPIKey("   ") == nil)
+        #expect(collector { _ in nil }.resolveAPIKey("op://missing") == nil)
+    }
+
+    // MARK: File resolution
+
+    @Test func resolveFilesForDirectorySortsByMtimeAndFiltersExtension() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let a = dir.appendingPathComponent("a.jsonl")
+        let b = dir.appendingPathComponent("b.jsonl")
+        let other = dir.appendingPathComponent("notes.txt")
+        try "1".write(to: a, atomically: true, encoding: .utf8)
+        try "2".write(to: b, atomically: true, encoding: .utf8)
+        try "x".write(to: other, atomically: true, encoding: .utf8)
+        // Make `a` older than `b`.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1000)], ofItemAtPath: a.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2000)], ofItemAtPath: b.path)
+
+        let source = AgentLogSource.directory(dir.path, format: .jsonl, fileExtension: "jsonl")
+        let files = LogSyncCollector.resolveFiles(source)
+        #expect(files.map(\.lastPathComponent) == ["a.jsonl", "b.jsonl"]) // oldest first, .txt excluded
+    }
+
+    @Test func resolveFilesForSpecificFile() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let f = dir.appendingPathComponent("x.jsonl")
+        try "1".write(to: f, atomically: true, encoding: .utf8)
+        #expect(LogSyncCollector.resolveFiles(.file(f.path, format: .jsonl)).count == 1)
+        // A directory passed as a .file source resolves to nothing.
+        #expect(LogSyncCollector.resolveFiles(.file(dir.path, format: .jsonl)).isEmpty)
+        // A missing file resolves to nothing.
+        #expect(LogSyncCollector.resolveFiles(.file(dir.appendingPathComponent("nope").path, format: .jsonl)).isEmpty)
+    }
+
+    @Test func agentSessionIDOnlyForSingleFile() {
+        let one = [URL(fileURLWithPath: "/x/834fd01d.jsonl")]
+        #expect(LogSyncCollector.agentSessionID(from: one) == "834fd01d")
+        let many = [URL(fileURLWithPath: "/x/a.jsonl"), URL(fileURLWithPath: "/x/b.jsonl")]
+        #expect(LogSyncCollector.agentSessionID(from: many) == nil)
+        #expect(LogSyncCollector.agentSessionID(from: []) == nil)
+    }
+
+    // MARK: Result → ledger mapping
+
+    @Test func ledgerEntryMapping() {
+        #expect(LogSyncCollector.ledgerEntry(for: .created, sha: "s", size: 1, at: 0).status == .uploaded)
+        #expect(LogSyncCollector.ledgerEntry(for: .alreadyExists, sha: "s", size: 1, at: 0).status == .uploaded)
+
+        let big = LogSyncCollector.ledgerEntry(for: .tooLarge, sha: "s", size: 1, at: 0)
+        #expect(big.status == .skippedPermanent)
+        #expect(big.reason == "too_large")
+
+        let bad = LogSyncCollector.ledgerEntry(for: .rejected(status: 404), sha: "s", size: 1, at: 0)
+        #expect(bad.status == .skippedPermanent)
+        #expect(bad.reason == "rejected_404")
+
+        #expect(LogSyncCollector.ledgerEntry(for: .transient, sha: "s", size: 1, at: 0).status == .failedTransient)
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
@@ -165,6 +165,46 @@ public enum SettingsRPC {
         ])
     }
 
+    /// The session-log collector block (CROW-1056). The Corveil API-key reference
+    /// is shown only when `reveal` is set OR it is an `op://…` pointer (which is a
+    /// reference, not the secret); a plaintext key is masked. `api_key_set`
+    /// reports presence either way, and `configured` distinguishes an absent block
+    /// (`logSync == nil`, the collector inert) from an all-defaults one.
+    public static func logsyncJSON(_ logSync: LogSyncConfig?, reveal: Bool) -> JSONValue {
+        let cfg = logSync ?? LogSyncConfig()
+        let apiKeyDisplay: String
+        if cfg.apiKeyRef.isEmpty {
+            apiKeyDisplay = ""
+        } else if reveal || cfg.apiKeyRef.hasPrefix("op://") {
+            apiKeyDisplay = cfg.apiKeyRef
+        } else {
+            apiKeyDisplay = "<hidden>"
+        }
+        return .object([
+            "enabled": .bool(cfg.enabled),
+            "base_url": .string(cfg.baseURL),
+            "api_key_ref": .string(apiKeyDisplay),
+            "api_key_set": .bool(!cfg.apiKeyRef.isEmpty),
+            "enabled_workspaces": stringArray(cfg.enabledWorkspaces),
+            "retention_days": .int(cfg.retentionDays),
+            "quiet_period_minutes": .int(cfg.quietPeriodMinutes),
+            "max_upload_bytes": .int(cfg.maxUploadBytes),
+            "configured": .bool(logSync != nil),
+        ])
+    }
+
+    /// PATCH helper for a string-array param: `nil` when absent/null ("leave
+    /// unchanged"), throws when present but not an array of strings.
+    public static func patchStringList(
+        _ params: [String: JSONValue], _ key: String
+    ) throws -> [String]? {
+        guard let value = params[key], value != .null else { return nil }
+        guard let array = value.arrayValue else {
+            throw RPCError.invalidParams("\(key) must be an array of strings")
+        }
+        return array.compactMap { $0.stringValue }
+    }
+
     /// The `ui` group is a *view* namespace, not a single `AppConfig` block:
     /// today `sidebar` and `switcher`, later `terminal` and anything else purely
     /// presentational. Nesting by config-block name mirrors `config.json` and
@@ -246,6 +286,34 @@ public enum SettingsRPC {
             throw RPCError.invalidParams("\(key) must be a non-empty string")
         }
         return text
+    }
+
+    /// PATCH helper for a string that MAY be set to empty: `nil` when absent/null
+    /// ("leave unchanged"), and an explicit `""` clears the stored value. Used for
+    /// `logsync-set`'s `base_url` / `api_key_ref`, where clearing is meaningful.
+    public static func patchStringAllowingEmpty(
+        _ params: [String: JSONValue], _ key: String
+    ) throws -> String? {
+        guard let value = params[key], value != .null else { return nil }
+        guard let text = value.stringValue else {
+            throw RPCError.invalidParams("\(key) must be a string")
+        }
+        return text
+    }
+
+    /// PATCH helper for an integer with a lower bound: `nil` when absent/null,
+    /// throws when present-but-not-an-integer or below `min`.
+    public static func patchBoundedInt(
+        _ params: [String: JSONValue], _ key: String, min: Int
+    ) throws -> Int? {
+        guard let value = params[key], value != .null else { return nil }
+        guard let n = value.intValue else {
+            throw RPCError.invalidParams("\(key) must be an integer")
+        }
+        guard n >= min else {
+            throw RPCError.invalidParams("\(key) must be at least \(min)")
+        }
+        return n
     }
 
     /// Whether a telemetry change needs a daemon restart to take effect.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1713,6 +1713,51 @@ There is deliberately **no `--password` flag** — a plaintext password in `argv
 
 ---
 
+## Session-Log Sync Commands
+
+The multi-harness session-log collector (CROW-1056) uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, attributed to your own Corveil API key. It is **opt-in and OFF by default** — nothing uploads until you enable it *and* opt a workspace in. Uploads are best-effort and never block or fail a session, and **no AWS credentials are stored on this machine** (the server performs the object-storage upload). These verbs are **local-only**, like `gateway` / `web-password` — they configure uploads from the daemon host and carry a Corveil API-key reference.
+
+### `crow logsync get`
+
+```bash
+crow logsync get
+crow logsync get --reveal   # unmask a plaintext API key (op:// refs are always shown)
+```
+
+Returns the collector block: `enabled`, `base_url`, `api_key_ref` (masked unless `--reveal` or an `op://…` reference), `api_key_set`, `enabled_workspaces`, `retention_days`, `quiet_period_minutes`, `max_upload_bytes`, and `configured` (whether the block exists at all).
+
+### `crow logsync set`
+
+PATCH — only the flags you pass change; at least one is required.
+
+```bash
+# Turn it on, point it at your Corveil API, opt a workspace in.
+crow logsync set --enabled true \
+  --base-url https://api.corveil.io \
+  --api-key-ref 'op://vault/corveil/api-key' \
+  --add-workspace Corveil
+crow logsync set --add-workspace Acme --remove-workspace Legacy
+crow logsync set --clear-workspaces          # opt every workspace out
+crow logsync set --enabled false             # stop uploading
+crow logsync set --api-key-ref ''            # clear the stored key
+```
+
+| Flag | Description |
+| --- | --- |
+| `--enabled true\|false` | Master switch (default false) |
+| `--base-url URL` | Corveil API base (hosts `POST /api/crow-sessions/{id}/artifacts`); empty clears |
+| `--api-key-ref REF` | Corveil API key as an `op://…` reference (preferred) or plaintext; empty clears |
+| `--add-workspace NAME` | Opt a workspace in (repeatable) |
+| `--remove-workspace NAME` | Opt a workspace out (repeatable) |
+| `--clear-workspaces` | Opt every workspace out |
+| `--retention-days N` | Local upload-ledger retention (0 = forever, default 30) |
+| `--quiet-period-minutes N` | Wait this long after a session's last activity before uploading (default 30) |
+| `--max-upload-bytes N` | Per-transcript upload cap (default 8000000) |
+
+Only Claude Code transcripts are collected today (its logs are the one harness partitioned by working directory); other harnesses are wired as their on-disk log locations are confirmed. Changes are live — the collector re-reads config each tick, so they apply within a few minutes with no restart.
+
+---
+
 ## MCP Commands
 
 Crow serves a **read-only** MCP surface so agent clients that speak MCP — Cowork, a Grok bot — can read the board without a Crow-launched session. Six tools over five read RPCs; there is no prompt-send, no session creation, and no config access. See [MCP](mcp.md) for client setup and the full tool list.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,9 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow list-terminals`](#crow-list-terminals) | List terminals for a session |
 | [`crow list-tickets`](#crow-list-tickets) | List the ticket board (issues, per-status counts, loading state) |
 | [`crow list-worktrees`](#crow-list-worktrees) | List worktrees for a session |
+| [`crow logsync`](#crow-logsync) | View or change session-log upload (opt-in, local-only) |
+| [`crow logsync get`](#crow-logsync-get) | Show the session-log collector settings |
+| [`crow logsync set`](#crow-logsync-set) | Change session-log upload settings |
 | [`crow mark-in-review`](#crow-mark-in-review) | Move a session to In Review |
 | [`crow mark-issue-done`](#crow-mark-issue-done) | Close the session's linked issue and complete the session |
 | [`crow mcp`](#crow-mcp) | Serve Crow over MCP, and manage the tokens remote clients use |
@@ -1045,6 +1048,64 @@ crow list-worktrees --session <session>
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--session` | `<session>` | yes | Session UUID |
+
+---
+
+## `crow logsync`
+
+View or change session-log upload (opt-in, local-only).
+
+```
+crow logsync <get|set>
+```
+
+The session-log collector uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, attributed to your own Corveil API key (no AWS credentials are stored on this machine). It is OFF by default and uploads nothing until you both enable it and opt a workspace in.
+
+Uploads are best-effort and never block or fail a session. Only Claude Code transcripts are collected today; other harnesses are wired as their on-disk log locations are confirmed.
+
+Subcommands: [`get`](#crow-logsync-get), [`set`](#crow-logsync-set).
+
+---
+
+## `crow logsync get`
+
+Show the session-log collector settings.
+
+```
+crow logsync get [--reveal]
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--reveal` | — | no | Reveal a plaintext API key (op:// references are always shown) |
+
+---
+
+## `crow logsync set`
+
+Change session-log upload settings.
+
+```
+crow logsync set [--enabled <enabled>] [--base-url <base-url>] [--api-key-ref <api-key-ref>] [--add-workspace <add-workspace> ...] [--remove-workspace <remove-workspace> ...] [--clear-workspaces] [--retention-days <retention-days>] [--quiet-period-minutes <quiet-period-minutes>] [--max-upload-bytes <max-upload-bytes>]
+```
+
+Only the flags you pass change; at least one is required.
+
+Turn the feature on with --enabled true, point it at your Corveil API with --base-url and --api-key-ref (an op://… 1Password reference is resolved at upload so the key never lands in config.json), then opt workspaces in with --add-workspace. Nothing uploads until a workspace is opted in.
+
+Live: the collector re-reads config each tick, so changes apply within a few minutes with no restart. Pass an empty string to --base-url/--api-key-ref to clear it.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--enabled` | `<enabled>` | no | Enable session-log upload (true or false) |
+| `--base-url` | `<base-url>` | no | Corveil API base URL (e.g. https://api.corveil.io) |
+| `--api-key-ref` | `<api-key-ref>` | no | Corveil API key: an op://… reference (preferred) or a plaintext key |
+| `--add-workspace` | `<add-workspace>` _(repeatable)_ | no | Opt a workspace in (repeatable) |
+| `--remove-workspace` | `<remove-workspace>` _(repeatable)_ | no | Opt a workspace out (repeatable) |
+| `--clear-workspaces` | — | no | Opt every workspace out |
+| `--retention-days` | `<retention-days>` | no | Days to keep the local upload ledger (0 = forever, default 30) |
+| `--quiet-period-minutes` | `<quiet-period-minutes>` | no | Wait this long after a session's last activity before uploading (default 30) |
+| `--max-upload-bytes` | `<max-upload-bytes>` | no | Per-transcript upload cap in bytes (default 8000000) |
 
 ---
 

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -1,0 +1,108 @@
+# Session-log collector (CROW-1056)
+
+Crow collects durable coding-session logs and — **opt-in per workspace, OFF by
+default** — uploads them to Corveil as session-transcript artifacts, with the
+Crow session's metadata attached. This is the **producer** side of epic
+[corveil/corveil#2425](https://github.com/corveil/corveil/issues/2425); the
+storage/endpoint side is [#2426](https://github.com/corveil/corveil/issues/2426)
+(merged in corveil/corveil#2433).
+
+## Why the adapter owns log locations
+
+Crow persists **no** transcript of its own — terminal scrollback is
+tmux-memory-only, captured on demand for browser replay, never written to disk.
+But **each harness writes its own durable logs**, in a different place and
+format. The `CodingAgent` adapter already knows how to launch each harness, so it
+also declares where that harness's logs live, via a new protocol capability:
+
+```swift
+func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource]
+```
+
+The protocol-extension default returns `[]` (the same opt-in idiom as
+`fallbackCandidates`), so a harness whose on-disk location is unconfirmed
+contributes nothing rather than uploading the wrong bytes.
+
+## Harness coverage
+
+Only **Claude Code** partitions its logs by working directory, which is what
+makes a Crow worktree map cleanly to exactly that session's transcripts:
+
+| Harness | On-disk location | Status |
+|---|---|---|
+| `claude-code` | `~/.claude/projects/<slug>/<uuid>.jsonl` (slug = worktree path, every non-alphanumeric → `-`) | **Wired.** One artifact per session; multiple `.jsonl` under the slug dir are concatenated. |
+| `codex` | `~/.codex/sessions/<YYYY>/…`, `~/.codex/archived_sessions`, `~/.codex/log` | Deferred — global, timestamp-partitioned; needs per-file `cwd` matching. |
+| `opencode` | `~/.local/share/opencode/storage/{session,message,part}`, `.../log` | Deferred — global storage keyed by opencode session id; needs project→worktree matching. |
+| `cursor` | `~/Library/Application Support/Cursor/User/workspaceStorage/<hash>/state.vscdb` | Deferred — per-workspace **SQLite**; needs `workspace.json` hash→path matching + chat-row extraction. |
+| `grok`, `antigravity`, `muse` | app state / TBD | Deferred — log locations unconfirmed. |
+
+The framework (collector, normalizer, uploader, ledger, config, CLI) is
+harness-general; wiring a deferred harness is implementing its `logSources`
+override plus, for `.sqlite`, a row extractor in `TranscriptNormalizer`.
+
+Harnesses map to the artifact contract's `harness` value via
+`LogSyncHarness(agentKind:)` — the four the server enumerates map directly, every
+other kind maps to `unknown`.
+
+## Pipeline
+
+```
+CrowDaemon.startLogSyncPoll (5-min tick, config read fresh each tick)
+  └─ LogSyncCollector.sweep(appState):
+       for each live session on an OPTED-IN workspace (SessionService.workspaceName):
+         agent.logSources(worktree) → resolve files → normalize to NDJSON
+         (skip until quiescent: terminal status, or newest file older than quietPeriod)
+         → TranscriptUploader → POST /api/crow-sessions/{sessionUID}/artifacts
+         → record in the local ledger (idempotent)
+```
+
+- **Attribution** is by worktree-path match (`AppState.sessionIDs(forWorktreePath:)`),
+  the same resolution the hook-event handler uses. Metadata attached as untrusted
+  sidecar hints: session UUID (the `{sessionUID}`), name, status, `agentKind`,
+  ticket URL/number, repo, org goal. The server derives the *authoring principal*
+  from the API key, never from these hints.
+- **Upload** authenticates with the workspace operator's own Corveil API key
+  (`Authorization: Bearer …`, resolved from an `op://…` reference via the same
+  `GatewayResolver.opRead` the gateway uses). The server performs the
+  object-storage upload — **no AWS credentials live on the laptop**.
+- **Format**: uncompressed NDJSON. The server sniffs content-encoding from magic
+  bytes, so plain NDJSON is stored with an empty `content_encoding`; gzip is a
+  future size optimization (it would let larger transcripts fit under the cap).
+
+## Guarantees (acceptance)
+
+- A completed session on an **opted-in** workspace has its transcript uploaded
+  with correct Crow metadata.
+- An **opted-out** workspace uploads nothing (per-workspace gate; default OFF).
+- **No AWS credential** on the laptop (server-side upload).
+- **Backfill is idempotent**: the on-disk ledger
+  (`{devRoot}/.claude/logsync-ledger.json`) plus the server's write-once 409 mean
+  a repeated sweep re-converges without re-uploading. The sweep visits every
+  known session, so enabling the feature backfills existing on-disk history.
+- **Upload failure never delays or fails a session**: the collector runs entirely
+  off the session lifecycle; each upload retries once, then the ledger records the
+  outcome (transient failures back off ~30 min).
+
+## Write-once and quiescence
+
+The server keys an artifact on `(session, harness, kind)` and rejects a second
+upload with 409. So the collector uploads a session's transcript **once, when it
+has gone quiescent** — terminal status (`completed`/`archived`) or no log-file
+activity within `quietPeriodMinutes` (default 30) — to avoid capturing a partial
+transcript it could never replace.
+
+## Controls — `crow logsync` (local-only, default OFF)
+
+`AppConfig.logSync` (`enabled`, `baseURL`, `apiKeyRef`, `enabledWorkspaces`,
+`retentionDays`, `quietPeriodMinutes`, `maxUploadBytes`) is **local-only**: like
+`managerGateway`/`webAuth`, its API key is stripped before the config reaches a
+browser and the whole block is writable only through the local-only
+`logsync-get`/`logsync-set` RPCs (`RPCWebSocketHandler.localOnlyDenial`), so the
+opt-in can never be flipped by a remote peer. See
+[cli-reference.md](cli-reference.md#session-log-sync-commands).
+
+## Depends on
+
+- The artifact contract + upload endpoint, [#2426](https://github.com/corveil/corveil/issues/2426)
+  (`POST /api/crow-sessions/{sessionUID}/artifacts`).
+- `docs/agent-harness-matrix.md`, ADR 0014 / 0015.


### PR DESCRIPTION
Closes #1056

Producer side of epic **corveil/corveil#2425**. Crow collects durable
coding-session transcripts and — **opt-in per workspace, OFF by default** —
uploads them to Corveil as session-transcript artifacts with the Crow session's
metadata attached, for backfill of existing on-disk history and ongoing sessions.

## Dependency / contract

The storage + endpoint side, **corveil/corveil#2426** (STORE), is **merged**
(corveil/corveil#2433). This client conforms to that contract:

```
POST {baseURL}/api/crow-sessions/{sessionUID}/artifacts
  Authorization: Bearer <the operator's own Corveil API key>
  body = NDJSON (server sniffs content-encoding from magic bytes)
  ?harness=&kind=session_transcript&format=ndjson&truncated=&event_count=
   &tool_call_count=&agent_session_id=&name=&status=&agent_kind=
   &ticket_url=&ticket_number=&repo=&org_goal=
  201 created · 409 duplicate (write-once per session,harness,kind) · 413 too large
```

Attribution is derived server-side from the API key; the metadata above is
untrusted sidecar hints. **No AWS credentials live on the laptop** — the server
performs the object-storage upload.

## What's here

- **`CodingAgent.logSources(worktreePath:harnessSessionID:)`** — new protocol
  capability (default `[]`, the `fallbackCandidates` opt-in idiom).
- **`AgentLogSource`** + the collector/uploader/normalizer/ledger in CrowCore.
- **`LogSyncCollector` + `startLogSyncPoll`** (5-min tick, config read fresh each
  tick) in CrowDaemon. Uploads a session only when it's quiescent (terminal
  status or no log activity within `quietPeriodMinutes`), because the server's
  write-once 409 forbids replacing a partial transcript.
- **`crow logsync get/set`** + `AppConfig.logSync` — **local-only** (gated in
  `RPCWebSocketHandler.localOnlyDenial`, stripped/restored in `SettingsSecrets`),
  so the opt-in can't be flipped and the API key can't leak via the browser /
  `set-config` path. Default OFF; a workspace uploads only when both enabled and
  listed in `enabledWorkspaces`.
- Parity-ledger rows (config fields + RPC methods), lane policy, `docs/cli.md`
  regen, `docs/cli-reference.md`, `docs/session-log-collector.md`, CLAUDE.md.

## Harness coverage

Only **Claude Code** partitions its logs by working directory
(`~/.claude/projects/<slug>`, slug = worktree path with every non-alphanumeric →
`-`, verified on disk), which is what lets a worktree map cleanly to exactly that
session's transcripts — so it is fully wired. Codex / OpenCode / Cursor store
logs globally (timestamp- or vscdb-hash-partitioned) and would need per-file cwd
matching / SQLite extraction to attribute correctly; they return `[]` for now
with their on-disk locations documented in `docs/session-log-collector.md`. The
framework is harness-general — wiring a deferred harness is just its `logSources`
override (plus, for Cursor, a `.sqlite` extractor).

## Guarantees (acceptance)

- Completed session on an **opted-in** workspace → transcript uploaded with Crow
  metadata. Opted-out → nothing.
- **No AWS credential** on the laptop (server-side upload).
- **Backfill is idempotent** (on-disk ledger `{devRoot}/.claude/logsync-ledger.json`
  + the server's write-once 409).
- **Upload failure never delays/fails a session** — the collector runs off the
  session lifecycle; one retry, then the ledger records and backs off.

## Tests

New unit tests for the slug rule, harness mapping, config codable + local-only
secret handling, the NDJSON normalizer (concat / counts / truncation / sqlite
skip), the uploader (request construction + status classification + retry), the
ledger, Claude `logSources`, and the collector's pure helpers. `make parity`
green (105 CLI/RPC methods match the ledger).

## Note for reviewers

Two CrowDaemon tests — `RPCLanePolicyTests.everyWriteMethodIsClassified`
(`corveil-verify` / `corveil-reinstall-skill` lack a lane rule) and
`WebNotificationCenterTests.bootCatchResetsTheHistory` — **fail on the branch
base independent of this change** (verified by stashing this branch's diff). They
are pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
