### PR TITLE
Wire Codex into the session-log collector + backfill (CROW-1089)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,14 +314,14 @@ crow logsync set [--retention-days N] [--quiet-period-minutes N] [--max-upload-b
 - **Opt a workspace in elsewhere**: `crow workspace edit --workspace NAME --upload-session-logs true` (or the checkbox) + a gateway via `crow gateway set`. There is no `crow logsync` flag that opts a workspace in — CROW-1070 dropped the global master switch, base URL, API key and `enabledWorkspaces` list.
 - **Security invariant**: the upload destination + credential come only from the workspace's **local-only** gateway (`{gateway.baseURL}/api/crow-sessions/{id}/artifacts` + `x-citadel-api-key`), never `--corveil-host` or any browser-writable field. A workspace with no gateway uploads nothing.
 - `set` is a PATCH (only the flags you pass change; at least one required). Live within ~1 collector tick (~5 min); no restart.
-- **Migration**: a legacy `crow logsync set --add-workspace` opt-in is carried over to `--upload-session-logs` on first boot (only when the old master switch was on). Only Claude Code transcripts are collected today; other harnesses are wired as their log paths are confirmed.
+- **Migration**: a legacy `crow logsync set --add-workspace` opt-in is carried over to `--upload-session-logs` on first boot (only when the old master switch was on). Claude Code and Codex transcripts are collected today (CROW-1089); other harnesses are wired as their log paths are confirmed.
 
 ### Session Backfill
 
-The historical session backfill (CROW-1075) — reconcile the coding-session transcripts already on disk (predating the live path, or reaped from Crow's store) and upload the ones you choose as real, fully-linked Corveil session artifacts. Claude Code only for v1.
+The historical session backfill (CROW-1075) — reconcile the coding-session transcripts already on disk (predating the live path, or reaped from Crow's store) and upload the ones you choose as real, fully-linked Corveil session artifacts. Claude Code and Codex for v1 (CROW-1089).
 
 ```
-crow backfill scan                                                      → {"sessions":[{uid,workspace,repo_name,owner_repo,ticket_number,confidence,upload_status,...}],"summary":{total,uploaded,linkable,repo_only,orphan}}
+crow backfill scan                                                      → {"sessions":[{uid,harness,workspace,repo_name,owner_repo,ticket_number,confidence,upload_status,...}],"summary":{total,uploaded,linkable,repo_only,orphan}}
 crow backfill upload --workspace NAME (--session UID … | --all-high-confidence | --all)   → {"results":[{uid,result,linked,owner_repo,ticket_number,reason}],"summary":{...}}
 ```
 

--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -190,4 +190,9 @@ public struct AntigravityAgent: CodingAgent {
     // default rather than risk pasting a stray `/rename` prompt into the model
     // (CROW-629). A documented Tier-2 gap; override once a rename command is
     // confirmed.
+
+    // `logSources` is intentionally NOT overridden (CROW-1089): Antigravity's CLI
+    // has no confirmed durable, cwd-attributable session-log location on disk, so
+    // it inherits the `[]` default. Wire it once a rollout/transcript path is
+    // verified.
 }

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/BackfillCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/BackfillCommands.swift
@@ -8,9 +8,11 @@ import Foundation
 // fully-linked Corveil session artifacts, reconstructing the workspace / repo /
 // ticket a live run would have carried.
 //
-// Claude Code only in v1 (the one harness whose logs are partitioned by working
-// directory). The upload is idempotent (a local ledger + the server's write-once
-// 409), throttled, and always user-initiated — never automatic or unbounded.
+// Claude Code and Codex in v1 (CROW-1089): Claude's logs are partitioned by
+// working directory, and Codex records the real cwd in each ~/.codex/sessions
+// rollout, so both reconstruct reliably. The upload is idempotent (a local ledger
+// + the server's write-once 409), throttled, and always user-initiated — never
+// automatic or unbounded.
 
 /// Parent command: `crow backfill <subcommand>`.
 public struct Backfill: ParsableCommand {
@@ -18,11 +20,11 @@ public struct Backfill: ParsableCommand {
         commandName: "backfill",
         abstract: "Reconcile and upload historical on-disk session transcripts",
         discussion: """
-        Scans the coding-session transcripts already on disk \
-        (~/.claude/projects), reconstructs each one's workspace, repo, and \
-        ticket/PR, and uploads the ones you choose to Corveil as session \
-        artifacts — so a backfilled session lands in the ontology \
-        indistinguishable from a live-captured one.
+        Scans the coding-session transcripts already on disk (Claude Code under \
+        ~/.claude/projects and Codex under ~/.codex/sessions), reconstructs each \
+        one's workspace, repo, and ticket/PR, and uploads the ones you choose to \
+        Corveil as session artifacts — so a backfilled session lands in the \
+        ontology indistinguishable from a live-captured one.
 
         A reconstructed ticket becomes a link only when the provider confirms it \
         exists; otherwise the session uploads repo-only, and a true orphan uploads \
@@ -78,7 +80,7 @@ public struct BackfillUpload: ParsableCommand {
 
     @Option(
         name: .customLong("session"),
-        help: "A Claude session UID to upload (repeatable). Mutually exclusive with --all/--all-high-confidence.")
+        help: "A session UID to upload (repeatable; Claude or Codex — UIDs come from `crow backfill scan`). Mutually exclusive with --all/--all-high-confidence.")
     var sessions: [String] = []
 
     @Flag(name: .customLong("all-high-confidence"), help: "Upload every not-yet-uploaded high-confidence session in this workspace")

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
@@ -25,9 +25,9 @@ public struct Logsync: ParsableCommand {
 
         These verbs tune only global behavior — ledger retention, the quiet period \
         before a transcript is captured, and the per-upload size cap. Uploads are \
-        best-effort and never block or fail a session. Only Claude Code transcripts \
-        are collected today; other harnesses are wired as their on-disk log \
-        locations are confirmed.
+        best-effort and never block or fail a session. Claude Code and Codex \
+        transcripts are collected today (CROW-1089); other harnesses are wired as \
+        their on-disk log locations are confirmed.
         """,
         subcommands: [LogsyncGet.self, LogsyncSet.self]
     )

--- a/Packages/CrowCodex/Sources/CrowCodex/CodexHome.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/CodexHome.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The Codex home directory, resolved the way every Crow ↔ Codex path resolves
+/// it: `$CODEX_HOME` when set and non-empty, otherwise `~/.codex`. An empty
+/// `CODEX_HOME=` is treated as unset — matching `LaunchScaffold` and
+/// `CodexTrustSeeder` — so it never yields a CWD-relative path.
+///
+/// A single source of truth so the launch, trust-seed, hook, and log-collection
+/// paths all look at the same tree. A user (or a launchd plist) that sets
+/// `CODEX_HOME` has Codex write its rollouts under that tree, so the session-log
+/// collector and backfill must read it too (CROW-1089).
+public enum CodexHome {
+    /// The resolved Codex home directory. `environment` is injectable for tests.
+    public static func path(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        if let env = environment["CODEX_HOME"], !env.isEmpty { return env }
+        return NSString(string: "~/.codex").expandingTildeInPath
+    }
+
+    /// `<codexHome>/sessions` — where Codex writes its date-partitioned
+    /// `rollout-<ts>-<uuid>.jsonl` transcripts.
+    public static func sessionsDir(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        (path(environment: environment) as NSString).appendingPathComponent("sessions")
+    }
+}

--- a/Packages/CrowCodex/Sources/CrowCodex/CodexTrustSeeder.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/CodexTrustSeeder.swift
@@ -115,16 +115,11 @@ public enum CodexTrustSeeder {
     }
 
     /// `$CODEX_HOME/config.toml` when `CODEX_HOME` is set and non-empty,
-    /// otherwise `~/.codex/config.toml`. Mirrors `LaunchScaffold`'s
-    /// empty-var-is-unset guard so an empty `CODEX_HOME=` never yields a
+    /// otherwise `~/.codex/config.toml`. Delegates the home resolution to
+    /// `CodexHome` — the one source of truth shared with the log collector and
+    /// the launch path (CROW-1089) — so an empty `CODEX_HOME=` never yields a
     /// CWD-relative path.
     private static func defaultConfigPath() -> String {
-        let codexHome: String
-        if let env = ProcessInfo.processInfo.environment["CODEX_HOME"], !env.isEmpty {
-            codexHome = env
-        } else {
-            codexHome = NSString(string: "~/.codex").expandingTildeInPath
-        }
-        return (codexHome as NSString).appendingPathComponent("config.toml")
+        (CodexHome.path() as NSString).appendingPathComponent("config.toml")
     }
 }

--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -234,4 +234,32 @@ public struct OpenAICodexAgent: CodingAgent {
     public func sessionRenameSlashCommand(newName: String) -> String? {
         "/rename \(newName)\n"
     }
+
+    /// Codex writes one NDJSON rollout per session under a global, date-partitioned
+    /// tree — `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO-ts>-<uuid>.jsonl` —
+    /// and records the working directory it ran in on the first line
+    /// (`session_meta.payload.cwd`, verified against `codex-cli` 0.100–0.141 rollouts).
+    ///
+    /// Unlike Claude, the rollouts are NOT partitioned by working directory, so a
+    /// worktree path can't be turned into a directory path. Attribution is instead
+    /// by **content**: the source scans the whole `sessions` tree recursively but
+    /// carries a `cwdFilter`, and the collector keeps only the rollouts whose
+    /// recorded `cwd` equals this worktree (`AgentLogCwdReader`). A rollout with no
+    /// readable cwd is dropped rather than guessed — an unattributable transcript
+    /// is worse than a missing one (CROW-1089).
+    ///
+    /// `harnessSessionID` is unused: the exact rollout filename also encodes a
+    /// timestamp, so a bare session id can't name the file, and cwd-matching is
+    /// the reliable selector regardless. The format is `.logDir` (the reserved
+    /// "concatenate per-session files into one NDJSON artifact" case) because a
+    /// Crow session may span several `codex`/`codex resume` invocations in the same
+    /// worktree, each its own rollout; the collector concatenates all cwd-matches
+    /// chronologically.
+    public func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] {
+        let sessionsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/sessions", isDirectory: true)
+        return [.directory(
+            sessionsDir.path, format: .logDir, fileExtension: "jsonl",
+            recursive: true, cwdFilter: worktreePath)]
+    }
 }

--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -236,9 +236,11 @@ public struct OpenAICodexAgent: CodingAgent {
     }
 
     /// Codex writes one NDJSON rollout per session under a global, date-partitioned
-    /// tree — `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO-ts>-<uuid>.jsonl` —
+    /// tree — `<codexHome>/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO-ts>-<uuid>.jsonl` —
     /// and records the working directory it ran in on the first line
     /// (`session_meta.payload.cwd`, verified against `codex-cli` 0.100–0.141 rollouts).
+    /// `codexHome` honors `$CODEX_HOME` (`CodexHome`), the same tree the launch,
+    /// trust-seed, and hook paths use, so a user who relocates it is still covered.
     ///
     /// Unlike Claude, the rollouts are NOT partitioned by working directory, so a
     /// worktree path can't be turned into a directory path. Attribution is instead
@@ -256,10 +258,8 @@ public struct OpenAICodexAgent: CodingAgent {
     /// worktree, each its own rollout; the collector concatenates all cwd-matches
     /// chronologically.
     public func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] {
-        let sessionsDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex/sessions", isDirectory: true)
         return [.directory(
-            sessionsDir.path, format: .logDir, fileExtension: "jsonl",
-            recursive: true, cwdFilter: worktreePath)]
+            CodexHome.sessionsDir(), format: .logDir, fileExtension: "jsonl",
+            fileNamePrefix: "rollout-", recursive: true, cwdFilter: worktreePath)]
     }
 }

