### PR TITLE
Add corveilConnection to AppConfig (secret-safe transport) (CROW-1118)

### DIFF
--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -201,7 +201,19 @@ struct ParityGateTests {
             logSync: LogSyncConfig(
                 retentionDays: 30,
                 quietPeriodMinutes: 30,
-                maxUploadBytes: 8_000_000)
+                maxUploadBytes: 8_000_000),
+            corveilConnection: CorveilConnection(
+                baseURL: "https://corveil.example",
+                clientID: "crow-probe-client",
+                connectedUser: CorveilConnectedUser(id: "u1", email: "probe@corp.com", name: "Probe"),
+                orgKeys: [
+                    CorveilOrgKey(
+                        orgID: "org1", orgName: "Acme", keyID: "key1",
+                        keyPrefix: "sk-citadel-AbC", createdAt: Date())
+                ],
+                oauth: CorveilOAuthTokens(
+                    accessToken: "at", refreshToken: "rt",
+                    registrationAccessToken: "rat", accessTokenExpiresAt: Date()))
         )
     }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -110,6 +110,17 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// browser-editable config block. `nil`/absent means all-default knobs.
     public var logSync: LogSyncConfig?
 
+    /// First-class Corveil integration connection state (CROW-1118; epic
+    /// CROW-1117). The source of truth for Crow's Corveil "Connect" (OAuth)
+    /// integration — base URL, self-registered client id, connected user, per-org
+    /// key metadata, and the OAuth tokens. The existing `WorkspaceGateway` +
+    /// logsync configs are *generated* from it. Absent (`nil`) means "not
+    /// connected". Its three OAuth token strings are secrets: `SettingsSecrets`
+    /// blanks them for the browser and restores the whole block on the way back,
+    /// so they never leave via `get-config`/`set-config` and a round-trip can't
+    /// clear the connection. See ``CorveilConnection``.
+    public var corveilConnection: CorveilConnection?
+
     /// Effective review-exclude patterns: the global `defaults.excludeReviewRepos`
     /// unioned with every workspace's per-workspace `excludeReviewRepos`. A repo
     /// excluded by any workspace (or the global default) is hidden from the review
@@ -174,7 +185,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
         jiraCredential: JiraCredential? = nil,
         webAuth: WebAuthConfig? = nil,
         mcpTokens: [MCPTokenRecord] = [],
-        logSync: LogSyncConfig? = nil
+        logSync: LogSyncConfig? = nil,
+        corveilConnection: CorveilConnection? = nil
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
@@ -202,6 +214,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.webAuth = webAuth
         self.mcpTokens = mcpTokens
         self.logSync = logSync
+        self.corveilConnection = corveilConnection
     }
 
     public init(from decoder: Decoder) throws {
@@ -256,6 +269,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         webAuth = try container.decodeIfPresent(WebAuthConfig.self, forKey: .webAuth)
         mcpTokens = try container.decodeIfPresent([MCPTokenRecord].self, forKey: .mcpTokens) ?? []
         logSync = try container.decodeIfPresent(LogSyncConfig.self, forKey: .logSync)
+        corveilConnection = try container.decodeIfPresent(CorveilConnection.self, forKey: .corveilConnection)
     }
 
     /// Pre-CROW-528 shape of the now-removed `atlassianMCP` config, decoded only
@@ -279,7 +293,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, switcher, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth, mcpTokens, logSync
+        case workspaces, defaults, notifications, sidebar, switcher, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, reviewAutoPermissionMode, coderViewAutoPermissionMode, telemetry, terminal, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, versionUpdate, jobs, defaultAgentKind, agentsByKind, managerGateway, jiraCredential, webAuth, mcpTokens, logSync, corveilConnection
     }
 
     /// Resolve the agent that should drive a newly-created session of the
