### PR TITLE
Fit the pane on in-place agent session switch (CROW-1091)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -6519,6 +6519,22 @@ function switchAgentWindow(win) {
   applySurfaceScrollback();
   resetScrollbackSync();
   selectWindow(win, { replay: false });
+  // CROW-1091: run the SAME sizing step the reload/connect attach runs, which
+  // this in-place path had skipped. `reloadTerminal`/onopen call `applyTermFit()`
+  // on attach — and `fitAddon.fit()` re-syncs xterm's scroll area, which is what
+  // gives the history scrollbar its geometry — so a shell switch already resized
+  // itself. The agent in-place switch (CROW-1035) did neither, so a switched-in
+  // surface kept the previous window's grid geometry and its scrollbar sizing
+  // until a manual reload re-ran the fit — the reported "no scroll bar until
+  // refresh." Fit here too (deferred a frame via fitTerminal so it measures the
+  // pane at its settled post-switch layout — the tab bar / header height differs
+  // between session kinds), and re-check the pinned-visible class right away so it
+  // reflects the switched-in buffer instead of the previous window's. No replay
+  // and no new PTY, so this stays clear of the CROW-1035 caret jump and CROW-1048
+  // chrome stacking a full reload would reintroduce; a same-size switch fits to
+  // identical cols/rows, so applyTermFit sends no SIGWINCH (#637).
+  fitTerminal();
+  updateTerminalScrollbar();
   // Do not arm CROW-1027 here. In-place switch has no new PTY and no
   // SIGWINCH, so the mid-reflow one-screen capture that heal exists for
   // cannot happen. A second select-window 250ms later (the fake-xterm

--- a/Packages/CrowDaemon/web-tests/session-switch-attach.test.js
+++ b/Packages/CrowDaemon/web-tests/session-switch-attach.test.js
@@ -22,6 +22,9 @@ const epilogue = `
   set term(v){ term = v; },
   set activeTerminal(v){ activeTerminal = v; },
   get activeTerminal(){ return activeTerminal; },
+  updateTerminalScrollbar(){ return updateTerminalScrollbar(); },
+  get fitScheduled(){ return fitScheduled; },
+  set fitScheduled(v){ fitScheduled = v; },
   SCROLLBACK_HEAL_MS,
   SCROLLBACK_HEAL_MAX,
   TERM_BUFFER_CLEAR,
@@ -192,6 +195,39 @@ console.log('\nno open socket: attachWindow only records the window (onopen will
   T.attachWindow(claude.window);
   check('records attachedWindow', T.attachedWindow === claude.window);
   check('does not throw without a socket', true);
+}
+
+// CROW-1091: the in-place agent switch (above) never ran the sizing step the
+// reload/connect attach runs. `reloadTerminal`/onopen call `applyTermFit()`, and
+// `fitAddon.fit()` re-syncs xterm's scroll area — the history scrollbar's
+// geometry — so a shell switch resized itself; the agent in-place path did not,
+// so a switched-in surface kept the previous window's grid geometry and stale
+// scrollbar sizing until a manual reload. So the switch must now schedule a fit
+// (`fitTerminal`, deferred a frame for the settled layout) and re-check the
+// pinned-visible class — WITHOUT reintroducing the replay it deliberately skips.
+const wrap = window.document.getElementById('terminal-wrap');
+console.log('\nCROW-1091: an in-place agent switch runs the same sizing step as a reload:');
+{
+  const sock = mount(cursor);
+  T.fitScheduled = false;
+  wrap.classList.remove('has-scrollback');
+  T.term.buffer.active.baseY = 42; // history present on the switched-in surface
+  T.attachWindow(cursor.window);
+  check('the switch schedules a fit (parity with the reload attach)', T.fitScheduled === true);
+  check('the history scrollbar is evaluated on switch, not left to a manual refresh',
+    wrap.classList.contains('has-scrollback'));
+  check('and it still skips the replay (no CROW-1035/1048 regression)',
+    selectWindowPayloads(sock)[0].replay === false);
+}
+
+console.log('\nCROW-1091: switching in a surface with no history leaves no stale bar:');
+{
+  const sock = mount(claude);
+  wrap.classList.add('has-scrollback'); // as if left on by the previous window
+  T.term.buffer.active.baseY = 0;       // alt-buffer agent: nothing to scroll
+  T.attachWindow(claude.window);
+  check('the stale scrollbar class is cleared on switch', !wrap.classList.contains('has-scrollback'));
+  check('still an in-place select-window', selectWindowCount(sock) === 1);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #1091

## Problem

Switching between coding sessions left the terminal with **no working scroll bar** until a manual reload — after which it appeared and scrolled normally.

## Root cause

CROW-1035 (#1036/#1051) moved agent session/tab switches off the full terminal reload onto an **in-place** `switchAgentWindow` (select-window with `replay:false`, no new PTY) to stop the caret jump (Claude) and footer-chrome stacking (Cursor).

But the reload/connect attach path also runs `applyTermFit()` on attach — and `fitAddon.fit()` re-syncs xterm's scroll area, which is exactly what gives the history scrollbar its geometry. The in-place switch ran **no fit at all**, so a switched-in agent surface kept the *previous* window's grid geometry and stale scrollbar sizing until a manual reload re-ran the fit. That matches the ticket's own hypothesis: the switch path and the refresh path weren't running the same sizing step.

## Fix

`switchAgentWindow` now runs the same sizing step the reload path runs, after the in-place `select-window`:

- **`fitTerminal()`** — deferred a frame (rAF), so it measures the pane at its *settled* post-switch layout (the tab-bar / header height differs between session kinds).
- **`updateTerminalScrollbar()`** — immediate, so the pinned-visible class reflects the switched-in buffer instead of the previous window's (clears a stale bar right away).

No replay and no new PTY, so this stays clear of the CROW-1035 caret jump and CROW-1048 chrome stacking a full reload would reintroduce. A same-size switch fits to identical cols/rows, so `applyTermFit` sends no SIGWINCH (#637); a genuine size change sends the one SIGWINCH it always needed.

## "Verified in all three front-ends"

The session-switch path **and** the pinned history scrollbar (CROW-1020) live only in `app.js`. The other two front-ends are single-terminal surfaces with neither, so the gap is structurally unreachable there — both confirmed:

- `web/terminal.html` — standalone debug page, no session switch, no `.has-scrollback`; already fits on `resize` and on WS open (`sendResize`).
- `CrowTerminal/…/terminal.html` — the retired macOS WKWebView surface (`crowInput`/`crowWrite` bridge, no WebSocket, no `select-window`); per app.js's own note it is "no longer a front-end to stay in sync with."

## Test plan

- Extends `session-switch-attach.test.js`: an in-place agent switch now (a) schedules a fit — parity with the reload attach, (b) evaluates the history scrollbar on switch rather than leaving it to a manual refresh, (c) still skips the replay (no CROW-1035/1048 regression), and (d) clears a stale bar when the switched-in surface has no history.
- `npm run test:ci` in `Packages/CrowDaemon/web-tests` — all suites green (terminal-scrollbar, terminal-reload, session-switch-attach included).
- Manual (ticket test plan): switch into a session with scrollback → the correctly-sized, working scroll bar shows immediately, no manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)