### PR TITLE
OpenCode: drop subagent child sessions from hook emission (CROW-1082)

### DIFF
--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeHookConfigWriter.swift
@@ -84,14 +84,20 @@ import CrowCore
 /// transition bookkeeping and never mapped to `Stop` — treating it as "done"
 /// would park the card on a turn that is still running.
 ///
-/// **Known gap (pre-existing, not CROW-1000).** OpenCode's bus is per-*server*
-/// and `session.status` carries no parent link, so a **subagent's** child
-/// session is mapped onto this plugin's one Crow session UUID: the child going
-/// idle emits a `Stop` while the parent is still working (measured 1.9 s early
-/// on 1.18.5). The deprecated `session.idle` behaved identically, so nothing
-/// here regresses it; closing it means correlating `session.created`'s
-/// `info.parentID` and ignoring non-root sessions. See
-/// `docs/agent-harness-matrix.md` → Hook async delivery.
+/// **Subagent child sessions are dropped (CROW-1082).** OpenCode's bus is
+/// per-*server* and `session.status` / `session.idle` carry only a `sessionID`
+/// with no parent link, so before this fix a **subagent's** child session was
+/// mapped onto this plugin's one Crow session UUID: the child going idle emitted
+/// a `Stop` while the parent was still working (measured 1.9 s early on 1.18.5),
+/// parking the card on `.done` mid-turn. `session.created` is the one event that
+/// exposes the parent link (`info.parentID`), so the plugin records every child
+/// session's id there and then **ignores that id's `session.status` /
+/// `session.idle`** — only the **root** session (no `parentID`) drives the card,
+/// and it also skips `SessionStart` for a child so a subagent never re-announces
+/// the parent. Scoped to the premature-`.done` failure: a child's tool hooks
+/// (`tool.execute.before`/`after`) still map to working state, which is correct
+/// because the parent *is* working. See `docs/agent-harness-matrix.md` → Hook
+/// async delivery.
 ///
 /// Permission detection uses the **first-class `permission.ask` hook**, not a
 /// bus `event.type`: the SDK `Event` union has no `permission.asked` literal
@@ -259,6 +265,14 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
         // session goes idle.
         const lastStatus = new Map();
 
