### PR TITLE
Auto-name additional Manager sessions from the first ask (CROW-1079)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,22 @@
 
 This is the development root managed by Crow. The Manager tab runs Claude Code here to orchestrate work sessions via the `crow` CLI.
 
+## Naming this Manager session
+
+Additional Managers are created as `Manager 2`, `Manager 3`, … — a title that tells the operator nothing about the work. As soon as you know what this session is for, give it a name that reflects that, so the sidebar stays legible.
+
+**On the first real ask of this session** — the first user turn that hands you actual work, not a greeting — and before you start that work:
+
+1. If `$CROW_SESSION_ID` is `00000000-0000-0000-0000-000000000000`, you are the **primary Manager**. Never rename it — stop here.
+2. Run `crow get-session --session "$CROW_SESSION_ID"` and read `name`. If it is **not** of the form `Manager <N>` (e.g. `Manager 2`), this session was already named — stop here.
+3. Otherwise derive a short title from the ask: 2–6 words or a short slug (`ios-keyboard-cursor`, `review crow-1078`, `file keyboard bug`). It must be non-empty, ≤256 characters, free of control characters, and must not collide with an existing name — check `crow list-sessions`.
+4. Rename through the CLI, so the persist / sidebar row / agent `/rename` (CROW-629) all run on one path:
+   ```
+   crow rename-session --session "$CROW_SESSION_ID" "<derived-name>"
+   ```
+
+Do this **once**. After step 4 the name is no longer `Manager <N>`, so step 2 keeps it from firing again on later turns. Never rename on every message, and never rename the primary Manager or a session the operator already named.
+
 ## Architecture Decision Records
 
 Architectural decisions live in [`docs/adr/`](docs/adr/). Read [`docs/adr/README.md`](docs/adr/README.md) for the index, and copy [`docs/adr/template.md`](docs/adr/template.md) to start a new one. When superseding a decision, update the old ADR's `Status` field to `Superseded by NNNN` — don't delete it. The history is the point.

--- a/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CLIDocsTests.swift
@@ -278,6 +278,27 @@ private func section(_ invocation: String, in markdown: String) -> String? {
     }
 }
 
+/// CROW-1079: an additional Manager self-renames from its first ask via
+/// `crow rename-session`. The instruction lives only in the Manager's
+/// scaffolded context, so if it falls out of either template source the
+/// behavior silently disappears — guard both. The shipped `.app` reads
+/// `Resources/CLAUDE.md.template`; dev builds read the repo `CLAUDE.md`
+/// (see `Scaffolder.bundledCLAUDEMD`), so the two must both carry it.
+@Test func managerContextExplainsSelfRename() throws {
+    for source in ["CLAUDE.md", "Resources/CLAUDE.md.template"] {
+        let doc = try repoFile(source)
+        #expect(
+            doc.contains("crow rename-session --session \"$CROW_SESSION_ID\""),
+            "\(source) no longer tells additional Managers to self-rename via crow rename-session (CROW-1079)"
+        )
+        // The primary-Manager guard is what keeps the nav pill as "Manager".
+        #expect(
+            doc.contains("00000000-0000-0000-0000-000000000000"),
+            "\(source) dropped the primary-Manager guard for self-rename (CROW-1079)"
+        )
+    }
+}
+
 // MARK: - Independent view of the command tree
 
 /// Walks `CommandConfiguration` a second time, keeping the concrete types so

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -2,6 +2,22 @@
 
 This is the development root managed by Crow. The Manager tab runs Claude Code here to orchestrate work sessions via the `crow` CLI.
 
