### PR TITLE
Persist verified harness transcript locations as a docs reference (CROW-1090)

### DIFF
--- a/docs/harness-transcript-locations.md
+++ b/docs/harness-transcript-locations.md
@@ -1,0 +1,199 @@
+# Harness transcript locations (CROW-1090)
+
+Field reference: **where each coding-agent harness writes a durable session
+transcript on disk**, and whether that transcript can be attributed to a Crow
+worktree without opening every file. This is the input the session-log collector
+([CROW-1056](https://github.com/corveil/crow/issues/1056),
+[session-log-collector.md](session-log-collector.md)) and the historical backfill
+([CROW-1075](https://github.com/corveil/crow/issues/1075),
+[session-backfill.md](session-backfill.md)) need before a harness can be wired.
+
+It exists so the verified locations captured while scoping
+[CROW-1089](https://github.com/corveil/crow/issues/1089) outlive that issue and
+land in front of whoever picks up the per-harness fan-out
+(**[#1095](https://github.com/corveil/crow/issues/1095)** Cursor ·
+**[#1096](https://github.com/corveil/crow/issues/1096)** OpenCode ·
+**[#1097](https://github.com/corveil/crow/issues/1097)** Antigravity ·
+**[#1098](https://github.com/corveil/crow/issues/1098)** Grok Build ·
+**[#1099](https://github.com/corveil/crow/issues/1099)** Muse Code) — so nobody
+re-discovers a path already found.
+
+## The wiring test
+
+The collector's `CodingAgent.logSources(worktreePath:harnessSessionID:)` hook
+returns `[AgentLogSource]`; the protocol default is `[]`. A harness is **cheap to
+wire iff a worktree path maps to its transcript files without reading every
+file's contents** — anything less risks uploading a transcript attributed to the
+wrong session, which is worse than uploading nothing (the reason the default is
+opt-in). Two attribution modes exist today:
+
+- **Path-partitioned** — the store's directory layout already encodes the working
+  directory, so a worktree path resolves straight to its transcripts with a
+  string transform. Claude Code is the reference (slug = worktree path, every
+  non-alphanumeric → `-`). `cwdFilter` is `nil`.
+- **Content-filtered** — the store pools transcripts globally, so the collector
+  scans the tree and keeps only files whose *recorded* `cwd` equals the worktree
+  (`AgentLogSource.cwdFilter` + `AgentLogCwdReader`). A file with no readable cwd
+  is dropped, never guessed. Codex is the reference.
+
+A store that is neither (no per-worktree layout **and** no recoverable cwd inside
+each transcript) cannot be attributed and stays on the `[]` default.
+
+## Reference table
+
+Every harness Crow registers, plus the non-harness tools investigated under
+CROW-1090. "cwd-attributable?" is the wiring test above.
+
+| Harness / tool | Binary | Crow-launched? | Store path | Transcript file | Format | cwd-attributable? | Status · ticket |
+|---|---|---|---|---|---|---|---|
+| Claude Code | `claude` | ✅ | `~/.claude/projects/<slug>/` (slug = worktree path, non-alnum → `-`) | `<uuid>.jsonl` | NDJSON | ✅ path-partitioned | **Wired** (CROW-1089) |
+| Codex | `codex` | ✅ | `~/.codex/sessions/<YYYY>/<MM>/<DD>/` | `rollout-<ts>-<uuid>.jsonl` | NDJSON | ✅ content-filtered (`session_meta.payload.cwd`) | **Wired** (CROW-1092) |
+| Cursor | `cursor-agent` | ✅ | `~/.cursor/chats/<id>/<sub>/` | `store.db` (+ sibling `meta.json`) | SQLite (opaque blobs) | ✅ cwd in `meta.json` | Deferred — needs blob extractor · [#1095](https://github.com/corveil/crow/issues/1095) |
+| OpenCode | `opencode` | ✅ | `~/.local/share/opencode/storage/{project,session,message,part}/` | scattered `message`/`part` records | multi-file object store | ✅ cwd in `project/<id>.json.worktree` | Deferred — needs reassembler · [#1096](https://github.com/corveil/crow/issues/1096) |
+| Grok Build | `grok` | ✅ | `~/.grok/sessions/<urlencoded-abs-cwd>/<uuid>/` | `chat_history.jsonl` | NDJSON | ✅ path-partitioned (URL-encoded cwd) | **Lead found** — verify identity, then wire · [#1098](https://github.com/corveil/crow/issues/1098) |
+| Antigravity | `agy` | ✅ | unknown | — | — | ❓ unconfirmed | Research-first · [#1097](https://github.com/corveil/crow/issues/1097) |
+| Muse Code | `muse` | ✅ | unknown | — | — | ❓ unconfirmed | Research-first · [#1099](https://github.com/corveil/crow/issues/1099) |
+| Cowork (Claude desktop, local-agent mode) | — (desktop app) | ❌ | `~/Library/Application Support/Claude/local-agent-mode-sessions/<acct>/<install>/local_<uuid>/` | `audit.jsonl` | NDJSON | ⚠️ cwd inside JSON, no path shortcut | Out of harness scope — see below |
+| Grok Bot | — (Electron app) | ❌ | `~/Library/Application Support/Grok Bot/` | — (leveldb / server-side) | — | ❌ no durable local transcript | No collectable log — skip |
+
+Wired-harness details live in
+[session-log-collector.md](session-log-collector.md#harness-coverage); the rows
+above summarize them for one-glance comparison. Cursor/OpenCode paths are from
+their fan-out tickets ([#1095](https://github.com/corveil/crow/issues/1095) /
+[#1096](https://github.com/corveil/crow/issues/1096)). The remaining rows are the
+CROW-1090 field findings, detailed next.
+
+## Field findings (CROW-1090)
+
+Captured live on **2026-08-21** (macOS, a single dev machine — the URL-encoded
+Grok paths were rooted at `/Users/danny/…`) and **re-verified 2026-08-24** on a
+second machine. Drift from the re-verification is called out per entry.
+
+### 1. Grok Build (`grok`) — path-partitioned, low-friction, wire first
+
+- **Store:** `~/.grok/sessions/<url-encoded-absolute-cwd>/`
+  - The directory name is the absolute worktree path URL-encoded — `/` → `%2F`
+    (e.g. `%2FUsers%2Fdanny%2FProjects%2Fdevroot%2Fcorveil%2Fshell-crm-359-…`).
+    This is a **different** encoding from Claude's `-` slug and from Codex's
+    read-the-recorded-cwd, so wiring needs a small URL-encode path helper rather
+    than reusing `AgentLogSource.posixPathSlug`.
+  - `prompt_history.jsonl` at the cwd level.
+  - `<session-uuid>/chat_history.jsonl` — the transcript. Verified 148 lines /
+    382 KB; roles `tool_result` / `reasoning` / `assistant` / `user` / `system`;
+    system prompt begins *"You are Grok 4.6 released by xAI…"*.
+  - siblings: `events.jsonl`, `hunk_records.jsonl`, `prompt_context.json`.
+  - global/index: `~/.grok/logs/unified.jsonl`, `~/.grok/sessions/session_search.sqlite`.
+  - **62** `chat_history.jsonl` files across worktrees on the capture machine.
+- **Attribution:** direct (path-partitioned). `logSources` would URL-encode the
+  worktree path and point at `~/.grok/sessions/<enc>/*/chat_history.jsonl`.
+  Already NDJSON → `AgentLogFormat.jsonl`, **no transform** — the single easiest
+  non-Claude harness to add.
+- ⚠️ **Identity caveat — confirm before wiring.** `~/.grok/` is grok-build's own
+  config home (Crow already treats `~/.grok/bin/agent` and
+  `~/.grok/trusted_folders.toml` as grok-build's — see
+  [agent-harness-matrix.md](agent-harness-matrix.md)), so `~/.grok/sessions/` is
+  almost certainly grok-build's store. But the `grok` binary **collides** with
+  the community `superagent-ai/grok-cli`, which also installs `grok`
+  (`GrokAgent.verifyBinaryIdentity`, CROW-911). #1098's spike must confirm the
+  store is written by xAI's grok-build — not the community CLI — before wiring, so
+  the collector never uploads a foreign tool's transcript under the `grok`
+  harness.
+- ⚠️ **Not re-verified on the second machine (2026-08-24):** grok-build is not
+  installed there, so `~/.grok/` is absent. The layout above stands on the
+  2026-08-21 capture only; #1098 re-confirms it live.
+- **Adapter state:** `logSources` intentionally not overridden —
+  `Packages/CrowGrok/Sources/CrowGrok/GrokAgent.swift` (the recorded note). This
+  finding is the lead that retires that note once #1098 verifies it.
+
+### 2. Cowork (Claude desktop app, local-agent mode) — real transcripts, ⚠️ not cwd-partitioned
+
+- **Store:** `~/Library/Application Support/Claude/local-agent-mode-sessions/<accountId>/<installId>/`
+  - `local_<uuid>.json` — session record (metadata; its `cwd` field points at the
+    session's *own* `outputs` dir; the user's real project is in
+    `userSelectedFolders`).
+  - `local_<uuid>/audit.jsonl` — the durable transcript. Verified 134 events /
+    201 KB on the capture machine; event types `system` / `assistant` / `user` /
+    `result` / `command_lifecycle` / `rate_limit_event`; real message text.
+  - `local_<uuid>/` also holds `.claude/`, `outputs/`, `uploads/`.
+  - secondary: `~/Library/Application Support/Claude/claude-code-sessions/<accountId>/<installId>/local_<uuid>.json`.
+- **Attribution:** ⚠️ **not** path-partitioned. Recovering the real project means
+  reading each `local_<uuid>.json`'s `userSelectedFolders` and matching a
+  worktree — there is no path-slug shortcut. The `audit.jsonl` format is
+  Claude-Code-shaped NDJSON, so the normalizer is reusable; only discovery is
+  harder.
+- ✅ **Re-verified 2026-08-24** on the second machine: the store exists with
+  **74** `local_*` entries (vs ~1,180 on the capture machine); the
+  `<accountId>/<installId>/local_<uuid>/{audit.jsonl,.claude/,outputs/,.audit-key}`
+  layout is exactly as documented.
+- **Scope:** Cowork is **not a Crow-launched harness** — see
+  [scope question](#scope-question).
+
+### 3. Grok Bot (Electron desktop app) — ❌ nothing collectable locally
+
+- **Store:** `~/Library/Application Support/Grok Bot/` — a Chromium/Electron
+  profile (`Local Storage/leveldb`, `blob_storage`, `Cache`, `Code Cache`,
+  `Cookies`, `Crashpad`, `Partitions/…`). The `sand-*` naming + statsig bootstrap
+  indicate a sandboxed web wrapper around grok.com; conversations are
+  **server-side**.
+- `~/.grokbot/` holds only local-exec-daemon connection/credential state, not
+  transcripts.
+- **Attribution:** N/A — there is no durable local transcript. Leave on the `[]`
+  default; do not point the collector here.
+- ✅ **Re-verified 2026-08-24** on the second machine: the Electron profile is
+  present with exactly the Chromium wrapper shape above, and `~/.grokbot/` carries
+  only daemon connection/credential/log files — no transcript. (Credential files
+  were not read.)
+
+## Scope question
+
+Two of the three field findings — **Cowork** and **Grok Bot** — are **not
+harnesses Crow launches**. Wiring them would mean the collector uploads
+transcripts from tools Crow does not drive. Before either is wired, decide the
+collector's scope:
+
+- **"Harnesses Crow launches"** (the current implicit scope) → Cowork and Grok
+  Bot stay out; only the seven registered `CodingAgent`s are candidates.
+- **"Any coding-agent transcript on the box"** → Cowork becomes wireable (its
+  `audit.jsonl` is real and reusable), pending the harder `userSelectedFolders`
+  discovery; Grok Bot remains impossible (no durable local log regardless).
+
+This doc records the locations either way; the scope call is a product decision,
+not blocked on discovery.
+
+## Per-ticket disposition
+
+- **[#1098](https://github.com/corveil/crow/issues/1098) (Grok Build)** — the
+  `~/.grok/sessions/<urlenc-cwd>/<uuid>/chat_history.jsonl` lead above is the path
+  its spike went looking for. Confirm binary identity (grok-build, not the
+  colliding community `grok-cli`) and re-confirm the layout on a machine with
+  grok-build installed, then wire it as a path-partitioned `.jsonl` source with a
+  URL-encode path helper. No new normalizer needed.
+- **[#1095](https://github.com/corveil/crow/issues/1095) (Cursor)** /
+  **[#1096](https://github.com/corveil/crow/issues/1096) (OpenCode)** — storage
+  already known (table above); these are "build the normalizer" tickets, not
+  research.
+- **[#1097](https://github.com/corveil/crow/issues/1097) (Antigravity)** /
+  **[#1099](https://github.com/corveil/crow/issues/1099) (Muse Code)** — still
+  genuinely unknown; CROW-1090 found no location for either. Research-first, as
+  their tickets say.
+
+## Caveats
+
+- All paths verified on macOS (darwin). Re-confirm on other machines and after a
+  Grok CLI / Cowork version bump before relying on the exact layout.
+- On-disk **formats** are not guaranteed schema-stable across versions; the
+  `AgentLogFormat.jsonl` normalizer should tolerate unknown event types.
+- The second-machine re-verification (2026-08-24) could confirm Cowork and Grok
+  Bot but **not** Grok Build (not installed there). The Grok Build layout rests on
+  the 2026-08-21 capture until #1098 re-confirms it live.
+
+## See also
+
+- [session-log-collector.md](session-log-collector.md) — the live collector
+  (CROW-1056) and its harness-coverage table.
+- [session-backfill.md](session-backfill.md) — the historical backfill
+  (CROW-1075).
+- [agent-harness-matrix.md](agent-harness-matrix.md) — what each harness can do,
+  and the `grok`/`agent`/`muse` binary-collision handling.
+- ADR [0014](adr/0014-pluggable-coding-agent-adapter.md) (adapter architecture) ·
+  [0015](adr/0015-harness-capability-tiers.md) (capability tiers).

--- a/docs/session-backfill.md
+++ b/docs/session-backfill.md
@@ -108,6 +108,8 @@ unbounded.
   reconstructs it the same way. Both make historical reconstruction reliable
   because every transcript records the authoritative `cwd`/`gitBranch`, not a
   lossy directory name. Other harnesses follow as their `logSources` land (see
-  [session-log-collector.md](session-log-collector.md)).
+  [session-log-collector.md](session-log-collector.md), and
+  [harness-transcript-locations.md](harness-transcript-locations.md) for the
+  verified per-harness on-disk locations).
 - Cursor (SQLite blob store) and OpenCode (multi-file object store) need a
   normalizer for their on-disk shapes before their transcripts can be backfilled.

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -38,7 +38,8 @@ the collector keeps only the rollouts whose recorded `cwd` matches the worktree
 | `codex` | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl` (already NDJSON; cwd in the first-line `session_meta.payload.cwd`) | **Wired.** Recursive `.logDir` source with a `cwdFilter`; the collector keeps only cwd-matching rollouts and concatenates them (`~/.codex/archived_sessions` and `.../log` are not scanned). |
 | `opencode` | `~/.local/share/opencode/storage/{project,session,message,part}` | Deferred — a `project/<id>.json`'s `worktree` maps to the cwd, but a session's `message`/`part` records must be reassembled into ordered NDJSON first. |
 | `cursor` | `~/.cursor/chats/<id>/<sub>/store.db` (CLI store; cwd in the sibling `meta.json`) | Deferred — the conversation is opaque blobs in a per-chat **SQLite** `store.db`; needs a blob extractor (a `.sqlite` normalizer). Not the Cursor IDE's `state.vscdb`. |
-| `grok`, `antigravity`, `muse` | app state / TBD | Deferred — no confirmed durable, cwd-attributable log location. |
+| `grok` | `~/.grok/sessions/<urlencoded-abs-cwd>/<uuid>/chat_history.jsonl` (NDJSON, path-partitioned) | Deferred — a **lead**, not yet wired (CROW-1090). Already NDJSON needing no transform, but the `grok` binary collides with the community `grok-cli`, so [#1098](https://github.com/corveil/crow/issues/1098) must confirm the store is xAI's grok-build's before wiring. See [harness-transcript-locations.md](harness-transcript-locations.md). |
+| `antigravity`, `muse` | app state / TBD | Deferred — no confirmed durable, cwd-attributable log location (CROW-1097 / CROW-1099). |
 
 The framework (collector, normalizer, uploader, ledger, config, CLI) is
 harness-general; wiring a deferred harness is implementing its `logSources`
@@ -177,6 +178,10 @@ nor change.
 
 ## See also
 
+- [harness-transcript-locations.md](harness-transcript-locations.md) — the
+  verified **on-disk transcript location** per harness (CROW-1090): the input this
+  collector's `logSources` overrides are built from, including the leads and
+  open questions feeding the CROW-1089 fan-out (#1095–#1099).
 - [session-backfill.md](session-backfill.md) — the **historical** backfill
   ([CROW-1075](https://github.com/corveil/crow/issues/1075)): a user-initiated
   reconciliation of the on-disk transcripts this session-centric collector never


### PR DESCRIPTION
## What

CROW-1090 was a **reference / field-notes** ticket: verified on-disk transcript
locations for harnesses the session-log collector (CROW-1056) might one day sense.
Its value — the paths — lived only in the issue. This persists them into the repo
so they outlive the issue and land in front of the CROW-1089 fan-out
(#1095–#1099).

Docs-only. No sensor wiring here — that's deferred to the per-harness tickets, per
the ticket's own instruction not to duplicate #1098.

## Changes

- **New `docs/harness-transcript-locations.md`** — the verified store path,
  transcript file, format, and cwd-attributability for every registered harness
  plus the three tools investigated under CROW-1090 (Grok Build, Cowork, Grok
  Bot). Includes the wiring test, the collector-scope question (Cowork and Grok
  Bot are **not** Crow-launched harnesses), and a per-fan-out-ticket disposition.
- **`docs/session-log-collector.md`** — split `grok` out of the deferred coverage
  row to record the discovered lead; added the new doc to *See also*.
- **`docs/session-backfill.md`** — cross-link to the new doc.

## Key findings

- **Grok Build** — `~/.grok/sessions/<urlencoded-abs-cwd>/<uuid>/chat_history.jsonl`
  (NDJSON, **path-partitioned** by URL-encoded cwd). This is the lead #1098's spike
  went looking for. Recorded **with an identity caveat**: the `grok` binary
  collides with the community `superagent-ai/grok-cli`, so #1098 must confirm the
  store belongs to xAI's grok-build before wiring.
- **Cowork** (Claude desktop, local-agent mode) — real `audit.jsonl` transcripts,
  but **not** cwd-partitioned (needs `userSelectedFolders` matching).
- **Grok Bot** — Electron web wrapper; **no durable local transcript**. Skip.

## Re-verification (2026-08-24, second machine)

- ✅ Cowork present (74 `local_*` entries; layout as documented).
- ✅ Grok Bot present (Electron profile shape; no transcript).
- ⚠️ Grok Build not installed on this machine, so its layout rests on the original
  2026-08-21 capture until #1098 re-confirms it live.

Closes #1090