### PR TITLE
Session-log upload: reuse the workspace AI gateway, drop the global logSync config (CROW-1070)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,20 +284,19 @@ crow web-password clear                                                 → {"sa
 
 ### Session-Log Sync
 
-Local-only (CROW-1056) — the multi-harness session-log collector's opt-in controls. Uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, authed by your own Corveil API key (no AWS creds on the laptop). **Default OFF**; nothing uploads until enabled *and* a workspace is opted in. Best-effort — never blocks or fails a session.
+The multi-harness session-log collector (CROW-1056). Uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts. **Default OFF**; best-effort — never blocks or fails a session. Since CROW-1070 the opt-in, destination and credential are all **per-workspace**: a workspace uploads iff its `--upload-session-logs` flag / Settings → Workspaces checkbox is on **and** it has an AI gateway, whose `baseURL` + `x-citadel-api-key` the upload reuses (no second key/host, no AWS creds on the laptop).
+
+`crow logsync` tunes only **global collector behavior** — no credential, so **not** local-only; it also backs the web Settings → General → Session logs section.
 
 ```
-crow logsync get [--reveal]                                             → {"logsync":{enabled,base_url,api_key_ref,api_key_set,enabled_workspaces,retention_days,quiet_period_minutes,max_upload_bytes,configured}}
-crow logsync set [--enabled true|false] [--base-url URL] [--api-key-ref REF]
-                 [--add-workspace NAME ...] [--remove-workspace NAME ...] [--clear-workspaces]
-                 [--retention-days N] [--quiet-period-minutes N] [--max-upload-bytes N]   → {"logsync":{...},"saved":true}
+crow logsync get                                                        → {"logsync":{retention_days,quiet_period_minutes,max_upload_bytes,configured}}
+crow logsync set [--retention-days N] [--quiet-period-minutes N] [--max-upload-bytes N]   → {"logsync":{...},"saved":true}
 ```
 
-- Local-only on `/rpc` (like `gateway`/`web-password`): the RPCs are refused for non-loopback peers, so the opt-in can't be flipped remotely.
-- `--api-key-ref` takes an `op://…` 1Password reference (resolved at upload, never at rest in `config.json`) or a plaintext key. `logsync get` masks a plaintext key unless `--reveal`; an `op://…` reference is always shown (it's a pointer, not the secret).
-- `set` is a PATCH (only the flags you pass change; at least one required). Workspace list edits compose: clear → remove → add. Empty `--base-url ''`/`--api-key-ref ''` clears that field.
-- Only Claude Code transcripts are collected today (its logs are the one harness partitioned by working directory); other harnesses are wired as their log paths are confirmed. Live within ~1 collector tick (~5 min); no restart.
-- **Two opt-in surfaces (CROW-1066).** `--add-workspace` here is the local-only list. The other is the per-workspace `crow workspace edit --upload-session-logs true` flag / Settings → Workspaces checkbox, which **reuses that workspace's gateway credential** instead of this block's `--api-key-ref`. Unlike this local-only block, that flag is a normal workspace field (browser-flippable). Both surfaces still require `--enabled true` + a `--base-url` here; the upload destination is always this block's `base_url`, never the browser-flippable `--corveil-host`. `logSync.enabled` stays the kill switch.
+- **Opt a workspace in elsewhere**: `crow workspace edit --workspace NAME --upload-session-logs true` (or the checkbox) + a gateway via `crow gateway set`. There is no `crow logsync` flag that opts a workspace in — CROW-1070 dropped the global master switch, base URL, API key and `enabledWorkspaces` list.
+- **Security invariant**: the upload destination + credential come only from the workspace's **local-only** gateway (`{gateway.baseURL}/api/crow-sessions/{id}/artifacts` + `x-citadel-api-key`), never `--corveil-host` or any browser-writable field. A workspace with no gateway uploads nothing.
+- `set` is a PATCH (only the flags you pass change; at least one required). Live within ~1 collector tick (~5 min); no restart.
+- **Migration**: a legacy `crow logsync set --add-workspace` opt-in is carried over to `--upload-session-logs` on first boot (only when the old master switch was on). Only Claude Code transcripts are collected today; other harnesses are wired as their log paths are confirmed.
 
 ### MCP
 

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
@@ -2,29 +2,32 @@ import ArgumentParser
 import CrowIPC
 import Foundation
 
-// `crow logsync` (CROW-1056): opt-in controls for the multi-harness session-log
-// collector. Like `crow gateway` / `crow web-password`, these verbs are
-// LOCAL-ONLY — the `logsync-get`/`logsync-set` RPCs are refused on the remote
-// `/rpc` path (RPCWebSocketHandler.localOnlyDenial) because they configure
-// transcript uploads off the daemon host and carry a Corveil API-key reference.
+// `crow logsync` (CROW-1056; slimmed in CROW-1070): the session-log collector's
+// global behavior knobs. The upload destination + credential are per-workspace
+// now (they reuse the workspace's AI gateway), and the opt-in is the per-workspace
+// `crow workspace edit --upload-session-logs` flag / Settings → Workspaces
+// checkbox — so this block carries no credential and is no longer local-only.
 //
 // `set` is a PATCH: only the flags you pass change; passing none is an error.
-// Booleans are `@Option ... Bool?` (three states: true / false / absent).
 
 /// Parent command: `crow logsync <subcommand>`.
 public struct Logsync: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "logsync",
-        abstract: "View or change session-log upload (opt-in, local-only)",
+        abstract: "View or change session-log upload behavior knobs",
         discussion: """
         The session-log collector uploads each opted-in workspace's coding-session \
-        transcripts to Corveil as session artifacts, attributed to your own Corveil \
-        API key (no AWS credentials are stored on this machine). It is OFF by \
-        default and uploads nothing until you both enable it and opt a workspace in.
+        transcripts to Corveil as session artifacts, reusing that workspace's AI \
+        gateway for the destination and credential (no AWS credentials are stored \
+        on this machine). Opt a workspace in with \
+        `crow workspace edit --workspace NAME --upload-session-logs true` (or the \
+        Settings → Workspaces checkbox); it uploads once it also has a gateway.
 
-        Uploads are best-effort and never block or fail a session. Only Claude Code \
-        transcripts are collected today; other harnesses are wired as their on-disk \
-        log locations are confirmed.
+        These verbs tune only global behavior — ledger retention, the quiet period \
+        before a transcript is captured, and the per-upload size cap. Uploads are \
+        best-effort and never block or fail a session. Only Claude Code transcripts \
+        are collected today; other harnesses are wired as their on-disk log \
+        locations are confirmed.
         """,
         subcommands: [LogsyncGet.self, LogsyncSet.self]
     )
@@ -34,60 +37,30 @@ public struct Logsync: ParsableCommand {
 
 public struct LogsyncGet: ParsableCommand {
     public static let configuration = CommandConfiguration(
-        commandName: "get", abstract: "Show the session-log collector settings")
-
-    @Flag(name: .long, help: "Reveal a plaintext API key (op:// references are always shown)")
-    var reveal = false
+        commandName: "get", abstract: "Show the session-log collector behavior knobs")
 
     public init() {}
 
     public func run() throws {
-        let params: [String: JSONValue] = reveal ? ["reveal": .bool(true)] : [:]
-        printJSON(try rpc("logsync-get", params: params))
+        printJSON(try rpc("logsync-get", params: [:]))
     }
 }
 
 public struct LogsyncSet: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "set",
-        abstract: "Change session-log upload settings",
+        abstract: "Change session-log upload behavior knobs",
         discussion: """
         Only the flags you pass change; at least one is required.
 
-        Turn the feature on with --enabled true, point it at your Corveil API with \
-        --base-url and --api-key-ref (an op://… 1Password reference is resolved at \
-        upload so the key never lands in config.json), then opt workspaces in with \
-        --add-workspace. Nothing uploads until a workspace is opted in.
+        Opt a workspace in (and set its gateway) elsewhere — with \
+        `crow workspace edit --upload-session-logs true` and `crow gateway set`. \
+        These flags only tune collector behavior.
 
         Live: the collector re-reads config each tick, so changes apply within a \
-        few minutes with no restart. Pass an empty string to --base-url/--api-key-ref \
-        to clear it.
+        few minutes with no restart.
         """
     )
