### PR TITLE
Wire Antigravity session logs via a runtime conversation→worktree map (CROW-1107)

### DIFF
--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityAgent.swift
@@ -31,6 +31,12 @@ public struct AntigravityAgent: CodingAgent {
     public let hookConfigWriter: any HookConfigWriter
     public let stateSignalSource: any StateSignalSource
 
+    /// Where `logSources` reads the runtime conversation→worktree map and the
+    /// Antigravity brain dir (CROW-1107). Default to the real global locations;
+    /// injectable so a test can point them at a temp tree.
+    private let conversationMapURL: URL
+    private let brainDir: String
+
     private let launcher: AntigravityLauncher
 
     /// Last-resort search paths for `agy`, checked only when a
@@ -59,10 +65,14 @@ public struct AntigravityAgent: CodingAgent {
 
     public init(
         hookConfigWriter: any HookConfigWriter = AntigravityHookConfigWriter(),
-        stateSignalSource: any StateSignalSource = AntigravitySignalSource()
+        stateSignalSource: any StateSignalSource = AntigravitySignalSource(),
+        conversationMapURL: URL = AntigravityConversationMap.defaultMapURL(),
+        brainDir: String = AntigravityHome.brainDir()
     ) {
         self.hookConfigWriter = hookConfigWriter
         self.stateSignalSource = stateSignalSource
+        self.conversationMapURL = conversationMapURL
+        self.brainDir = brainDir
         self.launcher = AntigravityLauncher()
     }
 
@@ -191,62 +201,35 @@ public struct AntigravityAgent: CodingAgent {
     // (CROW-629). A documented Tier-2 gap; override once a rename command is
     // confirmed.
 
-    // `logSources` is intentionally NOT overridden (CROW-1097, a CROW-1089
-    // follow-up). Antigravity's CLI *does* write a durable per-conversation
-    // transcript — the earlier "no confirmed location" note is now resolved — but
-    // that transcript is **not cwd-attributable by Crow's mechanism**, which is
-    // the property the collector needs. So, like Cursor and OpenCode (storage
-    // known, attribution/format the blocker), it stays on the `[]` default rather
-    // than upload transcripts it can't safely attribute to a worktree.
-    //
-    // Where `agy` writes (verified from Antigravity CLI docs + community tooling —
-    // `agy-explore`, `agentgrep`, the `antigravity-conversation-fix` recovery
-    // tool — NOT first-party on-disk inspection: `agy` isn't installed here
-    // (`crow agents list` → `available: false`) and running it needs
-    // Google-Sign-In/GCP auth, so a live session couldn't be captured):
-    //   • App-data root `~/.gemini/antigravity-cli/` (reuses the `~/.gemini`
-    //     home; the *IDE* uses `~/.gemini/antigravity-ide/` — a separate tree).
-    //   • Durable transcript, JSON Lines:
-    //     `…/brain/<conversation-id>/.system_generated/logs/transcript_full.jsonl`
-    //     (`transcript.jsonl` alongside it is the known-buggy truncated one).
-    //     Step records are `{step_index, type, source, status, created_at}`.
-    //   • Storage is **flat/global** — every project's conversations pool in one
-    //     `brain/` dir keyed only by id (like Codex's `~/.codex/sessions`, unlike
-    //     Claude's per-cwd slug dir), so attribution must be by *content*.
-    //
-    // Why the current `cwdFilter` path can't consume it: `AgentLogCwdReader` reads
-    // the recorded `cwd` from the *transcript head* (top-level `cwd` / Codex's
-    // `payload.cwd`). Antigravity records **no cwd in the transcript at all** —
-    // nothing on any line says which repo the agent ran in. So a `.logDir` +
-    // `cwdFilter: worktreePath` source would drop every file for a missing cwd
-    // ("dropped, never guessed", CROW-1089) and collect *zero* — a wiring that
-    // only looks wired. The cwd exists, but only in places the shared infra
-    // doesn't read: a **separate per-conversation SQLite DB** (`<id>.db`) as
-    // opaque protobuf trajectory metadata, and only *conditionally* (an absolute
-    // `file:///` path recorded "when `agy` starts inside a workspace it
-    // recognises"); or the **ephemeral** hook-stdin / status-line JSON payloads
-    // (`conversationId`, `workspacePaths`, `transcriptPath` on the hook; lowercase
-    // `cwd` on the status line); or the `…/cache/last_conversations.json`
-    // workspace→latest-conversation pointer (latest-only, so it can name a stale
-    // conversation — using it would guess). Reading any of those is
-    // a new normalizer/attribution subsystem, not a `logSources` override.
-    //
-    // Downstream, the same no-cwd fact also blocks *backfill*: `BackfillScanner`'s
-    // per-harness reconstruction reads cwd from the transcript head too, so a
-    // `reconstructAntigravity` written like `reconstructCodex` would resolve every
-    // session to `cwd == nil` → `.low`/orphan. NOT a blocker, and explicitly not a
-    // prerequisite for wiring: `LogSyncHarness` has no `antigravity` case, but that
-    // is by design — it maps to `.unknown`, so an upload is still accepted and
-    // attributed, just not harness-typed (`LogSyncSupport`; corveil#2426). Adding a
-    // first-class case is a quality-of-typing follow-up that does NOT gate wiring
-    // logs (the collector stamps the harness, then skips only when `logSources` is
-    // empty).
-    //
-    // Most promising future path for whoever wires this: Crow already runs
-    // Antigravity hooks and knows the worktree it launched `agy` in, and the hook
-    // stdin payload carries `conversationId` + `workspacePaths` (and
-    // `transcriptPath`, which names the log file directly) — so capturing that at
-    // runtime into a Crow-side conversation-id→worktree map would give exact,
-    // non-guessed attribution the transcript itself can't. That's a design
-    // follow-up, not this ticket.
+    /// Where `agy` writes durable session logs, resolved through the **runtime
+    /// conversation→worktree map** (CROW-1107, the wiring follow-up to CROW-1097).
+    ///
+    /// Antigravity pools every conversation's durable transcript in one flat/global
+    /// tree keyed only by id —
+    /// `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl`
+    /// (`transcript.jsonl` beside it is the known-buggy truncated one) — and records
+    /// **no cwd on any transcript line**. So, unlike Codex, a `cwdFilter` source can't
+    /// attribute a transcript to a worktree: it would drop every file and collect
+    /// zero (CROW-1097). The attribution instead comes from a fact only Crow holds:
+    /// it launched `agy` in a known worktree, and each Antigravity hook fires with
+    /// that session's `--session <uuid>`. The `hook-event` handler records
+    /// `conversationId → worktree` as hooks fire (`AntigravityConversationMap`);
+    /// here we read it back and return exactly this worktree's `transcript_full.jsonl`
+    /// files as `.file`/`.jsonl` sources (already NDJSON — no normalizer). A
+    /// transcript with no map entry is dropped, never guessed — the same invariant
+    /// as Codex's cwd filter.
+    ///
+    /// ⚠️ **Docs-derived, pending live-verify (CROW-1107).** `agy` isn't installable
+    /// here (`crow agents list` → `available: false`; Google-Sign-In/GCP-authed), so
+    /// the hook payload field name (`conversationId`) and the brain-dir template are
+    /// from Antigravity CLI docs + community tooling, not first-party capture. The
+    /// worktree is taken from Crow's own session ownership (never the payload), so a
+    /// wrong payload field yields "no map entry" (⇒ nothing uploaded), never a
+    /// misattribution. Confirm the field names against a live `agy` before promoting
+    /// Antigravity out of Tier-2 (ADR 0015).
+    public func logSources(worktreePath: String, harnessSessionID: String?) -> [AgentLogSource] {
+        AntigravityConversationMap.load(mapURL: conversationMapURL)
+            .transcripts(forWorktreePath: worktreePath, brainDir: brainDir)
+            .map { .file($0, format: .jsonl) }
+    }
 }

--- a/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentLogSourcesTests.swift
+++ b/Packages/CrowAntigravity/Tests/CrowAntigravityTests/AntigravityAgentLogSourcesTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import CrowAntigravity
+
+/// `AntigravityAgent.logSources` resolves through the runtime conversation→worktree
+/// map (CROW-1107): it returns exactly the transcripts the map attributes to the
+/// worktree, and nothing when the map has no entry — never a guess.
+@Suite struct AntigravityAgentLogSourcesTests {
+    private func makeTemp() -> (dir: URL, mapURL: URL, brain: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agy-agent-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir,
+                dir.appendingPathComponent("map.json"),
+                dir.appendingPathComponent("brain", isDirectory: true),
+                { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    private func writeTranscript(brain: URL, conversationID: String) throws {
+        let path = AntigravityHome.transcriptPath(conversationID: conversationID, brainDir: brain.path)
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
+        try "{}".write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    @Test func mapHitReturnsAFileSource() throws {
+        let (_, mapURL, brain, cleanup) = makeTemp()
+        defer { cleanup() }
+        try writeTranscript(brain: brain, conversationID: "C1")
+        #expect(AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/repo-1", mapURL: mapURL))
+
+        let agent = AntigravityAgent(conversationMapURL: mapURL, brainDir: brain.path)
+        let sources = agent.logSources(worktreePath: "/ws/repo-1", harnessSessionID: nil)
+        #expect(sources.count == 1)
+        #expect(sources[0].selector == .file)
+        #expect(sources[0].format == .jsonl)
+        #expect(sources[0].path
+            == AntigravityHome.transcriptPath(conversationID: "C1", brainDir: brain.path))
+    }
+
+    @Test func emptyMapReturnsNothing() {
+        let (_, mapURL, brain, cleanup) = makeTemp()
+        defer { cleanup() }
+        let agent = AntigravityAgent(conversationMapURL: mapURL, brainDir: brain.path)
+        #expect(agent.logSources(worktreePath: "/ws/repo-1", harnessSessionID: nil).isEmpty)
+    }
+
+    @Test func entryForADifferentWorktreeReturnsNothing() throws {
+        let (_, mapURL, brain, cleanup) = makeTemp()
+        defer { cleanup() }
+        try writeTranscript(brain: brain, conversationID: "C1")
+        #expect(AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/other", mapURL: mapURL))
+
+        let agent = AntigravityAgent(conversationMapURL: mapURL, brainDir: brain.path)
+        // The map attributes C1 to /ws/other, so a different worktree gets nothing —
+        // dropped, never guessed.
+        #expect(agent.logSources(worktreePath: "/ws/repo-1", harnessSessionID: nil).isEmpty)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/AntigravityConversationMap.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/AntigravityConversationMap.swift
@@ -97,9 +97,14 @@ public struct AntigravityConversationMap: Codable, Equatable, Sendable {
         /// The worktree Crow launched `agy` in for this conversation — taken from
         /// Crow's own session ownership, never the hook payload.
         public var worktreePath: String
-        /// The transcript path the hook payload named, if any — an optional hint;
-        /// the durable `transcript_full.jsonl` is derived from the conversation id
-        /// regardless (see `preferredTranscript`).
+        /// The transcript path the hook payload named, if any — retained purely as
+        /// **untrusted provenance**, so whoever live-verifies against a real `agy`
+        /// can compare what the hook reported against the derived brain-dir template
+        /// (CROW-1107). It is **never** used to locate the collectable file: the
+        /// durable `transcript_full.jsonl` is always derived from the conversation id
+        /// + `brainDir` (`transcripts(forWorktreePath:brainDir:)`), so a payload that
+        /// points outside `brainDir`, or uses a `~` the filesystem won't expand,
+        /// can't redirect or silently drop a collection (CROW-1107 review).
         public var transcriptPath: String?
         /// When the entry was last recorded, epoch seconds.
         public var updatedAt: Double
@@ -155,8 +160,15 @@ public struct AntigravityConversationMap: Codable, Equatable, Sendable {
         var matches: [(path: String, mtime: Date)] = []
         for (conversationID, entry) in conversations
         where (entry.worktreePath as NSString).standardizingPath == want {
-            let candidate = Self.preferredTranscript(
-                entry: entry, conversationID: conversationID, brainDir: brainDir)
+            // The collectable file is ALWAYS derived from the conversation id +
+            // `brainDir` — never from the recorded `transcriptPath`, which is
+            // untrusted hook provenance (see `Entry.transcriptPath`). This confines
+            // every collected path to `brainDir` and sidesteps the payload's `~`
+            // (which `fileExists` won't expand) and any out-of-tree location. A
+            // conversation id that isn't a safe single path component is dropped,
+            // never interpolated into a path (CROW-1107 review).
+            guard Self.isPathSafeConversationID(conversationID) else { continue }
+            let candidate = AntigravityHome.transcriptPath(conversationID: conversationID, brainDir: brainDir)
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: candidate, isDirectory: &isDir), !isDir.boolValue else { continue }
             let mtime = (try? URL(fileURLWithPath: candidate)
@@ -167,18 +179,14 @@ public struct AntigravityConversationMap: Codable, Equatable, Sendable {
         return matches.sorted { $0.mtime < $1.mtime }.map { $0.path }
     }
 
-    /// The `transcript_full.jsonl` for an entry: the sibling of a recorded
-    /// `transcriptPath` when present (the recorded *directory* is authoritative
-    /// even if the recorded file was the truncated `transcript.jsonl`), else
-    /// derived from the conversation id + `brainDir`.
-    static func preferredTranscript(entry: Entry, conversationID: String, brainDir: String) -> String {
-        if let recorded = entry.transcriptPath, !recorded.isEmpty {
-            let dir = (recorded as NSString).deletingLastPathComponent
-            if !dir.isEmpty {
-                return (dir as NSString).appendingPathComponent("transcript_full.jsonl")
-            }
-        }
-        return AntigravityHome.transcriptPath(conversationID: conversationID, brainDir: brainDir)
+    /// Whether `id` is a safe single path component to interpolate into the
+    /// brain-dir template — rejecting empty, `.` / `..`, and any id containing a
+    /// path separator or NUL, so an untrusted hook conversation id can never escape
+    /// `brainDir` (CROW-1107 review). Antigravity conversation ids are UUIDs, so a
+    /// real id is never rejected.
+    static func isPathSafeConversationID(_ id: String) -> Bool {
+        guard !id.isEmpty, id != ".", id != ".." else { return false }
+        return !id.contains("/") && !id.contains("\\") && !id.contains("\u{0}")
     }
 
     // MARK: - Writing (synchronous, NSLock-guarded, dedupe-cached)
@@ -207,7 +215,9 @@ public struct AntigravityConversationMap: Codable, Equatable, Sendable {
     ) -> Bool {
         let conv = conversationID.trimmingCharacters(in: .whitespacesAndNewlines)
         let wt = worktreePath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !conv.isEmpty, !wt.isEmpty else { return false }
+        // Reject an unsafe conversation id up front so it never reaches the map (it
+        // would only be dropped at read time anyway — CROW-1107 review).
+        guard !wt.isEmpty, isPathSafeConversationID(conv) else { return false }
         let transcript = transcriptPath?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedTranscript = (transcript?.isEmpty == false) ? transcript : nil
 
@@ -217,14 +227,15 @@ public struct AntigravityConversationMap: Codable, Equatable, Sendable {
         let cacheKey = mapURL.path + "\u{0}" + conv
         let cacheVal = wt + "\u{0}" + (normalizedTranscript ?? "")
         if recordedCache[cacheKey] == cacheVal { return false }
-        recordedCache[cacheKey] = cacheVal
 
         var map = load(mapURL: mapURL)
         let existing = map.conversations[conv]
         // Preserve a previously-recorded transcript hint when this event omits one.
         let effectiveTranscript = normalizedTranscript ?? existing?.transcriptPath
-        // No meaningful change (only `updatedAt` would move) ⇒ skip the write.
+        // No meaningful change (only `updatedAt` would move) ⇒ skip the write, but
+        // still cache: disk already matches, so future identical hooks can no-op.
         if existing?.worktreePath == wt, existing?.transcriptPath == effectiveTranscript {
+            recordedCache[cacheKey] = cacheVal
             return false
         }
         map.conversations[conv] = Entry(
@@ -235,6 +246,10 @@ public struct AntigravityConversationMap: Codable, Equatable, Sendable {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             let data = try JSONEncoder().encode(map)
             try data.write(to: mapURL, options: [.atomic])
+            // Cache ONLY after a durable write. A failed first persist must not
+            // poison the cache — otherwise later hooks for this conversation would
+            // short-circuit as a cache hit and never retry (CROW-1107 review).
+            recordedCache[cacheKey] = cacheVal
             return true
         } catch {
             CrowLog.info("[AntigravityConversationMap] failed to persist \(mapURL.path): \(error.localizedDescription)")

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/AntigravityConversationMap.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/AntigravityConversationMap.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+/// The Google Antigravity (`agy`) app-data home, resolved the way Crow's other
+/// harness homes are (`CodexHome`/`GrokHome`): honor `$GEMINI_HOME` when set and
+/// non-empty, otherwise `~/.gemini`, then descend into `antigravity-cli` — the
+/// CLI's own data root (the *IDE* uses a separate `~/.gemini/antigravity-ide/`
+/// tree).
+///
+/// ⚠️ **Docs-derived, pending live-verify (CROW-1107).** `agy` is not installable
+/// on Crow's dev machines (closed-source, Google-Sign-In/GCP-authed), so these
+/// paths come from Antigravity CLI docs + community tooling (`agy-explore`,
+/// `agentgrep`, the `antigravity-conversation-fix` recovery tool), **not**
+/// first-party on-disk capture. `$GEMINI_HOME` is honored defensively in case a
+/// user relocates the tree; confirm the exact root against a live `agy` before
+/// promoting Antigravity out of Tier-2 (ADR 0015).
+public enum AntigravityHome {
+    /// The Antigravity CLI app-data root. `environment` is injectable for tests.
+    public static func path(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        let base: String
+        if let env = environment["GEMINI_HOME"], !env.isEmpty {
+            base = env
+        } else {
+            base = NSString(string: "~/.gemini").expandingTildeInPath
+        }
+        return (base as NSString).appendingPathComponent("antigravity-cli")
+    }
+
+    /// `<home>/brain` — where `agy` pools every conversation's durable transcript,
+    /// keyed only by conversation id (flat/global, like Codex's `sessions`).
+    public static func brainDir(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        (path(environment: environment) as NSString).appendingPathComponent("brain")
+    }
+
+    /// The durable NDJSON transcript for a conversation:
+    /// `<brain>/<id>/.system_generated/logs/transcript_full.jsonl`. This is the
+    /// full log; the sibling `transcript.jsonl` is the known-buggy truncated one,
+    /// so it is never used.
+    public static func transcriptPath(
+        conversationID: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        transcriptPath(conversationID: conversationID, brainDir: brainDir(environment: environment))
+    }
+
+    /// Same, against an explicit brain dir (test seam / backfill scanner).
+    public static func transcriptPath(conversationID: String, brainDir: String) -> String {
+        var p = (brainDir as NSString).appendingPathComponent(conversationID)
+        p = (p as NSString).appendingPathComponent(".system_generated")
+        p = (p as NSString).appendingPathComponent("logs")
+        p = (p as NSString).appendingPathComponent("transcript_full.jsonl")
+        return p
+    }
+
+    /// The conversation-id directory a `transcript_full.jsonl` lives under — the
+    /// inverse of `transcriptPath`, walking three parents up (`logs` →
+    /// `.system_generated` → `<id>`). Used by the backfill scanner.
+    public static func conversationID(forTranscript file: URL) -> String? {
+        let id = file
+            .deletingLastPathComponent()   // …/logs
+            .deletingLastPathComponent()   // …/.system_generated
+            .deletingLastPathComponent()   // …/<id>
+            .lastPathComponent
+        return id.isEmpty ? nil : id
+    }
+}
+
+/// Crow's runtime `conversationId → worktree` map for Antigravity (CROW-1107).
+///
+/// Antigravity's transcript records no cwd on any line, so it is **not**
+/// cwd-attributable by the shared `cwdFilter` path the way Codex's rollouts are
+/// (CROW-1097). The attribution Crow *does* have is exact and non-guessed: it
+/// launched `agy` in a known worktree, and each Antigravity hook fires with that
+/// session's `--session <uuid>` baked into `.agents/hooks.json`. The hook stdin
+/// payload additionally carries the `conversationId`, which names the transcript's
+/// `brain/<id>/…` directory. So the daemon records `conversationId → worktree` as
+/// hooks fire (`record(...)`, from `CrowEngine`'s `hook-event` handler), and
+/// `AntigravityAgent.logSources` reads it back to return exactly this worktree's
+/// transcripts — a file with no map entry is dropped, never guessed (the same
+/// invariant as Codex's cwd filter).
+///
+/// Lives in `CrowCore` because both the writer (`CrowEngine`) and the reader
+/// (`CrowAntigravity`) import CrowCore, and CrowEngine does not depend on
+/// CrowAntigravity.
+///
+/// ⚠️ **Docs-derived, pending live-verify (CROW-1107).** See `AntigravityHome`.
+/// The worktree is taken from Crow's own session ownership (never the payload), so
+/// only `conversationId` is trusted from the un-verified hook payload — and even
+/// that only *selects* a transcript, so a wrong payload field name yields "no map
+/// entry" (⇒ nothing uploaded for that conversation), never a misattribution.
+public struct AntigravityConversationMap: Codable, Equatable, Sendable {
+    /// One conversation's attribution.
+    public struct Entry: Codable, Equatable, Sendable {
+        /// The worktree Crow launched `agy` in for this conversation — taken from
+        /// Crow's own session ownership, never the hook payload.
+        public var worktreePath: String
+        /// The transcript path the hook payload named, if any — an optional hint;
+        /// the durable `transcript_full.jsonl` is derived from the conversation id
+        /// regardless (see `preferredTranscript`).
+        public var transcriptPath: String?
+        /// When the entry was last recorded, epoch seconds.
+        public var updatedAt: Double
+
+        public init(worktreePath: String, transcriptPath: String? = nil, updatedAt: Double = 0) {
+            self.worktreePath = worktreePath
+            self.transcriptPath = transcriptPath
+            self.updatedAt = updatedAt
+        }
+    }
+
+    public var version: Int
+    public var conversations: [String: Entry]
+
+    public init(version: Int = 1, conversations: [String: Entry] = [:]) {
+        self.version = version
+        self.conversations = conversations
+    }
+
+    // MARK: - Reading (synchronous — the `logSources` reader path is synchronous)
+
+    /// The global map file, in Crow's state dir (`~/.local/share/crow/`, the same
+    /// root as `crow.sock`). Global and devRoot-independent because the reader
+    /// (`AntigravityAgent.logSources`) has no devRoot, and worktree paths are
+    /// absolute and unique across dev roots anyway. `testMapURLOverride` redirects
+    /// it in tests so nothing touches the real state dir.
+    public static func defaultMapURL() -> URL {
+        if let override = testMapURLOverride { return override }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/crow", isDirectory: true)
+            .appendingPathComponent("antigravity-conversations.json")
+    }
+
+    /// Load the persisted map (empty on any read/parse failure — best-effort).
+    public static func load(mapURL: URL = defaultMapURL()) -> AntigravityConversationMap {
+        guard let data = try? Data(contentsOf: mapURL),
+              let map = try? JSONDecoder().decode(AntigravityConversationMap.self, from: data)
+        else { return AntigravityConversationMap() }
+        return map
+    }
+
+    /// Absolute `transcript_full.jsonl` paths for the entries mapped to
+    /// `worktreePath` (path-standardized on both sides), **existence-checked** so a
+    /// missing file is dropped — never guessed. Sorted oldest-modified first, so a
+    /// worktree spanning several conversations concatenates chronologically.
+    public func transcripts(
+        forWorktreePath worktreePath: String,
+        brainDir: String = AntigravityHome.brainDir()
+    ) -> [String] {
+        let want = (worktreePath as NSString).standardizingPath
+        guard !want.isEmpty else { return [] }
+        let fm = FileManager.default
+        var matches: [(path: String, mtime: Date)] = []
+        for (conversationID, entry) in conversations
+        where (entry.worktreePath as NSString).standardizingPath == want {
+            let candidate = Self.preferredTranscript(
+                entry: entry, conversationID: conversationID, brainDir: brainDir)
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: candidate, isDirectory: &isDir), !isDir.boolValue else { continue }
+            let mtime = (try? URL(fileURLWithPath: candidate)
+                .resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            matches.append((candidate, mtime))
+        }
+        return matches.sorted { $0.mtime < $1.mtime }.map { $0.path }
+    }
+
+    /// The `transcript_full.jsonl` for an entry: the sibling of a recorded
+    /// `transcriptPath` when present (the recorded *directory* is authoritative
+    /// even if the recorded file was the truncated `transcript.jsonl`), else
+    /// derived from the conversation id + `brainDir`.
+    static func preferredTranscript(entry: Entry, conversationID: String, brainDir: String) -> String {
+        if let recorded = entry.transcriptPath, !recorded.isEmpty {
+            let dir = (recorded as NSString).deletingLastPathComponent
+            if !dir.isEmpty {
+                return (dir as NSString).appendingPathComponent("transcript_full.jsonl")
+            }
+        }
+        return AntigravityHome.transcriptPath(conversationID: conversationID, brainDir: brainDir)
+    }
+
+    // MARK: - Writing (synchronous, NSLock-guarded, dedupe-cached)
+
+    private static let lock = NSLock()
+    /// Skips the load-mutate-save when the `(map file, conversationId) → (worktree,
+    /// transcript)` mapping is already on file, so only the *first* hook event per
+    /// conversation writes — the frequent `PostToolUse` stream costs nothing after.
+    /// Keyed by map path so tests using different files never collide.
+    private nonisolated(unsafe) static var recordedCache: [String: String] = [:]
+    /// Test-only redirect for `defaultMapURL()`.
+    nonisolated(unsafe) static var testMapURLOverride: URL?
+
+    /// Record (or refresh) `conversationID → worktreePath` (+ an optional
+    /// `transcriptPath` hint), best-effort. Deduped in-memory and serialized with
+    /// `lock`; a write failure is swallowed (worst case: the transcript is picked
+    /// up a tick later, or not at all — never a session failure). Returns whether a
+    /// disk write actually happened.
+    @discardableResult
+    public static func record(
+        conversationID: String,
+        worktreePath: String,
+        transcriptPath: String? = nil,
+        now: Double = Date().timeIntervalSince1970,
+        mapURL: URL = defaultMapURL()
+    ) -> Bool {
+        let conv = conversationID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let wt = worktreePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !conv.isEmpty, !wt.isEmpty else { return false }
+        let transcript = transcriptPath?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedTranscript = (transcript?.isEmpty == false) ? transcript : nil
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        let cacheKey = mapURL.path + "\u{0}" + conv
+        let cacheVal = wt + "\u{0}" + (normalizedTranscript ?? "")
+        if recordedCache[cacheKey] == cacheVal { return false }
+        recordedCache[cacheKey] = cacheVal
+
+        var map = load(mapURL: mapURL)
+        let existing = map.conversations[conv]
+        // Preserve a previously-recorded transcript hint when this event omits one.
+        let effectiveTranscript = normalizedTranscript ?? existing?.transcriptPath
+        // No meaningful change (only `updatedAt` would move) ⇒ skip the write.
+        if existing?.worktreePath == wt, existing?.transcriptPath == effectiveTranscript {
+            return false
+        }
+        map.conversations[conv] = Entry(
+            worktreePath: wt, transcriptPath: effectiveTranscript, updatedAt: now)
+
+        do {
+            let dir = mapURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(map)
+            try data.write(to: mapURL, options: [.atomic])
+            return true
+        } catch {
+            CrowLog.info("[AntigravityConversationMap] failed to persist \(mapURL.path): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Reset the dedupe cache and the test URL override (tests only).
+    static func resetForTesting() {
+        lock.lock()
+        recordedCache.removeAll()
+        testMapURLOverride = nil
+        lock.unlock()
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
@@ -4,7 +4,7 @@ import Foundation
 /// been uploaded, reconstructing each one's workspace / repo / ticket so the
 /// Settings "Backfill history" dialog can show a reviewable list (CROW-1075).
 ///
-/// Five harnesses are wired: **Claude** (CROW-1075), whose logs are partitioned
+/// Six harnesses are wired: **Claude** (CROW-1075), whose logs are partitioned
 /// by working directory (`~/.claude/projects/<slug>/<uuid>.jsonl`); **Codex**
 /// (CROW-1089), whose rollouts pool globally under `~/.codex/sessions/<date>/…`
 /// but each record their own `cwd` in a first-line `session_meta` event; **Grok**

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/BackfillScanner.swift
@@ -11,21 +11,24 @@ import Foundation
 /// (CROW-1098), which partitions by working directory too, encoding the cwd into
 /// the directory name (`~/.grok/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl`);
 /// **Cursor** (CROW-1095), whose per-chat `~/.cursor/chats/<id>/<sub>/store.db`
-/// records its `cwd` in the sibling `meta.json`; and **OpenCode** (CROW-1096), whose
+/// records its `cwd` in the sibling `meta.json`; **OpenCode** (CROW-1096), whose
 /// sessions live in the `~/.local/share/opencode/opencode.db` SQLite store, each row
-/// recording the `directory` it ran in (`session.directory`). All make historical
-/// reconstruction reliable because the real `cwd` is recoverable — Claude/Codex
-/// record it in the transcript, Grok encodes it in the path, Cursor in a sibling
-/// file, OpenCode in a column — the authoritative signal, not a lossy directory
-/// name. The scan is disk- and git-only — it never touches the provider or the
-/// network, so it stays fast over hundreds of sessions (it never opens a Cursor
-/// `store.db`; the Cursor uid is the `<sub>` directory name and the cwd a tiny
-/// sibling JSON read); ticket *validation* is deferred to upload, where a link is
-/// actually asserted.
+/// recording the `directory` it ran in (`session.directory`); and **Antigravity**
+/// (CROW-1107), whose transcript records **no** cwd — its cwd is instead recovered
+/// from the runtime conversation→worktree map the live collector builds. The first
+/// five make historical reconstruction reliable because the real `cwd` is
+/// recoverable — Claude/Codex record it in the transcript, Grok encodes it in the
+/// path, Cursor in a sibling file, OpenCode in a column — the authoritative signal,
+/// not a lossy directory name; Antigravity relies on the map (a conversation with no
+/// map entry → `low`/orphan, never guessed). The scan is disk- and git-only — it
+/// never touches the provider or the network, so it stays fast over hundreds of
+/// sessions (it never opens a Cursor `store.db`; the Cursor uid is the `<sub>`
+/// directory name and the cwd a tiny sibling JSON read); ticket *validation* is
+/// deferred to upload, where a link is actually asserted.
 ///
 /// Everything effectful is injected (the projects directory, the Codex sessions
 /// directory, the Grok sessions directory, the Cursor chats directory, the OpenCode
-/// database path, the
+/// database path, the Antigravity brain directory + its conversation map, the
 /// git-remote reader, the clock), so the reconciliation logic is unit-testable
 /// against a temporary tree.
 public struct BackfillScanner: Sendable {
@@ -56,6 +59,14 @@ public struct BackfillScanner: Sendable {
     /// `OpenCodeHome`, which CrowCore can't import); this literal default is the
     /// fallback for a direct caller.
     let openCodeDatabaseURL: URL
+    /// The Antigravity brain dir (`AntigravityHome.brainDir()` by default) — where
+    /// `agy` pools each conversation's `.../logs/transcript_full.jsonl` (CROW-1107).
+    let antigravityBrainDir: URL
+    /// The runtime conversation→worktree map (`.load()` by default) — the only
+    /// attribution Antigravity has, since its transcript records no cwd (CROW-1107,
+    /// CROW-1097). A historical transcript whose conversation id isn't in the map
+    /// reconstructs to `cwd == nil` ⇒ `low`/orphan (never guessed).
+    let antigravityMap: AntigravityConversationMap
     /// Resolve a directory's `origin` remote URL (default: `git -C <dir> remote
     /// get-url origin`). Injected so tests need no real repos.
     let gitRemote: @Sendable (String) async -> String?
@@ -68,6 +79,8 @@ public struct BackfillScanner: Sendable {
         grokSessionsDir: URL? = nil,
         cursorChatsDir: URL? = nil,
         openCodeDatabaseURL: URL? = nil,
+        antigravityBrainDir: URL? = nil,
+        antigravityMap: AntigravityConversationMap? = nil,
         runner: any ShellRunner = ProcessShellRunner(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -82,6 +95,9 @@ public struct BackfillScanner: Sendable {
             .appendingPathComponent(".cursor/chats", isDirectory: true)
         self.openCodeDatabaseURL = openCodeDatabaseURL ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/opencode/opencode.db")
+        self.antigravityBrainDir = antigravityBrainDir
+            ?? URL(fileURLWithPath: AntigravityHome.brainDir(), isDirectory: true)
+        self.antigravityMap = antigravityMap ?? AntigravityConversationMap.load()
         self.gitRemote = { dir in
             (try? await runner.run(args: ["git", "-C", dir, "remote", "get-url", "origin"],
                                    env: [:], cwd: nil))?
@@ -91,11 +107,13 @@ public struct BackfillScanner: Sendable {
     }
 
     /// Test seam: inject the git-remote reader directly. `codexSessionsDir` /
-    /// `grokSessionsDir` / `cursorChatsDir` / `openCodeDatabaseURL` default to
-    /// nonexistent paths so a test that only stages Claude transcripts stays hermetic
-    /// (it never accidentally scans a dev machine's real `~/.codex/sessions`,
-    /// `~/.grok/sessions`, `~/.cursor/chats`, or `~/.local/share/opencode/opencode.db`);
-    /// a Codex/Grok/Cursor/OpenCode test passes an explicit temp path.
+    /// `grokSessionsDir` / `cursorChatsDir` / `openCodeDatabaseURL` /
+    /// `antigravityBrainDir` default to nonexistent paths so a test that only stages
+    /// Claude transcripts stays hermetic (it never accidentally scans a dev machine's
+    /// real `~/.codex/sessions`, `~/.grok/sessions`, `~/.cursor/chats`,
+    /// `~/.local/share/opencode/opencode.db`, or `~/.gemini/antigravity-cli/brain`);
+    /// a Codex/Grok/Cursor/OpenCode/Antigravity test passes an explicit temp path.
+    /// `antigravityMap` defaults to empty for the same reason.
     init(
         devRoot: String,
         projectsDir: URL,
@@ -103,6 +121,8 @@ public struct BackfillScanner: Sendable {
         grokSessionsDir: URL? = nil,
         cursorChatsDir: URL? = nil,
         openCodeDatabaseURL: URL? = nil,
+        antigravityBrainDir: URL? = nil,
+        antigravityMap: AntigravityConversationMap = AntigravityConversationMap(),
         gitRemote: @escaping @Sendable (String) async -> String?,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -116,13 +136,16 @@ public struct BackfillScanner: Sendable {
             ?? projectsDir.appendingPathComponent("__no_cursor_chats__", isDirectory: true)
         self.openCodeDatabaseURL = openCodeDatabaseURL
             ?? projectsDir.appendingPathComponent("__no_opencode_db__/opencode.db")
+        self.antigravityBrainDir = antigravityBrainDir
+            ?? projectsDir.appendingPathComponent("__no_antigravity_brain__", isDirectory: true)
+        self.antigravityMap = antigravityMap
         self.gitRemote = gitRemote
         self.now = now
     }
 
-    /// Reconcile every on-disk transcript (Claude + Codex + Grok + Cursor + OpenCode)
-    /// against
-    /// the ledger and return the reconstructed rows, newest first.
+    /// Reconcile every on-disk transcript (Claude + Codex + Grok + Cursor +
+    /// OpenCode + Antigravity) against the ledger and return the reconstructed rows,
+    /// newest first.
     public func scan(ledger: LogSyncLedger) async -> [BackfillSession] {
         let remotes = await resolveRemotes()
         let knownRepoNames = Array(Set(remotes.values.map { $0.repo }))
@@ -159,6 +182,13 @@ public struct BackfillScanner: Sendable {
         for session in openCodeSessions() {
             guard let s = reconstructOpenCode(
                 session: session, remotesByRepo: remotes,
+                knownRepoNames: knownRepoNames, ledger: ledger)
+            else { continue }
+            sessions.append(s)
+        }
+        for file in antigravityTranscriptFiles() {
+            guard let s = reconstructAntigravity(
+                file: file, remotesByRepo: remotes,
                 knownRepoNames: knownRepoNames, ledger: ledger)
             else { continue }
             sessions.append(s)
@@ -265,6 +295,27 @@ public struct BackfillScanner: Sendable {
             harness: .opencode, cwd: session.cwd, gitBranch: nil,
             remotesByRepo: remotesByRepo, knownRepoNames: knownRepoNames, ledger: ledger,
             mtimeOverride: mtime, sizeOverride: 0)
+    }
+
+    /// Reconstruct one Antigravity transcript (CROW-1107). The transcript records
+    /// no cwd, so — unlike every other harness — the `cwd` is recovered not from
+    /// the file or its path but from the **runtime conversation→worktree map** the
+    /// live collector builds (`antigravityMap`): the conversation id is the brain
+    /// sub-directory the file lives under (`brain/<id>/…`), and its map entry names
+    /// the worktree Crow launched `agy` in. A conversation with no map entry — a
+    /// session that predates the map, or one Crow never launched — reconstructs to
+    /// `cwd == nil` ⇒ `low`/orphan via `assemble`, never guessed. `uid` is the
+    /// conversation id; Antigravity records no git branch.
+    func reconstructAntigravity(
+        file: URL, remotesByRepo: [String: RepoRemote],
+        knownRepoNames: [String], ledger: LogSyncLedger
+    ) -> BackfillSession? {
+        guard let conversationID = AntigravityHome.conversationID(forTranscript: file) else { return nil }
+        let cwd = antigravityMap.conversations[conversationID]?.worktreePath
+        return assemble(
+            uid: conversationID, file: file, slug: conversationID, harness: .antigravity,
+            cwd: cwd, gitBranch: nil,
+            remotesByRepo: remotesByRepo, knownRepoNames: knownRepoNames, ledger: ledger)
     }
 
     /// Shared reconstruction: given a harness's already-extracted
@@ -428,6 +479,24 @@ public struct BackfillScanner: Sendable {
     /// on Linux where `OpenCodeStore` has no SQLite backing).
     func openCodeSessions() -> [OpenCodeStoreSession] {
         OpenCodeStore.sessions(databasePath: openCodeDatabaseURL.path).filter { !$0.isChild }
+    }
+
+    /// Every `transcript_full.jsonl` under `<antigravityBrainDir>` (recursively).
+    /// Antigravity nests them as `<brain>/<conv-id>/.system_generated/logs/transcript_full.jsonl`,
+    /// so the enumerator descends; the exact-name filter leaves out the truncated
+    /// sibling `transcript.jsonl`, keeping this in lockstep with the live collector
+    /// (which returns `transcript_full.jsonl` per map entry — CROW-1107).
+    func antigravityTranscriptFiles() -> [URL] {
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: antigravityBrainDir, includingPropertiesForKeys: [.isRegularFileKey]) else { return [] }
+        var out: [URL] = []
+        for case let url as URL in en where url.lastPathComponent == "transcript_full.jsonl" {
+            if (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
+                out.append(url)
+            }
+        }
+        return out
     }
 
     /// Build a `repoName → RepoRemote` map from the live clones under the dev

--- a/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncSupport.swift
+++ b/Packages/CrowCore/Sources/CrowCore/LogSync/LogSyncSupport.swift
@@ -9,9 +9,10 @@ import Foundation
 /// The **wire** value sent to the server (`wireValue`) is a strict subset — the
 /// server-side DB CHECK on `crow_session_artifacts.harness`
 /// (`claude`/`cursor`/`codex`/`opencode`/`unknown`). A harness the server does
-/// not yet enumerate (`.grok`) carries its own rawValue internally but sends
-/// `unknown` on the wire, so the upload is still accepted and attributed, just
-/// not harness-typed. Every other case's `wireValue` equals its `rawValue`.
+/// not yet enumerate (`.grok`, `.antigravity`) carries its own rawValue
+/// internally but sends `unknown` on the wire, so the upload is still accepted and
+/// attributed, just not harness-typed. Every other case's `wireValue` equals its
+/// `rawValue`.
 public enum LogSyncHarness: String, Sendable, Equatable, Codable, CaseIterable {
     case claude
     case cursor
@@ -20,24 +21,29 @@ public enum LogSyncHarness: String, Sendable, Equatable, Codable, CaseIterable {
     /// Grok Build (CROW-1098). Internal-only: `wireValue` collapses it to
     /// `unknown` because the server's CHECK does not (yet) accept `grok`.
     case grok
+    /// Antigravity (CROW-1107). Internal-only, exactly like `.grok`: `wireValue`
+    /// collapses it to `unknown` because the server's CHECK does not (yet) accept
+    /// `antigravity` (corveil#2426). Carrying the real case internally still lets
+    /// it drive a distinct ledger slot and backfill-row display.
+    case antigravity
     case unknown
 
     /// The value accepted by the server's `harness` CHECK (corveil#2426). Cases
     /// the server enumerates pass through their rawValue; a not-yet-recognized
-    /// harness (`.grok`) collapses to `unknown`. Keep this in sync with the DB
-    /// CHECK: when the server adds `grok`, drop it from the collapse list.
+    /// harness (`.grok`, `.antigravity`) collapses to `unknown`. Keep this in sync
+    /// with the DB CHECK: when the server adds one, drop it from the collapse list.
     public var wireValue: String {
         switch self {
-        case .grok: return LogSyncHarness.unknown.rawValue
+        case .grok, .antigravity: return LogSyncHarness.unknown.rawValue
         case .claude, .cursor, .codex, .opencode, .unknown: return rawValue
         }
     }
 
     /// Map a Crow `AgentKind` to its harness identifier. The four harnesses the
-    /// server enumerates map directly, and Grok maps to its internal `.grok`
-    /// (wire-collapsed to `unknown`); every other kind (Antigravity, Muse, or a
-    /// future one) maps to `.unknown` so the upload is still accepted and
-    /// attributed, just not harness-typed.
+    /// server enumerates map directly; Grok and Antigravity map to their internal
+    /// cases (wire-collapsed to `unknown`); every other kind (Muse, or a future
+    /// one) maps to `.unknown` so the upload is still accepted and attributed, just
+    /// not harness-typed.
     public init(agentKind: AgentKind) {
         switch agentKind {
         case .claudeCode: self = .claude
@@ -45,6 +51,7 @@ public enum LogSyncHarness: String, Sendable, Equatable, Codable, CaseIterable {
         case .codex: self = .codex
         case .openCode: self = .opencode
         case .grok: self = .grok
+        case .antigravity: self = .antigravity
         default: self = .unknown
         }
     }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentLogSourceTests.swift
@@ -53,13 +53,13 @@ import CrowCore
         #expect(LogSyncHarness(agentKind: .cursor) == .cursor)
         #expect(LogSyncHarness(agentKind: .codex) == .codex)
         #expect(LogSyncHarness(agentKind: .openCode) == .opencode)
-        // Grok is internally first-class (CROW-1098), even though it collapses to
-        // `unknown` on the wire.
+        // Grok (CROW-1098) and Antigravity (CROW-1107) are internally first-class,
+        // even though they collapse to `unknown` on the wire.
         #expect(LogSyncHarness(agentKind: .grok) == .grok)
+        #expect(LogSyncHarness(agentKind: .antigravity) == .antigravity)
     }
 
     @Test func mapsEverythingElseToUnknown() {
-        #expect(LogSyncHarness(agentKind: .antigravity) == .unknown)
         #expect(LogSyncHarness(agentKind: .muse) == .unknown)
     }
 
@@ -74,12 +74,15 @@ import CrowCore
         #expect(LogSyncArtifactKind.sessionTranscript.rawValue == "session_transcript")
     }
 
-    @Test func grokIsInternalButCollapsesToUnknownOnTheWire() {
+    @Test func internalHarnessesCollapseToUnknownOnTheWire() {
         // Internally distinct (drives the ledger slot / backfill display /
-        // format+agentKind), but the server doesn't enumerate `grok`, so the wire
-        // value is `unknown` — the upload is accepted, just not harness-typed.
+        // format+agentKind), but the server doesn't enumerate `grok` or
+        // `antigravity`, so the wire value is `unknown` — the upload is accepted,
+        // just not harness-typed.
         #expect(LogSyncHarness.grok.rawValue == "grok")
         #expect(LogSyncHarness.grok.wireValue == "unknown")
+        #expect(LogSyncHarness.antigravity.rawValue == "antigravity")
+        #expect(LogSyncHarness.antigravity.wireValue == "unknown")
     }
 
     @Test func serverEnumeratedHarnessesWireAsThemselves() {

--- a/Packages/CrowCore/Tests/CrowCoreTests/AntigravityConversationMapTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AntigravityConversationMapTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite struct AntigravityHomeTests {
+    @Test func resolvesUnderGeminiHome() {
+        let p = AntigravityHome.path(environment: [:])
+        #expect(p.hasSuffix("/.gemini/antigravity-cli"))
+    }
+
+    @Test func honorsGeminiHomeOverride() {
+        let p = AntigravityHome.path(environment: ["GEMINI_HOME": "/custom/gem"])
+        #expect(p == "/custom/gem/antigravity-cli")
+    }
+
+    @Test func brainDirAndTranscriptPathDerivation() {
+        let brain = AntigravityHome.brainDir(environment: ["GEMINI_HOME": "/g"])
+        #expect(brain == "/g/antigravity-cli/brain")
+        let t = AntigravityHome.transcriptPath(conversationID: "abc", brainDir: brain)
+        #expect(t == "/g/antigravity-cli/brain/abc/.system_generated/logs/transcript_full.jsonl")
+    }
+
+    @Test func conversationIDInvertsTranscriptPath() {
+        let t = AntigravityHome.transcriptPath(conversationID: "conv-42", brainDir: "/g/brain")
+        let id = AntigravityHome.conversationID(forTranscript: URL(fileURLWithPath: t))
+        #expect(id == "conv-42")
+    }
+}
+
+@Suite struct AntigravityConversationMapTests {
+    /// A temp dir + a map-file URL under it; cleans up and resets the static cache.
+    private func makeTemp() -> (dir: URL, mapURL: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agy-map-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let mapURL = dir.appendingPathComponent("map.json")
+        return (dir, mapURL, {
+            AntigravityConversationMap.resetForTesting()
+            try? FileManager.default.removeItem(at: dir)
+        })
+    }
+
+    /// Create a real `transcript_full.jsonl` for a conversation under a brain dir.
+    private func writeTranscript(brainDir: URL, conversationID: String, body: String = "{}") throws {
+        let path = AntigravityHome.transcriptPath(conversationID: conversationID, brainDir: brainDir.path)
+        let dir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try body.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    @Test func recordThenLoadRoundTrip() throws {
+        let (_, mapURL, cleanup) = makeTemp()
+        defer { cleanup() }
+
+        let wrote = AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/dev/ws/repo-1",
+            transcriptPath: "/brain/C1/.system_generated/logs/transcript.jsonl",
+            now: 100, mapURL: mapURL)
+        #expect(wrote)
+
+        let map = AntigravityConversationMap.load(mapURL: mapURL)
+        let entry = try #require(map.conversations["C1"])
+        #expect(entry.worktreePath == "/dev/ws/repo-1")
+        #expect(entry.transcriptPath == "/brain/C1/.system_generated/logs/transcript.jsonl")
+        #expect(entry.updatedAt == 100)
+    }
+
+    @Test func recordDedupesUnchangedPair() throws {
+        let (_, mapURL, cleanup) = makeTemp()
+        defer { cleanup() }
+
+        #expect(AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/a", now: 1, mapURL: mapURL))
+        // Same conversation → same worktree, no transcript change: no rewrite.
+        #expect(!AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/a", now: 2, mapURL: mapURL))
+        // A new worktree for the same conversation *is* a change.
+        #expect(AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/b", now: 3, mapURL: mapURL))
+        #expect(AntigravityConversationMap.load(mapURL: mapURL).conversations["C1"]?.worktreePath == "/ws/b")
+    }
+
+    @Test func recordRejectsBlankInput() {
+        let (_, mapURL, cleanup) = makeTemp()
+        defer { cleanup() }
+        #expect(!AntigravityConversationMap.record(conversationID: "", worktreePath: "/ws", mapURL: mapURL))
+        #expect(!AntigravityConversationMap.record(conversationID: "C", worktreePath: "  ", mapURL: mapURL))
+        #expect(AntigravityConversationMap.load(mapURL: mapURL).conversations.isEmpty)
+    }
+
+    @Test func transcriptsFilterByWorktreeAndExistence() throws {
+        let (dir, _, cleanup) = makeTemp()
+        defer { cleanup() }
+        let brain = dir.appendingPathComponent("brain", isDirectory: true)
+        try writeTranscript(brainDir: brain, conversationID: "A")   // worktree X
+        try writeTranscript(brainDir: brain, conversationID: "B")   // worktree Y
+        // "C" is mapped but its file is missing → dropped, never guessed.
+
+        let map = AntigravityConversationMap(conversations: [
+            "A": .init(worktreePath: "/ws/x"),
+            "B": .init(worktreePath: "/ws/y"),
+            "C": .init(worktreePath: "/ws/x"),
+        ])
+        let forX = map.transcripts(forWorktreePath: "/ws/x", brainDir: brain.path)
+        #expect(forX == [AntigravityHome.transcriptPath(conversationID: "A", brainDir: brain.path)])
+
+        let forY = map.transcripts(forWorktreePath: "/ws/y", brainDir: brain.path)
+        #expect(forY.count == 1)
+        #expect(forY[0].hasSuffix("/B/.system_generated/logs/transcript_full.jsonl"))
+
+        // A worktree with no mapped conversation → nothing.
+        #expect(map.transcripts(forWorktreePath: "/ws/z", brainDir: brain.path).isEmpty)
+    }
+
+    @Test func preferredTranscriptRedirectsToFullBesideARecordedTruncatedFile() {
+        // A recorded `transcript.jsonl` hint resolves to the durable
+        // `transcript_full.jsonl` in the same directory.
+        let entry = AntigravityConversationMap.Entry(
+            worktreePath: "/ws",
+            transcriptPath: "/brain/C/.system_generated/logs/transcript.jsonl")
+        let path = AntigravityConversationMap.preferredTranscript(
+            entry: entry, conversationID: "C", brainDir: "/other/brain")
+        #expect(path == "/brain/C/.system_generated/logs/transcript_full.jsonl")
+    }
+
+    @Test func preferredTranscriptDerivesFromConversationWhenNoHint() {
+        let entry = AntigravityConversationMap.Entry(worktreePath: "/ws")
+        let path = AntigravityConversationMap.preferredTranscript(
+            entry: entry, conversationID: "C", brainDir: "/b")
+        #expect(path == "/b/C/.system_generated/logs/transcript_full.jsonl")
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AntigravityConversationMapTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AntigravityConversationMapTests.swift
@@ -112,21 +112,66 @@ import Testing
         #expect(map.transcripts(forWorktreePath: "/ws/z", brainDir: brain.path).isEmpty)
     }
 
-    @Test func preferredTranscriptRedirectsToFullBesideARecordedTruncatedFile() {
-        // A recorded `transcript.jsonl` hint resolves to the durable
-        // `transcript_full.jsonl` in the same directory.
-        let entry = AntigravityConversationMap.Entry(
-            worktreePath: "/ws",
-            transcriptPath: "/brain/C/.system_generated/logs/transcript.jsonl")
-        let path = AntigravityConversationMap.preferredTranscript(
-            entry: entry, conversationID: "C", brainDir: "/other/brain")
-        #expect(path == "/brain/C/.system_generated/logs/transcript_full.jsonl")
+    @Test func transcriptsIgnoreRecordedHintAndDeriveFromBrainDir() throws {
+        let (dir, _, cleanup) = makeTemp()
+        defer { cleanup() }
+        let brain = dir.appendingPathComponent("brain", isDirectory: true)
+        try writeTranscript(brainDir: brain, conversationID: "A")
+
+        // The recorded hint points at a completely different tree (and uses `~`
+        // that `fileExists` never expands). It must be IGNORED: the collectable
+        // file is always derived from the conversation id + brainDir, so the real
+        // staged transcript is still found and no out-of-tree path is returned.
+        let map = AntigravityConversationMap(conversations: [
+            "A": .init(worktreePath: "/ws/x",
+                       transcriptPath: "~/somewhere/else/.system_generated/logs/transcript.jsonl"),
+        ])
+        let forX = map.transcripts(forWorktreePath: "/ws/x", brainDir: brain.path)
+        #expect(forX == [AntigravityHome.transcriptPath(conversationID: "A", brainDir: brain.path)])
     }
 
-    @Test func preferredTranscriptDerivesFromConversationWhenNoHint() {
-        let entry = AntigravityConversationMap.Entry(worktreePath: "/ws")
-        let path = AntigravityConversationMap.preferredTranscript(
-            entry: entry, conversationID: "C", brainDir: "/b")
-        #expect(path == "/b/C/.system_generated/logs/transcript_full.jsonl")
+    @Test func unsafeConversationIDIsNeverInterpolatedIntoAPath() throws {
+        let (dir, mapURL, cleanup) = makeTemp()
+        defer { cleanup() }
+        let brain = dir.appendingPathComponent("brain", isDirectory: true)
+
+        // A path-traversing / separator-bearing id is rejected at write time …
+        #expect(!AntigravityConversationMap.record(
+            conversationID: "../escape", worktreePath: "/ws/x", mapURL: mapURL))
+        #expect(!AntigravityConversationMap.record(
+            conversationID: "a/b", worktreePath: "/ws/x", mapURL: mapURL))
+        #expect(AntigravityConversationMap.load(mapURL: mapURL).conversations.isEmpty)
+
+        // … and even a map hand-built with an unsafe id yields no path at read time.
+        let map = AntigravityConversationMap(conversations: [
+            "../escape": .init(worktreePath: "/ws/x"),
+            "a/b": .init(worktreePath: "/ws/x"),
+        ])
+        #expect(map.transcripts(forWorktreePath: "/ws/x", brainDir: brain.path).isEmpty)
+
+        #expect(AntigravityConversationMap.isPathSafeConversationID("550e8400-e29b-41d4-a716-446655440000"))
+        for bad in ["", ".", "..", "a/b", "a\\b", "../x"] {
+            #expect(!AntigravityConversationMap.isPathSafeConversationID(bad))
+        }
+    }
+
+    @Test func aFailedWriteDoesNotPoisonTheDedupeCache() throws {
+        let (dir, _, cleanup) = makeTemp()
+        defer { cleanup() }
+        // Point the map at `<dir>/blocker/map.json` where `blocker` is a *file*, so
+        // the directory creation (and thus the write) fails.
+        let blocker = dir.appendingPathComponent("blocker")
+        try "x".write(to: blocker, atomically: true, encoding: .utf8)
+        let mapURL = blocker.appendingPathComponent("map.json")
+
+        // First record fails to persist (returns false) — and must NOT cache, so a
+        // retry after the obstruction clears still writes (CROW-1107 review).
+        #expect(!AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/a", mapURL: mapURL))
+
+        try FileManager.default.removeItem(at: blocker) // clear the obstruction
+        #expect(AntigravityConversationMap.record(
+            conversationID: "C1", worktreePath: "/ws/a", mapURL: mapURL))
+        #expect(AntigravityConversationMap.load(mapURL: mapURL).conversations["C1"]?.worktreePath == "/ws/a")
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/BackfillScannerTests.swift
@@ -417,6 +417,89 @@ import Testing
     }
 #endif
 
+    // MARK: - Antigravity (CROW-1107)
+
+    /// Write an Antigravity durable transcript at
+    /// `<brain>/<conv-id>/.system_generated/logs/transcript_full.jsonl`, plus the
+    /// truncated sibling `transcript.jsonl` the scanner must ignore.
+    private func writeAntigravityTranscript(in brainDir: URL, conversationID: String) throws {
+        let logs = brainDir
+            .appendingPathComponent(conversationID, isDirectory: true)
+            .appendingPathComponent(".system_generated", isDirectory: true)
+            .appendingPathComponent("logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        try """
+        {"step_index":0,"type":"user","source":"user","status":"ok","created_at":"2026-08-24T00:00:00Z"}
+        {"step_index":1,"type":"model","source":"agent","status":"ok","created_at":"2026-08-24T00:00:01Z"}
+        """.write(to: logs.appendingPathComponent("transcript_full.jsonl"),
+                  atomically: true, encoding: .utf8)
+        // The known-buggy truncated sibling — must NOT be picked up.
+        try "{}".write(to: logs.appendingPathComponent("transcript.jsonl"),
+                       atomically: true, encoding: .utf8)
+    }
+
+    @Test func reconstructsAntigravityViaRuntimeMap() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        let brain = URL(fileURLWithPath: devRoot)
+            .deletingLastPathComponent().appendingPathComponent("agy-brain", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: brain) }
+
+        // A live clone so the repo → owner/repo resolves.
+        let clone = URL(fileURLWithPath: devRoot)
+            .appendingPathComponent("RadiusMethod/crow", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: clone.appendingPathComponent(".git"), withIntermediateDirectories: true)
+
+        let cwd = "\(devRoot)/RadiusMethod/crow-1107-wire-antigravity-collector"
+        try writeAntigravityTranscript(in: brain, conversationID: "CONV-1")
+
+        // The runtime map supplies the cwd the transcript itself lacks.
+        let map = AntigravityConversationMap(conversations: [
+            "CONV-1": .init(worktreePath: cwd),
+        ])
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects,
+            antigravityBrainDir: brain, antigravityMap: map,
+            gitRemote: { path in
+                path.hasSuffix("/RadiusMethod/crow") ? "https://github.com/corveil/crow.git" : nil
+            })
+
+        let sessions = await scanner.scan(ledger: LogSyncLedger())
+        // Only the one transcript_full.jsonl — the truncated sibling is ignored.
+        #expect(sessions.count == 1)
+        let s = try #require(sessions.first { $0.claudeSessionUID == "CONV-1" })
+        #expect(s.harness == .antigravity)
+        #expect(s.cwd == cwd)             // recovered from the runtime map, not the file
+        #expect(s.workspace == "RadiusMethod")
+        #expect(s.worktreeName == "crow-1107-wire-antigravity-collector")
+        #expect(s.repoName == "crow")
+        #expect(s.ownerRepo == "corveil/crow")
+        #expect(s.ticketNumber == 1107)
+        #expect(s.confidence == .high)
+    }
+
+    @Test func antigravityWithNoMapEntryIsLowConfidenceOrphan() async throws {
+        let (devRoot, projects, cleanup) = try makeTree()
+        defer { cleanup() }
+        let brain = URL(fileURLWithPath: devRoot)
+            .deletingLastPathComponent().appendingPathComponent("agy-brain2", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: brain) }
+        try writeAntigravityTranscript(in: brain, conversationID: "CONV-ORPHAN")
+
+        // Empty map → the transcript's cwd stays unknown → orphan, never guessed.
+        let scanner = BackfillScanner(
+            devRoot: devRoot, projectsDir: projects, antigravityBrainDir: brain,
+            gitRemote: { _ in nil })
+        let s = try #require(
+            await scanner.scan(ledger: LogSyncLedger()).first { $0.claudeSessionUID == "CONV-ORPHAN" })
+        #expect(s.harness == .antigravity)
+        #expect(s.cwd == nil)
+        #expect(s.workspace == nil)
+        #expect(s.repoName == nil)
+        #expect(s.confidence == .low)
+    }
+
     @Test func summaryCountsByTier() {
         let sessions = [
             BackfillSession(claudeSessionUID: "a", filePath: "", slug: "", confidence: .high, uploadStatus: .uploaded),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/BackfillService.swift
@@ -51,13 +51,17 @@ struct BackfillService: Sendable {
         // trees the live collector and the launch paths read. CrowCore's
         // `BackfillScanner` can't import CrowCodex / CrowGrok / CrowCursor /
         // CrowOpenCode, so the daemon injects them all (CROW-1089, CROW-1098,
-        // CROW-1095, CROW-1096).
+        // CROW-1095, CROW-1096). Antigravity's brain dir is resolved by
+        // `AntigravityHome` inside CrowCore and its conversation→worktree map defaults
+        // to `.load()` inside the scanner — so neither is strictly injected, but the
+        // brain dir is passed explicitly for symmetry (CROW-1107).
         let s = scanner ?? BackfillScanner(
             devRoot: devRoot,
             codexSessionsDir: URL(fileURLWithPath: CodexHome.sessionsDir()),
             grokSessionsDir: URL(fileURLWithPath: GrokHome.sessionsDir()),
             cursorChatsDir: URL(fileURLWithPath: CursorHome.chatsDir()),
             openCodeDatabaseURL: URL(fileURLWithPath: OpenCodeHome.databasePath()),
+            antigravityBrainDir: URL(fileURLWithPath: AntigravityHome.brainDir()),
             now: now)
         return await s.scan(ledger: ledger)
     }
@@ -168,13 +172,14 @@ struct BackfillService: Sendable {
 
     /// The `agentKind` sidecar hint for a harness. Only the wired harnesses reach
     /// here; any other maps to Claude's kind as a harmless default (it never occurs
-    /// — the scanner only emits `.claude`/`.codex`/`.grok`/`.cursor`/`.opencode`).
+    /// — the scanner only emits `.claude`/`.codex`/`.grok`/`.cursor`/`.opencode`/`.antigravity`).
     static func agentKindRawValue(for harness: LogSyncHarness) -> String {
         switch harness {
         case .codex: return AgentKind.codex.rawValue
         case .grok: return AgentKind.grok.rawValue
         case .cursor: return AgentKind.cursor.rawValue
         case .opencode: return AgentKind.openCode.rawValue
+        case .antigravity: return AgentKind.antigravity.rawValue
         default: return AgentKind.claudeCode.rawValue
         }
     }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/BackfillServiceTests.swift
@@ -125,11 +125,13 @@ private struct StubRunner: ShellRunner {
         #expect(BackfillService.uploadFormat(for: .grok) == .jsonl) // single NDJSON transcript
         #expect(BackfillService.uploadFormat(for: .cursor) == .sqlite)
         #expect(BackfillService.uploadFormat(for: .opencode) == .openCodeStore)
+        #expect(BackfillService.uploadFormat(for: .antigravity) == .jsonl) // single NDJSON transcript
         #expect(BackfillService.agentKindRawValue(for: .claude) == AgentKind.claudeCode.rawValue)
         #expect(BackfillService.agentKindRawValue(for: .codex) == AgentKind.codex.rawValue)
         #expect(BackfillService.agentKindRawValue(for: .grok) == AgentKind.grok.rawValue)
         #expect(BackfillService.agentKindRawValue(for: .cursor) == AgentKind.cursor.rawValue)
         #expect(BackfillService.agentKindRawValue(for: .opencode) == AgentKind.openCode.rawValue)
+        #expect(BackfillService.agentKindRawValue(for: .antigravity) == AgentKind.antigravity.rawValue)
     }
 
     @Test func codexSessionUploadsUnderCodexHarnessSlot() async throws {

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -62,6 +62,39 @@ func hookToolName(from payload: [String: JSONValue]) -> String? {
     return payload["toolCall"]?.objectValue?["name"]?.stringValue
 }
 
+/// Extract Antigravity's conversation id from a hook stdin payload, trying the
+/// documented `conversationId` and a snake_case fallback (CROW-1107). The id names
+/// the transcript's `brain/<id>/…` directory, so the `hook-event` handler records
+/// it against the worktree Crow owns for the session.
+///
+/// ⚠️ Docs-derived, pending live-verify: `agy` can't be run here, so the exact
+/// field name is from Antigravity CLI docs, not first-party capture. A wrong name
+/// yields no id ⇒ no map entry ⇒ nothing uploaded for that conversation — never a
+/// misattribution (the worktree comes from session ownership, not the payload).
+func antigravityConversationID(from payload: [String: JSONValue]) -> String? {
+    for key in ["conversationId", "conversation_id"] {
+        if let v = payload[key]?.stringValue {
+            let trimmed = v.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+    }
+    return nil
+}
+
+/// Extract Antigravity's transcript-path hint from a hook payload (`transcriptPath`
+/// / `transcript_path`), if present — an optional locator only; the collector
+/// derives the durable `transcript_full.jsonl` from the conversation id regardless
+/// (CROW-1107).
+func antigravityTranscriptPath(from payload: [String: JSONValue]) -> String? {
+    for key in ["transcriptPath", "transcript_path"] {
+        if let v = payload[key]?.stringValue {
+            let trimmed = v.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+    }
+    return nil
+}
+
 /// Payload `cwd`s already logged as unresolved hook-event drops. An unmapped
 /// global hook config re-fires on every event, so without this the only
 /// diagnostic channel left after #903 (see the hook-event handler) would flood
@@ -1399,6 +1432,26 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                         ?? session?.agentKind
                         ?? capturedAppState.defaultAgentKind
                     let signalSource = AgentRegistry.shared.agent(for: resolvedKind)?.stateSignalSource
+
+                    // CROW-1107: capture Antigravity's conversation→worktree map.
+                    // `agy`'s transcript records no cwd, so it can't be attributed
+                    // by the shared `cwdFilter` path (CROW-1097). What Crow *does*
+                    // know is exact: it launched `agy` in this session's worktree,
+                    // and the hook carries the `conversationId` that names the
+                    // transcript's `brain/<id>/…` dir. Record the pairing so
+                    // `AntigravityAgent.logSources` can return exactly this
+                    // worktree's transcripts. The worktree comes from Crow's own
+                    // session ownership — never the payload — so there is no
+                    // possibility of misattribution (best-effort, deduped, and it
+                    // never blocks or fails the hook).
+                    if resolvedKind == .antigravity,
+                       let conversationID = antigravityConversationID(from: payload),
+                       let worktree = capturedAppState.primaryWorktree(for: sessionID)?.worktreePath {
+                        AntigravityConversationMap.record(
+                            conversationID: conversationID,
+                            worktreePath: worktree,
+                            transcriptPath: antigravityTranscriptPath(from: payload))
+                    }
 
                     let state = capturedAppState.hookState(for: sessionID)
                     let stateBefore = state.activityState

--- a/Packages/CrowEngine/Tests/CrowEngineTests/AntigravityHookMapCaptureTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/AntigravityHookMapCaptureTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import CrowCore
+import CrowPersistence
+import CrowIPC
+@testable import CrowEngine
+
+/// CROW-1107: an Antigravity hook records `conversationId → worktree` into the
+/// runtime map, and the worktree comes from Crow's **own session ownership** —
+/// never the hook payload — so there is no possibility of misattribution. The
+/// suite is `.serialized` because the tests share `testMapURLOverride`.
+@Suite("antigravity hook conversation map capture", .serialized)
+@MainActor
+struct AntigravityHookMapCaptureTests {
+
+    private func makeRouter(_ appState: AppState, _ store: JSONStore, devRoot: String) -> CommandRouter {
+        let service = SessionService(store: store, appState: appState, hostBridge: NoopHostBridge())
+        return makeEngineRouter(EngineContext(
+            appState: appState, store: store, sessionService: service,
+            issueTracker: nil, telemetryPort: nil, devRoot: devRoot,
+            hostBridge: NoopHostBridge(), loadConfig: { nil }, applyConfig: { _ in nil }))
+    }
+
+    private func makeSessionWithWorktree(_ appState: AppState, under tmp: URL, name: String) -> (Session, String) {
+        let session = Session(name: name)
+        appState.sessions.append(session)
+        let worktreePath = tmp.appendingPathComponent("ws/repo-1").path
+        appState.worktrees[session.id] = [
+            SessionWorktree(sessionID: session.id, repoName: "repo", repoPath: worktreePath,
+                            worktreePath: worktreePath, branch: "feature/x", isPrimary: true),
+        ]
+        return (session, worktreePath)
+    }
+
+    @Test("records the owned worktree, not the payload's workspacePaths")
+    func recordsOwnedWorktree() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-agy-capture-\(UUID().uuidString)")
+        let mapURL = tmp.appendingPathComponent("map.json")
+        AntigravityConversationMap.testMapURLOverride = mapURL
+        defer { AntigravityConversationMap.resetForTesting(); try? FileManager.default.removeItem(at: tmp) }
+
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+        let (session, worktreePath) = makeSessionWithWorktree(appState, under: tmp, name: "agy")
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        let response = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(session.id.uuidString),
+                "agent_kind": .string("antigravity"),
+                "event_name": .string("PostToolUse"),
+                // A payload whose `workspacePaths` point elsewhere — it must be
+                // ignored; only `conversationId` is read, and the worktree comes
+                // from Crow's session ownership.
+                "payload": .object([
+                    "conversationId": .string("CONV-XYZ"),
+                    "workspacePaths": .array([.string("/attacker/controlled")]),
+                    "transcriptPath": .string("/agy/brain/CONV-XYZ/.system_generated/logs/transcript.jsonl"),
+                ]),
+            ]))
+        #expect(response.error == nil)
+
+        let map = AntigravityConversationMap.load(mapURL: mapURL)
+        let entry = try #require(map.conversations["CONV-XYZ"])
+        #expect(entry.worktreePath == worktreePath)          // from ownership …
+        #expect(entry.worktreePath != "/attacker/controlled") // … NOT the payload
+        #expect(entry.transcriptPath == "/agy/brain/CONV-XYZ/.system_generated/logs/transcript.jsonl")
+    }
+
+    @Test("a non-antigravity hook records nothing")
+    func nonAntigravityRecordsNothing() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-agy-capture-\(UUID().uuidString)")
+        let mapURL = tmp.appendingPathComponent("map.json")
+        AntigravityConversationMap.testMapURLOverride = mapURL
+        defer { AntigravityConversationMap.resetForTesting(); try? FileManager.default.removeItem(at: tmp) }
+
+        let appState = AppState()
+        let store = JSONStore(directory: tmp)
+        let (session, _) = makeSessionWithWorktree(appState, under: tmp, name: "claude")
+
+        let router = makeRouter(appState, store, devRoot: tmp.path)
+        _ = await router.handle(request: JSONRPCRequest(
+            id: 1, method: "hook-event", params: [
+                "session_id": .string(session.id.uuidString),
+                "agent_kind": .string("claude-code"),
+                "event_name": .string("PostToolUse"),
+                "payload": .object(["conversationId": .string("CONV-XYZ")]),
+            ]))
+        #expect(AntigravityConversationMap.load(mapURL: mapURL).conversations.isEmpty)
+    }
+}

--- a/docs/harness-transcript-locations.md
+++ b/docs/harness-transcript-locations.md
@@ -37,9 +37,17 @@ opt-in). Two attribution modes exist today:
   (`AgentLogCwdReader`, Codex) or from a sibling metadata file
   (`CursorStore.recordedCwd` reads Cursor's `meta.json`). A file with no readable
   cwd is dropped, never guessed. Codex is the reference.
+- **Runtime-map** — the store pools transcripts globally **and** records no cwd, so
+  neither of the above works — but Crow launched the harness in a known worktree and
+  its hooks fire with the session's identity, so Crow captures the harness's own
+  `conversationId → worktree` pairing as it runs and reads it back at collection
+  time. Antigravity is the reference (`AntigravityConversationMap`, CROW-1107); the
+  worktree comes from Crow's own session ownership, never the payload, so a
+  transcript with no map entry is dropped, never guessed.
 
-A store that is neither (no per-worktree layout **and** no recoverable cwd inside
-each transcript) cannot be attributed and stays on the `[]` default.
+A store that is none of these (no per-worktree layout, no recoverable cwd inside
+each transcript, **and** no runtime pairing Crow can capture) cannot be attributed
+and stays on the `[]` default.
 
 ## Reference table
 
@@ -53,7 +61,7 @@ CROW-1090. "cwd-attributable?" is the wiring test above.
 | Cursor | `cursor-agent` | ✅ | `~/.cursor/chats/<chatId>/<subId>/` | `store.db` (+ sibling `meta.json`) | SQLite (content-addressed blobs, ordered by a root protobuf) | ✅ content-filtered (cwd in sibling `meta.json`) | **Wired** (CROW-1095) |
 | OpenCode | `opencode` | ✅ | `~/.local/share/opencode/opencode.db` (SQLite; 1.17+ — the pre-1.17 `storage/{project,session,message,part}/` JSON tree is legacy, migrated in on upgrade) | relational `session`/`message`/`part` rows | SQLite | ✅ content-filtered (`session.directory` column) | **Wired** (CROW-1096) |
 | Grok Build | `grok` | ✅ | `<$GROK_HOME or ~/.grok>/sessions/<urlencoded-abs-cwd>/<uuid>/` | `chat_history.jsonl` | NDJSON | ✅ path-partitioned (URL-encoded cwd) | **Wired** (CROW-1098) |
-| Antigravity | `agy` | ✅ | `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/` (pooled globally, keyed by id) | `transcript_full.jsonl` (`transcript.jsonl` is truncated) | NDJSON | ❌ no cwd in transcript (only off-transcript: per-conv SQLite DB / hooks / latest-only `cache/last_conversations.json`) | Deferred — durable log confirmed, **not** cwd-attributable · [#1097](https://github.com/corveil/crow/issues/1097) |
+| Antigravity | `agy` | ✅ | `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/` (pooled globally, keyed by id) | `transcript_full.jsonl` (`transcript.jsonl` is truncated) | NDJSON | ✅ runtime-map (`conversationId → worktree`, from Crow's hooks) | **Wired** (CROW-1107) — ⚠️ payload fields docs-derived, pending live-verify |
 | Muse Code | `muse` | ✅ | `~/.local/share/muse/sessions/<YYYY>/<MM>/<DD>/<id>/` | `session.jsonl` | NDJSON | ⚠️ likely content-filtered — cwd reported at `runtime.session.metadata.workspace_root` (line 1, 3rd-party parse), unverified live | Deferred — durable store found (Meta docs); verify `workspace_root`, then wire · [#1099](https://github.com/corveil/crow/issues/1099) |
 | Cowork (Claude desktop, local-agent mode) | — (desktop app) | ❌ | `~/Library/Application Support/Claude/local-agent-mode-sessions/<acct>/<install>/local_<uuid>/` | `audit.jsonl` | NDJSON | ⚠️ cwd inside JSON, no path shortcut | Out of harness scope — see below |
 | Grok Bot | — (Electron app) | ❌ | `~/Library/Application Support/Grok Bot/` | — (leveldb / server-side) | — | ❌ no durable local transcript | No collectable log — skip |
@@ -192,15 +200,23 @@ not blocked on discovery.
   tree in on upgrade. The collector/backfill read the database (`OpenCodeStore`),
   selecting cwd-matched top-level sessions and reassembling their rows into NDJSON.
 - **[#1097](https://github.com/corveil/crow/issues/1097) (Antigravity)** —
-  **resolved.** The `agy` CLI *does* write a durable NDJSON transcript at
+  **research resolved; wired by [#1107](https://github.com/corveil/crow/issues/1107).**
+  The `agy` CLI writes a durable NDJSON transcript at
   `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl`,
-  but pooled globally by conversation id with **no cwd on any line** — so it is
-  neither path-partitioned nor content-filterable, and stays on `[]`. The cwd
-  lives only off-transcript (a conditional protobuf-in-SQLite per-conversation DB,
-  the ephemeral hook / status-line payloads, or the latest-only
-  `cache/last_conversations.json` pointer).
-  Verified from Antigravity CLI docs + community tooling, not a live `agy` (not
-  installed; Google-Sign-In/GCP-gated). Full rationale in `AntigravityAgent.logSources`.
+  pooled globally by conversation id with **no cwd on any line** — so it is neither
+  path-partitioned nor content-filterable. #1097 deferred it on those grounds; #1107
+  wires it via the **runtime-map** mode instead: Crow launched `agy` in a known
+  worktree, and its Antigravity hooks fire with the session's `--session <uuid>`, so
+  the `hook-event` handler records `conversationId → worktree`
+  (`AntigravityConversationMap`) as hooks arrive, and `logSources` reads it back. The
+  worktree is taken from Crow's own session ownership, **never** the hook payload, so
+  a transcript with no map entry is dropped, never guessed. Backfill reuses the same
+  map (a conversation with no entry → `low`/orphan). ⚠️ **Docs-derived, pending
+  live-verify:** `agy` isn't installable on the dev machines (Google-Sign-In/GCP-
+  gated), so the hook payload field name (`conversationId`) and the brain-dir template
+  are from Antigravity CLI docs + community tooling, not first-party capture — confirm
+  against a live `agy` before promoting Antigravity out of Tier-2. Full rationale in
+  `AntigravityAgent.logSources` and `AntigravityConversationMap`.
 - **[#1099](https://github.com/corveil/crow/issues/1099) (Muse Code)** —
   **location answered (docs, not on-disk); attribution likely but unverified.**
   Muse writes a durable, global JSONL log at

--- a/docs/session-log-collector.md
+++ b/docs/session-log-collector.md
@@ -25,26 +25,29 @@ contributes nothing rather than uploading the wrong bytes.
 
 ## Harness coverage
 
-**Claude Code**, **Codex**, **Grok Build**, **Cursor**, and **OpenCode** are wired
-(CROW-1089 / CROW-1098 / CROW-1095 / CROW-1096). Claude and Grok partition their logs
-by working directory, so a Crow worktree maps straight to that session's transcripts
-— Claude by slugifying the path, Grok by URL-encoding it into the directory name.
-Codex and Cursor pool their stores globally, so they're attributed by **content**
-instead: the source scans the whole tree but carries a `cwdFilter`, and the collector
-keeps only the sessions whose recorded `cwd` matches the worktree. Codex records the
-cwd in its rollout head (`AgentLogCwdReader`); Cursor records it in the sibling
-`meta.json` (`CursorStore.recordedCwd`). A session with no readable cwd is dropped,
-never guessed. OpenCode (1.17.10+, Crow's documented window) keeps every session in
-one **SQLite database**, `~/.local/share/opencode/opencode.db` — relational `session`
-/ `message` / `part` tables, not a file per session — so its `.openCodeStore` source
-is that single file, and attribution is by the `session.directory` column read
-**inside** the database (`OpenCodeStore`) rather than by dropping files. The collector
-selects the top-level sessions whose `directory` matches the worktree and reassembles
-each into ordered NDJSON from its `message` / `part` rows. A session with no recorded
-directory is dropped, never guessed; child/subagent sessions are excluded (they belong
-to a parent, mirroring Claude's `subagents/` exclusion). The pre-1.17 JSON object
-store under `<dataDir>/storage/` is legacy that upstream migrates into the database on
-upgrade, so only the database is read.
+**Claude Code**, **Codex**, **Grok Build**, **Cursor**, **OpenCode**, and
+**Antigravity** are wired (CROW-1089, CROW-1098, CROW-1095, CROW-1096, CROW-1107).
+Claude and Grok partition their logs by working directory, so a Crow worktree maps
+straight to that session's transcripts — Claude by slugifying the path, Grok by
+URL-encoding it into the directory name. Codex and Cursor pool their stores globally,
+so they're attributed by **content** instead: the source scans the whole tree but
+carries a `cwdFilter`, and the collector keeps only the sessions whose recorded `cwd`
+matches the worktree. Codex records the cwd in its rollout head (`AgentLogCwdReader`);
+Cursor records it in the sibling `meta.json` (`CursorStore.recordedCwd`). A session
+with no readable cwd is dropped, never guessed. OpenCode (1.17.10+, Crow's documented
+window) keeps every session in one **SQLite database**,
+`~/.local/share/opencode/opencode.db` — relational `session` / `message` / `part`
+tables, not a file per session — so its `.openCodeStore` source is that single file,
+and attribution is by the `session.directory` column read **inside** the database
+(`OpenCodeStore`) rather than by dropping files. The collector selects the top-level
+sessions whose `directory` matches the worktree and reassembles each into ordered
+NDJSON from its `message` / `part` rows. A session with no recorded directory is
+dropped, never guessed; child/subagent sessions are excluded (they belong to a parent,
+mirroring Claude's `subagents/` exclusion). The pre-1.17 JSON object store under
+`<dataDir>/storage/` is legacy that upstream migrates into the database on upgrade, so
+only the database is read. Antigravity's transcript records **no cwd at all**, so none
+of these approaches works; it's attributed by a **runtime conversation→worktree map**
+Crow builds from its own hooks (see the row below).
 
 > **Platform.** The SQLite reader needs the `SQLite3` module. The Crow daemon that
 > runs the collector is macOS-only (an SDK module there); on the Linux CI lane, which
@@ -58,7 +61,7 @@ upgrade, so only the database is read.
 | `cursor` | `~/.cursor/chats/<chatId>/<subId>/store.db` (CLI store; cwd in the sibling `meta.json`) | **Wired.** Recursive `.sqlite` source (`fileExtension: db`) with a `cwdFilter`; `CursorStore` follows the `meta['0'].latestRootBlobId` root blob's ordered message-blob refs and emits each message's JSON as one NDJSON line. Not the Cursor IDE's `state.vscdb`. |
 | `grok` | `<$GROK_HOME or ~/.grok>/sessions/<url-encoded-cwd>/<uuid>/chat_history.jsonl` (already NDJSON; directory name is the cwd URL-encoded, `/`→`%2F`) | **Wired.** Recursive `.jsonl` source pointed at the encoded worktree directory, filtered to `chat_history.jsonl`; attribution is exact by construction (no `cwdFilter`), so sibling `events.jsonl` / `prompt_history.jsonl` are left out. |
 | `opencode` | `~/.local/share/opencode/opencode.db` (SQLite `session`/`message`/`part`; cwd in `session.directory`; `$XDG_DATA_HOME`-aware, via `OpenCodeHome`) | **Wired.** Single-file `.openCodeStore` source; `OpenCodeStore` selects the cwd-matched top-level sessions and reassembles each's `message`/`part` rows into ordered NDJSON, stamped `.logDir` on upload. Child sessions excluded; the pre-1.17 JSON `storage/` tree is not read. |
-| `antigravity` | `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl` (JSONL; pooled globally, keyed by id) | Deferred — the transcript records **no cwd** at all (step records are `step_index`/`type`/`source`/`status`/`created_at`), so a `cwdFilter` source would drop every file. The cwd lives only off-transcript (a conditional protobuf-in-SQLite per-conversation DB, the ephemeral hook / status-line payloads, or the latest-only `cache/last_conversations.json` pointer), which the current reader can't consume (CROW-1097). |
+| `antigravity` | `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl` (JSONL; pooled globally, keyed by id) | **Wired (CROW-1107).** The transcript records **no cwd** (step records are `step_index`/`type`/`source`/`status`/`created_at`), so no `cwdFilter` can attribute it. Instead a **runtime conversation→worktree map** (`AntigravityConversationMap`) is built as Crow's Antigravity hooks fire: the `hook-event` handler records `conversationId → worktree`, where the worktree is taken from Crow's **own session ownership** (never the payload), and `logSources` returns exactly that worktree's `transcript_full.jsonl` files. A transcript with no map entry is dropped, never guessed. ⚠️ Docs-derived: `agy` isn't installable on the dev machines, so the hook payload field (`conversationId`) and brain-dir template are unverified against a live `agy` — confirm before Tier-2 promotion. |
 | `muse` | `~/.local/share/muse/sessions/<YYYY>/<MM>/<DD>/<id>/session.jsonl` (durable, already JSONL) | Deferred — durable global JSONL store **confirmed** (Meta dev cookbook, CROW-1099). The cookbook documents no cwd field (its jq prints only event records, whose git refs `base_commit`/`base_ref` collide across worktrees), but a first-hand third-party parser reports the cwd at `runtime.session.metadata.workspace_root` (line 1), so attribution is **likely** possible (content-filtered, Codex-style). Format fits `.logDir` as-is; verify `workspace_root` on a real `session.jsonl` (Meta-auth-gated), then wire. |
 
 The framework (collector, normalizer, uploader, ledger, config, CLI) is
@@ -74,12 +77,12 @@ and Grok).
 
 Harnesses map to the artifact contract's `harness` value via
 `LogSyncHarness(agentKind:)`. The four the server enumerates
-(`claude`/`cursor`/`codex`/`opencode`) map directly. Grok maps to an internal
-`.grok` that drives the local ledger slot and the backfill display, but its
-`wireValue` collapses to `unknown` on the wire because the server's CHECK does not
-(yet) accept `grok` — the upload is still accepted and attributed (the true kind
-rides along in the `agent_kind` sidecar hint), just not harness-typed. Every other
-kind maps to `unknown`.
+(`claude`/`cursor`/`codex`/`opencode`) map directly. Grok and Antigravity each map
+to an internal case (`.grok` / `.antigravity`) that drives the local ledger slot and
+the backfill display, but whose `wireValue` collapses to `unknown` on the wire
+because the server's CHECK does not (yet) accept them — the upload is still accepted
+and attributed (the true kind rides along in the `agent_kind` sidecar hint), just not
+harness-typed. Every other kind maps to `unknown`.
 
 ## Pipeline
 


### PR DESCRIPTION
Closes #1107

Wiring follow-up to the CROW-1097 research spike (PR #1101). Antigravity's durable transcript (`~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl`) records **no cwd on any line**, so the shared `cwdFilter` path can't attribute it — #1097 kept `[]` on those grounds. This PR wires it via the attribution path #1097 identified: a **runtime conversation→worktree map** Crow builds from its own hooks.

## How it works
- **Capture** (`EngineRouter` hook-event handler): when an Antigravity hook fires, record `conversationId → worktree` into `AntigravityConversationMap`. The worktree is taken from **Crow's own session ownership** (`primaryWorktree(for:)`), never the payload — so there is no possibility of misattribution. Best-effort, deduped, never blocks or fails the hook.
- **Read** (`AntigravityAgent.logSources`): load the map, return exactly this worktree's `transcript_full.jsonl` files as `.file`/`.jsonl` sources (already NDJSON — no normalizer). A transcript with no map entry is **dropped, never guessed** (same invariant as Codex's cwd filter).
- **Harness typing**: first-class internal `LogSyncHarness.antigravity`, wire-collapsed to `unknown` (mirrors `.grok`; server DB CHECK — corveil#2426 — doesn't accept it yet).
- **Backfill** reuses the same map: `reconstructAntigravity` looks each transcript's `conversationId` up for its worktree (map hit → attributed like Codex/Grok; map miss → `low`/orphan, never guessed). No SQLite-protobuf reader.
- **Docs**: `session-log-collector.md` + `harness-transcript-locations.md` moved from Deferred to Wired (adds a "runtime-map" attribution mode).

## ⚠️ Hard-gate deviation — please read
The ticket's Step-1 hard gate is *"install + live-verify the hook payload fields before wiring — do not wire against docs alone."* **`agy` cannot be installed or run on this machine** (`crow agents list` → `available: false`; not on PATH; brain dir absent; running it needs Google-Sign-In/GCP auth). Per the ticket owner's decision (**"Wire defensively + caveat"**), the design mitigates the un-verifiable payload rather than trusting it:
- The worktree comes from **Crow's session ownership, never `workspacePaths`** — so the ticket's *"workspacePaths reliably equals the launch worktree"* verification is moot.
- Only `conversationId` is read from the payload (across candidate spellings `conversationId`/`conversation_id`); the transcript location is otherwise derived from the documented brain-dir template. A wrong payload field name yields *"no map entry"* (⇒ nothing uploaded), **never a misattribution**.
- Every code path + doc is caveated **"docs-derived; payload field names pending live-verify against a running `agy` before Tier-2 promotion."**

**Remaining pre-Tier-2 step:** confirm the hook payload field names + brain-dir template against a live `agy`.

## Tests
- CrowCore (786): `AntigravityConversationMapTests`, `AntigravityHomeTests`, `BackfillScannerTests` (map hit → attributed, miss → low), updated harness-typing tests.
- CrowAntigravity (44): `AntigravityAgentLogSourcesTests` (map hit → one source; empty/other-worktree → `[]`).
- CrowEngine: `AntigravityHookMapCaptureTests` (records the **owned** worktree, not the payload's `workspacePaths`; non-antigravity records nothing).
- CrowDaemon: `LogSyncCollectorTests` / `BackfillServiceTests` green.
- `make build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)