### PR TITLE
Add crow terminal get/set for wheel scroll settings (CROW-1085)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ crow cleanup get                                                        → {"cl
 crow cleanup set [--enabled true|false] [--retention-hours N]           → patch; live within ~1 board poll. Deletes completed/archived sessions incl. worktree + branch
 crow ui get                                                             → {"ui":{"sidebar":{"hide_session_details":…}}}
 crow ui set --hide-session-details true|false                           → patch; connected browsers repaint within ~2s
+crow terminal get                                                       → {"terminal":{"wheel_scroll_lines":…,"agent_wheel_notches":…}}
+crow terminal set [--wheel-scroll-lines N] [--agent-wheel-notches N]    → patch; wheel-scroll tuning (CROW-835, ADR 0013); both floor at 1; live on next scroll
 crow version                                                            → prints the stamped build version
 crow version --check                                                    → compare against corveil/crow main; human summary, exit 0/1/2
 crow version check                                                      → same as --check

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SettingsCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SettingsCommands.swift
@@ -307,3 +307,86 @@ public struct UISet: ParsableCommand {
         printJSON(result)
     }
 }
+
+// MARK: - crow terminal
+
+/// Parent command for terminal wheel-scroll tuning: `crow terminal <subcommand>`.
+public struct Terminal: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "terminal",
+        abstract: "View or change terminal wheel-scroll speed",
+        discussion: """
+        Wheel-scroll tuning for the web terminal (CROW-835, ADR 0013). The wheel \
+        is routed by surface: plain-shell / review surfaces scroll their own \
+        scrollback, so the knob is lines per physical notch; agent TUIs (Claude \
+        Code, Cursor, the Manager) own their scrolling, so the knob is how many \
+        wheel notches are forwarded to the app per physical notch. Each surface \
+        gets its own value.
+
+        These are the two `AppConfig.terminal` fields the web Settings sliders \
+        write; this is the CLI half. Not to be confused with the terminal-*tab* \
+        verbs (`new-terminal`, `list-terminals`, `send`, …), which manage panes.
+        """,
+        subcommands: [TerminalGet.self, TerminalSet.self]
+    )
+
+    public init() {}
+}
+
+public struct TerminalGet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "get", abstract: "Show the current terminal wheel-scroll settings")
+
+    public init() {}
+
+    public func run() throws {
+        let result = try rpc("terminal-get")
+        printJSON(result)
+    }
+}
+
+public struct TerminalSet: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Change terminal wheel-scroll speed",
+        discussion: """
+        Only the flags you pass change; at least one is required. Connected \
+        browsers pick the change up on their next scroll — no reload.
+
+        --wheel-scroll-lines sets scrollback lines per wheel notch on plain-shell \
+        and review surfaces (default 3). --agent-wheel-notches sets how many wheel \
+        reports are forwarded to the agent per physical notch (default 1 — one \
+        detent in, one out; raise it if agent scrolling feels too slow). Both floor \
+        at 1: a value of 0 would disable wheel scrolling on that surface.
+        """
+    )
+
+    @Option(
+        name: .customLong("wheel-scroll-lines"),
+        help: "Scrollback lines per wheel notch on plain-shell/review surfaces (minimum 1, default 3)")
+    var wheelScrollLines: Int?
+
+    @Option(
+        name: .customLong("agent-wheel-notches"),
+        help: "Wheel notches forwarded to the agent per physical notch (minimum 1, default 1)")
+    var agentWheelNotches: Int?
+
+    public init() {}
+
+    public func validate() throws {
+        guard wheelScrollLines != nil || agentWheelNotches != nil else {
+            throw ValidationError(
+                "Nothing to set — provide at least one of --wheel-scroll-lines, --agent-wheel-notches.")
+        }
+        if let wheelScrollLines { try validateWheelValue(wheelScrollLines, flag: "--wheel-scroll-lines") }
+        if let agentWheelNotches { try validateWheelValue(agentWheelNotches, flag: "--agent-wheel-notches") }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = [:]
+        if let wheelScrollLines { params["wheel_scroll_lines"] = .int(wheelScrollLines) }
+        if let agentWheelNotches { params["agent_wheel_notches"] = .int(agentWheelNotches) }
+        let result = try rpc("terminal-set", params: params)
+        printJSON(result)
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -41,6 +41,7 @@ public struct CrowCommand: ParsableCommand {
             Telemetry.self,
             Cleanup.self,
             UI.self,
+            Terminal.self,
             Automation.self,
             Notifications.self,
             Defaults.self,

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -204,6 +204,16 @@ func validateRetentionHours(_ value: Int) throws {
     }
 }
 
+/// Validate a `crow terminal set` wheel-scroll value (CROW-1085). Both knobs are
+/// a plain `Int` flooring at 1 — mirroring the daemon's `patchBoundedInt(min: 1)`
+/// and the web UI's `Math.max(1, …)` clamp — so 0 or negative is rejected here
+/// for a fast, local error rather than a round-trip.
+func validateWheelValue(_ value: Int, flag: String) throws {
+    guard value >= 1 else {
+        throw ValidationError("\(flag) must be at least 1 (got \(value)).")
+    }
+}
+
 /// Validate `crow defaults set --provider` (#810). Delegates to
 /// `ConfigDefaults.validProviders` rather than keeping a copy — `GitManager`
 /// compares the stored value with `==`, so an accepted casing variant would

--- a/Packages/CrowCLI/Tests/CrowCLITests/SettingsCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/SettingsCommandParsingTests.swift
@@ -140,12 +140,46 @@ import ArgumentParser
     }
 }
 