@@ -494,6 +508,195 @@ public struct JiraCredential: Codable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case username, tokenRef
+    }
+}
+
+/// First-class Corveil integration connection state (CROW-1118; epic CROW-1117).
+///
+/// The source of truth for Crow's Corveil **Connect** (OAuth) integration. A
+/// Connect button runs a Dynamic-Client-Registration + PKCE OAuth flow against
+/// Corveil's own authorization server over a `127.0.0.1` loopback callback; the
+/// result is stored here, and the existing per-workspace / Manager
+/// ``WorkspaceGateway`` + logsync configs are **generated** from it (org picker →
+/// gateway header + upload opt-in), so gateway resolution and the log collector
+/// are unchanged. Absent (`nil`) means "not connected".
+///
+/// **Secret-safe transport.** Like ``WorkspaceGateway`` and ``JiraCredential``, the
+/// whole block is authored only through the local-only Connect flow and its CLI
+/// verbs (corveil/crow#1120), never `set-config`: `SettingsSecrets` blanks the
+/// three OAuth token strings on the way to a browser and restores the stored
+/// connection verbatim on the way back, so a web round-trip can neither read the
+/// tokens nor clear the connection. The non-secret fields (base URL, client id,
+/// connected user, per-org key metadata, token expiry) pass through for a
+/// read-only display.
+///
+/// Decodes leniently (every field `decodeIfPresent … ?? default`) so a
+/// partially-written block never traps the whole config load — the CROW-814 /
+/// CROW-809 lesson.
+public struct CorveilConnection: Codable, Sendable, Equatable {
+    /// Corveil API base URL the OAuth flow and generated gateway resolve against.
+    public var baseURL: String
+    /// The OAuth client id Crow self-registered via Dynamic Client Registration.
+    public var clientID: String
+    /// The signed-in Corveil user this connection belongs to.
+    public var connectedUser: CorveilConnectedUser
+    /// Metadata (never key material) for the one auto-provisioned gateway key per
+    /// Corveil org. The `sk-citadel-…` value itself lives in the generated
+    /// ``WorkspaceGateway`` header, not here.
+    public var orgKeys: [CorveilOrgKey]
+    /// OAuth token material — the secrets. Stripped for transport by
+    /// `SettingsSecrets`.
+    public var oauth: CorveilOAuthTokens
+
+    /// Whether the connection has enough to be usable — a client id and an access
+    /// token. An all-empty block (e.g. a partially-written record) reads as unset.
+    public var isEmpty: Bool {
+        clientID.trimmingCharacters(in: .whitespaces).isEmpty
+            && oauth.accessToken.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    public init(
+        baseURL: String = "",
+        clientID: String = "",
+        connectedUser: CorveilConnectedUser = CorveilConnectedUser(),
+        orgKeys: [CorveilOrgKey] = [],
+        oauth: CorveilOAuthTokens = CorveilOAuthTokens()
+    ) {
+        self.baseURL = baseURL
+        self.clientID = clientID
+        self.connectedUser = connectedUser
+        self.orgKeys = orgKeys
+        self.oauth = oauth
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        baseURL = try c.decodeIfPresent(String.self, forKey: .baseURL) ?? ""
+        clientID = try c.decodeIfPresent(String.self, forKey: .clientID) ?? ""
+        connectedUser = try c.decodeIfPresent(CorveilConnectedUser.self, forKey: .connectedUser)
+            ?? CorveilConnectedUser()
+        orgKeys = try c.decodeIfPresent([CorveilOrgKey].self, forKey: .orgKeys) ?? []
+        oauth = try c.decodeIfPresent(CorveilOAuthTokens.self, forKey: .oauth) ?? CorveilOAuthTokens()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case baseURL, clientID, connectedUser, orgKeys, oauth
+    }
+}
+
+/// The signed-in Corveil user identity behind a ``CorveilConnection`` (CROW-1118).
+/// Not a secret — shown read-only in the Integrations UI. Empty strings mean "not
+/// yet populated"; decodes tolerantly so a partial record never traps the config
+/// load.
+public struct CorveilConnectedUser: Codable, Sendable, Equatable {
+    public var id: String
+    public var email: String
+    public var name: String
+
+    public init(id: String = "", email: String = "", name: String = "") {
+        self.id = id
+        self.email = email
+        self.name = name
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id) ?? ""
+        email = try c.decodeIfPresent(String.self, forKey: .email) ?? ""
+        name = try c.decodeIfPresent(String.self, forKey: .name) ?? ""
+    }
+
+    private enum CodingKeys: String, CodingKey { case id, email, name }
+}
+
+/// Metadata for the one auto-provisioned gateway key Crow mints per Corveil org
+/// (CROW-1118). Deliberately holds **no key material** — the `sk-citadel-…` value
+/// is written into the generated ``WorkspaceGateway`` header (a separate secret
+/// field), so this block is not a secret and needs no stripping. `keyID` is the
+/// handle a disconnect revokes by; `keyPrefix` lets the UI tell keys apart.
+/// Decodes tolerantly (missing field → empty / nil).
+public struct CorveilOrgKey: Codable, Sendable, Equatable {
+    /// Corveil organization id the key belongs to.
+    public var orgID: String
+    /// Human-readable org name, for the org dropdown.
+    public var orgName: String
+    /// Id of the auto-provisioned gateway key, used to revoke on disconnect.
+    public var keyID: String
+    /// Display prefix of the minted key (never the full `sk-citadel-…` value).
+    public var keyPrefix: String
+    /// When the key was provisioned. `nil` = unknown.
+    public var createdAt: Date?
+
+    public init(
+        orgID: String = "",
+        orgName: String = "",
+        keyID: String = "",
+        keyPrefix: String = "",
+        createdAt: Date? = nil
+    ) {
+        self.orgID = orgID
+        self.orgName = orgName
+        self.keyID = keyID
+        self.keyPrefix = keyPrefix
+        self.createdAt = createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        orgID = try c.decodeIfPresent(String.self, forKey: .orgID) ?? ""
+        orgName = try c.decodeIfPresent(String.self, forKey: .orgName) ?? ""
+        keyID = try c.decodeIfPresent(String.self, forKey: .keyID) ?? ""
+        keyPrefix = try c.decodeIfPresent(String.self, forKey: .keyPrefix) ?? ""
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case orgID, orgName, keyID, keyPrefix, createdAt
+    }
+}
+
+/// OAuth token material for a ``CorveilConnection`` — the secrets (CROW-1118).
+///
+/// All three token strings are blanked by `SettingsSecrets.strippedForTransport`
+/// before the config reaches a browser and restored from the stored config on the
+/// way back, exactly like a gateway header value: they never leave the machine via
+/// `get-config`/`set-config`, and a web round-trip can't clear them. Written only
+/// by the local-only Corveil OAuth client (corveil/crow#1120).
+/// `accessTokenExpiresAt` is not itself a secret but rides with the tokens as one
+/// unit. Decodes tolerantly so a partial record never traps the config load.
+public struct CorveilOAuthTokens: Codable, Sendable, Equatable {
+    /// User-scoped, cross-org OAuth access token (secret).
+    public var accessToken: String
+    /// OAuth refresh token used to renew `accessToken` (secret).
+    public var refreshToken: String
+    /// RFC 7592 registration access token — lets Crow manage (rotate/delete) its
+    /// own Dynamic Client Registration (secret).
+    public var registrationAccessToken: String
+    /// When `accessToken` expires; drives refresh. `nil` = unknown.
+    public var accessTokenExpiresAt: Date?
+
+    public init(
+        accessToken: String = "",
+        refreshToken: String = "",
+        registrationAccessToken: String = "",
+        accessTokenExpiresAt: Date? = nil
+    ) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.registrationAccessToken = registrationAccessToken
+        self.accessTokenExpiresAt = accessTokenExpiresAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try c.decodeIfPresent(String.self, forKey: .accessToken) ?? ""
+        refreshToken = try c.decodeIfPresent(String.self, forKey: .refreshToken) ?? ""
+        registrationAccessToken = try c.decodeIfPresent(String.self, forKey: .registrationAccessToken) ?? ""
+        accessTokenExpiresAt = try c.decodeIfPresent(Date.self, forKey: .accessTokenExpiresAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken, refreshToken, registrationAccessToken, accessTokenExpiresAt
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -703,5 +703,118 @@ public enum ParityLedger {
                 secret never lands in config.json. Same local-only constraint as \
                 `jiraCredential.username`; no verb exists yet.
                 """),
+
+        // MARK: Exempt — Corveil connection (CROW-1118)
+        //
+        // The whole `corveilConnection` block is authored only through the
+        // local-only Connect (OAuth) flow and its CLI verbs (corveil/crow#1120),
+        // never `set-config` — the same local-only constraint as `managerGateway`
+        // / `jiraCredential`. The three OAuth token strings are additionally
+        // blanked by `SettingsSecrets` on the way to a browser and restored on the
+        // way back, so they never leave the machine and a web round-trip can't
+        // clear them. Verbs land in corveil/crow#1120; until then the block has no
+        // CLI surface at all.
+
+        .field(
+            "corveilConnection.baseURL",
+            noCLI: """
+                Corveil API base URL of the active Connect (OAuth) integration \
+                (CROW-1118). Authored only by the local-only Connect flow; CLI verbs \
+                land in corveil/crow#1120.
+                """),
+        .field(
+            "corveilConnection.clientID",
+            noCLI: """
+                OAuth client id Crow self-registered via Dynamic Client Registration \
+                (CROW-1118). Written only by the local-only Connect flow; no \
+                `set-config` path.
+                """),
+        .field(
+            "corveilConnection.connectedUser.id",
+            noCLI: """
+                Corveil user id behind the connection (CROW-1118). Fetched during the \
+                local-only Connect flow and shown read-only; no CLI verb yet \
+                (corveil/crow#1120).
+                """),
+        .field(
+            "corveilConnection.connectedUser.email",
+            noCLI: """
+                Connected Corveil user email (CROW-1118). Read-only display of \
+                connection identity, authored by the local-only Connect flow; verbs \
+                in corveil/crow#1120.
+                """),
+        .field(
+            "corveilConnection.connectedUser.name",
+            noCLI: """
+                Connected Corveil user display name (CROW-1118). Read-only display, \
+                authored by the local-only Connect flow; no `set-config` path \
+                (corveil/crow#1120).
+                """),
+        .field(
+            "corveilConnection.orgKeys[].orgID",
+            noCLI: """
+                Corveil org id for one auto-provisioned gateway key (CROW-1118). \
+                Populated by the local-only org-provisioning step (corveil/crow#1121); \
+                not user-settable.
+                """),
+        .field(
+            "corveilConnection.orgKeys[].orgName",
+            noCLI: """
+                Display name of a Corveil org with an auto-provisioned key \
+                (CROW-1118). Populated by the local-only Connect / provisioning flow; \
+                no CLI verb yet.
+                """),
+        .field(
+            "corveilConnection.orgKeys[].keyID",
+            noCLI: """
+                Id of the auto-provisioned per-org gateway key — the handle a \
+                disconnect revokes by (CROW-1118). Minted server-side; not \
+                user-settable (corveil/crow#1121).
+                """),
+        .field(
+            "corveilConnection.orgKeys[].keyPrefix",
+            noCLI: """
+                Display prefix of the auto-provisioned per-org key so the UI can tell \
+                keys apart (CROW-1118). Derived from the minted key; not \
+                independently settable.
+                """),
+        .field(
+            "corveilConnection.orgKeys[].createdAt",
+            noCLI: """
+                Mint timestamp of the per-org gateway key (CROW-1118). Stamped when \
+                the key is provisioned by the local-only flow (corveil/crow#1121); \
+                not user-settable.
+                """),
+        .field(
+            "corveilConnection.oauth.accessToken",
+            noCLI: """
+                User-scoped OAuth access token (secret). Blanked by \
+                `SettingsSecrets.strippedForTransport` and restored from the stored \
+                config on `set-config`, so it never reaches a browser and a round-trip \
+                can't clear it. Written only by the local-only Corveil OAuth client \
+                (corveil/crow#1120).
+                """),
+        .field(
+            "corveilConnection.oauth.refreshToken",
+            noCLI: """
+                OAuth refresh token (secret). Same secret-safe transport as the access \
+                token — stripped for a browser, restored on the way back — and written \
+                only by the local-only Corveil OAuth client (corveil/crow#1120).
+                """),
+        .field(
+            "corveilConnection.oauth.registrationAccessToken",
+            noCLI: """
+                RFC 7592 registration access token that manages Crow's own DCR client \
+                (secret). Stripped for transport and restored from the stored config; \
+                authored only by the local-only Corveil OAuth client \
+                (corveil/crow#1120).
+                """),
+        .field(
+            "corveilConnection.oauth.accessTokenExpiresAt",
+            noCLI: """
+                Access-token expiry that drives refresh (CROW-1118). Written with the \
+                tokens by the local-only Corveil OAuth client (corveil/crow#1120); \
+                read-only connection-health display, with no `set-config` write path.
+                """),
     ]
 }

--- a/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
+++ b/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
@@ -4,12 +4,14 @@ import Foundation
 ///
 /// The desktop app edits `AppConfig` in-process, so its credential fields never
 /// leave the machine. The web Settings modal, however, ships the whole config to
-/// a browser to render the form. Three fields hold secrets that must **not** be
+/// a browser to render the form. Several fields hold secrets that must **not** be
 /// sent as plaintext, and — per the product decision — are **desktop-only,
 /// read-only on the web**:
 ///   - `jiraCredential.tokenRef` (Jira API token — `op://` ref or plaintext)
 ///   - `managerGateway.customHeaders` values (AI-gateway auth headers)
 ///   - each `workspaces[].gateway.customHeaders` value (per-workspace gateway auth)
+///   - `corveilConnection.oauth` token strings (Corveil OAuth access / refresh /
+///     registration-access tokens — CROW-1118)
 ///
 /// So the web round-trip is deliberately trivial: **strip** the credential values
 /// on the way out (the browser shows names/URLs/username read-only but never the
@@ -52,6 +54,18 @@ public enum SettingsSecrets {
         // behavior knobs (retention / quiet period / upload cap) — no credential
         // and no opt-in — so there is nothing to strip. Both the opt-in and the
         // upload credential are the per-workspace gateway, handled above.
+        //
+        // Corveil connection (CROW-1118): blank the OAuth token strings but keep
+        // the rest of the block (base URL, client id, connected user, per-org key
+        // metadata, token expiry) so the read-only Integrations view can show
+        // what's connected without ever seeing a token. Like a gateway header
+        // value, only the secret is blanked, not the surrounding structure — the
+        // block still decodes unchanged in shape.
+        if c.corveilConnection != nil {
+            c.corveilConnection?.oauth.accessToken = ""
+            c.corveilConnection?.oauth.refreshToken = ""
+            c.corveilConnection?.oauth.registrationAccessToken = ""
+        }
         return c
     }
 
@@ -84,6 +98,14 @@ public enum SettingsSecrets {
         // `current` means a round-trip is a no-op regardless of what came back.
         result.mcpTokens = current?.mcpTokens ?? []
         result.managerGateway = current?.managerGateway
+        // Corveil connection (CROW-1118): authored only through the local-only
+        // Connect (OAuth) flow and its CLI verbs (corveil/crow#1120), never
+        // `set-config`. Restore the whole block from `current` — exactly like
+        // `managerGateway` above — so a browser can neither read the OAuth tokens
+        // (blanked by `strippedForTransport`) nor change or clear the connection
+        // through a config save. A nil `current` drops it, so a client can't
+        // introduce a forged connection when no config is stored yet.
+        result.corveilConnection = current?.corveilConnection
         // Session-log collector (CROW-1070): the `logSync` block is now ordinary,
         // non-secret behavior tuning, so — unlike the gateways/tokens above — it is
         // NOT restored from `current`; the browser's edited knobs round-trip

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -1177,3 +1177,97 @@ import Testing
 @Test func sessionKindAllCasesCoversEveryRole() {
     #expect(SessionKind.allCases == [.work, .review, .job, .manager])
 }
+
+// MARK: - Corveil connection (CROW-1118)
+
+@Test func corveilConnectionFullRoundTrip() throws {
+    var config = AppConfig()
+    config.corveilConnection = CorveilConnection(
+        baseURL: "https://corveil.example",
+        clientID: "crow-client-id",
+        connectedUser: CorveilConnectedUser(id: "u1", email: "me@corp.com", name: "Me"),
+        orgKeys: [
+            CorveilOrgKey(
+                orgID: "org1", orgName: "Acme", keyID: "key1",
+                keyPrefix: "sk-citadel-AbC",
+                createdAt: Date(timeIntervalSince1970: 1_800_000_000)),
+        ],
+        oauth: CorveilOAuthTokens(
+            accessToken: "at", refreshToken: "rt", registrationAccessToken: "rat",
+            accessTokenExpiresAt: Date(timeIntervalSince1970: 1_900_000_000)))
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.corveilConnection == config.corveilConnection)
+}
+
+@Test func corveilConnectionDefaultsNilWhenKeyMissing() throws {
+    // A config written before the integration existed decodes with no connection.
+    let json = #"{"workspaces": []}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.corveilConnection == nil)
+}
+
+@Test func corveilConnectionUnsetKeyIsOmittedOnSave() throws {
+    // nil connection encodes as an ABSENT key (optional), not `null`.
+    let data = try JSONEncoder().encode(AppConfig())
+    let text = String(data: data, encoding: .utf8) ?? ""
+    #expect(!text.contains("corveilConnection"))
+}
+
+/// Acceptance (CROW-809 lesson): the block decodes leniently — a missing key
+/// never traps, and a partial object fills the rest from defaults rather than
+/// failing the whole config load.
+@Test func corveilConnectionDecodesLeniently() throws {
+    // Only some keys present, and even a nested block (`oauth`) partially filled.
+    let json = #"""
+    {"corveilConnection": {"baseURL": "https://corveil.example",
+      "connectedUser": {"email": "me@corp.com"},
+      "oauth": {"accessToken": "at"}}}
+    """#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    let conn = try #require(config.corveilConnection)
+    #expect(conn.baseURL == "https://corveil.example")
+    #expect(conn.clientID == "")                       // absent → default
+    #expect(conn.connectedUser.email == "me@corp.com")
+    #expect(conn.connectedUser.name == "")             // absent → default
+    #expect(conn.orgKeys.isEmpty)                       // absent → default
+    #expect(conn.oauth.accessToken == "at")
+    #expect(conn.oauth.refreshToken == "")             // absent → default
+    #expect(conn.oauth.accessTokenExpiresAt == nil)    // absent → nil
+}
+
+/// An empty `corveilConnection: {}` decodes to an all-default connection rather
+/// than trapping — the same tolerance every other settings block has (CROW-814).
+@Test func corveilConnectionDecodesEmptyObject() throws {
+    let json = #"{"corveilConnection": {}}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    let conn = try #require(config.corveilConnection)
+    #expect(conn.baseURL == "")
+    #expect(conn.isEmpty)
+}
+
+/// The CROW-809 regression proper: every stored field must be in `CodingKeys`,
+/// or the synthesized `encode(to:)` silently drops it on the next config save.
+/// A full connection read off disk must still be there after the re-encode.
+@Test func corveilConnectionSurvivesAConfigRewrite() throws {
+    let json = #"""
+    {"corveilConnection": {"baseURL": "https://corveil.example", "clientID": "cid",
+      "connectedUser": {"id": "u1", "email": "me@corp.com", "name": "Me"},
+      "orgKeys": [{"orgID": "org1", "orgName": "Acme", "keyID": "key1", "keyPrefix": "sk-citadel-AbC"}],
+      "oauth": {"accessToken": "at", "refreshToken": "rt", "registrationAccessToken": "rat"}}}
+    """#.data(using: .utf8)!
+    let loaded = try JSONDecoder().decode(AppConfig.self, from: json)
+    let rewritten = try JSONDecoder().decode(
+        AppConfig.self, from: try JSONEncoder().encode(loaded))
+    #expect(rewritten.corveilConnection == loaded.corveilConnection)
+    #expect(rewritten.corveilConnection?.orgKeys.first?.keyID == "key1")
+    #expect(rewritten.corveilConnection?.oauth.registrationAccessToken == "rat")
+}
+
+@Test func corveilConnectionIsEmptyReflectsClientAndAccessToken() {
+    #expect(CorveilConnection().isEmpty)
+    #expect(CorveilConnection(baseURL: "https://corveil.example").isEmpty)  // no client/token yet
+    #expect(!CorveilConnection(clientID: "cid").isEmpty)
+    #expect(!CorveilConnection(oauth: CorveilOAuthTokens(accessToken: "at")).isEmpty)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
@@ -29,6 +29,21 @@ import CrowCore
                 name: "grok-bot", prefix: "AbCdEfGh", hashB64: "TE9DQUwtVE9LRU4tSEFTSA==",
                 scopes: [.boardRead], expiresAt: Date(timeIntervalSince1970: 1_900_000_000)),
         ]
+        c.corveilConnection = CorveilConnection(
+            baseURL: "https://corveil.example",
+            clientID: "crow-client-id",
+            connectedUser: CorveilConnectedUser(id: "u1", email: "me@corp.com", name: "Me"),
+            orgKeys: [
+                CorveilOrgKey(
+                    orgID: "org1", orgName: "Acme", keyID: "key1",
+                    keyPrefix: "sk-citadel-AbC",
+                    createdAt: Date(timeIntervalSince1970: 1_800_000_000)),
+            ],
+            oauth: CorveilOAuthTokens(
+                accessToken: "CORVEIL-ACCESS-SECRET",
+                refreshToken: "CORVEIL-REFRESH-SECRET",
+                registrationAccessToken: "CORVEIL-REG-SECRET",
+                accessTokenExpiresAt: Date(timeIntervalSince1970: 1_900_000_000)))
         return c
     }
 
@@ -192,5 +207,80 @@ import CrowCore
         let incoming = SettingsSecrets.strippedForTransport(configWithSecrets())
         let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: nil)
         #expect(merged.mcpTokens.isEmpty)
+    }
+
+    // MARK: - Corveil connection (CROW-1118)
+
+    @Test func strippedBlanksCorveilOAuthTokensButKeepsTheRest() {
+        let stripped = SettingsSecrets.strippedForTransport(configWithSecrets())
+
+        // The three OAuth token strings are blanked…
+        #expect(stripped.corveilConnection?.oauth.accessToken == "")
+        #expect(stripped.corveilConnection?.oauth.refreshToken == "")
+        #expect(stripped.corveilConnection?.oauth.registrationAccessToken == "")
+        // …but everything the read-only Integrations view needs survives.
+        #expect(stripped.corveilConnection?.baseURL == "https://corveil.example")
+        #expect(stripped.corveilConnection?.clientID == "crow-client-id")
+        #expect(stripped.corveilConnection?.connectedUser.email == "me@corp.com")
+        #expect(stripped.corveilConnection?.orgKeys.first?.keyPrefix == "sk-citadel-AbC")
+        #expect(
+            stripped.corveilConnection?.oauth.accessTokenExpiresAt
+                == Date(timeIntervalSince1970: 1_900_000_000))
+    }
+
+    @Test func strippedCorveilTokensNeverAppearInTheSerializedConfig() throws {
+        let stripped = SettingsSecrets.strippedForTransport(configWithSecrets())
+        let text = try #require(String(data: JSONEncoder().encode(stripped), encoding: .utf8))
+        #expect(!text.contains("CORVEIL-ACCESS-SECRET"))
+        #expect(!text.contains("CORVEIL-REFRESH-SECRET"))
+        #expect(!text.contains("CORVEIL-REG-SECRET"))
+    }
+
+    @Test func preserveRestoresCorveilConnectionAndIgnoresBrowserEdits() {
+        // The connection is authored only through the local-only Connect flow, never
+        // `set-config`: a browser that tries to change ANY part of it — tokens or the
+        // non-secret display fields — is ignored, and the stored connection wins.
+        let current = configWithSecrets()
+        var incoming = SettingsSecrets.strippedForTransport(current)
+        incoming.corveilConnection = CorveilConnection(
+            baseURL: "https://evil.example",
+            clientID: "attacker-client",
+            connectedUser: CorveilConnectedUser(id: "evil", email: "evil@corp.com", name: "Evil"),
+            oauth: CorveilOAuthTokens(
+                accessToken: "EVIL-ACCESS", refreshToken: "EVIL-REFRESH",
+                registrationAccessToken: "EVIL-REG"))
+
+        let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+        #expect(merged.corveilConnection == current.corveilConnection)
+    }
+
+    @Test func preserveIgnoresBrowserClearingOfTheCorveilConnection() {
+        // The mirror image: a set-config that drops the connection must not
+        // disconnect. Disconnect is a local-only action, not a side effect of saving
+        // Settings.
+        let current = configWithSecrets()
+        var incoming = SettingsSecrets.strippedForTransport(current)
+        incoming.corveilConnection = nil
+
+        let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+        #expect(merged.corveilConnection == current.corveilConnection)
+    }
+
+    @Test func preserveWithNilCurrentDropsCorveilConnection() {
+        // No stored config to restore from — drop whatever the browser echoed rather
+        // than persist a (token-blanked) connection nobody authored locally.
+        let incoming = SettingsSecrets.strippedForTransport(configWithSecrets())
+        let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: nil)
+        #expect(merged.corveilConnection == nil)
+    }
+
+    @Test func corveilConnectionSurvivesAStripPreserveRoundTripUntouched() {
+        // The ticket's headline acceptance: a config with a connection survives a
+        // `set-config` (strip → preserve) byte-for-byte, tokens included.
+        let current = configWithSecrets()
+        let merged = SettingsSecrets.preservingSecrets(
+            incoming: SettingsSecrets.strippedForTransport(current), current: current)
+        #expect(merged.corveilConnection == current.corveilConnection)
+        #expect(merged.corveilConnection?.oauth.accessToken == "CORVEIL-ACCESS-SECRET")
     }
 }


### PR DESCRIPTION
Closes #1118

Part of epic #1117 (first-class Corveil integration). Adds the config object that later tickets read from; stays strictly within this ticket's scope (model + secret-safe transport — no CLI verbs, no OAuth client, no gateway/logsync generation).

## What

Introduces `AppConfig.corveilConnection` as the source of truth for the Corveil **Connect** (OAuth) integration:

- `baseURL`, `clientID` (DCR-registered) — non-secret
- `connectedUser` (`CorveilConnectedUser`) — read-only signed-in identity
- `orgKeys` (`[CorveilOrgKey]`) — per-org gateway-key **metadata** only. The `sk-citadel-…` key value itself flows into the generated `WorkspaceGateway` header (sibling #1124), never stored here.
- `oauth` (`CorveilOAuthTokens`) — the secrets: `accessToken` / `refreshToken` / `registrationAccessToken` + `accessTokenExpiresAt`

## Acceptance criteria

- **Lenient decode** — every field is `decodeIfPresent … ?? default`; a missing key never traps, a partial/empty object fills from defaults, and `CodingKeys` are complete so `encode(to:)` doesn't silently drop a field (CROW-809 / CROW-814 lesson). Covered by `corveilConnectionDecodesLeniently`, `…DecodesEmptyObject`, `…DefaultsNilWhenKeyMissing`, `…SurvivesAConfigRewrite`.
- **Secret-safe transport** — `SettingsSecrets.strippedForTransport` blanks the three OAuth token strings (keeping the rest for a read-only Integrations view); `preservingSecrets` restores the whole connection from the stored config, exactly like `managerGateway`. The block is authored only by the local-only Connect flow / CLI verbs (#1120), never `set-config`, so a browser can neither read the tokens nor change/clear the connection.
- **Round-trip** — `corveilConnectionSurvivesAStripPreserveRoundTripUntouched` + `stripThenPreserveIsIdentity` prove a config with a connection survives a `set-config` untouched; `strippedCorveilTokensNeverAppearInTheSerializedConfig` proves the tokens never serialize to a browser.

## Parity

Adds `ParityLedger.configFields` rows for all 14 new leaves (all `noCLI` — write verbs land in #1120) and inhabits the reflection probe, so `ParityGateTests` (\"Ledger covers exactly AppConfig's fields\", \"reflection probe reaches every subtree\") passes.

## Testing

- `swift test --package-path Packages/CrowCore` — 840 passed (incl. new AppConfig + SettingsSecrets tests)
- `swift test --package-path Packages/CrowCLI` — 384 passed (incl. ParityGateTests)
- `./scripts/check-cli-parity.sh` — clean
- `CrowEngine` + `CrowDaemon` build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)