### PR TITLE
Realign the xterm cursor when the iOS keyboard opens (CROW-1078)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -5633,11 +5633,33 @@ function ensureTerminal() {
   }
   // WebGL renderer for throughput; must load after open(). Falls back to the
   // default renderer if the GL context is unavailable or gets lost.
+  //
+  // CROW-1078: skipped on touch surfaces (iOS/iPad). A WebGL canvas is its own
+  // compositor layer that often fails to re-composite while Safari animates the
+  // *visual* viewport with the software keyboard, so the drawn cursor strands at
+  // its old screen position while the IME caret (a DOM textarea) follows the
+  // keyboard — the two land on different cells. The DOM/canvas renderer follows
+  // the viewport correctly and honors the viewport addon's post-inset repaint.
+  // `keyboardCapable()` is the SAME touch test the viewport addon gates on,
+  // shared from its namespace so the two can't drift; requiring `visualViewport`
+  // too makes this condition identical to "the viewport addon will engage" — so
+  // WebGL is dropped on exactly the surfaces where the keyboard can animate the
+  // viewport, and non-visualViewport webviews keep WebGL unchanged. If the addon
+  // failed to load, `skipWebgl` stays false and WebGL loads exactly as before.
+  let skipWebgl = false;
   try {
-    const webglAddon = new WebglAddon.WebglAddon();
-    webglAddon.onContextLoss(() => webglAddon.dispose());
-    term.loadAddon(webglAddon);
-  } catch (_) { /* WebGL unavailable → canvas/DOM renderer */ }
+    skipWebgl = !!window.visualViewport
+      && typeof CrowViewportAddon === 'object' && CrowViewportAddon
+      && typeof CrowViewportAddon.keyboardCapable === 'function'
+      && CrowViewportAddon.keyboardCapable();
+  } catch (_) { skipWebgl = false; }
+  if (!skipWebgl) {
+    try {
+      const webglAddon = new WebglAddon.WebglAddon();
+      webglAddon.onContextLoss(() => webglAddon.dispose());
+      term.loadAddon(webglAddon);
+    } catch (_) { /* WebGL unavailable → canvas/DOM renderer */ }
+  }
   term.onData(sendToPTY);
   // CROW-934: hydrate the shell scrollback from tmux when the user reaches the
   // top of what the live stream actually delivered.

--- a/Packages/CrowDaemon/web-tests/visual-viewport.test.js
+++ b/Packages/CrowDaemon/web-tests/visual-viewport.test.js
@@ -8,6 +8,11 @@ const { JSDOM } = require('jsdom');
 // the "leave every non-phone surface alone" guards are pinned without a device.
 // CROW-1045 adds the desktop-WKWebView guard: `visualViewport` presence is not a
 // keyboard, so a non-touch surface must stay fully inert (case 1b).
+// CROW-1078 adds the cursor reconciliation: re-home the off-screen helper
+// textarea so iOS stops chasing it (cases 10, 11), keep the keyboard-presence
+// test independent of a chased visual-viewport scroll (case 12), and repaint the
+// cursor when the inset changes (case 13). keyboardCapable is exported and shared
+// with app.js's WebGL gate (case 14).
 const ADDON_JS =
   __dirname + '/../../CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js';
 
@@ -70,10 +75,20 @@ function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP, keyboardCapab
   // term.open(), which is what the addon defaults its host to.
   const element = window.document.createElement('div');
   host.appendChild(element);
+  // The helper textarea xterm parks off-screen; the addon re-homes it and hooks
+  // its focus to reconcile the cursor (CROW-1078). A real element so a dispatched
+  // focus event reaches the addon's listener.
+  const textarea = window.document.createElement('textarea');
+  textarea.className = 'xterm-helper-textarea';
+  element.appendChild(textarea);
   const scrolls = [];
   const resizes = [];
+  const refreshes = [];
   const term = {
     element,
+    textarea,
+    rows: 24,
+    refresh: (a, b) => refreshes.push([a, b]),
     buffer: { active: { viewportY: 10, baseY: 10 } }, // at the live edge
     scrollToBottom: () => scrolls.push(1),
   };