+// MARK: - crow terminal
+
+@Test func terminalSetParsesWheelFlags() throws {
+    let cmd = try TerminalSet.parse([
+        "--wheel-scroll-lines", "5",
+        "--agent-wheel-notches", "2",
+    ])
+    #expect(cmd.wheelScrollLines == 5)
+    #expect(cmd.agentWheelNotches == 2)
+}
+
+@Test func terminalSetAcceptsOneFlag() throws {
+    let cmd = try TerminalSet.parse(["--wheel-scroll-lines", "8"])
+    #expect(cmd.wheelScrollLines == 8)
+    #expect(cmd.agentWheelNotches == nil)
+}
+
+@Test func terminalSetRequiresAtLeastOneField() {
+    #expect(throws: (any Error).self) {
+        _ = try TerminalSet.parse([])
+    }
+}
+
+@Test func terminalSetRejectsBelowOne() {
+    // Both knobs floor at 1 — 0 or negative would disable wheel scrolling.
+    #expect(throws: (any Error).self) {
+        _ = try TerminalSet.parse(["--wheel-scroll-lines", "0"])
+    }
+    #expect(throws: (any Error).self) {
+        _ = try TerminalSet.parse(["--agent-wheel-notches", "0"])
+    }
+}
+
 // MARK: - Groups
 
 @Test func settingsGetCommandsTakeNoArguments() throws {
     _ = try TelemetryGet.parse([])
     _ = try CleanupGet.parse([])
     _ = try UIGet.parse([])
+    _ = try TerminalGet.parse([])
 }
 
 @Test func settingsGroupsRouteToSubcommands() throws {
@@ -155,10 +189,13 @@ import ArgumentParser
     #expect(try Cleanup.parseAsRoot(["set", "--enabled", "true"]) is CleanupSet)
     #expect(try UI.parseAsRoot(["get"]) is UIGet)
     #expect(try UI.parseAsRoot(["set", "--hide-session-details", "true"]) is UISet)
+    #expect(try Terminal.parseAsRoot(["get"]) is TerminalGet)
+    #expect(try Terminal.parseAsRoot(["set", "--wheel-scroll-lines", "5"]) is TerminalSet)
 }
 
 @Test func settingsGroupsRejectUnknownSubcommands() {
     #expect(throws: (any Error).self) { _ = try Telemetry.parseAsRoot(["enable"]) }
     #expect(throws: (any Error).self) { _ = try Cleanup.parseAsRoot(["run"]) }
     #expect(throws: (any Error).self) { _ = try UI.parseAsRoot(["open"]) }
+    #expect(throws: (any Error).self) { _ = try Terminal.parseAsRoot(["scroll"]) }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -300,6 +300,8 @@ public enum ParityLedger {
         .write("backfill-upload", cli: "backfill upload"),
         .read("ui-get", cli: "ui get"),
         .write("ui-set", cli: "ui set"),
+        .read("terminal-get", cli: "terminal get"),
+        .write("terminal-set", cli: "terminal set"),
         .read("version-update-get", cli: "version get"),
         .write("version-update-set", cli: "version set"),
         .write("version-update-check", cli: "version check"),
@@ -422,10 +424,10 @@ public enum ParityLedger {
     /// The rows below are the honest state of the milestone. The settings blocks
     /// that already have verbs are covered: `telemetry`, `cleanup`, `sidebar`,
     /// `notifications`, gateways and jobs, `defaults` since CROW-810, agent
-    /// selection since CROW-811, `workspaces[].*` since CROW-809 and the
-    /// automation toggles since CROW-812. What the web Settings tab still owns
-    /// exclusively is `terminal.*` and `jiraCredential.*`; the `webAuth` hash and
-    /// salt are writable but readable nowhere.
+    /// selection since CROW-811, `workspaces[].*` since CROW-809, the automation
+    /// toggles since CROW-812 and `terminal.*` since CROW-1085. What the web
+    /// Settings tab still owns exclusively is `jiraCredential.*`; the `webAuth`
+    /// hash and salt are writable but readable nowhere.
     ///
     /// Coverage is per-direction, so a covered block can still hold a read-only
     /// row — the server-assigned `jobs[].id`/`createdAt`/`lastRunAt`,
@@ -681,22 +683,14 @@ public enum ParityLedger {
         .field("autoRespond.autoRebaseAndResolveConflicts", read: "automation get", write: "automation set"),
         .field("autoRespond.autoReRequestReview", read: "automation get", write: "automation set"),
 
-        // MARK: Exempt — terminal tuning and Jira credential
+        // MARK: Exempt — Jira credential
 
         .field(
             "terminal.wheelScrollLines",
-            noCLI: """
-                Scrollback lines per wheel notch on plain-shell surfaces (CROW-835, \
-                ADR 0013). Web Settings only — the `ui` verb covers the sidebar block, \
-                not this one.
-                """),
+            read: "terminal get", write: "terminal set"),
         .field(
             "terminal.agentWheelNotches",
-            noCLI: """
-                Wheel notches forwarded per physical notch on agent surfaces \
-                (CROW-835, ADR 0013). Web Settings only — see \
-                `terminal.wheelScrollLines`.
-                """),
+            read: "terminal get", write: "terminal set"),
         .field(
             "jiraCredential.username",
             noCLI: """

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -683,14 +683,12 @@ public enum ParityLedger {
         .field("autoRespond.autoRebaseAndResolveConflicts", read: "automation get", write: "automation set"),
         .field("autoRespond.autoReRequestReview", read: "automation get", write: "automation set"),
 
+        // Terminal wheel-scroll tuning (CROW-835), CLI-covered since CROW-1085.
+        .field("terminal.wheelScrollLines", read: "terminal get", write: "terminal set"),
+        .field("terminal.agentWheelNotches", read: "terminal get", write: "terminal set"),
+
         // MARK: Exempt — Jira credential
 
-        .field(
-            "terminal.wheelScrollLines",
-            read: "terminal get", write: "terminal set"),
-        .field(
-            "terminal.agentWheelNotches",
-            read: "terminal get", write: "terminal set"),
         .field(
             "jiraCredential.username",
             noCLI: """

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -1682,6 +1682,8 @@ func makeCommandRouter(
         },
         "logsync-get": { params in logsyncGetHandler(params: params, devRoot: devRoot) },
         "logsync-set": { params in try await logsyncSetHandler(params: params, devRoot: devRoot) },
+        "terminal-get": { params in terminalGetHandler(params: params, devRoot: devRoot) },
+        "terminal-set": { params in try await terminalSetHandler(params: params, devRoot: devRoot) },
         "ui-get": { _ in
             let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
             return ["ui": SettingsRPC.uiJSON(sidebar: config.sidebar, switcher: config.switcher)]
@@ -2699,6 +2701,44 @@ private func logsyncSetHandler(params: [String: JSONValue], devRoot: String) asy
         return [
             "logsync": SettingsRPC.logsyncJSON(logSync),
             "saved": .bool(true),
+        ]
+    }
+}
+
+/// `terminal-get` (CROW-1085): echo the terminal wheel-scroll knobs. A pure
+/// read, mirroring `cleanup-get` / `ui-get`.
+private func terminalGetHandler(params: [String: JSONValue], devRoot: String) -> [String: JSONValue] {
+    let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+    return ["terminal": SettingsRPC.terminalJSON(config.terminal)]
+}
+
+/// `terminal-set` (CROW-1085): PATCH the terminal wheel-scroll knobs — the CLI
+/// half of the CROW-835 web Settings sliders (ADR 0016 parity). Extracted from
+/// the handler dictionary so the big literal stays inside the type-checker's
+/// budget. Both knobs floor at 1, matching the web UI's `Math.max(1, …)` clamp:
+/// zero lines-per-notch or zero notches-forwarded would disable wheel scrolling
+/// on that surface entirely.
+private func terminalSetHandler(params: [String: JSONValue], devRoot: String) async throws -> [String: JSONValue] {
+    try await mapRPCError {
+        let wheelScrollLines = try SettingsRPC.patchBoundedInt(params, "wheel_scroll_lines", min: 1)
+        let agentWheelNotches = try SettingsRPC.patchBoundedInt(params, "agent_wheel_notches", min: 1)
+
+        guard wheelScrollLines != nil || agentWheelNotches != nil else {
+            throw RPCError.invalidParams(
+                "Nothing to set — provide at least one of wheel_scroll_lines, agent_wheel_notches.")
+        }
+
+        let terminal: TerminalSettings = try mutateConfig(devRoot: devRoot) { config in
+            if let wheelScrollLines { config.terminal.wheelScrollLines = wheelScrollLines }
+            if let agentWheelNotches { config.terminal.agentWheelNotches = agentWheelNotches }
+            return config.terminal
+        }
+        // Connected browsers re-read the terminal config slice off the
+        // `configReloaded` push that fires when config.json's mtime moves, so a
+        // new wheel speed applies on the next scroll — no restart, no reload.
+        return [
+            "terminal": SettingsRPC.terminalJSON(terminal),
+            "restart_required": .bool(false),
         ]
     }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -1103,14 +1103,14 @@ import CrowPersistence
     }
 
     @Test func settingsRPCsAreAllowedRemotely() throws {
-        // The granular telemetry/cleanup/ui RPCs (CROW-814) and automation-*
-        // (CROW-812) are deliberately un-gated. A remote peer can already change
-        // every one of these fields via the un-gated `set-config` path (see
-        // setConfigHarmlessToggleIsAllowedRemotely, which flips `remoteControlEnabled`
-        // — an automation field), so gating them would only push remote callers back
-        // onto the whole-config blob — a strictly larger surface. `automation-set`
-        // writes three `defaults` list fields but cannot reach `defaults.binaries`,
-        // which stays local-only.
+        // The granular telemetry/cleanup/ui/terminal RPCs (CROW-814, CROW-1085)
+        // and automation-* (CROW-812) are deliberately un-gated. A remote peer
+        // can already change every one of these fields via the un-gated
+        // `set-config` path (see setConfigHarmlessToggleIsAllowedRemotely, which
+        // flips `remoteControlEnabled` — an automation field), so gating them
+        // would only push remote callers back onto the whole-config blob — a
+        // strictly larger surface. `automation-set` writes three `defaults` list
+        // fields but cannot reach `defaults.binaries`, which stays local-only.
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
@@ -1119,6 +1119,7 @@ import CrowPersistence
             "telemetry-get", "telemetry-set",
             "cleanup-get", "cleanup-set",
             "ui-get", "ui-set",
+            "terminal-get", "terminal-set",
             "automation-get", "automation-set",
         ]
         for method in methods {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SettingsHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SettingsHandlerTests.swift
@@ -202,6 +202,55 @@ import CrowEngine
         #expect(onDisk.switcher.binding == "esc+tab")
     }
 
+    // MARK: - terminal (CROW-1085)
+
+    @Test @MainActor func terminalSetPatchesWheelKnobs() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let resp = await call("terminal-set", [
+            "wheel_scroll_lines": .int(5),
+            "agent_wheel_notches": .int(2),
+        ], devRoot: devRoot)
+
+        #expect(resp.result?["terminal"] == .object([
+            "wheel_scroll_lines": .int(5),
+            "agent_wheel_notches": .int(2),
+        ]))
+        #expect(resp.result?["restart_required"] == .bool(false))
+
+        let onDisk = try #require(ConfigStore.loadConfig(devRoot: devRoot))
+        #expect(onDisk.terminal.wheelScrollLines == 5)
+        #expect(onDisk.terminal.agentWheelNotches == 2)
+    }
+
+    /// A one-field patch leaves the other knob at its stored value — the PATCH
+    /// contract, same as the switcher fields.
+    @Test @MainActor func terminalSetLeavesUnpatchedKnobAlone() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        var seed = AppConfig()
+        seed.terminal = TerminalSettings(wheelScrollLines: 8, agentWheelNotches: 3)
+        try ConfigStore.saveConfig(seed, devRoot: devRoot)
+
+        _ = await call("terminal-set", ["wheel_scroll_lines": .int(2)], devRoot: devRoot)
+
+        let onDisk = try #require(ConfigStore.loadConfig(devRoot: devRoot))
+        #expect(onDisk.terminal.wheelScrollLines == 2)
+        #expect(onDisk.terminal.agentWheelNotches == 3)
+    }
+
+    @Test @MainActor func terminalGetEchoesDefaults() async {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let resp = await call("terminal-get", devRoot: devRoot)
+        #expect(resp.result?["terminal"] == .object([
+            "wheel_scroll_lines": .int(3),
+            "agent_wheel_notches": .int(1),
+        ]))
+    }
+
     // MARK: - restart_required
 
     @Test @MainActor func telemetryReportsRestartOnlyForEnabledOrPort() async throws {
@@ -231,6 +280,9 @@ import CrowEngine
 
         let ui = await call("ui-set", ["hide_session_details": .bool(true)], devRoot: devRoot)
         #expect(ui.result?["restart_required"] == .bool(false))
+
+        let terminal = await call("terminal-set", ["wheel_scroll_lines": .int(5)], devRoot: devRoot)
+        #expect(terminal.result?["restart_required"] == .bool(false))
     }
 
     // MARK: - Rejections