--- a/Packages/CrowCodex/Tests/CrowCodexTests/CodexAgentLogSourcesTests.swift
+++ b/Packages/CrowCodex/Tests/CrowCodexTests/CodexAgentLogSourcesTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowCodex
+
+@Suite struct CodexAgentLogSourcesTests {
+    private var home: String { FileManager.default.homeDirectoryForCurrentUser.path }
+
+    @Test func cwdFilteredRecursiveSessionsSource() {
+        let sources = OpenAICodexAgent().logSources(
+            worktreePath: "/Users/j/Dev/acme-1", harnessSessionID: nil)
+        #expect(sources.count == 1)
+        let s = sources[0]
+        // Globally stored, so a directory (not a file) — recursive over the date
+        // tree, filtered to `.jsonl`, attributed by the worktree it ran in.
+        #expect(s.selector == .directory)
+        #expect(s.format == .logDir)
+        #expect(s.fileExtension == "jsonl")
+        #expect(s.recursive == true)
+        #expect(s.cwdFilter == "/Users/j/Dev/acme-1")
+        #expect(s.path == home + "/.codex/sessions")
+    }
+
+    @Test func harnessSessionIDIsIgnoredForAttribution() {
+        // Unlike Claude, a known session id does not name the file (the rollout
+        // filename also carries a timestamp) — cwd-matching is the selector, so
+        // the source is identical whether or not an id is passed.
+        let withID = OpenAICodexAgent().logSources(worktreePath: "/a/b", harnessSessionID: "UUID-1")
+        let withoutID = OpenAICodexAgent().logSources(worktreePath: "/a/b", harnessSessionID: nil)
+        #expect(withID == withoutID)
+        #expect(withID[0].cwdFilter == "/a/b")
+    }
+}

