### PR TITLE
Session backfill: reconcile & upload historical on-disk transcripts (CROW-1075)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,19 @@ crow logsync set [--retention-days N] [--quiet-period-minutes N] [--max-upload-b
 - `set` is a PATCH (only the flags you pass change; at least one required). Live within ~1 collector tick (~5 min); no restart.
 - **Migration**: a legacy `crow logsync set --add-workspace` opt-in is carried over to `--upload-session-logs` on first boot (only when the old master switch was on). Only Claude Code transcripts are collected today; other harnesses are wired as their log paths are confirmed.
 
+### Session Backfill
+
+The historical session backfill (CROW-1075) — reconcile the coding-session transcripts already on disk (predating the live path, or reaped from Crow's store) and upload the ones you choose as real, fully-linked Corveil session artifacts. Claude Code only for v1.
+
+```
+crow backfill scan                                                      → {"sessions":[{uid,workspace,repo_name,owner_repo,ticket_number,confidence,upload_status,...}],"summary":{total,uploaded,linkable,repo_only,orphan}}
+crow backfill upload --workspace NAME (--session UID … | --all-high-confidence | --all)   → {"results":[{uid,result,linked,owner_repo,ticket_number,reason}],"summary":{...}}
+```
+
+- `scan` is disk- and git-only (no provider calls) — fast over hundreds of sessions. Reconstructs each session's workspace/repo/ticket from the transcript's own `cwd`/`gitBranch` (authoritative, not the lossy slug) plus live git remotes; `confidence` is `high` (repo + ticket) · `medium` (repo only) · `low` (orphan).
+- `upload` reuses the **live path** and is **idempotent** (local ledger + server write-once 409). `--workspace` names the workspace whose local-only gateway supplies the destination + credential (same security invariant as the live collector). Choose exactly one selection mode; `--all-high-confidence`/`--all` scope to that workspace's sessions.
+- A reconstructed ticket becomes a **REFERENCE only when the provider (`gh`/`glab`) confirms it exists** — otherwise the session uploads repo-only, and a true orphan uploads attributed but unlinked. Never automatic or unbounded — the user always chooses.
+
 ### MCP
 
 Crow's read-only MCP surface (CROW-1004) — six tools over five read RPCs, so an MCP client can read the board without a Crow-launched session. No prompt-send, no writes. See `docs/mcp.md` and ADR 0019.

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/BackfillCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/BackfillCommands.swift
@@ -1,0 +1,116 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+// `crow backfill` (CROW-1075): the historical session backfill. Captures the
+// coding-session transcripts already on disk — sessions that predate the live
+// upload path or were reaped from Crow's store — and uploads them as real,
+// fully-linked Corveil session artifacts, reconstructing the workspace / repo /
+// ticket a live run would have carried.
+//
+// Claude Code only in v1 (the one harness whose logs are partitioned by working
+// directory). The upload is idempotent (a local ledger + the server's write-once
+// 409), throttled, and always user-initiated — never automatic or unbounded.
+
+/// Parent command: `crow backfill <subcommand>`.
+public struct Backfill: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "backfill",
+        abstract: "Reconcile and upload historical on-disk session transcripts",
+        discussion: """
+        Scans the coding-session transcripts already on disk \
+        (~/.claude/projects), reconstructs each one's workspace, repo, and \
+        ticket/PR, and uploads the ones you choose to Corveil as session \
+        artifacts — so a backfilled session lands in the ontology \
+        indistinguishable from a live-captured one.
+
+        A reconstructed ticket becomes a link only when the provider confirms it \
+        exists; otherwise the session uploads repo-only, and a true orphan uploads \
+        attributed but unlinked. Uploads reuse the named workspace's AI gateway for \
+        the destination and credential (no AWS credentials on this machine) and are \
+        idempotent — re-running never duplicates.
+        """,
+        subcommands: [BackfillScan.self, BackfillUpload.self]
+    )
+
+    public init() {}
+}
+
+public struct BackfillScan: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "scan",
+        abstract: "List on-disk sessions with reconstructed metadata and upload status",
+        discussion: """
+        Disk- and git-only (no provider calls), so it's fast over hundreds of \
+        sessions. Each row carries the recovered workspace/repo/ticket, a \
+        confidence tier (high = repo + ticket, medium = repo only, low = orphan), \
+        and its ledger upload status. Ticket links are validated at upload, not here.
+        """
+    )
+
+    public init() {}
+
+    public func run() throws {
+        // A scan reads every transcript's head and resolves git remotes — allow
+        // well past the 30s default on a large history.
+        printJSON(try rpc("backfill-scan", params: [:], timeoutSeconds: 180))
+    }
+}
+
+public struct BackfillUpload: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "upload",
+        abstract: "Upload selected historical sessions (idempotent)",
+        discussion: """
+        Choose sessions with repeated --session <uid> (UIDs come from \
+        `crow backfill scan`), or bulk-select this workspace's history with \
+        --all-high-confidence (repo + validated ticket) or --all. Exactly one \
+        selection mode is required.
+
+        --workspace names the workspace whose AI gateway supplies the upload \
+        destination and credential; it must have a gateway configured. Uploads are \
+        serial and idempotent, so a re-run only fills gaps.
+        """
+    )
+
+    @Option(name: .customLong("workspace"), help: "Workspace whose gateway supplies the upload destination + credential")
+    var workspace: String
+
+    @Option(
+        name: .customLong("session"),
+        help: "A Claude session UID to upload (repeatable). Mutually exclusive with --all/--all-high-confidence.")
+    var sessions: [String] = []
+
+    @Flag(name: .customLong("all-high-confidence"), help: "Upload every not-yet-uploaded high-confidence session in this workspace")
+    var allHighConfidence = false
+
+    @Flag(name: .customLong("all"), help: "Upload every not-yet-uploaded session in this workspace")
+    var all = false
+
+    public init() {}
+
+    public func validate() throws {
+        if workspace.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--workspace is required — its gateway supplies the upload destination and credential.")
+        }
+        let modes = [!sessions.isEmpty, allHighConfidence, all].filter { $0 }.count
+        guard modes == 1 else {
+            throw ValidationError(
+                "Choose exactly one selection: one or more --session <uid>, "
+                + "or --all-high-confidence, or --all.")
+        }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["workspace": .string(workspace)]
+        if !sessions.isEmpty {
+            params["sessions"] = .array(sessions.map { .string($0) })
+        } else if allHighConfidence {
+            params["select"] = .string("high")
+        } else if all {
+            params["select"] = .string("all")
+        }
+        // A large upload run is serial network I/O — give it real headroom.
+        printJSON(try rpc("backfill-upload", params: params, timeoutSeconds: 600))
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -50,6 +50,7 @@ public struct CrowCommand: ParsableCommand {
             Gateway.self,
             WebPassword.self,
             Logsync.self,
+            Backfill.self,
             MCP.self,
             AddWorktree.self,
             ListWorktrees.self,

--- a/Packages/CrowCLI/Tests/CrowCLITests/BackfillCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/BackfillCommandParsingTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+import ArgumentParser
+@testable import CrowCLILib
+
+// MARK: - `crow backfill` parsing (CROW-1075)
+
+@Test func backfillRoutesToSubcommands() throws {
+    #expect(try Backfill.parseAsRoot(["scan"]) is BackfillScan)
+    #expect(try Backfill.parseAsRoot(["upload", "--workspace", "R", "--all"]) is BackfillUpload)
+}
+
+@Test func backfillUploadParsesExplicitSessions() throws {
+    let cmd = try BackfillUpload.parse(["--workspace", "RadiusMethod", "--session", "a", "--session", "b"])
+    #expect(cmd.workspace == "RadiusMethod")
+    #expect(cmd.sessions == ["a", "b"])
+    #expect(cmd.allHighConfidence == false)
+    #expect(cmd.all == false)
+}
+
+@Test func backfillUploadParsesBulkFlags() throws {
+    let hi = try BackfillUpload.parse(["--workspace", "R", "--all-high-confidence"])
+    #expect(hi.allHighConfidence == true)
+    let all = try BackfillUpload.parse(["--workspace", "R", "--all"])
+    #expect(all.all == true)
+}
+
+@Test func backfillUploadRequiresExactlyOneSelectionMode() {
+    // None.
+    #expect(throws: (any Error).self) {
+        _ = try BackfillUpload.parse(["--workspace", "R"])
+    }
+    // Two at once.
+    #expect(throws: (any Error).self) {
+        _ = try BackfillUpload.parse(["--workspace", "R", "--all", "--all-high-confidence"])
+    }
+    #expect(throws: (any Error).self) {
+        _ = try BackfillUpload.parse(["--workspace", "R", "--session", "a", "--all"])
+    }
+}
+
+@Test func backfillUploadRequiresWorkspace() {
+    #expect(throws: (any Error).self) {
+        _ = try BackfillUpload.parse(["--all"])
+    }
+    #expect(throws: (any Error).self) {
+        _ = try BackfillUpload.parse(["--workspace", "   ", "--all"])
+    }
+}

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -263,11 +263,15 @@ struct ParityGateTests {
 
     /// Rows whose deliberate `isWrite` classification disagrees with the name.
     ///
-    /// Empty today. The hand classification always wins — a method named
-    /// `get-something` that mutates state is a write, full stop. This set only
-    /// forces the disagreement to be *stated* rather than sitting unnoticed in a
-    /// row nobody re-reads.
-    static let namingExceptions: Set<String> = []
+    /// The hand classification always wins — a method named `get-something` that
+    /// mutates state is a write, full stop. This set only forces the disagreement
+    /// to be *stated* rather than sitting unnoticed in a row nobody re-reads.
+    static let namingExceptions: Set<String> = [
+        // `backfill-scan` reconciles on-disk transcripts and returns them — a pure
+        // read — but its name isn't `get-`/`list-` prefixed, so the heuristic
+        // presumes a write (CROW-1075).
+        "backfill-scan",
+    ]
 
     /// `isWrite` is hand-set per row, deliberately, because a `get-`/`list-`
     /// heuristic would wave through a future write named `get-something`. But

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillReconstruction.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillReconstruction.swift
@@ -1,0 +1,370 @@
+import Foundation
+
+/// How confident the reconstruction is that a historical on-disk transcript can
+/// be attached to a real workspace / repo / ticket (CROW-1075).
+///
+/// The tiers drive the Settings dialog's default selection and the honesty of
+/// the eventual upload: only a `high` session asserts a validated ticket
+/// REFERENCE, a `medium` one uploads repo-only, and a `low` one uploads as an
+/// attributed-but-unlinked Conversation (or is left unselected).
+public enum BackfillConfidence: String, Sendable, Equatable, Codable, CaseIterable {
+    /// Workspace + repo recovered **and** a ticket number parsed from the
+    /// worktree name. Whether that ticket actually *validates* against the
+    /// provider is decided at upload time (`TicketValidator`); the tier only
+    /// says the metadata is fully shaped.
+    case high
+    /// A repo was recovered (worktree under a workspace, or a git remote) but no
+    /// ticket number — uploads repo-only.
+    case medium
+    /// Neither a workspace nor a repo could be matched — a true orphan
+    /// (`~/Downloads/…`, an ad-hoc `claude` run, a path outside the dev root).
+    /// Uploads only if explicitly selected, as an attributed Conversation with
+    /// no fabricated links.
+    case low
+}
+
+/// What a parsed ticket turned out to be once validated against the provider.
+public enum BackfillTicketKind: String, Sendable, Equatable, Codable {
+    case issue
+    case pullRequest = "pull_request"
+    /// A number was parsed but not yet validated (the scan does not hit the
+    /// provider — validation happens at upload).
+    case unvalidated
+    /// Validated and the provider reported it does not exist — no REFERENCE is
+    /// asserted for it.
+    case notFound = "not_found"
+}
+
+/// The upload status of a historical session, reconciled from the local ledger
+/// (`logsync-ledger.json`) during a scan.
+public enum BackfillUploadStatus: String, Sendable, Equatable, Codable {
+    /// No ledger entry — never attempted.
+    case new
+    /// Stored (201) or already present (409) — an idempotent success.
+    case uploaded
+    /// Rejected in a way retrying can't fix (too large / auth / validation).
+    case skipped
+    /// A transient failure was recorded; a retry is allowed.
+    case failed
+}
+
+/// A repo's identity, parsed from a git remote URL. `owner/repo` is what the
+/// provider CLIs (`gh`, `glab`) address, so it is what ticket validation and the
+/// upload sidecar need.
+public struct RepoRemote: Sendable, Equatable {
+    /// e.g. `github.com`, `gitlab.example.com`, `repo1.dso.mil`.
+    public let host: String
+    /// The owner / org / (GitLab) group path, e.g. `corveil` or
+    /// `big-bang/product/packages`.
+    public let owner: String
+    /// The repo (project) name, e.g. `crow`.
+    public let repo: String
+
+    public init(host: String, owner: String, repo: String) {
+        self.host = host
+        self.owner = owner
+        self.repo = repo
+    }
+
+    /// `owner/repo` — the slug `gh -R …` and the sidecar `repo` hint use.
+    public var slug: String { "\(owner)/\(repo)" }
+
+    /// Whether the host is (public or enterprise) GitHub, which decides whether
+    /// `gh` or `glab` validates it.
+    public var isGitHub: Bool { host == "github.com" || host.hasPrefix("github.") }
+
+    /// Parse a git remote URL (`git remote get-url origin`) into its parts.
+    /// Handles the two forms git prints:
+    /// - `https://github.com/owner/repo.git`
+    /// - `git@github.com:owner/repo.git`
+    /// GitLab subgroups (`host/group/sub/repo`) are preserved: `owner` keeps the
+    /// full group path and `repo` is the last segment. Returns `nil` for a URL
+    /// that isn't a recognizable `host + path` (e.g. a bare local path).
+    public static func parse(_ raw: String) -> RepoRemote? {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return nil }
+        if s.hasSuffix(".git") { s = String(s.dropLast(4)) }
+
+        var host = ""
+        var path = ""
+        if let range = s.range(of: "://") {
+            // scheme://[user@]host/path
+            var rest = String(s[range.upperBound...])
+            if let at = rest.firstIndex(of: "@") { rest = String(rest[rest.index(after: at)...]) }
+            guard let slash = rest.firstIndex(of: "/") else { return nil }
+            host = String(rest[..<slash])
+            path = String(rest[rest.index(after: slash)...])
+        } else if let at = s.firstIndex(of: "@"), let colon = s.firstIndex(of: ":"), at < colon {
+            // scp-like: user@host:path
+            host = String(s[s.index(after: at)..<colon])
+            path = String(s[s.index(after: colon)...])
+        } else {
+            return nil
+        }
+
+        // Strip a port (`host:22`) that a scp-like URL never has but an https one
+        // might carry after the host in odd configs.
+        if let colon = host.firstIndex(of: ":") { host = String(host[..<colon]) }
+        let segments = path.split(separator: "/").map(String.init).filter { !$0.isEmpty }
+        guard segments.count >= 2, !host.isEmpty else { return nil }
+        let repo = segments.last!
+        let owner = segments.dropLast().joined(separator: "/")
+        guard !owner.isEmpty, !repo.isEmpty else { return nil }
+        return RepoRemote(host: host, owner: owner, repo: repo)
+    }
+}
+
+/// One historical coding session reconstructed from an on-disk transcript
+/// (CROW-1075). This is the row the Settings "Backfill history" table renders and
+/// the unit the uploader acts on. Everything but the identity fields is
+/// best-effort — a `low`-confidence orphan carries only the file facts.
+public struct BackfillSession: Sendable, Equatable, Codable {
+    /// The Claude session UUID — the `.jsonl` stem. Used verbatim as the upload
+    /// `{uid}`: stable, unique, and the natural idempotency key (decision #1).
+    public var claudeSessionUID: String
+    /// Absolute path to the transcript file.
+    public var filePath: String
+    /// The Claude project-slug directory name the file lives under.
+    public var slug: String
+    /// Working directory recorded in the transcript (authoritative — not the
+    /// lossy slug). `nil` only for a transcript that recorded none.
+    public var cwd: String?
+    /// Git branch recorded in the transcript, a secondary metadata source.
+    public var gitBranch: String?
+    /// Newest file modification, epoch seconds — the session's "date".
+    public var modifiedAt: Double
+    /// Transcript size in bytes.
+    public var sizeBytes: Int
+
+    /// Reconstructed workspace (first path component of `cwd` under the dev
+    /// root). `nil` ⇒ the session ran outside any workspace (orphan).
+    public var workspace: String?
+    /// The worktree directory name (`<repo>-<number>-<slug>`), when `cwd` is a
+    /// worktree under a workspace.
+    public var worktreeName: String?
+    /// Bare repo name parsed from the worktree/branch, before owner resolution.
+    public var repoName: String?
+    /// `owner/repo`, resolved from a live git remote when one is reachable.
+    public var ownerRepo: String?
+    /// The repo host (`github.com`, …) when resolved, so validation picks the
+    /// right provider CLI.
+    public var host: String?
+    /// Ticket / PR number parsed from the worktree name (corroborated by the
+    /// branch). Whether it validates is decided at upload.
+    public var ticketNumber: Int?
+    /// What the ticket turned out to be, once validated (`unvalidated` until
+    /// then).
+    public var ticketKind: BackfillTicketKind
+    /// Whether the worktree directory still exists on disk (a stronger signal
+    /// and the only case a `git remote` read is possible for this exact path).
+    public var worktreeExists: Bool
+
+    public var confidence: BackfillConfidence
+    /// Reconciled from the ledger at scan time.
+    public var uploadStatus: BackfillUploadStatus
+
+    public init(
+        claudeSessionUID: String,
+        filePath: String,
+        slug: String,
+        cwd: String? = nil,
+        gitBranch: String? = nil,
+        modifiedAt: Double = 0,
+        sizeBytes: Int = 0,
+        workspace: String? = nil,
+        worktreeName: String? = nil,
+        repoName: String? = nil,
+        ownerRepo: String? = nil,
+        host: String? = nil,
+        ticketNumber: Int? = nil,
+        ticketKind: BackfillTicketKind = .unvalidated,
+        worktreeExists: Bool = false,
+        confidence: BackfillConfidence = .low,
+        uploadStatus: BackfillUploadStatus = .new
+    ) {
+        self.claudeSessionUID = claudeSessionUID
+        self.filePath = filePath
+        self.slug = slug
+        self.cwd = cwd
+        self.gitBranch = gitBranch
+        self.modifiedAt = modifiedAt
+        self.sizeBytes = sizeBytes
+        self.workspace = workspace
+        self.worktreeName = worktreeName
+        self.repoName = repoName
+        self.ownerRepo = ownerRepo
+        self.host = host
+        self.ticketNumber = ticketNumber
+        self.ticketKind = ticketKind
+        self.worktreeExists = worktreeExists
+        self.confidence = confidence
+        self.uploadStatus = uploadStatus
+    }
+}
+
+/// The result of attempting to back-fill one session (CROW-1075) — returned per
+/// session so the Settings dialog and the CLI can show a truthful per-row
+/// outcome (uploaded / linked / skipped-already / failed + reason).
+public struct BackfillUploadOutcome: Sendable, Equatable, Codable {
+    public var claudeSessionUID: String
+    /// Terminal disposition of the attempt.
+    public enum Result: String, Sendable, Equatable, Codable {
+        case uploaded          // 201 stored
+        case alreadyUploaded   // ledger says done, or server 409 — idempotent
+        case skipped           // nothing to upload / no gateway / empty file
+        case failed            // transient or permanent failure
+    }
+    public var result: Result
+    /// Whether a **validated** ticket REFERENCE was included in the sidecar. A
+    /// repo-only or orphan upload is `false` — no fabricated link.
+    public var linked: Bool
+    public var ownerRepo: String?
+    public var ticketNumber: Int?
+    public var ticketKind: BackfillTicketKind?
+    /// Human-readable reason for a skip/failure (e.g. `no gateway for workspace`,
+    /// `too_large`, `transient`).
+    public var reason: String?
+
+    public init(
+        claudeSessionUID: String,
+        result: Result,
+        linked: Bool = false,
+        ownerRepo: String? = nil,
+        ticketNumber: Int? = nil,
+        ticketKind: BackfillTicketKind? = nil,
+        reason: String? = nil
+    ) {
+        self.claudeSessionUID = claudeSessionUID
+        self.result = result
+        self.linked = linked
+        self.ownerRepo = ownerRepo
+        self.ticketNumber = ticketNumber
+        self.ticketKind = ticketKind
+        self.reason = reason
+    }
+}
+
+/// Pure metadata reconstruction for a historical session (CROW-1075). Every
+/// function here is a total, side-effect-free transform of strings the scanner
+/// has already read (the transcript's `cwd`/`gitBranch`, the workspace list, and
+/// a `repoName → RepoRemote` map built from live git remotes), so the whole of
+/// the "fill in the gaps" logic is unit-testable without touching disk or the
+/// network.
+public enum BackfillReconstructor {
+    /// The workspace folder name for a `cwd`: `{devRoot}/{workspace}/…` →
+    /// `{workspace}`. Mirrors `SessionService.workspaceName` (which lives in
+    /// CrowEngine and can't be imported here) — pure path math, so it is copied
+    /// rather than shared, and pinned by a test asserting the two agree.
+    public static func workspace(cwd: String, devRoot: String) -> String? {
+        let root = (devRoot as NSString).standardizingPath
+        let full = (cwd as NSString).standardizingPath
+        guard full.hasPrefix(root + "/") else { return nil }
+        let relative = String(full.dropFirst(root.count + 1))
+        return relative.split(separator: "/").first.map(String.init)
+    }
+
+    /// The worktree directory name — the second path component under the dev
+    /// root (`{devRoot}/{workspace}/{worktree}/…` → `{worktree}`). `nil` when the
+    /// cwd is the workspace root itself or lies outside the dev root.
+    public static func worktreeName(cwd: String, devRoot: String) -> String? {
+        let root = (devRoot as NSString).standardizingPath
+        let full = (cwd as NSString).standardizingPath
+        guard full.hasPrefix(root + "/") else { return nil }
+        let parts = String(full.dropFirst(root.count + 1)).split(separator: "/").map(String.init)
+        return parts.count >= 2 ? parts[1] : nil
+    }
+
+    /// Parse a Crow-convention worktree directory name into `(repo, ticket)`.
+    ///
+    /// The name is `<repo>-<number>-<slug>`, but both `<repo>` and `<slug>` can
+    /// contain dashes and digits, so the split is ambiguous from the string
+    /// alone (`corveil-cloud-terraform-331-…` vs `alloy-86-502-…`). The
+    /// disambiguator is `knownRepoNames` — the repo names of live clones found
+    /// under the dev root: the **longest** one that prefixes the worktree name
+    /// wins, and the digits right after it are the ticket. Only when no known
+    /// repo matches does it fall back to the greedy generic split (lower
+    /// confidence). A review clone (`<repo>-pr-<n>`) is recognized too.
+    public static func parseWorktree(
+        _ name: String, knownRepoNames: [String]
+    ) -> (repo: String?, ticket: Int?) {
+        // Review clones live at `{devRoot}/crow-reviews/{repo}-pr-{N}`.
+        if let r = name.range(of: "-pr-") {
+            let repo = String(name[..<r.lowerBound])
+            let tail = String(name[r.upperBound...])
+            let digits = tail.prefix { $0.isNumber }
+            if !repo.isEmpty, let n = Int(digits) { return (repo, n) }
+        }
+
+        // Longest known repo that the worktree name starts with.
+        let candidates = knownRepoNames
+            .filter { name == $0 || name.hasPrefix($0 + "-") }
+            .sorted { $0.count > $1.count }
+        if let repo = candidates.first {
+            if name == repo { return (repo, nil) }
+            let tail = name.dropFirst(repo.count + 1) // drop "repo-"
+            let digits = tail.prefix { $0.isNumber }
+            return (repo, Int(digits))
+        }
+
+        // Generic fallback: first non-numeric run, then the first number.
+        // `^(.+?)-(\d+)(?:-.*)?$`
+        let parts = name.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
+        for i in 1..<max(parts.count, 1) where i < parts.count {
+            if let n = Int(parts[i]), !parts[i].isEmpty {
+                let repo = parts[0..<i].joined(separator: "-")
+                return (repo.isEmpty ? nil : repo, n)
+            }
+        }
+        return (name.isEmpty ? nil : name, nil)
+    }
+
+    /// A plausible ticket number from a git branch (`feature/crow-1075-slug` →
+    /// 1075), used to corroborate (or, when the worktree name has none, supply)
+    /// the number. Takes the first number that is flanked by a dash on the left
+    /// — a bare leading number in a branch is unusual and skipped.
+    public static func ticketNumber(fromBranch branch: String) -> Int? {
+        let scalars = Array(branch)
+        var i = 0
+        while i < scalars.count {
+            if scalars[i].isNumber, i > 0, scalars[i - 1] == "-" {
+                var j = i
+                while j < scalars.count, scalars[j].isNumber { j += 1 }
+                // Require a trailing dash so a slug like `-v2` doesn't read as
+                // the ticket, matching the `<num>-<slug>` convention.
+                if j < scalars.count, scalars[j] == "-" {
+                    return Int(String(scalars[i..<j]))
+                }
+                i = j
+            } else {
+                i += 1
+            }
+        }
+        return nil
+    }
+
+    /// The confidence tier for a reconstructed session, before provider
+    /// validation. `high` needs a repo **and** a ticket number; `medium` a repo
+    /// alone; `low` is an orphan with neither a workspace nor a repo.
+    public static func confidence(
+        workspace: String?, repoName: String?, ticket: Int?
+    ) -> BackfillConfidence {
+        if repoName != nil, ticket != nil { return .high }
+        if repoName != nil || workspace != nil { return .medium }
+        return .low
+    }
+
+    /// Build a public issue/PR URL for the sidecar `ticket_url` hint, once the
+    /// kind is known. `nil` when the pieces aren't all present.
+    public static func ticketURL(
+        remote: RepoRemote?, number: Int?, kind: BackfillTicketKind
+    ) -> String? {
+        guard let remote, let number else { return nil }
+        let segment: String
+        switch kind {
+        case .pullRequest: segment = remote.isGitHub ? "pull" : "merge_requests"
+        case .issue: segment = "issues"
+        case .unvalidated, .notFound: return nil
+        }
+        return "https://\(remote.host)/\(remote.owner)/\(remote.repo)/\(segment)/\(number)"
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+/// Reconciles the coding-session transcripts already on disk against what has
+/// been uploaded, reconstructing each one's workspace / repo / ticket so the
+/// Settings "Backfill history" dialog can show a reviewable list (CROW-1075).
+///
+/// Claude is the only harness wired for v1 (the same reason the live collector
+/// is Claude-only): its logs are partitioned by working directory, and every
+/// event records the real `cwd`/`gitBranch`, which is what makes historical
+/// reconstruction reliable. The scan is disk- and git-only — it never touches
+/// the provider or the network, so it stays fast over hundreds of sessions;
+/// ticket *validation* is deferred to upload, where a link is actually asserted.
+///
+/// Everything effectful is injected (the projects directory, the git-remote
+/// reader, the clock), so the reconciliation logic is unit-testable against a
+/// temporary tree.
+public struct BackfillScanner: Sendable {
+    let devRoot: String
+    /// `~/.claude/projects` by default — where Claude writes per-project slug
+    /// directories of `<session-uuid>.jsonl` transcripts.
+    let projectsDir: URL
+    /// Resolve a directory's `origin` remote URL (default: `git -C <dir> remote
+    /// get-url origin`). Injected so tests need no real repos.
+    let gitRemote: @Sendable (String) async -> String?
+    let now: @Sendable () -> Date
+
+    public init(
+        devRoot: String,
+        projectsDir: URL? = nil,
+        runner: any ShellRunner = ProcessShellRunner(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.devRoot = devRoot
+        self.projectsDir = projectsDir ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+        self.gitRemote = { dir in
+            (try? await runner.run(args: ["git", "-C", dir, "remote", "get-url", "origin"],
+                                   env: [:], cwd: nil))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        self.now = now
+    }
+
+    /// Test seam: inject the git-remote reader directly.
+    init(
+        devRoot: String,
+        projectsDir: URL,
+        gitRemote: @escaping @Sendable (String) async -> String?,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.devRoot = devRoot
+        self.projectsDir = projectsDir
+        self.gitRemote = gitRemote
+        self.now = now
+    }
+
+    /// Reconcile every on-disk Claude transcript against the ledger and return
+    /// the reconstructed rows, newest first.
+    public func scan(ledger: LogSyncLedger) async -> [BackfillSession] {
+        let remotes = await resolveRemotes()
+        let knownRepoNames = Array(Set(remotes.values.map { $0.repo }))
+        let files = transcriptFiles()
+
+        var sessions: [BackfillSession] = []
+        sessions.reserveCapacity(files.count)
+        for file in files {
+            guard let s = reconstruct(file: file, remotesByRepo: remotes,
+                                      knownRepoNames: knownRepoNames, ledger: ledger)
+            else { continue }
+            sessions.append(s)
+        }
+        sessions.sort { $0.modifiedAt > $1.modifiedAt }
+        return sessions
+    }
+
+    // MARK: - Reconstruction of one file
+
+    func reconstruct(
+        file: URL, remotesByRepo: [String: RepoRemote],
+        knownRepoNames: [String], ledger: LogSyncLedger
+    ) -> BackfillSession? {
+        let uid = file.deletingPathExtension().lastPathComponent
+        guard !uid.isEmpty else { return nil }
+        let slug = file.deletingLastPathComponent().lastPathComponent
+        let values = try? file.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+        let mtime = values?.contentModificationDate?.timeIntervalSince1970 ?? 0
+        let size = values?.fileSize ?? 0
+
+        let head = TranscriptHeadReader.read(file)
+        let cwd = head.cwd
+
+        var session = BackfillSession(
+            claudeSessionUID: uid, filePath: file.path, slug: slug,
+            cwd: cwd, gitBranch: head.gitBranch, modifiedAt: mtime, sizeBytes: size)
+
+        if let cwd {
+            session.workspace = BackfillReconstructor.workspace(cwd: cwd, devRoot: devRoot)
+            session.worktreeName = BackfillReconstructor.worktreeName(cwd: cwd, devRoot: devRoot)
+            session.worktreeExists = FileManager.default.fileExists(atPath: cwd)
+        }
+
+        if let worktree = session.worktreeName {
+            let (repo, ticket) = BackfillReconstructor.parseWorktree(worktree, knownRepoNames: knownRepoNames)
+            session.repoName = repo
+            // Prefer the worktree-parsed ticket; fall back to the branch.
+            session.ticketNumber = ticket
+                ?? session.gitBranch.flatMap { BackfillReconstructor.ticketNumber(fromBranch: $0) }
+            if let repo, let remote = remotesByRepo[repo] {
+                session.ownerRepo = remote.slug
+                session.host = remote.host
+            }
+        } else if session.repoName == nil, let branch = session.gitBranch {
+            // No worktree component (cwd is a bare clone) — the branch may still
+            // carry a ticket number, but without a repo it stays medium/low.
+            session.ticketNumber = BackfillReconstructor.ticketNumber(fromBranch: branch)
+        }
+
+        session.confidence = BackfillReconstructor.confidence(
+            workspace: session.workspace, repoName: session.repoName, ticket: session.ticketNumber)
+        session.uploadStatus = Self.status(
+            for: uid, ledger: ledger, now: now().timeIntervalSince1970)
+        return session
+    }
+
+    /// Map a ledger entry (keyed on the Claude UID + Claude harness) to the
+    /// row's display status.
+    static func status(for uid: String, ledger: LogSyncLedger, now: Double) -> BackfillUploadStatus {
+        let key = LogSyncLedger.key(sessionUID: uid, harness: .claude, kind: .sessionTranscript)
+        guard let entry = ledger.entries[key] else { return .new }
+        switch entry.status {
+        case .uploaded: return .uploaded
+        case .skippedPermanent: return .skipped
+        case .failedTransient: return .failed
+        }
+    }
+
+    // MARK: - Enumeration & git
+
+    /// Top-level `<slug>/<uuid>.jsonl` transcripts only — the same non-recursive
+    /// shape the live collector's Claude `logSources` uses, so nested
+    /// `subagents/agent-*.jsonl` are excluded (they belong to a parent session,
+    /// not their own).
+    func transcriptFiles() -> [URL] {
+        let fm = FileManager.default
+        guard let slugDirs = try? fm.contentsOfDirectory(
+            at: projectsDir, includingPropertiesForKeys: [.isDirectoryKey]) else { return [] }
+        var out: [URL] = []
+        for dir in slugDirs {
+            guard (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+            guard let files = try? fm.contentsOfDirectory(
+                at: dir, includingPropertiesForKeys: [.isRegularFileKey]) else { continue }
+            for f in files where f.pathExtension == "jsonl" {
+                if (try? f.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
+                    out.append(f)
+                }
+            }
+        }
+        return out
+    }
+
+    /// Build a `repoName → RepoRemote` map from the live clones under the dev
+    /// root (`{devRoot}/{workspace}/{repoOrWorktree}`), reading each one's
+    /// `origin`. One resolvable clone (main checkout or a still-present worktree)
+    /// is enough to give every reaped worktree of the same repo its `owner/repo`.
+    /// Remotes are read concurrently and deduped by parsed repo name.
+    func resolveRemotes() async -> [String: RepoRemote] {
+        let fm = FileManager.default
+        var candidates: [String] = []
+        guard let workspaces = try? fm.contentsOfDirectory(
+            at: URL(fileURLWithPath: devRoot), includingPropertiesForKeys: [.isDirectoryKey]) else { return [:] }
+        for ws in workspaces {
+            guard (try? ws.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+            guard let repos = try? fm.contentsOfDirectory(
+                at: ws, includingPropertiesForKeys: [.isDirectoryKey]) else { continue }
+            for repo in repos where (try? repo.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true {
+                let gitPath = repo.appendingPathComponent(".git")
+                if fm.fileExists(atPath: gitPath.path) { candidates.append(repo.path) }
+            }
+        }
+
+        let results = await withTaskGroup(of: RepoRemote?.self) { group -> [RepoRemote] in
+            for path in candidates {
+                group.addTask { await gitRemote(path).flatMap { RepoRemote.parse($0) } }
+            }
+            var acc: [RepoRemote] = []
+            for await r in group { if let r { acc.append(r) } }
+            return acc
+        }
+
+        var map: [String: RepoRemote] = [:]
+        for remote in results where map[remote.repo] == nil { map[remote.repo] = remote }
+        return map
+    }
+}
+
+/// Aggregate counts for the Settings dialog's summary line (CROW-1075).
+public struct BackfillSummary: Sendable, Equatable, Codable {
+    public var total: Int
+    public var uploaded: Int
+    public var linkable: Int   // high confidence (repo + ticket)
+    public var repoOnly: Int   // medium
+    public var orphan: Int     // low
+
+    public init(total: Int = 0, uploaded: Int = 0, linkable: Int = 0, repoOnly: Int = 0, orphan: Int = 0) {
+        self.total = total
+        self.uploaded = uploaded
+        self.linkable = linkable
+        self.repoOnly = repoOnly
+        self.orphan = orphan
+    }
+
+    public init(sessions: [BackfillSession]) {
+        self.init(
+            total: sessions.count,
+            uploaded: sessions.filter { $0.uploadStatus == .uploaded }.count,
+            linkable: sessions.filter { $0.confidence == .high }.count,
+            repoOnly: sessions.filter { $0.confidence == .medium }.count,
+            orphan: sessions.filter { $0.confidence == .low }.count)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncLedgerStore.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncLedgerStore.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// The single in-process owner of the upload ledger (CROW-1075).
+///
+/// The live collector used to `load` the ledger fresh, mutate it across a whole
+/// sweep, and `save` at the end — safe only because it was the *sole* writer
+/// (`LogSyncLedger` says as much). Backfill (CROW-1075) is a second, concurrent
+/// writer: a user-initiated `backfill-upload` can run while the 5-minute poll
+/// tick is mid-sweep. Two independent load→mutate→save cycles would lose
+/// updates. This actor removes that hazard by keeping the ledger in memory and
+/// serializing every read-modify-write; both the collector and the backfill
+/// handler go through the one instance for a given dev root.
+///
+/// Persistence is write-through (each `record`/`prune` saves), and the value
+/// type `LogSyncLedger` keeps all the pure logic — this actor only owns
+/// concurrency and disk I/O.
+public actor LogSyncLedgerStore {
+    private let devRoot: String
+    private var ledger: LogSyncLedger
+    private var loaded = false
+
+    public init(devRoot: String) {
+        self.devRoot = devRoot
+        self.ledger = LogSyncLedger()
+    }
+
+    /// Lazily load the on-disk ledger the first time it's touched, so
+    /// constructing the store is cheap and a test can pre-seed the file.
+    private func ensureLoaded() {
+        guard !loaded else { return }
+        ledger = LogSyncLedger.load(devRoot: devRoot)
+        loaded = true
+    }
+
+    /// Whether this artifact slot should be uploaded now (delegates to the value
+    /// type's policy).
+    public func shouldUpload(key: String, now: Double, retryBackoff: Double) -> Bool {
+        ensureLoaded()
+        return ledger.shouldUpload(key: key, now: now, retryBackoff: retryBackoff)
+    }
+
+    /// Record an outcome and persist. Best-effort — a write failure is swallowed
+    /// (the worst case is a duplicate upload the server 409s), matching the
+    /// collector's existing tolerance.
+    public func record(key: String, entry: LogSyncLedger.Entry) {
+        ensureLoaded()
+        ledger.record(key: key, entry: entry)
+        persist()
+    }
+
+    /// Prune aged entries and persist.
+    public func prune(retentionDays: Int, now: Double) {
+        ensureLoaded()
+        ledger.prune(retentionDays: retentionDays, now: now)
+        persist()
+    }
+
+    /// A snapshot of the current ledger, for reconciling scan status.
+    public func snapshot() -> LogSyncLedger {
+        ensureLoaded()
+        return ledger
+    }
+
+    private func persist() {
+        do { try ledger.save(devRoot: devRoot) }
+        catch { CrowLog.info("[LogSync] failed to persist log-sync ledger: \(error.localizedDescription)") }
+    }
+
+    // MARK: - Per-dev-root sharing
+
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var instances: [String: LogSyncLedgerStore] = [:]
+
+    /// The one store for a dev root, created on first use. The collector poll
+    /// loop and the backfill RPC handler both resolve their store this way, so a
+    /// single actor mediates every ledger write in the process.
+    public static func shared(devRoot: String) -> LogSyncLedgerStore {
+        let key = (devRoot as NSString).standardizingPath
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = instances[key] { return existing }
+        let store = LogSyncLedgerStore(devRoot: key)
+        instances[key] = store
+        return store
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TicketValidator.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TicketValidator.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Confirms a reconstructed ticket actually exists on the provider before Crow
+/// asserts a link for it (CROW-1075, decision #3). Backfill reconstructs a
+/// `(repo, number)` from a worktree name; that number might be a real issue, a
+/// real PR, or nothing (a typo, a since-deleted ticket, a number that was never
+/// a ticket at all). Uploading a fabricated REFERENCE would put a false edge
+/// into a permanent, org-readable graph, so the uploader only stamps a ticket
+/// hint into the sidecar when this validator reports `.issue` or `.pullRequest`.
+///
+/// One `gh api repos/{owner}/{repo}/issues/{n}` (or `glab`) call answers both
+/// "does it exist" and "issue vs PR" — GitHub's issues endpoint returns PRs too,
+/// distinguished by a `pull_request` member. Results are cached per
+/// `host/owner/repo#n` so a scan/upload of many sessions in one repo pays once.
+public actor TicketValidator {
+    private let runner: any ShellRunner
+    private var cache: [String: BackfillTicketKind] = [:]
+
+    public init(runner: any ShellRunner = ProcessShellRunner()) {
+        self.runner = runner
+    }
+
+    /// Validate `(remote, number)`. Returns `.issue`/`.pullRequest` when the
+    /// provider confirms it, `.notFound` on a clean 404, and `.unvalidated` when
+    /// the check couldn't run (no CLI, auth failure, network) — the caller treats
+    /// everything but the first two as "assert no link".
+    public func validate(remote: RepoRemote, number: Int) async -> BackfillTicketKind {
+        let key = "\(remote.host)/\(remote.owner)/\(remote.repo)#\(number)"
+        if let cached = cache[key] { return cached }
+        let kind = remote.isGitHub
+            ? await validateGitHub(remote: remote, number: number)
+            : await validateGitLab(remote: remote, number: number)
+        cache[key] = kind
+        return kind
+    }
+
+    // MARK: - GitHub
+
+    private func validateGitHub(remote: RepoRemote, number: Int) async -> BackfillTicketKind {
+        var args = ["gh", "api"]
+        if remote.host != "github.com" { args += ["--hostname", remote.host] }
+        args.append("repos/\(remote.owner)/\(remote.repo)/issues/\(number)")
+        do {
+            let out = try await runner.run(args: args, env: [:], cwd: nil)
+            return Self.classifyGitHub(json: out)
+        } catch let ShellRunnerError.nonZeroExit(_, output) {
+            // A 404 is a definitive "does not exist"; any other failure (auth,
+            // rate limit, offline) is inconclusive, so don't claim not-found.
+            return output.contains("Not Found") || output.contains("HTTP 404")
+                ? .notFound : .unvalidated
+        } catch {
+            return .unvalidated
+        }
+    }
+
+    /// Classify a GitHub issues-endpoint JSON body: a `pull_request` member marks
+    /// it a PR, otherwise it's an issue. A body missing a `number` isn't a valid
+    /// ticket payload → inconclusive.
+    static func classifyGitHub(json: String) -> BackfillTicketKind {
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return .unvalidated }
+        guard obj["number"] != nil else { return .unvalidated }
+        return obj["pull_request"] != nil ? .pullRequest : .issue
+    }
+
+    // MARK: - GitLab
+
+    private func validateGitLab(remote: RepoRemote, number: Int) async -> BackfillTicketKind {
+        let project = "\(remote.owner)/\(remote.repo)"
+            .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? "\(remote.owner)/\(remote.repo)"
+        // GitLab keeps issues and MRs in separate namespaces sharing an `iid`
+        // space, so try an issue first, then a merge request.
+        if await gitlabExists(host: remote.host, path: "projects/\(project)/issues/\(number)") {
+            return .issue
+        }
+        if await gitlabExists(host: remote.host, path: "projects/\(project)/merge_requests/\(number)") {
+            return .pullRequest
+        }
+        return .unvalidated
+    }
+
+    private func gitlabExists(host: String, path: String) async -> Bool {
+        var args = ["glab", "api"]
+        if host != "gitlab.com" { args += ["--hostname", host] }
+        args.append(path)
+        do {
+            let out = try await runner.run(args: args, env: [:], cwd: nil)
+            guard let data = out.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return false }
+            return obj["iid"] != nil || obj["id"] != nil
+        } catch {
+            return false
+        }
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptHead.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptHead.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// The few facts the backfill scan needs out of a Claude `.jsonl` transcript,
+/// read from its head without parsing the whole (often multi-MB) file
+/// (CROW-1075). Claude records the real working directory and git branch on its
+/// event lines, so these are the **authoritative** metadata source — far more
+/// reliable than reversing the lossy project-slug directory name.
+public struct TranscriptHead: Sendable, Equatable {
+    public var sessionID: String?
+    public var cwd: String?
+    public var gitBranch: String?
+    /// First `timestamp` seen (ISO-8601 string, verbatim) — a fallback "date"
+    /// when the file mtime is misleading.
+    public var firstTimestamp: String?
+
+    public init(
+        sessionID: String? = nil, cwd: String? = nil,
+        gitBranch: String? = nil, firstTimestamp: String? = nil
+    ) {
+        self.sessionID = sessionID
+        self.cwd = cwd
+        self.gitBranch = gitBranch
+        self.firstTimestamp = firstTimestamp
+    }
+
+    /// Whether every field of interest is filled, so the reader can stop early.
+    var isComplete: Bool {
+        sessionID != nil && cwd != nil && gitBranch != nil && firstTimestamp != nil
+    }
+}
+
+/// Reads the leading events of a Claude transcript to recover its
+/// `cwd`/`gitBranch`/`sessionId` (CROW-1075). The line parse is pure and
+/// unit-tested; the file read is a thin wrapper that streams line by line and
+/// stops as soon as every field is found (Claude fills them within the first
+/// handful of message events) or a line budget is hit.
+public enum TranscriptHeadReader {
+    /// Fold one JSON event line into the accumulating head. Only the four fields
+    /// of interest are decoded; everything else is ignored. A non-JSON or
+    /// unrelated line leaves the head unchanged.
+    public static func absorb(_ line: String, into head: inout TranscriptHead) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+        func str(_ key: String) -> String? {
+            guard let v = obj[key] as? String else { return nil }
+            let t = v.trimmingCharacters(in: .whitespacesAndNewlines)
+            return t.isEmpty ? nil : t
+        }
+        if head.sessionID == nil { head.sessionID = str("sessionId") }
+        if head.cwd == nil { head.cwd = str("cwd") }
+        if head.gitBranch == nil { head.gitBranch = str("gitBranch") }
+        if head.firstTimestamp == nil { head.firstTimestamp = str("timestamp") }
+    }
+
+    /// Parse a whole in-memory transcript body (test/fixture convenience).
+    public static func parse(_ body: String, maxLines: Int = 400) -> TranscriptHead {
+        var head = TranscriptHead()
+        var seen = 0
+        for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            if seen >= maxLines || head.isComplete { break }
+            seen += 1
+            absorb(String(line), into: &head)
+        }
+        return head
+    }
+
+    /// Stream a transcript file's head from disk. Reads in bounded chunks and
+    /// stops once the head is complete or `maxLines` is reached, so a large file
+    /// costs only its first few KB. Returns an empty head on an unreadable file.
+    public static func read(_ url: URL, maxLines: Int = 400) -> TranscriptHead {
+        var head = TranscriptHead()
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return head }
+        defer { try? handle.close() }
+        var buffer = Data()
+        var lines = 0
+        let newline: UInt8 = 0x0A
+        while lines < maxLines, !head.isComplete {
+            guard let chunk = try? handle.read(upToCount: 65_536), !chunk.isEmpty else { break }
+            buffer.append(chunk)
+            while let idx = buffer.firstIndex(of: newline) {
+                let lineData = buffer[buffer.startIndex..<idx]
+                buffer.removeSubrange(buffer.startIndex...idx)
+                lines += 1
+                if let line = String(data: lineData, encoding: .utf8) {
+                    absorb(line, into: &head)
+                }
+                if head.isComplete || lines >= maxLines { break }
+            }
+        }
+        // A final partial line (no trailing newline) within budget.
+        if !head.isComplete, lines < maxLines, !buffer.isEmpty,
+           let line = String(data: buffer, encoding: .utf8) {
+            absorb(line, into: &head)
+        }
+        return head
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -294,6 +294,10 @@ public enum ParityLedger {
         .write("cleanup-set", cli: "cleanup set"),
         .read("logsync-get", cli: "logsync get"),
         .write("logsync-set", cli: "logsync set"),
+        // Historical session backfill (CROW-1075). `scan` reconciles on-disk
+        // transcripts; `upload` pushes a user-selected set through the live path.
+        .read("backfill-scan", cli: "backfill scan"),
+        .write("backfill-upload", cli: "backfill upload"),
         .read("ui-get", cli: "ui get"),
         .write("ui-set", cli: "ui set"),
         .read("version-update-get", cli: "version get"),

--- a/Packages/CrowCore/Tests/CrowCoreTests/BackfillReconstructionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BackfillReconstructionTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite struct BackfillReconstructionTests {
+
+    // MARK: - RepoRemote.parse
+
+    @Test func parsesHTTPSRemote() {
+        let r = RepoRemote.parse("https://github.com/corveil/crow.git")
+        #expect(r == RepoRemote(host: "github.com", owner: "corveil", repo: "crow"))
+        #expect(r?.slug == "corveil/crow")
+        #expect(r?.isGitHub == true)
+    }
+
+    @Test func parsesScpLikeRemote() {
+        let r = RepoRemote.parse("git@github.com:RadiusMethod/corveil.git")
+        #expect(r == RepoRemote(host: "github.com", owner: "RadiusMethod", repo: "corveil"))
+    }
+
+    @Test func parsesGitLabSubgroupsIntoOwnerPath() {
+        let r = RepoRemote.parse("https://repo1.dso.mil/big-bang/product/packages/grafana.git")
+        #expect(r?.host == "repo1.dso.mil")
+        #expect(r?.owner == "big-bang/product/packages")
+        #expect(r?.repo == "grafana")
+        #expect(r?.isGitHub == false)
+    }
+
+    @Test func rejectsNonRemoteStrings() {
+        #expect(RepoRemote.parse("") == nil)
+        #expect(RepoRemote.parse("/some/local/path") == nil)
+        #expect(RepoRemote.parse("git@github.com") == nil) // no path
+    }
+
+    // MARK: - workspace / worktree from cwd
+
+    @Test func derivesWorkspaceAndWorktreeFromCwd() {
+        let dev = "/Users/j/Dev2"
+        let cwd = "/Users/j/Dev2/RadiusMethod/crow-1075-session-backfill"
+        #expect(BackfillReconstructor.workspace(cwd: cwd, devRoot: dev) == "RadiusMethod")
+        #expect(BackfillReconstructor.worktreeName(cwd: cwd, devRoot: dev) == "crow-1075-session-backfill")
+    }
+
+    @Test func cwdOutsideDevRootHasNoWorkspace() {
+        let dev = "/Users/j/Dev2"
+        let cwd = "/Users/j/Downloads/scratch"
+        #expect(BackfillReconstructor.workspace(cwd: cwd, devRoot: dev) == nil)
+        #expect(BackfillReconstructor.worktreeName(cwd: cwd, devRoot: dev) == nil)
+    }
+
+    @Test func cwdAtWorkspaceRootHasNoWorktree() {
+        let dev = "/Users/j/Dev2"
+        #expect(BackfillReconstructor.workspace(cwd: "/Users/j/Dev2/RadiusMethod", devRoot: dev) == "RadiusMethod")
+        #expect(BackfillReconstructor.worktreeName(cwd: "/Users/j/Dev2/RadiusMethod", devRoot: dev) == nil)
+    }
+
+    // MARK: - parseWorktree
+
+    @Test func parsesSimpleWorktreeWithKnownRepo() {
+        let (repo, ticket) = BackfillReconstructor.parseWorktree(
+            "crow-1075-session-backfill", knownRepoNames: ["crow", "corveil"])
+        #expect(repo == "crow")
+        #expect(ticket == 1075)
+    }
+
+    @Test func knownRepoDisambiguatesMultiDashRepoName() {
+        // The hard case: `corveil-cloud-terraform` is a repo, so 331 is the
+        // ticket — not `corveil` with ticket "cloud".
+        let (repo, ticket) = BackfillReconstructor.parseWorktree(
+            "corveil-cloud-terraform-331-right-size-api-task",
+            knownRepoNames: ["corveil", "crow", "corveil-cloud-terraform"])
+        #expect(repo == "corveil-cloud-terraform")
+        #expect(ticket == 331)
+    }
+
+    @Test func fallsBackToGenericSplitWithoutKnownRepo() {
+        let (repo, ticket) = BackfillReconstructor.parseWorktree(
+            "alloy-2520-receiver-traces", knownRepoNames: [])
+        #expect(repo == "alloy")
+        #expect(ticket == 2520)
+    }
+
+    @Test func parsesReviewClone() {
+        let (repo, ticket) = BackfillReconstructor.parseWorktree(
+            "corveil-cloud-terraform-pr-319", knownRepoNames: [])
+        #expect(repo == "corveil-cloud-terraform")
+        #expect(ticket == 319)
+    }
+
+    @Test func worktreeWithNoNumberYieldsRepoOnly() {
+        let (repo, ticket) = BackfillReconstructor.parseWorktree(
+            "codename-spotlight", knownRepoNames: ["codename-spotlight"])
+        #expect(repo == "codename-spotlight")
+        #expect(ticket == nil)
+    }
+
+    // MARK: - ticketNumber(fromBranch:)
+
+    @Test func extractsTicketNumberFromBranch() {
+        #expect(BackfillReconstructor.ticketNumber(fromBranch: "feature/crow-1075-session-backfill") == 1075)
+        #expect(BackfillReconstructor.ticketNumber(fromBranch: "feature/corveil-2100-sonnet-5-billing-rate") == 2100)
+    }
+
+    @Test func branchWithNoDashDelimitedNumberIsNil() {
+        #expect(BackfillReconstructor.ticketNumber(fromBranch: "main") == nil)
+        #expect(BackfillReconstructor.ticketNumber(fromBranch: "feature/cleanup-v2") == nil) // trailing, no closing dash
+    }
+
+    // MARK: - confidence
+
+    @Test func confidenceTiers() {
+        #expect(BackfillReconstructor.confidence(workspace: "R", repoName: "crow", ticket: 1) == .high)
+        #expect(BackfillReconstructor.confidence(workspace: "R", repoName: "crow", ticket: nil) == .medium)
+        #expect(BackfillReconstructor.confidence(workspace: "R", repoName: nil, ticket: nil) == .medium)
+        #expect(BackfillReconstructor.confidence(workspace: nil, repoName: nil, ticket: nil) == .low)
+    }
+
+    // MARK: - ticketURL
+
+    @Test func buildsValidatedTicketURLs() {
+        let gh = RepoRemote(host: "github.com", owner: "corveil", repo: "crow")
+        #expect(BackfillReconstructor.ticketURL(remote: gh, number: 12, kind: .issue)
+            == "https://github.com/corveil/crow/issues/12")
+        #expect(BackfillReconstructor.ticketURL(remote: gh, number: 12, kind: .pullRequest)
+            == "https://github.com/corveil/crow/pull/12")
+    }
+
+    @Test func unvalidatedTicketHasNoURL() {
+        let gh = RepoRemote(host: "github.com", owner: "corveil", repo: "crow")
+        #expect(BackfillReconstructor.ticketURL(remote: gh, number: 12, kind: .unvalidated) == nil)
+        #expect(BackfillReconstructor.ticketURL(remote: gh, number: nil, kind: .issue) == nil)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite struct BackfillScannerTests {
+    /// Build a temp dev root + a temp Claude projects dir, returning both paths.
+    private func makeTree() throws -> (devRoot: String, projects: URL, cleanup: () -> Void) {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backfill-scan-\(UUID().uuidString)", isDirectory: true)
+        let devRoot = base.appendingPathComponent("Dev2", isDirectory: true)
+        let projects = base.appendingPathComponent("projects", isDirectory: true)
+        try FileManager.default.createDirectory(at: devRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        return (devRoot.path, projects, { try? FileManager.default.removeItem(at: base) })
+    }
+
+    private func writeTranscript(
+        in projects: URL, slug: String, uid: String, cwd: String, branch: String
+    ) throws {
+        let dir = projects.appendingPathComponent(slug, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let body = """
+        {"type":"mode","sessionId":"\(uid)"}
+        {"type":"user","sessionId":"\(uid)","cwd":"\(cwd)","gitBranch":"\(branch)","timestamp":"2026-08-19T00:00:00Z"}
+        """
+        try body.write(to: dir.appendingPathComponent("\(uid).jsonl"), atomically: true, encoding: .utf8)
+    }
+
+    @Test func reconstructsHighConfidenceSession() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+
+        // A live clone so the repo → owner/repo resolves.
+        let clone = URL(fileURLWithPath: devRoot)
+            .appendingPathComponent("RadiusMethod/crow", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: clone.appendingPathComponent(".git"), withIntermediateDirectories: true)
+
+        let cwd = "\(devRoot)/RadiusMethod/crow-1075-session-backfill"
+        try writeTranscript(
+            in: projects, slug: "slug1", uid: "UID-1", cwd: cwd,
+            branch: "feature/crow-1075-session-backfill")
+
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects,
+            gitRemote: { path in
+                path.hasSuffix("/RadiusMethod/crow") ? "https://github.com/corveil/crow.git" : nil
+            })
+
+        let sessions = await scanner.scan(ledger: LogSyncLedger())
+        #expect(sessions.count == 1)
+        let s = try #require(sessions.first)
+        #expect(s.claudeSessionUID == "UID-1")
+        #expect(s.workspace == "RadiusMethod")
+        #expect(s.worktreeName == "crow-1075-session-backfill")
+        #expect(s.repoName == "crow")
+        #expect(s.ownerRepo == "corveil/crow")
+        #expect(s.host == "github.com")
+        #expect(s.ticketNumber == 1075)
+        #expect(s.confidence == .high)
+        #expect(s.uploadStatus == .new)
+    }
+
+    @Test func orphanSessionOutsideDevRootIsLowConfidence() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        try writeTranscript(
+            in: projects, slug: "slug2", uid: "UID-2",
+            cwd: "/Users/j/Downloads/scratch", branch: "main")
+
+        let scanner = BackfillScanner(devRoot: devRoot, projectsDir: projects, gitRemote: { _ in nil })
+        let sessions = await scanner.scan(ledger: LogSyncLedger())
+        let s = try #require(sessions.first { $0.claudeSessionUID == "UID-2" })
+        #expect(s.workspace == nil)
+        #expect(s.repoName == nil)
+        #expect(s.confidence == .low)
+    }
+
+    @Test func ledgerStatusIsReconciled() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        try writeTranscript(
+            in: projects, slug: "slug3", uid: "UID-3",
+            cwd: "\(devRoot)/RadiusMethod/crow-9-x", branch: "feature/crow-9-x")
+
+        var ledger = LogSyncLedger()
+        ledger.record(
+            key: LogSyncLedger.key(sessionUID: "UID-3", harness: .claude, kind: .sessionTranscript),
+            entry: .init(status: .uploaded, sha256: "s", sizeBytes: 1, at: 1))
+
+        let scanner = BackfillScanner(devRoot: devRoot, projectsDir: projects, gitRemote: { _ in nil })
+        let sessions = await scanner.scan(ledger: ledger)
+        let s = try #require(sessions.first { $0.claudeSessionUID == "UID-3" })
+        #expect(s.uploadStatus == .uploaded)
+    }
+
+    @Test func summaryCountsByTier() {
+        let sessions = [
+            BackfillSession(claudeSessionUID: "a", filePath: "", slug: "", confidence: .high, uploadStatus: .uploaded),
+            BackfillSession(claudeSessionUID: "b", filePath: "", slug: "", confidence: .high, uploadStatus: .new),
+            BackfillSession(claudeSessionUID: "c", filePath: "", slug: "", confidence: .medium, uploadStatus: .new),
+            BackfillSession(claudeSessionUID: "d", filePath: "", slug: "", confidence: .low, uploadStatus: .new),
+        ]
+        let sum = BackfillSummary(sessions: sessions)
+        #expect(sum.total == 4)
+        #expect(sum.uploaded == 1)
+        #expect(sum.linkable == 2)
+        #expect(sum.repoOnly == 1)
+        #expect(sum.orphan == 1)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/LogSyncLedgerStoreTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/LogSyncLedgerStoreTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite struct LogSyncLedgerStoreTests {
+    private func tempDevRoot() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ledger-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.path
+    }
+
+    @Test func recordsAndSnapshotsThroughDisk() async throws {
+        let devRoot = try tempDevRoot()
+        let store = LogSyncLedgerStore(devRoot: devRoot)
+        let key = LogSyncLedger.key(sessionUID: "abc", harness: .claude, kind: .sessionTranscript)
+
+        #expect(await store.shouldUpload(key: key, now: 0, retryBackoff: 0))
+        await store.record(key: key, entry: .init(status: .uploaded, sha256: "s", sizeBytes: 10, at: 1))
+        #expect(await store.shouldUpload(key: key, now: 0, retryBackoff: 0) == false)
+
+        // Persisted to disk — a fresh load sees it.
+        let onDisk = LogSyncLedger.load(devRoot: devRoot)
+        #expect(onDisk.entries[key]?.status == .uploaded)
+    }
+
+    @Test func concurrentRecordsLoseNoUpdates() async throws {
+        let devRoot = try tempDevRoot()
+        let store = LogSyncLedgerStore(devRoot: devRoot)
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<50 {
+                group.addTask {
+                    let key = LogSyncLedger.key(
+                        sessionUID: "s\(i)", harness: .claude, kind: .sessionTranscript)
+                    await store.record(key: key, entry: .init(
+                        status: .uploaded, sha256: "s", sizeBytes: i, at: Double(i)))
+                }
+            }
+        }
+        let snap = await store.snapshot()
+        #expect(snap.entries.count == 50)
+        // And the final persisted file has all 50 (no lost writes).
+        #expect(LogSyncLedger.load(devRoot: devRoot).entries.count == 50)
+    }
+
+    @Test func sharedReturnsSameInstancePerDevRoot() async throws {
+        let devRoot = try tempDevRoot()
+        let a = LogSyncLedgerStore.shared(devRoot: devRoot)
+        let b = LogSyncLedgerStore.shared(devRoot: devRoot)
+        #expect(a === b)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/TicketValidatorTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TicketValidatorTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// A `ShellRunner` that answers from an injected closure and counts calls, for
+/// unit-testing subprocess-backed logic without a real `gh`/`glab`.
+actor ScriptedShellRunner: ShellRunner {
+    let answer: @Sendable ([String]) -> Result<String, Error>
+    private(set) var callCount = 0
+
+    init(_ answer: @escaping @Sendable ([String]) -> Result<String, Error>) {
+        self.answer = answer
+    }
+
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        await bump()
+        switch answer(args) {
+        case .success(let out): return out
+        case .failure(let err): throw err
+        }
+    }
+
+    private func bump() { callCount += 1 }
+    func calls() -> Int { callCount }
+}
+
+@Suite struct TicketValidatorTests {
+    private let ghRemote = RepoRemote(host: "github.com", owner: "corveil", repo: "crow")
+
+    @Test func classifiesIssue() async {
+        let runner = ScriptedShellRunner { _ in .success(#"{"number": 12, "title": "x"}"#) }
+        let v = TicketValidator(runner: runner)
+        #expect(await v.validate(remote: ghRemote, number: 12) == .issue)
+    }
+
+    @Test func classifiesPullRequest() async {
+        let runner = ScriptedShellRunner { _ in
+            .success(#"{"number": 12, "pull_request": {"url": "..."}}"#)
+        }
+        let v = TicketValidator(runner: runner)
+        #expect(await v.validate(remote: ghRemote, number: 12) == .pullRequest)
+    }
+
+    @Test func cleanNotFoundIsNotFound() async {
+        let runner = ScriptedShellRunner { _ in
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "gh: Not Found (HTTP 404)"))
+        }
+        let v = TicketValidator(runner: runner)
+        #expect(await v.validate(remote: ghRemote, number: 999) == .notFound)
+    }
+
+    @Test func otherErrorIsInconclusive() async {
+        // An auth/network failure must NOT be reported as not-found (that would
+        // suppress a real link); it's inconclusive so the caller uploads repo-only.
+        let runner = ScriptedShellRunner { _ in
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "error connecting to api.github.com"))
+        }
+        let v = TicketValidator(runner: runner)
+        #expect(await v.validate(remote: ghRemote, number: 12) == .unvalidated)
+    }
+
+    @Test func cachesPerTicket() async {
+        let runner = ScriptedShellRunner { _ in .success(#"{"number": 12}"#) }
+        let v = TicketValidator(runner: runner)
+        _ = await v.validate(remote: ghRemote, number: 12)
+        _ = await v.validate(remote: ghRemote, number: 12)
+        #expect(await runner.calls() == 1)
+    }
+
+    @Test func passesHostnameForEnterpriseHost() async {
+        let runner = ScriptedShellRunner { args in
+            // Enterprise host must be passed via --hostname.
+            args.contains("--hostname") && args.contains("github.acme.com")
+                ? .success(#"{"number": 5}"#)
+                : .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "Not Found"))
+        }
+        let v = TicketValidator(runner: runner)
+        let ent = RepoRemote(host: "github.acme.com", owner: "o", repo: "r")
+        #expect(await v.validate(remote: ent, number: 5) == .issue)
+    }
+
+    @Test func classifyGitHubHelper() {
+        #expect(TicketValidator.classifyGitHub(json: #"{"number": 1}"#) == .issue)
+        #expect(TicketValidator.classifyGitHub(json: #"{"number": 1, "pull_request": {}}"#) == .pullRequest)
+        #expect(TicketValidator.classifyGitHub(json: #"{"message": "Not Found"}"#) == .unvalidated)
+        #expect(TicketValidator.classifyGitHub(json: "garbage") == .unvalidated)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/TranscriptHeadReaderTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TranscriptHeadReaderTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite struct TranscriptHeadReaderTests {
+    /// A realistic Claude transcript head: the first lines are control events
+    /// with no cwd, and the message events carry cwd/gitBranch/timestamp.
+    private let sample = """
+    {"type":"mode","sessionId":"dfb5e99e-3195-4342-89fd-4025f1b7f09e"}
+    {"type":"permission-mode","sessionId":"dfb5e99e-3195-4342-89fd-4025f1b7f09e"}
+    {"type":"user","sessionId":"dfb5e99e-3195-4342-89fd-4025f1b7f09e","cwd":"/Users/j/Dev2/RadiusMethod/crow-1075-session-backfill","gitBranch":"feature/crow-1075-session-backfill","version":"2.1.236","timestamp":"2026-08-19T23:28:12.852Z"}
+    """
+
+    @Test func parsesCwdBranchSessionFromHead() {
+        let head = TranscriptHeadReader.parse(sample)
+        #expect(head.sessionID == "dfb5e99e-3195-4342-89fd-4025f1b7f09e")
+        #expect(head.cwd == "/Users/j/Dev2/RadiusMethod/crow-1075-session-backfill")
+        #expect(head.gitBranch == "feature/crow-1075-session-backfill")
+        #expect(head.firstTimestamp == "2026-08-19T23:28:12.852Z")
+    }
+
+    @Test func ignoresNonJSONAndEmptyLines() {
+        let body = "\nnot json\n{\"cwd\":\"/x\",\"sessionId\":\"s\"}\n"
+        let head = TranscriptHeadReader.parse(body)
+        #expect(head.cwd == "/x")
+        #expect(head.sessionID == "s")
+        #expect(head.gitBranch == nil)
+    }
+
+    @Test func readsHeadFromDiskAndStopsEarly() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("thr-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("s.jsonl")
+        // Head fields in the first lines, then a large tail that must not be read
+        // in full (the reader stops once the head is complete).
+        var body = sample + "\n"
+        body += String(repeating: "{\"type\":\"noise\"}\n", count: 100_000)
+        try body.write(to: file, atomically: true, encoding: .utf8)
+
+        let head = TranscriptHeadReader.read(file)
+        #expect(head.cwd == "/Users/j/Dev2/RadiusMethod/crow-1075-session-backfill")
+        #expect(head.gitBranch == "feature/crow-1075-session-backfill")
+    }
+
+    @Test func unreadableFileYieldsEmptyHead() {
+        let head = TranscriptHeadReader.read(URL(fileURLWithPath: "/nope/does/not/exist.jsonl"))
+        #expect(head == TranscriptHead())
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
@@ -1,0 +1,148 @@
+import Foundation
+import CrowCore
+
+/// The daemon-side orchestration behind `backfill-scan` / `backfill-upload`
+/// (CROW-1075). It composes the CrowCore pieces — the disk scanner, the ticket
+/// validator, the shared ledger store — with the **live** upload path
+/// (`TranscriptNormalizer` + `TranscriptUploader`), so a back-filled session
+/// lands through exactly the same endpoint and idempotency machinery as a
+/// live-captured one; only the `{uid}` (a Claude session UUID rather than a Crow
+/// session UUID) and the reconstructed sidecar differ.
+///
+/// Lives in CrowDaemon because it reuses `LogSyncCollector`'s `sha256Hex` /
+/// `ledgerEntry` (Crypto isn't a CrowCore dependency) and the same
+/// `GatewayResolver`-backed credential path.
+struct BackfillService: Sendable {
+    let devRoot: String
+    let uploader: TranscriptUploader
+    let validator: TicketValidator
+    /// Resolves an `op://…` reference to a secret (defaults to 1Password).
+    let resolveSecret: @Sendable (String) -> String?
+    let now: @Sendable () -> Date
+
+    init(
+        devRoot: String,
+        uploader: TranscriptUploader = TranscriptUploader(),
+        validator: TicketValidator = TicketValidator(),
+        resolveSecret: @escaping @Sendable (String) -> String? = { GatewayResolver.opRead($0) },
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.devRoot = devRoot
+        self.uploader = uploader
+        self.validator = validator
+        self.resolveSecret = resolveSecret
+        self.now = now
+    }
+
+    // MARK: - Scan
+
+    /// Reconcile the on-disk transcripts against the ledger.
+    func scan(scanner: BackfillScanner? = nil) async -> [BackfillSession] {
+        let store = LogSyncLedgerStore.shared(devRoot: devRoot)
+        let ledger = await store.snapshot()
+        let s = scanner ?? BackfillScanner(devRoot: devRoot, now: now)
+        return await s.scan(ledger: ledger)
+    }
+
+    // MARK: - Upload one session
+
+    /// Upload one reconstructed session through the live path, gating the ticket
+    /// REFERENCE on provider validation (decision #3). `upload` is the resolved
+    /// `(baseURL, apiKey)` from the chosen workspace's gateway — the same
+    /// destination + credential the live collector uses.
+    func upload(
+        session: BackfillSession,
+        upload: (baseURL: String, apiKey: String),
+        maxUploadBytes: Int
+    ) async -> BackfillUploadOutcome {
+        let store = LogSyncLedgerStore.shared(devRoot: devRoot)
+        let uid = session.claudeSessionUID
+        let key = LogSyncLedger.key(sessionUID: uid, harness: .claude, kind: .sessionTranscript)
+        let nowEpoch = now().timeIntervalSince1970
+
+        // Idempotent: a slot the ledger records as uploaded or permanently
+        // skipped is never re-attempted (retryBackoff 0 still lets a prior
+        // transient failure retry).
+        guard await store.shouldUpload(key: key, now: nowEpoch, retryBackoff: 0) else {
+            return BackfillUploadOutcome(
+                claudeSessionUID: uid, result: .alreadyUploaded,
+                ownerRepo: session.ownerRepo, ticketNumber: session.ticketNumber)
+        }
+
+        let file = URL(fileURLWithPath: session.filePath)
+        guard let transcript = TranscriptNormalizer.normalize(
+            files: [file], format: .jsonl, maxBytes: max(1, maxUploadBytes)) else {
+            return BackfillUploadOutcome(
+                claudeSessionUID: uid, result: .skipped, ownerRepo: session.ownerRepo,
+                reason: "empty_or_unreadable")
+        }
+
+        // Validate the reconstructed ticket before asserting any link.
+        var ticketURL: String?
+        var linkedNumber: Int?
+        var ticketKind: BackfillTicketKind?
+        var linked = false
+        if let ownerRepo = session.ownerRepo, let host = session.host,
+           let number = session.ticketNumber, let remote = Self.remote(ownerRepo: ownerRepo, host: host) {
+            let kind = await validator.validate(remote: remote, number: number)
+            ticketKind = kind
+            if kind == .issue || kind == .pullRequest {
+                ticketURL = BackfillReconstructor.ticketURL(remote: remote, number: number, kind: kind)
+                linkedNumber = ticketURL != nil ? number : nil
+                linked = ticketURL != nil
+            }
+        }
+
+        let metadata = LogSyncSessionMetadata(
+            name: session.worktreeName ?? session.slug,
+            status: nil, // a historical session's Crow status is genuinely unknown
+            agentKind: AgentKind.claudeCode.rawValue,
+            ticketURL: ticketURL,
+            ticketNumber: linkedNumber,
+            repo: session.ownerRepo,
+            orgGoal: nil)
+
+        let result = await uploader.upload(
+            baseURL: upload.baseURL, apiKey: upload.apiKey,
+            sessionUID: uid, harness: .claude, kind: .sessionTranscript, format: .jsonl,
+            transcript: transcript, metadata: metadata, agentSessionID: uid)
+
+        let sha = LogSyncCollector.sha256Hex(transcript.data)
+        let entry = LogSyncCollector.ledgerEntry(
+            for: result, sha: sha, size: transcript.data.count, at: nowEpoch)
+        await store.record(key: key, entry: entry)
+
+        return Self.outcome(
+            uid: uid, result: result, linked: linked,
+            ownerRepo: session.ownerRepo, ticketNumber: linkedNumber, ticketKind: ticketKind)
+    }
+
+    // MARK: - Helpers
+
+    /// Split a resolved `owner/repo` back into a `RepoRemote` for URL/validation.
+    static func remote(ownerRepo: String, host: String) -> RepoRemote? {
+        guard let slash = ownerRepo.lastIndex(of: "/") else { return nil }
+        let owner = String(ownerRepo[..<slash])
+        let repo = String(ownerRepo[ownerRepo.index(after: slash)...])
+        guard !owner.isEmpty, !repo.isEmpty else { return nil }
+        return RepoRemote(host: host, owner: owner, repo: repo)
+    }
+
+    static func outcome(
+        uid: String, result: TranscriptUploadResult, linked: Bool,
+        ownerRepo: String?, ticketNumber: Int?, ticketKind: BackfillTicketKind?
+    ) -> BackfillUploadOutcome {
+        let disposition: BackfillUploadOutcome.Result
+        var reason: String?
+        switch result {
+        case .created: disposition = .uploaded
+        case .alreadyExists: disposition = .alreadyUploaded
+        case .tooLarge: disposition = .skipped; reason = "too_large"
+        case .rejected(let s): disposition = .failed; reason = "rejected_\(s)"
+        case .transient: disposition = .failed; reason = "transient"
+        }
+        return BackfillUploadOutcome(
+            claudeSessionUID: uid, result: disposition, linked: linked,
+            ownerRepo: ownerRepo, ticketNumber: ticketNumber, ticketKind: ticketKind, reason: reason)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
@@ -65,10 +65,15 @@ struct LogSyncCollector {
             appState.sessions.map { ($0, appState.worktrees(for: $0.id)) }
         }
 
-        var ledger = LogSyncLedger.load(devRoot: devRoot)
         let nowDate = now()
         let nowEpoch = nowDate.timeIntervalSince1970
         let quietPeriod = TimeInterval(max(0, config.quietPeriodMinutes) * 60)
+
+        // Route ledger reads/writes through the shared, serialized store so the
+        // user-initiated backfill (CROW-1075) can write concurrently without
+        // losing updates. Both the poll loop and the backfill RPC handler resolve
+        // the same actor via `shared(devRoot:)`.
+        let ledgerStore = LogSyncLedgerStore.shared(devRoot: devRoot)
 
         for (session, worktrees) in snapshot {
             // Manager sessions run at the dev root, not in a workspace worktree.
@@ -100,7 +105,7 @@ struct LogSyncCollector {
             let harness = LogSyncHarness(agentKind: session.agentKind)
             let kind = LogSyncArtifactKind.sessionTranscript
             let ledgerKey = LogSyncLedger.key(sessionUID: session.id.uuidString, harness: harness, kind: kind)
-            guard ledger.shouldUpload(key: ledgerKey, now: nowEpoch, retryBackoff: retryBackoff) else { continue }
+            guard await ledgerStore.shouldUpload(key: ledgerKey, now: nowEpoch, retryBackoff: retryBackoff) else { continue }
 
             // Where does this harness write its logs? Empty for harnesses whose
             // on-disk logs are not yet wired (everything but Claude today).
@@ -144,18 +149,13 @@ struct LogSyncCollector {
                 transcript: transcript, metadata: metadata, agentSessionID: agentSessionID)
 
             let entry = Self.ledgerEntry(for: result, sha: sha, size: transcript.data.count, at: nowEpoch)
-            ledger.record(key: ledgerKey, entry: entry)
+            await ledgerStore.record(key: ledgerKey, entry: entry)
             if result.isSuccess {
                 LogSyncLog.info("uploaded transcript for session \(session.id.uuidString) (\(harness.rawValue), \(transcript.data.count) bytes)")
             }
         }
 
-        ledger.prune(retentionDays: config.retentionDays, now: nowEpoch)
-        do {
-            try ledger.save(devRoot: devRoot)
-        } catch {
-            LogSyncLog.info("failed to persist log-sync ledger: \(error.localizedDescription)")
-        }
+        await ledgerStore.prune(retentionDays: config.retentionDays, now: nowEpoch)
     }
 
     // MARK: - Pure helpers (unit-tested)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCDispatcher.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCDispatcher.swift
@@ -75,6 +75,13 @@ actor RPCDispatcher {
         /// and transition its ticket. Two at once would double every provider
         /// call.
         case tracker
+
+        /// The user-initiated historical backfill (`backfill-upload`, CROW-1075).
+        /// A single long upload run serializes against itself — two concurrent
+        /// backfills would double the provider validation and upload work — while
+        /// staying off the `config` lane so a lengthy backfill never blocks
+        /// ordinary Settings saves.
+        case backfill
     }
 
     // MARK: - Configuration

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2093,6 +2093,7 @@ func makeCommandRouter(
     handlers.merge(makeWorkspaceHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeMCPTokenHandlers(devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeCorveilHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
+    handlers.merge(makeBackfillHandlers(devRoot: devRoot)) { existing, _ in existing }
     return CommandRouter(handlers: handlers, fallback: fallback)
 }
 
@@ -2165,6 +2166,161 @@ private func makeMCPTokenHandlers(devRoot: String) -> [String: CommandRouter.Han
             }
         },
     ]
+}
+
+/// The `backfill-*` verb group — the historical session backfill (CROW-1075).
+///
+/// Its own function for the type-checker-budget reason `makeMCPTokenHandlers`
+/// states, and it must stay in this file so `scripts/check-cli-parity.sh` can
+/// grep the registrations.
+///
+/// - `backfill-scan` (read): reconcile the on-disk Claude transcripts against
+///   the upload ledger and return the reconstructed rows + a summary. Disk- and
+///   git-only; no provider calls, so it stays fast over hundreds of sessions.
+/// - `backfill-upload` (write): upload a user-selected set through the live path,
+///   idempotently, using the named workspace's gateway for destination +
+///   credential (the same security invariant as the live collector — the
+///   destination is never a browser-writable field). Serial and capped; never an
+///   automatic or unbounded flood.
+///
+/// Not local-only: like `logsync`, no credential travels in the params (the key
+/// is resolved server-side from the local-only gateway), so it backs a web
+/// Settings panel.
+private func makeBackfillHandlers(devRoot: String) -> [String: CommandRouter.Handler] {
+    [
+        "backfill-scan": { _ in
+            let service = BackfillService(devRoot: devRoot)
+            let sessions = await service.scan()
+            return [
+                "sessions": .array(sessions.map { backfillSessionJSON($0) }),
+                "summary": backfillSummaryJSON(BackfillSummary(sessions: sessions)),
+            ]
+        },
+        "backfill-upload": { params in
+            try await mapRPCError {
+                guard let workspaceName = params["workspace"]?.stringValue,
+                      !workspaceName.isEmpty else {
+                    throw RPCError.invalidParams(
+                        "workspace is required — its gateway supplies the upload destination and credential.")
+                }
+                let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+                guard let workspace = config.workspaces.first(where: {
+                    $0.name.lowercased() == workspaceName.lowercased()
+                }) else {
+                    throw RPCError.invalidParams("No workspace named \"\(workspaceName)\".")
+                }
+                guard let upload = LogSyncCollector.resolvedUpload(
+                    for: workspace, resolveSecret: { GatewayResolver.opRead($0) }) else {
+                    throw RPCError.invalidParams(
+                        "Workspace \"\(workspaceName)\" has no reusable Corveil gateway "
+                        + "(needs a base URL and an x-citadel-api-key).")
+                }
+                let logSync = config.logSync ?? LogSyncConfig()
+                let service = BackfillService(devRoot: devRoot)
+
+                // Selection: an explicit UID list (what the Settings table sends),
+                // or a `select` selector over a fresh scan scoped to this
+                // workspace (the "import all high-confidence" convenience).
+                let explicit = (params["sessions"]?.arrayValue ?? []).compactMap(\.stringValue)
+                var toUpload: [BackfillSession] = []
+                if !explicit.isEmpty {
+                    let scanned = await service.scan()
+                    let byUID = Dictionary(scanned.map { ($0.claudeSessionUID, $0) },
+                                           uniquingKeysWith: { first, _ in first })
+                    toUpload = explicit.compactMap { byUID[$0] }
+                } else if let selectMode = params["select"]?.stringValue {
+                    let scanned = await service.scan()
+                    let scope = scanned.filter { $0.workspace?.lowercased() == workspaceName.lowercased() }
+                    switch selectMode {
+                    case "high": toUpload = scope.filter { $0.confidence == .high && $0.uploadStatus != .uploaded }
+                    case "all": toUpload = scope.filter { $0.uploadStatus != .uploaded }
+                    default: throw RPCError.invalidParams("select must be \"high\" or \"all\".")
+                    }
+                } else {
+                    throw RPCError.invalidParams(
+                        "Provide sessions (a list of UIDs) or select (\"high\" | \"all\").")
+                }
+
+                // Cap the batch — the user always chooses, never an unbounded
+                // flood (acceptance). A larger selection uploads in chunks.
+                let cap = 1000
+                if toUpload.count > cap { toUpload = Array(toUpload.prefix(cap)) }
+
+                var results: [BackfillUploadOutcome] = []
+                results.reserveCapacity(toUpload.count)
+                for session in toUpload {
+                    let outcome = await service.upload(
+                        session: session, upload: upload,
+                        maxUploadBytes: max(1, logSync.maxUploadBytes))
+                    results.append(outcome)
+                }
+                return [
+                    "results": .array(results.map { backfillOutcomeJSON($0) }),
+                    "summary": backfillResultSummaryJSON(results),
+                ]
+            }
+        },
+    ]
+}
+
+/// Serialize one reconstructed session for the Settings table (snake_case keys,
+/// matching the other RPC payloads).
+private func backfillSessionJSON(_ s: BackfillSession) -> JSONValue {
+    var obj: [String: JSONValue] = [
+        "uid": .string(s.claudeSessionUID),
+        "file_path": .string(s.filePath),
+        "slug": .string(s.slug),
+        "modified_at": .double(s.modifiedAt),
+        "size_bytes": .int(s.sizeBytes),
+        "confidence": .string(s.confidence.rawValue),
+        "upload_status": .string(s.uploadStatus.rawValue),
+        "ticket_kind": .string(s.ticketKind.rawValue),
+        "worktree_exists": .bool(s.worktreeExists),
+    ]
+    func put(_ key: String, _ value: String?) { if let value { obj[key] = .string(value) } }
+    put("cwd", s.cwd)
+    put("git_branch", s.gitBranch)
+    put("workspace", s.workspace)
+    put("worktree_name", s.worktreeName)
+    put("repo_name", s.repoName)
+    put("owner_repo", s.ownerRepo)
+    put("host", s.host)
+    if let n = s.ticketNumber { obj["ticket_number"] = .int(n) }
+    return .object(obj)
+}
+
+private func backfillSummaryJSON(_ s: BackfillSummary) -> JSONValue {
+    .object([
+        "total": .int(s.total),
+        "uploaded": .int(s.uploaded),
+        "linkable": .int(s.linkable),
+        "repo_only": .int(s.repoOnly),
+        "orphan": .int(s.orphan),
+    ])
+}
+
+private func backfillOutcomeJSON(_ o: BackfillUploadOutcome) -> JSONValue {
+    var obj: [String: JSONValue] = [
+        "uid": .string(o.claudeSessionUID),
+        "result": .string(o.result.rawValue),
+        "linked": .bool(o.linked),
+    ]
+    if let r = o.ownerRepo { obj["owner_repo"] = .string(r) }
+    if let n = o.ticketNumber { obj["ticket_number"] = .int(n) }
+    if let k = o.ticketKind { obj["ticket_kind"] = .string(k.rawValue) }
+    if let reason = o.reason { obj["reason"] = .string(reason) }
+    return .object(obj)
+}
+
+private func backfillResultSummaryJSON(_ results: [BackfillUploadOutcome]) -> JSONValue {
+    .object([
+        "total": .int(results.count),
+        "uploaded": .int(results.filter { $0.result == .uploaded }.count),
+        "already": .int(results.filter { $0.result == .alreadyUploaded }.count),
+        "linked": .int(results.filter { $0.linked }.count),
+        "skipped": .int(results.filter { $0.result == .skipped }.count),
+        "failed": .int(results.filter { $0.result == .failed }.count),
+    ])
 }
 
 /// The `corveil-*` verb group — Settings → Corveil CLI's **Verify** and

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -138,6 +138,10 @@ enum RPCLanePolicy {
         "job-delete": .fixed(.config),
         "job-duplicate": .fixed(.config),
         "version-update-set": .fixed(.config),
+        // Long, user-initiated upload run — its own lane so it serializes against
+        // itself (never two concurrent backfills) without blocking config writes
+        // (CROW-1075).
+        "backfill-upload": .fixed(.backfill),
         // Already single-flight: a second caller awaits the in-flight compare
         // instead of spawning another `gh auth token` subprocess + GitHub call.
         "version-update-check": .concurrent,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -23,6 +23,10 @@ const RPC_DEFAULT_TIMEOUT_MS = 30000;
 const RPC_TIMEOUTS_MS = {
   // Rebuilds the whole scorecard from the event log.
   'rebuild-scorecard': 180000,
+  // Historical backfill (CROW-1075): scan reads hundreds of transcript heads +
+  // git remotes; upload is serial network I/O over the selected set.
+  'backfill-scan': 180000,
+  'backfill-upload': 600000,
   // Shell out to gh/glab/Jira across every configured repo; clone a repo and
   // spawn tmux; run a job's full command.
   'refresh-tickets': 120000,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
@@ -273,3 +273,41 @@
 .st-about-update.st-update-ok { color: var(--text-muted); }
 .st-about-update.st-update-behind { color: var(--gold); }
 .st-about-update.st-update-unknown { color: var(--text-muted); font-style: italic; }
+
+/* -------- Backfill history dialog (CROW-1075) -------- */
+.backfill-modal { width: min(1040px, 96vw); height: min(720px, 92vh); }
+.backfill-summary {
+  font-size: 12px; color: var(--text-secondary);
+  padding-bottom: 10px; margin-bottom: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.backfill-filters { display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap; }
+.backfill-filter-text { flex: 1 1 240px; min-width: 160px; }
+.backfill-sel { flex: 0 0 auto; width: auto; }
+.backfill-table-wrap {
+  overflow: auto; border: 1px solid var(--border-subtle); border-radius: 8px;
+  max-height: 100%;
+}
+.backfill-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.backfill-table th, .backfill-table td {
+  text-align: left; padding: 6px 10px; white-space: nowrap;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.backfill-table thead th {
+  position: sticky; top: 0; z-index: 1;
+  background: var(--bg-card); color: var(--text-secondary);
+  font-weight: 600;
+}
+.backfill-table tbody tr:hover { background: rgba(221, 196, 130, 0.05); }
+.backfill-check { width: 32px; text-align: center; }
+.backfill-repo { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text-primary); }
+.backfill-conf { color: var(--text-muted); }
+.backfill-row.conf-high .backfill-conf { color: var(--green); }
+.backfill-row.conf-medium .backfill-conf { color: var(--gold); }
+.backfill-row.conf-low .backfill-conf { color: var(--text-muted); }
+.backfill-status.status-uploaded { color: var(--green); }
+.backfill-status.status-skipped { color: var(--orange); }
+.backfill-status.status-failed { color: var(--red); }
+.backfill-status.status-new { color: var(--text-muted); }
+.backfill-empty { padding: 28px; text-align: center; color: var(--text-muted); font-size: 13px; }
+.backfill-note { font-size: 12px; color: var(--text-secondary); flex: 1 1 auto; }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -1672,6 +1672,264 @@
       ? 'Uploads this workspace’s coding-session transcripts to Corveil, reusing its AI-gateway URL and credential (no second key or host needed). That’s the only setting required — collector timing and size limits live under Settings → General → Session logs.'
       : 'Turn on the AI Gateway for this workspace above first — the upload reuses its URL and credential.'));
     body.appendChild(slField);
+
+    // Historical backfill (CROW-1075): reconcile the transcripts already on disk
+    // (predating the live path, or reaped from the store) and upload the ones you
+    // choose. Reuses this workspace's gateway for the upload, so it's gated on one
+    // being configured, exactly like the checkbox above.
+    const bfField = el('div', 'st-field');
+    const bfBtn = el('button', 'action-btn', 'Backfill history…');
+    bfBtn.type = 'button';
+    bfBtn.disabled = !hasGateway;
+    if (!hasGateway) bfBtn.title = 'Turn on the AI Gateway for this workspace first — the upload reuses its URL and credential.';
+    bfBtn.onclick = () => openBackfillDialog(d.name);
+    bfField.appendChild(bfBtn);
+    bfField.appendChild(el('div', 'st-help',
+      'Scan the coding-session transcripts already on disk, review the reconstructed workspace / repo / ticket for each, and upload the ones you select — idempotently, through the same path as live sessions.'));
+    body.appendChild(bfField);
+  }
+
+  // ---- Backfill history dialog (CROW-1075) --------------------------------
+  //
+  // A self-contained overlay (its own backdrop over the workspace sub-form) that
+  // scans the on-disk transcripts, shows the reconstructed workspace/repo/ticket
+  // per session with a confidence tier and ledger status, and uploads a selected
+  // subset. Mirrors the Allowlist board's filter + multi-select + counted-primary
+  // pattern, but stands alone rather than joining Settings' render() cycle so its
+  // scan/selection state can't be clobbered by an unrelated repaint.
+
+  function bfHumanBytes(n) {
+    if (!n) return '0 B';
+    const u = ['B', 'KB', 'MB', 'GB']; let i = 0; let v = n;
+    while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+    return (i === 0 ? v : v.toFixed(1)) + ' ' + u[i];
+  }
+  function bfFmtDate(epoch) {
+    if (!epoch) return '—';
+    try { return new Date(epoch * 1000).toISOString().slice(0, 10); } catch (_) { return '—'; }
+  }
+  const BF_CONF_LABEL = { high: 'High', medium: 'Repo only', low: 'Orphan' };
+  const BF_STATUS_LABEL = { new: 'Not uploaded', uploaded: 'Uploaded', skipped: 'Skipped', failed: 'Failed' };
+
+  function openBackfillDialog(workspaceName) {
+    let sessions = [];
+    const selected = new Set();
+    const filters = { workspace: '', status: '', confidence: '', text: '' };
+    let uploading = false;
+    let note = '';
+
+    const overlay = el('div', 'settings-backdrop settings-subform-overlay backfill-overlay');
+    const modal = el('div', 'settings-modal backfill-modal');
+    overlay.appendChild(modal);
+
+    function close() { document.removeEventListener('keydown', onKey); overlay.remove(); }
+    function onKey(e) { if (e.key === 'Escape' && !uploading) close(); }
+    document.addEventListener('keydown', onKey);
+
+    const head = el('div', 'settings-head');
+    head.appendChild(el('div', 'settings-title', 'Backfill history — ' + workspaceName));
+    const closeBtn = el('button', 'settings-close', '×');
+    closeBtn.onclick = close;
+    head.appendChild(closeBtn);
+    modal.appendChild(head);
+
+    const body = el('div', 'settings-body');
+    const summary = el('div', 'backfill-summary', 'Scanning ~/.claude/projects…');
+    body.appendChild(summary);
+
+    const filterRow = el('div', 'backfill-filters');
+    const textInput = el('input', 'st-input backfill-filter-text');
+    textInput.type = 'text';
+    textInput.placeholder = 'Filter by repo, ticket, slug…';
+    textInput.oninput = () => { filters.text = textInput.value.trim().toLowerCase(); refresh(); };
+    filterRow.appendChild(textInput);
+    const wsSel = el('select', 'st-input backfill-sel');
+    wsSel.onchange = () => { filters.workspace = wsSel.value; refresh(); };
+    const stSel = el('select', 'st-input backfill-sel');
+    stSel.onchange = () => { filters.status = stSel.value; refresh(); };
+    const cfSel = el('select', 'st-input backfill-sel');
+    cfSel.onchange = () => { filters.confidence = cfSel.value; refresh(); };
+    filterRow.appendChild(wsSel);
+    filterRow.appendChild(stSel);
+    filterRow.appendChild(cfSel);
+    body.appendChild(filterRow);
+
+    const tableWrap = el('div', 'backfill-table-wrap');
+    tableWrap.appendChild(el('div', 'backfill-empty', 'Scanning…'));
+    body.appendChild(tableWrap);
+    modal.appendChild(body);
+
+    const foot = el('div', 'settings-foot');
+    const noteEl = el('div', 'backfill-note');
+    foot.appendChild(noteEl);
+    foot.appendChild(el('div', 'settings-foot-spacer'));
+    const selAllBtn = el('button', 'action-btn', 'Select all (filtered)');
+    selAllBtn.onclick = () => {
+      const vis = visibleSessions().filter(bfSelectable);
+      const allSel = vis.length > 0 && vis.every((s) => selected.has(s.uid));
+      vis.forEach((s) => { if (allSel) selected.delete(s.uid); else selected.add(s.uid); });
+      refresh();
+    };
+    foot.appendChild(selAllBtn);
+    const uploadBtn = el('button', 'action-btn action-primary', 'Backfill (0)');
+    uploadBtn.onclick = doUpload;
+    foot.appendChild(uploadBtn);
+    modal.appendChild(foot);
+
+    document.body.appendChild(overlay);
+
+    // A session is selectable when it hasn't already uploaded.
+    function bfSelectable(s) { return (s.upload_status || 'new') !== 'uploaded'; }
+
+    function setOptions(sel, opts, value) {
+      sel.innerHTML = '';
+      opts.forEach(([v, l]) => {
+        const o = el('option', null, l); o.value = v;
+        if (v === value) o.selected = true;
+        sel.appendChild(o);
+      });
+    }
+    function fillSelectOptions() {
+      const wss = Array.from(new Set(sessions.map((s) => s.workspace).filter(Boolean))).sort();
+      setOptions(wsSel, [['', 'All workspaces']].concat(wss.map((w) => [w, w])), filters.workspace);
+      setOptions(stSel, [['', 'Any status'], ['new', 'Not uploaded'], ['uploaded', 'Uploaded'], ['skipped', 'Skipped'], ['failed', 'Failed']], filters.status);
+      setOptions(cfSel, [['', 'Any confidence'], ['high', 'High'], ['medium', 'Repo only'], ['low', 'Orphan']], filters.confidence);
+    }
+
+    function visibleSessions() {
+      return sessions.filter((s) => {
+        if (filters.workspace && s.workspace !== filters.workspace) return false;
+        if (filters.status && (s.upload_status || 'new') !== filters.status) return false;
+        if (filters.confidence && s.confidence !== filters.confidence) return false;
+        if (filters.text) {
+          const hay = [s.repo_name, s.owner_repo, s.slug, s.workspace, s.worktree_name, String(s.ticket_number || '')].join(' ').toLowerCase();
+          if (hay.indexOf(filters.text) === -1) return false;
+        }
+        return true;
+      });
+    }
+
+    function ticketCell(s) {
+      if (!s.ticket_number) return '—';
+      const kind = s.ticket_kind === 'pull_request' ? 'PR' : '#';
+      return (s.owner_repo ? '' : '') + kind + s.ticket_number;
+    }
+
+    function refresh() {
+      fillSelectOptions();
+      const vis = visibleSessions();
+      tableWrap.innerHTML = '';
+      if (!sessions.length) {
+        tableWrap.appendChild(el('div', 'backfill-empty', 'No coding-session transcripts found on disk.'));
+      } else if (!vis.length) {
+        tableWrap.appendChild(el('div', 'backfill-empty', 'No sessions match the current filters.'));
+      } else {
+        const table = el('table', 'backfill-table');
+        const thead = el('thead');
+        const hr = el('tr');
+        const selectableVis = vis.filter(bfSelectable);
+        const allSel = selectableVis.length > 0 && selectableVis.every((s) => selected.has(s.uid));
+        const thCheck = el('th', 'backfill-check');
+        const hCb = el('input'); hCb.type = 'checkbox'; hCb.checked = allSel; hCb.disabled = uploading || !selectableVis.length;
+        hCb.onchange = () => { selectableVis.forEach((s) => { if (hCb.checked) selected.add(s.uid); else selected.delete(s.uid); }); refresh(); };
+        thCheck.appendChild(hCb);
+        hr.appendChild(thCheck);
+        ['Workspace', 'Repo', 'Ticket', 'Date', 'Size', 'Status', 'Confidence'].forEach((h) => hr.appendChild(el('th', null, h)));
+        thead.appendChild(hr);
+        table.appendChild(thead);
+
+        const tbody = el('tbody');
+        vis.forEach((s) => {
+          const tr = el('tr', 'backfill-row conf-' + (s.confidence || 'low'));
+          const tdc = el('td', 'backfill-check');
+          const cb = el('input'); cb.type = 'checkbox';
+          cb.checked = selected.has(s.uid);
+          cb.disabled = uploading || !bfSelectable(s);
+          cb.onchange = () => { if (cb.checked) selected.add(s.uid); else selected.delete(s.uid); updateCount(); };
+          tdc.appendChild(cb);
+          tr.appendChild(tdc);
+          tr.appendChild(el('td', null, s.workspace || '—'));
+          tr.appendChild(el('td', 'backfill-repo', s.owner_repo || s.repo_name || '—'));
+          tr.appendChild(el('td', null, ticketCell(s)));
+          tr.appendChild(el('td', null, bfFmtDate(s.modified_at)));
+          tr.appendChild(el('td', null, bfHumanBytes(s.size_bytes)));
+          const st = s.upload_status || 'new';
+          const tdSt = el('td', 'backfill-status status-' + st, BF_STATUS_LABEL[st] || st);
+          if (s._outcome && s._outcome.reason) tdSt.title = s._outcome.reason;
+          tr.appendChild(tdSt);
+          tr.appendChild(el('td', 'backfill-conf', BF_CONF_LABEL[s.confidence] || s.confidence || '—'));
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        tableWrap.appendChild(table);
+      }
+      updateCount();
+      noteEl.textContent = note;
+    }
+
+    function updateCount() {
+      uploadBtn.textContent = 'Backfill (' + selected.size + ')';
+      uploadBtn.disabled = uploading || selected.size === 0;
+    }
+
+    function summarize(sm) {
+      if (!sm) return '';
+      return sm.total + ' on disk · ' + sm.uploaded + ' uploaded · '
+        + sm.linkable + ' fully linkable · ' + (sm.repo_only + sm.orphan) + ' repo-only/orphan';
+    }
+
+    async function scan() {
+      summary.textContent = 'Scanning ~/.claude/projects…';
+      try {
+        const res = await rpc('backfill-scan', {});
+        sessions = res.sessions || [];
+        // Default-select this workspace's high-confidence, not-yet-uploaded rows —
+        // the safe "import my history" starting point; everything else is opt-in.
+        sessions.forEach((s) => {
+          if (s.confidence === 'high' && (s.upload_status || 'new') !== 'uploaded' && s.workspace === workspaceName) {
+            selected.add(s.uid);
+          }
+        });
+        summary.textContent = summarize(res.summary);
+      } catch (e) {
+        summary.textContent = 'Scan failed: ' + ((e && e.message) || e);
+        sessions = [];
+      }
+      refresh();
+    }
+
+    async function doUpload() {
+      const uids = Array.from(selected);
+      if (!uids.length || uploading) return;
+      uploading = true;
+      uploadBtn.textContent = 'Uploading ' + uids.length + '…';
+      uploadBtn.disabled = true;
+      note = '';
+      refresh();
+      try {
+        const res = await rpc('backfill-upload', { workspace: workspaceName, sessions: uids });
+        const byUid = {};
+        (res.results || []).forEach((r) => { byUid[r.uid] = r; });
+        sessions.forEach((s) => {
+          const r = byUid[s.uid];
+          if (!r) return;
+          s.upload_status = (r.result === 'uploaded' || r.result === 'already') ? 'uploaded'
+            : (r.result === 'skipped' ? 'skipped' : 'failed');
+          s._outcome = r;
+        });
+        selected.clear();
+        const sm = res.summary || {};
+        note = 'Uploaded ' + (sm.uploaded || 0) + ' · linked ' + (sm.linked || 0)
+          + ' · already ' + (sm.already || 0) + ' · skipped ' + (sm.skipped || 0)
+          + ' · failed ' + (sm.failed || 0);
+      } catch (e) {
+        note = 'Upload failed: ' + ((e && e.message) || e);
+      }
+      uploading = false;
+      refresh();
+    }
+
+    scan();
   }
 
   // ---- Job sub-form -------------------------------------------------------

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowDaemon
+
+/// A fake upload transport that returns a fixed HTTP status (mirrors the
+/// approach in `TranscriptUploaderTests`).
+private struct FixedStatusTransport: TranscriptUploadTransport {
+    let status: Int
+    func perform(_ request: URLRequest) async throws -> Int { status }
+}
+
+/// A `ShellRunner` answering from a closure, for the ticket validator.
+private struct StubRunner: ShellRunner {
+    let answer: @Sendable ([String]) -> Result<String, Error>
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        switch answer(args) {
+        case .success(let s): return s
+        case .failure(let e): throw e
+        }
+    }
+}
+
+@Suite struct BackfillServiceTests {
+    private func tempDevRoot() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backfill-svc-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.path
+    }
+
+    private func writeTranscript(_ devRoot: String, uid: String, lines: Int = 3) throws -> String {
+        let dir = URL(fileURLWithPath: devRoot).appendingPathComponent("t", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("\(uid).jsonl")
+        let body = (0..<lines).map { #"{"type":"user","i":\#($0)}"# }.joined(separator: "\n")
+        try body.write(to: file, atomically: true, encoding: .utf8)
+        return file.path
+    }
+
+    private func service(_ devRoot: String, status: Int, ticket: Result<String, Error>) -> BackfillService {
+        BackfillService(
+            devRoot: devRoot,
+            uploader: TranscriptUploader(transport: FixedStatusTransport(status: status)),
+            validator: TicketValidator(runner: StubRunner { _ in ticket }),
+            resolveSecret: { _ in nil },
+            now: { Date(timeIntervalSince1970: 1000) })
+    }
+
+    private func session(_ devRoot: String, uid: String, path: String) -> BackfillSession {
+        BackfillSession(
+            claudeSessionUID: uid, filePath: path, slug: "t",
+            workspace: "RadiusMethod", worktreeName: "crow-12-x", repoName: "crow",
+            ownerRepo: "corveil/crow", host: "github.com", ticketNumber: 12,
+            confidence: .high, uploadStatus: .new)
+    }
+
+    @Test func uploadsAndLinksValidatedTicket() async throws {
+        let devRoot = try tempDevRoot()
+        let path = try writeTranscript(devRoot, uid: "UID-A")
+        let svc = service(devRoot, status: 201, ticket: .success(#"{"number":12}"#))
+
+        let outcome = await svc.upload(
+            session: session(devRoot, uid: "UID-A", path: path),
+            upload: (baseURL: "https://corveil.io", apiKey: "k"), maxUploadBytes: 8_000_000)
+
+        #expect(outcome.result == .uploaded)
+        #expect(outcome.linked == true)
+        #expect(outcome.ticketKind == .issue)
+        #expect(outcome.ticketNumber == 12)
+
+        // Ledger recorded — a second attempt is an idempotent no-op.
+        let again = await svc.upload(
+            session: session(devRoot, uid: "UID-A", path: path),
+            upload: (baseURL: "https://corveil.io", apiKey: "k"), maxUploadBytes: 8_000_000)
+        #expect(again.result == .alreadyUploaded)
+    }
+
+    @Test func unvalidatedTicketUploadsRepoOnly() async throws {
+        let devRoot = try tempDevRoot()
+        let path = try writeTranscript(devRoot, uid: "UID-B")
+        // Provider says 404 → no link asserted.
+        let svc = service(devRoot, status: 201,
+                          ticket: .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "Not Found")))
+        let outcome = await svc.upload(
+            session: session(devRoot, uid: "UID-B", path: path),
+            upload: (baseURL: "https://corveil.io", apiKey: "k"), maxUploadBytes: 8_000_000)
+        #expect(outcome.result == .uploaded)
+        #expect(outcome.linked == false)
+        #expect(outcome.ownerRepo == "corveil/crow") // repo-only still carries the repo
+    }
+
+    @Test func emptyTranscriptIsSkipped() async throws {
+        let devRoot = try tempDevRoot()
+        let path = try writeTranscript(devRoot, uid: "UID-C", lines: 0)
+        let svc = service(devRoot, status: 201, ticket: .success(#"{"number":12}"#))
+        let outcome = await svc.upload(
+            session: session(devRoot, uid: "UID-C", path: path),
+            upload: (baseURL: "https://corveil.io", apiKey: "k"), maxUploadBytes: 8_000_000)
+        #expect(outcome.result == .skipped)
+        #expect(outcome.reason == "empty_or_unreadable")
+    }
+
+    @Test func serverConflictIsIdempotentSuccess() async throws {
+        let devRoot = try tempDevRoot()
+        let path = try writeTranscript(devRoot, uid: "UID-D")
+        let svc = service(devRoot, status: 409, ticket: .success(#"{"number":12}"#))
+        let outcome = await svc.upload(
+            session: session(devRoot, uid: "UID-D", path: path),
+            upload: (baseURL: "https://corveil.io", apiKey: "k"), maxUploadBytes: 8_000_000)
+        #expect(outcome.result == .alreadyUploaded)
+    }
+
+    @Test func remoteHelperSplitsOwnerRepo() {
+        #expect(BackfillService.remote(ownerRepo: "corveil/crow", host: "github.com")
+                == RepoRemote(host: "github.com", owner: "corveil", repo: "crow"))
+        #expect(BackfillService.remote(ownerRepo: "noslash", host: "github.com") == nil)
+    }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1748,6 +1748,48 @@ Only Claude Code transcripts are collected today (its logs are the one harness p
 
 ---
 
+## Session Backfill Commands
+
+The **historical session backfill** (CROW-1075) captures the coding-session transcripts already on disk — sessions that predate the live upload path or were reaped from Crow's store — and uploads them as **real, fully-linked** Corveil session artifacts, reconstructing the workspace / repo / ticket a live run would have carried. The live collector is session-centric (it walks Crow's store); this is the one-time reconciliation of the on-disk backlog. Claude Code only for v1 (the harness whose logs are partitioned by working directory).
+
+It reuses the live upload path, so it inherits its guarantees: the destination + credential come only from the named workspace's **local-only** AI gateway (never a browser-writable field), no AWS credentials touch this machine, and every upload is **idempotent** (a local ledger + the server's write-once 409). It is always **user-initiated** — never automatic or unbounded.
+
+### `crow backfill scan`
+
+```bash
+crow backfill scan
+```
+
+Reconciles every on-disk Claude transcript (`~/.claude/projects/**/*.jsonl`) against the upload ledger and returns the reconstructed rows plus a `summary`. Disk- and git-only (no provider calls), so it stays fast over hundreds of sessions. Each row carries the recovered `workspace` / `repo_name` / `owner_repo` / `ticket_number`, a `confidence` tier, and its ledger `upload_status`:
+
+| Confidence | Meaning |
+| --- | --- |
+| `high` | Repo resolved **and** a ticket number recovered — uploads with a validated ticket link |
+| `medium` | Repo recovered but no ticket — uploads repo-only |
+| `low` | Neither workspace nor repo matched (a true orphan) — uploads attributed but unlinked, only if selected |
+
+Ticket links are **validated at upload, not here** — a reconstructed `(repo, number)` becomes a REFERENCE only when the provider (`gh`/`glab`) confirms it exists.
+
+### `crow backfill upload`
+
+```bash
+crow backfill upload --workspace RadiusMethod --session <uid> --session <uid>
+crow backfill upload --workspace RadiusMethod --all-high-confidence
+crow backfill upload --workspace RadiusMethod --all
+```
+
+Uploads a chosen set through the live path, idempotently and serially. `--workspace` names the workspace whose gateway supplies the upload destination and credential (it must have a gateway configured). Choose sessions in exactly one way:
+
+| Flag | Description |
+| --- | --- |
+| `--session <uid>` | A Claude session UID to upload (repeatable; UIDs come from `crow backfill scan`) |
+| `--all-high-confidence` | Every not-yet-uploaded **high-confidence** session in this workspace |
+| `--all` | Every not-yet-uploaded session in this workspace |
+
+Returns a per-session `results` list (each `uploaded` / `already` / `skipped` / `failed`, whether it was `linked` to a validated ticket, and a `reason` for a skip/failure) and a roll-up `summary`. Re-running never duplicates — a slot the ledger records as uploaded is skipped.
+
+---
+
 ## MCP Commands
 
 Crow serves a **read-only** MCP surface so agent clients that speak MCP — Cowork, a Grok bot — can read the board without a Crow-launched session. Six tools over five read RPCs; there is no prompt-send, no session creation, and no config access. See [MCP](mcp.md) for client setup and the full tool list.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,9 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow autostart install`](#crow-autostart-install) | Register crowd to start at login (idempotent; re-points after an upgrade) |
 | [`crow autostart status`](#crow-autostart-status) | Report whether crowd is set to start at login, and whether it's running |
 | [`crow autostart uninstall`](#crow-autostart-uninstall) | Remove the login item (leaves a running crowd alone) |
+| [`crow backfill`](#crow-backfill) | Reconcile and upload historical on-disk session transcripts |
+| [`crow backfill scan`](#crow-backfill-scan) | List on-disk sessions with reconstructed metadata and upload status |
+| [`crow backfill upload`](#crow-backfill-upload) | Upload selected historical sessions (idempotent) |
 | [`crow batch-work-on-issues`](#crow-batch-work-on-issues) | Start working on several tickets in one batch |
 | [`crow cleanup`](#crow-cleanup) | View or change automatic session cleanup |
 | [`crow cleanup get`](#crow-cleanup-get) | Show the current cleanup settings |
@@ -373,6 +376,55 @@ crow autostart uninstall [--json]
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--json` | — | no | Print the status as JSON |
+
+---
+
+## `crow backfill`
+
+Reconcile and upload historical on-disk session transcripts.
+
+```
+crow backfill <scan|upload>
+```
+
+Scans the coding-session transcripts already on disk (~/.claude/projects), reconstructs each one's workspace, repo, and ticket/PR, and uploads the ones you choose to Corveil as session artifacts — so a backfilled session lands in the ontology indistinguishable from a live-captured one.
+
+A reconstructed ticket becomes a link only when the provider confirms it exists; otherwise the session uploads repo-only, and a true orphan uploads attributed but unlinked. Uploads reuse the named workspace's AI gateway for the destination and credential (no AWS credentials on this machine) and are idempotent — re-running never duplicates.
+
+Subcommands: [`scan`](#crow-backfill-scan), [`upload`](#crow-backfill-upload).
+
+---
+
+## `crow backfill scan`
+
+List on-disk sessions with reconstructed metadata and upload status.
+
+```
+crow backfill scan
+```
+
+Disk- and git-only (no provider calls), so it's fast over hundreds of sessions. Each row carries the recovered workspace/repo/ticket, a confidence tier (high = repo + ticket, medium = repo only, low = orphan), and its ledger upload status. Ticket links are validated at upload, not here.
+
+---
+
+## `crow backfill upload`
+
+Upload selected historical sessions (idempotent).
+
+```
+crow backfill upload --workspace <workspace> [--session <session> ...] [--all-high-confidence] [--all]
+```
+
+Choose sessions with repeated --session <uid> (UIDs come from `crow backfill scan`), or bulk-select this workspace's history with --all-high-confidence (repo + validated ticket) or --all. Exactly one selection mode is required.
+
+--workspace names the workspace whose AI gateway supplies the upload destination and credential; it must have a gateway configured. Uploads are serial and idempotent, so a re-run only fills gaps.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--workspace` | `<workspace>` | yes | Workspace whose gateway supplies the upload destination + credential |
+| `--session` | `<session>` _(repeatable)_ | no | A Claude session UID to upload (repeatable). Mutually exclusive with --all/--all-high-confidence. |
+| `--all-high-confidence` | — | no | Upload every not-yet-uploaded high-confidence session in this workspace |
+| `--all` | — | no | Upload every not-yet-uploaded session in this workspace |
 
 ---
 

--- a/docs/session-backfill.md
+++ b/docs/session-backfill.md
@@ -1,0 +1,109 @@
+# Session backfill (CROW-1075)
+
+A **user-initiated** backfill that captures the coding-session history already on
+disk — sessions that predate the live upload path ([#1056](https://github.com/corveil/crow/issues/1056))
+or were reaped from Crow's store — and uploads them as **real, fully-linked**
+Corveil session artifacts, not orphans. Part of epic
+[corveil/corveil#2425](https://github.com/corveil/corveil/issues/2425).
+
+The live collector (`LogSyncCollector`) is **session-centric**: it walks Crow's
+`store.json` and uploads one artifact per live, quiescent Crow session. It never
+touches the disk. But the disk holds the real history — hundreds of Claude
+`.jsonl` transcripts under `~/.claude/projects`, most orphaned from any Crow
+session record. This feature is strictly that **historical backlog**: for the
+current user now, and for every new user who arrives with a big backlog.
+
+## The server contract is already there (decision #2)
+
+No corveil companion change is needed. `POST /api/crow-sessions/{uid}/artifacts`
+([corveil#2426](https://github.com/corveil/corveil/issues/2426), merged in
+corveil#2433) already:
+
+- **Creates the `crow_sessions` parent from an arbitrary `{uid}`.** The parent is
+  a Class-A object, not an FK to a pre-existing Crow session — that is the whole
+  point of the design (interactive sessions have no `worker_run`). The live
+  collector already uploads with a session UUID the server has never seen, so
+  using a **Claude session UUID (the `.jsonl` stem)** as `{uid}` is the same
+  shape (decision #1).
+- **Derives the authoring `Person` server-side from the API key**, never from the
+  payload. The sidecar (`repo`, `ticket_url`, …) is *untrusted hints*.
+- **Builds `REFERENCES` downstream** in the derive job
+  ([corveil-cloud-terraform#459](https://github.com/corveil/corveil-cloud-terraform/issues/459))
+  from the *validated* reconstructed repo/ticket.
+- **Is write-once** — a second upload of the same `(session, harness, kind)` is a
+  409, treated as an idempotent success.
+
+The producer-side obligation (decision #3) is therefore only: **never stamp a
+`ticket_url`/`ticket_number` into the sidecar unless the provider confirms the
+issue/PR exists.**
+
+## Reconstruction — "fill in the gaps"
+
+For each on-disk transcript, `BackfillScanner` recovers what a live run would
+have sent, working from the **transcript's own recorded `cwd` and `gitBranch`**
+(authoritative — not the lossy project-slug directory name, which flattens every
+`/` and `-` alike):
+
+- **Workspace** = the first path component of `cwd` under the dev root.
+- **Worktree** = the next component, `<repo>-<number>-<slug>`.
+- **Repo → `owner/repo`** = the `<repo>` matched against a `repoName → RepoRemote`
+  map built by reading the `origin` remote of the live clones under the dev root.
+  One resolvable clone (a main checkout or any still-present worktree) gives every
+  reaped worktree of that repo its `owner/repo`. The known repo names also
+  disambiguate the `<repo>-<number>` split (`corveil-cloud-terraform-331-…` →
+  repo `corveil-cloud-terraform`, ticket 331, not repo `corveil`).
+- **Ticket** = the `<number>`, corroborated by the branch.
+- **Person** = server-derived from the API key (always correct).
+
+Each session gets a confidence tier:
+
+| Tier | Condition | Upload |
+|---|---|---|
+| `high` | repo resolved **and** a ticket number parsed | validated ticket link |
+| `medium` | repo resolved, no ticket | repo-only |
+| `low` | no workspace / no repo (orphan) | attributed, unlinked — only if selected |
+
+The scan is **disk- and git-only** (no provider calls), so it is fast over
+hundreds of sessions. Ticket **validation** is deferred to upload, where a link
+is actually asserted: `TicketValidator` runs one `gh api repos/{o}/{r}/issues/{n}`
+(GitHub returns issues and PRs, distinguished by a `pull_request` member) — a
+clean 404 means no link, an auth/network failure is inconclusive (repo-only, not
+a false "not found").
+
+## Upload — reuse the live path, idempotently
+
+`BackfillService.upload` normalizes the single `.jsonl` with the same
+`TranscriptNormalizer`, validates the ticket, builds the sidecar (gating the
+ticket fields on validation), and POSTs through the same `TranscriptUploader` as
+the live collector. Destination and credential come **solely** from the named
+workspace's local-only AI gateway — the same security invariant as the live path;
+no browser-writable field can redirect a credential-bearing upload, and no AWS
+credential touches the laptop.
+
+Idempotency is doubly enforced: the local ledger (`logsync-ledger.json`) skips a
+slot already recorded uploaded, and the server 409s a duplicate. Because backfill
+is a **second writer** to that ledger (the poll loop is the first), both now go
+through a shared, serialized `LogSyncLedgerStore` actor so no update is lost.
+
+Uploads are serial, capped, and **always user-initiated** — never automatic or
+unbounded.
+
+## Surfaces
+
+- **Settings → Workspaces → (edit) → Session logs → "Backfill history…"** — a
+  reviewable table (workspace · repo · ticket · date · size · status ·
+  confidence) with filters, multi-select, select-all-by-filter, and a counted
+  "Backfill (N)" action that reports per-session outcomes. Gated on the workspace
+  having a gateway (the upload reuses it), like the opt-in checkbox beside it.
+- **CLI** — `crow backfill scan` and
+  `crow backfill upload --workspace NAME (--session UID… | --all-high-confidence | --all)`.
+  See [cli-reference.md](cli-reference.md#session-backfill-commands).
+
+## Scope (v1)
+
+- **Claude Code only** — the one harness whose logs are partitioned by working
+  directory, which is what makes historical reconstruction reliable. Other
+  harnesses follow as their `logSources` land (see
+  [session-log-collector.md](session-log-collector.md)).
+- Cursor additionally needs SQLite extraction in the normalizer before its
+  transcripts can be backfilled.

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -168,3 +168,10 @@ nor change.
 - The artifact contract + upload endpoint, [#2426](https://github.com/corveil/corveil/issues/2426)
   (`POST /api/crow-sessions/{sessionUID}/artifacts`).
 - `docs/agent-harness-matrix.md`, ADR 0014 / 0015.
+
+## See also
+
+- [session-backfill.md](session-backfill.md) — the **historical** backfill
+  ([CROW-1075](https://github.com/corveil/crow/issues/1075)): a user-initiated
+  reconciliation of the on-disk transcripts this session-centric collector never
+  reaches (reaped or ad-hoc sessions), reusing this same upload path.


### PR DESCRIPTION
Closes #1075. Part of epic corveil/corveil#2425.

A **user-initiated** backfill that captures the coding-session history already on disk — sessions that predate the live upload path (#1056) or were reaped from Crow's store — and uploads them as **real, fully-linked** Corveil session artifacts, not orphans. The live collector is session-centric (it walks Crow's store, ~3 sessions); the disk holds the real history (hundreds of Claude `.jsonl` under `~/.claude/projects`, most orphaned from any Crow session). This is strictly that historical backlog.

## Open decision #2 — settled, **no corveil companion change needed**

`POST /api/crow-sessions/{uid}/artifacts` (corveil#2426, merged in corveil#2433) already supports everything this PR needs:

- **(a) creates the `crow_sessions` parent from a `{uid}` with no prior Crow session** — the parent is a Class-A object, not an FK to a pre-existing session (interactive sessions have no `worker_run`). This is proven empirically: the live collector already uploads with Crow session UUIDs the server had never seen (there are 2 such successful uploads in the local ledger). A Claude session UUID (the jsonl stem) is the same shape → used as `{uid}` (decision #1).
- **(b) builds `REFERENCES` from *validated* reconstructed hints** — done downstream by the derive job (corveil-cloud-terraform#459). The endpoint stores the sidecar as untrusted hints and derives `Person` from the API key. The producer obligation (decision #3) is therefore only to **gate the ticket hint on `gh`/`glab` confirmation**, which this PR does.

## Reconstruction

Works from each transcript's **own recorded `cwd`/`gitBranch`** — authoritative, not the lossy project-slug directory name (measured: 100% of transcripts carry `cwd`+`gitBranch` in-content; ~80% resolve to `owner/repo` via a live git remote). Workspace = path under the dev root; `owner/repo` = `<repo>` matched against a `repoName → RepoRemote` map built from live clones' `origin` remotes (which also disambiguate the `<repo>-<number>` split, e.g. `corveil-cloud-terraform-331-…`); ticket = the `<number>`, corroborated by the branch.

| Confidence | Condition | Upload |
|---|---|---|
| `high` | repo + ticket | validated ticket link |
| `medium` | repo only | repo-only |
| `low` | orphan | attributed, unlinked (only if selected) |

The scan is disk- and git-only (fast over hundreds of sessions); **ticket validation is deferred to upload**, where a `(repo, number)` becomes a REFERENCE only when `gh`/`glab` confirms it — a clean 404 → no link, an auth/network failure → inconclusive (repo-only, never a false "not found"). **No fabricated links.**

## Upload

Reuses the live path (`TranscriptNormalizer` + `TranscriptUploader`) and its security invariant: destination + credential come **only** from the named workspace's local-only AI gateway (never a browser-writable field); no AWS creds on the laptop. Idempotent via the ledger + the server's 409. Serial, capped, **always user-initiated** — never automatic or unbounded.

Backfill is a **second writer** to `logsync-ledger.json`, so it and the poll loop now share a serialized `LogSyncLedgerStore` actor (removes a lost-update hazard).

## Surfaces

- **Settings → Workspaces → (edit) → Session logs → "Backfill history…"** — reviewable table (workspace · repo · ticket · date · size · status · confidence) with filters, multi-select, select-all-by-filter, and a counted "Backfill (N)" action reporting per-session outcomes.
- **CLI** — `crow backfill scan` and `crow backfill upload --workspace NAME (--session UID… | --all-high-confidence | --all)`.

## Tests

- CrowCore (all green): reconstruction (remote-URL parse, `<repo>-<num>` disambiguation, workspace/worktree, confidence, ticket URLs), transcript-head reader, ticket validator (issue/PR/404/inconclusive + caching), ledger-store concurrency, scanner reconstruction + ledger reconciliation.
- CrowDaemon: `BackfillService` upload (validated-link / repo-only / empty-skip / 409-idempotent).
- CrowCLI: verb parsing + parity gates; `scripts/check-cli-parity.sh` green.
- `v1` is **Claude Code only** (the one harness whose logs are partitioned by working directory).

### Note for reviewers
Two test failures on the CI run are **pre-existing on `main`**, not introduced here (verified by stashing this branch's changes): `RPCLanePolicyTests` (`corveil-verify`/`corveil-reinstall-skill` are ledgered writes with no lane) and `WebNotificationCenterTests.bootCatchResetsTheHistory`. This PR adds zero new failures. The web dialog is straightforward glue over the already-tested `rpc` plumbing (JS syntax-checked); its substantive logic is unit-tested crowd-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)