@@ -241,7 +293,7 @@ import CrowEngine
 
         // A no-op write would still rewrite config.json and fire a spurious
         // "Config reloaded" notification in every open browser.
-        for method in ["telemetry-set", "cleanup-set", "ui-set"] {
+        for method in ["telemetry-set", "cleanup-set", "ui-set", "terminal-set"] {
             let resp = await call(method, devRoot: devRoot)
             #expect(resp.error?.code == RPCErrorCode.invalidParams, "\(method) must reject empty params")
         }
@@ -259,6 +311,9 @@ import CrowEngine
             ("telemetry-set", ["retention_days": .int(-1)]),
             ("cleanup-set", ["retention_hours": .int(0)]),
             ("cleanup-set", ["retention_hours": .int(-24)]),
+            ("terminal-set", ["wheel_scroll_lines": .int(0)]),
+            ("terminal-set", ["agent_wheel_notches": .int(0)]),
+            ("terminal-set", ["wheel_scroll_lines": .int(-3)]),
         ]
         for (method, params) in cases {
             let resp = await call(method, params, devRoot: devRoot)
@@ -277,6 +332,7 @@ import CrowEngine
             ("cleanup-set", ["enabled": .int(1)]),
             ("ui-set", ["hide_session_details": .string("yes")]),
             ("telemetry-set", ["port": .string("4318")]),
+            ("terminal-set", ["wheel_scroll_lines": .string("5")]),
         ]
         for (method, params) in cases {
             let resp = await call(method, params, devRoot: devRoot)

--- a/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SettingsRPCSupport.swift
@@ -165,6 +165,17 @@ public enum SettingsRPC {
         ])
     }
 
