### PR TITLE
Refactor: retire duplicated shellQuote onto ShellLaunchArgs (CROW-1087)

### DIFF
--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -73,7 +73,7 @@ public struct AntigravityAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let agentPath = AntigravityLaunchArgs.shellQuote(launchBinary() ?? "agy")
+        let agentPath = ShellLaunchArgs.shellQuote(launchBinary() ?? "agy")
         // Bounded auto-permission — a no-op suffix on the pinned version (see
         // `AntigravityLaunchArgs.autoPermissionSuffix`); kept for call-site
         // uniformity so a future bounded flag lands once for every path.
@@ -181,7 +181,7 @@ public struct AntigravityAgent: CodingAgent {
         // control doesn't apply. Terminal backend appends the submitting Enter,
         // so return the command without a trailing newline (cross-agent
         // convention).
-        let agentPath = AntigravityLaunchArgs.shellQuote(launchBinary() ?? "agy")
+        let agentPath = ShellLaunchArgs.shellQuote(launchBinary() ?? "agy")
         return agentPath + AntigravityLaunchArgs.autoPermissionSuffix(autoPermissionMode)
     }
 

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityHookConfigWriter.swift
@@ -80,7 +80,7 @@ public struct AntigravityHookConfigWriter: HookConfigWriter {
     static func crowCommand(sessionID: UUID, event: String, crowPath: String) -> String {
         // Quote the crow path — devRoot is user-chosen (`/Users/x/My Projects/…`
         // would otherwise split the command).
-        "\(AntigravityLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent antigravity --event \(event) >/dev/null 2>&1; printf '{}'"
+        "\(ShellLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent antigravity --event \(event) >/dev/null 2>&1; printf '{}'"
     }
 
     /// One `{type, command, timeout}` handler object.

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLaunchArgs.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLaunchArgs.swift
@@ -1,15 +1,11 @@
 import Foundation
+import CrowCore
 
 /// Helpers for building the argument string appended to an `agy` (Google
 /// Antigravity CLI) invocation. Centralized so `AntigravityAgent`, the
 /// launcher, and tests share one implementation of the flag choices — mirrors
 /// `CursorLaunchArgs` / `OpenCodeLaunchArgs` (#860).
 public enum AntigravityLaunchArgs {
-    /// POSIX single-quote escape for safe interpolation into a shell command line.
-    public static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Auto-permission flags for unattended `.job` launches. Returns a
     /// leading-space suffix or `""`.
     ///

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLauncher.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityLauncher.swift
@@ -90,9 +90,9 @@ public actor AntigravityLauncher {
         try prompt.write(to: promptPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o600], ofItemAtPath: promptPath.path)
-        return "cd \(AntigravityLaunchArgs.shellQuote(worktreePath)) && "
+        return "cd \(ShellLaunchArgs.shellQuote(worktreePath)) && "
             + ShellLaunchArgs.evalPromptLaunch(
-                prefix: "\(AntigravityLaunchArgs.shellQuote(binary)) -p",
+                prefix: "\(ShellLaunchArgs.shellQuote(binary)) -p",
                 promptPath: promptPath.path).trimmingCharacters(in: .newlines) + "\n"
     }
 }

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookConfigWriter.swift
@@ -74,7 +74,7 @@ public struct ClaudeHookConfigWriter: HookConfigWriter {
     /// silently broke all 17 hooks. Matches `CursorHookConfigWriter` and
     /// `AntigravityHookConfigWriter`, which already quote for this reason.
     static func hookCommand(crowPath: String, sessionID: UUID, event: String) -> String {
-        "\(ClaudeLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --event \(event)"
+        "\(ShellLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --event \(event)"
     }
 
     /// Generate the hooks dictionary for a session.

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeHookRepair.swift
@@ -54,7 +54,7 @@ public enum ClaudeHookRepair {
 
         var binary = String(command[command.startIndex..<markerRange.lowerBound])
             .trimmingCharacters(in: .whitespaces)
-        // Reverse `ClaudeLaunchArgs.shellQuote`. Only a fully-wrapped value is
+        // Reverse `ShellLaunchArgs.shellQuote`. Only a fully-wrapped value is
         // accepted; a partially quoted path is a shape we never wrote. Content
         // inside single quotes is inert to the shell, so it needs no further
         // scrutiny — but an *unquoted* segment (every pre-#897 file on disk) is

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeLaunchArgs.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeLaunchArgs.swift
@@ -6,11 +6,6 @@ import CrowCore
 /// Centralized so worker-session launches, the Manager tab, and crow-CLI-spawned
 /// terminals all produce consistent flags — and so the logic is independently testable.
 public enum ClaudeLaunchArgs {
-    /// POSIX single-quote escape for safe interpolation into a shell command line.
-    public static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Flags to append after the `claude` binary path.
     ///
     /// Returns a string beginning with a leading space — e.g.
@@ -36,7 +31,7 @@ public enum ClaudeLaunchArgs {
         if remoteControl {
             s += " --rc"
             if let name = sessionName, !name.isEmpty {
-                s += " --name \(shellQuote(name))"
+                s += " --name \(ShellLaunchArgs.shellQuote(name))"
             }
         }
         return s
@@ -67,10 +62,10 @@ public enum ClaudeLaunchArgs {
         guard let resolved else {
             return "unset ANTHROPIC_BASE_URL ANTHROPIC_CUSTOM_HEADERS && "
         }
-        let baseAssignment = "export ANTHROPIC_BASE_URL=\(shellQuote(resolved.baseURL))"
+        let baseAssignment = "export ANTHROPIC_BASE_URL=\(ShellLaunchArgs.shellQuote(resolved.baseURL))"
         if resolved.customHeaders.contains("\n") {
             return "unset ANTHROPIC_CUSTOM_HEADERS && " + baseAssignment + " && "
         }
-        return baseAssignment + " ANTHROPIC_CUSTOM_HEADERS=\(shellQuote(resolved.customHeaders)) && "
+        return baseAssignment + " ANTHROPIC_CUSTOM_HEADERS=\(ShellLaunchArgs.shellQuote(resolved.customHeaders)) && "
     }
 }

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeLaunchArgsTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeLaunchArgsTests.swift
@@ -26,12 +26,6 @@ import CrowCore
     #expect(result == " --rc --name 'Bob'\\''s session'")
 }
 
-@Test func claudeLaunchArgsShellQuoteBasics() {
-    #expect(ClaudeLaunchArgs.shellQuote("plain") == "'plain'")
-    #expect(ClaudeLaunchArgs.shellQuote("with space") == "'with space'")
-    #expect(ClaudeLaunchArgs.shellQuote("has'quote") == "'has'\\''quote'")
-}
-
 @Test func claudeLaunchArgsAutoPermissionModeOnly() {
     #expect(ClaudeLaunchArgs.argsSuffix(remoteControl: false, sessionName: nil, autoPermissionMode: true)
         == " --permission-mode auto")

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -119,7 +119,7 @@ public struct CursorAgent: CodingAgent {
         autoPermissionMode: Bool,
         telemetryPort: UInt16?
     ) -> String? {
-        let agentPath = CursorLaunchArgs.shellQuote(resolvedLaunchBinary)
+        let agentPath = ShellLaunchArgs.shellQuote(resolvedLaunchBinary)
         // The `--trust` workspace-trust seed (skips the folder-trust dialog on a
         // fresh worktree — the per-launch analogue of `ClaudeTrustSeeder`,
         // CROW-890) rides EVERY launch path, `.review` included as of CROW-954.
@@ -251,7 +251,7 @@ public struct CursorAgent: CodingAgent {
         // network/filesystem-blocked — see `CursorLaunchArgs`). Terminal backend
         // appends the submitting Enter, so we return the command without a
         // trailing newline to match the cross-agent convention.
-        let agentPath = CursorLaunchArgs.shellQuote(resolvedLaunchBinary)
+        let agentPath = ShellLaunchArgs.shellQuote(resolvedLaunchBinary)
         return agentPath + CursorLaunchArgs.launchSuffix(
             seedTrust: true, autoPermissionMode: autoPermissionMode)
     }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorHookConfigWriter.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorHookConfigWriter.swift
@@ -84,7 +84,7 @@ public struct CursorHookConfigWriter: HookConfigWriter {
         // path — `findCrowBinary` prefers `{devRoot}/.claude/bin/crow` and
         // devRoot is user-chosen (`/Users/x/My Projects/…` would otherwise split
         // the command and silently stop every hook from firing).
-        let command = "\(CursorLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent cursor --event \(crowEvent)"
+        let command = "\(ShellLaunchArgs.shellQuote(crowPath)) hook-event --session \(sessionID.uuidString) --agent cursor --event \(crowEvent)"
         var entry: [String: Any] = [
             "type": "command",
             "command": command,

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorLaunchArgs.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorLaunchArgs.swift
@@ -1,15 +1,11 @@
 import Foundation
+import CrowCore
 
 /// Helpers for building the argument string appended to an `agent` (Cursor CLI)
 /// invocation. Centralized so `CursorAgent`, the launcher, and tests share one
 /// implementation of the flag choices — mirrors `ClaudeLaunchArgs` and
 /// `OpenCodeLaunchArgs` (#829).
 public enum CursorLaunchArgs {
-    /// POSIX single-quote escape for safe interpolation into a shell command line.
-    public static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Workspace-trust seed appended to **every** Crow-launched Cursor command
     /// (auto-launch, Manager, and the handoff one-shot) — `.review` included. A
     /// leading-space suffix so callers concatenate it onto the shell-quoted

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorLauncher.swift
@@ -104,9 +104,9 @@ public actor CursorLauncher {
         // `endOfOptions: true` — same commander parser as `CursorAgent`, so a
         // handoff note beginning with `-` would be read as a flag and abort the
         // launch (CROW-968). See `ShellLaunchArgs.evalPromptLaunch`.
-        return "cd \(CursorLaunchArgs.shellQuote(worktreePath)) && "
+        return "cd \(ShellLaunchArgs.shellQuote(worktreePath)) && "
             + ShellLaunchArgs.evalPromptLaunch(
-                prefix: "\(CursorLaunchArgs.shellQuote(binary))\(trust)",
+                prefix: "\(ShellLaunchArgs.shellQuote(binary))\(trust)",
                 promptPath: promptPath.path,
                 endOfOptions: true).trimmingCharacters(in: .newlines) + "\n"
     }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorLaunchArgsTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorLaunchArgsTests.swift
@@ -47,8 +47,4 @@ struct CursorLaunchArgsTests {
         #expect(CursorLaunchArgs.launchSuffix(seedTrust: false, autoPermissionMode: true) == " --force --approve-mcps")
         #expect(CursorLaunchArgs.launchSuffix(seedTrust: false, autoPermissionMode: true).contains("--trust") == false)
     }
-
-    @Test func shellQuoteEscapesSingleQuotes() {
-        #expect(CursorLaunchArgs.shellQuote("a'b") == "'a'\\''b'")
-    }
 }

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -178,7 +178,7 @@ public struct GrokAgent: CodingAgent {
         // `grok` collides with `superagent-ai/grok-cli`, so `defaults.binaries.grok`
         // is the *expected* config here, and an override path with a space would
         // otherwise word-split when the terminal backend runs it (#861 review r8).
-        return GrokLaunchArgs.shellQuote(launchBinary() ?? "grok")
+        return ShellLaunchArgs.shellQuote(launchBinary() ?? "grok")
     }
 
     /// Grok's TUI exposes `/rename` (alias `/title`) for the current session

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokHookConfigWriter.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokHookConfigWriter.swift
@@ -86,7 +86,7 @@ public struct GrokHookConfigWriter: HookConfigWriter {
         var hooks: [String: Any] = [:]
 
         for event in allEvents {
-            let command = "\(shellQuote(crowPath)) hook-event --session \(sid) --event \(event)"
+            let command = "\(ShellLaunchArgs.shellQuote(crowPath)) hook-event --session \(sid) --event \(event)"
             var hookEntry: [String: Any] = [
                 "type": "command",
                 "command": command,
@@ -197,16 +197,5 @@ public struct GrokHookConfigWriter: HookConfigWriter {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(atPath: dir), contents.isEmpty else { return }
         try? fm.removeItem(atPath: dir)
-    }
-
-    /// POSIX single-quote the `crow` binary path in the hook command. Grok runs
-    /// a command hook through `sh -c` whenever it contains a space (verified:
-    /// `xai-grok-hooks/src/runner/command.rs` — `is_shell_command` is true for
-    /// any command with a space, and ours always has one), so a `crow` path with
-    /// a space would word-split unquoted. Quoting hardens against that; the
-    /// session UUID and event names are space-free and need none. (#861 review
-    /// round 4, Green — Cursor quotes here too.)
-    private static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokLaunchArgs.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokLaunchArgs.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CrowCore
 
 /// Helpers for building Grok Build launch commands. Centralized so `GrokAgent`,
 /// `GrokLauncher`, and tests share one implementation of the run-then-continue
@@ -52,11 +53,6 @@ public enum GrokLaunchArgs {
         "Bash(rm -rf /*)",
     ]
 
-    /// POSIX single-quote escape for paths interpolated into shell commands.
-    public static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Auto-permission flag suffix (leading space), or `""` when off.
     /// `--always-approve` so Grok matches Claude Code Auto (`gh pr create`
     /// included), plus hard `--deny` guards (deny still wins).
@@ -64,7 +60,7 @@ public enum GrokLaunchArgs {
         guard autoPermissionMode else { return "" }
         var out = " --always-approve"
         for rule in hardDenyRules {
-            out += " --deny \(shellQuote(rule))"
+            out += " --deny \(ShellLaunchArgs.shellQuote(rule))"
         }
         return out
     }
@@ -89,8 +85,8 @@ public enum GrokLaunchArgs {
         promptPath: String,
         autoPermissionMode: Bool
     ) -> String {
-        let bin = shellQuote(binary)
-        let quotedPath = shellQuote(promptPath)
+        let bin = ShellLaunchArgs.shellQuote(binary)
+        let quotedPath = ShellLaunchArgs.shellQuote(promptPath)
         let flags = autoPermissionSuffix(autoPermissionMode: autoPermissionMode)
         return "\(headlessLeg(bin: bin, flags: flags, quotedPath: quotedPath))"
             + "; \(resumeLeg(bin: bin, flags: flags))\n"
@@ -126,7 +122,7 @@ public enum GrokLaunchArgs {
         binary: String,
         autoPermissionMode: Bool
     ) -> String {
-        let bin = shellQuote(binary)
+        let bin = ShellLaunchArgs.shellQuote(binary)
         let flags = autoPermissionSuffix(autoPermissionMode: autoPermissionMode)
         return "\(resumeLeg(bin: bin, flags: flags))\n"
     }
@@ -161,7 +157,7 @@ public enum GrokLaunchArgs {
     /// opens a TUI at Grok's default `ask` policy instead of a dead pane.
     /// `binary` is shell-quoted (see `firstLaunchChainedCommand`).
     public static func bareCommand(binary: String, autoPermissionMode: Bool = false) -> String {
-        let bin = shellQuote(binary)
+        let bin = ShellLaunchArgs.shellQuote(binary)
         let flags = autoPermissionSuffix(autoPermissionMode: autoPermissionMode)
         guard !flags.isEmpty else { return "\(bin)\n" }
         return "\(bin)\(flags) || { [ $? -eq 2 ] && \(bin); }\n"

--- a/Packages/CrowGrok/Tests/CrowGrokTests/GrokLaunchArgsTests.swift
+++ b/Packages/CrowGrok/Tests/CrowGrokTests/GrokLaunchArgsTests.swift
@@ -4,11 +4,6 @@ import Testing
 @Suite("GrokLaunchArgs")
 struct GrokLaunchArgsTests {
 
-    @Test func shellQuoteWrapsAndEscapes() {
-        #expect(GrokLaunchArgs.shellQuote("/tmp/p.md") == "'/tmp/p.md'")
-        #expect(GrokLaunchArgs.shellQuote("a'b") == "'a'\\''b'")
-    }
-
     @Test func autoPermissionSuffixOffIsEmpty() {
         #expect(GrokLaunchArgs.autoPermissionSuffix(autoPermissionMode: false) == "")
     }

--- a/Packages/CrowMuse/Sources/CrowMuse/MuseHookConfigWriter.swift
+++ b/Packages/CrowMuse/Sources/CrowMuse/MuseHookConfigWriter.swift
@@ -68,7 +68,7 @@ public struct MuseHookConfigWriter: HookConfigWriter {
         var hooks: [String: Any] = [:]
 
         for event in allEvents {
-            let command = "\(shellQuote(crowPath)) hook-event --session \(sid) --event \(event)"
+            let command = "\(ShellLaunchArgs.shellQuote(crowPath)) hook-event --session \(sid) --event \(event)"
             var hookEntry: [String: Any] = [
                 "type": "command",
                 "command": command,
@@ -163,10 +163,6 @@ public struct MuseHookConfigWriter: HookConfigWriter {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(atPath: dir), contents.isEmpty else { return }
         try? fm.removeItem(atPath: dir)
-    }
-
-    private static func shellQuote(_ s: String) -> String {
-        MuseLaunchArgs.shellQuote(s)
     }
 
     // MARK: - Git-tracked probe (mirrors CursorHookConfigWriter / Antigravity)

--- a/Packages/CrowMuse/Sources/CrowMuse/MuseLaunchArgs.swift
+++ b/Packages/CrowMuse/Sources/CrowMuse/MuseLaunchArgs.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CrowCore
 
 /// Helpers for building Muse Code (`muse`) launch commands. Centralized so
 /// `MuseAgent`, `MuseLauncher`, and tests share one implementation of the
@@ -43,11 +44,6 @@ import Foundation
 /// Meta-auth-gated. Every flag is a version-pinned re-check target.
 public enum MuseLaunchArgs {
 
-    /// POSIX single-quote escape for paths interpolated into shell commands.
-    public static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Bounded auto-permission flag suffix (leading space), or `""` when off.
     /// `--disable-approval` only — never `--yolo` / `--disable-sandbox`.
     public static func autoPermissionSuffix(autoPermissionMode: Bool) -> String {
@@ -76,8 +72,8 @@ public enum MuseLaunchArgs {
         autoPermissionMode: Bool,
         trustWorkspace: Bool
     ) -> String {
-        let bin = shellQuote(binary)
-        let quotedPath = shellQuote(promptPath)
+        let bin = ShellLaunchArgs.shellQuote(binary)
+        let quotedPath = ShellLaunchArgs.shellQuote(promptPath)
         let flags = flagSuffix(
             autoPermissionMode: autoPermissionMode, trustWorkspace: trustWorkspace)
         return "\(headlessLeg(bin: bin, flags: flags, quotedPath: quotedPath))"
@@ -105,7 +101,7 @@ public enum MuseLaunchArgs {
         autoPermissionMode: Bool,
         trustWorkspace: Bool
     ) -> String {
-        let bin = shellQuote(binary)
+        let bin = ShellLaunchArgs.shellQuote(binary)
         let flags = flagSuffix(
             autoPermissionMode: autoPermissionMode, trustWorkspace: trustWorkspace)
         return "\(resumeLeg(bin: bin, flags: flags))\n"
@@ -125,7 +121,7 @@ public enum MuseLaunchArgs {
     /// a future review-shaped interactive launch can withhold it; today's
     /// `.work` always passes `true`.
     public static func bareCommand(binary: String, trustWorkspace: Bool) -> String {
-        "\(shellQuote(binary))\(trustSuffix(trustWorkspace: trustWorkspace))\n"
+        "\(ShellLaunchArgs.shellQuote(binary))\(trustSuffix(trustWorkspace: trustWorkspace))\n"
     }
 
     /// Manager launch line: quoted binary + optional auto-perm + trust,
@@ -135,7 +131,7 @@ public enum MuseLaunchArgs {
         autoPermissionMode: Bool,
         trustWorkspace: Bool
     ) -> String {
-        shellQuote(binary)
+        ShellLaunchArgs.shellQuote(binary)
             + flagSuffix(autoPermissionMode: autoPermissionMode, trustWorkspace: trustWorkspace)
     }
 }

--- a/Packages/CrowMuse/Sources/CrowMuse/MuseLauncher.swift
+++ b/Packages/CrowMuse/Sources/CrowMuse/MuseLauncher.swift
@@ -101,6 +101,6 @@ public actor MuseLauncher {
             autoPermissionMode: false,
             trustWorkspace: trustWorkspace
         ).trimmingCharacters(in: .newlines)
-        return "cd \(MuseLaunchArgs.shellQuote(worktreePath)) && { \(inner); }\n"
+        return "cd \(ShellLaunchArgs.shellQuote(worktreePath)) && { \(inner); }\n"
     }
 }

--- a/Packages/CrowMuse/Tests/CrowMuseTests/MuseLaunchArgsTests.swift
+++ b/Packages/CrowMuse/Tests/CrowMuseTests/MuseLaunchArgsTests.swift
@@ -4,11 +4,6 @@ import Testing
 @Suite("MuseLaunchArgs")
 struct MuseLaunchArgsTests {
 
-    @Test func shellQuoteWrapsAndEscapes() {
-        #expect(MuseLaunchArgs.shellQuote("/tmp/p.md") == "'/tmp/p.md'")
-        #expect(MuseLaunchArgs.shellQuote("a'b") == "'a'\\''b'")
-    }
-
     @Test func autoPermissionSuffixOffIsEmpty() {
         #expect(MuseLaunchArgs.autoPermissionSuffix(autoPermissionMode: false) == "")
     }

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeLaunchArgs.swift
@@ -60,11 +60,6 @@ public enum OpenCodeLaunchArgs {
         return version >= tuiAutoRemovedVersion && version < tuiAutoReintroducedVersion
     }
 
-    /// POSIX single-quote escape for paths interpolated into shell commands.
-    public static func shellQuote(_ s: String) -> String {
-        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
     /// Whether `opencode --help` advertises the TUI `--auto` flag.
     public static func parseTUISupportsAuto(from helpText: String) -> Bool {
         helpText.contains("--auto")


### PR DESCRIPTION
Refs #1087 — **Refactor 1, bucket 1** (the zero-risk `shellQuote` retirement the ticket's sequencing names as the first PR).

## What

The POSIX single-quote helper `shellQuote` was re-declared **byte-for-byte in 8 places** across the coding-agent adapter packages, even though the shared `ShellLaunchArgs.shellQuote` (CrowCore) already existed and `CrowCodex` already called it directly:

| Retired copy | Kind |
|---|---|
| `ClaudeLaunchArgs.shellQuote` | `*LaunchArgs` |
| `CursorLaunchArgs.shellQuote` | `*LaunchArgs` |
| `OpenCodeLaunchArgs.shellQuote` | `*LaunchArgs` (was public, unused) |
| `GrokLaunchArgs.shellQuote` | `*LaunchArgs` |
| `MuseLaunchArgs.shellQuote` | `*LaunchArgs` |
| `AntigravityLaunchArgs.shellQuote` | `*LaunchArgs` |
| `GrokHookConfigWriter.shellQuote` | `*HookConfigWriter` |
| `MuseHookConfigWriter.shellQuote` | `*HookConfigWriter` (already a delegating wrapper) |

All 8 are removed; every call site now uses `ShellLaunchArgs.shellQuote`, matching the existing **CrowCodex end-state** (which already had no local copy). The four `*LaunchArgs` files that imported only `Foundation` (Cursor/Grok/Muse/Antigravity) gain `import CrowCore` — all 7 adapter packages already declare the CrowCore dependency in `Package.swift`.

## Why this is pure consolidation (no behavioral change)

`ShellLaunchArgs.shellQuote` is **byte-identical** to the retired copies:
```swift
"'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
```
So every launch-line and hook-command string is unchanged. The Grok/Muse `shellQuotesSpacedCrowPath` **hook-writer output tests still pass verbatim**, which is the direct end-to-end evidence that the emitted strings didn't move.

The four redundant per-adapter `shellQuote` **unit** tests (Claude/Cursor/Grok/Muse) are removed — that exact behavior is covered by `ShellLaunchArgsTests`, the canonical home.

**Out of scope, intentionally left untouched:** `TerminalCockpit.shellQuote` (CrowDaemon tmux layer, not an adapter). This bucket is scoped to the 7 adapter packages + `ShellLaunchArgs`, per the ticket.

## Before / after

- **8** duplicate `shellQuote` declarations removed → repo-wide `static func shellQuote` declarations drop from 10 to 2 (`ShellLaunchArgs` canonical + the out-of-scope `TerminalCockpit`).
- **Net −61 lines** (33 insertions, 94 deletions across 22 files).

## Verification

- `swift build` — full crow + crowd graph compiles clean (`Build complete!`).
- Tests pass: `CrowCore` (759), `CrowClaude` (95), `CrowCursor` (79), `CrowOpenCode` (59), `CrowGrok` (57), `CrowMuse` (57), `CrowAntigravity` (41).
- `make parity` — notification catalogs, CLI/RPC parity (109 methods), no-NSLog all green.

## Follow-ups (later PRs, per the ticket's sequencing)

Remaining Refactor-1 buckets — shared prompt builder (`jiraArm` strategy), `SignalSource` base, per-worktree JSON hook-writer base, scaffolder/TOML-seeder fold — then Refactor 2 (RPC handler surfaces) and Refactor 3 (provider-backend plumbing). One bucket per PR, as the ticket asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)