+## Naming this Manager session
+
+Additional Managers are created as `Manager 2`, `Manager 3`, … — a title that tells the operator nothing about the work. As soon as you know what this session is for, give it a name that reflects that, so the sidebar stays legible.
+
+**On the first real ask of this session** — the first user turn that hands you actual work, not a greeting — and before you start that work:
+
+1. If `$CROW_SESSION_ID` is `00000000-0000-0000-0000-000000000000`, you are the **primary Manager**. Never rename it — stop here.
+2. Run `crow get-session --session "$CROW_SESSION_ID"` and read `name`. If it is **not** of the form `Manager <N>` (e.g. `Manager 2`), this session was already named — stop here.
+3. Otherwise derive a short title from the ask: 2–6 words or a short slug (`ios-keyboard-cursor`, `review crow-1078`, `file keyboard bug`). It must be non-empty, ≤256 characters, free of control characters, and must not collide with an existing name — check `crow list-sessions`.
+4. Rename through the CLI, so the persist / sidebar row / agent `/rename` (CROW-629) all run on one path:
+   ```
+   crow rename-session --session "$CROW_SESSION_ID" "<derived-name>"
+   ```
+
+Do this **once**. After step 4 the name is no longer `Manager <N>`, so step 2 keeps it from firing again on later turns. Never rename on every message, and never rename the primary Manager or a session the operator already named.
+
 ## crow CLI Reference
 
 The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. All commands require `dangerouslyDisableSandbox: true` and return JSON.


### PR DESCRIPTION
Closes #1079

## What

A new additional Manager is always titled `Manager N` — a name that says nothing about the work it was opened for, so the sidebar fills with indistinguishable extra Managers until someone renames them by hand.

This teaches an additional Manager to name **itself** from its first ask, entirely through its scaffolded context — no new server-side machinery.

## How

Both sources that Crow scaffolds into `{devRoot}/.claude/CLAUDE.md` gain a **"Naming this Manager session"** section:

- `CLAUDE.md` (repo root — dev builds, via `Scaffolder.loadFromRepo`)
- `Resources/CLAUDE.md.template` (shipped `.app` — via `Bundle.main`)

Placed above the preserved `## Known Issues / Corrections` boundary, so the scaffolder's replace-above-the-boundary logic redeploys it every launch.

On the **first real ask**, an additional Manager:

1. **Skips the primary Manager** — if `$CROW_SESSION_ID` is `00000000-…`, stop (keeps the nav pill as "Manager").
2. **Fires once** — `crow get-session` → if the name is no longer `Manager <N>`, it was already renamed, stop.
3. **Derives a legal title** — 2–6 words / short slug, non-empty, ≤256 chars, no control chars, no collision (`crow list-sessions`).
4. **Renames via the CLI** — `crow rename-session --session "$CROW_SESSION_ID" "<derived>"`, so the existing path does persist + sidebar row + CROW-629 agent `/rename`. No parallel `session.name` write.

`$CROW_SESSION_ID` is already in the Manager terminal env (`SessionService.artifactsEnv`).

## Not changed

`create-manager` still allocates `Manager N` — the ask isn't known until the first turn, so no Swift change is needed. A server-side `create-manager --prompt` variant (the ticket's optional "rename immediately" path) was considered and **skipped**: the daemon can't summarize a prompt into a title, so it wouldn't rename immediately as imagined, and prompt-seeding is a separate feature. The instruction path already covers the first-ask case.

## Test

New CrowCLI doc-drift guard `managerContextExplainsSelfRename` asserts **both** templates carry the `crow rename-session --session "$CROW_SESSION_ID"` instruction and the primary-UUID guard, so it can't silently drop out of either source.

`swift test --filter CLIDocsTests` (CrowCLI) — all 7 pass, including the existing `committedGeneratedDocIsUpToDate` (CLI-reference parity unaffected).

## Acceptance

- [x] Creating a Manager via `+` / `crow create-manager` still starts as `Manager N`
- [x] After the first ask, the extra Manager's title becomes a derived name
- [x] Rename performed with `crow rename-session --session $CROW_SESSION_ID …` (visible in the transcript)
- [x] `rename-session` side effects still fire (persist, sidebar, CROW-629 `/rename`)
- [x] Primary Manager pill stays `Manager`
- [x] A Manager the user already renamed is left alone
- [x] Desktop / worker / review / job sessions unchanged