+    /// Terminal wheel-scroll tuning (CROW-835, ADR 0013). Two knobs with
+    /// different natural units — plain-shell scrollback *lines* per notch, and
+    /// agent-TUI *notches* forwarded per physical notch — so each is echoed on
+    /// its own key. Snake-case scalars, matching the other settings blocks.
+    public static func terminalJSON(_ terminal: TerminalSettings) -> JSONValue {
+        .object([
+            "wheel_scroll_lines": .int(terminal.wheelScrollLines),
+            "agent_wheel_notches": .int(terminal.agentWheelNotches),
+        ])
+    }
+
     /// The session-log collector's behavior knobs (CROW-1056; slimmed in
     /// CROW-1070). No credential and no opt-in list live here any more — both are
     /// per-workspace via the gateway — so nothing is masked. `configured`

--- a/Packages/CrowEngine/Tests/CrowEngineTests/SettingsRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/SettingsRPCSupportTests.swift
@@ -120,6 +120,23 @@ struct SettingsRPCSupportTests {
         ]))
     }
 
+    @Test func terminalJSONUsesSnakeCaseScalars() throws {
+        let json = SettingsRPC.terminalJSON(
+            TerminalSettings(wheelScrollLines: 5, agentWheelNotches: 2))
+        #expect(json == .object([
+            "wheel_scroll_lines": .int(5),
+            "agent_wheel_notches": .int(2),
+        ]))
+    }
+
+    /// The defaults the CLI echoes when nothing has been set (CROW-835).
+    @Test func terminalJSONEchoesDefaults() throws {
+        #expect(SettingsRPC.terminalJSON(TerminalSettings()) == .object([
+            "wheel_scroll_lines": .int(3),
+            "agent_wheel_notches": .int(1),
+        ]))
+    }
+
     /// Unlike `get-config`, these responses carry no credential shell at all, so
     /// they need no `SettingsSecrets.strippedForTransport` pass. Pin that, because
     /// a future "just reuse the config encoder" refactor would quietly break it.
