### PR TITLE
Wire Cursor into the session-log collector + backfill (CROW-1095)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,11 +314,11 @@ crow logsync set [--retention-days N] [--quiet-period-minutes N] [--max-upload-b
 - **Opt a workspace in elsewhere**: `crow workspace edit --workspace NAME --upload-session-logs true` (or the checkbox) + a gateway via `crow gateway set`. There is no `crow logsync` flag that opts a workspace in — CROW-1070 dropped the global master switch, base URL, API key and `enabledWorkspaces` list.
 - **Security invariant**: the upload destination + credential come only from the workspace's **local-only** gateway (`{gateway.baseURL}/api/crow-sessions/{id}/artifacts` + `x-citadel-api-key`), never `--corveil-host` or any browser-writable field. A workspace with no gateway uploads nothing.
 - `set` is a PATCH (only the flags you pass change; at least one required). Live within ~1 collector tick (~5 min); no restart.
-- **Migration**: a legacy `crow logsync set --add-workspace` opt-in is carried over to `--upload-session-logs` on first boot (only when the old master switch was on). Claude Code, Codex, and Grok Build transcripts are collected today (CROW-1089, CROW-1098); other harnesses are wired as their log paths are confirmed.
+- **Migration**: a legacy `crow logsync set --add-workspace` opt-in is carried over to `--upload-session-logs` on first boot (only when the old master switch was on). Claude Code, Codex, Grok Build, and Cursor transcripts are collected today (CROW-1089 / CROW-1098 / CROW-1095); other harnesses are wired as their log paths are confirmed.
 
 ### Session Backfill
 
-The historical session backfill (CROW-1075) — reconcile the coding-session transcripts already on disk (predating the live path, or reaped from Crow's store) and upload the ones you choose as real, fully-linked Corveil session artifacts. Claude Code, Codex, and Grok Build for v1 (CROW-1089, CROW-1098).
+The historical session backfill (CROW-1075) — reconcile the coding-session transcripts already on disk (predating the live path, or reaped from Crow's store) and upload the ones you choose as real, fully-linked Corveil session artifacts. Claude Code, Codex, Grok Build, and Cursor for v1 (CROW-1089 / CROW-1098 / CROW-1095).
 
 ```
 crow backfill scan                                                      → {"sessions":[{uid,harness,workspace,repo_name,owner_repo,ticket_number,confidence,upload_status,...}],"summary":{total,uploaded,linkable,repo_only,orphan}}

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/BackfillCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/BackfillCommands.swift
@@ -8,10 +8,11 @@ import Foundation
 // fully-linked Corveil session artifacts, reconstructing the workspace / repo /
 // ticket a live run would have carried.
 //
-// Claude Code, Codex, and Grok Build in v1 (CROW-1089, CROW-1098): Claude and
-// Grok partition their logs by working directory (Grok URL-encodes the cwd into
-// its ~/.grok/sessions directory name), and Codex records the real cwd in each
-// ~/.codex/sessions rollout, so all three reconstruct reliably. The upload is
+// Claude Code, Codex, Grok Build, and Cursor in v1 (CROW-1089 / CROW-1098 /
+// CROW-1095): Claude and Grok partition their logs by working directory (Grok
+// URL-encodes the cwd into its ~/.grok/sessions directory name), Codex records the
+// real cwd in each ~/.codex/sessions rollout, and Cursor records it in the sibling
+// meta.json of each ~/.cursor/chats store, so all reconstruct reliably. The upload is
 // idempotent (a local ledger + the server's write-once 409), throttled, and
 // always user-initiated — never automatic or unbounded.
 
@@ -22,8 +23,9 @@ public struct Backfill: ParsableCommand {
         abstract: "Reconcile and upload historical on-disk session transcripts",
         discussion: """
         Scans the coding-session transcripts already on disk (Claude Code under \
-        ~/.claude/projects, Codex under ~/.codex/sessions, and Grok Build under \
-        ~/.grok/sessions), reconstructs each one's workspace, repo, and ticket/PR, \
+        ~/.claude/projects, Codex under ~/.codex/sessions, Grok Build under \
+        ~/.grok/sessions, and Cursor under ~/.cursor/chats), reconstructs each \
+        one's workspace, repo, and ticket/PR, \
         and uploads the ones you choose to Corveil as session artifacts — so a \
         backfilled session lands in the ontology indistinguishable from a \
         live-captured one.
@@ -82,7 +84,7 @@ public struct BackfillUpload: ParsableCommand {
 
     @Option(
         name: .customLong("session"),
-        help: "A session UID to upload (repeatable; Claude Code, Codex, or Grok Build — UIDs come from `crow backfill scan`). Mutually exclusive with --all/--all-high-confidence.")
+        help: "A session UID to upload (repeatable; Claude Code, Codex, Grok Build, or Cursor — UIDs come from `crow backfill scan`). Mutually exclusive with --all/--all-high-confidence.")
     var sessions: [String] = []
 
     @Flag(name: .customLong("all-high-confidence"), help: "Upload every not-yet-uploaded high-confidence session in this workspace")

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/LogsyncCommands.swift
@@ -25,9 +25,10 @@ public struct Logsync: ParsableCommand {
 
         These verbs tune only global behavior — ledger retention, the quiet period \
         before a transcript is captured, and the per-upload size cap. Uploads are \
-        best-effort and never block or fail a session. Claude Code, Codex, and Grok \
-        Build transcripts are collected today (CROW-1089, CROW-1098); other harnesses \
-        are wired as their on-disk log locations are confirmed.
+        best-effort and never block or fail a session. Claude Code, Codex, Grok \
+        Build, and Cursor transcripts are collected today (CROW-1089 / CROW-1098 / \
+        CROW-1095); other harnesses are wired as their on-disk log locations are \
+        confirmed.
         """,
         subcommands: [LogsyncGet.self, LogsyncSet.self]
     )

--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentLogSource.swift
@@ -10,10 +10,14 @@ public enum AgentLogFormat: String, Sendable, Codable, Equatable, CaseIterable {
     /// transformation before upload.
     case jsonl
     /// A SQLite database. The Cursor CLI (`cursor-agent`) stores each chat's
-    /// conversation as opaque blobs inside a per-chat `store.db`
-    /// (`~/.cursor/chats/<id>/<sub>/store.db`, tables `blobs`/`meta`). Requires
-    /// blob extraction before it becomes NDJSON — not yet wired (see
-    /// `CursorAgent`). Note this is the *CLI's* store, not the Cursor IDE's
+    /// conversation as content-addressed blobs inside a per-chat `store.db`
+    /// (`~/.cursor/chats/<id>/<sub>/store.db`, tables `blobs`/`meta`). **Wired**
+    /// (CROW-1095): `CursorStore` follows the `meta['0'].latestRootBlobId` root
+    /// blob's ordered message-blob refs and emits each message's JSON as one NDJSON
+    /// line; `TranscriptNormalizer` concatenates the resulting lines. The cwd for
+    /// attribution comes from the sibling `meta.json`, not the transcript, so the
+    /// collector reads it via `CursorStore.recordedCwd` rather than
+    /// `AgentLogCwdReader`. Note this is the *CLI's* store, not the Cursor IDE's
     /// `state.vscdb`.
     case sqlite
     /// A directory (or set) of per-session log files the collector concatenates

--- a/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/CodingAgent.swift
@@ -331,13 +331,14 @@ public protocol CodingAgent: Sendable {
     ///
     /// Opt-in: the protocol default returns `[]`, so a harness whose on-disk log
     /// location is unconfirmed contributes nothing rather than uploading the
-    /// wrong bytes. `ClaudeCodeAgent`, `OpenAICodexAgent`, and `GrokAgent` are
-    /// wired today (CROW-1089, CROW-1098): Claude and Grok partition their logs by
-    /// working directory (Grok by URL-encoding the cwd into the directory name),
-    /// and Codex's globally-stored rollouts carry a `cwdFilter` so the collector
-    /// attributes them by their recorded `cwd`. Cursor (SQLite blob store) and
-    /// OpenCode (multi-file object store) still return `[]` pending a normalizer
-    /// for their on-disk shapes; see each adapter for the specific blocker.
+    /// wrong bytes. `ClaudeCodeAgent`, `OpenAICodexAgent`, `GrokAgent`, and
+    /// `CursorAgent` are wired today (CROW-1089 / CROW-1098 / CROW-1095): Claude and
+    /// Grok partition their logs by working directory (Grok by URL-encoding the cwd
+    /// into the directory name), while Codex's and Cursor's globally-stored sessions
+    /// carry a `cwdFilter` so the collector attributes them by their recorded `cwd`
+    /// (Codex in the rollout head, Cursor in the sibling `meta.json`). OpenCode
+    /// (multi-file object store) still returns `[]` pending a normalizer for its
+    /// on-disk shape; see the adapter for the specific blocker.
     func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource]
 }
 
@@ -502,8 +503,9 @@ public extension CodingAgent {
     /// durable-log location is unconfirmed — or whose logs are not partitioned
     /// by working directory *and* have no cwd-attribution wired — contributes
     /// nothing until its adapter overrides this. `ClaudeCodeAgent` (per-worktree
-    /// slug directory), `OpenAICodexAgent` (cwd-filtered global rollouts), and
-    /// `GrokAgent` (per-worktree URL-encoded directory) override it today
-    /// (CROW-1089, CROW-1098).
+    /// slug directory), `OpenAICodexAgent` (cwd-filtered global rollouts),
+    /// `GrokAgent` (per-worktree URL-encoded directory), and `CursorAgent`
+    /// (cwd-filtered global `.sqlite` stores) override it today
+    /// (CROW-1089 / CROW-1098 / CROW-1095).
     func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] { [] }
 }

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
@@ -4,22 +4,26 @@ import Foundation
 /// been uploaded, reconstructing each one's workspace / repo / ticket so the
 /// Settings "Backfill history" dialog can show a reviewable list (CROW-1075).
 ///
-/// Three harnesses are wired: **Claude**, whose logs are partitioned by
-/// working directory (`~/.claude/projects/<slug>/<uuid>.jsonl`); **Codex**,
-/// whose rollouts pool globally under `~/.codex/sessions/<date>/…` but each record
-/// their own `cwd` in a first-line `session_meta` event (CROW-1089); and **Grok**,
-/// which partitions by working directory too, encoding the cwd into the directory
-/// name (`~/.grok/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl`, CROW-1098).
-/// All three make historical reconstruction reliable because the real `cwd` is
-/// recoverable — Claude/Codex record it in the transcript, Grok encodes it in the
-/// path — the authoritative signal, not a lossy directory name. The
-/// scan is disk- and git-only — it never touches the provider or the network, so
-/// it stays fast over hundreds of sessions; ticket *validation* is deferred to
-/// upload, where a link is actually asserted.
+/// Four harnesses are wired: **Claude** (CROW-1075), whose logs are partitioned
+/// by working directory (`~/.claude/projects/<slug>/<uuid>.jsonl`); **Codex**
+/// (CROW-1089), whose rollouts pool globally under `~/.codex/sessions/<date>/…`
+/// but each record their own `cwd` in a first-line `session_meta` event; **Grok**
+/// (CROW-1098), which partitions by working directory too, encoding the cwd into
+/// the directory name (`~/.grok/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl`);
+/// and **Cursor** (CROW-1095), whose per-chat `~/.cursor/chats/<id>/<sub>/store.db`
+/// records its `cwd` in the sibling `meta.json`. All make historical
+/// reconstruction reliable because the real `cwd` is recoverable — Claude/Codex
+/// record it in the transcript, Grok encodes it in the path, Cursor in a sibling
+/// file — the authoritative signal, not a lossy directory name. The scan is disk-
+/// and git-only — it never touches the provider or the network, so it stays fast
+/// over hundreds of sessions (it never opens a `store.db`; the Cursor uid is the
+/// `<sub>` directory name and the cwd a tiny sibling JSON read); ticket
+/// *validation* is deferred to upload, where a link is actually asserted.
 ///
 /// Everything effectful is injected (the projects directory, the Codex sessions
-/// directory, the git-remote reader, the clock), so the reconciliation logic is
-/// unit-testable against a temporary tree.
+/// directory, the Grok sessions directory, the Cursor chats directory, the
+/// git-remote reader, the clock), so the reconciliation logic is unit-testable
+/// against a temporary tree.
 public struct BackfillScanner: Sendable {
     let devRoot: String
     /// `~/.claude/projects` by default — where Claude writes per-project slug
@@ -37,6 +41,12 @@ public struct BackfillScanner: Sendable {
     /// CrowCore can't import); this literal default is the fallback for a direct
     /// caller.
     let grokSessionsDir: URL
+    /// `~/.cursor/chats` by default — where the `cursor-agent` CLI writes each
+    /// chat's `<chatId>/<subId>/store.db` + sibling `meta.json` (CROW-1095). The
+    /// daemon injects the `$CURSOR_CONFIG_DIR`-resolved tree (via `CursorHome`,
+    /// which CrowCore can't import); this literal default is the fallback for a
+    /// direct caller.
+    let cursorChatsDir: URL
     /// Resolve a directory's `origin` remote URL (default: `git -C <dir> remote
     /// get-url origin`). Injected so tests need no real repos.
     let gitRemote: @Sendable (String) async -> String?
@@ -47,6 +57,7 @@ public struct BackfillScanner: Sendable {
         projectsDir: URL? = nil,
         codexSessionsDir: URL? = nil,
         grokSessionsDir: URL? = nil,
+        cursorChatsDir: URL? = nil,
         runner: any ShellRunner = ProcessShellRunner(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -57,6 +68,8 @@ public struct BackfillScanner: Sendable {
             .appendingPathComponent(".codex/sessions", isDirectory: true)
         self.grokSessionsDir = grokSessionsDir ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".grok/sessions", isDirectory: true)
+        self.cursorChatsDir = cursorChatsDir ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cursor/chats", isDirectory: true)
         self.gitRemote = { dir in
             (try? await runner.run(args: ["git", "-C", dir, "remote", "get-url", "origin"],
                                    env: [:], cwd: nil))?
@@ -66,15 +79,16 @@ public struct BackfillScanner: Sendable {
     }
 
     /// Test seam: inject the git-remote reader directly. `codexSessionsDir` /
-    /// `grokSessionsDir` default to nonexistent paths so a test that only stages
-    /// Claude transcripts stays hermetic (it never accidentally scans a dev
-    /// machine's real `~/.codex/sessions` or `~/.grok/sessions`); a Codex or Grok
-    /// test passes an explicit temp dir.
+    /// `grokSessionsDir` / `cursorChatsDir` default to nonexistent paths so a test
+    /// that only stages Claude transcripts stays hermetic (it never accidentally
+    /// scans a dev machine's real `~/.codex/sessions`, `~/.grok/sessions`, or
+    /// `~/.cursor/chats`); a Codex/Grok/Cursor test passes an explicit temp dir.
     init(
         devRoot: String,
         projectsDir: URL,
         codexSessionsDir: URL? = nil,
         grokSessionsDir: URL? = nil,
+        cursorChatsDir: URL? = nil,
         gitRemote: @escaping @Sendable (String) async -> String?,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -84,12 +98,14 @@ public struct BackfillScanner: Sendable {
             ?? projectsDir.appendingPathComponent("__no_codex_sessions__", isDirectory: true)
         self.grokSessionsDir = grokSessionsDir
             ?? projectsDir.appendingPathComponent("__no_grok_sessions__", isDirectory: true)
+        self.cursorChatsDir = cursorChatsDir
+            ?? projectsDir.appendingPathComponent("__no_cursor_chats__", isDirectory: true)
         self.gitRemote = gitRemote
         self.now = now
     }
 
-    /// Reconcile every on-disk transcript (Claude + Codex + Grok) against the
-    /// ledger and return the reconstructed rows, newest first.
+    /// Reconcile every on-disk transcript (Claude + Codex + Grok + Cursor) against
+    /// the ledger and return the reconstructed rows, newest first.
     public func scan(ledger: LogSyncLedger) async -> [BackfillSession] {
         let remotes = await resolveRemotes()
         let knownRepoNames = Array(Set(remotes.values.map { $0.repo }))
@@ -111,6 +127,13 @@ public struct BackfillScanner: Sendable {
         }
         for file in grokChatHistoryFiles() {
             guard let s = reconstructGrok(
+                file: file, remotesByRepo: remotes,
+                knownRepoNames: knownRepoNames, ledger: ledger)
+            else { continue }
+            sessions.append(s)
+        }
+        for file in cursorStoreFiles() {
+            guard let s = reconstructCursor(
                 file: file, remotesByRepo: remotes,
                 knownRepoNames: knownRepoNames, ledger: ledger)
             else { continue }
@@ -176,6 +199,25 @@ public struct BackfillScanner: Sendable {
         return assemble(
             uid: uid, file: file, slug: encodedCwd, harness: .grok,
             cwd: cwd, gitBranch: nil,
+            remotesByRepo: remotesByRepo, knownRepoNames: knownRepoNames, ledger: ledger)
+    }
+
+    /// Reconstruct one Cursor chat from its `store.db`. The scan never opens the
+    /// database: the uid is the `<subId>` directory name (== `meta['0'].agentId`,
+    /// verified) and the cwd is read from the tiny sibling `meta.json`
+    /// (`CursorStore.recordedCwd`) — keeping the scan disk-only and fast even over
+    /// hundreds of chats. Cursor records no git branch, so `gitBranch` stays `nil`;
+    /// the message extraction is deferred to upload. A chat with no recoverable cwd
+    /// is dropped, never guessed (CROW-1095).
+    func reconstructCursor(
+        file: URL, remotesByRepo: [String: RepoRemote],
+        knownRepoNames: [String], ledger: LogSyncLedger
+    ) -> BackfillSession? {
+        let subID = file.deletingLastPathComponent().lastPathComponent
+        guard !subID.isEmpty else { return nil }
+        return assemble(
+            uid: subID, file: file, slug: subID, harness: .cursor,
+            cwd: CursorStore.recordedCwd(forStoreDB: file), gitBranch: nil,
             remotesByRepo: remotesByRepo, knownRepoNames: knownRepoNames, ledger: ledger)
     }
 
@@ -305,6 +347,23 @@ public struct BackfillScanner: Sendable {
         var out: [URL] = []
         for case let url as URL in en where url.pathExtension == "jsonl"
             && url.lastPathComponent.hasPrefix("chat_history") {
+            if (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
+                out.append(url)
+            }
+        }
+        return out
+    }
+
+    /// Every `store.db` under `~/.cursor/chats` (recursively across the
+    /// `<chatId>/<subId>/` tree). The sibling `store.db-wal` / `store.db-shm` /
+    /// `meta.json` / `prompt_history.json` are excluded by the exact `store.db`
+    /// filename, so only the one database per chat is enumerated.
+    func cursorStoreFiles() -> [URL] {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: cursorChatsDir, includingPropertiesForKeys: [.isRegularFileKey]) else { return [] }
+        var out: [URL] = []
+        for case let url as URL in en where url.lastPathComponent == "store.db" {
             if (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
                 out.append(url)
             }

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/CursorStore.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/CursorStore.swift
@@ -1,0 +1,235 @@
+import Foundation
+#if canImport(SQLite3)
+import SQLite3
+#endif
+
+/// Reads the Cursor CLI's per-chat store — `~/.cursor/chats/<chatId>/<subId>/
+/// store.db` plus its sibling `meta.json` — into the two shapes the collector and
+/// the backfill need (CROW-1095):
+///  - the **ordered conversation** as NDJSON message lines, and
+///  - the **recorded cwd** used to attribute a globally-stored chat to a worktree.
+///
+/// On-disk shape (reverse-engineered against `cursor-agent 2026.08.04`):
+///  - `store.db` is a SQLite database with two tables — `blobs(id TEXT PRIMARY
+///    KEY, data BLOB)` and `meta(key TEXT PRIMARY KEY, value TEXT)`. Blobs are
+///    **content-addressed** (`id == sha256(data)`).
+///  - `meta['0']` is a hex-encoded JSON object carrying `latestRootBlobId` (the
+///    current conversation head) and `agentId` (== the `<subId>` directory name).
+///  - The **root blob** is a protobuf whose repeated field 1 (`0x0A 0x20 <32-byte
+///    id>`) lists the conversation's message-blob ids **in order**.
+///  - Each **message blob** is one compact, single-line JSON object
+///    (`{"role":"system|user|assistant|tool","content":…}`) — already the NDJSON
+///    line we upload.
+///
+/// A `blobEncryptionKey` also rides `meta['0']`; today's blobs are plaintext, but
+/// this reader is defensive: a message blob that is not valid UTF-8 JSON is
+/// dropped, so if a future Cursor build actually encrypts the blobs the extractor
+/// yields `nil` (upload nothing) rather than shipping ciphertext (CROW-1095).
+///
+/// Pure and dependency-free apart from the system `SQLite3` module (no external
+/// package), so both the live collector and the backfill route through one
+/// extractor and it is unit-testable in CrowCore against a constructed `store.db`.
+public enum CursorStore {
+    /// The working directory recorded for a chat, read from the **sibling
+    /// `meta.json`** next to `storeDB` (`{"…","cwd":"/abs/path"}`). This is the
+    /// Cursor attribution signal — unlike Codex, the cwd is not in the transcript
+    /// itself, so `AgentLogCwdReader` (a transcript-head reader) does not apply.
+    /// Returns `nil` when the sibling is missing/unreadable or carries no cwd — an
+    /// unattributable chat is then dropped, never guessed.
+    public static func recordedCwd(forStoreDB storeDB: URL) -> String? {
+        let metaJSON = storeDB.deletingLastPathComponent()
+            .appendingPathComponent("meta.json")
+        guard let data = try? Data(contentsOf: metaJSON),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let cwd = obj["cwd"] as? String else { return nil }
+        let trimmed = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The chat's own session UID — `meta['0'].agentId`, which is also the
+    /// `<subId>` directory name. The live path keys uploads on the Crow session
+    /// UUID, but the backfill needs the harness's own stable id; the directory
+    /// name is authoritative and cheap (no SQLite), so the scanner prefers it and
+    /// this reader is the fallback for a direct caller that has only the file.
+    public static func agentId(fromStoreDB storeDB: URL) -> String? {
+        #if canImport(SQLite3)
+        return withDatabase(storeDB) { db in
+            guard let metaObj = metaZero(db) else { return nil }
+            let id = (metaObj["agentId"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return (id?.isEmpty == false) ? id : nil
+        } ?? nil
+        #else
+        return nil
+        #endif
+    }
+
+    /// The chat's messages as ordered NDJSON lines (each an already-compact JSON
+    /// object), or `nil` when the store can't be opened, has no conversation, or
+    /// none of its message blobs are plaintext JSON. Each returned `Data` is one
+    /// line with no trailing newline; the caller joins them.
+    public static func messageLines(fromStoreDB storeDB: URL) -> [Data]? {
+        #if canImport(SQLite3)
+        return withDatabase(storeDB) { db -> [Data]? in
+            guard let metaObj = metaZero(db),
+                  let rootId = (metaObj["latestRootBlobId"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !rootId.isEmpty,
+                  let rootBlob = blob(db, id: rootId) else { return nil }
+
+            let refs = messageRefs(inRoot: rootBlob)
+            guard !refs.isEmpty else { return nil }
+
+            var lines: [Data] = []
+            lines.reserveCapacity(refs.count)
+            for ref in refs {
+                guard let data = blob(db, id: ref), let line = jsonLine(data) else { continue }
+                lines.append(line)
+            }
+            return lines.isEmpty ? nil : lines
+        } ?? nil
+        #else
+        return nil
+        #endif
+    }
+
+    // MARK: - Blob-graph parsing (pure, platform-independent)
+
+    /// The ordered message-blob ids listed in a root blob's repeated protobuf
+    /// field 1. Other fields (conversation metadata Cursor also packs into the
+    /// root) are skipped by wire type, so only the message refs — in their encoded
+    /// order, which is conversation order — are returned. Each id is the lowercase
+    /// hex of the 32-byte reference, matching the `blobs.id` text column.
+    static func messageRefs(inRoot data: Data) -> [String] {
+        let bytes = [UInt8](data)
+        var i = 0
+        var refs: [String] = []
+
+        func readVarint() -> UInt64? {
+            var shift: UInt64 = 0
+            var result: UInt64 = 0
+            while i < bytes.count {
+                let b = bytes[i]; i += 1
+                result |= UInt64(b & 0x7f) << shift
+                if b & 0x80 == 0 { return result }
+                shift += 7
+                if shift >= 64 { return nil }
+            }
+            return nil
+        }
+
+        while i < bytes.count {
+            guard let tag = readVarint() else { break }
+            let field = tag >> 3
+            let wire = tag & 7
+            switch wire {
+            case 0: // varint
+                if readVarint() == nil { return refs }
+            case 1: // 64-bit
+                i += 8
+            case 5: // 32-bit
+                i += 4
+            case 2: // length-delimited
+                guard let len = readVarint() else { return refs }
+                let n = Int(len)
+                guard n >= 0, i + n <= bytes.count else { return refs }
+                if field == 1 {
+                    refs.append(bytes[i..<(i + n)].map { String(format: "%02x", $0) }.joined())
+                }
+                i += n
+            default: // 3/4 (groups, deprecated) or anything unexpected — stop cleanly
+                return refs
+            }
+        }
+        return refs
+    }
+
+    /// A message blob → one NDJSON line, or `nil` if it isn't plaintext UTF-8 JSON
+    /// (an object/array). The UTF-8 + leading-`{`/`[` guard is what makes a future
+    /// encrypted build fail closed: ciphertext is almost never valid UTF-8, and if
+    /// it were, it would not lead with a JSON opener. Any stray CR/LF inside the
+    /// blob is stripped so one blob stays one NDJSON line.
+    static func jsonLine(_ data: Data) -> Data? {
+        guard let s = String(data: data, encoding: .utf8) else { return nil }
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first, first == "{" || first == "[" else { return nil }
+        let oneLine = trimmed.replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+        return oneLine.data(using: .utf8)
+    }
+
+    // MARK: - SQLite access
+
+    #if canImport(SQLite3)
+    /// SQLite wants a copy of a bound string (the default would keep a dangling
+    /// pointer once the Swift `String` is freed).
+    private static let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    /// Open `storeDB` **read-only** (never mutate a user's chat store, and never
+    /// take a write lock on a DB `cursor-agent` may still hold) and run `body`.
+    /// A quiescent store — the only kind the collector uploads, gated by the quiet
+    /// period — opens cleanly; a store whose `-wal`/`-shm` a crash left in a state
+    /// a read-only connection can't attach to simply yields `nil` (best-effort).
+    private static func withDatabase<T>(_ storeDB: URL, _ body: (OpaquePointer) -> T) -> T? {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(storeDB.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let db else {
+            if db != nil { sqlite3_close(db) }
+            return nil
+        }
+        defer { sqlite3_close(db) }
+        return body(db)
+    }
+
+    /// Decode the hex-encoded JSON at `meta['0']` into its object, or `nil`.
+    private static func metaZero(_ db: OpaquePointer) -> [String: Any]? {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "SELECT value FROM meta WHERE key='0'", -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW, let c = sqlite3_column_text(stmt, 0) else { return nil }
+        let hex = String(cString: c)
+        guard let json = Data(hexEncoded: hex),
+              let obj = try? JSONSerialization.jsonObject(with: json) as? [String: Any] else { return nil }
+        return obj
+    }
+
+    /// The `data` BLOB for a content id, or `nil` when absent.
+    private static func blob(_ db: OpaquePointer, id: String) -> Data? {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "SELECT data FROM blobs WHERE id=?", -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, id, -1, transient)
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        guard let ptr = sqlite3_column_blob(stmt, 0) else {
+            // A zero-length blob reports a nil pointer but is still a valid row.
+            return sqlite3_column_bytes(stmt, 0) == 0 ? Data() : nil
+        }
+        let n = Int(sqlite3_column_bytes(stmt, 0))
+        return Data(bytes: ptr, count: n)
+    }
+    #endif
+}
+
+private extension Data {
+    /// Decode a hex string (even length, `[0-9a-fA-F]`) into bytes, or `nil`.
+    init?(hexEncoded hex: String) {
+        let chars = Array(hex.utf8)
+        guard chars.count % 2 == 0 else { return nil }
+        var out = [UInt8](); out.reserveCapacity(chars.count / 2)
+        func nibble(_ c: UInt8) -> UInt8? {
+            switch c {
+            case 0x30...0x39: return c - 0x30          // 0-9
+            case 0x61...0x66: return c - 0x61 + 10     // a-f
+            case 0x41...0x46: return c - 0x41 + 10     // A-F
+            default: return nil
+            }
+        }
+        var idx = 0
+        while idx < chars.count {
+            guard let hi = nibble(chars[idx]), let lo = nibble(chars[idx + 1]) else { return nil }
+            out.append(hi << 4 | lo)
+            idx += 2
+        }
+        self = Data(out)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptNormalizer.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/TranscriptNormalizer.swift
@@ -31,8 +31,8 @@ public enum TranscriptNormalizer {
     /// order they should be concatenated) into a single NDJSON body.
     ///
     /// Returns `nil` when there is nothing to upload (no files, all empty) or the
-    /// format cannot be normalized yet (`.sqlite` — Cursor row extraction is not
-    /// wired).
+    /// format yields no plaintext transcript (`.sqlite` — a Cursor store that is
+    /// unreadable, empty, or whose blobs aren't plaintext JSON).
     public static func normalize(
         files: [URL],
         format: AgentLogFormat,
@@ -42,10 +42,12 @@ public enum TranscriptNormalizer {
         case .jsonl, .logDir:
             return concatenateNDJSON(files: files, maxBytes: maxBytes)
         case .sqlite:
-            // Chat-row extraction out of Cursor's state.vscdb is not implemented
-            // yet; declaring the source without a normalizer would upload the raw
-            // database, which is the wrong shape. Skip until extraction lands.
-            return nil
+            // Cursor's `store.db` keeps the conversation as content-addressed
+            // blobs, not NDJSON on disk; `CursorStore` extracts the ordered
+            // message lines (an unreadable or encrypted store yields none), which
+            // are then concatenated into the same NDJSON artifact as every other
+            // harness (CROW-1095).
+            return concatenateCursorStores(files: files, maxBytes: maxBytes)
         }
     }
 
@@ -94,6 +96,35 @@ public enum TranscriptNormalizer {
         }
         guard !out.isEmpty else { return nil }
 
+        let (events, toolCalls) = countEvents(out)
+        return NormalizedTranscript(
+            data: out, eventCount: events, toolCallCount: toolCalls, truncated: truncated)
+    }
+
+    /// Extract each Cursor `store.db`'s ordered message lines (`CursorStore`) and
+    /// concatenate them into one NDJSON body, bounded by `maxBytes` and marked
+    /// truncated if the cap is hit. A store that yields no plaintext messages
+    /// contributes nothing; if none do, the result is `nil` (upload nothing).
+    /// Each line is appended whole — a line that would cross the cap ends the
+    /// concatenation, so the body is always valid NDJSON, never a partial object.
+    private static func concatenateCursorStores(files: [URL], maxBytes: Int) -> NormalizedTranscript? {
+        guard maxBytes > 0 else { return nil }
+        let newline: UInt8 = 0x0A
+        var out = Data()
+        out.reserveCapacity(min(maxBytes, 1 << 20))
+        var truncated = false
+
+        outer: for url in files {
+            guard let lines = CursorStore.messageLines(fromStoreDB: url) else { continue }
+            for line in lines {
+                // +1 for the separating newline after this line.
+                if out.count + line.count + 1 > maxBytes { truncated = true; break outer }
+                out.append(line)
+                out.append(newline)
+            }
+        }
+
+        guard !out.isEmpty else { return nil }
         let (events, toolCalls) = countEvents(out)
         return NormalizedTranscript(
             data: out, eventCount: events, toolCallCount: toolCalls, truncated: truncated)

--- a/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
@@ -201,6 +201,8 @@ import Testing
         #expect(s2.uploadStatus == .uploaded)
     }
 
+    // MARK: Grok harness (CROW-1098)
+
     @Test func reconstructsGrokHighConfidenceSession() async throws {
         let (devRoot, projects, cleanup) = try makeTree()
         defer { cleanup() }
@@ -264,6 +266,70 @@ import Testing
             entry: .init(status: .uploaded, sha256: "s", sizeBytes: 1, at: 1))
         let s2 = try #require(await scanner.scan(ledger: ledger2).first { $0.claudeSessionUID == "GROK-UID-2" })
         #expect(s2.uploadStatus == .uploaded)
+    }
+
+    // MARK: Cursor harness (CROW-1095)
+
+    @Test func reconstructsCursorHighConfidenceSession() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        let cursorChats = URL(fileURLWithPath: devRoot)
+            .deletingLastPathComponent().appendingPathComponent("cursor-chats", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: cursorChats) }
+
+        // A live clone so the repo → owner/repo resolves.
+        let clone = URL(fileURLWithPath: devRoot)
+            .appendingPathComponent("RadiusMethod/crow", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: clone.appendingPathComponent(".git"), withIntermediateDirectories: true)
+
+        // The cwd lives in the sibling meta.json; the uid is the `<subId>` dir.
+        let cwd = "\(devRoot)/RadiusMethod/crow-1095-wire-cursor-logs"
+        _ = try CursorStoreFixture.write(
+            dir: cursorChats.appendingPathComponent("chatA/SUBID-1", isDirectory: true),
+            agentID: "SUBID-1", cwd: cwd, messages: [#"{"role":"user","content":"hi"}"#])
+
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects, cursorChatsDir: cursorChats,
+            gitRemote: { path in
+                path.hasSuffix("/RadiusMethod/crow") ? "https://github.com/corveil/crow.git" : nil
+            })
+
+        let sessions = await scanner.scan(ledger: LogSyncLedger())
+        // Only the Cursor chat — the (empty) Claude/Codex dirs contribute none.
+        let s = try #require(sessions.first { $0.claudeSessionUID == "SUBID-1" })
+        #expect(s.harness == .cursor)
+        #expect(s.workspace == "RadiusMethod")
+        #expect(s.worktreeName == "crow-1095-wire-cursor-logs")
+        #expect(s.repoName == "crow")
+        #expect(s.ownerRepo == "corveil/crow")
+        #expect(s.ticketNumber == 1095)
+        #expect(s.confidence == .high)
+        // The scan is disk-only: the filePath points at the store.db, but cwd/uid
+        // came from the dir name + meta.json, never from opening the database.
+        #expect(s.filePath.hasSuffix("SUBID-1/store.db"))
+    }
+
+    @Test func cursorChatWithoutCwdIsDroppedToLowConfidence() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        let cursorChats = URL(fileURLWithPath: devRoot)
+            .deletingLastPathComponent().appendingPathComponent("cursor-chats-2", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: cursorChats) }
+
+        // No cwd in meta.json → unattributable → orphan (low), never misfiled.
+        _ = try CursorStoreFixture.write(
+            dir: cursorChats.appendingPathComponent("chatB/SUBID-2", isDirectory: true),
+            agentID: "SUBID-2", cwd: nil, messages: [#"{"role":"user"}"#])
+
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects, cursorChatsDir: cursorChats, gitRemote: { _ in nil })
+        let s = try #require(await scanner.scan(ledger: LogSyncLedger())
+            .first { $0.claudeSessionUID == "SUBID-2" })
+        #expect(s.harness == .cursor)
+        #expect(s.cwd == nil)
+        #expect(s.workspace == nil)
+        #expect(s.confidence == .low)
     }
 
     @Test func summaryCountsByTier() {

--- a/Packages/CrowCore/Tests/CrowCoreTests/CursorStoreTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CursorStoreTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import Testing
+@testable import CrowCore
+#if canImport(SQLite3)
+import SQLite3
+#endif
+
+/// Builds a minimal Cursor `store.db` (+ sibling `meta.json`) the way
+/// `cursor-agent` lays one out — content-addressed `blobs`, a `meta['0']`
+/// hex-JSON header pointing at a root blob whose repeated protobuf field 1 lists
+/// the ordered message-blob ids — so `CursorStore` can be exercised without a real
+/// Cursor install (CROW-1095). Shared across the CrowCore test target.
+enum CursorStoreFixture {
+    #if canImport(SQLite3)
+    private static let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    #endif
+
+    /// 32 deterministic bytes for a blob id seeded by `n`.
+    static func id32(_ n: Int) -> [UInt8] { (0..<32).map { UInt8((n &* 31 &+ $0) & 0xff) } }
+    static func hex(_ bytes: [UInt8]) -> String { bytes.map { String(format: "%02x", $0) }.joined() }
+
+    /// Write `<dir>/store.db` + `<dir>/meta.json`. `messages` are stored in order;
+    /// a non-nil `garbageBlob` is inserted as a raw blob referenced **last** in the
+    /// root, to exercise the plaintext-JSON guard. Returns the `store.db` URL.
+    @discardableResult
+    static func write(
+        dir: URL, agentID: String, cwd: String?,
+        messages: [String], garbageBlob: [UInt8]? = nil
+    ) throws -> URL {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let storeDB = dir.appendingPathComponent("store.db")
+
+        // meta.json sibling (carries the cwd for attribution).
+        var metaJSON: [String: Any] = ["schemaVersion": 1, "hasConversation": true]
+        if let cwd { metaJSON["cwd"] = cwd }
+        try JSONSerialization.data(withJSONObject: metaJSON)
+            .write(to: dir.appendingPathComponent("meta.json"))
+
+        #if canImport(SQLite3)
+        var db: OpaquePointer?
+        #expect(sqlite3_open(storeDB.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        exec(db, "CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB);")
+        exec(db, "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);")
+
+        var refs: [[UInt8]] = []
+        for (i, msg) in messages.enumerated() {
+            let id = id32(i + 1)
+            insertBlob(db, id: hex(id), data: Data(msg.utf8))
+            refs.append(id)
+        }
+        if let garbageBlob {
+            let id = id32(9001)
+            insertBlob(db, id: hex(id), data: Data(garbageBlob))
+            refs.append(id)
+        }
+
+        // Root protobuf: repeated field 1 refs, then a couple of non-field-1
+        // fields (a length-delimited field 5 and a varint field 8) to exercise the
+        // wire-type skipping — Cursor packs conversation metadata alongside.
+        var root = Data()
+        for id in refs { root.append(0x0A); root.append(0x20); root.append(contentsOf: id) }
+        root.append(contentsOf: [0x2A, 0x03, 0x01, 0x02, 0x03]) // field 5, len 3
+        root.append(contentsOf: [0x40, 0x96, 0x01])             // field 8, varint 150
+        let rootID = id32(7777)
+        insertBlob(db, id: hex(rootID), data: root)
+
+        let meta0: [String: Any] = [
+            "agentId": agentID,
+            "latestRootBlobId": hex(rootID),
+            "blobEncryptionKey": String(repeating: "0", count: 64),
+        ]
+        let meta0Hex = try JSONSerialization.data(withJSONObject: meta0)
+            .map { String(format: "%02x", $0) }.joined()
+        insertMeta(db, key: "0", value: meta0Hex)
+        #else
+        // No SQLite on this platform (the Linux CI runner — SQLite3 is a
+        // macOS-SDK module): create the `store.db` FILE as a placeholder so
+        // filesystem/scan tests (which only need the filename + sibling meta.json)
+        // still run here. The content-level extraction tests are `#if
+        // canImport(SQLite3)`-guarded and run on macOS (release.yml), where Crow's
+        // daemon — and the Cursor extractor — actually run.
+        try Data().write(to: storeDB)
+        #endif
+        return storeDB
+    }
+
+    #if canImport(SQLite3)
+    private static func exec(_ db: OpaquePointer?, _ sql: String) {
+        #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+    }
+    private static func insertBlob(_ db: OpaquePointer?, id: String, data: Data) {
+        var stmt: OpaquePointer?
+        #expect(sqlite3_prepare_v2(db, "INSERT INTO blobs (id, data) VALUES (?, ?)", -1, &stmt, nil) == SQLITE_OK)
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, id, -1, transient)
+        _ = data.withUnsafeBytes { raw in
+            sqlite3_bind_blob(stmt, 2, raw.baseAddress, Int32(data.count), transient)
+        }
+        #expect(sqlite3_step(stmt) == SQLITE_DONE)
+    }
+    private static func insertMeta(_ db: OpaquePointer?, key: String, value: String) {
+        var stmt: OpaquePointer?
+        #expect(sqlite3_prepare_v2(db, "INSERT INTO meta (key, value) VALUES (?, ?)", -1, &stmt, nil) == SQLITE_OK)
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, key, -1, transient)
+        sqlite3_bind_text(stmt, 2, value, -1, transient)
+        #expect(sqlite3_step(stmt) == SQLITE_DONE)
+    }
+    #endif
+}
+
+@Suite struct CursorStoreTests {
+    private func tmp() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // The SQLite-backed extraction tests run only where `SQLite3` is importable
+    // (macOS — release.yml); the Linux CI (`canImport(SQLite3) == false`) skips
+    // them, exactly as it skips the Darwin-only CrowTelemetry SQLite tests. The
+    // cwd / protobuf / JSON-guard tests below are pure Foundation and run
+    // everywhere.
+    #if canImport(SQLite3)
+    @Test func extractsOrderedMessagesAndDropsNonJSON() throws {
+        let base = try tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        let messages = [
+            #"{"role":"system","content":"sys"}"#,
+            #"{"role":"user","content":"hi"}"#,
+            #"{"role":"assistant","content":[{"type":"text","text":"yo"}]}"#,
+        ]
+        // A ciphertext-like trailing blob (invalid UTF-8) must be dropped, not
+        // emitted — the guard that keeps a future encrypted build failing closed.
+        let db = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("sub"), agentID: "sub", cwd: "/ws/x",
+            messages: messages, garbageBlob: [0xff, 0x00, 0x80, 0x01])
+        let lines = try #require(CursorStore.messageLines(fromStoreDB: db))
+        #expect(lines.count == 3)
+        #expect(lines.map { String(data: $0, encoding: .utf8) } == messages)
+    }
+    #endif
+
+    @Test func recordedCwdReadsSiblingMetaJSON() throws {
+        let base = try tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        let db = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("s1"), agentID: "s1", cwd: "/ws/y",
+            messages: [#"{"role":"user"}"#])
+        #expect(CursorStore.recordedCwd(forStoreDB: db) == "/ws/y")
+
+        // A chat with no cwd in its meta.json is unattributable → nil (dropped).
+        let db2 = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("s2"), agentID: "s2", cwd: nil,
+            messages: [#"{"role":"user"}"#])
+        #expect(CursorStore.recordedCwd(forStoreDB: db2) == nil)
+        // A missing store/sibling is also nil, never a crash.
+        #expect(CursorStore.recordedCwd(forStoreDB: base.appendingPathComponent("nope/store.db")) == nil)
+    }
+
+    #if canImport(SQLite3)
+    @Test func agentIdFromMetaZero() throws {
+        let base = try tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        let db = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("SUBID"), agentID: "AGENT-1", cwd: "/w",
+            messages: [#"{"role":"user"}"#])
+        #expect(CursorStore.agentId(fromStoreDB: db) == "AGENT-1")
+    }
+    #endif
+
+    @Test func messageRefsSkipsNonFieldOneFields() {
+        var root = Data()
+        let a = [UInt8](repeating: 0xAB, count: 32)
+        let b = [UInt8](repeating: 0xCD, count: 32)
+        root.append(0x0A); root.append(0x20); root.append(contentsOf: a)
+        root.append(contentsOf: [0x2A, 0x02, 0x09, 0x09]) // field 5, len 2 — skipped
+        root.append(0x0A); root.append(0x20); root.append(contentsOf: b)
+        root.append(contentsOf: [0x40, 0x96, 0x01])       // field 8 varint — skipped
+        #expect(CursorStore.messageRefs(inRoot: root)
+            == [String(repeating: "ab", count: 32), String(repeating: "cd", count: 32)])
+        // A truncated length prefix stops cleanly rather than reading OOB.
+        #expect(CursorStore.messageRefs(inRoot: Data([0x0A, 0x20, 0x01, 0x02])).isEmpty)
+    }
+
+    @Test func jsonLineGuardsUTF8AndLeadingOpener() {
+        #expect(CursorStore.jsonLine(Data(#"{"a":1}"#.utf8)) != nil)
+        #expect(CursorStore.jsonLine(Data(#"[1,2]"#.utf8)) != nil)
+        #expect(CursorStore.jsonLine(Data([0xff, 0xfe])) == nil)        // not UTF-8
+        #expect(CursorStore.jsonLine(Data("plain text".utf8)) == nil)  // no JSON opener
+        // A stray newline inside a blob is collapsed so one blob stays one line.
+        let collapsed = CursorStore.jsonLine(Data("{\"a\":\n1}".utf8))
+            .flatMap { String(data: $0, encoding: .utf8) }
+        #expect(collapsed == "{\"a\": 1}")
+    }
+
+    // MARK: TranscriptNormalizer .sqlite
+
+    #if canImport(SQLite3)
+    @Test func normalizerSqliteConcatenatesStoresInOrder() throws {
+        let base = try tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        let db1 = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("s1"), agentID: "s1", cwd: "/w",
+            messages: [#"{"role":"system"}"#, #"{"role":"user"}"#])
+        let db2 = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("s2"), agentID: "s2", cwd: "/w",
+            messages: [#"{"role":"assistant"}"#])
+
+        let t = try #require(TranscriptNormalizer.normalize(
+            files: [db1, db2], format: .sqlite, maxBytes: 1_000_000))
+        #expect(t.eventCount == 3)
+        #expect(t.truncated == false)
+        let lines = String(data: t.data, encoding: .utf8)!.split(separator: "\n")
+        #expect(lines.count == 3)
+        #expect(lines[0].contains("system"))
+        #expect(lines[1].contains("user"))
+        #expect(lines[2].contains("assistant"))
+
+        // An unreadable/absent store yields nothing (upload nothing, never garbage).
+        #expect(TranscriptNormalizer.normalize(
+            files: [base.appendingPathComponent("gone.db")], format: .sqlite, maxBytes: 1000) == nil)
+    }
+
+    @Test func normalizerSqliteTruncatesAtWholeLines() throws {
+        let base = try tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        let messages = (0..<10).map { #"{"role":"user","i":\#($0)}"# }
+        let db = try CursorStoreFixture.write(
+            dir: base.appendingPathComponent("s"), agentID: "s", cwd: "/w", messages: messages)
+        // A cap that admits only a couple of lines: the body is truncated but still
+        // parses as clean NDJSON (no partial object).
+        let t = try #require(TranscriptNormalizer.normalize(files: [db], format: .sqlite, maxBytes: 60))
+        #expect(t.truncated == true)
+        let body = String(data: t.data, encoding: .utf8)!
+        for line in body.split(separator: "\n") {
+            #expect(line.hasPrefix("{") && line.hasSuffix("}"))
+        }
+    }
+    #endif
+}

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -306,11 +306,38 @@ public struct CursorAgent: CodingAgent {
             runner: probeRunner)
     }
 
-    // `logSources` is intentionally NOT overridden (CROW-1089): the `cursor-agent`
-    // CLI stores each chat's conversation as opaque blobs in a per-chat SQLite
-    // `store.db` (`~/.cursor/chats/<id>/<sub>/store.db`) — the cwd is recoverable
-    // from the sibling `meta.json`, but the transcript needs a `store.db` blob
-    // extractor (a `.sqlite` normalizer) that isn't built yet, so it stays on the
-    // `[]` default rather than upload the wrong bytes. (This is the CLI's store,
-    // not the Cursor IDE's `state.vscdb`.)
+    /// The `cursor-agent` CLI writes each chat to a content-addressed SQLite store
+    /// under a global tree — `<cursorHome>/chats/<chatId>/<subId>/store.db` — with
+    /// the working directory it ran in recorded in the **sibling `meta.json`**
+    /// (verified against `cursor-agent 2026.08.04`). `cursorHome` honors
+    /// `$CURSOR_CONFIG_DIR` (`CursorHome`), the same tree the MCP-bridge path uses.
+    ///
+    /// Like Codex — and unlike Claude — the stores are NOT partitioned by working
+    /// directory, so a worktree path can't be turned into a directory path.
+    /// Attribution is by **content**: the source scans the whole `chats` tree
+    /// recursively for `store.db` files but carries a `cwdFilter`, and the
+    /// collector keeps only the chats whose recorded `cwd` equals this worktree.
+    /// Because Cursor records the cwd in the sibling `meta.json` (not the
+    /// transcript), the collector reads it via `CursorStore.recordedCwd` rather
+    /// than `AgentLogCwdReader`; a chat with no readable cwd is dropped rather than
+    /// guessed — an unattributable transcript is worse than a missing one
+    /// (CROW-1095).
+    ///
+    /// `harnessSessionID` is unused: the store is named by a content hash tree, not
+    /// a session id, and cwd-matching is the reliable selector regardless. The
+    /// format is `.sqlite` (`CursorStore` extracts the ordered messages at upload
+    /// time); a Crow session may span several `<subId>` chats in the same worktree,
+    /// each its own `store.db`, so the collector concatenates all cwd-matches
+    /// chronologically. `fileNamePrefix: "store"` + `fileExtension: "db"` selects
+    /// exactly `store.db` — in lockstep with the backfill scanner's exact
+    /// `store.db` name match (`BackfillScanner.cursorStoreFiles`), so a stray
+    /// `*.db` a tool might drop under `<CursorHome>/chats` can't slip into the live
+    /// path even with a matching cwd (the same lockstep CROW-1089 added
+    /// `fileNamePrefix` for Codex's `rollout-`). The `-wal`/`-shm` siblings are
+    /// already excluded by the `db` extension (`db-wal`/`db-shm`).
+    public func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] {
+        return [.directory(
+            CursorHome.chatsDir(), format: .sqlite, fileExtension: "db",
+            fileNamePrefix: "store", recursive: true, cwdFilter: worktreePath)]
+    }
 }

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorHome.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorHome.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The Cursor CLI's config/data home, resolved the way every Crow ↔ Cursor path
+/// resolves it: `$CURSOR_CONFIG_DIR` when set and non-empty, otherwise
+/// `~/.cursor`. An empty `CURSOR_CONFIG_DIR=` is treated as unset — matching
+/// `CursorMCPConfigWriter` — so it never yields a CWD-relative path.
+///
+/// A single source of truth so the MCP-bridge and session-log-collection paths
+/// look at the same tree. A user (or a launchd plist) that sets
+/// `CURSOR_CONFIG_DIR` has Cursor keep its per-chat stores under that tree, so
+/// the session-log collector and backfill must read it too (CROW-1095).
+public enum CursorHome {
+    /// The resolved Cursor home directory. `environment` is injectable for tests.
+    public static func path(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        if let env = environment["CURSOR_CONFIG_DIR"], !env.isEmpty { return env }
+        return NSString(string: "~/.cursor").expandingTildeInPath
+    }
+
+    /// `<cursorHome>/chats` — where the `cursor-agent` CLI writes each chat's
+    /// `<chatId>/<subId>/store.db` (SQLite) + sibling `meta.json`. This is the
+    /// CLI's per-chat store, **not** the Cursor IDE's `workspaceStorage`.
+    public static func chatsDir(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        (path(environment: environment) as NSString).appendingPathComponent("chats")
+    }
+}

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorMCPConfigWriter.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorMCPConfigWriter.swift
@@ -42,9 +42,10 @@ public enum CursorMCPConfigWriter {
     /// a possibly-large `~/.claude.json`); the write is global and self-heals on
     /// the next launch, so fire-and-forget is fine.
     public static func bridgeJiraMCPDefault() {
-        let cursorHome = ProcessInfo.processInfo.environment["CURSOR_CONFIG_DIR"]
-            .flatMap { $0.isEmpty ? nil : $0 }
-            ?? NSString(string: "~/.cursor").expandingTildeInPath
+        // Resolve the Cursor home through the shared `CursorHome` resolver (honors
+        // `$CURSOR_CONFIG_DIR`, empty-is-unset) — one source of truth with the
+        // session-log collector's chats path (CROW-1095).
+        let cursorHome = CursorHome.path()
         bridgeJiraMCP(cursorMCPPath: (cursorHome as NSString).appendingPathComponent("mcp.json"))
     }
 

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentLogSourcesTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentLogSourcesTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowCursor
+
+@Suite struct CursorAgentLogSourcesTests {
+    @Test func cwdFilteredRecursiveSqliteSource() {
+        let sources = CursorAgent().logSources(
+            worktreePath: "/Users/j/Dev/acme-1", harnessSessionID: nil)
+        #expect(sources.count == 1)
+        let s = sources[0]
+        // Globally stored (a directory, not a file), scanned recursively over the
+        // `<chatId>/<subId>/` tree, filtered to `store.db` and attributed by the
+        // worktree it ran in.
+        #expect(s.selector == .directory)
+        #expect(s.format == .sqlite)
+        #expect(s.fileExtension == "db")   // excludes store.db-wal / store.db-shm
+        #expect(s.fileNamePrefix == "store") // exact `store.db`, in lockstep with backfill
+        #expect(s.recursive == true)
+        #expect(s.cwdFilter == "/Users/j/Dev/acme-1")
+        // Points at the resolved Cursor chats tree (honors $CURSOR_CONFIG_DIR).
+        #expect(s.path == CursorHome.chatsDir())
+    }
+
+    @Test func harnessSessionIDIsIgnoredForAttribution() {
+        // The store is named by a content-hash tree, not a session id, so cwd
+        // matching is the selector — the source is identical with or without an id.
+        let withID = CursorAgent().logSources(worktreePath: "/a/b", harnessSessionID: "UUID-1")
+        let withoutID = CursorAgent().logSources(worktreePath: "/a/b", harnessSessionID: nil)
+        #expect(withID == withoutID)
+        #expect(withID[0].cwdFilter == "/a/b")
+    }
+}

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorHomeTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorHomeTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import CrowCursor
+
+@Suite struct CursorHomeTests {
+    @Test func honorsCursorConfigDirWhenSetAndNonEmpty() {
+        let env = ["CURSOR_CONFIG_DIR": "/custom/cursor"]
+        #expect(CursorHome.path(environment: env) == "/custom/cursor")
+        #expect(CursorHome.chatsDir(environment: env) == "/custom/cursor/chats")
+    }
+
+    @Test func emptyCursorConfigDirIsTreatedAsUnset() {
+        // An empty `CURSOR_CONFIG_DIR=` must NOT yield a CWD-relative path — it
+        // falls back to `~/.cursor` like every other Crow ↔ Cursor path.
+        let home = NSString(string: "~/.cursor").expandingTildeInPath
+        #expect(CursorHome.path(environment: ["CURSOR_CONFIG_DIR": ""]) == home)
+        #expect(CursorHome.chatsDir(environment: ["CURSOR_CONFIG_DIR": ""]) == home + "/chats")
+    }
+
+    @Test func fallsBackToTildeCursorWhenUnset() {
+        let home = NSString(string: "~/.cursor").expandingTildeInPath
+        #expect(CursorHome.path(environment: [:]) == home)
+        #expect(CursorHome.chatsDir(environment: [:]) == home + "/chats")
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
@@ -2,6 +2,7 @@ import Foundation
 import CrowCore
 import CrowCodex
 import CrowGrok
+import CrowCursor
 
 /// The daemon-side orchestration behind `backfill-scan` / `backfill-upload`
 /// (CROW-1075). It composes the CrowCore pieces — the disk scanner, the ticket
@@ -42,15 +43,17 @@ struct BackfillService: Sendable {
     func scan(scanner: BackfillScanner? = nil) async -> [BackfillSession] {
         let store = LogSyncLedgerStore.shared(devRoot: devRoot)
         let ledger = await store.snapshot()
-        // Resolve the Codex sessions tree through `CodexHome` (honors `$CODEX_HOME`)
-        // and the Grok sessions tree through `GrokHome` (honors `$GROK_HOME`) — the
+        // Resolve the Codex sessions tree through `CodexHome` (honors `$CODEX_HOME`),
+        // the Grok sessions tree through `GrokHome` (honors `$GROK_HOME`), and the
+        // Cursor chats tree through `CursorHome` (honors `$CURSOR_CONFIG_DIR`) — the
         // same trees the live collector and the launch paths read. CrowCore's
-        // `BackfillScanner` can't import CrowCodex/CrowGrok, so the daemon injects
-        // both (CROW-1089, CROW-1098).
+        // `BackfillScanner` can't import CrowCodex/CrowGrok/CrowCursor, so the daemon
+        // injects all three (CROW-1089, CROW-1098, CROW-1095).
         let s = scanner ?? BackfillScanner(
             devRoot: devRoot,
             codexSessionsDir: URL(fileURLWithPath: CodexHome.sessionsDir()),
             grokSessionsDir: URL(fileURLWithPath: GrokHome.sessionsDir()),
+            cursorChatsDir: URL(fileURLWithPath: CursorHome.chatsDir()),
             now: now)
         return await s.scan(ledger: ledger)
     }
@@ -132,21 +135,28 @@ struct BackfillService: Sendable {
 
     // MARK: - Helpers
 
-    /// The upload `format` stamp for a harness's on-disk transcript. Claude and
+    /// The upload `format` stamp for a harness's on-disk transcript, honest about
+    /// its on-disk shape so `TranscriptNormalizer` reads it correctly: Claude and
     /// Grok each write a single NDJSON transcript (`.jsonl`); a Codex rollout is one
-    /// of a set of per-session files the collector concatenates (`.logDir`). All
-    /// three normalize through `concatenateNDJSON`, but the stamp is honest.
+    /// of a set of per-session NDJSON files the collector concatenates (`.logDir`);
+    /// a Cursor chat is a content-addressed SQLite `store.db` (`.sqlite`) whose
+    /// messages `CursorStore` extracts.
     static func uploadFormat(for harness: LogSyncHarness) -> AgentLogFormat {
-        harness == .codex ? .logDir : .jsonl
+        switch harness {
+        case .codex: return .logDir
+        case .cursor: return .sqlite
+        default: return .jsonl
+        }
     }
 
     /// The `agentKind` sidecar hint for a harness. Only the wired harnesses reach
     /// here; any other maps to Claude's kind as a harmless default (it never
-    /// occurs — the scanner only emits `.claude`/`.codex`/`.grok`).
+    /// occurs — the scanner only emits `.claude`/`.codex`/`.grok`/`.cursor`).
     static func agentKindRawValue(for harness: LogSyncHarness) -> String {
         switch harness {
         case .codex: return AgentKind.codex.rawValue
         case .grok: return AgentKind.grok.rawValue
+        case .cursor: return AgentKind.cursor.rawValue
         default: return AgentKind.claudeCode.rawValue
         }
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/LogSyncCollector.swift
@@ -108,10 +108,12 @@ struct LogSyncCollector {
             guard await ledgerStore.shouldUpload(key: ledgerKey, now: nowEpoch, retryBackoff: retryBackoff) else { continue }
 
             // Where does this harness write its logs? Empty for harnesses whose
-            // on-disk logs are not yet wired (everything but Claude, Codex, and
-            // Grok today — CROW-1089, CROW-1098). A Codex source carries a
-            // `cwdFilter` that `resolveFiles` applies to attribute a global rollout
-            // to this worktree; Claude and Grok partition by worktree directly.
+            // on-disk logs are not yet wired (everything but Claude, Codex, Grok,
+            // and Cursor today — CROW-1089 / CROW-1098 / CROW-1095). A
+            // globally-stored harness's source carries a `cwdFilter` that
+            // `resolveFiles` applies to attribute one worktree's sessions out of the
+            // shared tree (Codex/Cursor); Claude and Grok partition by worktree
+            // directly.
             guard let agent = AgentRegistry.shared.agent(for: session.agentKind) else { continue }
             let sources = agent.logSources(worktreePath: worktree.worktreePath, harnessSessionID: nil)
             guard !sources.isEmpty else { continue }
@@ -128,9 +130,10 @@ struct LogSyncCollector {
             }
 
             // Pick the single format for the artifact stamp. Claude and Grok
-            // sources are `.jsonl`; Codex sources are `.logDir` (a set of
-            // per-session rollouts concatenated). A mixed set would be unusual —
-            // take the first source's format.
+            // sources are `.jsonl`; Codex sources are `.logDir` (per-session
+            // rollouts concatenated); Cursor sources are `.sqlite` (`CursorStore`
+            // extracts the messages). A mixed set would be unusual — take the first
+            // source's format.
             let format = sources.first?.format ?? .jsonl
             guard let transcript = TranscriptNormalizer.normalize(
                 files: files, format: format, maxBytes: max(1, config.maxUploadBytes))
@@ -278,25 +281,39 @@ struct LogSyncCollector {
                 if let prefix = source.fileNamePrefix, !url.lastPathComponent.hasPrefix(prefix) { return false }
                 return true
             }
-            filtered = applyingCwdFilter(filtered, source.cwdFilter)
+            filtered = applyingCwdFilter(filtered, source.cwdFilter, format: source.format)
             return filtered.sorted { a, b in
                 (Self.modificationDate(a) ?? .distantPast) < (Self.modificationDate(b) ?? .distantPast)
             }
         }
     }
 
-    /// Keep only files whose recorded `cwd` (read cheaply from the head via
-    /// `AgentLogCwdReader`) equals `cwdFilter`, path-standardized on both sides.
+    /// Keep only files whose recorded `cwd` (read from the head for NDJSON via
+    /// `AgentLogCwdReader`, or the sibling `meta.json` for a Cursor `.sqlite` store
+    /// via `CursorStore`) equals `cwdFilter`, path-standardized on both sides.
     /// `nil` filter is a no-op (Claude, whose slug directory is already the
     /// filter). A file with no readable cwd never matches — an unattributable
-    /// transcript is dropped, not guessed (CROW-1089).
-    static func applyingCwdFilter(_ files: [URL], _ cwdFilter: String?) -> [URL] {
+    /// transcript is dropped, not guessed (CROW-1089 / CROW-1095).
+    static func applyingCwdFilter(
+        _ files: [URL], _ cwdFilter: String?, format: AgentLogFormat = .logDir
+    ) -> [URL] {
         guard let cwdFilter else { return files }
         let want = (cwdFilter as NSString).standardizingPath
         guard !want.isEmpty else { return [] }
         return files.filter { url in
-            guard let cwd = AgentLogCwdReader.read(url) else { return false }
+            guard let cwd = recordedCwd(of: url, format: format) else { return false }
             return (cwd as NSString).standardizingPath == want
+        }
+    }
+
+    /// The working directory a resolved log file recorded, choosing the reader by
+    /// on-disk shape: a Cursor `.sqlite` store keeps its cwd in the sibling
+    /// `meta.json` (`CursorStore.recordedCwd`), while Claude/Codex NDJSON records
+    /// it in the transcript head (`AgentLogCwdReader`).
+    static func recordedCwd(of url: URL, format: AgentLogFormat) -> String? {
+        switch format {
+        case .sqlite: return CursorStore.recordedCwd(forStoreDB: url)
+        case .jsonl, .logDir: return AgentLogCwdReader.read(url)
         }
     }
 
@@ -304,16 +321,40 @@ struct LogSyncCollector {
         (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
     }
 
+    /// The newest mtime across `files` **and their SQLite `-wal`/`-shm`
+    /// siblings**, so the quiet-period check sees a still-active store as active.
+    /// A Cursor `store.db` in WAL mode commits to `store.db-wal`, not the main
+    /// file, so checking only the resolved `store.db` could read a chat as
+    /// quiescent while `cursor-agent` is still writing — and the server's
+    /// write-once 409 would then freeze that partial transcript. Probing the
+    /// siblings is a no-op for a harness (Claude/Codex) whose resolved files have
+    /// none (CROW-1095).
     static func newestModification(_ files: [URL]) -> Date? {
-        files.compactMap { modificationDate($0) }.max()
+        var newest: Date?
+        for url in files {
+            for candidate in [url,
+                              URL(fileURLWithPath: url.path + "-wal"),
+                              URL(fileURLWithPath: url.path + "-shm")] {
+                if let d = modificationDate(candidate), d > (newest ?? .distantPast) {
+                    newest = d
+                }
+            }
+        }
+        return newest
     }
 
-    /// The harness's own session id when exactly one file backs the transcript
-    /// (its filename stem, e.g. the Claude `.jsonl` UUID); nil when several files
-    /// were concatenated.
+    /// The harness's own session id when exactly one file backs the transcript;
+    /// nil when several files were concatenated. For Claude/Codex it is the file's
+    /// stem (the `.jsonl` UUID); for a Cursor `store.db` — always that literal name
+    /// — it is the parent `<subId>` directory (the chat's agentId), since the stem
+    /// "store" identifies nothing.
     static func agentSessionID(from files: [URL]) -> String? {
         guard files.count == 1 else { return nil }
-        return files[0].deletingPathExtension().lastPathComponent
+        let file = files[0]
+        if file.lastPathComponent == "store.db" {
+            return file.deletingLastPathComponent().lastPathComponent
+        }
+        return file.deletingPathExtension().lastPathComponent
     }
 
     static func sha256Hex(_ data: Data) -> String {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -1734,7 +1734,7 @@
     modal.appendChild(head);
 
     const body = el('div', 'settings-body');
-    const summary = el('div', 'backfill-summary', 'Scanning ~/.claude/projects and ~/.codex/sessions…');
+    const summary = el('div', 'backfill-summary', 'Scanning ~/.claude/projects, ~/.codex/sessions and ~/.cursor/chats…');
     body.appendChild(summary);
 
     const filterRow = el('div', 'backfill-filters');
@@ -1879,7 +1879,7 @@
     }
 
     async function scan() {
-      summary.textContent = 'Scanning ~/.claude/projects and ~/.codex/sessions…';
+      summary.textContent = 'Scanning ~/.claude/projects, ~/.codex/sessions and ~/.cursor/chats…';
       try {
         const res = await rpc('backfill-scan', {});
         sessions = res.sessions || [];

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
@@ -123,9 +123,11 @@ private struct StubRunner: ShellRunner {
         #expect(BackfillService.uploadFormat(for: .claude) == .jsonl)
         #expect(BackfillService.uploadFormat(for: .codex) == .logDir)
         #expect(BackfillService.uploadFormat(for: .grok) == .jsonl) // single NDJSON transcript
+        #expect(BackfillService.uploadFormat(for: .cursor) == .sqlite)
         #expect(BackfillService.agentKindRawValue(for: .claude) == AgentKind.claudeCode.rawValue)
         #expect(BackfillService.agentKindRawValue(for: .codex) == AgentKind.codex.rawValue)
         #expect(BackfillService.agentKindRawValue(for: .grok) == AgentKind.grok.rawValue)
+        #expect(BackfillService.agentKindRawValue(for: .cursor) == AgentKind.cursor.rawValue)
     }
 
     @Test func codexSessionUploadsUnderCodexHarnessSlot() async throws {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/LogSyncCollectorTests.swift
@@ -211,6 +211,95 @@ import CrowCore
         #expect(LogSyncCollector.applyingCwdFilter([a, b], "   ").isEmpty)
     }
 
+    // MARK: cwd-filtered resolution — Cursor sqlite store (CROW-1095)
+
+    /// A Cursor `.sqlite` source reads the cwd from the **sibling `meta.json`**
+    /// (via `CursorStore.recordedCwd`), not the transcript head, so the filter and
+    /// `resolveFiles` both keep only the store.db whose chat ran in this worktree,
+    /// and the `-wal`/`-shm` siblings never leak in.
+    @Test func resolveFilesSqliteKeepsCwdMatchingStoreDBs() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        func chat(_ name: String, cwd: String?) throws -> URL {
+            let sub = dir.appendingPathComponent(name, isDirectory: true)
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            let db = sub.appendingPathComponent("store.db")
+            try Data("x".utf8).write(to: db)
+            // Siblings that must be excluded by the `db` extension filter.
+            try Data("w".utf8).write(to: sub.appendingPathComponent("store.db-wal"))
+            try Data("s".utf8).write(to: sub.appendingPathComponent("store.db-shm"))
+            if let cwd {
+                try #"{"cwd":"\#(cwd)"}"#.write(
+                    to: sub.appendingPathComponent("meta.json"), atomically: true, encoding: .utf8)
+            }
+            return db
+        }
+        let mine = try chat("chatA/s1", cwd: "/dev/ws/repo-1095")
+        _ = try chat("chatB/s2", cwd: "/dev/ws/repo-999")   // other worktree
+        _ = try chat("chatC/s3", cwd: nil)                  // no cwd → unattributable
+
+        let source = AgentLogSource.directory(
+            dir.path, format: .sqlite, fileExtension: "db",
+            recursive: true, cwdFilter: "/dev/ws/repo-1095")
+        // Exactly the one matching store.db — the -wal/-shm siblings, the other
+        // worktree's chat, and the unattributable chat are all excluded. Compare by
+        // suffix so the enumerator's `/private/var` symlink resolution doesn't
+        // spuriously differ from `mine`'s `/var` path.
+        let resolved = LogSyncCollector.resolveFiles(source)
+        #expect(resolved.count == 1)
+        #expect(resolved.first?.lastPathComponent == "store.db")
+        #expect(resolved.first?.path.hasSuffix("chatA/s1/store.db") == true)
+        #expect(mine.lastPathComponent == "store.db")
+
+        // recordedCwd dispatches on format: `.sqlite` → sibling meta.json.
+        #expect(LogSyncCollector.recordedCwd(of: mine, format: .sqlite) == "/dev/ws/repo-1095")
+        let noMeta = dir.appendingPathComponent("chatC/s3/store.db")
+        #expect(LogSyncCollector.recordedCwd(of: noMeta, format: .sqlite) == nil)
+    }
+
+    /// `agentSessionID` for a single Cursor store is the parent `<subId>` dir (the
+    /// chat's agentId), since the file stem "store" identifies nothing.
+    @Test func agentSessionIDForCursorStoreIsParentDir() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("chatA/SUBID-9", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let db = sub.appendingPathComponent("store.db")
+        try Data("x".utf8).write(to: db)
+        #expect(LogSyncCollector.agentSessionID(from: [db]) == "SUBID-9")
+    }
+
+    /// The quiet-period `newestModification` must see a SQLite `-wal`/`-shm`
+    /// sibling's mtime, so a Cursor chat still committing to its WAL (while the
+    /// main `store.db` mtime is stale) is not read as quiescent and uploaded
+    /// partial (CROW-1095). A non-SQLite file with no siblings is unaffected.
+    @Test func newestModificationIncludesWalShmSiblings() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let db = dir.appendingPathComponent("store.db")
+        try Data("x".utf8).write(to: db)
+        let wal = dir.appendingPathComponent("store.db-wal")
+        try Data("w".utf8).write(to: wal)
+
+        // store.db is old; the WAL is fresh (an active commit).
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1000)], ofItemAtPath: db.path)
+        let walTime = Date(timeIntervalSince1970: 9000)
+        try FileManager.default.setAttributes(
+            [.modificationDate: walTime], ofItemAtPath: wal.path)
+
+        // The newest reflects the WAL, not the stale main file.
+        #expect(LogSyncCollector.newestModification([db]) == walTime)
+
+        // A plain file with no WAL/SHM siblings is just its own mtime.
+        let plain = dir.appendingPathComponent("a.jsonl")
+        try Data("j".utf8).write(to: plain)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1000)], ofItemAtPath: plain.path)
+        #expect(LogSyncCollector.newestModification([plain]) == Date(timeIntervalSince1970: 1000))
+    }
+
     // MARK: Result → ledger mapping
 
     @Test func ledgerEntryMapping() {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1763,13 +1763,13 @@ crow logsync set --quiet-period-minutes 15 --max-upload-bytes 4000000
 | `--quiet-period-minutes N` | Wait this long after a session's last activity before uploading (default 30) |
 | `--max-upload-bytes N` | Per-transcript upload cap (default 8000000) |
 
-Claude Code, Codex, and Grok Build transcripts are collected today (CROW-1089, CROW-1098): Claude's and Grok's logs are partitioned by working directory (Grok URL-encodes the cwd into its `~/.grok/sessions` directory name), and Codex's globally-stored `~/.codex/sessions` rollouts are attributed by the `cwd` each records. Other harnesses are wired as their on-disk log locations are confirmed. Changes are live — the collector re-reads config each tick, so they apply within a few minutes with no restart.
+Claude Code, Codex, Grok Build, and Cursor transcripts are collected today (CROW-1089 / CROW-1098 / CROW-1095): Claude's and Grok's logs are partitioned by working directory (Grok URL-encodes the cwd into its `~/.grok/sessions` directory name), while Codex's globally-stored `~/.codex/sessions` rollouts and Cursor's globally-stored `~/.cursor/chats` stores are attributed by the `cwd` each records (Codex in its rollout head, Cursor in the sibling `meta.json`). Other harnesses are wired as their on-disk log locations are confirmed. Changes are live — the collector re-reads config each tick, so they apply within a few minutes with no restart.
 
 ---
 
 ## Session Backfill Commands
 
-The **historical session backfill** (CROW-1075) captures the coding-session transcripts already on disk — sessions that predate the live upload path or were reaped from Crow's store — and uploads them as **real, fully-linked** Corveil session artifacts, reconstructing the workspace / repo / ticket a live run would have carried. The live collector is session-centric (it walks Crow's store); this is the one-time reconciliation of the on-disk backlog. Claude Code, Codex, and Grok Build are wired (CROW-1089, CROW-1098): Claude's and Grok's logs are partitioned by working directory (Grok decodes the cwd from its URL-encoded `~/.grok/sessions` directory name), and Codex records the real `cwd` in each `~/.codex/sessions` rollout, so all three reconstruct reliably.
+The **historical session backfill** (CROW-1075) captures the coding-session transcripts already on disk — sessions that predate the live upload path or were reaped from Crow's store — and uploads them as **real, fully-linked** Corveil session artifacts, reconstructing the workspace / repo / ticket a live run would have carried. The live collector is session-centric (it walks Crow's store); this is the one-time reconciliation of the on-disk backlog. Claude Code, Codex, Grok Build, and Cursor are wired (CROW-1089 / CROW-1098 / CROW-1095): Claude's and Grok's logs are partitioned by working directory (Grok decodes the cwd from its URL-encoded `~/.grok/sessions` directory name), Codex records the real `cwd` in each `~/.codex/sessions` rollout, and Cursor records it in the sibling `meta.json` of each `~/.cursor/chats` store, so all reconstruct reliably.
 
 It reuses the live upload path, so it inherits its guarantees: the destination + credential come only from the named workspace's **local-only** AI gateway (never a browser-writable field), no AWS credentials touch this machine, and every upload is **idempotent** (a local ledger + the server's write-once 409). It is always **user-initiated** — never automatic or unbounded.
 
@@ -1779,7 +1779,7 @@ It reuses the live upload path, so it inherits its guarantees: the destination +
 crow backfill scan
 ```
 
-Reconciles every on-disk Claude transcript (`~/.claude/projects/**/*.jsonl`) and Codex rollout (`~/.codex/sessions/**/rollout-*.jsonl`) against the upload ledger and returns the reconstructed rows plus a `summary`. Disk- and git-only (no provider calls), so it stays fast over hundreds of sessions. Each row carries its `harness` (`claude`/`codex`), the recovered `workspace` / `repo_name` / `owner_repo` / `ticket_number`, a `confidence` tier, and its ledger `upload_status`:
+Reconciles every on-disk Claude transcript (`~/.claude/projects/**/*.jsonl`), Codex rollout (`~/.codex/sessions/**/rollout-*.jsonl`), and Cursor store (`~/.cursor/chats/**/store.db`) against the upload ledger and returns the reconstructed rows plus a `summary`. Disk- and git-only (no provider calls), so it stays fast over hundreds of sessions. Each row carries its `harness` (`claude`/`codex`/`cursor`), the recovered `workspace` / `repo_name` / `owner_repo` / `ticket_number`, a `confidence` tier, and its ledger `upload_status`:
 
 | Confidence | Meaning |
 | --- | --- |
@@ -1801,7 +1801,7 @@ Uploads a chosen set through the live path, idempotently and serially. `--worksp
 
 | Flag | Description |
 | --- | --- |
-| `--session <uid>` | A session UID to upload (repeatable; Claude Code, Codex, or Grok Build — UIDs come from `crow backfill scan`) |
+| `--session <uid>` | A session UID to upload (repeatable; Claude Code, Codex, Grok Build, or Cursor — UIDs come from `crow backfill scan`) |
 | `--all-high-confidence` | Every not-yet-uploaded **high-confidence** session in this workspace |
 | `--all` | Every not-yet-uploaded session in this workspace |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,7 +390,7 @@ Reconcile and upload historical on-disk session transcripts.
 crow backfill <scan|upload>
 ```
 
-Scans the coding-session transcripts already on disk (Claude Code under ~/.claude/projects, Codex under ~/.codex/sessions, and Grok Build under ~/.grok/sessions), reconstructs each one's workspace, repo, and ticket/PR, and uploads the ones you choose to Corveil as session artifacts — so a backfilled session lands in the ontology indistinguishable from a live-captured one.
+Scans the coding-session transcripts already on disk (Claude Code under ~/.claude/projects, Codex under ~/.codex/sessions, Grok Build under ~/.grok/sessions, and Cursor under ~/.cursor/chats), reconstructs each one's workspace, repo, and ticket/PR, and uploads the ones you choose to Corveil as session artifacts — so a backfilled session lands in the ontology indistinguishable from a live-captured one.
 
 A reconstructed ticket becomes a link only when the provider confirms it exists; otherwise the session uploads repo-only, and a true orphan uploads attributed but unlinked. Uploads reuse the named workspace's AI gateway for the destination and credential (no AWS credentials on this machine) and are idempotent — re-running never duplicates.
 
@@ -425,7 +425,7 @@ Choose sessions with repeated --session <uid> (UIDs come from `crow backfill sca
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--workspace` | `<workspace>` | yes | Workspace whose gateway supplies the upload destination + credential |
-| `--session` | `<session>` _(repeatable)_ | no | A session UID to upload (repeatable; Claude Code, Codex, or Grok Build — UIDs come from `crow backfill scan`). Mutually exclusive with --all/--all-high-confidence. |
+| `--session` | `<session>` _(repeatable)_ | no | A session UID to upload (repeatable; Claude Code, Codex, Grok Build, or Cursor — UIDs come from `crow backfill scan`). Mutually exclusive with --all/--all-high-confidence. |
 | `--all-high-confidence` | — | no | Upload every not-yet-uploaded high-confidence session in this workspace |
 | `--all` | — | no | Upload every not-yet-uploaded session in this workspace |
 
@@ -1116,7 +1116,7 @@ crow logsync <get|set>
 
 The session-log collector uploads each opted-in workspace's coding-session transcripts to Corveil as session artifacts, reusing that workspace's AI gateway for the destination and credential (no AWS credentials are stored on this machine). Opt a workspace in with `crow workspace edit --workspace NAME --upload-session-logs true` (or the Settings → Workspaces checkbox); it uploads once it also has a gateway.
 
-These verbs tune only global behavior — ledger retention, the quiet period before a transcript is captured, and the per-upload size cap. Uploads are best-effort and never block or fail a session. Claude Code, Codex, and Grok Build transcripts are collected today (CROW-1089, CROW-1098); other harnesses are wired as their on-disk log locations are confirmed.
+These verbs tune only global behavior — ledger retention, the quiet period before a transcript is captured, and the per-upload size cap. Uploads are best-effort and never block or fail a session. Claude Code, Codex, Grok Build, and Cursor transcripts are collected today (CROW-1089 / CROW-1098 / CROW-1095); other harnesses are wired as their on-disk log locations are confirmed.
 
 Subcommands: [`get`](#crow-logsync-get), [`set`](#crow-logsync-set).
 

--- a/docs/harness-transcript-locations.md
+++ b/docs/harness-transcript-locations.md
@@ -33,8 +33,10 @@ opt-in). Two attribution modes exist today:
   non-alphanumeric → `-`). `cwdFilter` is `nil`.
 - **Content-filtered** — the store pools transcripts globally, so the collector
   scans the tree and keeps only files whose *recorded* `cwd` equals the worktree
-  (`AgentLogSource.cwdFilter` + `AgentLogCwdReader`). A file with no readable cwd
-  is dropped, never guessed. Codex is the reference.
+  (`AgentLogSource.cwdFilter`). The cwd is read from the transcript head
+  (`AgentLogCwdReader`, Codex) or from a sibling metadata file
+  (`CursorStore.recordedCwd` reads Cursor's `meta.json`). A file with no readable
+  cwd is dropped, never guessed. Codex is the reference.
 
 A store that is neither (no per-worktree layout **and** no recoverable cwd inside
 each transcript) cannot be attributed and stays on the `[]` default.
@@ -48,7 +50,7 @@ CROW-1090. "cwd-attributable?" is the wiring test above.
 |---|---|---|---|---|---|---|---|
 | Claude Code | `claude` | ✅ | `~/.claude/projects/<slug>/` (slug = worktree path, non-alnum → `-`) | `<uuid>.jsonl` | NDJSON | ✅ path-partitioned | **Wired** (CROW-1089) |
 | Codex | `codex` | ✅ | `~/.codex/sessions/<YYYY>/<MM>/<DD>/` | `rollout-<ts>-<uuid>.jsonl` | NDJSON | ✅ content-filtered (`session_meta.payload.cwd`) | **Wired** (CROW-1092) |
-| Cursor | `cursor-agent` | ✅ | `~/.cursor/chats/<id>/<sub>/` | `store.db` (+ sibling `meta.json`) | SQLite (opaque blobs) | ✅ cwd in `meta.json` | Deferred — needs blob extractor · [#1095](https://github.com/corveil/crow/issues/1095) |
+| Cursor | `cursor-agent` | ✅ | `~/.cursor/chats/<chatId>/<subId>/` | `store.db` (+ sibling `meta.json`) | SQLite (content-addressed blobs, ordered by a root protobuf) | ✅ content-filtered (cwd in sibling `meta.json`) | **Wired** (CROW-1095) |
 | OpenCode | `opencode` | ✅ | `~/.local/share/opencode/storage/{project,session,message,part}/` | scattered `message`/`part` records | multi-file object store | ✅ cwd in `project/<id>.json.worktree` | Deferred — needs reassembler · [#1096](https://github.com/corveil/crow/issues/1096) |
 | Grok Build | `grok` | ✅ | `<$GROK_HOME or ~/.grok>/sessions/<urlencoded-abs-cwd>/<uuid>/` | `chat_history.jsonl` | NDJSON | ✅ path-partitioned (URL-encoded cwd) | **Wired** (CROW-1098) |
 | Antigravity | `agy` | ✅ | `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/` (pooled globally, keyed by id) | `transcript_full.jsonl` (`transcript.jsonl` is truncated) | NDJSON | ❌ no cwd in transcript (only off-transcript: per-conv SQLite DB / hooks / latest-only `cache/last_conversations.json`) | Deferred — durable log confirmed, **not** cwd-attributable · [#1097](https://github.com/corveil/crow/issues/1097) |

--- a/docs/session-backfill.md
+++ b/docs/session-backfill.md
@@ -101,18 +101,23 @@ unbounded.
 
 ## Scope
 
-- **Claude Code, Codex, and Grok Build** — the harnesses whose transcripts can be
-  reliably attributed to a worktree (CROW-1089, CROW-1098). Claude and Grok
-  partition their logs by working directory (Claude slugifies the path; Grok
-  URL-encodes it into the directory name, `~/.grok/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl`,
-  so the scan recovers the cwd by decoding the directory name). Codex pools its
+- **Claude Code, Codex, Grok Build, and Cursor** — the harnesses whose transcripts
+  can be reliably attributed to a worktree (CROW-1089 / CROW-1098 / CROW-1095).
+  Claude and Grok partition their logs by working directory (Claude slugifies the
+  path; Grok URL-encodes it into the directory name,
+  `~/.grok/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl`, so the scan
+  recovers the cwd by decoding the directory name). Codex pools its
   `~/.codex/sessions/**/rollout-*.jsonl` globally but records the real `cwd` in
-  each rollout's first-line `session_meta`, so the scan reconstructs it that way.
-  All three make historical reconstruction reliable because the authoritative
-  `cwd` is recoverable, not a lossy directory name. Other harnesses follow as
+  each rollout's first-line `session_meta`; Cursor pools its
+  `~/.cursor/chats/<id>/<sub>/store.db` globally but records the `cwd` in the
+  sibling `meta.json`. All make historical reconstruction reliable because the
+  authoritative `cwd` is recoverable, not a lossy directory name. The scan stays
+  disk- and git-only — for Cursor the uid is the `<subId>` directory name and the
+  cwd a tiny sibling JSON read, so the `store.db` is opened only at upload time
+  (where `CursorStore` extracts the ordered messages). Other harnesses follow as
   their `logSources` land (see
   [session-log-collector.md](session-log-collector.md), and
   [harness-transcript-locations.md](harness-transcript-locations.md) for the
   verified per-harness on-disk locations).
-- Cursor (SQLite blob store) and OpenCode (multi-file object store) need a
-  normalizer for their on-disk shapes before their transcripts can be backfilled.
+- OpenCode (multi-file object store) still needs a normalizer for its on-disk
+  shape before its transcripts can be backfilled.

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -25,30 +25,34 @@ contributes nothing rather than uploading the wrong bytes.
 
 ## Harness coverage
 
-**Claude Code**, **Codex**, and **Grok Build** are wired (CROW-1089, CROW-1098).
-Claude and Grok partition their logs by working directory, so a Crow worktree maps
-straight to that session's transcripts — Claude by slugifying the path, Grok by
-URL-encoding it into the directory name. Codex pools its rollouts globally, so it's
-attributed by **content** instead: the source scans the whole `sessions` tree but
-carries a `cwdFilter`, and the collector keeps only the rollouts whose recorded
-`cwd` matches the worktree (`AgentLogCwdReader`). A rollout with no readable cwd is
-dropped, never guessed.
+**Claude Code**, **Codex**, **Grok Build**, and **Cursor** are wired (CROW-1089 /
+CROW-1098 / CROW-1095). Claude and Grok partition their logs by working directory,
+so a Crow worktree maps straight to that session's transcripts — Claude by
+slugifying the path, Grok by URL-encoding it into the directory name. Codex and
+Cursor pool their stores globally, so they're attributed by **content** instead:
+the source scans the whole tree but carries a `cwdFilter`, and the collector keeps
+only the sessions whose recorded `cwd` matches the worktree. Codex records the cwd
+in its rollout head (`AgentLogCwdReader`); Cursor records it in the sibling
+`meta.json` (`CursorStore.recordedCwd`). A session with no readable cwd is dropped,
+never guessed.
 
 | Harness | On-disk location | Status |
 |---|---|---|
 | `claude-code` | `~/.claude/projects/<slug>/<uuid>.jsonl` (slug = worktree path, every non-alphanumeric → `-`) | **Wired.** One artifact per session; multiple `.jsonl` under the slug dir are concatenated. |
 | `codex` | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl` (already NDJSON; cwd in the first-line `session_meta.payload.cwd`) | **Wired.** Recursive `.logDir` source with a `cwdFilter`; the collector keeps only cwd-matching rollouts and concatenates them (`~/.codex/archived_sessions` and `.../log` are not scanned). |
+| `cursor` | `~/.cursor/chats/<chatId>/<subId>/store.db` (CLI store; cwd in the sibling `meta.json`) | **Wired.** Recursive `.sqlite` source (`fileExtension: db`) with a `cwdFilter`; `CursorStore` follows the `meta['0'].latestRootBlobId` root blob's ordered message-blob refs and emits each message's JSON as one NDJSON line. Not the Cursor IDE's `state.vscdb`. |
 | `grok` | `<$GROK_HOME or ~/.grok>/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl` (already NDJSON; directory name is the cwd URL-encoded, `/`→`%2F`) | **Wired.** Recursive `.jsonl` source pointed at the encoded worktree directory, filtered to `chat_history.jsonl`; attribution is exact by construction (no `cwdFilter`), so sibling `events.jsonl` / `prompt_history.jsonl` are left out. |
 | `opencode` | `~/.local/share/opencode/storage/{project,session,message,part}` | Deferred — a `project/<id>.json`'s `worktree` maps to the cwd, but a session's `message`/`part` records must be reassembled into ordered NDJSON first. |
-| `cursor` | `~/.cursor/chats/<id>/<sub>/store.db` (CLI store; cwd in the sibling `meta.json`) | Deferred — the conversation is opaque blobs in a per-chat **SQLite** `store.db`; needs a blob extractor (a `.sqlite` normalizer). Not the Cursor IDE's `state.vscdb`. |
 | `antigravity` | `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl` (JSONL; pooled globally, keyed by id) | Deferred — the transcript records **no cwd** at all (step records are `step_index`/`type`/`source`/`status`/`created_at`), so a `cwdFilter` source would drop every file. The cwd lives only off-transcript (a conditional protobuf-in-SQLite per-conversation DB, the ephemeral hook / status-line payloads, or the latest-only `cache/last_conversations.json` pointer), which the current reader can't consume (CROW-1097). |
 | `muse` | `~/.local/share/muse/sessions/<YYYY>/<MM>/<DD>/<id>/session.jsonl` (durable, already JSONL) | Deferred — durable global JSONL store **confirmed** (Meta dev cookbook, CROW-1099). The cookbook documents no cwd field (its jq prints only event records, whose git refs `base_commit`/`base_ref` collide across worktrees), but a first-hand third-party parser reports the cwd at `runtime.session.metadata.workspace_root` (line 1), so attribution is **likely** possible (content-filtered, Codex-style). Format fits `.logDir` as-is; verify `workspace_root` on a real `session.jsonl` (Meta-auth-gated), then wire. |
 
 The framework (collector, normalizer, uploader, ledger, config, CLI) is
 harness-general; wiring a deferred harness is implementing its `logSources`
-override — plus, for `.sqlite`/multi-file stores, a normalizer for that on-disk
-shape. A globally-stored harness attributes by `cwdFilter` rather than a
-per-worktree path (Codex is the reference); a directory-partitioned one maps the
+override — plus, for a `.sqlite`/multi-file store, a normalizer for that on-disk
+shape (the Cursor `.sqlite` store is normalized by `CursorStore`). A
+globally-stored harness attributes by `cwdFilter` rather than a per-worktree path
+(Codex and Cursor are the references), reading the cwd from the transcript head or
+a sibling metadata file as its shape dictates; a directory-partitioned one maps the
 worktree path straight to its directory (Claude and Grok).
 
 Harnesses map to the artifact contract's `harness` value via


### PR DESCRIPTION
Closes #1095

## What & why

The session-log collector (CROW-1056) and historical backfill (CROW-1075) were architected multi-harness; CROW-1089 (#1092) wired **Claude + Codex**. This wires **Cursor** end-to-end — live collector **and** backfill — as the third harness, so `cursor-agent` transcripts ship to Corveil as session-transcript artifacts the same way.

## Cursor's on-disk shape (reverse-engineered)

The blocker recorded in `CursorAgent` was the missing `.sqlite` normalizer. Investigation against `cursor-agent 2026.08.04` on this machine (488 real chats) established the format:

```
~/.cursor/chats/<chatId>/<subId>/store.db     # SQLite: blobs + meta
~/.cursor/chats/<chatId>/<subId>/meta.json    # sibling; carries the cwd
```

- `blobs(id TEXT PRIMARY KEY, data BLOB)`, content-addressed (`id == sha256(data)`), `meta(key TEXT, value TEXT)`.
- `meta['0']` is **hex-encoded JSON** → `latestRootBlobId`, `agentId` (== the `<subId>` dir), and a `blobEncryptionKey`.
- The **root blob** is a protobuf whose repeated **field 1** lists the conversation's message-blob ids **in order**.
- Each **message blob** is one compact JSON object (`{"role":…,"content":…}`) — already the NDJSON line.

The `blobEncryptionKey` is present but today's blobs are **plaintext**. The extractor is therefore defensive: a message blob that isn't valid UTF-8 JSON is dropped, so if a future Cursor build actually encrypts the blobs the extractor yields **nothing** rather than shipping ciphertext — the *"wrong bytes are worse than none"* bar the ticket sets.

## How

**New `.sqlite` normalizer + cwd reader (`CursorStore`, CrowCore, `import SQLite3`):**
- Follows `meta['0'].latestRootBlobId` → the root blob's ordered field-1 refs → each message blob, emitting one NDJSON line per message. `TranscriptNormalizer`'s `.sqlite` case concatenates them (max-bytes bounded, whole-line truncation).
- Reads the cwd from the **sibling `meta.json`** — Cursor records cwd *beside* the transcript, not in it, so `AgentLogCwdReader` (a transcript-head reader, the Codex mechanism) doesn't apply. The collector's cwd filter now dispatches on format: `.sqlite` → sibling `meta.json`, else the head.

**Live collector:** `CursorAgent.logSources` returns a recursive, cwd-filtered `.sqlite` directory source over `<CursorHome>/chats` (`fileExtension: "db"` uniquely selects `store.db`, not its `-wal`/`-shm` siblings). `CursorHome` honors `$CURSOR_CONFIG_DIR` — one source of truth, shared with the MCP-bridge path (mirrors `CodexHome`).

**Backfill:** `BackfillScanner` reconciles Cursor stores too, staying **disk-only** — the uid is the `<subId>` dir name and the cwd is the tiny sibling JSON, so no `store.db` is opened during a scan (only at upload). `BackfillService` keys the ledger / upload / format (`.sqlite`) / `agentKind` off `harness`.

**Attribution that can't misattribute:** exact cwd match; a chat with no recoverable cwd is dropped, never guessed.

## Docs

`session-log-collector.md`, `session-backfill.md`, `cli-reference.md`, `cli.md` (regenerated), `CLAUDE.md`, plus the CLI help text and the backfill web UI: Claude + Codex → **+ Cursor**.

## Testing

`swift test` green across **CrowCore (773)**, **CrowCursor (85)**, and the **CrowDaemon** logsync + backfill suites. New tests cover the `store.db` blob extractor (ordering + the encryption/garbage guard + protobuf wire-type skipping), the sibling-`meta.json` cwd reader, the cwd-filter dispatch (excluding `-wal`/`-shm` and unattributable chats), Cursor backfill reconstruction (high-confidence + no-cwd → low), and the harness-scoped mapping. `crow` + `crowd` link clean.

> [!NOTE]
> Two failing `CrowDaemon` tests — `RPCLanePolicyTests` (naming `terminal-set`/`corveil-verify`/`corveil-reinstall-skill`) and `WebNotificationCenterTests.bootCatchResetsTheHistory` — are **pre-existing on `main`** and untouched by this change (none of `RPCLanePolicy`/`RPCHandlers`/`WebNotification` are in this diff; the verbs they name belong to CROW-1085 / CROW-1011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