@@ -89,7 +104,7 @@ function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP, keyboardCapab
   };
 
   return {
-    window, vv, host, term, addon, scrolls, resizes, listeners, flush, frames, emit,
+    window, vv, host, term, addon, scrolls, resizes, refreshes, listeners, flush, frames, emit,
     activate: () => addon.activate(term),
     height: () => host.style.height,
     // A keyboard of `px`, iOS-style: visual viewport shrinks, layout does not.
@@ -97,6 +112,12 @@ function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP, keyboardCapab
     // `display: none` — the web app hides the terminal while a board is open.
     hide: () => { clientHeight = 0; },
     show: () => { clientHeight = LAYOUT_HEIGHT - hostTop; },
+    // iOS raises the keyboard on focus; dispatch it, then settle the frame.
+    focus: () => { textarea.dispatchEvent(new window.Event('focus')); flush(); },
+    // The on-screen park <style> the addon injects (touch surfaces only).
+    homeStyle: () => window.document.getElementById('crow-vv-textarea-home'),
+    // The addon's exported namespace (keyboardCapable is shared with app.js).
+    ns: () => ctx.CrowViewportAddon,
   };
 }
 
@@ -263,6 +284,95 @@ function makeWorld({ hasVisualViewport = true, hostTop = HOST_TOP, keyboardCapab
   // A frame already in flight must not touch a disposed terminal.
   w.flush();
   check('no pin after dispose', w.scrolls.length === 0);
+}
+
+// ---- 10. Touch surface re-homes the parked helper textarea -----------------
+// CROW-1078 #1: xterm parks .xterm-helper-textarea at left:-9999em. On a touch
+// surface iOS scrolls the visual viewport to chase that off-screen field the
+// instant it's focused, stranding the cursor. The addon re-parks it on-screen
+// with a stylesheet rule that must yield to xterm's own inline sync.
+{
+  console.log('touch surface re-homes the parked helper textarea');
+  const w = makeWorld();
+  check('no park style before activate', !w.homeStyle());
+  w.activate();
+  const style = w.homeStyle();
+  check('injects the on-screen park style', !!style);
+  check('parks the field on-screen, not at -9999em',
+    !!style && /left:\s*0/.test(style.textContent) && !/9999/.test(style.textContent));
+  check('rule is NOT !important (so xterm inline sync still wins the cell)',
+    !!style && !/!important/i.test(style.textContent));
+  check('targets the helper textarea',
+    !!style && /\.xterm-helper-textarea/.test(style.textContent));
+}
+
+// ---- 11. Focus reconciles the cursor the moment the keyboard is raised ------
+// iOS opens the keyboard on focus, before the trailing vv resize/scroll — so a
+// focus reconcile makes the first keyboard frame correct.
+{
+  console.log('focus reconciles when the keyboard is raised');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(300);     // keyboard-sized shrink already present at focus time
+  w.focus();
+  check('focus sized the host', w.height() === '380px');
+  check('focus repainted the cursor', w.refreshes.length >= 1);
+}
+
+// ---- 12. A chased visual-viewport scroll still reads as a keyboard ----------
+// CROW-1078 #4: iOS scrolls the visual viewport (offsetTop grows) to chase the
+// textarea. The OLD occlusion test, layoutHeight - (offsetTop + height), then
+// computes ~0 and wrongly restores. Keyboard height, layoutHeight - height, is
+// independent of the scroll and still fires; sizing still uses offsetTop.
+{
+  console.log('chased visual-viewport scroll still reads as keyboard');
+  const w = makeWorld();
+  w.activate();
+  w.vv.offsetTop = 200; // iOS scrolled down chasing the field
+  w.keyboard(300);      // vv.height = 500
+  w.emit();
+  // Old math: 800 - (200 + 500) = 100 ≤ 120 → would have restored (no keyboard).
+  // New math: 800 - 500 = 300 > 120 → detected.
+  check('still detects the keyboard', w.resizes.length === 1);
+  // Sizing uses visibleBottom = offsetTop + height = 700; host top is 120.
+  check('host sized to the visible bottom (offsetTop honored)', w.height() === '580px');
+  check('cursor repainted on apply', w.refreshes.length >= 1);
+}
+
+// ---- 13. Cursor is repainted on both apply and restore ---------------------
+// CROW-1078 #3: after the inset is applied or released the drawn cursor can lag
+// the moved host, so the addon forces a repaint each way.
+{
+  console.log('cursor repainted on apply and restore');
+  const w = makeWorld();
+  w.activate();
+  w.keyboard(300);
+  w.emit();
+  const afterOpen = w.refreshes.length;
+  check('repaints when the inset is applied', afterOpen >= 1);
+  check('repaint spans the whole grid', w.refreshes[0][0] === 0 && w.refreshes[0][1] === 23);
+  w.keyboard(0);
+  w.emit();
+  check('repaints again when the inset is released', w.refreshes.length > afterOpen);
+}
+
+// ---- 14. keyboardCapable is exported and shared with app.js -----------------
+// CROW-1078 #5: app.js drops WebGL on touch surfaces using THIS test, so it must
+// be exported and agree with the addon's own gate.
+{
+  console.log('keyboardCapable is exported and shared');
+  const phone = makeWorld();                          // coarse pointer
+  check('exported as a function', typeof phone.ns().keyboardCapable === 'function');
+  check('true on a touch surface', phone.ns().keyboardCapable() === true);
+  const desk = makeWorld({ keyboardCapable: false }); // desktop WKWebView
+  check('false on a non-touch surface', desk.ns().keyboardCapable() === false);
+  // And the desktop surface injects no park style / wires no focus reconcile.
+  desk.activate();
+  check('desktop injects no park style', !desk.homeStyle());
+  desk.keyboard(300);
+  desk.focus();
+  check('desktop does not size on focus', desk.height() === '');
+  check('desktop does not repaint on focus', desk.refreshes.length === 0);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/xterm/xterm-addon-crow-viewport.js
@@ -35,6 +35,21 @@
 // that: coarse pointer or touch points. Desktop fails both and stays inert,
 // exactly like the no-`visualViewport` case; phones and tablets are unchanged.
 //
+// CROW-1078: opening the keyboard also left the xterm *cursor* misaligned — the
+// drawn caret and the iOS IME/caret accessory landing on different cells. Two
+// causes, both handled here so the reconciliation lives in one shared place
+// instead of per front-end: (1) iOS scrolls the visual viewport to chase
+// xterm's helper textarea, which parks off-screen at `left:-9999em` — so re-home
+// the parked state on-screen (touch only), and the field no longer flies away,
+// which also keeps the occlusion maths honest (see `_apply`). (2) after an inset
+// is applied or restored the drawn cursor can lag the moved host — so force a
+// repaint, which also re-runs xterm's textarea sync onto the cell. A WebGL
+// canvas is a compositor layer that ignores that repaint while iOS animates the
+// viewport, so `app.js` drops WebGL on touch surfaces (sharing the exported
+// `keyboardCapable`, below) and uses the DOM renderer there. All of it stays
+// behind the same keyboardCapable + visualViewport guards, so desktop and
+// non-touch webviews are wholly unchanged.
+//
 // Loaded via <script src> (not ES modules), so it exposes a namespaced UMD-style
 // global matching the vendored addons
 // (window.FitAddon.FitAddon → window.CrowViewportAddon.CrowViewportAddon).
@@ -97,6 +112,8 @@
     this._savedHeight = '';     // the inline height we found there, restored on undo
     this._keyboardOpen = false;
     this._pending = false;      // a frame is already scheduled
+    this._textarea = null;      // xterm's focus/IME helper textarea (CROW-1078)
+    this._onFocus = null;       // re-sync when the keyboard is raised on focus
   }
 
   // ITerminalAddon.activate — must run after term.open() so term.element exists.
@@ -128,6 +145,20 @@
     // the visual viewport within an unchanged layout viewport as a scroll.
     vv.addEventListener('resize', this._onChange);
     vv.addEventListener('scroll', this._onChange);
+
+    // CROW-1078: stop iOS scrolling the visual viewport to chase the off-screen
+    // helper textarea, and reconcile the cursor the moment the keyboard is
+    // raised. `_homeTextarea` re-parks the field on-screen (a no-op once it's on
+    // a real cell — xterm's inline sync wins). The `focus` listener reconciles
+    // right when iOS opens the keyboard, so the first keyboard frame is already
+    // correct instead of waiting for the vv resize/scroll that trails it.
+    this._homeTextarea();
+    var textarea = term.textarea;
+    if (textarea && typeof textarea.addEventListener === 'function') {
+      this._textarea = textarea;
+      this._onFocus = function () { self._schedule(); };
+      textarea.addEventListener('focus', this._onFocus);
+    }
 
     // Evaluate once up front — a terminal can be attached with the keyboard
     // already open (switching sessions/tabs mid-typing).
@@ -164,9 +195,19 @@
     // a tab bar). `offsetTop` is how far the visual viewport has been pushed
     // down inside the layout viewport, so it must be added, not subtracted.
     var visibleBottom = vv.offsetTop + vv.height;
-    var occluded = layoutHeight - visibleBottom;
 
-    if (occluded <= KEYBOARD_MIN_OCCLUSION) {
+    // Is a software keyboard up? The shrink of the VISIBLE height against the
+    // layout viewport — `layoutHeight - vv.height` — is the keyboard's height,
+    // and it is independent of how far iOS has scrolled the visual viewport
+    // (`offsetTop`). Testing `layoutHeight - visibleBottom` instead let a scroll
+    // that iOS did to chase the off-screen helper textarea read as "no keyboard"
+    // (offsetTop + height ≈ layoutHeight → ≈ 0) even with the keyboard open —
+    // CROW-1078 #4. On these `overflow: hidden` pages nothing but the keyboard
+    // shrinks the visible height, so this can't false-positive; `visibleBottom`
+    // (which DOES need offsetTop) still drives the sizing below.
+    var keyboardHeight = layoutHeight - vv.height;
+
+    if (keyboardHeight <= KEYBOARD_MIN_OCCLUSION) {
       this._restore();
       return;
     }
@@ -221,10 +262,53 @@
     return !b || b.viewportY >= b.baseY;
   };
 
+  // Re-home xterm's parked helper textarea from off-screen-left to the on-screen
+  // top-left, once per document, on touch surfaces only (the caller is already
+  // behind the keyboardCapable guard). xterm hides the caret by parking
+  // `.xterm-helper-textarea` at `left:-9999em`; the instant it's focused iOS
+  // scrolls the *visual* viewport to drag that off-screen field into view, which
+  // shifts offsetLeft/offsetTop, strands the drawn cursor, and muddies the
+  // occlusion test (CROW-1078 #1/#4). The rule (deliberately NOT `!important`,
+  // and appended after xterm.css so it wins the parked state on equal
+  // specificity) moves only the park. It yields to xterm's own inline left/top —
+  // written on cursor-move/render — so the field still tracks the cursor cell; it
+  // just never flies to -9999em in between. Offset compensation is intentionally
+  // NOT applied: the textarea and the drawn cursor are siblings in the same
+  // absolute coordinate space, so they move together under a visual-viewport
+  // shift — subtracting `offset*` would de-align them, not align them.
+  CrowViewportAddon.prototype._homeTextarea = function () {
+    var doc = global.document;
+    if (!doc || !doc.head || doc.getElementById('crow-vv-textarea-home')) {
+      return;
+    }
+    var style = doc.createElement('style');
+    style.id = 'crow-vv-textarea-home';
+    style.textContent = '.xterm .xterm-helper-textarea{left:0;}';
+    doc.head.appendChild(style);
+  };
+
+  // Repaint the grid so the drawn cursor catches up to a just-changed host inset,
+  // and xterm's textarea sync re-runs onto the cell (CROW-1078 #3). A no-op-safe
+  // nudge on any renderer; WebGL is not used on touch surfaces (app.js drops it
+  // there, #5) precisely because its compositor layer would ignore this.
+  CrowViewportAddon.prototype._resyncCursor = function () {
+    var term = this._term;
+    if (!term || typeof term.refresh !== 'function') {
+      return;
+    }
+    try {
+      var rows = (typeof term.rows === 'number' && term.rows > 0) ? term.rows : 1;
+      term.refresh(0, rows - 1);
+    } catch (_) { /* renderer not ready → the pending fit repaints next frame */ }
+  };
+
   CrowViewportAddon.prototype._refit = function (pin) {
     if (this._onResize) {
       try { this._onResize(); } catch (_) { /* the page's fit is its own problem */ }
     }
+    // The host's inset just changed (or was released) — drag the drawn cursor
+    // and the IME caret back onto the cell (CROW-1078 #3).
+    this._resyncCursor();
     if (!pin) {
       return;
     }
@@ -249,16 +333,30 @@
       this._vv.removeEventListener('resize', this._onChange);
       this._vv.removeEventListener('scroll', this._onChange);
     }
+    if (this._textarea && this._onFocus) {
+      this._textarea.removeEventListener('focus', this._onFocus);
+    }
     if (this._applied && this._host) {
       this._host.style.height = this._savedHeight;
     }
+    // The injected `#crow-vv-textarea-home` <style> is left in place on purpose:
+    // it is document-global, id-guarded, inert without an xterm textarea, and a
+    // recycled/next terminal on the same document still wants the on-screen park.
     this._applied = false;
     this._keyboardOpen = false;
     this._onChange = null;
+    this._onFocus = null;
+    this._textarea = null;
     this._vv = null;
     this._host = null;
     this._term = null;
   };
 