@@ -138,6 +155,7 @@ struct SettingsRPCSupportTests {
             SettingsRPC.telemetryJSON(TelemetryConfig()),
             SettingsRPC.cleanupJSON(CleanupConfig()),
             SettingsRPC.uiJSON(sidebar: SidebarSettings(), switcher: SwitcherSettings()),
+            SettingsRPC.terminalJSON(TerminalSettings()),
             SettingsRPC.automationJSON(AppConfig()),
             SettingsRPC.automationJSON(loaded),
         ]

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -52,6 +52,8 @@ crow cleanup get                                                        → {"cl
 crow cleanup set [--enabled true|false] [--retention-hours N]           → patch; live within ~1 board poll. Deletes completed/archived sessions incl. worktree + branch
 crow ui get                                                             → {"ui":{"sidebar":{"hide_session_details":…}}}
 crow ui set --hide-session-details true|false                           → patch; connected browsers repaint within ~2s
+crow terminal get                                                       → {"terminal":{"wheel_scroll_lines":…,"agent_wheel_notches":…}}
+crow terminal set [--wheel-scroll-lines N] [--agent-wheel-notches N]    → patch; wheel-scroll tuning (CROW-835, ADR 0013); both floor at 1; live on next scroll
 crow version                                                            → prints the stamped build version
 crow version --check                                                    → compare against corveil/crow main; human summary, exit 0/1/2
 crow version check                                                      → same as --check

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -498,6 +498,25 @@ crow ui set --hide-session-details true
 
 Settings are grouped by the config block they belong to, so `get` returns `{"ui": {"sidebar": {...}}}` and gains further blocks as more view options become configurable. Connected browsers pick the change up within a couple of seconds — no reload.
 
+### `crow terminal get | set`
+
+Terminal wheel-scroll speed — the two `AppConfig.terminal` knobs behind the CROW-835 Settings sliders (ADR 0013). Not to be confused with the terminal-*tab* verbs (`new-terminal`, `list-terminals`, `send`, …) that manage panes.
+
+```bash
+crow terminal get
+crow terminal set --wheel-scroll-lines 5
+crow terminal set --agent-wheel-notches 2
+```
+
+| Flag                    | Required | Description                                                                            |
+| ----------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `--wheel-scroll-lines`  | no¹      | Scrollback lines scrolled per wheel notch on plain-shell / review surfaces (min 1, default 3) |
+| `--agent-wheel-notches` | no¹      | Wheel notches forwarded to the agent (Claude Code / Cursor / Manager) per physical notch (min 1, default 1) |
+
+¹ At least one flag is required.
+
+The web terminal routes the wheel by surface (ADR 0013): a plain shell owns its own scrollback, so its knob is *lines per notch*; an agent TUI owns its scrolling, so its knob is how many *notches* Crow forwards per physical notch — raise it if agent scrolling feels sluggish. `get` returns `{"terminal":{"wheel_scroll_lines":…,"agent_wheel_notches":…}}`. Both floor at 1 (a value of 0 would disable wheel scrolling on that surface); the daemon and the CLI both reject a lower value. The change is live — connected browsers apply the new speed on their next scroll, no reload.
+
 ### `crow version` / `crow version check` / `crow version get | set`
 
 Compare the running build against `corveil/crow` `main` (CROW-938). The daemon owns the GitHub compare call and caches the result; the CLI and Settings → About read it back.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,6 +120,9 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow telemetry`](#crow-telemetry) | View or change session-analytics collection |
 | [`crow telemetry get`](#crow-telemetry-get) | Show the current telemetry settings |
 | [`crow telemetry set`](#crow-telemetry-set) | Change telemetry settings |
+| [`crow terminal`](#crow-terminal) | View or change terminal wheel-scroll speed |
+| [`crow terminal get`](#crow-terminal-get) | Show the current terminal wheel-scroll settings |
+| [`crow terminal set`](#crow-terminal-set) | Change terminal wheel-scroll speed |
 | [`crow transition-ticket`](#crow-transition-ticket) | Transition a session's ticket to a pipeline status |
 | [`crow ui`](#crow-ui) | View or change UI display preferences |
 | [`crow ui get`](#crow-ui-get) | Show the current UI display preferences |
@@ -1806,6 +1809,51 @@ Only the flags you pass change; at least one is required.
 | `--enabled` | `<enabled>` | no | Enable the OTLP receiver (true or false) |
 | `--port` | `<port>` | no | OTLP HTTP receiver port (1024-65535, default 4318) |
 | `--retention-days` | `<retention-days>` | no | Days of telemetry to keep; 0 keeps forever (default 180) |
+
+---
+
+## `crow terminal`
+
+View or change terminal wheel-scroll speed.
+
+```
+crow terminal <get|set>
+```
+
+Wheel-scroll tuning for the web terminal (CROW-835, ADR 0013). The wheel is routed by surface: plain-shell / review surfaces scroll their own scrollback, so the knob is lines per physical notch; agent TUIs (Claude Code, Cursor, the Manager) own their scrolling, so the knob is how many wheel notches are forwarded to the app per physical notch. Each surface gets its own value.
+
+These are the two `AppConfig.terminal` fields the web Settings sliders write; this is the CLI half. Not to be confused with the terminal-*tab* verbs (`new-terminal`, `list-terminals`, `send`, …), which manage panes.
+
+Subcommands: [`get`](#crow-terminal-get), [`set`](#crow-terminal-set).
+
+---
+
+## `crow terminal get`
+
+Show the current terminal wheel-scroll settings.
+
+```
+crow terminal get
+```
+
+---
+
+## `crow terminal set`
+
+Change terminal wheel-scroll speed.
+
+```
+crow terminal set [--wheel-scroll-lines <wheel-scroll-lines>] [--agent-wheel-notches <agent-wheel-notches>]
+```
+
+Only the flags you pass change; at least one is required. Connected browsers pick the change up on their next scroll — no reload.
+
+--wheel-scroll-lines sets scrollback lines per wheel notch on plain-shell and review surfaces (default 3). --agent-wheel-notches sets how many wheel reports are forwarded to the agent per physical notch (default 1 — one detent in, one out; raise it if agent scrolling feels too slow). Both floor at 1: a value of 0 would disable wheel scrolling on that surface.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--wheel-scroll-lines` | `<wheel-scroll-lines>` | no | Scrollback lines per wheel notch on plain-shell/review surfaces (minimum 1, default 3) |
+| `--agent-wheel-notches` | `<agent-wheel-notches>` | no | Wheel notches forwarded to the agent per physical notch (minimum 1, default 1) |
 
 ---
 


### PR DESCRIPTION
Closes #1085

## What

Adds a `crow terminal get|set` verb family so agents and scripts can read and change the terminal wheel-scroll knobs (`terminal.wheelScrollLines`, `terminal.agentWheelNotches`) that CROW-835 shipped web-Settings-only. Closes the ADR 0016 control-plane parity gap the ledger documented as exempt.

## Changes

- **RPC** (`RPCHandlers.swift`): `terminal-get` / `terminal-set` handlers, extracted as standalone functions (like the logsync pair) to keep the router dictionary literal inside the type-checker's budget. Both knobs floor at 1, matching the web UI's `Math.max(1, …)` clamp; live setting → `restart_required: false`.
- **Engine** (`SettingsRPCSupport.swift`): `SettingsRPC.terminalJSON` for the snake-case wire shape.
- **CLI** (`SettingsCommands.swift`, `CrowCommand.swift`, `Validation.swift`): `crow terminal get` / `crow terminal set [--wheel-scroll-lines N] [--agent-wheel-notches N]`, with local min-1 validation. Distinct from the terminal-*tab* verbs (`new-terminal`, `send`, …).
- **Parity** (`ParityLedger.swift`): promoted `terminal.wheelScrollLines` / `terminal.agentWheelNotches` from the exempt block to covered (`read: terminal get`, `write: terminal set`), added the two `rpcMethods` rows, and updated the prose that named `terminal.*` as web-only.
- **Docs**: hand-written `crow terminal` section in `cli-reference.md`, entries in `CLAUDE.md` + `Resources/CLAUDE.md.template`, regenerated `cli.md`.
- **Tests**: `terminalJSON` shape/defaults (CrowEngine); CLI parse + min-1 rejection + group routing (CrowCLI); daemon persistence, PATCH-leaves-other-knob, and empty/out-of-range/wrong-type rejection (CrowDaemon).

## Test plan

- `crow terminal get` → `{"terminal":{"wheel_scroll_lines":3,"agent_wheel_notches":1}}` on a fresh config.
- `crow terminal set --wheel-scroll-lines 5 --agent-wheel-notches 2` persists both and returns `restart_required: false`; a connected web terminal picks up the new speed on its next scroll.
- `crow terminal set --wheel-scroll-lines 0` is rejected (CLI validation) and, at the RPC layer, `wheel_scroll_lines: 0` → `invalid params`.
- `crow terminal set` with no flags → "Nothing to set" error (no config write, no spurious "Config reloaded" chime).

### CI / local verification
- `scripts/check-cli-parity.sh`: registered methods match the ledger (109 methods).
- CrowCLI suite (384 tests): parity gates, `committedGeneratedDocIsUpToDate`, `generatedDocCoversEveryCommandAndFlag`, hand-written + CLAUDE.md doc coverage, settings parsing — all green.
- CrowEngine `SettingsRPCSupportTests` and CrowCore (759 tests) — green.
- CrowDaemon test target compiles cleanly (its `RPCLedgerParityTests` / `SettingsHandlerTests` run in CI's Darwin lane — not run locally, which would boot the live daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)