--- a/Packages/CrowCodex/Tests/CrowCodexTests/CodexAgentLogSourcesTests.swift
+++ b/Packages/CrowCodex/Tests/CrowCodexTests/CodexAgentLogSourcesTests.swift
@@ -4,8 +4,6 @@ import CrowCore
 @testable import CrowCodex
 
 @Suite struct CodexAgentLogSourcesTests {
-    private var home: String { FileManager.default.homeDirectoryForCurrentUser.path }
-
     @Test func cwdFilteredRecursiveSessionsSource() {
         let sources = OpenAICodexAgent().logSources(
             worktreePath: "/Users/j/Dev/acme-1", harnessSessionID: nil)
@@ -16,9 +14,12 @@ import CrowCore
         #expect(s.selector == .directory)
         #expect(s.format == .logDir)
         #expect(s.fileExtension == "jsonl")
+        #expect(s.fileNamePrefix == "rollout-") // only Codex rollouts, in lockstep with backfill
         #expect(s.recursive == true)
         #expect(s.cwdFilter == "/Users/j/Dev/acme-1")
-        #expect(s.path == home + "/.codex/sessions")
+        // Points at the resolved Codex sessions tree (honors $CODEX_HOME), not a
+        // hardcoded `~/.codex` — asserted against the shared resolver.
+        #expect(s.path == CodexHome.sessionsDir())
     }
 
     @Test func harnessSessionIDIsIgnoredForAttribution() {

--- a/Packages/CrowCodex/Tests/CrowCodexTests/CodexHomeTests.swift
+++ b/Packages/CrowCodex/Tests/CrowCodexTests/CodexHomeTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import CrowCodex
+
+@Suite struct CodexHomeTests {
+    @Test func honorsCodexHomeWhenSetAndNonEmpty() {
+        let env = ["CODEX_HOME": "/custom/codex"]
+        #expect(CodexHome.path(environment: env) == "/custom/codex")
+        #expect(CodexHome.sessionsDir(environment: env) == "/custom/codex/sessions")
+    }
+
+    @Test func emptyCodexHomeIsTreatedAsUnset() {
+        // An empty `CODEX_HOME=` must NOT yield a CWD-relative path — it falls
+        // back to `~/.codex` like every other Crow ↔ Codex path.
+        let home = NSString(string: "~/.codex").expandingTildeInPath
+        #expect(CodexHome.path(environment: ["CODEX_HOME": ""]) == home)
+        #expect(CodexHome.sessionsDir(environment: ["CODEX_HOME": ""]) == home + "/sessions")
+    }
+
+    @Test func fallsBackToTildeCodexWhenUnset() {
+        let home = NSString(string: "~/.codex").expandingTildeInPath
+        #expect(CodexHome.path(environment: [:]) == home)
+        #expect(CodexHome.sessionsDir(environment: [:]) == home + "/sessions")
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
@@ -58,6 +58,13 @@ public struct AgentLogSource: Sendable, Equatable {
     /// collected (e.g. `"jsonl"`); `nil` collects every regular file. Ignored
     /// for `.file`.
     public let fileExtension: String?
+    /// When `selector == .directory`, only files whose name begins with this
+    /// prefix are collected (e.g. `"rollout-"` for Codex). `nil` accepts any
+    /// name. Keeps the live collector and the backfill scanner in lockstep — both
+    /// select a Codex rollout by the same `rollout-*.jsonl` shape, so a stray
+    /// `.jsonl` that Codex might one day drop beside its rollouts can't slip into
+    /// the live path even if it happened to carry a matching cwd (CROW-1089).
+    public let fileNamePrefix: String?
     /// When `selector == .directory`, whether to descend into subdirectories.
     /// Defaults to `false` (Claude's slug directory is flat).
     public let recursive: Bool
@@ -79,6 +86,7 @@ public struct AgentLogSource: Sendable, Equatable {
         selector: Selector,
         format: AgentLogFormat,
         fileExtension: String? = nil,
+        fileNamePrefix: String? = nil,
         recursive: Bool = false,
         cwdFilter: String? = nil
     ) {
@@ -86,6 +94,7 @@ public struct AgentLogSource: Sendable, Equatable {
         self.selector = selector
         self.format = format
         self.fileExtension = fileExtension
+        self.fileNamePrefix = fileNamePrefix
         self.recursive = recursive
         self.cwdFilter = cwdFilter
     }
@@ -95,19 +104,21 @@ public struct AgentLogSource: Sendable, Equatable {
         AgentLogSource(path: path, selector: .file, format: format)
     }
 
-    /// A directory source, optionally filtered by file extension and — for a
-    /// globally-stored harness — by the working directory each file recorded
-    /// (`cwdFilter`).
+    /// A directory source, optionally filtered by file extension / name prefix
+    /// and — for a globally-stored harness — by the working directory each file
+    /// recorded (`cwdFilter`).
     public static func directory(
         _ path: String,
         format: AgentLogFormat,
         fileExtension: String? = nil,
+        fileNamePrefix: String? = nil,
         recursive: Bool = false,
         cwdFilter: String? = nil
     ) -> AgentLogSource {
         AgentLogSource(
             path: path, selector: .directory, format: format,
-            fileExtension: fileExtension, recursive: recursive, cwdFilter: cwdFilter)
+            fileExtension: fileExtension, fileNamePrefix: fileNamePrefix,
+            recursive: recursive, cwdFilter: cwdFilter)
     }
 
     /// Slugify a POSIX path the way Claude Code names its per-project log

--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
@@ -9,12 +9,19 @@ public enum AgentLogFormat: String, Sendable, Codable, Equatable, CaseIterable {
     /// this (`~/.claude/projects/<slug>/<uuid>.jsonl`), so it needs no
     /// transformation before upload.
     case jsonl
-    /// A SQLite database (Cursor stores chat rows inside a per-workspace
-    /// `state.vscdb`). Requires row extraction before it becomes NDJSON — not
-    /// yet wired (see `CursorAgent.logSources`).
+    /// A SQLite database. The Cursor CLI (`cursor-agent`) stores each chat's
+    /// conversation as opaque blobs inside a per-chat `store.db`
+    /// (`~/.cursor/chats/<id>/<sub>/store.db`, tables `blobs`/`meta`). Requires
+    /// blob extraction before it becomes NDJSON — not yet wired (see
+    /// `CursorAgent`). Note this is the *CLI's* store, not the Cursor IDE's
+    /// `state.vscdb`.
     case sqlite
     /// A directory (or set) of per-session log files the collector concatenates
-    /// into one NDJSON artifact (Codex rollout files, OpenCode storage).
+    /// into one NDJSON artifact. Codex rollout files (`~/.codex/sessions/**/
+    /// rollout-*.jsonl`) use this: each rollout is already newline-delimited JSON,
+    /// so the concatenation needs no per-line transformation — only cwd-matching
+    /// to attribute a globally-stored rollout to a worktree (see the `cwdFilter`
+    /// field and `OpenAICodexAgent.logSources`).
     case logDir
 }
 
@@ -54,19 +61,33 @@ public struct AgentLogSource: Sendable, Equatable {
     /// When `selector == .directory`, whether to descend into subdirectories.
     /// Defaults to `false` (Claude's slug directory is flat).
     public let recursive: Bool
+    /// When set, keep only the resolved files whose *recorded* working directory
+    /// equals this path — the attribution mechanism for a harness whose logs are
+    /// **globally stored** rather than partitioned into a per-worktree directory.
+    ///
+    /// Claude needs no filter: its slug directory already contains exactly this
+    /// worktree's transcripts, so `cwdFilter` is `nil`. Codex is the opposite —
+    /// its rollouts pool under `~/.codex/sessions/<date>/…` regardless of cwd, so
+    /// the collector must read each candidate's head, extract the `cwd` it
+    /// recorded (`AgentLogCwdReader`), and keep only exact matches. A file with no
+    /// readable cwd is dropped, never guessed: an unattributable transcript is
+    /// worse than a missing one (CROW-1089).
+    public let cwdFilter: String?
 
     public init(
         path: String,
         selector: Selector,
         format: AgentLogFormat,
         fileExtension: String? = nil,
-        recursive: Bool = false
+        recursive: Bool = false,
+        cwdFilter: String? = nil
     ) {
         self.path = path
         self.selector = selector
         self.format = format
         self.fileExtension = fileExtension
         self.recursive = recursive
+        self.cwdFilter = cwdFilter
     }
 
     /// A single-file source.
@@ -74,16 +95,19 @@ public struct AgentLogSource: Sendable, Equatable {
         AgentLogSource(path: path, selector: .file, format: format)
     }
 
-    /// A directory source, optionally filtered by file extension.
+    /// A directory source, optionally filtered by file extension and — for a
+    /// globally-stored harness — by the working directory each file recorded
+    /// (`cwdFilter`).
     public static func directory(
         _ path: String,
         format: AgentLogFormat,
         fileExtension: String? = nil,
-        recursive: Bool = false
+        recursive: Bool = false,
+        cwdFilter: String? = nil
     ) -> AgentLogSource {
         AgentLogSource(
             path: path, selector: .directory, format: format,
-            fileExtension: fileExtension, recursive: recursive)
+            fileExtension: fileExtension, recursive: recursive, cwdFilter: cwdFilter)
     }
 
     /// Slugify a POSIX path the way Claude Code names its per-project log

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -331,9 +331,12 @@ public protocol CodingAgent: Sendable {
     ///
     /// Opt-in: the protocol default returns `[]`, so a harness whose on-disk log
     /// location is unconfirmed contributes nothing rather than uploading the
-    /// wrong bytes. Only Claude Code is fully wired today (its logs are the only
-    /// ones partitioned by working directory); the globally-stored harnesses
-    /// (Codex/Cursor/OpenCode) return `[]` pending per-harness cwd matching.
+    /// wrong bytes. `ClaudeCodeAgent` and `OpenAICodexAgent` are wired today
+    /// (CROW-1089): Claude's logs are partitioned by working directory, and Codex's
+    /// globally-stored rollouts carry a `cwdFilter` so the collector attributes
+    /// them by their recorded `cwd`. Cursor (SQLite blob store) and OpenCode
+    /// (multi-file object store) still return `[]` pending a normalizer for their
+    /// on-disk shapes; see each adapter for the specific blocker.
     func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource]
 }
 
@@ -496,7 +499,9 @@ public extension CodingAgent {
 
     /// Opt-in default: no known log sources (CROW-1056). A harness whose
     /// durable-log location is unconfirmed — or whose logs are not partitioned
-    /// by working directory — contributes nothing until its adapter overrides
-    /// this. Only `ClaudeCodeAgent` overrides it today.
+    /// by working directory *and* have no cwd-attribution wired — contributes
+    /// nothing until its adapter overrides this. `ClaudeCodeAgent` (per-worktree
+    /// slug directory) and `OpenAICodexAgent` (cwd-filtered global rollouts)
+    /// override it today (CROW-1089).
     func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] { [] }
 }

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillReconstruction.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillReconstruction.swift
@@ -119,8 +119,16 @@ public struct RepoRemote: Sendable, Equatable {
 /// the unit the uploader acts on. Everything but the identity fields is
 /// best-effort — a `low`-confidence orphan carries only the file facts.
 public struct BackfillSession: Sendable, Equatable, Codable {
-    /// The Claude session UUID — the `.jsonl` stem. Used verbatim as the upload
-    /// `{uid}`: stable, unique, and the natural idempotency key (decision #1).
+    /// The harness that wrote this transcript (CROW-1089). Determines the ledger
+    /// key's harness slot and the upload's `harness` value, so a Claude and a
+    /// Codex session with the same UID never collide. Defaults to `.claude` for
+    /// back-compat with rows persisted before the field existed.
+    public var harness: LogSyncHarness
+    /// The harness session UID — the transcript's identity. For Claude it is the
+    /// `.jsonl` stem; for Codex it is the rollout's `session_meta.payload.id`.
+    /// Used verbatim as the upload `{uid}`: stable, unique, and the natural
+    /// idempotency key (decision #1). Named `claudeSessionUID` for historical
+    /// reasons — it is any harness's session UID now.
     public var claudeSessionUID: String
     /// Absolute path to the transcript file.
     public var filePath: String
@@ -167,6 +175,7 @@ public struct BackfillSession: Sendable, Equatable, Codable {
         claudeSessionUID: String,
         filePath: String,
         slug: String,
+        harness: LogSyncHarness = .claude,
         cwd: String? = nil,
         gitBranch: String? = nil,
         modifiedAt: Double = 0,
@@ -185,6 +194,7 @@ public struct BackfillSession: Sendable, Equatable, Codable {
         self.claudeSessionUID = claudeSessionUID
         self.filePath = filePath
         self.slug = slug
+        self.harness = harness
         self.cwd = cwd
         self.gitBranch = gitBranch
         self.modifiedAt = modifiedAt

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillReconstruction.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillReconstruction.swift
@@ -217,6 +217,9 @@ public struct BackfillSession: Sendable, Equatable, Codable {
 /// outcome (uploaded / linked / skipped-already / failed + reason).
 public struct BackfillUploadOutcome: Sendable, Equatable, Codable {
     public var claudeSessionUID: String
+    /// The harness this outcome is for — so a UI keying results back to scan rows
+    /// distinguishes a Claude and a Codex session that share a UID (CROW-1089).
+    public var harness: LogSyncHarness
     /// Terminal disposition of the attempt.
     public enum Result: String, Sendable, Equatable, Codable {
         case uploaded          // 201 stored
@@ -238,6 +241,7 @@ public struct BackfillUploadOutcome: Sendable, Equatable, Codable {
     public init(
         claudeSessionUID: String,
         result: Result,
+        harness: LogSyncHarness = .claude,
         linked: Bool = false,
         ownerRepo: String? = nil,
         ticketNumber: Int? = nil,
@@ -246,6 +250,7 @@ public struct BackfillUploadOutcome: Sendable, Equatable, Codable {
     ) {
         self.claudeSessionUID = claudeSessionUID
         self.result = result
+        self.harness = harness
         self.linked = linked
         self.ownerRepo = ownerRepo
         self.ticketNumber = ticketNumber

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
@@ -24,7 +24,9 @@ public struct BackfillScanner: Sendable {
     let projectsDir: URL
     /// `~/.codex/sessions` by default — where Codex writes date-partitioned
     /// `rollout-<ts>-<uuid>.jsonl` files (CROW-1089). Distinct from
-    /// `~/.codex/archived_sessions`, which is deliberately not scanned.
+    /// `~/.codex/archived_sessions`, which is deliberately not scanned. The daemon
+    /// injects the `$CODEX_HOME`-resolved tree (via `CodexHome`, which CrowCore
+    /// can't import); this literal default is the fallback for a direct caller.
     let codexSessionsDir: URL
     /// Resolve a directory's `origin` remote URL (default: `git -C <dir> remote
     /// get-url origin`). Injected so tests need no real repos.

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
@@ -4,21 +4,28 @@ import Foundation
 /// been uploaded, reconstructing each one's workspace / repo / ticket so the
 /// Settings "Backfill history" dialog can show a reviewable list (CROW-1075).
 ///
-/// Claude is the only harness wired for v1 (the same reason the live collector
-/// is Claude-only): its logs are partitioned by working directory, and every
-/// event records the real `cwd`/`gitBranch`, which is what makes historical
-/// reconstruction reliable. The scan is disk- and git-only — it never touches
-/// the provider or the network, so it stays fast over hundreds of sessions;
-/// ticket *validation* is deferred to upload, where a link is actually asserted.
+/// Two harnesses are wired (CROW-1089): **Claude**, whose logs are partitioned by
+/// working directory (`~/.claude/projects/<slug>/<uuid>.jsonl`), and **Codex**,
+/// whose rollouts pool globally under `~/.codex/sessions/<date>/…` but each record
+/// their own `cwd` in a first-line `session_meta` event. Both make historical
+/// reconstruction reliable because every transcript records the real
+/// `cwd`/`gitBranch` — the authoritative signal, not a lossy directory name. The
+/// scan is disk- and git-only — it never touches the provider or the network, so
+/// it stays fast over hundreds of sessions; ticket *validation* is deferred to
+/// upload, where a link is actually asserted.
 ///
-/// Everything effectful is injected (the projects directory, the git-remote
-/// reader, the clock), so the reconciliation logic is unit-testable against a
-/// temporary tree.
+/// Everything effectful is injected (the projects directory, the Codex sessions
+/// directory, the git-remote reader, the clock), so the reconciliation logic is
+/// unit-testable against a temporary tree.
 public struct BackfillScanner: Sendable {
     let devRoot: String
     /// `~/.claude/projects` by default — where Claude writes per-project slug
     /// directories of `<session-uuid>.jsonl` transcripts.
     let projectsDir: URL
+    /// `~/.codex/sessions` by default — where Codex writes date-partitioned
+    /// `rollout-<ts>-<uuid>.jsonl` files (CROW-1089). Distinct from
+    /// `~/.codex/archived_sessions`, which is deliberately not scanned.
+    let codexSessionsDir: URL
     /// Resolve a directory's `origin` remote URL (default: `git -C <dir> remote
     /// get-url origin`). Injected so tests need no real repos.
     let gitRemote: @Sendable (String) async -> String?
@@ -27,12 +34,15 @@ public struct BackfillScanner: Sendable {
     public init(
         devRoot: String,
         projectsDir: URL? = nil,
+        codexSessionsDir: URL? = nil,
         runner: any ShellRunner = ProcessShellRunner(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.devRoot = devRoot
         self.projectsDir = projectsDir ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude/projects", isDirectory: true)
+        self.codexSessionsDir = codexSessionsDir ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/sessions", isDirectory: true)
         self.gitRemote = { dir in
             (try? await runner.run(args: ["git", "-C", dir, "remote", "get-url", "origin"],
                                    env: [:], cwd: nil))?
@@ -41,31 +51,43 @@ public struct BackfillScanner: Sendable {
         self.now = now
     }
 
-    /// Test seam: inject the git-remote reader directly.
+    /// Test seam: inject the git-remote reader directly. `codexSessionsDir`
+    /// defaults to a nonexistent path so a test that only stages Claude
+    /// transcripts stays hermetic (it never accidentally scans a dev machine's
+    /// real `~/.codex/sessions`); a Codex test passes an explicit temp dir.
     init(
         devRoot: String,
         projectsDir: URL,
+        codexSessionsDir: URL? = nil,
         gitRemote: @escaping @Sendable (String) async -> String?,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.devRoot = devRoot
         self.projectsDir = projectsDir
+        self.codexSessionsDir = codexSessionsDir
+            ?? projectsDir.appendingPathComponent("__no_codex_sessions__", isDirectory: true)
         self.gitRemote = gitRemote
         self.now = now
     }
 
-    /// Reconcile every on-disk Claude transcript against the ledger and return
-    /// the reconstructed rows, newest first.
+    /// Reconcile every on-disk transcript (Claude + Codex) against the ledger and
+    /// return the reconstructed rows, newest first.
     public func scan(ledger: LogSyncLedger) async -> [BackfillSession] {
         let remotes = await resolveRemotes()
         let knownRepoNames = Array(Set(remotes.values.map { $0.repo }))
-        let files = transcriptFiles()
 
         var sessions: [BackfillSession] = []
-        sessions.reserveCapacity(files.count)
-        for file in files {
-            guard let s = reconstruct(file: file, remotesByRepo: remotes,
-                                      knownRepoNames: knownRepoNames, ledger: ledger)
+        for file in transcriptFiles() {
+            guard let s = reconstructClaude(
+                file: file, remotesByRepo: remotes,
+                knownRepoNames: knownRepoNames, ledger: ledger)
+            else { continue }
+            sessions.append(s)
+        }
+        for file in codexRolloutFiles() {
+            guard let s = reconstructCodex(
+                file: file, remotesByRepo: remotes,
+                knownRepoNames: knownRepoNames, ledger: ledger)
             else { continue }
             sessions.append(s)
         }
@@ -75,23 +97,57 @@ public struct BackfillScanner: Sendable {
 
     // MARK: - Reconstruction of one file
 
-    func reconstruct(
+    /// Reconstruct one Claude transcript: uid is the `.jsonl` stem, slug is the
+    /// project-slug parent directory, and the head is read with the flat top-level
+    /// keys Claude fills within its first handful of events.
+    func reconstructClaude(
         file: URL, remotesByRepo: [String: RepoRemote],
         knownRepoNames: [String], ledger: LogSyncLedger
     ) -> BackfillSession? {
         let uid = file.deletingPathExtension().lastPathComponent
         guard !uid.isEmpty else { return nil }
         let slug = file.deletingLastPathComponent().lastPathComponent
+        let head = TranscriptHeadReader.read(file)
+        return assemble(
+            uid: uid, file: file, slug: slug, harness: .claude,
+            cwd: head.cwd, gitBranch: head.gitBranch,
+            remotesByRepo: remotesByRepo, knownRepoNames: knownRepoNames, ledger: ledger)
+    }
+
+    /// Reconstruct one Codex rollout: cwd/uid come from the first `session_meta`
+    /// line (nested under `payload`), so the head is read with a tiny line budget
+    /// — Codex never fills `gitBranch`, so the general reader would otherwise scan
+    /// to its cap. The uid is the rollout's own `payload.id`, falling back to the
+    /// UUID embedded in the `rollout-<ts>-<uuid>` filename.
+    func reconstructCodex(
+        file: URL, remotesByRepo: [String: RepoRemote],
+        knownRepoNames: [String], ledger: LogSyncLedger
+    ) -> BackfillSession? {
+        let head = TranscriptHeadReader.read(file, maxLines: 4)
+        let uid = head.sessionID ?? Self.codexUID(fromFilename: file)
+        guard let uid, !uid.isEmpty else { return nil }
+        return assemble(
+            uid: uid, file: file, slug: file.deletingPathExtension().lastPathComponent,
+            harness: .codex, cwd: head.cwd, gitBranch: head.gitBranch,
+            remotesByRepo: remotesByRepo, knownRepoNames: knownRepoNames, ledger: ledger)
+    }
+
+    /// Shared reconstruction: given a harness's already-extracted
+    /// `(uid, cwd, gitBranch)`, fill in the workspace/repo/ticket the same way for
+    /// every harness (the derivation is pure `cwd`/branch math — see
+    /// `BackfillReconstructor`).
+    func assemble(
+        uid: String, file: URL, slug: String, harness: LogSyncHarness,
+        cwd: String?, gitBranch: String?,
+        remotesByRepo: [String: RepoRemote], knownRepoNames: [String], ledger: LogSyncLedger
+    ) -> BackfillSession? {
         let values = try? file.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
         let mtime = values?.contentModificationDate?.timeIntervalSince1970 ?? 0
         let size = values?.fileSize ?? 0
 
-        let head = TranscriptHeadReader.read(file)
-        let cwd = head.cwd
-
         var session = BackfillSession(
-            claudeSessionUID: uid, filePath: file.path, slug: slug,
-            cwd: cwd, gitBranch: head.gitBranch, modifiedAt: mtime, sizeBytes: size)
+            claudeSessionUID: uid, filePath: file.path, slug: slug, harness: harness,
+            cwd: cwd, gitBranch: gitBranch, modifiedAt: mtime, sizeBytes: size)
 
         if let cwd {
             session.workspace = BackfillReconstructor.workspace(cwd: cwd, devRoot: devRoot)
@@ -118,14 +174,28 @@ public struct BackfillScanner: Sendable {
         session.confidence = BackfillReconstructor.confidence(
             workspace: session.workspace, repoName: session.repoName, ticket: session.ticketNumber)
         session.uploadStatus = Self.status(
-            for: uid, ledger: ledger, now: now().timeIntervalSince1970)
+            for: uid, harness: harness, ledger: ledger, now: now().timeIntervalSince1970)
         return session
     }
 
-    /// Map a ledger entry (keyed on the Claude UID + Claude harness) to the
-    /// row's display status.
-    static func status(for uid: String, ledger: LogSyncLedger, now: Double) -> BackfillUploadStatus {
-        let key = LogSyncLedger.key(sessionUID: uid, harness: .claude, kind: .sessionTranscript)
+    /// The UUID embedded in a Codex `rollout-<ISO-timestamp>-<uuid>.jsonl`
+    /// filename — the last five hyphen-separated groups (a v7 UUID). Used only
+    /// when the head could not be read; the `payload.id` is preferred.
+    static func codexUID(fromFilename file: URL) -> String? {
+        let stem = file.deletingPathExtension().lastPathComponent
+        guard stem.hasPrefix("rollout-") else { return nil }
+        let groups = stem.split(separator: "-")
+        guard groups.count >= 5 else { return nil }
+        let uuid = groups.suffix(5).joined(separator: "-")
+        return uuid.isEmpty ? nil : uuid
+    }
+
+    /// Map a ledger entry (keyed on the session UID + its harness) to the row's
+    /// display status.
+    static func status(
+        for uid: String, harness: LogSyncHarness, ledger: LogSyncLedger, now: Double
+    ) -> BackfillUploadStatus {
+        let key = LogSyncLedger.key(sessionUID: uid, harness: harness, kind: .sessionTranscript)
         guard let entry = ledger.entries[key] else { return .new }
         switch entry.status {
         case .uploaded: return .uploaded
@@ -153,6 +223,23 @@ public struct BackfillScanner: Sendable {
                 if (try? f.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
                     out.append(f)
                 }
+            }
+        }
+        return out
+    }
+
+    /// Every `rollout-*.jsonl` under `~/.codex/sessions` (recursively, across the
+    /// `<YYYY>/<MM>/<DD>` date tree). `~/.codex/archived_sessions` and `.../log`
+    /// are siblings of this directory, so they are naturally excluded.
+    func codexRolloutFiles() -> [URL] {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: codexSessionsDir, includingPropertiesForKeys: [.isRegularFileKey]) else { return [] }
+        var out: [URL] = []
+        for case let url as URL in en where url.pathExtension == "jsonl"
+            && url.lastPathComponent.hasPrefix("rollout-") {
+            if (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
+                out.append(url)
             }
         }
         return out

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncSupport.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncSupport.swift
@@ -5,7 +5,7 @@ import Foundation
 /// CHECK exactly, so an out-of-set value never reaches the endpoint (it would
 /// 400). Crow's own harness roster is larger than this set; anything without a
 /// first-class value maps to `.unknown`.
-public enum LogSyncHarness: String, Sendable, Equatable, CaseIterable {
+public enum LogSyncHarness: String, Sendable, Equatable, Codable, CaseIterable {
     case claude
     case cursor
     case codex

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptHead.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptHead.swift
@@ -38,20 +38,38 @@ public enum TranscriptHeadReader {
     /// Fold one JSON event line into the accumulating head. Only the four fields
     /// of interest are decoded; everything else is ignored. A non-JSON or
     /// unrelated line leaves the head unchanged.
+    ///
+    /// Two harness shapes are recognized, so one reader serves both the Claude
+    /// backfill and the Codex one (CROW-1089):
+    ///  - **Claude** records `cwd` / `gitBranch` / `sessionId` / `timestamp` as
+    ///    top-level keys on its event lines.
+    ///  - **Codex** records them on its first `session_meta` line under a nested
+    ///    `payload` object (`payload.cwd`, `payload.id`, `payload.timestamp`);
+    ///    Codex writes no git branch, so `gitBranch` simply stays `nil`.
+    /// The two never collide — Claude transcripts carry no `payload` key — so the
+    /// nested lookup is a harmless fallback for Claude and the whole source for
+    /// Codex.
     public static func absorb(_ line: String, into head: inout TranscriptHead) {
         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return }
-        func str(_ key: String) -> String? {
-            guard let v = obj[key] as? String else { return nil }
+        func str(_ dict: [String: Any], _ key: String) -> String? {
+            guard let v = dict[key] as? String else { return nil }
             let t = v.trimmingCharacters(in: .whitespacesAndNewlines)
             return t.isEmpty ? nil : t
         }
-        if head.sessionID == nil { head.sessionID = str("sessionId") }
-        if head.cwd == nil { head.cwd = str("cwd") }
-        if head.gitBranch == nil { head.gitBranch = str("gitBranch") }
-        if head.firstTimestamp == nil { head.firstTimestamp = str("timestamp") }
+        let payload = obj["payload"] as? [String: Any]
+        if head.sessionID == nil {
+            head.sessionID = str(obj, "sessionId") ?? payload.flatMap { str($0, "id") }
+        }
+        if head.cwd == nil {
+            head.cwd = str(obj, "cwd") ?? payload.flatMap { str($0, "cwd") }
+        }
+        if head.gitBranch == nil { head.gitBranch = str(obj, "gitBranch") }
+        if head.firstTimestamp == nil {
+            head.firstTimestamp = str(obj, "timestamp") ?? payload.flatMap { str($0, "timestamp") }
+        }
     }
 
     /// Parse a whole in-memory transcript body (test/fixture convenience).
@@ -95,5 +113,50 @@ public enum TranscriptHeadReader {
             absorb(line, into: &head)
         }
         return head
+    }
+}
+
+/// Reads *only* the working directory a harness log recorded, from the head of
+/// the file, and stops the instant it finds one (CROW-1089).
+///
+/// This is the live collector's per-file attribution probe for a globally-stored
+/// harness (Codex): `LogSyncCollector.resolveFiles` calls it for every candidate
+/// rollout to decide whether that rollout ran in the session's worktree. It must
+/// stay cheap — a Codex rollout's first `session_meta` line alone can be several
+/// KB, and there can be hundreds of them — so unlike `TranscriptHeadReader.read`
+/// (which keeps reading until *all* head fields are found, and Codex never fills
+/// `gitBranch`) this returns as soon as `cwd` appears, scanning only a handful of
+/// lines. `cwd` is on line 1 for both Claude and Codex; the small `maxLines`
+/// budget is slack for a harness that emits a preamble line first.
+public enum AgentLogCwdReader {
+    /// The recorded `cwd` from the head of `url`, or `nil` if none is found within
+    /// `maxLines`. Uses `TranscriptHeadReader.absorb`, so it recognizes both the
+    /// Claude (top-level `cwd`) and Codex (`payload.cwd`) shapes.
+    public static func read(_ url: URL, maxLines: Int = 8) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        var head = TranscriptHead()
+        var buffer = Data()
+        var lines = 0
+        let newline: UInt8 = 0x0A
+        while lines < maxLines, head.cwd == nil {
+            guard let chunk = try? handle.read(upToCount: 65_536), !chunk.isEmpty else { break }
+            buffer.append(chunk)
+            while let idx = buffer.firstIndex(of: newline) {
+                let lineData = buffer[buffer.startIndex..<idx]
+                buffer.removeSubrange(buffer.startIndex...idx)
+                lines += 1
+                if let line = String(data: lineData, encoding: .utf8) {
+                    TranscriptHeadReader.absorb(line, into: &head)
+                }
+                if head.cwd != nil || lines >= maxLines { break }
+            }
+        }
+        // A final partial line (no trailing newline) within budget.
+        if head.cwd == nil, lines < maxLines, !buffer.isEmpty,
+           let line = String(data: buffer, encoding: .utf8) {
+            TranscriptHeadReader.absorb(line, into: &head)
+        }
+        return head.cwd
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
@@ -31,6 +31,18 @@ import CrowCore
         #expect(s.selector == .directory)
         #expect(s.fileExtension == "jsonl")
         #expect(s.recursive == false)
+        #expect(s.cwdFilter == nil)
+    }
+
+    @Test func directoryFactoryCarriesCwdFilterAndRecursion() {
+        // The Codex shape: a recursive, cwd-filtered global store.
+        let s = AgentLogSource.directory(
+            "/home/.codex/sessions", format: .logDir, fileExtension: "jsonl",
+            recursive: true, cwdFilter: "/dev/ws/repo-1")
+        #expect(s.selector == .directory)
+        #expect(s.format == .logDir)
+        #expect(s.recursive == true)
+        #expect(s.cwdFilter == "/dev/ws/repo-1")
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
@@ -35,12 +35,13 @@ import CrowCore
     }
 
     @Test func directoryFactoryCarriesCwdFilterAndRecursion() {
-        // The Codex shape: a recursive, cwd-filtered global store.
+        // The Codex shape: a recursive, cwd-filtered, prefix-scoped global store.
         let s = AgentLogSource.directory(
             "/home/.codex/sessions", format: .logDir, fileExtension: "jsonl",
-            recursive: true, cwdFilter: "/dev/ws/repo-1")
+            fileNamePrefix: "rollout-", recursive: true, cwdFilter: "/dev/ws/repo-1")
         #expect(s.selector == .directory)
         #expect(s.format == .logDir)
+        #expect(s.fileNamePrefix == "rollout-")
         #expect(s.recursive == true)
         #expect(s.cwdFilter == "/dev/ws/repo-1")
     }

--- a/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
@@ -26,6 +26,22 @@ import Testing
         try body.write(to: dir.appendingPathComponent("\(uid).jsonl"), atomically: true, encoding: .utf8)
     }
 
+    /// Write a Codex rollout — a first-line `session_meta` with cwd/id nested
+    /// under `payload`, in the `<YYYY>/<MM>/<DD>` date tree Codex uses.
+    private func writeCodexRollout(
+        in codexSessions: URL, uid: String, cwd: String
+    ) throws {
+        let dir = codexSessions.appendingPathComponent("2026/08/19", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let body = """
+        {"timestamp":"2026-08-19T00:00:00Z","type":"session_meta","payload":{"id":"\(uid)","cwd":"\(cwd)","git":{}}}
+        {"timestamp":"2026-08-19T00:00:01Z","type":"event_msg","payload":{"type":"task_started"}}
+        """
+        try body.write(
+            to: dir.appendingPathComponent("rollout-2026-08-19T00-00-00-\(uid).jsonl"),
+            atomically: true, encoding: .utf8)
+    }
+
     @Test func reconstructsHighConfidenceSession() async throws {
         let (devRoot, projects, cleanup) = try makeTree()
         defer { cleanup() }
@@ -92,6 +108,69 @@ import Testing
         let sessions = await scanner.scan(ledger: ledger)
         let s = try #require(sessions.first { $0.claudeSessionUID == "UID-3" })
         #expect(s.uploadStatus == .uploaded)
+    }
+
+    @Test func reconstructsCodexHighConfidenceSession() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        let codex = URL(fileURLWithPath: devRoot)
+            .deletingLastPathComponent().appendingPathComponent("codex-sessions", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codex) }
+
+        // A live clone so the repo → owner/repo resolves.
+        let clone = URL(fileURLWithPath: devRoot)
+            .appendingPathComponent("RadiusMethod/crow", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: clone.appendingPathComponent(".git"), withIntermediateDirectories: true)
+
+        let cwd = "\(devRoot)/RadiusMethod/crow-1089-wire-harness-log-collector"
+        try writeCodexRollout(in: codex, uid: "CODEX-UID-1", cwd: cwd)
+
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects, codexSessionsDir: codex,
+            gitRemote: { path in
+                path.hasSuffix("/RadiusMethod/crow") ? "https://github.com/corveil/crow.git" : nil
+            })
+
+        let sessions = await scanner.scan(ledger: LogSyncLedger())
+        // Only the Codex rollout — the (empty) Claude projects dir contributes none.
+        let s = try #require(sessions.first { $0.claudeSessionUID == "CODEX-UID-1" })
+        #expect(s.harness == .codex)
+        #expect(s.workspace == "RadiusMethod")
+        #expect(s.worktreeName == "crow-1089-wire-harness-log-collector")
+        #expect(s.repoName == "crow")
+        #expect(s.ownerRepo == "corveil/crow")
+        #expect(s.ticketNumber == 1089)
+        #expect(s.confidence == .high)
+    }
+
+    @Test func codexLedgerStatusKeyedByCodexHarness() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        let codex = URL(fileURLWithPath: devRoot)
+            .deletingLastPathComponent().appendingPathComponent("codex-sessions2", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codex) }
+        try writeCodexRollout(in: codex, uid: "CODEX-UID-2", cwd: "\(devRoot)/RadiusMethod/crow-9-x")
+
+        // A Claude ledger entry for the SAME uid must NOT mark the Codex row
+        // uploaded — the harness slot distinguishes them.
+        var ledger = LogSyncLedger()
+        ledger.record(
+            key: LogSyncLedger.key(sessionUID: "CODEX-UID-2", harness: .claude, kind: .sessionTranscript),
+            entry: .init(status: .uploaded, sha256: "s", sizeBytes: 1, at: 1))
+
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects, codexSessionsDir: codex, gitRemote: { _ in nil })
+        let s = try #require(await scanner.scan(ledger: ledger).first { $0.claudeSessionUID == "CODEX-UID-2" })
+        #expect(s.uploadStatus == .new) // the Claude-harness entry does not apply
+
+        // Now record it under the CODEX harness — it reconciles.
+        var ledger2 = LogSyncLedger()
+        ledger2.record(
+            key: LogSyncLedger.key(sessionUID: "CODEX-UID-2", harness: .codex, kind: .sessionTranscript),
+            entry: .init(status: .uploaded, sha256: "s", sizeBytes: 1, at: 1))
+        let s2 = try #require(await scanner.scan(ledger: ledger2).first { $0.claudeSessionUID == "CODEX-UID-2" })
+        #expect(s2.uploadStatus == .uploaded)
     }
 
     @Test func summaryCountsByTier() {

--- a/Packages/CrowCore/Tests/CrowCoreTests/TranscriptHeadReaderTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TranscriptHeadReaderTests.swift
@@ -48,4 +48,46 @@ import Testing
         let head = TranscriptHeadReader.read(URL(fileURLWithPath: "/nope/does/not/exist.jsonl"))
         #expect(head == TranscriptHead())
     }
+
+    // MARK: Codex rollout shape (CROW-1089)
+
+    /// A Codex rollout's first line records cwd/id/timestamp under a nested
+    /// `payload`, and no git branch. One reader must handle both shapes.
+    private let codexSample = """
+    {"timestamp":"2026-06-01T21:33:36.314Z","type":"session_meta","payload":{"id":"019e851b-213a-7cb3-8f08-1cb867fb118a","timestamp":"2026-06-01T21:33:28.251Z","cwd":"/Users/j/Dev2/RadiusMethod/corveil-ecs","originator":"codex-tui","git":{}}}
+    {"timestamp":"2026-06-01T21:33:36.315Z","type":"event_msg","payload":{"type":"task_started"}}
+    """
+
+    @Test func parsesCodexPayloadCwdIdTimestamp() {
+        let head = TranscriptHeadReader.parse(codexSample)
+        #expect(head.sessionID == "019e851b-213a-7cb3-8f08-1cb867fb118a")
+        #expect(head.cwd == "/Users/j/Dev2/RadiusMethod/corveil-ecs")
+        #expect(head.firstTimestamp == "2026-06-01T21:33:36.314Z") // top-level wins
+        #expect(head.gitBranch == nil) // Codex records no branch
+    }
+
+    @Test func agentLogCwdReaderReadsClaudeAndCodexHeads() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cwdreader-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let claude = dir.appendingPathComponent("claude.jsonl")
+        try (sample + "\n").write(to: claude, atomically: true, encoding: .utf8)
+        #expect(AgentLogCwdReader.read(claude) == "/Users/j/Dev2/RadiusMethod/crow-1075-session-backfill")
+
+        // Codex cwd on line 1 (nested), then a large tail that must NOT be read —
+        // AgentLogCwdReader stops the instant cwd is found.
+        let codex = dir.appendingPathComponent("rollout.jsonl")
+        var body = codexSample + "\n"
+        body += String(repeating: "{\"type\":\"noise\",\"payload\":{}}\n", count: 100_000)
+        try body.write(to: codex, atomically: true, encoding: .utf8)
+        #expect(AgentLogCwdReader.read(codex) == "/Users/j/Dev2/RadiusMethod/corveil-ecs")
+
+        // A file whose head carries no cwd yields nil (never guessed).
+        let noCwd = dir.appendingPathComponent("nocwd.jsonl")
+        try "{\"type\":\"x\"}\n".write(to: noCwd, atomically: true, encoding: .utf8)
+        #expect(AgentLogCwdReader.read(noCwd) == nil)
+        #expect(AgentLogCwdReader.read(URL(fileURLWithPath: "/nope/x.jsonl")) == nil)
+    }
 }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -305,4 +305,12 @@ public struct CursorAgent: CodingAgent {
             markers: Self.identityMarkers,
             runner: probeRunner)
     }
+
+    // `logSources` is intentionally NOT overridden (CROW-1089): the `cursor-agent`
+    // CLI stores each chat's conversation as opaque blobs in a per-chat SQLite
+    // `store.db` (`~/.cursor/chats/<id>/<sub>/store.db`) — the cwd is recoverable
+    // from the sibling `meta.json`, but the transcript needs a `store.db` blob
+    // extractor (a `.sqlite` normalizer) that isn't built yet, so it stays on the
+    // `[]` default rather than upload the wrong bytes. (This is the CLI's store,
+    // not the Cursor IDE's `state.vscdb`.)
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CrowCore
+import CrowCodex
 
 /// The daemon-side orchestration behind `backfill-scan` / `backfill-upload`
 /// (CROW-1075). It composes the CrowCore pieces — the disk scanner, the ticket
@@ -40,7 +41,14 @@ struct BackfillService: Sendable {
     func scan(scanner: BackfillScanner? = nil) async -> [BackfillSession] {
         let store = LogSyncLedgerStore.shared(devRoot: devRoot)
         let ledger = await store.snapshot()
-        let s = scanner ?? BackfillScanner(devRoot: devRoot, now: now)
+        // Resolve the Codex sessions tree through `CodexHome` (honors `$CODEX_HOME`),
+        // the same tree the live collector and the launch path read — CrowCore's
+        // `BackfillScanner` can't import CrowCodex, so the daemon injects it
+        // (CROW-1089).
+        let s = scanner ?? BackfillScanner(
+            devRoot: devRoot,
+            codexSessionsDir: URL(fileURLWithPath: CodexHome.sessionsDir()),
+            now: now)
         return await s.scan(ledger: ledger)
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
@@ -57,7 +57,9 @@ struct BackfillService: Sendable {
     ) async -> BackfillUploadOutcome {
         let store = LogSyncLedgerStore.shared(devRoot: devRoot)
         let uid = session.claudeSessionUID
-        let key = LogSyncLedger.key(sessionUID: uid, harness: .claude, kind: .sessionTranscript)
+        let harness = session.harness
+        let format = Self.uploadFormat(for: harness)
+        let key = LogSyncLedger.key(sessionUID: uid, harness: harness, kind: .sessionTranscript)
         let nowEpoch = now().timeIntervalSince1970
 
         // Idempotent: a slot the ledger records as uploaded or permanently
@@ -71,7 +73,7 @@ struct BackfillService: Sendable {
 
         let file = URL(fileURLWithPath: session.filePath)
         guard let transcript = TranscriptNormalizer.normalize(
-            files: [file], format: .jsonl, maxBytes: max(1, maxUploadBytes)) else {
+            files: [file], format: format, maxBytes: max(1, maxUploadBytes)) else {
             return BackfillUploadOutcome(
                 claudeSessionUID: uid, result: .skipped, ownerRepo: session.ownerRepo,
                 reason: "empty_or_unreadable")
@@ -96,7 +98,7 @@ struct BackfillService: Sendable {
         let metadata = LogSyncSessionMetadata(
             name: session.worktreeName ?? session.slug,
             status: nil, // a historical session's Crow status is genuinely unknown
-            agentKind: AgentKind.claudeCode.rawValue,
+            agentKind: Self.agentKindRawValue(for: harness),
             ticketURL: ticketURL,
             ticketNumber: linkedNumber,
             repo: session.ownerRepo,
@@ -104,7 +106,7 @@ struct BackfillService: Sendable {
 
         let result = await uploader.upload(
             baseURL: upload.baseURL, apiKey: upload.apiKey,
-            sessionUID: uid, harness: .claude, kind: .sessionTranscript, format: .jsonl,
+            sessionUID: uid, harness: harness, kind: .sessionTranscript, format: format,
             transcript: transcript, metadata: metadata, agentSessionID: uid)
 
         let sha = LogSyncCollector.sha256Hex(transcript.data)
@@ -118,6 +120,24 @@ struct BackfillService: Sendable {
     }
 
     // MARK: - Helpers
+
+    /// The upload `format` stamp for a harness's on-disk transcript. Both wired
+    /// harnesses normalize through `concatenateNDJSON`, but the stamp is honest:
+    /// Claude writes a single NDJSON transcript (`.jsonl`); a Codex rollout is one
+    /// of a set of per-session files the collector concatenates (`.logDir`).
+    static func uploadFormat(for harness: LogSyncHarness) -> AgentLogFormat {
+        harness == .codex ? .logDir : .jsonl
+    }
+
+    /// The `agentKind` sidecar hint for a harness. Only the two wired harnesses
+    /// reach here; any other maps to Claude's kind as a harmless default (it never
+    /// occurs — the scanner only emits `.claude`/`.codex`).
+    static func agentKindRawValue(for harness: LogSyncHarness) -> String {
+        switch harness {
+        case .codex: return AgentKind.codex.rawValue
+        default: return AgentKind.claudeCode.rawValue
+        }
+    }
 
     /// Split a resolved `owner/repo` back into a `RepoRemote` for URL/validation.
     static func remote(ownerRepo: String, host: String) -> RepoRemote? {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
@@ -75,7 +75,7 @@ struct BackfillService: Sendable {
         // transient failure retry).
         guard await store.shouldUpload(key: key, now: nowEpoch, retryBackoff: 0) else {
             return BackfillUploadOutcome(
-                claudeSessionUID: uid, result: .alreadyUploaded,
+                claudeSessionUID: uid, result: .alreadyUploaded, harness: harness,
                 ownerRepo: session.ownerRepo, ticketNumber: session.ticketNumber)
         }
 
@@ -83,8 +83,8 @@ struct BackfillService: Sendable {
         guard let transcript = TranscriptNormalizer.normalize(
             files: [file], format: format, maxBytes: max(1, maxUploadBytes)) else {
             return BackfillUploadOutcome(
-                claudeSessionUID: uid, result: .skipped, ownerRepo: session.ownerRepo,
-                reason: "empty_or_unreadable")
+                claudeSessionUID: uid, result: .skipped, harness: harness,
+                ownerRepo: session.ownerRepo, reason: "empty_or_unreadable")
         }
 
         // Validate the reconstructed ticket before asserting any link.
@@ -123,7 +123,7 @@ struct BackfillService: Sendable {
         await store.record(key: key, entry: entry)
 
         return Self.outcome(
-            uid: uid, result: result, linked: linked,
+            uid: uid, result: result, harness: harness, linked: linked,
             ownerRepo: session.ownerRepo, ticketNumber: linkedNumber, ticketKind: ticketKind)
     }
 
@@ -157,7 +157,7 @@ struct BackfillService: Sendable {
     }
 
     static func outcome(
-        uid: String, result: TranscriptUploadResult, linked: Bool,
+        uid: String, result: TranscriptUploadResult, harness: LogSyncHarness, linked: Bool,
         ownerRepo: String?, ticketNumber: Int?, ticketKind: BackfillTicketKind?
     ) -> BackfillUploadOutcome {
         let disposition: BackfillUploadOutcome.Result
@@ -170,7 +170,7 @@ struct BackfillService: Sendable {
         case .transient: disposition = .failed; reason = "transient"
         }
         return BackfillUploadOutcome(
-            claudeSessionUID: uid, result: disposition, linked: linked,
+            claudeSessionUID: uid, result: disposition, harness: harness, linked: linked,
             ownerRepo: ownerRepo, ticketNumber: ticketNumber, ticketKind: ticketKind, reason: reason)
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LaunchScaffold.swift
@@ -139,11 +139,12 @@ enum LaunchScaffold {
 
         if AgentRegistry.shared.agent(for: .codex) != nil {
             attempt("Codex scaffold") { try CodexScaffolder.scaffold(devRoot: devRoot) }
-            // An empty `CODEX_HOME=` is treated as unset — otherwise
-            // `appendingPathComponent("hooks.json")` on "" is a relative path
-            // and the config writes into the process CWD, matching the empty
-            // `XDG_CONFIG_HOME` guard below (#766 review).
-            let codexHome = nonEmptyEnv("CODEX_HOME") ?? NSString(string: "~/.codex").expandingTildeInPath
+            // Codex home via the shared `CodexHome` resolver (empty `CODEX_HOME=`
+            // is treated as unset — otherwise `appendingPathComponent("hooks.json")`
+            // on "" is a relative path and the config writes into the process CWD,
+            // matching the empty `XDG_CONFIG_HOME` guard below, #766 review). One
+            // source of truth with the log collector and trust-seed paths (CROW-1089).
+            let codexHome = CodexHome.path()
             // Sweep any `.crow-codex-*.tmp` left by a crash between
             // `writeConfigPrivately`'s createFile and rename(2) — a 0600 temp
             // that may hold mirrored MCP tokens (#843 review round 5). Nothing

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
@@ -273,7 +273,8 @@ struct LogSyncCollector {
             var filtered = files.filter { url in
                 guard (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
                 else { return false }
-                if let ext = source.fileExtension { return url.pathExtension == ext }
+                if let ext = source.fileExtension, url.pathExtension != ext { return false }
+                if let prefix = source.fileNamePrefix, !url.lastPathComponent.hasPrefix(prefix) { return false }
                 return true
             }
             filtered = applyingCwdFilter(filtered, source.cwdFilter)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
@@ -108,7 +108,9 @@ struct LogSyncCollector {
             guard await ledgerStore.shouldUpload(key: ledgerKey, now: nowEpoch, retryBackoff: retryBackoff) else { continue }
 
             // Where does this harness write its logs? Empty for harnesses whose
-            // on-disk logs are not yet wired (everything but Claude today).
+            // on-disk logs are not yet wired (everything but Claude and Codex
+            // today — CROW-1089). A Codex source carries a `cwdFilter` that
+            // `resolveFiles` applies to attribute a global rollout to this worktree.
             guard let agent = AgentRegistry.shared.agent(for: session.agentKind) else { continue }
             let sources = agent.logSources(worktreePath: worktree.worktreePath, harnessSessionID: nil)
             guard !sources.isEmpty else { continue }
@@ -124,8 +126,10 @@ struct LogSyncCollector {
                 if let newest, nowDate.timeIntervalSince(newest) < quietPeriod { continue }
             }
 
-            // Pick the single format (all Claude sources are .jsonl; a mixed set
-            // would be unusual — take the first source's format).
+            // Pick the single format for the artifact stamp. Claude sources are
+            // `.jsonl`; Codex sources are `.logDir` (a set of per-session rollouts
+            // concatenated). A mixed set would be unusual — take the first source's
+            // format.
             let format = sources.first?.format ?? .jsonl
             guard let transcript = TranscriptNormalizer.normalize(
                 files: files, format: format, maxBytes: max(1, config.maxUploadBytes))
@@ -242,7 +246,11 @@ struct LogSyncCollector {
     }
 
     /// Expand a log source to concrete regular files, oldest-modified first so a
-    /// concatenated transcript reads chronologically.
+    /// concatenated transcript reads chronologically. When the source carries a
+    /// `cwdFilter` (a globally-stored harness like Codex), only files whose
+    /// recorded working directory matches are kept — the attribution step that
+    /// stops one worktree's upload from swallowing every session's rollouts
+    /// (CROW-1089).
     static func resolveFiles(_ source: AgentLogSource) -> [URL] {
         let fm = FileManager.default
         switch source.selector {
@@ -262,15 +270,31 @@ struct LogSyncCollector {
                     at: dir, includingPropertiesForKeys: keys) else { return [] }
                 files = contents
             }
-            let filtered = files.filter { url in
+            var filtered = files.filter { url in
                 guard (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
                 else { return false }
                 if let ext = source.fileExtension { return url.pathExtension == ext }
                 return true
             }
+            filtered = applyingCwdFilter(filtered, source.cwdFilter)
             return filtered.sorted { a, b in
                 (Self.modificationDate(a) ?? .distantPast) < (Self.modificationDate(b) ?? .distantPast)
             }
+        }
+    }
+
+    /// Keep only files whose recorded `cwd` (read cheaply from the head via
+    /// `AgentLogCwdReader`) equals `cwdFilter`, path-standardized on both sides.
+    /// `nil` filter is a no-op (Claude, whose slug directory is already the
+    /// filter). A file with no readable cwd never matches — an unattributable
+    /// transcript is dropped, not guessed (CROW-1089).
+    static func applyingCwdFilter(_ files: [URL], _ cwdFilter: String?) -> [URL] {
+        guard let cwdFilter else { return files }
+        let want = (cwdFilter as NSString).standardizingPath
+        guard !want.isEmpty else { return [] }
+        return files.filter { url in
+            guard let cwd = AgentLogCwdReader.read(url) else { return false }
+            return (cwd as NSString).standardizingPath == want
         }
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2270,6 +2270,7 @@ private func makeBackfillHandlers(devRoot: String) -> [String: CommandRouter.Han
 private func backfillSessionJSON(_ s: BackfillSession) -> JSONValue {
     var obj: [String: JSONValue] = [
         "uid": .string(s.claudeSessionUID),
+        "harness": .string(s.harness.rawValue),
         "file_path": .string(s.filePath),
         "slug": .string(s.slug),
         "modified_at": .double(s.modifiedAt),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2227,9 +2227,15 @@ private func makeBackfillHandlers(devRoot: String) -> [String: CommandRouter.Han
                 var toUpload: [BackfillSession] = []
                 if !explicit.isEmpty {
                     let scanned = await service.scan()
-                    let byUID = Dictionary(scanned.map { ($0.claudeSessionUID, $0) },
-                                           uniquingKeysWith: { first, _ in first })
-                    toUpload = explicit.compactMap { byUID[$0] }
+                    // Select every scanned row whose UID was requested — a set
+                    // membership test, not a uid→session map. A UID shared across
+                    // harnesses (a Claude and a Codex session) therefore uploads
+                    // BOTH rows instead of silently dropping one; each lands in its
+                    // own harness-scoped ledger slot (CROW-1089). Cross-harness UID
+                    // collisions are vanishingly rare, but keeping both reachable
+                    // costs nothing and matches `--all`/`--all-high-confidence`.
+                    let wanted = Set(explicit)
+                    toUpload = scanned.filter { wanted.contains($0.claudeSessionUID) }
                 } else if let selectMode = params["select"]?.stringValue {
                     let scanned = await service.scan()
                     let scope = scanned.filter { $0.workspace?.lowercased() == workspaceName.lowercased() }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2311,6 +2311,7 @@ private func backfillSummaryJSON(_ s: BackfillSummary) -> JSONValue {
 private func backfillOutcomeJSON(_ o: BackfillUploadOutcome) -> JSONValue {
     var obj: [String: JSONValue] = [
         "uid": .string(o.claudeSessionUID),
+        "harness": .string(o.harness.rawValue),
         "result": .string(o.result.rawValue),
         "linked": .bool(o.linked),
     ]

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -1908,10 +1908,13 @@
       refresh();
       try {
         const res = await rpc('backfill-upload', { workspace: workspaceName, sessions: uids });
-        const byUid = {};
-        (res.results || []).forEach((r) => { byUid[r.uid] = r; });
+        // Key results by (uid, harness): a UID shared by a Claude and a Codex row
+        // maps each scan row to its own outcome instead of overwriting (CROW-1089).
+        const outcomeKey = (o) => (o.uid || '') + ' ' + (o.harness || 'claude');
+        const byKey = {};
+        (res.results || []).forEach((r) => { byKey[outcomeKey(r)] = r; });
         sessions.forEach((s) => {
-          const r = byUid[s.uid];
+          const r = byKey[outcomeKey(s)];
           if (!r) return;
           s.upload_status = (r.result === 'uploaded' || r.result === 'already') ? 'uploaded'
             : (r.result === 'skipped' ? 'skipped' : 'failed');

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -1879,7 +1879,7 @@
     }
 
     async function scan() {
-      summary.textContent = 'Scanning ~/.claude/projects…';
+      summary.textContent = 'Scanning ~/.claude/projects and ~/.codex/sessions…';
       try {
         const res = await rpc('backfill-scan', {});
         sessions = res.sessions || [];

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -1734,7 +1734,7 @@
     modal.appendChild(head);
 
     const body = el('div', 'settings-body');
-    const summary = el('div', 'backfill-summary', 'Scanning ~/.claude/projects…');
+    const summary = el('div', 'backfill-summary', 'Scanning ~/.claude/projects and ~/.codex/sessions…');
     body.appendChild(summary);
 
     const filterRow = el('div', 'backfill-filters');

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
@@ -137,6 +137,7 @@ private struct StubRunner: ShellRunner {
             session: s, upload: (baseURL: "https://corveil.io", apiKey: "k"),
             maxUploadBytes: 8_000_000)
         #expect(outcome.result == .uploaded)
+        #expect(outcome.harness == .codex) // the outcome carries its harness for UI keying
 
         // Idempotent within the codex slot: a re-run is a no-op...
         let again = await svc.upload(

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
@@ -116,4 +116,41 @@ private struct StubRunner: ShellRunner {
                 == RepoRemote(host: "github.com", owner: "corveil", repo: "crow"))
         #expect(BackfillService.remote(ownerRepo: "noslash", host: "github.com") == nil)
     }
+
+    // MARK: Codex harness (CROW-1089)
+
+    @Test func harnessMappingHelpers() {
+        #expect(BackfillService.uploadFormat(for: .claude) == .jsonl)
+        #expect(BackfillService.uploadFormat(for: .codex) == .logDir)
+        #expect(BackfillService.agentKindRawValue(for: .claude) == AgentKind.claudeCode.rawValue)
+        #expect(BackfillService.agentKindRawValue(for: .codex) == AgentKind.codex.rawValue)
+    }
+
+    @Test func codexSessionUploadsUnderCodexHarnessSlot() async throws {
+        let devRoot = try tempDevRoot()
+        let path = try writeTranscript(devRoot, uid: "CDX-1")
+        let svc = service(devRoot, status: 201, ticket: .success(#"{"number":12}"#))
+        var s = session(devRoot, uid: "CDX-1", path: path)
+        s.harness = .codex
+
+        let outcome = await svc.upload(
+            session: s, upload: (baseURL: "https://corveil.io", apiKey: "k"),
+            maxUploadBytes: 8_000_000)
+        #expect(outcome.result == .uploaded)
+
+        // Idempotent within the codex slot: a re-run is a no-op...
+        let again = await svc.upload(
+            session: s, upload: (baseURL: "https://corveil.io", apiKey: "k"),
+            maxUploadBytes: 8_000_000)
+        #expect(again.result == .alreadyUploaded)
+
+        // ...but the SAME uid under the Claude harness is a distinct slot that has
+        // not been uploaded, so it proceeds (the harness disambiguates the ledger).
+        var claudeTwin = s
+        claudeTwin.harness = .claude
+        let twin = await svc.upload(
+            session: claudeTwin, upload: (baseURL: "https://corveil.io", apiKey: "k"),
+            maxUploadBytes: 8_000_000)
+        #expect(twin.result == .uploaded)
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
@@ -161,6 +161,52 @@ import CrowCore
         #expect(LogSyncCollector.agentSessionID(from: []) == nil)
     }
 
+    // MARK: cwd-filtered resolution (CROW-1089 — Codex global store)
+
+    /// A recursive, cwd-filtered directory source (the Codex shape) keeps only the
+    /// rollouts whose recorded `cwd` matches the worktree, across the date tree.
+    @Test func resolveFilesAppliesCwdFilterRecursively() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let day = dir.appendingPathComponent("2026/08/19", isDirectory: true)
+        try FileManager.default.createDirectory(at: day, withIntermediateDirectories: true)
+
+        func rollout(_ name: String, cwd: String?) throws -> URL {
+            let url = day.appendingPathComponent(name)
+            let head = cwd.map {
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"x\",\"cwd\":\"\($0)\"}}\n"
+            } ?? "{\"type\":\"session_meta\",\"payload\":{\"id\":\"x\"}}\n"
+            try head.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        }
+        let mine = try rollout("rollout-mine.jsonl", cwd: "/dev/ws/repo-1089")
+        _ = try rollout("rollout-other.jsonl", cwd: "/dev/ws/repo-999")
+        _ = try rollout("rollout-nocwd.jsonl", cwd: nil) // unattributable → dropped
+
+        let source = AgentLogSource.directory(
+            dir.path, format: .logDir, fileExtension: "jsonl",
+            recursive: true, cwdFilter: "/dev/ws/repo-1089")
+        let files = LogSyncCollector.resolveFiles(source)
+        #expect(files.map(\.lastPathComponent) == [mine.lastPathComponent])
+    }
+
+    @Test func applyingCwdFilterDropsUnattributableAndNoOpsWhenNil() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let a = dir.appendingPathComponent("a.jsonl")
+        try "{\"cwd\":\"/dev/ws/repo-1\"}\n".write(to: a, atomically: true, encoding: .utf8)
+        let b = dir.appendingPathComponent("b.jsonl")
+        try "{\"type\":\"x\"}\n".write(to: b, atomically: true, encoding: .utf8) // no cwd
+
+        // nil filter is a no-op (Claude path): both survive.
+        #expect(LogSyncCollector.applyingCwdFilter([a, b], nil).count == 2)
+        // A concrete filter keeps only the match; the cwd-less file is dropped.
+        let kept = LogSyncCollector.applyingCwdFilter([a, b], "/dev/ws/repo-1")
+        #expect(kept.map(\.lastPathComponent) == ["a.jsonl"])
+        // A blank filter matches nothing (never "match everything").
+        #expect(LogSyncCollector.applyingCwdFilter([a, b], "   ").isEmpty)
+    }
+
     // MARK: Result → ledger mapping
 
     @Test func ledgerEntryMapping() {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
@@ -182,10 +182,14 @@ import CrowCore
         let mine = try rollout("rollout-mine.jsonl", cwd: "/dev/ws/repo-1089")
         _ = try rollout("rollout-other.jsonl", cwd: "/dev/ws/repo-999")
         _ = try rollout("rollout-nocwd.jsonl", cwd: nil) // unattributable → dropped
+        // A non-rollout `.jsonl` with a matching cwd must still be excluded by the
+        // `rollout-` name prefix — keeps the live path in lockstep with backfill
+        // (CROW-1089), even if Codex ever drops other jsonl beside its rollouts.
+        _ = try rollout("history.jsonl", cwd: "/dev/ws/repo-1089")
 
         let source = AgentLogSource.directory(
             dir.path, format: .logDir, fileExtension: "jsonl",
-            recursive: true, cwdFilter: "/dev/ws/repo-1089")
+            fileNamePrefix: "rollout-", recursive: true, cwdFilter: "/dev/ws/repo-1089")
         let files = LogSyncCollector.resolveFiles(source)
         #expect(files.map(\.lastPathComponent) == [mine.lastPathComponent])
     }

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift
@@ -234,4 +234,8 @@ public struct GrokAgent: CodingAgent {
             markers: Self.identityMarkers,
             runner: probeRunner)
     }
+
+    // `logSources` is intentionally NOT overridden (CROW-1089): Grok Build has no
+    // confirmed durable, cwd-attributable session-log location on disk, so it
+    // inherits the `[]` default. Wire it once a transcript path is verified.
 }

--- a/Packages/CrowMuse/Sources/CrowMuse/MuseAgent.swift
+++ b/Packages/CrowMuse/Sources/CrowMuse/MuseAgent.swift
@@ -237,4 +237,8 @@ public struct MuseAgent: CodingAgent {
             markers: Self.identityMarkers,
             runner: probeRunner)
     }
+
+    // `logSources` is intentionally NOT overridden (CROW-1089): Muse Code has no
+    // confirmed durable, cwd-attributable session-log location on disk, so it
+    // inherits the `[]` default. Wire it once a transcript path is verified.
 }

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeAgent.swift
@@ -178,4 +178,12 @@ public struct OpenCodeAgent: CodingAgent {
     public func sessionRenameSlashCommand(newName: String) -> String? {
         "/rename \(newName)\n"
     }
+
+    // `logSources` is intentionally NOT overridden (CROW-1089): OpenCode keeps a
+    // multi-file object store (`~/.local/share/opencode/storage/{project,session,
+    // message,part}/`) rather than one transcript per session. A
+    // `project/<id>.json`'s `worktree` field maps a project to its cwd, but
+    // reassembling a session's scattered `message`/`part` records into ordered
+    // NDJSON is a normalizer that isn't built yet, so it stays on the `[]`
+    // default rather than upload a malformed transcript.
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1801,7 +1801,7 @@ Uploads a chosen set through the live path, idempotently and serially. `--worksp
 
 | Flag | Description |
 | --- | --- |
-| `--session <uid>` | A Claude session UID to upload (repeatable; UIDs come from `crow backfill scan`) |
+| `--session <uid>` | A session UID to upload (repeatable; Claude or Codex — UIDs come from `crow backfill scan`) |
 | `--all-high-confidence` | Every not-yet-uploaded **high-confidence** session in this workspace |
 | `--all` | Every not-yet-uploaded session in this workspace |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1763,13 +1763,13 @@ crow logsync set --quiet-period-minutes 15 --max-upload-bytes 4000000
 | `--quiet-period-minutes N` | Wait this long after a session's last activity before uploading (default 30) |
 | `--max-upload-bytes N` | Per-transcript upload cap (default 8000000) |
 
-Only Claude Code transcripts are collected today (its logs are the one harness partitioned by working directory); other harnesses are wired as their on-disk log locations are confirmed. Changes are live — the collector re-reads config each tick, so they apply within a few minutes with no restart.
+Claude Code and Codex transcripts are collected today (CROW-1089): Claude's logs are partitioned by working directory, and Codex's globally-stored `~/.codex/sessions` rollouts are attributed by the `cwd` each records. Other harnesses are wired as their on-disk log locations are confirmed. Changes are live — the collector re-reads config each tick, so they apply within a few minutes with no restart.
 
 ---
 
 ## Session Backfill Commands
 
-The **historical session backfill** (CROW-1075) captures the coding-session transcripts already on disk — sessions that predate the live upload path or were reaped from Crow's store — and uploads them as **real, fully-linked** Corveil session artifacts, reconstructing the workspace / repo / ticket a live run would have carried. The live collector is session-centric (it walks Crow's store); this is the one-time reconciliation of the on-disk backlog. Claude Code only for v1 (the harness whose logs are partitioned by working directory).
+The **historical session backfill** (CROW-1075) captures the coding-session transcripts already on disk — sessions that predate the live upload path or were reaped from Crow's store — and uploads them as **real, fully-linked** Corveil session artifacts, reconstructing the workspace / repo / ticket a live run would have carried. The live collector is session-centric (it walks Crow's store); this is the one-time reconciliation of the on-disk backlog. Claude Code and Codex are wired (CROW-1089): Claude's logs are partitioned by working directory, and Codex records the real `cwd` in each `~/.codex/sessions` rollout, so both reconstruct reliably.
 
 It reuses the live upload path, so it inherits its guarantees: the destination + credential come only from the named workspace's **local-only** AI gateway (never a browser-writable field), no AWS credentials touch this machine, and every upload is **idempotent** (a local ledger + the server's write-once 409). It is always **user-initiated** — never automatic or unbounded.
 
@@ -1779,7 +1779,7 @@ It reuses the live upload path, so it inherits its guarantees: the destination +
 crow backfill scan
 ```
 
-Reconciles every on-disk Claude transcript (`~/.claude/projects/**/*.jsonl`) against the upload ledger and returns the reconstructed rows plus a `summary`. Disk- and git-only (no provider calls), so it stays fast over hundreds of sessions. Each row carries the recovered `workspace` / `repo_name` / `owner_repo` / `ticket_number`, a `confidence` tier, and its ledger `upload_status`:
+Reconciles every on-disk Claude transcript (`~/.claude/projects/**/*.jsonl`) and Codex rollout (`~/.codex/sessions/**/rollout-*.jsonl`) against the upload ledger and returns the reconstructed rows plus a `summary`. Disk- and git-only (no provider calls), so it stays fast over hundreds of sessions. Each row carries its `harness` (`claude`/`codex`), the recovered `workspace` / `repo_name` / `owner_repo` / `ticket_number`, a `confidence` tier, and its ledger `upload_status`:
 
 | Confidence | Meaning |
 | --- | --- |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,7 +390,7 @@ Reconcile and upload historical on-disk session transcripts.
 crow backfill <scan|upload>
 ```
 
-Scans the coding-session transcripts already on disk (~/.claude/projects), reconstructs each one's workspace, repo, and ticket/PR, and uploads the ones you choose to Corveil as session artifacts — so a backfilled session lands in the ontology indistinguishable from a live-captured one.
+Scans the coding-session transcripts already on disk (Claude Code under ~/.claude/projects and Codex under ~/.codex/sessions), reconstructs each one's workspace, repo, and ticket/PR, and uploads the ones you choose to Corveil as session artifacts — so a backfilled session lands in the ontology indistinguishable from a live-captured one.
 
 A reconstructed ticket becomes a link only when the provider confirms it exists; otherwise the session uploads repo-only, and a true orphan uploads attributed but unlinked. Uploads reuse the named workspace's AI gateway for the destination and credential (no AWS credentials on this machine) and are idempotent — re-running never duplicates.
 
@@ -425,7 +425,7 @@ Choose sessions with repeated --session <uid> (UIDs come from `crow backfill sca
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--workspace` | `<workspace>` | yes | Workspace whose gateway supplies the upload destination + credential |
-| `--session` | `<session>` _(repeatable)_ | no | A Claude session UID to upload (repeatable). Mutually exclusive with --all/--all-high-confidence. |
+| `--session` | `<session>` _(repeatable)_ | no | A session UID to upload (repeatable; Claude or Codex — UIDs come from `crow backfill scan`). Mutually exclusive with --all/--all-high-confidence. |
 | `--all-high-confidence` | — | no | Upload every not-yet-uploaded high-confidence session in this workspace |
 | `--all` | — | no | Upload every not-yet-uploaded session in this workspace |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1116,7 +1116,7 @@ crow logsync <get|set>
 
 The session-log collector uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, reusing that workspace's AI gateway for the destination and credential (no AWS credentials are stored on this machine). Opt a workspace in with `crow workspace edit --workspace NAME --upload-session-logs true` (or the Settings → Workspaces checkbox); it uploads once it also has a gateway.
 
-These verbs tune only global behavior — ledger retention, the quiet period before a transcript is captured, and the per-upload size cap. Uploads are best-effort and never block or fail a session. Only Claude Code transcripts are collected today; other harnesses are wired as their on-disk log locations are confirmed.
+These verbs tune only global behavior — ledger retention, the quiet period before a transcript is captured, and the per-upload size cap. Uploads are best-effort and never block or fail a session. Claude Code and Codex transcripts are collected today (CROW-1089); other harnesses are wired as their on-disk log locations are confirmed.
 
 Subcommands: [`get`](#crow-logsync-get), [`set`](#crow-logsync-set).
 

--- a/docs/session-backfill.md
+++ b/docs/session-backfill.md
@@ -99,11 +99,15 @@ unbounded.
   `crow backfill upload --workspace NAME (--session UID… | --all-high-confidence | --all)`.
   See [cli-reference.md](cli-reference.md#session-backfill-commands).
 
-## Scope (v1)
+## Scope
 
-- **Claude Code only** — the one harness whose logs are partitioned by working
-  directory, which is what makes historical reconstruction reliable. Other
-  harnesses follow as their `logSources` land (see
+- **Claude Code and Codex** — the two harnesses whose transcripts can be reliably
+  attributed to a worktree (CROW-1089). Claude partitions its logs by working
+  directory; Codex pools its `~/.codex/sessions/**/rollout-*.jsonl` globally but
+  records the real `cwd` in each rollout's first-line `session_meta`, so the scan
+  reconstructs it the same way. Both make historical reconstruction reliable
+  because every transcript records the authoritative `cwd`/`gitBranch`, not a
+  lossy directory name. Other harnesses follow as their `logSources` land (see
   [session-log-collector.md](session-log-collector.md)).
-- Cursor additionally needs SQLite extraction in the normalizer before its
-  transcripts can be backfilled.
+- Cursor (SQLite blob store) and OpenCode (multi-file object store) need a
+  normalizer for their on-disk shapes before their transcripts can be backfilled.

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -25,20 +25,26 @@ contributes nothing rather than uploading the wrong bytes.
 
 ## Harness coverage
 
-Only **Claude Code** partitions its logs by working directory, which is what
-makes a Crow worktree map cleanly to exactly that session's transcripts:
+**Claude Code** and **Codex** are wired (CROW-1089). Claude partitions its logs
+by working directory, so a Crow worktree maps straight to that session's
+transcripts. Codex pools its rollouts globally, so it's attributed by **content**
+instead: the source scans the whole `sessions` tree but carries a `cwdFilter`, and
+the collector keeps only the rollouts whose recorded `cwd` matches the worktree
+(`AgentLogCwdReader`). A rollout with no readable cwd is dropped, never guessed.
 
 | Harness | On-disk location | Status |
 |---|---|---|
 | `claude-code` | `~/.claude/projects/<slug>/<uuid>.jsonl` (slug = worktree path, every non-alphanumeric → `-`) | **Wired.** One artifact per session; multiple `.jsonl` under the slug dir are concatenated. |
-| `codex` | `~/.codex/sessions/<YYYY>/…`, `~/.codex/archived_sessions`, `~/.codex/log` | Deferred — global, timestamp-partitioned; needs per-file `cwd` matching. |
-| `opencode` | `~/.local/share/opencode/storage/{session,message,part}`, `.../log` | Deferred — global storage keyed by opencode session id; needs project→worktree matching. |
-| `cursor` | `~/Library/Application Support/Cursor/User/workspaceStorage/<hash>/state.vscdb` | Deferred — per-workspace **SQLite**; needs `workspace.json` hash→path matching + chat-row extraction. |
-| `grok`, `antigravity`, `muse` | app state / TBD | Deferred — log locations unconfirmed. |
+| `codex` | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl` (already NDJSON; cwd in the first-line `session_meta.payload.cwd`) | **Wired.** Recursive `.logDir` source with a `cwdFilter`; the collector keeps only cwd-matching rollouts and concatenates them (`~/.codex/archived_sessions` and `.../log` are not scanned). |
+| `opencode` | `~/.local/share/opencode/storage/{project,session,message,part}` | Deferred — a `project/<id>.json`'s `worktree` maps to the cwd, but a session's `message`/`part` records must be reassembled into ordered NDJSON first. |
+| `cursor` | `~/.cursor/chats/<id>/<sub>/store.db` (CLI store; cwd in the sibling `meta.json`) | Deferred — the conversation is opaque blobs in a per-chat **SQLite** `store.db`; needs a blob extractor (a `.sqlite` normalizer). Not the Cursor IDE's `state.vscdb`. |
+| `grok`, `antigravity`, `muse` | app state / TBD | Deferred — no confirmed durable, cwd-attributable log location. |
 
 The framework (collector, normalizer, uploader, ledger, config, CLI) is
 harness-general; wiring a deferred harness is implementing its `logSources`
-override plus, for `.sqlite`, a row extractor in `TranscriptNormalizer`.
+override — plus, for `.sqlite`/multi-file stores, a normalizer for that on-disk
+shape. A globally-stored harness attributes by `cwdFilter` rather than a
+per-worktree path (Codex is the reference).
 
 Harnesses map to the artifact contract's `harness` value via
 `LogSyncHarness(agentKind:)` — the four the server enumerates map directly, every


### PR DESCRIPTION
Closes #1089

## What & why

The session-log collector (CROW-1056) and historical backfill (CROW-1075) were architected multi-harness but only **Claude Code** was wired — the one harness whose logs are partitioned by working directory. This wires **Codex** end-to-end (live collector **and** backfill) as the second harness.

### Codex over Cursor — an evidence-based deviation from the ticket's suggestion

The ticket names Cursor as "the strongest candidate," based on the `AgentLogSource` note that Cursor uses a `state.vscdb`. On-disk investigation showed that's the Cursor **IDE**; the `cursor-agent` **CLI** that Crow actually launches stores each chat as opaque blobs in a per-chat SQLite `store.db` (`~/.cursor/chats/<id>/<sub>/store.db`) — an undocumented binary format needing a bespoke extractor.

**Codex is objectively cleaner and more reliable:**

| | Storage | Format | cwd attribution |
|---|---|---|---|
| **Codex** ✅ | `~/.codex/sessions/**/rollout-*.jsonl` | **already NDJSON** | `session_meta.payload.cwd` (first line) |
| Cursor | `~/.cursor/chats/<id>/<sub>/store.db` | SQLite **blobs** | `meta.json` cwd, but content needs a blob extractor |
| OpenCode | `storage/{project,session,message,part}/` | multi-file object store | `project.json.worktree`, but needs multi-file reassembly |

Codex fits the existing NDJSON normalizer with **zero new parsing** and gives cwd→session attribution that can't misattribute — exactly the *"uploading the wrong bytes is worse than uploading nothing"* bar the ticket sets. It also matches the reserved `AgentLogFormat.logDir` case, whose doc already named Codex.

## How

**New mechanism — cwd attribution for globally-stored harnesses:**
- `AgentLogSource` gains a `cwdFilter`. A source can declare "scan this whole tree, but keep only files whose *recorded* cwd matches this worktree."
- `AgentLogCwdReader` reads the cwd from a log head cheaply (top-level for Claude, nested `payload.cwd` for Codex), stopping at the first hit so it doesn't scan whole multi-KB rollouts.
- `LogSyncCollector.resolveFiles` applies the filter. A file with **no readable cwd is dropped, never guessed.**
- `OpenAICodexAgent.logSources` returns a recursive, cwd-filtered `.logDir` source over `~/.codex/sessions`.

**Backfill:**
- `BackfillScanner` now reconciles Claude projects **and** Codex rollouts, sharing one `assemble` step (workspace/repo/ticket derivation is pure cwd math, already harness-agnostic).
- `BackfillSession` carries its `harness`; `BackfillService` keys the ledger, upload, format (`.logDir`) and `agentKind` off it — so a Claude and a Codex session with the same UID never collide.

**Unwired harnesses** keep the `[]` default, each with a one-line note of the *real* blocker: Cursor (SQLite blob store), OpenCode (multi-file object store), Antigravity/Muse (no confirmed durable, cwd-attributable log).

## Acceptance

- [x] One additional harness (Codex) wired end-to-end: live collector + backfill
- [x] cwd→session attribution that can't misattribute (exact `cwd` match; no-cwd files dropped)
- [x] Unwired harnesses keep `[]` + a one-line "why" comment
- [x] Docs updated (session-log-collector, session-backfill, cli-reference, cli, CLAUDE.md): "Claude only" → "Claude + Codex"

## Testing

`swift test` green across the three packages (CrowCore 764, CrowCodex 92, CrowDaemon backfill+collector suites). New tests cover Codex head parsing, `AgentLogCwdReader`, the cwd-filter (incl. dropping unattributable files), Codex backfill reconstruction, and harness-scoped ledger keying. Root `swift build` (`crow` + `crowd`) links clean.

> [!NOTE]
> Cursor and OpenCode remain unwired by design — each needs a normalizer for its on-disk shape (SQLite blob extraction / multi-file assembly), which is follow-up work now documented at the adapter and in `docs/session-log-collector.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