-
-    @Option(name: .long, help: "Enable session-log upload (true or false)")
-    var enabled: Bool?
-
-    @Option(name: .customLong("base-url"), help: "Corveil API base URL (e.g. https://api.corveil.io)")
-    var baseURL: String?
-
-    @Option(
-        name: .customLong("api-key-ref"),
-        help: "Corveil API key: an op://… reference (preferred) or a plaintext key")
-    var apiKeyRef: String?
-
-    @Option(
-        name: .customLong("add-workspace"),
-        help: "Opt a workspace in (repeatable)")
-    var addWorkspace: [String] = []
-
-    @Option(
-        name: .customLong("remove-workspace"),
-        help: "Opt a workspace out (repeatable)")
-    var removeWorkspace: [String] = []
-
-    @Flag(name: .customLong("clear-workspaces"), help: "Opt every workspace out")
-    var clearWorkspaces = false
 
     @Option(
         name: .customLong("retention-days"),
@@ -107,13 +80,11 @@ public struct LogsyncSet: ParsableCommand {
     public init() {}
 
     public func validate() throws {
-        let anySet = enabled != nil || baseURL != nil || apiKeyRef != nil
-            || retentionDays != nil || quietPeriodMinutes != nil || maxUploadBytes != nil
-            || !addWorkspace.isEmpty || !removeWorkspace.isEmpty || clearWorkspaces
+        let anySet = retentionDays != nil || quietPeriodMinutes != nil || maxUploadBytes != nil
         guard anySet else {
             throw ValidationError(
-                "Nothing to set — provide at least one flag (e.g. --enabled, --base-url, "
-                + "--api-key-ref, --add-workspace).")
+                "Nothing to set — provide at least one flag (--retention-days, "
+                + "--quiet-period-minutes, --max-upload-bytes).")
         }
         if let retentionDays, retentionDays < 0 {
             throw ValidationError("--retention-days must be 0 or greater (0 = forever).")
@@ -128,19 +99,9 @@ public struct LogsyncSet: ParsableCommand {
 
     public func run() throws {
         var params: [String: JSONValue] = [:]
-        if let enabled { params["enabled"] = .bool(enabled) }
-        if let baseURL { params["base_url"] = .string(baseURL) }
-        if let apiKeyRef { params["api_key_ref"] = .string(apiKeyRef) }
         if let retentionDays { params["retention_days"] = .int(retentionDays) }
         if let quietPeriodMinutes { params["quiet_period_minutes"] = .int(quietPeriodMinutes) }
         if let maxUploadBytes { params["max_upload_bytes"] = .int(maxUploadBytes) }
-        if !addWorkspace.isEmpty {
-            params["add_workspaces"] = .array(addWorkspace.map { .string($0) })
-        }
-        if !removeWorkspace.isEmpty {
-            params["remove_workspaces"] = .array(removeWorkspace.map { .string($0) })
-        }
-        if clearWorkspaces { params["clear_workspaces"] = .bool(true) }
         printJSON(try rpc("logsync-set", params: params))
     }
 }

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -200,10 +200,6 @@ struct ParityGateTests {
                     expiresAt: Date())
             ],
             logSync: LogSyncConfig(
-                enabled: true,
-                baseURL: "https://api.corveil.example",
-                apiKeyRef: "op://probe/corveil/key",
-                enabledWorkspaces: ["probe"],
                 retentionDays: 30,
                 quietPeriodMinutes: 30,
                 maxUploadBytes: 8_000_000)

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncMigration.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncMigration.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// One-shot migration of the legacy global `logSync` opt-in to the per-workspace
+/// `uploadSessionLogs` checkbox (CROW-1070).
+///
+/// CROW-1070 removed `logSync.enabled` / `baseURL` / `apiKeyRef` /
+/// `enabledWorkspaces` — the upload destination + credential now come from the
+/// opting-in workspace's own local-only `gateway`, and the opt-in is the
+/// per-workspace `WorkspaceInfo.uploadSessionLogs` flag. A user who had opted a
+/// workspace in through the old CLI list (`crow logsync set --add-workspace …`)
+/// should keep uploading without re-ticking anything, so on first boot we carry
+/// that opt-in over.
+///
+/// The pure ``migrate(config:rawJSON:)`` reads the removed keys from the raw JSON
+/// (they no longer exist on ``LogSyncConfig``) and folds any `enabledWorkspaces`
+/// name into the matching workspace's `uploadSessionLogs`. Re-encoding the config
+/// drops the removed keys, so the migration is idempotent — a second pass sees no
+/// removed key and returns `nil`.
+public enum LogSyncMigration {
+    /// The legacy `logSync` keys removed in CROW-1070, decoded from the raw config
+    /// JSON. All optional: a non-nil value means the key was present, which is what
+    /// arms the one-shot migration.
+    private struct LegacyLogSync: Decodable {
+        var enabled: Bool?
+        var enabledWorkspaces: [String]?
+        var baseURL: String?
+        var apiKeyRef: String?
+
+        /// Whether the raw config carried any key CROW-1070 removed — the trigger
+        /// for a migrate-and-rewrite (which then drops them, so it won't re-fire).
+        var hasAnyRemovedKey: Bool {
+            enabled != nil || enabledWorkspaces != nil || baseURL != nil || apiKeyRef != nil
+        }
+    }
+
+    private struct RawConfigProbe: Decodable {
+        var logSync: LegacyLogSync?
+    }
+
+    /// Given the loaded `config` and the raw JSON it was decoded from, return a
+    /// migrated config, or `nil` when there is nothing to migrate.
+    ///
+    /// Fires only when the raw JSON still carries a removed `logSync` key. It folds
+    /// a legacy `enabledWorkspaces` opt-in into the matching workspace's
+    /// `uploadSessionLogs` — **only** when the legacy master switch `enabled` was
+    /// true, so a workspace that uploaded nothing before (switch off, or listed but
+    /// inert) keeps uploading nothing rather than being silently turned on. Callers
+    /// persist the result; the slim encode drops the removed keys, making a repeat
+    /// pass a no-op.
+    public static func migrate(config: AppConfig, rawJSON: Data) -> AppConfig? {
+        guard let probe = try? JSONDecoder().decode(RawConfigProbe.self, from: rawJSON),
+              let legacy = probe.logSync, legacy.hasAnyRemovedKey
+        else { return nil }
+
+        var migrated = config
+        if legacy.enabled == true, let names = legacy.enabledWorkspaces, !names.isEmpty {
+            let wanted = Set(names.map { $0.lowercased() })
+            for i in migrated.workspaces.indices
+            where wanted.contains(migrated.workspaces[i].name.lowercased()) {
+                migrated.workspaces[i].uploadSessionLogs = true
+            }
+        }
+        return migrated
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -102,12 +102,12 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// one. Minted/revoked via the local-only `mcp-token-*` RPCs.
     public var mcpTokens: [MCPTokenRecord]
 
-    /// Session-log collector settings (CROW-1056). Opt-in, local-only, default
-    /// OFF. When enabled, the daemon uploads opted-in workspaces' harness session
-    /// transcripts to Corveil as session-artifacts. `nil`/absent means never
-    /// configured — the collector is inert. Like `managerGateway`/`webAuth`, its
-    /// API-key value is stripped before the config reaches a browser and it is
-    /// writable only through the local-only `logsync-set` RPC (`SettingsSecrets`).
+    /// Session-log collector behavior tuning (CROW-1056; slimmed in CROW-1070).
+    /// Holds only the three global knobs — ledger retention, quiet period, upload
+    /// cap. The opt-in and the upload destination + credential are per-workspace
+    /// (the `uploadSessionLogs` checkbox reusing that workspace's local-only
+    /// `gateway`), so this block carries no secret and is an ordinary
+    /// browser-editable config block. `nil`/absent means all-default knobs.
     public var logSync: LogSyncConfig?
 
     /// Effective review-exclude patterns: the global `defaults.excludeReviewRepos`
@@ -643,21 +643,20 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
     public var sessionEnv: [String: String]?
 
     /// Opt this workspace's coding-session transcripts in to Corveil upload
-    /// (CROW-1066). The follow-up to the CLI-only `logSync.enabledWorkspaces`
-    /// list: a per-workspace checkbox in Settings → Workspaces that **reuses the
-    /// workspace's own `gateway` credential** so the operator never re-enters a
-    /// Corveil API key. `LogSyncCollector` uploads a session only when the
-    /// local-only master switch `logSync.enabled` is on **and** the session's
-    /// workspace either sets this flag or appears in `logSync.enabledWorkspaces`.
+    /// (CROW-1066; sole opt-in since CROW-1070). A per-workspace checkbox in
+    /// Settings → Workspaces that **reuses this workspace's own `gateway`** for
+    /// both the upload destination (`{gateway.baseURL}/api/crow-sessions/…`) and
+    /// the credential (its `x-citadel-api-key`), so the operator never re-enters a
+    /// Corveil key or host. `LogSyncCollector` uploads a session iff this flag is
+    /// set **and** the workspace has a gateway to reuse — there is no separate
+    /// master switch.
     ///
-    /// Unlike the rest of the `logSync` block — which is local-only, so a remote
-    /// peer cannot flip it — this rides on the workspace record and is therefore
-    /// **browser-flippable** through `set-config` / `workspace edit`. That is a
-    /// deliberate, bounded relaxation (CROW-1066): it only reuses a credential the
-    /// workspace already holds (the gateway key, itself local-only and never
-    /// readable/authorable from the web), the upload destination stays the
-    /// local-only `logSync.baseURL`, and `logSync.enabled` remains the local kill
-    /// switch. Default `false`.
+    /// The reuse is what makes browser-flippability safe: the destination +
+    /// credential come only from the **local-only** `gateway` (never readable or
+    /// authorable from the web, and never from the browser-writable `corveilHost`),
+    /// so a remote peer ticking this box can at most turn one workspace's upload
+    /// on/off, to the operator's own Corveil, with a credential it can neither see
+    /// nor change. Default `false`.
     public var uploadSessionLogs: Bool
 
     /// The CLI tool name derived from the current `provider` value.
@@ -1190,37 +1189,22 @@ public struct CleanupConfig: Codable, Sendable, Equatable {
     enum CodingKeys: String, CodingKey { case enabled, retentionHours }
 }
 
-/// Session-log upload settings (CROW-1056) — the opt-in, local-only control
-/// block for the multi-harness session-log collector.
+/// Session-log collector **behavior tuning** (CROW-1056, slimmed in CROW-1070) —
+/// the global knobs for the multi-harness session-log collector.
 ///
-/// **Local-only, default OFF.** This block configures uploads *from the daemon
-/// host* and carries a Corveil API-key reference, so — like `managerGateway` /
-/// `webAuth` / `mcpTokens` — it is stripped before the config reaches a browser
-/// (`SettingsSecrets`) and is writable only through the local-only `logsync-set`
-/// RPC, never `set-config`. Nothing uploads unless a local operator turns it on.
+/// **Not a secret; not the opt-in.** Since CROW-1070 the upload *destination* and
+/// *credential* are the opting-in workspace's own **local-only AI gateway**
+/// (`WorkspaceInfo.gateway`) — never a field in this block — and the opt-in is the
+/// per-workspace `WorkspaceInfo.uploadSessionLogs` checkbox. So this block carries
+/// no credential, no destination and no opt-in list: only three behavior knobs.
+/// It is therefore an ordinary, browser-editable config block (Settings → General
+/// → "Session logs"), reachable over `set-config` and the (no-longer-local-only)
+/// `crow logsync` CLI alike.
 ///
-/// The collector uploads a session's transcript only when **both** `enabled` is
-/// true **and** the session's workspace name is listed in `enabledWorkspaces`
-/// (the per-workspace opt-in — matched case-insensitively). Uploads are
-/// best-effort and never block or fail a session.
+/// The removed `enabled` / `baseURL` / `apiKeyRef` / `enabledWorkspaces` fields are
+/// migrated on first boot by ``LogSyncMigration`` — a legacy `enabledWorkspaces`
+/// opt-in becomes the matching workspace's `uploadSessionLogs`.
 public struct LogSyncConfig: Codable, Sendable, Equatable {
-    /// Master switch. `false` (the default) means the collector does nothing.
-    public var enabled: Bool
-    /// Corveil API base URL that hosts `POST /api/crow-sessions/{id}/artifacts`
-    /// (e.g. `https://api.corveil.io`). Empty disables uploads even when
-    /// `enabled` is true.
-    public var baseURL: String
-    /// The developer's own Corveil API key, as an `op://…` 1Password reference
-    /// (resolved at upload via `GatewayResolver.opRead`, so the secret never
-    /// lands at rest in `config.json`) or a plaintext key. Sent as
-    /// `Authorization: Bearer <key>`. The upload is authenticated as — and
-    /// attributed to — this principal, server-side; there are no AWS credentials
-    /// on the laptop.
-    public var apiKeyRef: String
-    /// Names of the workspaces opted in to transcript upload. A session uploads
-    /// only if its workspace name appears here (case-insensitive). Empty = no
-    /// workspace uploads, which is the default even when `enabled` is true.
-    public var enabledWorkspaces: [String]
     /// Days to retain entries in the local upload ledger before pruning
     /// (housekeeping only — mirrors `TelemetryConfig.retentionDays`; the server
     /// enforces its own artifact retention). 0 keeps entries forever.
@@ -1236,43 +1220,28 @@ public struct LogSyncConfig: Codable, Sendable, Equatable {
     public var maxUploadBytes: Int
 
     public init(
-        enabled: Bool = false,
-        baseURL: String = "",
-        apiKeyRef: String = "",
-        enabledWorkspaces: [String] = [],
         retentionDays: Int = 30,
         quietPeriodMinutes: Int = 30,
         maxUploadBytes: Int = 8_000_000
     ) {
-        self.enabled = enabled
-        self.baseURL = baseURL
-        self.apiKeyRef = apiKeyRef
-        self.enabledWorkspaces = enabledWorkspaces
         self.retentionDays = retentionDays
         self.quietPeriodMinutes = quietPeriodMinutes
         self.maxUploadBytes = maxUploadBytes
     }
 
     /// Per-key tolerant decode — an older `config.json` lacking any field (or the
-    /// whole block) still decodes (CROW-814 idiom).
+    /// whole block) still decodes (CROW-814 idiom). The removed CROW-1070 keys
+    /// (`enabled`/`baseURL`/`apiKeyRef`/`enabledWorkspaces`) are simply ignored
+    /// here and dropped on the next encode; ``LogSyncMigration`` reads them once,
+    /// from the raw JSON, to carry a legacy opt-in over to `uploadSessionLogs`.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
-        baseURL = try c.decodeIfPresent(String.self, forKey: .baseURL) ?? ""
-        apiKeyRef = try c.decodeIfPresent(String.self, forKey: .apiKeyRef) ?? ""
-        enabledWorkspaces = try c.decodeIfPresent([String].self, forKey: .enabledWorkspaces) ?? []
         retentionDays = try c.decodeIfPresent(Int.self, forKey: .retentionDays) ?? 30
         quietPeriodMinutes = try c.decodeIfPresent(Int.self, forKey: .quietPeriodMinutes) ?? 30
         maxUploadBytes = try c.decodeIfPresent(Int.self, forKey: .maxUploadBytes) ?? 8_000_000
     }
 
-    /// Whether this workspace name is opted in (case-insensitive).
-    public func uploadsWorkspace(_ name: String) -> Bool {
-        let lower = name.lowercased()
-        return enabledWorkspaces.contains { $0.lowercased() == lower }
-    }
-
     enum CodingKeys: String, CodingKey {
-        case enabled, baseURL, apiKeyRef, enabledWorkspaces, retentionDays, quietPeriodMinutes, maxUploadBytes
+        case retentionDays, quietPeriodMinutes, maxUploadBytes
     }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -147,8 +147,6 @@ public enum ParityLedger {
         "mcp-token-revoke",
         "corveil-verify",
         "corveil-reinstall-skill",
-        "logsync-get",
-        "logsync-set",
     ]
 
     /// Every method reachable through the live router pair — the daemon's
@@ -483,12 +481,10 @@ public enum ParityLedger {
         .field("workspaces[].gateway.baseURL", read: "gateway get", write: "gateway set"),
         .field("workspaces[].gateway.customHeaders", read: "gateway get", write: "gateway set"),
 
-        // Session-log collector (CROW-1056). Local-socket only, like the gateway
-        // block: `logsync get`/`logsync set` are refused on the remote /rpc path.
-        .field("logSync.enabled", read: "logsync get", write: "logsync set"),
-        .field("logSync.baseURL", read: "logsync get", write: "logsync set"),
-        .field("logSync.apiKeyRef", read: "logsync get", write: "logsync set"),
-        .field("logSync.enabledWorkspaces", read: "logsync get", write: "logsync set"),
+        // Session-log collector behavior knobs (CROW-1056; slimmed in CROW-1070).
+        // No longer local-only: the block holds no credential and no opt-in (both
+        // are per-workspace via the gateway), so it round-trips over `set-config`
+        // (Settings → General → Session logs) and the `crow logsync` CLI alike.
         .field("logSync.retentionDays", read: "logsync get", write: "logsync set"),
         .field("logSync.quietPeriodMinutes", read: "logsync get", write: "logsync set"),
         .field("logSync.maxUploadBytes", read: "logsync get", write: "logsync set"),
@@ -650,12 +646,11 @@ public enum ParityLedger {
         .field("workspaces[].jiraStatusMap", read: "workspace get", write: "workspace edit"),
         .field("workspaces[].corveilHost", read: "workspace get", write: "workspace edit"),
         .field("workspaces[].sessionEnv", read: "workspace get", write: "workspace edit"),
-        // Per-workspace session-log opt-in (CROW-1066). Unlike the `logSync` block
-        // above, this rides on the workspace record and is intentionally writable
-        // from the same surfaces as every other workspace field — `workspace edit`
-        // over the socket, `set-config` from an authenticated browser — because it
-        // only reuses a credential the workspace already holds and `logSync.enabled`
-        // stays the local-only kill switch.
+        // Per-workspace session-log opt-in (CROW-1066; sole opt-in since
+        // CROW-1070). Writable from the same surfaces as every other workspace
+        // field — `workspace edit` over the socket, `set-config` from an
+        // authenticated browser — because it only reuses a credential the workspace
+        // already holds (its local-only gateway) and can't redirect the upload.
         .field("workspaces[].uploadSessionLogs", read: "workspace get", write: "workspace edit"),
 
         // MARK: Automation toggles (web Settings tab + `crow automation`)

--- a/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
+++ b/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
@@ -48,11 +48,10 @@ public enum SettingsSecrets {
             if let gateway = w.gateway { w.gateway = stripHeaderValues(gateway) }
             return w
         }
-        // Session-log collector (CROW-1056): blank the Corveil API-key reference
-        // but keep the rest of the block so the read-only web view can show what
-        // is configured. Like the gateway/token secrets, it is authored only via
-        // the local-only `logsync-set` RPC.
-        if c.logSync != nil { c.logSync?.apiKeyRef = "" }
+        // Session-log collector (CROW-1070): the `logSync` block now holds only
+        // behavior knobs (retention / quiet period / upload cap) — no credential
+        // and no opt-in — so there is nothing to strip. Both the opt-in and the
+        // upload credential are the per-workspace gateway, handled above.
         return c
     }
 
@@ -85,11 +84,12 @@ public enum SettingsSecrets {
         // `current` means a round-trip is a no-op regardless of what came back.
         result.mcpTokens = current?.mcpTokens ?? []
         result.managerGateway = current?.managerGateway
-        // Session-log collector (CROW-1056): the whole block is authored only via
-        // the local-only `logsync-set` RPC, so a `set-config` round-trip always
-        // restores the stored value — a browser can neither enable uploads,
-        // opt a workspace in, nor introduce a plaintext API key here.
-        result.logSync = current?.logSync
+        // Session-log collector (CROW-1070): the `logSync` block is now ordinary,
+        // non-secret behavior tuning, so — unlike the gateways/tokens above — it is
+        // NOT restored from `current`; the browser's edited knobs round-trip
+        // through `set-config` like Telemetry / Cleanup. It can't carry a credential
+        // or redirect an upload (both are the per-workspace gateway), so there is
+        // nothing here for a remote peer to abuse.
         if let current {
             let currentGatewaysByID = Dictionary(
                 current.workspaces.map { ($0.id, $0.gateway) },

--- a/Packages/CrowCore/Tests/CrowCoreTests/LogSyncConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/LogSyncConfigTests.swift
@@ -3,89 +3,88 @@ import Testing
 import CrowCore
 
 @Suite struct LogSyncConfigTests {
-    @Test func defaultsAreOff() {
+    @Test func defaultsAreTheDefaults() {
         let c = LogSyncConfig()
-        #expect(c.enabled == false)
-        #expect(c.baseURL.isEmpty)
-        #expect(c.apiKeyRef.isEmpty)
-        #expect(c.enabledWorkspaces.isEmpty)
         #expect(c.retentionDays == 30)
         #expect(c.quietPeriodMinutes == 30)
         #expect(c.maxUploadBytes == 8_000_000)
     }
 
-    @Test func uploadsWorkspaceIsCaseInsensitive() {
-        let c = LogSyncConfig(enabledWorkspaces: ["Acme", "Corveil"])
-        #expect(c.uploadsWorkspace("acme"))
-        #expect(c.uploadsWorkspace("CORVEIL"))
-        #expect(!c.uploadsWorkspace("other"))
-    }
-
     @Test func codableRoundTrip() throws {
-        let c = LogSyncConfig(
-            enabled: true, baseURL: "https://api.corveil.io",
-            apiKeyRef: "op://vault/corveil/key", enabledWorkspaces: ["ws1"],
-            retentionDays: 14, quietPeriodMinutes: 10, maxUploadBytes: 1_000_000)
+        let c = LogSyncConfig(retentionDays: 14, quietPeriodMinutes: 10, maxUploadBytes: 1_000_000)
         let data = try JSONEncoder().encode(c)
         let decoded = try JSONDecoder().decode(LogSyncConfig.self, from: data)
         #expect(decoded == c)
     }
 
     @Test func tolerantDecodeOfPartialBlock() throws {
-        // An older config.json with only some keys still decodes to defaults.
-        let json = #"{"enabled": true, "baseURL": "https://x"}"#
+        // An older config.json with only some knobs still decodes to defaults.
+        let json = #"{"retentionDays": 7}"#
         let decoded = try JSONDecoder().decode(LogSyncConfig.self, from: Data(json.utf8))
-        #expect(decoded.enabled)
-        #expect(decoded.baseURL == "https://x")
-        #expect(decoded.retentionDays == 30) // defaulted
-        #expect(decoded.maxUploadBytes == 8_000_000)
+        #expect(decoded.retentionDays == 7)
+        #expect(decoded.quietPeriodMinutes == 30) // defaulted
+        #expect(decoded.maxUploadBytes == 8_000_000) // defaulted
+    }
+
+    @Test func decodeIgnoresRemovedKeysAndReEncodeDropsThem() throws {
+        // A config written before CROW-1070 still carries the removed keys. They
+        // must decode without error (ignored) and NOT survive a re-encode, so the
+        // slim block replaces them on the next save.
+        let json = #"""
+        {"enabled": true, "baseURL": "https://x", "apiKeyRef": "op://v/k",
+         "enabledWorkspaces": ["ws1"], "retentionDays": 14}
+        """#
+        let decoded = try JSONDecoder().decode(LogSyncConfig.self, from: Data(json.utf8))
+        #expect(decoded.retentionDays == 14) // the one surviving knob
+        let reencoded = try JSONEncoder().encode(decoded)
+        let obj = try JSONSerialization.jsonObject(with: reencoded) as? [String: Any]
+        #expect(obj?.keys.sorted() == ["maxUploadBytes", "quietPeriodMinutes", "retentionDays"])
+        #expect(obj?["enabled"] == nil)
+        #expect(obj?["baseURL"] == nil)
+        #expect(obj?["apiKeyRef"] == nil)
+        #expect(obj?["enabledWorkspaces"] == nil)
     }
 
     @Test func appConfigRoundTripsLogSyncAndDefaultsToNil() throws {
-        // Absent block decodes to nil (collector inert) and re-encodes without it.
+        // Absent block decodes to nil (all-default knobs) and re-encodes without it.
         let bare = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
         #expect(bare.logSync == nil)
 
         var c = AppConfig()
-        c.logSync = LogSyncConfig(enabled: true, baseURL: "https://api", apiKeyRef: "op://v/k")
+        c.logSync = LogSyncConfig(retentionDays: 14)
         let data = try JSONEncoder().encode(c)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.logSync == c.logSync)
     }
 }
 
-/// The log-sync block is local-only: its API key is stripped for the browser and
-/// the whole block is restored from the stored config on a set-config round-trip.
+/// Since CROW-1070 the `logSync` block holds only behavior knobs — no credential,
+/// no opt-in — so it is an ordinary, browser-editable config block: NOT stripped
+/// for transport and NOT restored from the stored config on a set-config
+/// round-trip (unlike the gateways/tokens, which are).
 @Suite struct LogSyncSecretsTests {
-    @Test func apiKeyStrippedForTransport() {
+    @Test func blockIsNotStrippedForTransport() {
         var c = AppConfig()
-        c.logSync = LogSyncConfig(enabled: true, baseURL: "https://api", apiKeyRef: "op://v/k",
-                                  enabledWorkspaces: ["ws1"])
+        c.logSync = LogSyncConfig(retentionDays: 14, quietPeriodMinutes: 10, maxUploadBytes: 1_000_000)
         let stripped = SettingsSecrets.strippedForTransport(c)
-        #expect(stripped.logSync?.apiKeyRef == "")
-        // Non-secret fields still visible read-only.
-        #expect(stripped.logSync?.enabled == true)
-        #expect(stripped.logSync?.baseURL == "https://api")
-        #expect(stripped.logSync?.enabledWorkspaces == ["ws1"])
+        // The knobs reach the browser intact — there is nothing secret to blank.
+        #expect(stripped.logSync == c.logSync)
     }
 
-    @Test func setConfigCannotChangeLogSync() {
+    @Test func setConfigCanChangeLogSync() {
         var stored = AppConfig()
-        stored.logSync = LogSyncConfig(enabled: true, baseURL: "https://api",
-                                       apiKeyRef: "op://v/k", enabledWorkspaces: ["ws1"])
-        // A hostile/edited browser config trying to enable an extra workspace and
-        // plant a plaintext key.
+        stored.logSync = LogSyncConfig(retentionDays: 30)
+        // The browser edits a knob and saves — the incoming value wins (the block
+        // is not restored from `current`).
         var incoming = AppConfig()
-        incoming.logSync = LogSyncConfig(enabled: true, baseURL: "https://evil",
-                                         apiKeyRef: "plaintext-stolen",
-                                         enabledWorkspaces: ["ws1", "ws2"])
+        incoming.logSync = LogSyncConfig(retentionDays: 90, quietPeriodMinutes: 5)
         let result = SettingsSecrets.preservingSecrets(incoming: incoming, current: stored)
-        #expect(result.logSync == stored.logSync) // stored wins entirely
+        #expect(result.logSync == incoming.logSync)
     }
 
-    @Test func roundTripIsNoOp() {
+    @Test func roundTripPreservesKnobs() {
         var c = AppConfig()
-        c.logSync = LogSyncConfig(enabled: true, baseURL: "https://api", apiKeyRef: "op://v/k")
+        c.logSync = LogSyncConfig(retentionDays: 90, quietPeriodMinutes: 15, maxUploadBytes: 4_000_000)
         let restored = SettingsSecrets.preservingSecrets(
             incoming: SettingsSecrets.strippedForTransport(c), current: c)
         #expect(restored.logSync == c.logSync)

--- a/Packages/CrowCore/Tests/CrowCoreTests/LogSyncMigrationTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/LogSyncMigrationTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import CrowCore
+
+@Suite struct LogSyncMigrationTests {
+    /// Raw config JSON with a legacy `logSync` block, plus one workspace.
+    private func rawConfig(logSyncJSON: String, workspaceName: String = "Corveil") -> Data {
+        Data(#"""
+        {"workspaces": [{"id": "\#(UUID().uuidString)", "name": "\#(workspaceName)",
+          "provider": "github", "cli": "gh"}],
+         "logSync": \#(logSyncJSON)}
+        """#.utf8)
+    }
+
+    private func decoded(_ raw: Data) throws -> AppConfig {
+        try JSONDecoder().decode(AppConfig.self, from: raw)
+    }
+
+    @Test func migratesEnabledWorkspacesWhenMasterSwitchWasOn() throws {
+        let raw = rawConfig(logSyncJSON: #"""
+        {"enabled": true, "baseURL": "https://api", "apiKeyRef": "op://v/k",
+         "enabledWorkspaces": ["corveil"]}
+        """#)
+        let config = try decoded(raw)
+        #expect(config.workspaces[0].uploadSessionLogs == false) // legacy list, not the flag
+
+        let migrated = try #require(LogSyncMigration.migrate(config: config, rawJSON: raw))
+        #expect(migrated.workspaces[0].uploadSessionLogs == true) // folded in (case-insensitive)
+    }
+
+    @Test func doesNotEnableWhenMasterSwitchWasOff() throws {
+        // A workspace listed but with `enabled: false` uploaded nothing before, so
+        // the migration must not silently turn it on.
+        let raw = rawConfig(logSyncJSON: #"""
+        {"enabled": false, "enabledWorkspaces": ["Corveil"]}
+        """#)
+        let config = try decoded(raw)
+        let migrated = try #require(LogSyncMigration.migrate(config: config, rawJSON: raw))
+        #expect(migrated.workspaces[0].uploadSessionLogs == false)
+    }
+
+    @Test func firesOnAnyRemovedKeyEvenWithoutList() throws {
+        // A block carrying only a removed key (no `enabledWorkspaces`) still fires,
+        // so the re-encode drops the dead key — but changes no opt-in.
+        let raw = rawConfig(logSyncJSON: #"{"baseURL": "https://api"}"#)
+        let config = try decoded(raw)
+        let migrated = try #require(LogSyncMigration.migrate(config: config, rawJSON: raw))
+        #expect(migrated.workspaces[0].uploadSessionLogs == false)
+    }
+
+    @Test func slimBlockIsANoOp() throws {
+        // A config already on the slim shape has no removed key → nothing to do.
+        let raw = rawConfig(logSyncJSON: #"{"retentionDays": 14, "quietPeriodMinutes": 30, "maxUploadBytes": 8000000}"#)
+        let config = try decoded(raw)
+        #expect(LogSyncMigration.migrate(config: config, rawJSON: raw) == nil)
+    }
+
+    @Test func absentBlockIsANoOp() throws {
+        let raw = Data(#"""
+        {"workspaces": [{"id": "\#(UUID().uuidString)", "name": "Corveil",
+          "provider": "github", "cli": "gh"}]}
+        """#.utf8)
+        let config = try decoded(raw)
+        #expect(LogSyncMigration.migrate(config: config, rawJSON: raw) == nil)
+    }
+
+    @Test func isIdempotentAcrossReEncode() throws {
+        // Migrate → encode (slim) → decode → migrate again is a no-op: the removed
+        // keys are gone after the first save, so the second pass returns nil.
+        let raw = rawConfig(logSyncJSON: #"""
+        {"enabled": true, "enabledWorkspaces": ["Corveil"], "retentionDays": 14}
+        """#)
+        let config = try decoded(raw)
+        let migrated = try #require(LogSyncMigration.migrate(config: config, rawJSON: raw))
+        #expect(migrated.workspaces[0].uploadSessionLogs == true)
+        #expect(migrated.logSync?.retentionDays == 14) // knob preserved
+
+        let reencoded = try JSONEncoder().encode(migrated)
+        let reloaded = try JSONDecoder().decode(AppConfig.self, from: reencoded)
+        #expect(LogSyncMigration.migrate(config: reloaded, rawJSON: reencoded) == nil)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
@@ -92,26 +92,24 @@ import CrowCore
         #expect(merged == current)
     }
 
-    /// CROW-1066: the per-workspace `uploadSessionLogs` opt-in rides on the
-    /// workspace record (not the local-only `logSync` block), so a browser edit of
-    /// it must survive `preservingSecrets` — unlike the `logSync` block, which is
-    /// always restored from `current`. This is the intended, bounded relaxation:
-    /// the checkbox is browser-flippable; the credential and master switch are not.
-    @Test func preservingKeepsBrowserToggleOfUploadSessionLogsButNotLogSyncBlock() {
+    /// CROW-1066/1070: the per-workspace `uploadSessionLogs` opt-in rides on the
+    /// workspace record and survives `preservingSecrets` (browser-flippable). Since
+    /// CROW-1070 the `logSync` block holds only non-secret behavior knobs, so it is
+    /// ALSO browser-writable — the browser's edit wins rather than being restored
+    /// from `current`. Neither can leak or redirect a credential (both the upload
+    /// credential and destination are the per-workspace gateway).
+    @Test func preservingKeepsBrowserEditsToUploadOptInAndLogSyncKnobs() {
         let wsID = UUID()
         var current = configWithSecrets(workspaceID: wsID)
-        current.logSync = LogSyncConfig(enabled: true, baseURL: "https://api.corveil.io",
-                                        apiKeyRef: "op://vault/corveil/key")
+        current.logSync = LogSyncConfig(retentionDays: 30)
 
         var incoming = SettingsSecrets.strippedForTransport(current)
-        incoming.workspaces[0].uploadSessionLogs = true  // browser ticks the checkbox
-        // A browser trying to change the local-only master switch must be ignored.
-        incoming.logSync = LogSyncConfig(enabled: true, baseURL: "https://evil.example",
-                                         apiKeyRef: "evil", enabledWorkspaces: ["ws"])
+        incoming.workspaces[0].uploadSessionLogs = true                             // browser ticks the checkbox
+        incoming.logSync = LogSyncConfig(retentionDays: 90, quietPeriodMinutes: 5)  // browser tunes a knob
 
         let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
         #expect(merged.workspaces[0].uploadSessionLogs == true)  // browser edit kept
-        #expect(merged.logSync == current.logSync)               // local-only block restored, not the browser's
+        #expect(merged.logSync == incoming.logSync)              // browser knobs win (no longer restored)
     }
 
     @Test func preserveIgnoresBrowserCredentialEdits() {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -381,9 +381,13 @@ public enum CrowDaemon {
             appState: appState, devRoot: options.devRoot)
 
         // Drive the session-log collector (CROW-1056). Opt-in and default OFF —
-        // the tick is a cheap no-op until `logSync` is enabled with an opted-in
-        // workspace. Terminal-independent (it reads harness log files off disk),
-        // so it runs whenever `crowd` runs.
+        // the tick is a cheap no-op until a workspace ticks `uploadSessionLogs`
+        // and has a gateway to reuse. Terminal-independent (it reads harness log
+        // files off disk), so it runs whenever `crowd` runs.
+        //
+        // First carry any legacy global `logSync` opt-in over to the per-workspace
+        // checkbox (CROW-1070), once, under the config lock before the poll starts.
+        ConfigStore.migrateLogSyncAtBoot(devRoot: options.devRoot)
         startLogSyncPoll(appState: appState, devRoot: options.devRoot)
 
         // Wire the IssueTracker's config-flag providers and its notification-only

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
@@ -11,8 +11,9 @@ import CrowPersistence
 /// with the session's metadata attached.
 ///
 /// Design guarantees:
-/// - **Opt-in, default OFF.** Nothing uploads unless `logSync.enabled` is true
-///   *and* the session's workspace is listed in `logSync.enabledWorkspaces`.
+/// - **Opt-in, default OFF.** Nothing uploads unless a session's workspace ticks
+///   `uploadSessionLogs` **and** that workspace has a `gateway` to reuse (the
+///   upload destination + credential come from it — CROW-1070).
 /// - **Non-blocking / best-effort.** This runs entirely off the session
 ///   lifecycle; a failed or slow upload never delays or fails a session. One
 ///   retry inside the uploader, then the ledger records and (for transient
@@ -47,29 +48,16 @@ struct LogSyncCollector {
     /// One collection pass. Reads config fresh so a Settings edit applies within
     /// one tick.
     func sweep(appState: AppState) async {
-        guard let appConfig = ConfigStore.loadConfig(devRoot: devRoot),
-              let config = appConfig.logSync,
-              config.enabled
-        else { return }
-        // Cheap exit before touching the store or disk: nothing opted in via
-        // either surface — the per-workspace checkbox (CROW-1066) or the legacy,
-        // local-only `enabledWorkspaces` list.
-        let anyWorkspaceOptIn = appConfig.workspaces.contains { $0.uploadSessionLogs }
-        guard anyWorkspaceOptIn || !config.enabledWorkspaces.isEmpty else { return }
+        guard let appConfig = ConfigStore.loadConfig(devRoot: devRoot) else { return }
+        // Behavior tuning only (retention / quiet period / upload cap); an absent
+        // block means all-default knobs (CROW-1070).
+        let config = appConfig.logSync ?? LogSyncConfig()
 
-        // The upload destination is the local-only, operator-set `logSync.baseURL`
-        // — deliberately NOT the browser-flippable `corveilHost` (CROW-1066): a
-        // remote peer who can tick the per-workspace checkbox must not also be able
-        // to redirect a credential-bearing upload to a host it chose. Empty ⇒ off.
-        let baseURL = config.baseURL.trimmingCharacters(in: .whitespaces)
-        guard !baseURL.isEmpty else {
-            LogSyncLog.warnOnce("log-sync enabled but logSync.baseURL is empty; nothing will upload")
-            return
-        }
-        // Global Corveil key (may be nil): authenticates the legacy list path and
-        // is the fallback when a per-workspace opt-in has no reusable gateway
-        // credential. Resolved once per sweep.
-        let globalAPIKey = resolveAPIKey(config.apiKeyRef)
+        // Cheap exit before touching the store or disk: nothing opted in. Since
+        // CROW-1070 the sole opt-in is the per-workspace `uploadSessionLogs`
+        // checkbox — the legacy global master switch and `enabledWorkspaces` list
+        // are gone (a legacy opt-in is migrated to this flag at boot).
+        guard appConfig.workspaces.contains(where: { $0.uploadSessionLogs }) else { return }
 
         // Snapshot the live sessions + their worktrees on the main actor, then do
         // all filesystem/network work off it.
@@ -90,29 +78,24 @@ struct LogSyncCollector {
             guard let workspaceName = SessionService.workspaceName(
                     forWorktreePath: worktree.worktreePath, devRoot: devRoot)
             else { continue }
-            let workspace = appConfig.workspaces.first {
+            // The per-workspace checkbox is the whole opt-in (matched
+            // case-insensitively, like every other workspace lookup).
+            guard let workspace = appConfig.workspaces.first(where: {
                 $0.name.lowercased() == workspaceName.lowercased()
-            }
+            }), workspace.uploadSessionLogs else { continue }
 
-            // Opt-in via either surface: the per-workspace checkbox (CROW-1066) or
-            // the legacy `enabledWorkspaces` list (matched case-insensitively).
-            let optedInViaWorkspace = workspace?.uploadSessionLogs == true
-            guard optedInViaWorkspace || config.uploadsWorkspace(workspaceName) else { continue }
-
-            // Reuse the workspace's own gateway credential when it opted in that way
-            // (CROW-1066) so the operator never re-enters a Corveil key; otherwise
-            // fall back to the global `logSync` key.
-            let resolvedKey: String? = {
-                if optedInViaWorkspace, let gateway = workspace?.gateway, !gateway.isEmpty,
-                   let key = Self.corveilAPIKey(from: gateway, resolveSecret: resolveSecret) {
-                    return key
-                }
-                return globalAPIKey
-            }()
-            guard let apiKey = resolvedKey else {
-                LogSyncLog.warnOnce("log-sync: no Corveil API key for workspace \"\(workspaceName)\" (no reusable gateway credential and no global logSync.apiKeyRef); skipping")
+            // Destination + credential come SOLELY from this workspace's local-only
+            // `gateway` (CROW-1070) — never the browser-flippable `corveilHost` or
+            // any other web-writable field, so a remote peer who ticked the checkbox
+            // cannot redirect a credential-bearing upload to a host it chose. No
+            // gateway (or no resolvable key / blank base URL) ⇒ nothing to reuse ⇒
+            // skip. This is the security invariant, asserted in the tests.
+            guard let upload = Self.resolvedUpload(for: workspace, resolveSecret: resolveSecret) else {
+                LogSyncLog.warnOnce("log-sync: workspace \"\(workspaceName)\" opted in but has no reusable Corveil gateway (needs a base URL and an x-citadel-api-key); skipping")
                 continue
             }
+            let baseURL = upload.baseURL
+            let apiKey = upload.apiKey
 
             let harness = LogSyncHarness(agentKind: session.agentKind)
             let kind = LogSyncArtifactKind.sessionTranscript
@@ -177,15 +160,29 @@ struct LogSyncCollector {
 
     // MARK: - Pure helpers (unit-tested)
 
-    /// Resolve an API key reference: `op://…` via `resolveSecret`, otherwise the
-    /// literal value. Returns nil for a blank ref or a failed `op` read.
-    func resolveAPIKey(_ ref: String) -> String? {
-        Self.resolveRef(ref, resolveSecret: resolveSecret)
+    /// The upload destination + credential for a workspace, derived **solely** from
+    /// its local-only `gateway` (CROW-1070). This is the security invariant: the
+    /// destination is `{gateway.baseURL}/api/crow-sessions/…` and the credential is
+    /// the gateway's Corveil key — never `corveilHost` or any other browser-writable
+    /// field, so a remote peer who ticked the `uploadSessionLogs` checkbox cannot
+    /// redirect a credential-bearing upload.
+    ///
+    /// Returns `nil` — meaning "upload nothing" — when the workspace has no gateway,
+    /// the gateway carries no resolvable Corveil key, or its base URL is blank. A
+    /// browser-writable field alone can therefore never produce an upload.
+    static func resolvedUpload(
+        for workspace: WorkspaceInfo, resolveSecret: (String) -> String?
+    ) -> (baseURL: String, apiKey: String)? {
+        guard let gateway = workspace.gateway, !gateway.isEmpty else { return nil }
+        let baseURL = gateway.baseURL.trimmingCharacters(in: .whitespaces)
+        guard !baseURL.isEmpty else { return nil }
+        guard let apiKey = corveilAPIKey(from: gateway, resolveSecret: resolveSecret) else { return nil }
+        return (baseURL, apiKey)
     }
 
     /// Resolve an `op://…` reference (via `resolveSecret`) or return a plaintext
-    /// value literally. Nil for a blank ref or a failed `op` read. Shared by the
-    /// global-key and per-workspace gateway-credential paths (CROW-1066).
+    /// value literally. Nil for a blank ref or a failed `op` read. Used by the
+    /// per-workspace gateway-credential path (CROW-1066).
     static func resolveRef(_ ref: String, resolveSecret: (String) -> String?) -> String? {
         let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2504,83 +2504,47 @@ private func mutateConfig<T>(devRoot: String, _ transform: (inout AppConfig) thr
     }
 }
 
-/// `logsync-get` (CROW-1056): echo the session-log collector block. `reveal`
-/// unmasks a plaintext API key (an `op://…` reference is always shown — it is a
-/// pointer, not the secret).
+/// `logsync-get` (CROW-1056; slimmed in CROW-1070): echo the session-log
+/// collector's behavior knobs. No secret to reveal any more — the credential and
+/// destination are per-workspace on the gateway.
 private func logsyncGetHandler(params: [String: JSONValue], devRoot: String) -> [String: JSONValue] {
-    let reveal = params["reveal"]?.boolValue ?? false
     let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-    return ["logsync": SettingsRPC.logsyncJSON(config.logSync, reveal: reveal)]
+    return ["logsync": SettingsRPC.logsyncJSON(config.logSync)]
 }
 
-/// `logsync-set` (CROW-1056): PATCH the session-log collector block. Extracted
-/// from the handler dictionary so the big literal stays inside the type-checker's
-/// budget. Local-only (gated in `RPCWebSocketHandler.localOnlyDenial`).
+/// `logsync-set` (CROW-1056; slimmed in CROW-1070): PATCH the session-log
+/// collector's behavior knobs. Extracted from the handler dictionary so the big
+/// literal stays inside the type-checker's budget. No longer local-only — the
+/// block carries no credential and no opt-in (both are per-workspace via the
+/// gateway), so it is an ordinary config write, like `telemetry-set`.
 private func logsyncSetHandler(params: [String: JSONValue], devRoot: String) async throws -> [String: JSONValue] {
     try await mapRPCError {
-        let enabled = try SettingsRPC.patchBool(params, "enabled")
-        let baseURL = try SettingsRPC.patchStringAllowingEmpty(params, "base_url")
-        let apiKeyRef = try SettingsRPC.patchStringAllowingEmpty(params, "api_key_ref")
         let retentionDays = try SettingsRPC.patchBoundedInt(params, "retention_days", min: 0)
         let quietPeriod = try SettingsRPC.patchBoundedInt(params, "quiet_period_minutes", min: 0)
         let maxUploadBytes = try SettingsRPC.patchBoundedInt(params, "max_upload_bytes", min: 1)
-        let addWorkspaces = try SettingsRPC.patchStringList(params, "add_workspaces")
-        let removeWorkspaces = try SettingsRPC.patchStringList(params, "remove_workspaces")
-        let clearWorkspaces = try SettingsRPC.patchBool(params, "clear_workspaces") ?? false
 
-        let anySet = enabled != nil || baseURL != nil || apiKeyRef != nil
-            || retentionDays != nil || quietPeriod != nil || maxUploadBytes != nil
-            || addWorkspaces != nil || removeWorkspaces != nil || clearWorkspaces
+        let anySet = retentionDays != nil || quietPeriod != nil || maxUploadBytes != nil
         guard anySet else {
             throw RPCError.invalidParams(
-                "Nothing to set — provide at least one of enabled, base_url, api_key_ref, "
-                + "retention_days, quiet_period_minutes, max_upload_bytes, "
-                + "add_workspaces, remove_workspaces, clear_workspaces.")
+                "Nothing to set — provide at least one of retention_days, "
+                + "quiet_period_minutes, max_upload_bytes.")
         }
 
         let logSync: LogSyncConfig = try mutateConfig(devRoot: devRoot) { config in
             var block = config.logSync ?? LogSyncConfig()
-            if let enabled { block.enabled = enabled }
-            if let baseURL { block.baseURL = baseURL }
-            if let apiKeyRef { block.apiKeyRef = apiKeyRef }
             if let retentionDays { block.retentionDays = retentionDays }
             if let quietPeriod { block.quietPeriodMinutes = quietPeriod }
             if let maxUploadBytes { block.maxUploadBytes = maxUploadBytes }
-            block.enabledWorkspaces = editedWorkspaceList(
-                current: block.enabledWorkspaces,
-                clear: clearWorkspaces, remove: removeWorkspaces, add: addWorkspaces)
             config.logSync = block
             return block
         }
         // The collector re-reads config from disk every tick, so this takes
         // effect within ~5 min — no restart.
         return [
-            "logsync": SettingsRPC.logsyncJSON(logSync, reveal: true),
+            "logsync": SettingsRPC.logsyncJSON(logSync),
             "saved": .bool(true),
         ]
     }
-}
-
-/// Apply clear/remove/add to a workspace opt-in list, case-insensitively and
-/// de-duplicated (clear first, then remove, then add — `defaults set` semantics).
-private func editedWorkspaceList(
-    current: [String], clear: Bool, remove: [String]?, add: [String]?
-) -> [String] {
-    var list = clear ? [] : current
-    if let remove, !remove.isEmpty {
-        let drop = Set(remove.map { $0.lowercased() })
-        list = list.filter { !drop.contains($0.lowercased()) }
-    }
-    if let add {
-        for name in add {
-            let trimmed = name.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty,
-                  !list.contains(where: { $0.lowercased() == trimmed.lowercased() })
-            else { continue }
-            list.append(trimmed)
-        }
-    }
-    return list
 }
 
 /// Like ``mutateConfig(devRoot:_:)`` but skips the disk write when `transform`

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -336,13 +336,6 @@ enum RPCWebSocketHandler {
         case "gateway-get", "gateway-set", "web-password-get", "web-password-set":
             // Secret reads *and* writes (CROW-815) — see the doc comment above.
             return "gateway and web-password management is local-only"
-        case "logsync-get", "logsync-set":
-            // Session-log collector (CROW-1056). `logsync-set` enables uploading
-            // developers' session transcripts off the daemon host and carries a
-            // Corveil API-key reference; `logsync-get` can reveal it. Both configure
-            // an upload capability from the host, so — like `gateway-*` — they are
-            // loopback-only. The opt-in must never be flippable by a remote peer.
-            return "session-log sync management is local-only"
         case "mcp-token-list", "mcp-token-mint", "mcp-token-revoke":
             // MCP bearer tokens (CROW-1004). `mcp-token-mint` returns the plaintext
             // token exactly once, so a remote peer that could call it would be

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -633,6 +633,22 @@
     body.appendChild(selectField('Retention', cfg.cleanup, 'retentionHours', [
       [1, '1 hour'], [4, '4 hours'], [8, '8 hours'], [24, '1 day'], [72, '3 days'], [168, '7 days'], [720, '30 days'],
     ], { number: true }));
+
+    // Session-log upload tuning (CROW-1070). Global collector behavior only —
+    // per-workspace opt-in (and the reused Corveil gateway) live on each workspace
+    // under Settings → Workspaces. No credential here.
+    cfg.logSync = cfg.logSync || {};
+    body.appendChild(group('Session logs'));
+    body.appendChild(el('div', 'st-help',
+      'Timing and size limits for the session-transcript upload. Opt a workspace in — and configure its AI gateway — under Settings → Workspaces.'));
+    body.appendChild(selectField('Quiet period', cfg.logSync, 'quietPeriodMinutes', [
+      [5, '5 minutes'], [15, '15 minutes'], [30, '30 minutes (default)'], [60, '1 hour'], [120, '2 hours'],
+    ], { number: true, help: 'Wait this long after a session’s last activity before capturing its transcript (a session is uploaded once, when quiescent).' }));
+    body.appendChild(selectField('Ledger retention', cfg.logSync, 'retentionDays', [
+      [30, '30 days (default)'], [90, '90 days'], [180, '6 months'], [365, '1 year'], [0, 'Forever'],
+    ], { number: true, help: 'How long the local upload ledger keeps a record of each session before pruning.' }));
+    body.appendChild(textField('Max upload size (bytes)', cfg.logSync, 'maxUploadBytes',
+      { number: true, type: 'number', help: 'Per-transcript upload cap (default 8000000). Larger transcripts are truncated and flagged.' }));
   }
 
   // Path + Verify + Reinstall skill for the Corveil CLI (CROW-1011).
@@ -1635,12 +1651,12 @@
       }));
     }
 
-    // Session-log upload opt-in (CROW-1066). A plain workspace field, so it
-    // round-trips through the normal Save (`set-config`) — unlike the gateway
-    // above, which is local-only. The upload REUSES this workspace's gateway
+    // Session-log upload opt-in (CROW-1066; sole opt-in since CROW-1070). A plain
+    // workspace field, so it round-trips through the normal Save (`set-config`).
+    // The upload REUSES this workspace's gateway for BOTH destination and
     // credential, so the checkbox is meaningful only when a gateway is set:
-    // disabled with a tooltip otherwise. The global master switch / base URL /
-    // API key stay on the local-only `logSync` block (`crow logsync`).
+    // disabled with a tooltip otherwise. There is no separate master switch — a
+    // ticked box plus a configured gateway is the whole opt-in.
     body.appendChild(group('Session logs'));
     const hasGateway = !!(d.gateway && (d.gateway.baseURL
       || (d.gateway.customHeaders && Object.keys(d.gateway.customHeaders).length)));
@@ -1649,15 +1665,15 @@
     slCb.type = 'checkbox';
     slCb.checked = !!d.uploadSessionLogs;
     slCb.disabled = !hasGateway;
-    if (!hasGateway) slRow.title = 'Configure a Corveil gateway first — the upload reuses its credential.';
+    if (!hasGateway) slRow.title = 'Turn on the AI Gateway for this workspace first — the upload reuses its URL and credential.';
     slCb.onchange = () => { d.uploadSessionLogs = slCb.checked; markDirty(); };
     slRow.appendChild(slCb);
     slRow.appendChild(el('span', 'st-switch-label', 'Upload session transcripts to Corveil'));
     const slField = el('div', 'st-field');
     slField.appendChild(slRow);
     slField.appendChild(el('div', 'st-help', hasGateway
-      ? 'Uploads this workspace’s coding-session transcripts to Corveil, reusing its gateway credential (no second key needed). Also requires the local-only log-sync master switch — enable it on the daemon host with `crow logsync set --enabled true`.'
-      : 'Configure a Corveil gateway above first — the upload reuses its credential.'));
+      ? 'Uploads this workspace’s coding-session transcripts to Corveil, reusing its AI-gateway URL and credential (no second key or host needed). That’s the only setting required — collector timing and size limits live under Settings → General → Session logs.'
+      : 'Turn on the AI Gateway for this workspace above first — the upload reuses its URL and credential.'));
     body.appendChild(slField);
   }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -974,20 +974,17 @@ import CrowPersistence
                 == "MCP token management is local-only")
         }
     }
-    @Test func logsyncMethodsAreLocalOnly() {
-        // `logsync-set` enables uploading developers' session transcripts off the
-        // host and carries a Corveil API-key reference; `logsync-get` can reveal
-        // it. A remote peer must not be able to flip the opt-in or read the key,
-        // so both are gated like the gateway/MCP-token surfaces (CROW-1056). This
-        // regression test is what stops a refactor silently dropping either method
-        // from the `localOnlyDenial` switch.
+    @Test func logsyncMethodsAreNotLocalOnly() {
+        // CROW-1070 removed the credential + opt-in from the `logSync` block — it
+        // now holds only behavior knobs (retention / quiet period / upload cap), and
+        // both the upload credential and destination are the per-workspace gateway.
+        // So, unlike the gateway / MCP-token surfaces, `logsync-*` is an ordinary
+        // config surface reachable remotely (that's what backs the web Settings →
+        // General → Session logs section). This regression test stops a refactor
+        // re-adding a local-only gate that would break that section.
         for method in ["logsync-get", "logsync-set"] {
-            let req = JSONRPCRequest(id: 1, method: method, params: [
-                "enabled": .bool(true),
-                "api_key_ref": .string("plaintext-would-be-stolen"),
-            ])
-            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
-                == "session-log sync management is local-only")
+            let req = JSONRPCRequest(id: 1, method: method, params: ["retention_days": .int(14)])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot()) == nil)
         }
     }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
@@ -4,10 +4,6 @@ import CrowCore
 @testable import CrowDaemon
 
 @Suite struct LogSyncCollectorTests {
-    private func collector(resolveSecret: @escaping (String) -> String? = { _ in nil }) -> LogSyncCollector {
-        LogSyncCollector(devRoot: "/tmp/does-not-matter", resolveSecret: resolveSecret)
-    }
-
     private func tempDir() throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("logsync-collector-\(UUID().uuidString)", isDirectory: true)
@@ -15,20 +11,90 @@ import CrowCore
         return dir
     }
 
-    // MARK: API key resolution
+    // MARK: Reference resolution (op:// vs plaintext)
 
-    @Test func resolvesPlaintextKeyLiterally() {
-        #expect(collector().resolveAPIKey("sk-citadel-abc") == "sk-citadel-abc")
+    @Test func resolvesPlaintextRefLiterally() {
+        #expect(LogSyncCollector.resolveRef("sk-citadel-abc", resolveSecret: { _ in nil }) == "sk-citadel-abc")
     }
 
     @Test func resolvesOpReference() {
-        let c = collector { $0 == "op://vault/corveil/key" ? "RESOLVED" : nil }
-        #expect(c.resolveAPIKey("op://vault/corveil/key") == "RESOLVED")
+        let key = LogSyncCollector.resolveRef("op://vault/corveil/key") { $0 == "op://vault/corveil/key" ? "RESOLVED" : nil }
+        #expect(key == "RESOLVED")
     }
 
-    @Test func blankOrUnresolvableKeyIsNil() {
-        #expect(collector().resolveAPIKey("   ") == nil)
-        #expect(collector { _ in nil }.resolveAPIKey("op://missing") == nil)
+    @Test func blankOrUnresolvableRefIsNil() {
+        #expect(LogSyncCollector.resolveRef("   ", resolveSecret: { _ in nil }) == nil)
+        #expect(LogSyncCollector.resolveRef("op://missing", resolveSecret: { _ in nil }) == nil)
+    }
+
+    // MARK: Upload destination + credential come ONLY from the gateway (CROW-1070)
+
+    /// An opted-in Corveil workspace, optionally with a (browser-writable)
+    /// `corveilHost` set to prove it can't influence the upload destination.
+    private func corveilWorkspace(
+        gateway: WorkspaceGateway?, corveilHost: String? = nil
+    ) -> WorkspaceInfo {
+        WorkspaceInfo(name: "Corveil", corveilHost: corveilHost,
+                      uploadSessionLogs: true, gateway: gateway)
+    }
+
+    @Test func resolvedUploadComesFromTheGateway() {
+        let gw = WorkspaceGateway(
+            baseURL: "https://corveil.io",
+            customHeaders: ["x-citadel-api-key": "Bearer sk-real"])
+        let upload = LogSyncCollector.resolvedUpload(
+            for: corveilWorkspace(gateway: gw), resolveSecret: { _ in nil })
+        #expect(upload?.baseURL == "https://corveil.io")
+        #expect(upload?.apiKey == "sk-real") // Bearer stripped for the uploader to re-wrap
+    }
+
+    @Test func browserWritableCorveilHostCannotRedirectTheUpload() {
+        // THE security invariant: a hostile `corveilHost` (browser-flippable) must
+        // not change where a credential-bearing upload goes. The destination is the
+        // local-only gateway, full stop.
+        let gw = WorkspaceGateway(
+            baseURL: "https://corveil.io",
+            customHeaders: ["x-citadel-api-key": "Bearer sk-real"])
+        let ws = corveilWorkspace(gateway: gw, corveilHost: "https://evil.example")
+        let upload = LogSyncCollector.resolvedUpload(for: ws, resolveSecret: { _ in nil })
+        #expect(upload?.baseURL == "https://corveil.io")
+        #expect(upload?.baseURL.contains("evil") == false)
+    }
+
+    @Test func noGatewayResolvesToNilEvenWithCorveilHost() {
+        // A browser-writable field alone can never supply an upload destination:
+        // with no gateway to reuse, `resolvedUpload` is nil and nothing uploads.
+        let ws = corveilWorkspace(gateway: nil, corveilHost: "https://evil.example")
+        #expect(LogSyncCollector.resolvedUpload(for: ws, resolveSecret: { _ in nil }) == nil)
+    }
+
+    @Test func emptyGatewayOrMissingKeyResolvesToNil() {
+        // An empty gateway has nothing to reuse.
+        #expect(LogSyncCollector.resolvedUpload(
+            for: corveilWorkspace(gateway: WorkspaceGateway(baseURL: "", customHeaders: [:])),
+            resolveSecret: { _ in nil }) == nil)
+        // A gateway with a base URL but no recognizable Corveil key can't authenticate.
+        let noKey = WorkspaceGateway(baseURL: "https://corveil.io", customHeaders: ["X-Other": "v"])
+        #expect(LogSyncCollector.resolvedUpload(
+            for: corveilWorkspace(gateway: noKey), resolveSecret: { _ in nil }) == nil)
+    }
+
+    @Test func corveilHostIsBrowserWritableButDoesNotAffectTheDestination() {
+        // End-to-end: a browser CAN change `corveilHost` through the normal
+        // set-config round-trip, yet that never touches the gateway-derived upload
+        // destination (the gateway itself is restored from the stored config).
+        let gw = WorkspaceGateway(
+            baseURL: "https://corveil.io",
+            customHeaders: ["x-citadel-api-key": "Bearer sk-real"])
+        let stored = AppConfig(workspaces: [corveilWorkspace(gateway: gw, corveilHost: "https://corveil.io")])
+        var incoming = stored
+        incoming.workspaces[0].corveilHost = "https://evil.example" // browser flips it
+        let merged = SettingsSecrets.preservingSecrets(
+            incoming: SettingsSecrets.strippedForTransport(incoming), current: stored)
+        #expect(merged.workspaces[0].corveilHost == "https://evil.example") // the field IS browser-writable
+        let upload = LogSyncCollector.resolvedUpload(
+            for: merged.workspaces[0], resolveSecret: { _ in nil })
+        #expect(upload?.baseURL == "https://corveil.io") // …but the upload host is unchanged
     }
 
     // MARK: Gateway credential reuse (CROW-1066)

--- a/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
@@ -165,27 +165,13 @@ public enum SettingsRPC {
         ])
     }
 
-    /// The session-log collector block (CROW-1056). The Corveil API-key reference
-    /// is shown only when `reveal` is set OR it is an `op://…` pointer (which is a
-    /// reference, not the secret); a plaintext key is masked. `api_key_set`
-    /// reports presence either way, and `configured` distinguishes an absent block
-    /// (`logSync == nil`, the collector inert) from an all-defaults one.
-    public static func logsyncJSON(_ logSync: LogSyncConfig?, reveal: Bool) -> JSONValue {
+    /// The session-log collector's behavior knobs (CROW-1056; slimmed in
+    /// CROW-1070). No credential and no opt-in list live here any more — both are
+    /// per-workspace via the gateway — so nothing is masked. `configured`
+    /// distinguishes an absent block (`logSync == nil`) from an all-defaults one.
+    public static func logsyncJSON(_ logSync: LogSyncConfig?) -> JSONValue {
         let cfg = logSync ?? LogSyncConfig()
-        let apiKeyDisplay: String
-        if cfg.apiKeyRef.isEmpty {
-            apiKeyDisplay = ""
-        } else if reveal || cfg.apiKeyRef.hasPrefix("op://") {
-            apiKeyDisplay = cfg.apiKeyRef
-        } else {
-            apiKeyDisplay = "<hidden>"
-        }
         return .object([
-            "enabled": .bool(cfg.enabled),
-            "base_url": .string(cfg.baseURL),
-            "api_key_ref": .string(apiKeyDisplay),
-            "api_key_set": .bool(!cfg.apiKeyRef.isEmpty),
-            "enabled_workspaces": stringArray(cfg.enabledWorkspaces),
             "retention_days": .int(cfg.retentionDays),
             "quiet_period_minutes": .int(cfg.quietPeriodMinutes),
             "max_upload_bytes": .int(cfg.maxUploadBytes),

--- a/Packages/CrowPersistence/Sources/CrowPersistence/ConfigStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/ConfigStore.swift
@@ -123,6 +123,33 @@ public final class ConfigStore: Sendable {
         return try body()
     }
 
+    // MARK: - One-shot migrations
+
+    /// Migrate a legacy global `logSync` opt-in to the per-workspace
+    /// `uploadSessionLogs` checkbox (CROW-1070), once, at daemon boot.
+    ///
+    /// Runs under the config-write lock, before the collector poll and RPC serving
+    /// start, so there is no writer to race. Reads the config file once; skips
+    /// silently if it is absent or undecodable (never overwriting a malformed
+    /// config with defaults, matching ``loadConfig``). Idempotent: once the removed
+    /// keys are dropped by the re-encode, ``LogSyncMigration/migrate(config:rawJSON:)``
+    /// returns `nil` and nothing is written.
+    public static func migrateLogSyncAtBoot(devRoot: String) {
+        withConfigLock {
+            let url = configURL(devRoot: devRoot)
+            guard let raw = try? Data(contentsOf: url),
+                  let config = try? JSONDecoder().decode(AppConfig.self, from: raw),
+                  let migrated = LogSyncMigration.migrate(config: config, rawJSON: raw)
+            else { return }
+            do {
+                try saveConfig(migrated, devRoot: devRoot)
+                CrowLog.info("[LogSyncMigration] carried a legacy logSync opt-in over to per-workspace uploadSessionLogs")
+            } catch {
+                CrowLog.info("[LogSyncMigration] failed to persist migrated config: \(error.localizedDescription)")
+            }
+        }
+    }
+
     // MARK: - Import from CMUX workspace-repos.json
 
     /// Import config from `~/.claude/workspace-repos.json` (legacy CMUX format).

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/ConfigStoreTests.swift
@@ -53,6 +53,56 @@ import Testing
     #expect(loaded?.coderViewAutoPermissionMode == false)
 }
 
+@Test func migrateLogSyncAtBootFoldsLegacyOptInAndDropsDeadKeys() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let claudeDir = tmpDir.appendingPathComponent(".claude", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+
+    // A pre-CROW-1070 config: the old master switch on, a workspace opted in via
+    // the legacy list (case-insensitively), and a retention knob.
+    let json = #"""
+    {"workspaces": [{"id": "\#(UUID().uuidString)", "name": "Corveil", "provider": "github", "cli": "gh"}],
+     "logSync": {"enabled": true, "baseURL": "https://api", "apiKeyRef": "op://v/k",
+                 "enabledWorkspaces": ["corveil"], "retentionDays": 14}}
+    """#
+    let configURL = claudeDir.appendingPathComponent("config.json")
+    try json.write(to: configURL, atomically: true, encoding: .utf8)
+
+    ConfigStore.migrateLogSyncAtBoot(devRoot: tmpDir.path)
+
+    let migrated = try #require(ConfigStore.loadConfig(devRoot: tmpDir.path))
+    #expect(migrated.workspaces[0].uploadSessionLogs == true) // folded into the checkbox
+    #expect(migrated.logSync?.retentionDays == 14)            // behavior knob preserved
+
+    // The removed credential/opt-in keys are gone from the file on disk.
+    let raw = try String(contentsOf: configURL, encoding: .utf8)
+    #expect(!raw.contains("apiKeyRef"))
+    #expect(!raw.contains("enabledWorkspaces"))
+
+    // Idempotent: a second boot changes nothing.
+    ConfigStore.migrateLogSyncAtBoot(devRoot: tmpDir.path)
+    let again = try #require(ConfigStore.loadConfig(devRoot: tmpDir.path))
+    #expect(again.workspaces[0].uploadSessionLogs == true)
+}
+
+@Test func migrateLogSyncAtBootIsANoOpWithoutLegacyKeys() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let claudeDir = tmpDir.appendingPathComponent(".claude", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+
+    var config = AppConfig(workspaces: [WorkspaceInfo(name: "Corveil")])
+    config.logSync = LogSyncConfig(retentionDays: 90)
+    try ConfigStore.saveConfig(config, to: claudeDir)
+    let before = try Data(contentsOf: claudeDir.appendingPathComponent("config.json"))
+
+    ConfigStore.migrateLogSyncAtBoot(devRoot: tmpDir.path)
+
+    let after = try Data(contentsOf: claudeDir.appendingPathComponent("config.json"))
+    #expect(before == after) // no rewrite when there is nothing to migrate
+}
+
 @Test func configStoreCoderViewAutoPermissionModeRoundTrip() throws {
     let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     let claudeDir = tmpDir.appendingPathComponent(".claude", isDirectory: true)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1460,7 +1460,7 @@ Notes:
 | `--clear-session-env`        | Drop every session env var                                                  |
 | `--review-blocking-severity` | Review finding severity that forces `--request-changes`: `red`, `yellow`, or `green` (repeatable) |
 | `--clear-review-blocking-severities` | Restore the default review blocking set (`red` + `yellow`)          |
-| `--upload-session-logs`      | Upload this workspace's coding-session transcripts to Corveil, reusing its gateway credential: `true` or `false` |
+| `--upload-session-logs`      | Upload this workspace's coding-session transcripts to Corveil, reusing its AI gateway for both URL and credential: `true` or `false` |
 
 Notes:
 
@@ -1473,7 +1473,7 @@ Notes:
 - **Fields are checked against the resulting workspace.** `--host` on a GitHub workspace, or any `--jira-*` flag on a workspace whose task provider isn't Jira, is an error rather than a value that would be stored and never read. Set the provider in the same invocation and both apply. Clearing a stranded field is always allowed.
 - **`--session-env` is one variable per entry.** The `/crow-workspace` setup script reads the map as one `KEY=VALUE` per line and splits each at the first `=`, so both delimiters are reserved: a newline in a key or value is rejected (it would smuggle in a second variable), and so is a `=` in a *key* (it would come back as a different variable). A `=` in a value is fine — the split takes only the first one. Keys additionally may not contain whitespace or control characters, since no shell could reference them. All enforced server-side, not just by the CLI.
 - **`--session-env` values are not credentials.** Unlike a gateway header they are stored in plain `config.json` and are not stripped from the web Settings payload. Put tokens in a gateway header instead.
-- **`--upload-session-logs` opts this workspace's session transcripts in to Corveil upload (CROW-1066), reusing its gateway credential** so you don't re-enter a Corveil key. It is the CLI twin of the Settings → Workspaces checkbox and, unlike the local-only `crow logsync` block, is a normal workspace field — so a remote `set-config` can flip it too. Uploads still require the local-only master switch (`crow logsync set --enabled true`), which stays the kill switch, and a base URL on the `logSync` block (the destination is never the browser-flippable `--corveil-host`). A workspace with no gateway falls back to the global `logSync` API key. See [session-log-collector.md](session-log-collector.md#per-workspace-ui-opt-in-that-reuses-the-gateway-credential-crow-1066).
+- **`--upload-session-logs` opts this workspace's session transcripts in to Corveil upload (CROW-1066/1070), reusing its AI gateway for both the upload URL and the credential** so you don't re-enter a Corveil key or host. It is the CLI twin of the Settings → Workspaces checkbox and is a normal workspace field, so a remote `set-config` can flip it too. There is **no** separate master switch: a ticked box plus a configured gateway is the whole opt-in. A workspace with no gateway uploads nothing — the destination is only ever the local-only gateway `baseURL`, never the browser-flippable `--corveil-host`. See [session-log-collector.md](session-log-collector.md#opt-in-and-controls-crow-1070).
 - **`cli` is derived, never set.** It follows `--provider` (`gh` / `glab`) on every write, so a stale value from an older config is repaired by any edit.
 - There is no `--gateway` flag; see [Gateway Commands](#gateway-commands).
 
@@ -1717,43 +1717,31 @@ There is deliberately **no `--password` flag** — a plaintext password in `argv
 
 ## Session-Log Sync Commands
 
-The multi-harness session-log collector (CROW-1056) uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, attributed to your own Corveil API key. It is **opt-in and OFF by default** — nothing uploads until you enable it *and* opt a workspace in. Uploads are best-effort and never block or fail a session, and **no AWS credentials are stored on this machine** (the server performs the object-storage upload). These verbs are **local-only**, like `gateway` / `web-password` — they configure uploads from the daemon host and carry a Corveil API-key reference.
+The multi-harness session-log collector (CROW-1056) uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts. It is **opt-in and OFF by default**. Since CROW-1070 the opt-in, the upload destination and the credential are all **per-workspace**: a workspace uploads iff its `--upload-session-logs` flag / Settings → Workspaces checkbox is on **and** it has an AI gateway, whose `baseURL` + `x-citadel-api-key` the upload reuses (so no second key or host, and no AWS credentials on this machine — the server performs the object-storage upload).
 
-> **Two ways to opt a workspace in.** `--add-workspace` (below) is the local-only list on this block. The second surface (CROW-1066) is the per-workspace `--upload-session-logs` flag / Settings → Workspaces checkbox, which **reuses the workspace's gateway credential** instead of the `--api-key-ref` here — see [`crow workspace edit`](#workspace-commands) and [session-log-collector.md](session-log-collector.md#per-workspace-ui-opt-in-that-reuses-the-gateway-credential-crow-1066). Either surface opts a workspace in; both still require `--enabled true` and a `--base-url` on this block.
+These `crow logsync` verbs tune only **global collector behavior** — ledger retention, the quiet period before a transcript is captured, and the per-upload size cap. They carry no credential, so — unlike `gateway` / `web-password` — they are **not** local-only and back the web Settings → General → **Session logs** section too.
+
+> **To opt a workspace in**, use [`crow workspace edit --workspace NAME --upload-session-logs true`](#workspace-commands) (or the Settings → Workspaces checkbox) and give the workspace an AI gateway with [`crow gateway set`](#gateways--secrets). There is no `crow logsync` flag that opts a workspace in.
 
 ### `crow logsync get`
 
 ```bash
 crow logsync get
-crow logsync get --reveal   # unmask a plaintext API key (op:// refs are always shown)
 ```
 
-Returns the collector block: `enabled`, `base_url`, `api_key_ref` (masked unless `--reveal` or an `op://…` reference), `api_key_set`, `enabled_workspaces`, `retention_days`, `quiet_period_minutes`, `max_upload_bytes`, and `configured` (whether the block exists at all).
+Returns the behavior knobs: `retention_days`, `quiet_period_minutes`, `max_upload_bytes`, and `configured` (whether a `logSync` block exists at all).
 
 ### `crow logsync set`
 
 PATCH — only the flags you pass change; at least one is required.
 
 ```bash
-# Turn it on, point it at your Corveil API, opt a workspace in.
-crow logsync set --enabled true \
-  --base-url https://api.corveil.io \
-  --api-key-ref 'op://vault/corveil/api-key' \
-  --add-workspace Corveil
-crow logsync set --add-workspace Acme --remove-workspace Legacy
-crow logsync set --clear-workspaces          # opt every workspace out
-crow logsync set --enabled false             # stop uploading
-crow logsync set --api-key-ref ''            # clear the stored key
+crow logsync set --retention-days 90
+crow logsync set --quiet-period-minutes 15 --max-upload-bytes 4000000
 ```
 
 | Flag | Description |
 | --- | --- |
-| `--enabled true\|false` | Master switch (default false) |
-| `--base-url URL` | Corveil API base (hosts `POST /api/crow-sessions/{id}/artifacts`); empty clears |
-| `--api-key-ref REF` | Corveil API key as an `op://…` reference (preferred) or plaintext; empty clears |
-| `--add-workspace NAME` | Opt a workspace in (repeatable) |
-| `--remove-workspace NAME` | Opt a workspace out (repeatable) |
-| `--clear-workspaces` | Opt every workspace out |
 | `--retention-days N` | Local upload-ledger retention (0 = forever, default 30) |
 | `--quiet-period-minutes N` | Wait this long after a session's last activity before uploading (default 30) |
 | `--max-upload-bytes N` | Per-transcript upload cap (default 8000000) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,9 +72,9 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow list-terminals`](#crow-list-terminals) | List terminals for a session |
 | [`crow list-tickets`](#crow-list-tickets) | List the ticket board (issues, per-status counts, loading state) |
 | [`crow list-worktrees`](#crow-list-worktrees) | List worktrees for a session |
-| [`crow logsync`](#crow-logsync) | View or change session-log upload (opt-in, local-only) |
-| [`crow logsync get`](#crow-logsync-get) | Show the session-log collector settings |
-| [`crow logsync set`](#crow-logsync-set) | Change session-log upload settings |
+| [`crow logsync`](#crow-logsync) | View or change session-log upload behavior knobs |
+| [`crow logsync get`](#crow-logsync-get) | Show the session-log collector behavior knobs |
+| [`crow logsync set`](#crow-logsync-set) | Change session-log upload behavior knobs |
 | [`crow mark-in-review`](#crow-mark-in-review) | Move a session to In Review |
 | [`crow mark-issue-done`](#crow-mark-issue-done) | Close the session's linked issue and complete the session |
 | [`crow mcp`](#crow-mcp) | Serve Crow over MCP, and manage the tokens remote clients use |
@@ -1053,15 +1053,15 @@ crow list-worktrees --session <session>
 
 ## `crow logsync`
 
-View or change session-log upload (opt-in, local-only).
+View or change session-log upload behavior knobs.
 
 ```
 crow logsync <get|set>
 ```
 
-The session-log collector uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, attributed to your own Corveil API key (no AWS credentials are stored on this machine). It is OFF by default and uploads nothing until you both enable it and opt a workspace in.
+The session-log collector uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, reusing that workspace's AI gateway for the destination and credential (no AWS credentials are stored on this machine). Opt a workspace in with `crow workspace edit --workspace NAME --upload-session-logs true` (or the Settings → Workspaces checkbox); it uploads once it also has a gateway.
 
-Uploads are best-effort and never block or fail a session. Only Claude Code transcripts are collected today; other harnesses are wired as their on-disk log locations are confirmed.
+These verbs tune only global behavior — ledger retention, the quiet period before a transcript is captured, and the per-upload size cap. Uploads are best-effort and never block or fail a session. Only Claude Code transcripts are collected today; other harnesses are wired as their on-disk log locations are confirmed.
 
 Subcommands: [`get`](#crow-logsync-get), [`set`](#crow-logsync-set).
 
@@ -1069,40 +1069,30 @@ Subcommands: [`get`](#crow-logsync-get), [`set`](#crow-logsync-set).
 
 ## `crow logsync get`
 
-Show the session-log collector settings.
+Show the session-log collector behavior knobs.
 
 ```
-crow logsync get [--reveal]
+crow logsync get
 ```
-
-| Flag | Value | Required | Description |
-| --- | --- | --- | --- |
-| `--reveal` | — | no | Reveal a plaintext API key (op:// references are always shown) |
 
 ---
 
 ## `crow logsync set`
 
-Change session-log upload settings.
+Change session-log upload behavior knobs.
 
 ```
-crow logsync set [--enabled <enabled>] [--base-url <base-url>] [--api-key-ref <api-key-ref>] [--add-workspace <add-workspace> ...] [--remove-workspace <remove-workspace> ...] [--clear-workspaces] [--retention-days <retention-days>] [--quiet-period-minutes <quiet-period-minutes>] [--max-upload-bytes <max-upload-bytes>]
+crow logsync set [--retention-days <retention-days>] [--quiet-period-minutes <quiet-period-minutes>] [--max-upload-bytes <max-upload-bytes>]
 ```
 
 Only the flags you pass change; at least one is required.
 
-Turn the feature on with --enabled true, point it at your Corveil API with --base-url and --api-key-ref (an op://… 1Password reference is resolved at upload so the key never lands in config.json), then opt workspaces in with --add-workspace. Nothing uploads until a workspace is opted in.
+Opt a workspace in (and set its gateway) elsewhere — with `crow workspace edit --upload-session-logs true` and `crow gateway set`. These flags only tune collector behavior.
 
-Live: the collector re-reads config each tick, so changes apply within a few minutes with no restart. Pass an empty string to --base-url/--api-key-ref to clear it.
+Live: the collector re-reads config each tick, so changes apply within a few minutes with no restart.
 
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
-| `--enabled` | `<enabled>` | no | Enable session-log upload (true or false) |
-| `--base-url` | `<base-url>` | no | Corveil API base URL (e.g. https://api.corveil.io) |
-| `--api-key-ref` | `<api-key-ref>` | no | Corveil API key: an op://… reference (preferred) or a plaintext key |
-| `--add-workspace` | `<add-workspace>` _(repeatable)_ | no | Opt a workspace in (repeatable) |
-| `--remove-workspace` | `<remove-workspace>` _(repeatable)_ | no | Opt a workspace out (repeatable) |
-| `--clear-workspaces` | — | no | Opt every workspace out |
 | `--retention-days` | `<retention-days>` | no | Days to keep the local upload ledger (0 = forever, default 30) |
 | `--quiet-period-minutes` | `<quiet-period-minutes>` | no | Wait this long after a session's last activity before uploading (default 30) |
 | `--max-upload-bytes` | `<max-upload-bytes>` | no | Per-transcript upload cap in bytes (default 8000000) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,8 @@ A workspace can route its Claude Code sessions through a proxy/gateway (e.g. an 
 - **`baseURL`** — exported as `ANTHROPIC_BASE_URL` for the session's `claude` launches.
 - **`customHeaders`** — a `Name: Value` map exported as `ANTHROPIC_CUSTOM_HEADERS` (newline-separated). Both fields must be set together; a `baseURL` with no headers (or vice versa) is rejected when the config is loaded.
 
+> **Also reused for session-log upload (CROW-1070):** when a workspace opts in to Corveil transcript upload (the Settings → Workspaces "Upload session transcripts to Corveil" checkbox / `crow workspace edit --upload-session-logs true`), the collector reuses **this same gateway** — POSTing to `{baseURL}/api/crow-sessions/{id}/artifacts` with the gateway's `x-citadel-api-key`. No second key or host is needed, and because the gateway config is local-only (see [Gateways & Secrets](cli-reference.md#gateways--secrets)) the upload destination can never be a browser-writable field. See [session-log-collector.md](session-log-collector.md).
+
 When a session resolves to a workspace with a `gateway`, Crow injects these vars two ways so they apply on the initial launch *and* survive manual `claude` re-runs:
 
 1. **Launch line** — the `claude` invocation is prefixed with the env-var assignments, overriding any global `~/.zshrc` export for that launch. (When a workspace has multiple headers, the header value can't go on the line — an embedded newline would submit the command early — so it's carried by `settings.local.json` and the launch line instead `unset`s any inherited `ANTHROPIC_CUSTOM_HEADERS` so the gateway's `baseURL` is never paired with stale global headers.)

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -91,75 +91,77 @@ has gone quiescent** — terminal status (`completed`/`archived`) or no log-file
 activity within `quietPeriodMinutes` (default 30) — to avoid capturing a partial
 transcript it could never replace.
 
-## Controls — `crow logsync` (local-only, default OFF)
+## Opt-in and controls (CROW-1070)
 
-`AppConfig.logSync` (`enabled`, `baseURL`, `apiKeyRef`, `enabledWorkspaces`,
-`retentionDays`, `quietPeriodMinutes`, `maxUploadBytes`) is **local-only**: like
-`managerGateway`/`webAuth`, its API key is stripped before the config reaches a
-browser and the whole block is writable only through the local-only
-`logsync-get`/`logsync-set` RPCs (`RPCWebSocketHandler.localOnlyDenial`), so the
-opt-in can never be flipped by a remote peer. See
-[cli-reference.md](cli-reference.md#session-log-sync-commands).
+A workspace uploads its coding-session transcripts iff **both**:
 
-## Per-workspace UI opt-in that reuses the gateway credential (CROW-1066)
+1. its **"Upload session transcripts to Corveil"** checkbox is on
+   (`WorkspaceInfo.uploadSessionLogs`, default `false`) — set in Settings →
+   Workspaces or with `crow workspace edit --workspace NAME --upload-session-logs true`; **and**
+2. the workspace has an **AI gateway** configured.
 
-The CLI-only opt-in above works but has friction: a user must drop to a terminal
-(`crow logsync set --add-workspace …`) and, for a Corveil workspace, re-enter a
-Corveil API key they already configured once as the workspace's **AI gateway**.
-CROW-1066 adds a second opt-in surface — a **checkbox in Settings → Workspaces**,
-"Upload session transcripts to Corveil" — that **reuses that workspace's gateway
-credential** instead of asking for a second key.
+That is the whole opt-in. There is no separate global master switch, base URL or
+API-key reference — CROW-1070 removed them. The upload **destination and
+credential are the workspace's own gateway** (see below), so ticking the box on a
+workspace that already routes its LLM traffic through Corveil is all it takes.
 
-- **Model.** A per-workspace `WorkspaceInfo.uploadSessionLogs: Bool` (default
-  `false`), decode-tolerant and in `CodingKeys` like every other workspace field.
-  Unlike `logSync.enabledWorkspaces` it rides on the workspace record, so the
-  existing Settings → Workspaces form, the `set-config` round-trip and
-  `crow workspace edit --upload-session-logs` all reach it with no new plumbing.
-- **Opt-in is the union of both surfaces.** `LogSyncCollector` uploads a session
-  when the local-only master switch `logSync.enabled` is on **and** the session's
-  workspace either sets `uploadSessionLogs` **or** appears in
-  `logSync.enabledWorkspaces`. The legacy CLI path is unchanged.
-- **Credential reuse.** For a workspace opted in via the checkbox, the collector
-  resolves the upload key from that workspace's `gateway` — the Corveil key it
-  already holds — via the same `op://…` resolution the gateway launch path uses,
-  falling back to the global `logSync.apiKeyRef` when the workspace has no
-  reusable gateway credential.
-- **UI.** The checkbox is **disabled with a tooltip** ("Configure a Corveil
-  gateway first") when the workspace has no gateway — the reuse is the whole
-  point, so the control is only meaningful with a gateway to reuse. The master
-  switch / base URL / retention / quiet-period stay on the local-only `logSync`
-  block.
+The remaining global block, `AppConfig.logSync`, holds only **behavior knobs** —
+`retentionDays`, `quietPeriodMinutes`, `maxUploadBytes`. These are not credentials,
+so unlike the pre-1070 block they are an ordinary, browser-editable config surface:
+Settings → General → **Session logs**, or the (no-longer-local-only) `crow logsync`
+CLI. See [cli-reference.md](cli-reference.md#session-log-sync-commands).
 
-### Three decisions resolved in CROW-1066
+### Gateway reuse — destination and credential (the security invariant)
 
-1. **Artifact base URL: the global, local-only `logSync.baseURL`.** The gateway
-   `baseURL` is the *LLM proxy* endpoint (`ANTHROPIC_BASE_URL`), a different
-   host/path from the REST artifact endpoint, so it is never used for the upload.
-   We also deliberately do **not** derive the destination from the workspace's
-   `corveilHost`: that field is **browser-flippable**, and letting a browser-set
-   value choose where a *credential-bearing* upload goes would let an
-   authenticated remote peer redirect the workspace's Corveil key to a host it
-   chose (an exfiltration vector). The destination therefore stays the local-only
-   `logSync.baseURL`; only the per-workspace on/off toggle is browser-flippable. A
-   future need for per-workspace REST hosts would add a *local-only* override, not
-   reuse a browser-writable field.
-2. **Which gateway header carries the key.** Crow's established Corveil-gateway
-   convention is the header **`x-citadel-api-key`** with a `Bearer sk-citadel-…`
-   value (see [configuration.md](configuration.md#ai-gateway)). The collector
-   looks the credential up case-insensitively, preferring `x-citadel-api-key` then
-   `authorization` / `x-api-key` / `x-corveil-key` defensively, resolves an
-   `op://…` value, and strips a leading `Bearer ` so `TranscriptUploader` can
-   re-wrap the bare key as `Authorization: Bearer <key>` (double-prefixing would
-   401).
-3. **Security tradeoff: acceptable, bounded.** Making `uploadSessionLogs`
-   browser-flippable relaxes the previously all-local-only posture, but narrowly:
-   it only *reuses* a credential the workspace already holds (the gateway key,
-   itself local-only — never readable or authorable from the web via
-   `SettingsSecrets`), the destination stays local-operator-owned (decision 1),
-   and the master `logSync.enabled` remains **local-only and the kill switch** —
-   with it off, no workspace uploads regardless of any checkbox. So the only thing
-   a remote peer gains is toggling one workspace's transcript upload on/off, to
-   the operator's own Corveil, with a credential it can neither see nor change.
+For an opted-in workspace, `LogSyncCollector.resolvedUpload(for:)` derives the
+upload target **solely** from that workspace's local-only `gateway`:
+
+- **Destination** = `{gateway.baseURL}/api/crow-sessions/{sessionUID}/artifacts`.
+  The Corveil gateway `baseURL` is the Corveil host root (e.g. `https://corveil.io`
+  — see [configuration.md](configuration.md#ai-gateway)), which is exactly where the
+  REST artifact endpoint lives.
+- **Credential** = the gateway's Corveil key. The collector looks it up
+  case-insensitively, preferring `x-citadel-api-key` then `authorization` /
+  `x-api-key` / `x-corveil-key` defensively, resolves an `op://…` reference the same
+  way the gateway launch path does, and strips a leading `Bearer ` so
+  `TranscriptUploader` can re-wrap the bare key as `Authorization: Bearer <key>`.
+
+**The invariant:** the destination and credential come only from the **local-only**
+gateway — never from `corveilHost` or any other browser-writable field. `corveilHost`
+is browser-flippable, so letting it choose where a *credential-bearing* upload goes
+would let an authenticated remote peer redirect the workspace's Corveil key to a host
+it chose (an exfiltration vector). `resolvedUpload` never reads it; a workspace with no
+gateway (or no resolvable key) returns `nil` and uploads nothing — a browser field
+alone can never supply a destination. This is asserted in `LogSyncCollectorTests`
+(`browserWritableCorveilHostCannotRedirectTheUpload`, `noGatewayResolvesToNilEvenWithCorveilHost`).
+
+Why this is safe where the earlier design wasn't: the `crow gateway` config is itself
+**local-only** (CROW-815 — it carries credentials, so the remote `/rpc` path refuses
+it and only the local Unix socket can write it). Reusing it introduces **zero** new
+exposure — it is the same local-only, already-trusted key going to the same Corveil
+host that already receives the workspace's LLM traffic. The only thing a remote peer
+gains from the browser-flippable checkbox is toggling one workspace's transcript
+upload on/off, to the operator's own Corveil, with a credential it can neither see
+nor change.
+
+### Decisions recorded here (CROW-1070)
+
+1. **Dropped the global `logSync.enabled` master switch.** A ticked checkbox plus a
+   configured gateway is the only gate. The old switch was the "check the box and
+   nothing happens" foot-gun (uploads also required a separate `crow logsync set
+   --enabled true`), so removing it is the fix, not a regression.
+2. **The behavior knobs (`retentionDays`/`quietPeriodMinutes`/`maxUploadBytes`) moved
+   to the web Settings UI** (General → Session logs) as well as the CLI, since they
+   carry no credential. A slim, no-longer-local-only `crow logsync get/set` stays for
+   control-plane parity (ADR 0016) and headless hosts.
+3. **Migration.** A legacy opt-in via `crow logsync set --add-workspace` (the removed
+   `logSync.enabledWorkspaces` list) is carried over on first boot by
+   `LogSyncMigration` / `ConfigStore.migrateLogSyncAtBoot` — a listed workspace's
+   `uploadSessionLogs` is set (only when the legacy master switch was on, so a
+   workspace that uploaded nothing before keeps uploading nothing). The removed keys
+   (`enabled`/`baseURL`/`apiKeyRef`/`enabledWorkspaces`) drop on the re-encode, so the
+   migration is idempotent. A legacy workspace with no gateway simply needs a gateway
+   configured before it uploads — that reuse is now the point.
 
 ## Depends on
 


### PR DESCRIPTION
## Summary

Makes Corveil session-transcript upload a **single per-workspace opt-in** that **reuses that workspace's local-only AI gateway** for both the upload destination and the credential, and removes the parallel global `logSync` config (`enabled` / `baseURL` / `apiKeyRef` / `enabledWorkspaces`).

Before: a user had to tick the Settings → Workspaces checkbox **and** separately run `crow logsync set --enabled true --base-url … --api-key-ref …` — re-entering the same Corveil key + host the workspace already holds as its AI gateway. Ticking only the box did nothing, with no signal why.

Now: a workspace uploads iff its **"Upload session transcripts to Corveil"** checkbox is on **and** it has an AI gateway configured. The upload reuses `{gateway.baseURL}/api/crow-sessions/{id}/artifacts` + the gateway's `x-citadel-api-key`. No second key or host; no master switch.

Builds on CROW-1056 (#1061) and CROW-1066 (#1067), both already on `main`.

## The security invariant (the point of the ticket)

The upload **destination + credential come solely from the workspace's local-only `gateway`** — never from `corveilHost` or any browser-writable field. The `crow gateway` config is local-only (CROW-815: it carries credentials, so the remote `/rpc` path refuses it), so reusing it adds **zero** new exposure — it's the same already-trusted key going to the same Corveil host that already receives the workspace's LLM traffic.

Enforced by a pure `LogSyncCollector.resolvedUpload(for:resolveSecret:)` that reads only `workspace.gateway`, plus tests in `LogSyncCollectorTests`:
- `browserWritableCorveilHostCannotRedirectTheUpload` — a hostile `corveilHost` cannot change where a credential-bearing upload goes.
- `noGatewayResolvesToNilEvenWithCorveilHost` — a browser-writable field alone can never supply a destination; no gateway ⇒ nothing uploads.
- `corveilHostIsBrowserWritableButDoesNotAffectTheDestination` — end-to-end through `strippedForTransport` → flip `corveilHost` → `preservingSecrets`, the gateway-derived destination is unchanged.

CROW-1066 had avoided reusing the gateway destination because it conflated it with the browser-flippable `corveilHost`. But the documented gateway `baseURL` is the Corveil host root (`https://corveil.io`), so `{baseURL}/api/crow-sessions/…` is exactly the REST endpoint — and it's local-only, unlike `corveilHost`. This PR corrects that conflation.

## Decisions resolved (recorded in `docs/session-log-collector.md`)

1. **Dropped the global `logSync.enabled` master switch.** Checkbox + a configured gateway is the only gate — that removes the "check the box and nothing happens" foot-gun.
2. **The behavior knobs moved to the web Settings UI.** `retentionDays` / `quietPeriodMinutes` / `maxUploadBytes` are now a global **Settings → General → Session logs** section (they carry no credential). `logSync` is therefore no longer local-only; a slim, no-longer-local-only `crow logsync get/set` stays for control-plane parity (ADR 0016) and headless hosts.
3. **Legacy opt-ins auto-migrate at boot.** `LogSyncMigration` / `ConfigStore.migrateLogSyncAtBoot` folds any `logSync.enabledWorkspaces` name into that workspace's `uploadSessionLogs` — only when the legacy master switch was on, so a workspace that uploaded nothing before keeps uploading nothing. Idempotent (the removed keys drop on re-encode).

## UI

The checkbox was already gated on the gateway (CROW-1066); this PR keeps that (disabled + tooltip when no gateway) and rewrites the help text, which no longer references the removed master switch. Adds the global "Session logs" knobs section to the General tab.

## Acceptance criteria

- ✅ With only the AI Gateway + the checkbox (no `crow logsync` at all), a quiescent session uploads to that workspace's Corveil and the ledger records `status: uploaded`.
- ✅ Destination + credential are provably taken from the local-only gateway; a browser-writable field can never redirect them (tested).
- ✅ The checkbox is disabled with a tooltip when the gateway is off, enabled when on.
- ✅ No separate `logSync.baseURL` / `apiKeyRef` / global `enabled` required.

## Testing

- New: `LogSyncMigrationTests`, `ConfigStoreTests.migrateLogSyncAtBoot*`, and the `resolvedUpload` security-invariant tests in `LogSyncCollectorTests`.
- Updated: `LogSyncConfigTests` (slim block; now browser-editable, not stripped), `SettingsSecretsTests`, `DaemonSecurityTests` (logsync is no longer local-only), `ParityGateTests`.
- Full suites pass for CrowCore (723), CrowEngine (787), CrowCLI (374), CrowPersistence (58), CrowIPC (120). CrowDaemon: 450/452 — the 2 failures (`RPCLanePolicyTests` corveil lanes, `WebNotificationCenter.bootCatchResetsTheHistory`) reproduce on the clean base branch and are unrelated to this change.
- `docs/cli.md` regenerated via `make docs`; `./scripts/check-cli-parity.sh` passes.

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)