+        // sessionIDs of subagent CHILD sessions. OpenCode's bus is per-server
+        // and `session.status`/`session.idle` carry only a `sessionID` with no
+        // parent link, so a child going idle would mark the parent's card
+        // `.done` mid-turn. `session.created` is the one event carrying
+        // `info.parentID`, so we record every child there and drop its
+        // status/idle events below — only the root session drives the card.
+        const childSessions = new Set();
+
         async function emit($, cwd, event, extra) {
           try {
             const payload = JSON.stringify(Object.assign({ cwd }, extra || {}));
@@ -292,14 +306,30 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
           return {
             event: async ({ event }) => {
               switch (event.type) {
-                case "session.created":
+                case "session.created": {
+                  // A subagent runs as a CHILD session on the same per-server
+                  // bus. `info.parentID` is the only place the parent link is
+                  // exposed, so record child ids here and drop their lifecycle
+                  // events below. Root sessions (no parentID) alone drive the
+                  // card — and a child never re-announces via SessionStart.
+                  const info = (event.properties && event.properties.info) || {};
+                  if (info.parentID) {
+                    childSessions.add(info.id);
+                    break;
+                  }
                   await emit($, cwd, "SessionStart", { source: "startup" });
                   break;
+                }
                 case "session.status": {
                   // Canonical idle/busy signal (`session.idle` is deprecated).
                   sawSessionStatus = true;
                   const props = event.properties || {};
                   const id = props.sessionID || "";
+                  // A subagent's status must never move the parent's card: its
+                  // idle would falsely mark it `.done`. Drop after the latch
+                  // above so a child-only status still disables the deprecated
+                  // `session.idle` fallback.
+                  if (childSessions.has(id)) break;
                   const raw = (props.status && props.status.type) || "";
                   // `retry` is a busy sub-state (provider retry mid-turn), NOT a
                   // finished turn — fold it into `busy` so a busy→retry→busy
@@ -324,12 +354,17 @@ public struct OpenCodeHookConfigWriter: HookConfigWriter {
                   }
                   break;
                 }
-                case "session.idle":
+                case "session.idle": {
                   // Deprecated upstream, and emitted alongside
                   // `session.status {idle}` on builds that have it — so only
                   // act on it when this build never spoke `session.status`.
+                  // Same child guard as `session.status`: a subagent's idle
+                  // must not mark the parent's card done.
+                  const id = (event.properties && event.properties.sessionID) || "";
+                  if (childSessions.has(id)) break;
                   if (!sawSessionStatus) await emit($, cwd, "Stop");
                   break;
+                }
                 case "session.error":
                   await emit($, cwd, "Notification", { message: "Session error" });
                   break;

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeHookConfigWriterTests.swift
@@ -72,6 +72,23 @@ struct OpenCodeHookConfigWriterTests {
         #expect(js.contains("if (state === \"busy\") {"))
     }
 
+    @Test func pluginSourceDropsSubagentChildSessions() {
+        // CROW-1082: a subagent runs as a CHILD session on the same per-server
+        // bus, but `session.status`/`session.idle` carry only a `sessionID`. The
+        // plugin records child ids from `session.created`'s `info.parentID` and
+        // drops that id's status/idle, so a child idling can't mark the parent's
+        // card `.done` mid-turn.
+        let js = OpenCodeHookConfigWriter.pluginSource(crowPath: "/bin/crow")
+        // A set of child session ids, populated from `session.created`.
+        #expect(js.contains("const childSessions = new Set();"))
+        #expect(js.contains("if (info.parentID) {"))
+        #expect(js.contains("childSessions.add(info.id);"))
+        // Both the modern and deprecated idle paths guard on membership.
+        #expect(js.contains("if (childSessions.has(id)) break;"))
+        // The deprecated fallback reads the sessionID it previously ignored.
+        #expect(js.contains("event.properties.sessionID"))
+    }
+
     @Test func globalPluginSourceSelfSuppressesWhenPerProjectExists() {
         // Global variant (no session UUID): SESSION empty, cwd-match emit, and
         // a guard that defers to a per-project plugin so events don't double-emit.

--- a/docs/agent-harness-matrix.md
+++ b/docs/agent-harness-matrix.md
@@ -545,18 +545,20 @@ the UUID-scoped tier in CROW-1060). See
   reads as done. ⚠️ **Still open:** the probe was headless, so the *interactive
   TUI* claim CROW-545 originally asked about is inferred (same server bus), not
   measured — a TUI job session is the remaining human re-check.
-- **OpenCode child sessions leak into the parent's card** (confirmed 2026-08-13,
-  opencode 1.18.5; **pre-existing**, not introduced by CROW-1000). The bus is
-  per-server, and `session.status` / `session.idle` carry only a `sessionID` —
-  no parent link — so a **subagent's** status is mapped onto the one Crow
-  session UUID like the parent's. A run that delegated to a subagent emitted
+- **OpenCode child sessions are dropped from the card** (CROW-1082; gap
+  confirmed 2026-08-13, opencode 1.18.5). The bus is per-server, and
+  `session.status` / `session.idle` carry only a `sessionID` with no parent
+  link, so a **subagent's** status would otherwise map onto the one Crow session
+  UUID like the parent's — a run that delegated to a subagent emitted
   `SessionStart` (child `session.created`), then `Stop` when the **child** went
-  idle **1.9 s before the parent finished**, leaving the card `.done` mid-turn.
-  The deprecated `session.idle` had the identical failure, so this is a
-  standing gap rather than a regression. Fixing it means correlating
-  `session.created`'s `info.parentID` and dropping non-root sessions — a
-  distinct behavior change (it also re-opens what `SessionStart`/`PreToolUse`
-  should mean for subagents), so it is **not** in CROW-1000.
+  idle **1.9 s before the parent finished**, parking the card on `.done`
+  mid-turn. `session.created` is the one event exposing the parent link
+  (`info.parentID`), so the plugin records every child session's id there and
+  then **ignores that id's `session.status` / `session.idle`** — only the
+  **root** session (no `parentID`) drives the card, and a child no longer
+  re-announces via `SessionStart`. Scoped to the premature-`.done` failure: a
+  child's tool hooks still map to working state, which is correct because the
+  parent *is* working.
 
 > **Apply-order caveat (#903).** Since `crow hook-event` became fire-and-forget,
 > `PreToolUse` being non-async only guarantees the daemon *accepts* it ahead of
@@ -947,6 +949,7 @@ against current upstream CLIs.
 | Cursor `PostToolUse` / `Notification` async timing unconfirmed | — (empirical) | `CursorSignalSource` | 2026-07-24 |
 | Cursor interactive `--trust` (workspace-trust seed) — reverses the earlier headless-only omission; now emitted on **every** kind incl. `.review` | **min: Cursor CLI ≥ 2026.07.20** (changelog: interactive); verified `agent 2026.08.04` (`--help` drops "headless mode only"; pty run with no `--print` writes `.workspace-trusted` / `"trustMethod": "cli-flag"`) | `CursorLaunchArgs.trustSuffix` | 2026-08-10 (CROW-954) — emitted on every path. The `.review` carve-out is **removed**: `--force` was observed NOT to suppress the trust dialog (the CROW-890 "unverified" note, now settled), so the carve-out stranded unattended reviews on a prompt that gated nothing — review already runs `--force --approve-mcps`. Review clones are now defended by the launch-path `.cursor/` strip (`shouldStripCursorReviewClone`) instead. Pre-2026.07.20 CLI out of support; probed 2026.07.23 that the parser ignores a mode-gated flag (`--output-format json --version` exits 0), so older builds no-op `--trust` rather than reject. Re-probe if `--help` ever restores the headless-only qualifier |
 | OpenCode "done" signal is `session.status {idle}`, not the deprecated `session.idle` | opencode **1.18.5** (probed; `session.status` present) | `OpenCodeHookConfigWriter` | 2026-08-13 (CROW-1000) — upstream publishes **both** at turn end (`session/status.ts` `set` → Status then Idle, 246 µs apart), so the plugin latches on the first `session.status` and drops the compat event; older builds keep the `session.idle` fallback. `session.status` fires on every status write, not only on changes, so transitions are deduped per `sessionID`. ⚠️ Probed via headless `opencode run`, **not** the interactive TUI — the TUI pass is the open human re-check, as is a build ≥ **1.18.16** (the version the ticket cites for the deprecation docs). Re-probe if upstream stops emitting `session.idle` (fallback becomes dead code) or adds a fourth `SessionStatus` type |
+| OpenCode subagent child sessions carry no parent link on `session.status`/`session.idle` — only `session.created`'s `info.parentID` does | opencode **1.18.5** (child idle measured 1.9 s before parent finish) | `OpenCodeHookConfigWriter` | 2026-08-20 (CROW-1082) — plugin records every child id from `session.created` and drops that id's status/idle so only the **root** session moves the card; a child no longer emits `SessionStart` either. Scoped to premature `.done`; child tool hooks still map to working (parent is working). Re-probe if upstream stops populating `info.parentID` on `session.created`, or starts stamping a parent id onto `session.status`/`session.idle` (the guard could then key off that directly) |
 | Antigravity flags (`agy` hooks events, `-p` non-TTY stdout, `-c`/`--conversation` resume) | `agy` **v1.1.7 (2026-07-26)** | `AntigravityAgent` / `AntigravityHookConfigWriter` | 2026-07-26 — re-probe on upgrade |
 | Antigravity structured-stdout (would promote toward first-class parity) | upstream FRs **#119/#597** (`--output-format stream-json`), **#31** (ACP) | `AntigravitySignalSource` | 2026-07-26 — hooks are the only transport until either lands |
 | Antigravity bounded auto-permission has no verified interactive launch flag | `agy` **v1.1.7**; headless `-p` ignores `permissions.allow` (issue #548) | `AntigravityLaunchArgs.autoPermissionSuffix` | 2026-07-26 |


### PR DESCRIPTION
Closes #1082

## Problem

OpenCode's event bus is per-server and `session.status` / `session.idle` carry only a `sessionID` with **no parent link**, so a subagent's **child** session was mapped onto the plugin's one Crow session UUID. The child going idle emitted a `Stop` while the parent was still working (measured **1.9 s early** on opencode 1.18.5), parking the parent's card on `.done` mid-turn. The deprecated `session.idle` path failed identically — a standing gap, not a CROW-1000 regression.

## Fix

`session.created` is the one event exposing the parent link (`info.parentID`). The generated plugin now:

- records every **child** session's id (`info.parentID` present) into a `childSessions` set, and
- **ignores that id's `session.status` / `session.idle`** — so only the **root** session (no `parentID`) can move the card, and a child no longer re-announces via `SessionStart`.

Scoped narrowly to the premature-`.done` failure per the ticket: a child's tool hooks (`tool.execute.before/after`) still map to working state, which is correct because the parent *is* working.

Two details that matter:

- The `sawSessionStatus` latch is set **before** the child guard, so a subagent-only run still disables the deprecated `session.idle` fallback.
- **Single-session behavior is unchanged** — a root session is never added to `childSessions`, so every guard is a no-op for it.

## Changes

- `OpenCodeHookConfigWriter.swift` — plugin body + type doc.
- `docs/agent-harness-matrix.md` — the async-delivery bullet and a new empirical-verification row.
- Added `pluginSourceDropsSubagentChildSessions` test.

## Test plan

- `swift test` in `Packages/CrowOpenCode` — 59 tests pass, including the new one.
- Acceptance (live re-check): an OpenCode session that spawns a subagent keeps its Crow card in a working state until the **root** session goes idle; existing single-session behavior unchanged.

🐦‍⬛ Generated with [Claude Code](https://claude.com/claude-code)