### PR TITLE
Judge PRs against existing architecture, not only the diff (CROW-1062)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/ReviewVerdictPolicy.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ReviewVerdictPolicy.swift
@@ -179,12 +179,20 @@ public enum ReviewVerdictPolicy {
     /// surfaces one. These three rules give the reviewer a way to say "your call,
     /// approved" by capping such findings at Green, which the default and red-only
     /// policies treat as non-blocking.
+    ///
+    /// The third rule ("grade against the diff, not the roadmap") also carries the
+    /// CROW-1062 reconciliation: an *architectural* mismatch — a change that
+    /// reinvents an existing pathway, misreads the current control flow, or assumes
+    /// a behavior the codebase already has — is a defect in the shape of what is
+    /// written, so it stays gradeable at Yellow/Red rather than being waved through
+    /// as a future refactor. That is the grade-side counterpart to the Step 3
+    /// "Architecture & Existing Patterns" study the skill body now requires.
     public static let gradingGuidanceBlock = """
     Grading discipline — the rules below bound the **severity you may assign** to a finding. They hold no matter which severities gate the verdict above, because they are about how to grade, not about what blocks:
 
     - **An accepted risk is not a blocker.** A hazard the PR explicitly documents and consciously accepts is at most **Green**. When the diff is correct and the only disagreement is whether to accept a risk the author has already called out, that acceptance is the author's decision to make — state your view in the body and let the verdict follow the grade, rather than blocking on it.
     - **Do not re-block a declined finding.** A finding you raised in an earlier round that the author has answered with a rationale — rather than a code change — may be restated at most as **Green**. Re-raising the same point at a blocking severity round after round is not permitted; if you remain unconvinced, leave it Green and, if it is worth tracking, file a follow-up issue instead of holding up the PR.
-    - **Grade against the diff, not the roadmap.** Severity measures a defect in what is written. "The code is correct, but a hazard it identifies is left unenforced" is **Green** — not Yellow or Red. A future improvement you would like to see is not a defect in this change.
+    - **Grade against the diff, not the roadmap.** Severity measures a defect in what is written. "The code is correct, but a hazard it identifies is left unenforced" is **Green** — not Yellow or Red. A future improvement you would like to see is not a defect in this change. But building the wrong *shape* is a defect in what is written: a change that reinvents a pathway the codebase already has, misreads the current control flow, or assumes a behavior the system already provides may be graded **Yellow** or **Red**, not waved through as a future refactor. Study the surrounding architecture before you decide which of the two this is.
     """
 
     // MARK: - Helpers

--- a/Packages/CrowCore/Tests/CrowCoreTests/ReviewVerdictPolicyTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ReviewVerdictPolicyTests.swift
@@ -256,4 +256,55 @@ struct ReviewVerdictPolicyTests {
         #expect(byDefault == everything)
         #expect(redOnly == ReviewVerdictPolicy.gradingGuidanceBlock)
     }
+
+    // MARK: - Architecture study (CROW-1062)
+
+    /// The Step 3 "Architecture & Existing Patterns" study step is static prose in
+    /// the skill body (not a placeholder), so it must survive expansion under any
+    /// workspace policy and reach every harness. Pin it on the real skill the same
+    /// way `expandingTheRealSkillReproducesTodaysDefaultText` pins the verdict
+    /// blocks: a reword or a dropped step fails here.
+    @Test func expandedSkillCarriesTheArchitectureStudyStepForEveryPolicy() throws {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        var found: URL?
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent("skills/crow-review-pr/SKILL.md")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                found = candidate
+                break
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        let skill = try String(contentsOf: try #require(found), encoding: .utf8)
+
+        for blocking in [ReviewSeverity.defaultBlocking, [.red], ReviewSeverity.allCases] {
+            let expanded = ReviewVerdictPolicy.expand(skill, blocking: blocking)
+            // The study step, its two load-bearing instructions, and the grade it
+            // mandates for architectural mismatch.
+            #expect(expanded.contains("Architecture & Existing Patterns (study this before scoring the diff):"),
+                    "\(blocking) lost the architecture study step")
+            #expect(expanded.contains("Name the existing pathway the change should have extended"),
+                    "\(blocking) lost the name-the-existing-pathway instruction")
+            #expect(expanded.contains("Invents a parallel mechanism where a small extension of current behavior would do."),
+                    "\(blocking) lost the reinvented-pathway finding")
+            #expect(expanded.contains("grade them **Yellow** (should-fix) or **Red** (must-fix), never Green"),
+                    "\(blocking) lost the Yellow/Red grade for architecture findings")
+            // The posted review body must carry the section too, so the study is visible.
+            #expect(expanded.contains("### Architecture / Existing Patterns"),
+                    "\(blocking) lost the review-body architecture section")
+        }
+    }
+
+    /// The grade-side reconciliation (CROW-1062): the third grading rule now carves
+    /// an architectural defect out of "roadmap", so a reviewer cannot cap a
+    /// reinvented-pathway finding at Green by calling it a future refactor. Adding
+    /// this must not disturb the three loop-breaking rule headers.
+    @Test func gradingGuidanceLetsArchitectureDefectsBlock() {
+        let guidance = ReviewVerdictPolicy.gradingGuidanceBlock
+        #expect(guidance.contains("may be graded **Yellow** or **Red**, not waved through as a future refactor."))
+        // The three loop-breakers survive unchanged.
+        #expect(guidance.contains("An accepted risk is not a blocker."))
+        #expect(guidance.contains("Do not re-block a declined finding."))
+        #expect(guidance.contains("Grade against the diff, not the roadmap."))
+    }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SessionServiceReviewPromptTests.swift
@@ -49,6 +49,28 @@ struct SessionServiceReviewPromptTests {
     \(ReviewVerdictPolicy.notesPlaceholder)
     """
 
+    /// SKILL-shaped fixture carrying the CROW-1062 static architecture-study prose
+    /// (the Step 3 sub-step + the review-body section) alongside the placeholders.
+    /// Because the study step is static prose — not a placeholder — the inline
+    /// pipeline (frontmatter strip, `$ARGUMENTS`, attribution expansion) must carry
+    /// it through untouched. Kept minimal so a reword in the real skill fails the
+    /// CrowCore pin, while this asserts the *transport* preserves it.
+    private static let architectureFixtureSkillBody = """
+    # Crow Review PR
+    Review PR $ARGUMENTS.
+
+    **Architecture & Existing Patterns (study this before scoring the diff):**
+
+    - Name the existing pathway the change should have extended, or state plainly that none exists.
+    - Invents a parallel mechanism where a small extension of current behavior would do.
+
+    These are defects in **this change** — grade them **Yellow** (should-fix) or **Red** (must-fix), never Green "consider later."
+
+    ### Architecture / Existing Patterns
+
+    \(ReviewVerdictPolicy.rulePlaceholder)
+    """
+
     /// `fixtureSkillBody` with the real skill's YAML frontmatter prepended — the
     /// shape `Scaffolder.bundledReviewSkill()` actually returns in production, and
     /// the one that killed every Cursor review (CROW-968).
@@ -331,6 +353,39 @@ struct SessionServiceReviewPromptTests {
                 // No verdict-family placeholder may survive expansion.
                 #expect(!prompt.contains("{{CROW_REVIEW_"))
             }
+        }
+    }
+
+    /// CROW-1062: the Step 3 architecture-study prose is static (not a
+    /// placeholder), so the inline pipeline — frontmatter strip, `$ARGUMENTS`
+    /// substitution, attribution expansion — must carry it to every non-Claude
+    /// harness verbatim. If the strip or expansion ever dropped a static section,
+    /// the inlining agents would review against the diff only while the copied
+    /// SKILL.md (which Claude reads) still had it. Mirrors the grading-guidance
+    /// transport test above.
+    @Test func buildReviewPromptCarriesTheArchitectureStudyForEveryInlineAgent() {
+        for agentKind: AgentKind in [.cursor, .openCode, .codex, .grok, .antigravity, .muse] {
+            let prompt = SessionService.buildReviewPrompt(
+                prURL: Self.prURL,
+                prTitle: Self.prTitle,
+                repoSlug: Self.repoSlug,
+                prNumber: Self.prNumber,
+                agentKind: agentKind,
+                skillBody: Self.architectureFixtureSkillBody
+            )
+
+            #expect(prompt.contains("Architecture & Existing Patterns (study this before scoring the diff):"),
+                    "\(agentKind.rawValue) lost the architecture study step")
+            #expect(prompt.contains("Name the existing pathway the change should have extended"),
+                    "\(agentKind.rawValue) lost the name-the-existing-pathway instruction")
+            #expect(prompt.contains("grade them **Yellow** (should-fix) or **Red** (must-fix), never Green"),
+                    "\(agentKind.rawValue) lost the Yellow/Red grade for architecture findings")
+            #expect(prompt.contains("### Architecture / Existing Patterns"),
+                    "\(agentKind.rawValue) lost the review-body architecture section")
+            // The transport must not cost us the existing substitutions.
+            #expect(prompt.contains(Self.prURL))
+            #expect(!prompt.contains("$ARGUMENTS"))
+            #expect(!prompt.contains("{{CROW_REVIEW_"))
         }
     }
 

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -45,7 +45,21 @@ gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,additions,deleti
 
 ### Step 3: Review the Code
 
-Read all changed files in the PR. For each file, analyze:
+**Architecture & Existing Patterns (study this before scoring the diff):**
+
+A PR can be correct in isolation yet wrong for the codebase — it reinvents a pathway that already exists, or builds the wrong shape because it misread the current control flow. Judge the change against how the system works **today**, not only against its own hunks:
+
+- Read the surrounding modules, the call sites the change touches, and any ADRs in that area (`docs/adr/`) — not just the changed lines.
+- Name the existing pathway the change should have extended, or state plainly that none exists.
+- Raise a finding when the PR:
+  - Invents a parallel mechanism where a small extension of current behavior would do.
+  - Over-engineers relative to the established patterns in the same area.
+  - Assumes a behavior is missing that the codebase already provides.
+  - Misunderstands the current control flow and builds the wrong shape because of it.
+
+These are defects in **this change**, not future improvements — grade them **Yellow** (should-fix) or **Red** (must-fix), never Green "consider later." A forced redesign or a reject is in scope when the approach cannot be made to fit an existing pattern.
+
+Then read all changed files in the PR. For each file, analyze:
 
 **Security Review:**
 - Authentication/authorization issues
@@ -104,6 +118,10 @@ Draft the review using this format:
 
 ### Critical Issues (if any)
 [List blocking issues that must be fixed]
+
+### Architecture / Existing Patterns
+- **Existing pathway:** [name the current path the change should have used, or "none — this is a genuinely new capability"]
+- [Architecture findings, if any — with file references and severity. State when the PR reinvents an existing path, over-engineers, assumes a behavior the codebase already has, or misreads the current control flow.]
 
 ### Security Review
 **Strengths:**

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -45,7 +45,21 @@ gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,additions,deleti
 
 ### Step 3: Review the Code
 
-Read all changed files in the PR. For each file, analyze:
+**Architecture & Existing Patterns (study this before scoring the diff):**
+
+A PR can be correct in isolation yet wrong for the codebase — it reinvents a pathway that already exists, or builds the wrong shape because it misread the current control flow. Judge the change against how the system works **today**, not only against its own hunks:
+
+- Read the surrounding modules, the call sites the change touches, and any ADRs in that area (`docs/adr/`) — not just the changed lines.
+- Name the existing pathway the change should have extended, or state plainly that none exists.
+- Raise a finding when the PR:
+  - Invents a parallel mechanism where a small extension of current behavior would do.
+  - Over-engineers relative to the established patterns in the same area.
+  - Assumes a behavior is missing that the codebase already provides.
+  - Misunderstands the current control flow and builds the wrong shape because of it.
+
+These are defects in **this change**, not future improvements — grade them **Yellow** (should-fix) or **Red** (must-fix), never Green "consider later." A forced redesign or a reject is in scope when the approach cannot be made to fit an existing pattern.
+
+Then read all changed files in the PR. For each file, analyze:
 
 **Security Review:**
 - Authentication/authorization issues
@@ -104,6 +118,10 @@ Draft the review using this format:
 
 ### Critical Issues (if any)
 [List blocking issues that must be fixed]
+
+### Architecture / Existing Patterns
+- **Existing pathway:** [name the current path the change should have used, or "none — this is a genuinely new capability"]
+- [Architecture findings, if any — with file references and severity. State when the PR reinvents an existing path, over-engineers, assumes a behavior the codebase already has, or misreads the current control flow.]
 
 ### Security Review
 **Strengths:**


### PR DESCRIPTION
Closes #1062

## Problem

`crow-review-pr` was a local-diff review — security + a short quality list, all scoped to the changed hunks. Nothing required the reviewer to study how the system works today, and the grading guidance actively pulled away from architectural blocking ("grade against the diff, not the roadmap"). So a PR that reinvents an existing pathway, over-engineers, or misreads the current control flow could be correct in isolation and still get approved.

## Change (prompt-only)

Single source of truth is `Resources/crow-review-pr-SKILL.md.template`, pinned byte-identical to `skills/crow-review-pr/SKILL.md` and loaded by `bundledReviewSkill()`; it flows to both the copied `SKILL.md` (Claude) and the inlined `.crow-review-prompt.md` (Cursor/Codex/OpenCode/Grok/Antigravity/Muse via `buildReviewPrompt`). The study step is **static prose**, so one edit reaches every harness.

- **Step 3 — Architecture & Existing Patterns (study before scoring).** Read surrounding modules, call sites, and ADRs — not just the hunks. Name the existing pathway the change should have used, or state none exists. Raise a finding when the PR invents a parallel mechanism, over-engineers, assumes a behavior the codebase already has, or builds the wrong shape from a misread control flow. These are **Yellow/Red**, not Green "consider later"; a forced redesign/reject is in scope when the approach can't fit an existing pattern.
- **Review-body template** gains an `### Architecture / Existing Patterns` section so the study is visible in the posted review.
- **Grade-side reconciliation** in `ReviewVerdictPolicy.gradingGuidanceBlock`: the "grade against the diff, not the roadmap" bullet now carves out an architectural mismatch (reinvented path, misread control flow, false missing-behavior assumption) as a *defect in what is written* — gradeable Yellow/Red, not waved through as a future refactor. The three loop-breaking rules are otherwise untouched.

**Verdict machinery unchanged** — CROW-963 per-workspace `reviewBlockingSeverities`, CROW-974 target + verdict-consistency guardrails, and accepted-risk / declined-finding rules are all preserved.

## Verify

- Template and copied `SKILL.md` stay byte-identical (`bothHalvesOfTheBundledSkillCarryEveryPlaceholder` ✓).
- CrowCore `ReviewVerdictPolicyTests`: new `expandedSkillCarriesTheArchitectureStudyStepForEveryPolicy` (study step + body section present under every policy) and `gradingGuidanceLetsArchitectureDefectsBlock` (reconciliation present, three loop-breakers intact). 21 tests ✓.
- CrowEngine `SessionServiceReviewPromptTests`: new `buildReviewPromptCarriesTheArchitectureStudyForEveryInlineAgent` (inline pipeline transports the study step to every non-Claude agent). 20 tests ✓.
- Manual (per ticket test plan): a review session on a PR that adds a new path beside an existing one should now Request changes and name the existing pathway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)