-  global.CrowViewportAddon = { CrowViewportAddon: CrowViewportAddon };
+  // `keyboardCapable` is exported alongside the addon so other surfaces (app.js's
+  // WebGL gate, CROW-1078 #5) share this one touch test instead of re-deriving it
+  // and drifting — the parity trap this addon exists to avoid.
+  global.CrowViewportAddon = {
+    CrowViewportAddon: CrowViewportAddon,
+    keyboardCapable: function () { return keyboardCapable(global); },
+  };
 })(typeof globalThis !== 'undefined' ? globalThis : window);


### PR DESCRIPTION
Closes #1078

## Problem

On iOS/iPad Safari, opening the software keyboard left the xterm caret off the cell it belonged to: the **drawn** cursor (canvas/WebGL) and the **iOS IME/caret accessory** landed on different cells, so typed input no longer matched where the cursor was painted. CROW-988 (#996) refit the host *height* so the prompt clears the keyboard, but never resynced the *cursor*.

Two coordinate systems diverge the moment the keyboard opens:
1. **iOS chases the off-screen textarea.** xterm parks `.xterm-helper-textarea` at `left:-9999em`; the instant it's focused, Safari scrolls the *visual* viewport to drag that off-screen field into view — shifting `offsetLeft/offsetTop`, stranding the drawn cursor, and (as a side effect) collapsing the keyboard-occlusion math to ~0 so the CROW-988 fit thinks there's no keyboard.
2. **WebGL doesn't re-composite.** On iOS a WebGL canvas is a compositor layer that often doesn't re-composite while the visual viewport animates with the keyboard, so the drawn cursor stays at its old screen position.

## Fix

All the cursor/viewport reconciliation lives in the **shared `CrowViewportAddon`** — served from one source (`CrowTerminal/…/xterm-addon-crow-viewport.js`) to *both* web front-ends (`app.js` and web `terminal.html`), so they can't hand-mirror-drift. Built on the existing CROW-988 / CROW-1045 host-height path, not replacing it.

- **Re-home the parked textarea** (touch surfaces only): a stylesheet rule moves `.xterm-helper-textarea`'s *parked* state from `left:-9999em` to on-screen `left:0`. It is deliberately **not** `!important` and is appended after `xterm.css`, so it wins only the parked state and yields to xterm's own inline cursor-cell sync (written on cursor-move/render). iOS no longer flies off to `-9999em`.
- **Keyboard detection is now offset-independent:** the presence test is `layoutHeight - vv.height` (the keyboard's height) instead of `layoutHeight - (offsetTop + vv.height)` — a large `offsetTop` (from a chased scroll) used to collapse that to ~0 and read as "no keyboard." Host *sizing* still uses `offsetTop`, so CROW-988's "prompt stays above the keyboard" is unchanged.
- **Repaint on inset apply/restore:** forces the drawn cursor to follow the moved host and re-runs xterm's textarea sync onto the cell.
- **Reconcile on textarea `focus`:** makes the first keyboard frame correct instead of waiting for the trailing vv resize/scroll.
- **`app.js` drops WebGL on touch surfaces** (`visualViewport` present **and** `keyboardCapable()` — the *same* test exported once from the addon, so the two can't drift). The DOM/canvas renderer follows the viewport and honors the repaint; WebGL's compositor layer ignores it. Desktop and non-`visualViewport` webviews keep WebGL.

### One intentional deviation from the ticket's proposed steps

The ticket suggests *subtracting* `visualViewport.offsetLeft/offsetTop` when placing the textarea. I did **not** do that, on purpose: xterm's helper textarea and the drawn cursor are siblings in the **same absolute coordinate space**, so a visual-viewport shift moves them together — subtracting `offset*` from only the textarea would *de*-align it from the canvas cursor, not align it. The real defects are the off-screen chase (fixed by the on-screen park) and WebGL not re-compositing (fixed by dropping WebGL on touch); the acceptance criteria — caret and IME accessory on the same cell — are met by those. Rationale is documented in `_homeTextarea`.

## Tests

`Packages/CrowDaemon/web-tests/visual-viewport.test.js` gains 21 assertions (textarea home, focus reconcile, chased-scroll detection, apply/restore repaint, shared `keyboardCapable` export). The whole `test:ci` suite is green:

```
cd Packages/CrowDaemon/web-tests && npm ci && npm run test:ci   # exit 0
```

Desktop / non-touch stays fully inert (existing CROW-1045 cases + new case 14 confirm no park style, no focus reconcile, WebGL retained).

## Manual verification (human-side — iOS/iPad Safari, cannot be done from CI)

On **iPhone and iPad Safari**, against the web UI:
1. Tap the terminal to open the keyboard → the blinking cursor stays on the same cell as the prompt/typed text, fully visible above the keyboard; the IME/caret accessory (when shown) sits on that same cell, not offset.
2. Type a few characters → what you type lands where the cursor is drawn.
3. Rotate the device / change keyboard height with the keyboard open → cursor stays aligned.
4. Close the keyboard → full-height grid restored, cursor still on the correct cell, no leftover gap/clip/drift.
5. Confirm a **desktop** browser and the macOS app are unchanged (WebGL still used on desktop; no layout change).