### PR TITLE
Add Corveil OAuth client: DCR + PKCE + loopback callback + refresh (CROW-1119)

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
@@ -1,0 +1,184 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+
+/// The three moving parts that sit *around* ``CorveilOAuthClient`` for the
+/// Connect flow (CROW-1119): the in-flight-authorization store that ties a
+/// browser callback back to its PKCE verifier, the local-only config write that
+/// persists the resulting tokens, and the load→refresh→store helper that renews
+/// an access token.
+///
+/// The client itself is pure HTTP; everything here is Crow-side state.
+
+// MARK: - In-flight authorization
+
+/// One pending authorization, created when Connect opens the browser and consumed
+/// (once) when the loopback callback arrives. Carries the PKCE `codeVerifier` and
+/// the `state` that the callback is validated against, plus the context the token
+/// exchange and the config write need.
+struct CorveilPendingAuthorization: Sendable, Equatable {
+    let state: String
+    let codeVerifier: String
+    let clientID: String
+    let redirectURI: String
+    let baseURL: String
+    let registrationAccessToken: String
+    let scope: String
+    let createdAt: Date
+}
+
+/// Holds pending authorizations keyed by `state` between the Connect POST and the
+/// loopback callback. Single-use (``consume(state:now:)`` removes the entry) and
+/// TTL-bounded, so a state can't be replayed and abandoned flows don't accumulate.
+///
+/// `state` is the OAuth anti-forgery value **and** the lookup key: a callback whose
+/// `state` isn't present (never issued, already consumed, or expired) is rejected,
+/// which is exactly the PKCE/`state` validation the ticket calls for. Lock-guarded
+/// so the concurrent HTTP handlers can share one instance.
+final class CorveilPendingAuthStore: @unchecked Sendable {
+    /// How long a browser has to complete consent before the pending state expires.
+    static let defaultTTL: TimeInterval = 10 * 60
+
+    private let lock = NSLock()
+    private var byState: [String: CorveilPendingAuthorization] = [:]
+    private let ttl: TimeInterval
+
+    init(ttl: TimeInterval = defaultTTL) { self.ttl = ttl }
+
+    /// Record a freshly-started authorization.
+    func put(_ pending: CorveilPendingAuthorization) {
+        lock.lock(); defer { lock.unlock() }
+        byState[pending.state] = pending
+    }
+
+    /// Remove and return the authorization for `state`, or nil if it was never
+    /// issued, already consumed, or has expired. Single-use by construction.
+    func consume(state: String, now: Date = Date()) -> CorveilPendingAuthorization? {
+        lock.lock(); defer { lock.unlock() }
+        guard let pending = byState.removeValue(forKey: state) else { return nil }
+        guard now.timeIntervalSince(pending.createdAt) <= ttl else { return nil }
+        return pending
+    }
+
+    /// Drop expired entries (called periodically by the daemon so long-abandoned
+    /// flows don't leak memory).
+    func prune(now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        byState = byState.filter { now.timeIntervalSince($0.value.createdAt) <= ttl }
+    }
+
+    /// Current count — for tests.
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return byState.count
+    }
+}
+
+// MARK: - Persistence (the local-only write door)
+
+/// Writes the Corveil connection into `config.json`.
+///
+/// This IS the local-only door the callback stores tokens through: it is reachable
+/// only from ``CorveilIntegrationRoutes`` handlers that have already passed the
+/// local-direct gate, and it writes the OAuth token strings that
+/// `SettingsSecrets.strippedForTransport` blanks — so a browser can neither read
+/// nor set them (corveil/crow#1118). `SettingsSecrets` names the OAuth flow as a
+/// legitimate author of `corveilConnection`; the CLI verbs are a second author
+/// (corveil/crow#1120), which is why the read-modify-write goes through
+/// `ConfigStore.withConfigLock`, shared with every other config writer.
+enum CorveilConnectionPersistence {
+    /// Store the tokens from a fresh connect, merging into any existing connection
+    /// (a reconnect) so the connected user and per-org key metadata a later step
+    /// populated (corveil/crow#1121) survive a token refresh-by-reconnect. Base URL,
+    /// client id, and the whole OAuth block are overwritten.
+    static func store(
+        devRoot: String,
+        baseURL: String,
+        clientID: String,
+        tokens: CorveilOAuthTokens
+    ) throws {
+        try ConfigStore.withConfigLock {
+            var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            var connection = config.corveilConnection ?? CorveilConnection()
+            connection.baseURL = baseURL
+            connection.clientID = clientID
+            connection.oauth = tokens
+            config.corveilConnection = connection
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+        }
+    }
+
+    /// Replace only the OAuth token block (after a refresh), keeping base URL,
+    /// client id, connected user, and org-key metadata. Returns false when there is
+    /// no stored connection to update.
+    @discardableResult
+    static func updateTokens(devRoot: String, tokens: CorveilOAuthTokens) throws -> Bool {
+        try ConfigStore.withConfigLock {
+            var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            guard var connection = config.corveilConnection else { return false }
+            connection.oauth = tokens
+            config.corveilConnection = connection
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+            return true
+        }
+    }
+}
+
+// MARK: - Refresh
+
+/// Renews a stored connection's access token (RFC 6749 §6). This is the reusable
+/// refresh primitive the ticket requires ("access-token refresh works"); the
+/// scheduling/health/reconnect UX that decides *when* to call it is a later step
+/// (corveil/crow#1125).
+enum CorveilConnectionRefresher {
+    enum RefreshError: Error, CustomStringConvertible {
+        case noConnection
+        case notRefreshable  // no refresh token, or no usable base URL
+
+        var description: String {
+            switch self {
+            case .noConnection: return "no Corveil connection is stored"
+            case .notRefreshable: return "the stored connection has no refresh token or base URL"
+            }
+        }
+    }
+
+    /// Load the stored connection, exchange its refresh token for a new token pair,
+    /// merge in the rotated refresh token, persist, and return the new tokens.
+    @discardableResult
+    static func refresh(
+        devRoot: String,
+        client: CorveilOAuthClient = .live,
+        now: Date = Date()
+    ) async throws -> CorveilOAuthTokens {
+        guard let connection = ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection else {
+            throw RefreshError.noConnection
+        }
+        let refreshToken = connection.oauth.refreshToken.trimmingCharacters(in: .whitespaces)
+        guard !refreshToken.isEmpty, let endpoints = CorveilOAuthClient.Endpoints(baseURL: connection.baseURL) else {
+            throw RefreshError.notRefreshable
+        }
+
+        let response = try await client.refresh(
+            endpoints: endpoints, clientID: connection.clientID, refreshToken: refreshToken)
+        let tokens = mergedTokens(existing: connection.oauth, response: response, now: now)
+        try CorveilConnectionPersistence.updateTokens(devRoot: devRoot, tokens: tokens)
+        return tokens
+    }
+
+    /// Fold a token response into the stored OAuth block: the new access token and
+    /// its fresh expiry always win; the refresh token is replaced only when the
+    /// server actually rotated it (a response may omit it), and the registration
+    /// access token — not part of a refresh — is carried through untouched.
+    static func mergedTokens(
+        existing: CorveilOAuthTokens,
+        response: CorveilOAuthClient.TokenResponse,
+        now: Date
+    ) -> CorveilOAuthTokens {
+        CorveilOAuthTokens(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken.isEmpty ? existing.refreshToken : response.refreshToken,
+            registrationAccessToken: existing.registrationAccessToken,
+            accessTokenExpiresAt: response.expiresAt(now: now))
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilIntegrationRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilIntegrationRoutes.swift
@@ -1,0 +1,268 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+import HTTPTypes
+import Hummingbird
+import NIOCore
+
+/// The browser-facing HTTP surface of the Corveil **Connect** (OAuth) flow
+/// (CROW-1119): the loopback callback the authorization server redirects to, plus
+/// the Connect trigger that self-registers the client and opens the consent page.
+///
+///   - `POST /integrations/corveil/connect` — gated exactly like the other secret
+///     writes (``SecretRoutes/gateOK`` = local-direct **and** same-origin): a
+///     remote/proxied session, even a logged-in one, is refused, and a cross-site
+///     page in the local browser can't drive it. Registers a fresh public PKCE
+///     client (DCR), stashes the in-flight `state`/verifier, opens the browser, and
+///     returns the authorize URL.
+///   - `GET /integrations/corveil/callback` — the redirect target. Gated
+///     **local-direct** only (``SecretRoutes/isLocalDirect`` = loopback peer, no
+///     `X-Forwarded-For`): a top-level browser redirect carries no `Origin`, so the
+///     CSRF arm of `gateOK` doesn't apply, and the redirect must be reachable by a
+///     plain navigation. Validates `state` against the stored pending record
+///     (single-use), exchanges the `code` (with the PKCE `code_verifier`) for
+///     tokens, and stores them through the local-only config door.
+///
+/// Same shape and gating rationale as ``SecretRoutes`` / ``CorveilRoutes`` /
+/// ``AutostartRoutes``: dedicated HTTP routes rather than JSON-RPC methods, because
+/// the handlers need the peer address + `X-Forwarded-For` for the locality check,
+/// and because writing the OAuth tokens is a host-local privilege a remote peer
+/// must not hold. The token exchange/refresh primitives live in
+/// ``CorveilOAuthClient``; the pending-state store and config write in
+/// ``CorveilConnectionStore``.
+enum CorveilIntegrationRoutes {
+    static let connectPath = "/integrations/corveil/connect"
+    static let callbackPath = CorveilOAuthClient.callbackPath
+
+    /// Persist freshly-exchanged tokens. Injected in tests; defaults to the
+    /// local-only config write in ``CorveilConnectionPersistence``.
+    typealias TokenPersist =
+        @Sendable (_ baseURL: String, _ clientID: String, _ tokens: CorveilOAuthTokens) throws -> Void
+
+    static func mount(
+        on router: Router<CrowHTTPContext>,
+        boundHost: String,
+        devRoot: String,
+        httpPort: Int,
+        pending: CorveilPendingAuthStore,
+        client: CorveilOAuthClient = .live,
+        scope: String = CorveilOAuthClient.defaultScope,
+        openBrowser: @escaping @Sendable (URL) -> Void = defaultOpenBrowser,
+        persist: TokenPersist? = nil
+    ) {
+        let redirectURI = CorveilOAuthClient.redirectURI(httpPort: httpPort)
+        let store: TokenPersist = persist ?? { baseURL, clientID, tokens in
+            try CorveilConnectionPersistence.store(
+                devRoot: devRoot, baseURL: baseURL, clientID: clientID, tokens: tokens)
+        }
+
+        // MARK: Connect — start the flow. Local-only + same-origin (CSRF).
+        router.post(RouterPath(connectPath)) { request, context -> Response in
+            guard SecretRoutes.gateOK(request, context, boundHost: boundHost) else {
+                return json(["error": "local-only"], status: .forbidden)
+            }
+            struct Body: Decodable { let baseURL: String? }
+            let body = await decode(Body.self, request)
+
+            // The base URL comes from the request (the Integrations UI supplies it),
+            // falling back to a previously-connected base URL. There is no hardcoded
+            // production default — the connection's base URL is configuration.
+            let requested = (body?.baseURL ?? "").trimmingCharacters(in: .whitespaces)
+            let stored = ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection?.baseURL ?? ""
+            let baseURL = requested.isEmpty ? stored : requested
+            guard !baseURL.isEmpty else {
+                return json(["error": "a Corveil base URL is required"], status: .badRequest)
+            }
+            guard let endpoints = CorveilOAuthClient.Endpoints(baseURL: baseURL) else {
+                return json(["error": CorveilOAuthClient.Failure.invalidBaseURL(baseURL).description],
+                            status: .badRequest)
+            }
+
+            // Self-register a fresh public client. Fresh per connect: the backend
+            // issues a client_id per install and refuses cross-org reuse.
+            let registration: CorveilOAuthClient.Registration
+            do {
+                registration = try await client.register(
+                    endpoints: endpoints, redirectURI: redirectURI, scope: scope)
+            } catch {
+                return json(["error": describe(error)], status: .badGateway)
+            }
+
+            let pkce = CorveilOAuthClient.makePKCE()
+            let state = CorveilOAuthClient.makeState()
+            pending.put(CorveilPendingAuthorization(
+                state: state,
+                codeVerifier: pkce.verifier,
+                clientID: registration.clientID,
+                redirectURI: redirectURI,
+                baseURL: baseURL,
+                registrationAccessToken: registration.registrationAccessToken,
+                scope: registration.scope,
+                createdAt: Date()))
+
+            let authorizeURL = CorveilOAuthClient.authorizeURL(
+                endpoints: endpoints, clientID: registration.clientID, redirectURI: redirectURI,
+                scope: registration.scope, state: state, pkce: pkce)
+            openBrowser(authorizeURL)
+            return json(["authorizeURL": authorizeURL.absoluteString])
+        }
+
+        // MARK: Callback — the loopback redirect target. Local-direct only.
+        router.get(RouterPath(callbackPath)) { request, context -> Response in
+            guard SecretRoutes.isLocalDirect(request, context) else {
+                return page(title: "Not available",
+                            message: "This page is only reachable from the machine running Crow.",
+                            success: false, status: .forbidden)
+            }
+
+            let query = request.uri.queryParameters
+            func param(_ name: String) -> String {
+                query[name[...]].map(String.init)?.trimmingCharacters(in: .whitespaces) ?? ""
+            }
+
+            // The authorization server signals a denial/error by redirecting with
+            // `error` (+ optional `error_description`) instead of a `code`.
+            let oauthError = param("error")
+            if !oauthError.isEmpty {
+                let description = param("error_description")
+                return page(title: "Corveil sign-in was cancelled",
+                            message: description.isEmpty ? oauthError : "\(oauthError): \(description)",
+                            success: false, status: .badRequest)
+            }
+
+            let code = param("code")
+            let state = param("state")
+            guard !code.isEmpty, !state.isEmpty else {
+                return page(title: "Invalid sign-in response",
+                            message: "The Corveil redirect was missing its authorization code or state.",
+                            success: false, status: .badRequest)
+            }
+
+            // `state` validation: the callback must match a pending authorization we
+            // started (single-use, unexpired). A mismatch means a forged, replayed,
+            // or stale callback.
+            guard let flow = pending.consume(state: state) else {
+                return page(title: "Sign-in link expired",
+                            message: "This Corveil sign-in link has already been used or has expired. "
+                                + "Start the connection again from Crow.",
+                            success: false, status: .badRequest)
+            }
+
+            let response: CorveilOAuthClient.TokenResponse
+            do {
+                response = try await client.exchangeCode(
+                    endpoints: CorveilOAuthClient.Endpoints(baseURL: flow.baseURL)!,
+                    clientID: flow.clientID, code: code,
+                    codeVerifier: flow.codeVerifier, redirectURI: flow.redirectURI)
+            } catch {
+                return page(title: "Couldn't complete sign-in",
+                            message: describe(error), success: false, status: .badRequest)
+            }
+
+            let tokens = CorveilOAuthTokens(
+                accessToken: response.accessToken,
+                refreshToken: response.refreshToken,
+                registrationAccessToken: flow.registrationAccessToken,
+                accessTokenExpiresAt: response.expiresAt(now: Date()))
+            do {
+                try store(flow.baseURL, flow.clientID, tokens)
+            } catch {
+                return page(title: "Signed in, but couldn't save",
+                            message: "Crow received the Corveil tokens but failed to store them: "
+                                + error.localizedDescription,
+                            success: false, status: .internalServerError)
+            }
+
+            return page(title: "Connected to Corveil",
+                        message: "You can close this tab and return to Crow.",
+                        success: true, status: .ok)
+        }
+    }
+
+    // MARK: - Browser opener
+
+    /// Open `url` in the host's default browser. Best-effort and fire-and-forget:
+    /// Connect still returns the authorize URL, so a failed launch degrades to
+    /// "click this link" rather than blocking the flow.
+    static let defaultOpenBrowser: @Sendable (URL) -> Void = { url in
+        #if os(macOS)
+        launchDetached("/usr/bin/open", [url.absoluteString])
+        #else
+        launchDetached("/usr/bin/env", ["xdg-open", url.absoluteString])
+        #endif
+    }
+
+    private static func launchDetached(_ executable: String, _ arguments: [String]) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        // Reap the child so the long-lived daemon doesn't accumulate zombies
+        // (matches `launchHostProcess` in RPCHandlers).
+        process.terminationHandler = { _ in }
+        try? process.run()
+    }
+
+    // MARK: - HTTP helpers
+
+    private static func describe(_ error: Error) -> String {
+        (error as? CorveilOAuthClient.Failure)?.description ?? error.localizedDescription
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, _ request: Request) async -> T? {
+        guard let buffer = try? await request.body.collect(upTo: 64 * 1024) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: Data(buffer.readableBytesView))
+    }
+
+    private static func json(_ dict: [String: Any], status: HTTPResponse.Status = .ok) -> Response {
+        let data = (try? JSONSerialization.data(withJSONObject: dict)) ?? Data("{}".utf8)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json; charset=utf-8"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data)))
+    }
+
+    /// A minimal self-contained HTML result page for the callback (no external
+    /// assets — this renders in the browser after the redirect).
+    static func page(
+        title: String, message: String, success: Bool, status: HTTPResponse.Status
+    ) -> Response {
+        let accent = success ? "#1a7f37" : "#b42318"
+        let mark = success ? "✓" : "✕"
+        let html = """
+        <!doctype html><html lang="en"><head><meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>\(escape(title))</title>
+        <style>
+          :root { color-scheme: light dark; }
+          body { font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+                 margin: 0; display: grid; min-height: 100vh; place-items: center;
+                 background: Canvas; color: CanvasText; }
+          .card { max-width: 30rem; padding: 2rem 2.25rem; text-align: center; }
+          .mark { width: 3rem; height: 3rem; margin: 0 auto 1rem; border-radius: 50%;
+                  display: grid; place-items: center; font-size: 1.5rem; color: #fff;
+                  background: \(accent); }
+          h1 { font-size: 1.25rem; margin: 0 0 .5rem; }
+          p { margin: 0; opacity: .8; }
+        </style></head>
+        <body><main class="card">
+          <div class="mark">\(mark)</div>
+          <h1>\(escape(title))</h1>
+          <p>\(escape(message))</p>
+        </main></body></html>
+        """
+        return Response(
+            status: status,
+            headers: [.contentType: "text/html; charset=utf-8"],
+            body: .init(byteBuffer: ByteBuffer(string: html)))
+    }
+
+    /// Escape the five HTML-significant characters so a provider-supplied
+    /// `error_description` can't inject markup into the result page.
+    private static func escape(_ value: String) -> String {
+        value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilIntegrationRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilIntegrationRoutes.swift
@@ -252,7 +252,17 @@ enum CorveilIntegrationRoutes {
         """
         return Response(
             status: status,
-            headers: [.contentType: "text/html; charset=utf-8"],
+            headers: [
+                .contentType: "text/html; charset=utf-8",
+                // Defense in depth behind escape(): the page loads no scripts and no
+                // external resources, so lock it to inline styles only and forbid
+                // framing. Escaping the provider-supplied strings is the real control;
+                // these make a future interpolation slip inert.
+                .contentSecurityPolicy:
+                    "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; "
+                    + "form-action 'none'; frame-ancestors 'none'",
+                HTTPField.Name("x-frame-options")!: "DENY",
+            ],
             body: .init(byteBuffer: ByteBuffer(string: html)))
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOAuthClient.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOAuthClient.swift
@@ -90,13 +90,14 @@ struct CorveilOAuthClient: Sendable {
         let token: URL
 
         /// Resolve from a base URL like `https://app.corveil.example`. A trailing
-        /// slash is tolerated. Returns nil for a URL with no scheme/host so the
-        /// caller can surface ``Failure/invalidBaseURL(_:)`` instead of building
-        /// nonsense endpoints.
+        /// slash is tolerated. Returns nil unless the URL is an `http`/`https` URL
+        /// with a host, so a `file://`, `javascript://`, or custom-scheme base URL is
+        /// rejected here rather than reaching the browser or the transport.
         init?(baseURL: String) {
             let trimmed = baseURL.trimmingCharacters(in: .whitespaces)
             guard let root = URL(string: trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed),
-                  root.scheme != nil, root.host != nil
+                  let scheme = root.scheme?.lowercased(), scheme == "http" || scheme == "https",
+                  root.host != nil
             else { return nil }
             register = root.appendingPathComponent("mcp/oauth/register")
             authorize = root.appendingPathComponent("mcp/oauth/authorize")
@@ -117,7 +118,7 @@ struct CorveilOAuthClient: Sendable {
     /// Generate a fresh PKCE pair: a 32-byte random verifier (43 base64url chars,
     /// within RFC 7636's 43–128 range) and its S256 challenge.
     static func makePKCE() -> PKCE {
-        let verifier = base64URL(randomBytes(32))
+        let verifier = base64URL(PasswordHash.randomBytes(32))
         return PKCE(verifier: verifier, challenge: challenge(for: verifier))
     }
 
@@ -128,7 +129,7 @@ struct CorveilOAuthClient: Sendable {
     }
 
     /// A fresh anti-forgery `state` value (32 bytes of entropy, base64url).
-    static func makeState() -> String { base64URL(randomBytes(32)) }
+    static func makeState() -> String { base64URL(PasswordHash.randomBytes(32)) }
 
     // MARK: - Dynamic Client Registration (RFC 7591)
 
@@ -307,11 +308,17 @@ struct CorveilOAuthClient: Sendable {
     }
 
     /// `expires_in` may decode as an `Int`, a JSON number (`Double`), or a string —
-    /// accept all three, reject the rest.
+    /// accept all three, but never trap. A non-finite or out-of-`Int`-range `Double`
+    /// (a buggy or hostile AS could return `1e20` in a 2xx token body, after the
+    /// pending `state` is already consumed) returns nil rather than fatal-erroring
+    /// `Int(_:)`. `Int(_:)` on a string already returns nil on overflow or a
+    /// non-integer format, so no expiry is worse than a crashed daemon.
     private static func intValue(_ value: Any?) -> Int? {
         switch value {
         case let int as Int: return int
-        case let double as Double: return Int(double)
+        case let double as Double:
+            guard double.isFinite, double >= Double(Int.min), double < Double(Int.max) else { return nil }
+            return Int(double)
         case let string as String: return Int(string)
         default: return nil
         }
@@ -342,11 +349,5 @@ struct CorveilOAuthClient: Sendable {
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
-    }
-
-    private static func randomBytes(_ count: Int) -> [UInt8] {
-        var bytes = [UInt8](repeating: 0, count: count)
-        for index in bytes.indices { bytes[index] = UInt8.random(in: .min ... .max) }
-        return bytes
     }
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOAuthClient.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOAuthClient.swift
@@ -1,0 +1,352 @@
+import Crypto
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking  // URLRequest/URLResponse/URLSession live here on Linux
+#endif
+
+/// The Corveil OAuth 2.0 client backing the **Connect** flow (CROW-1119).
+///
+/// Corveil runs its own OAuth Authorization Server — the RFC 7591 Dynamic Client
+/// Registration surface at `/mcp/oauth/*` — so Crow talks to Corveil directly and
+/// **self-registers**: no manual client provisioning, no WorkOS redirect-URI
+/// change (WorkOS is only the human login *inside* the authorize step). This type
+/// is the protocol half: it registers a public PKCE client, builds the authorize
+/// URL, exchanges the code, and refreshes the access token. It performs **no I/O
+/// beyond HTTP** — the loopback callback route, the in-flight-state store, and the
+/// config write live in ``CorveilIntegrationRoutes`` / ``CorveilConnectionStore``.
+///
+/// The four operations are exactly RFC 6749 (§4.1 authorization code, §6 refresh),
+/// RFC 7591 (DCR), and RFC 7636 (PKCE S256) as the Corveil backend implements
+/// them (`go/internal/handler/oauth_{register,authorize,token}.go`):
+///   - **register** — `POST {base}/mcp/oauth/register`, JSON, `token_endpoint_auth_method:"none"`
+///     (public client, PKCE-only) with the loopback redirect URI.
+///   - **authorize** — `GET {base}/mcp/oauth/authorize?…` opened in the browser.
+///   - **token exchange** — `POST {base}/mcp/oauth/token`, form-urlencoded,
+///     `grant_type=authorization_code` + `code_verifier`.
+///   - **refresh** — the same endpoint with `grant_type=refresh_token`; the server
+///     rotates the refresh token, so the response's `refresh_token` replaces ours.
+///
+/// `transport` is injected so tests drive the whole flow against a stub without a
+/// live Corveil — the same pattern as ``VersionUpdateClient`` / ``JiraTransitionClient``.
+struct CorveilOAuthClient: Sendable {
+    /// Performs one HTTP round-trip. Defaults to `URLSession.shared` in ``live``.
+    var transport: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    /// The production client, backed by `URLSession`.
+    static let live = CorveilOAuthClient(
+        transport: { try await URLSession.shared.data(for: $0) })
+
+    /// The OAuth scopes the Corveil connected app needs: read the user's orgs (the
+    /// org dropdown) and mint the one per-org gateway key. From the epic
+    /// (corveil/crow#1117); the backend may downscope, which is its concern.
+    static let defaultScope = "orgs.read keys.provision"
+
+    /// The loopback callback path, mounted by ``CorveilIntegrationRoutes``. The
+    /// redirect URI registered at DCR time is `http://127.0.0.1:{port}{callbackPath}`.
+    static let callbackPath = "/integrations/corveil/callback"
+
+    /// The redirect URI for a given crowd HTTP port. `127.0.0.1` (not `localhost`)
+    /// so it matches the loopback-peer gate on the callback route exactly, and is a
+    /// loopback host the backend accepts for an `http://` redirect (RFC 8252 §7.3).
+    static func redirectURI(httpPort: Int) -> String {
+        "http://127.0.0.1:\(httpPort)\(callbackPath)"
+    }
+
+    // MARK: - Errors
+
+    /// Every way the flow can fail, with enough detail to render a diagnostic.
+    enum Failure: Error, Equatable, CustomStringConvertible {
+        /// The base URL couldn't be turned into the `/mcp/oauth/*` endpoints.
+        case invalidBaseURL(String)
+        /// The transport threw (DNS, TLS, connection refused, …).
+        case transport(String)
+        /// A non-2xx response that did **not** carry an OAuth error body.
+        case http(status: Int, body: String)
+        /// A structured OAuth error (`{"error":…,"error_description":…}`), from any endpoint.
+        case oauth(error: String, description: String?)
+        /// A 2xx response whose body didn't decode / lacked a required field.
+        case malformedResponse(String)
+
+        var description: String {
+            switch self {
+            case .invalidBaseURL(let url): return "invalid Corveil base URL: \(url)"
+            case .transport(let message): return "network error: \(message)"
+            case .http(let status, let body):
+                return "Corveil returned HTTP \(status): \(body.prefix(200))"
+            case .oauth(let error, let description):
+                return description.map { "\(error): \($0)" } ?? error
+            case .malformedResponse(let detail): return "unexpected Corveil response: \(detail)"
+            }
+        }
+    }
+
+    // MARK: - Endpoints
+
+    /// The three `/mcp/oauth/*` endpoints, resolved against a Corveil base URL.
+    struct Endpoints: Sendable, Equatable {
+        let register: URL
+        let authorize: URL
+        let token: URL
+
+        /// Resolve from a base URL like `https://app.corveil.example`. A trailing
+        /// slash is tolerated. Returns nil for a URL with no scheme/host so the
+        /// caller can surface ``Failure/invalidBaseURL(_:)`` instead of building
+        /// nonsense endpoints.
+        init?(baseURL: String) {
+            let trimmed = baseURL.trimmingCharacters(in: .whitespaces)
+            guard let root = URL(string: trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed),
+                  root.scheme != nil, root.host != nil
+            else { return nil }
+            register = root.appendingPathComponent("mcp/oauth/register")
+            authorize = root.appendingPathComponent("mcp/oauth/authorize")
+            token = root.appendingPathComponent("mcp/oauth/token")
+        }
+    }
+
+    // MARK: - PKCE (RFC 7636)
+
+    /// A PKCE verifier/challenge pair. `challenge` is `BASE64URL(SHA256(verifier))`
+    /// and `method` is always `S256` — the only method the backend accepts.
+    struct PKCE: Sendable, Equatable {
+        let verifier: String
+        let challenge: String
+        var method: String { "S256" }
+    }
+
+    /// Generate a fresh PKCE pair: a 32-byte random verifier (43 base64url chars,
+    /// within RFC 7636's 43–128 range) and its S256 challenge.
+    static func makePKCE() -> PKCE {
+        let verifier = base64URL(randomBytes(32))
+        return PKCE(verifier: verifier, challenge: challenge(for: verifier))
+    }
+
+    /// The S256 code challenge for a verifier: `BASE64URL(SHA256(ASCII(verifier)))`
+    /// (RFC 7636 §4.2). Exposed so tests can pin it against the RFC's test vector.
+    static func challenge(for verifier: String) -> String {
+        base64URL(Array(SHA256.hash(data: Data(verifier.utf8))))
+    }
+
+    /// A fresh anti-forgery `state` value (32 bytes of entropy, base64url).
+    static func makeState() -> String { base64URL(randomBytes(32)) }
+
+    // MARK: - Dynamic Client Registration (RFC 7591)
+
+    /// What a successful DCR gives us back. `registrationAccessToken` is the RFC
+    /// 7592 token that lets Crow later rotate/delete this client.
+    struct Registration: Sendable, Equatable {
+        let clientID: String
+        let registrationAccessToken: String
+        let registrationClientURI: String
+        let scope: String
+    }
+
+    /// Self-register a **public** (`token_endpoint_auth_method: none`) client with
+    /// the loopback redirect URI. Registers `authorization_code` + `refresh_token`
+    /// grants and the `code` response type.
+    func register(
+        endpoints: Endpoints,
+        redirectURI: String,
+        clientName: String = "Crow",
+        scope: String = defaultScope
+    ) async throws -> Registration {
+        var request = URLRequest(url: endpoints.register)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body: [String: Any] = [
+            "client_name": clientName,
+            "redirect_uris": [redirectURI],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": scope,
+            "token_endpoint_auth_method": "none",
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        let json = try await sendExpectingJSON(request)
+        guard let clientID = json["client_id"] as? String, !clientID.isEmpty else {
+            throw Failure.malformedResponse("registration response had no client_id")
+        }
+        return Registration(
+            clientID: clientID,
+            registrationAccessToken: (json["registration_access_token"] as? String) ?? "",
+            registrationClientURI: (json["registration_client_uri"] as? String) ?? "",
+            scope: (json["scope"] as? String) ?? scope)
+    }
+
+    // MARK: - Authorization request (RFC 6749 §4.1.1 + PKCE)
+
+    /// Build the browser authorize URL. Pure string assembly — no I/O.
+    static func authorizeURL(
+        endpoints: Endpoints,
+        clientID: String,
+        redirectURI: String,
+        scope: String,
+        state: String,
+        pkce: PKCE
+    ) -> URL {
+        var components = URLComponents(url: endpoints.authorize, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: pkce.challenge),
+            URLQueryItem(name: "code_challenge_method", value: pkce.method),
+        ]
+        return components.url!
+    }
+
+    // MARK: - Token endpoint (RFC 6749 §4.1.3 / §6)
+
+    /// The tokens a successful exchange or refresh yields.
+    struct TokenResponse: Sendable, Equatable {
+        let accessToken: String
+        let refreshToken: String
+        let tokenType: String
+        let expiresIn: Int?
+        let scope: String
+
+        /// Absolute expiry of `accessToken`, `expiresIn` seconds after `now`.
+        func expiresAt(now: Date) -> Date? {
+            expiresIn.map { now.addingTimeInterval(TimeInterval($0)) }
+        }
+    }
+
+    /// Exchange an authorization `code` for tokens, presenting the PKCE
+    /// `code_verifier`. `client_id` is sent in the form body — the backend reads it
+    /// there for a public client (no secret).
+    func exchangeCode(
+        endpoints: Endpoints,
+        clientID: String,
+        code: String,
+        codeVerifier: String,
+        redirectURI: String
+    ) async throws -> TokenResponse {
+        try await postToken(endpoints: endpoints, fields: [
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirectURI),
+            ("code_verifier", codeVerifier),
+            ("client_id", clientID),
+        ])
+    }
+
+    /// Refresh the access token. The backend rotates the refresh token, so the
+    /// returned `refreshToken` supersedes the one presented.
+    func refresh(
+        endpoints: Endpoints,
+        clientID: String,
+        refreshToken: String,
+        scope: String? = nil
+    ) async throws -> TokenResponse {
+        var fields: [(String, String)] = [
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refreshToken),
+            ("client_id", clientID),
+        ]
+        if let scope, !scope.isEmpty { fields.append(("scope", scope)) }
+        return try await postToken(endpoints: endpoints, fields: fields)
+    }
+
+    // MARK: - Shared token POST
+
+    private func postToken(
+        endpoints: Endpoints,
+        fields: [(String, String)]
+    ) async throws -> TokenResponse {
+        var request = URLRequest(url: endpoints.token)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = Data(Self.formURLEncode(fields).utf8)
+
+        let json = try await sendExpectingJSON(request)
+        guard let accessToken = json["access_token"] as? String, !accessToken.isEmpty else {
+            throw Failure.malformedResponse("token response had no access_token")
+        }
+        return TokenResponse(
+            accessToken: accessToken,
+            refreshToken: (json["refresh_token"] as? String) ?? "",
+            tokenType: (json["token_type"] as? String) ?? "Bearer",
+            expiresIn: Self.intValue(json["expires_in"]),
+            scope: (json["scope"] as? String) ?? "")
+    }
+
+    // MARK: - HTTP + parsing helpers
+
+    /// Run `request`, map transport/HTTP/OAuth failures to ``Failure``, and return
+    /// the decoded JSON object on 2xx.
+    private func sendExpectingJSON(_ request: URLRequest) async throws -> [String: Any] {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await transport(request)
+        } catch {
+            throw Failure.transport(error.localizedDescription)
+        }
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let parsed = try? JSONSerialization.jsonObject(with: data)
+        let object = parsed as? [String: Any]
+
+        guard (200...299).contains(status) else {
+            // OAuth errors are a JSON `{error, error_description}` body (RFC 6749
+            // §5.2 / RFC 7591 §3.2.2) — surface those specifically; fall back to a
+            // raw HTTP failure otherwise.
+            if let object, let error = object["error"] as? String {
+                throw Failure.oauth(error: error, description: object["error_description"] as? String)
+            }
+            throw Failure.http(status: status, body: String(decoding: data, as: UTF8.self))
+        }
+        guard let object else {
+            throw Failure.malformedResponse("response body was not a JSON object")
+        }
+        return object
+    }
+
+    /// `expires_in` may decode as an `Int`, a JSON number (`Double`), or a string —
+    /// accept all three, reject the rest.
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int: return int
+        case let double as Double: return Int(double)
+        case let string as String: return Int(string)
+        default: return nil
+        }
+    }
+
+    /// `application/x-www-form-urlencoded` body: percent-encode each key and value
+    /// with the unreserved set only (so `+`, `/`, `=` in a token never break the
+    /// encoding), joined with `&`.
+    static func formURLEncode(_ fields: [(String, String)]) -> String {
+        fields.map { "\(percentEncode($0.0))=\(percentEncode($0.1))" }.joined(separator: "&")
+    }
+
+    private static let unreserved: CharacterSet = {
+        // RFC 3986 unreserved: ALPHA / DIGIT / "-" / "." / "_" / "~"
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-._~")
+        return set
+    }()
+
+    private static func percentEncode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? value
+    }
+
+    /// Base64url without padding (RFC 7636 §A) — the encoding for PKCE verifiers,
+    /// challenges, and `state`.
+    static func base64URL(_ bytes: [UInt8]) -> String {
+        Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func randomBytes(_ count: Int) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: count)
+        for index in bytes.indices { bytes[index] = UInt8.random(in: .min ... .max) }
+        return bytes
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -553,6 +553,21 @@ public enum CrowDaemon {
         // path on this machine.
         CorveilRoutes.mount(
             on: httpRouter, boundHost: options.host, devRoot: options.devRoot, appState: appState)
+        // Corveil Connect (OAuth) flow (CROW-1119): the loopback callback +
+        // Connect trigger. Local-only, same rationale as the routes above — the
+        // callback stores user-scoped OAuth tokens on the host. The in-flight
+        // authorization store lives for the daemon's lifetime; a periodic prune
+        // drops abandoned flows.
+        let corveilPendingAuth = CorveilPendingAuthStore()
+        Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(300))
+                corveilPendingAuth.prune()
+            }
+        }
+        CorveilIntegrationRoutes.mount(
+            on: httpRouter, boundHost: options.host, devRoot: options.devRoot,
+            httpPort: options.httpPort, pending: corveilPendingAuth)
         // Read-only MCP for off-box clients (CROW-1004). Authenticates with a scoped
         // bearer token minted by `crow mcp token mint`, NOT the web-session cookie —
         // `/mcp` is listed in `WebAuthMiddleware.isAuthExempt` for that reason, and

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilIntegrationRouteTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilIntegrationRouteTests.swift
@@ -1,0 +1,324 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import Testing
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@testable import CrowDaemon
+
+/// End-to-end coverage of the Corveil Connect routes over a real loopback server
+/// (CROW-1119): the local-only gating on both routes, and the full
+/// connect → callback → tokens-stored path against a stub Corveil backend.
+///
+/// Same harness as ``CorveilRouteGatingTests``: routes are mounted on a live
+/// `.test(.live)` server so a refactor that drops the gate fails here, and each
+/// refused case asserts the Corveil backend was never called.
+@Suite struct CorveilIntegrationRouteTests {
+
+    // MARK: - Stub backend + capture boxes
+
+    /// Records the paths the client hit, so a refused request can assert the
+    /// backend was never reached.
+    private final class CallLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var paths: [String] = []
+        func record(_ request: URLRequest) {
+            lock.lock(); paths.append(request.url?.path ?? ""); lock.unlock()
+        }
+        var all: [String] { lock.lock(); defer { lock.unlock() }; return paths }
+        var hitRegister: Bool { all.contains { $0.hasSuffix("/register") } }
+        var hitToken: Bool { all.contains { $0.hasSuffix("/token") } }
+    }
+
+    /// Captures what the persistence door was asked to store.
+    private final class PersistBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _tokens: CorveilOAuthTokens?
+        private var _clientID = ""
+        private var _baseURL = ""
+        private var _calls = 0
+        func record(baseURL: String, clientID: String, tokens: CorveilOAuthTokens) {
+            lock.lock()
+            _baseURL = baseURL; _clientID = clientID; _tokens = tokens; _calls += 1
+            lock.unlock()
+        }
+        var tokens: CorveilOAuthTokens? { lock.lock(); defer { lock.unlock() }; return _tokens }
+        var clientID: String { lock.lock(); defer { lock.unlock() }; return _clientID }
+        var baseURL: String { lock.lock(); defer { lock.unlock() }; return _baseURL }
+        var calls: Int { lock.lock(); defer { lock.unlock() }; return _calls }
+    }
+
+    /// Captures the URL Connect asked the browser to open.
+    private final class OpenBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _url: URL?
+        func record(_ url: URL) { lock.lock(); _url = url; lock.unlock() }
+        var url: URL? { lock.lock(); defer { lock.unlock() }; return _url }
+    }
+
+    private func json(_ dict: [String: Any]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: dict)) ?? Data()
+    }
+
+    /// A stub Corveil backend: `/register` mints a client, `/token` mints tokens.
+    private func backend(log: CallLog) -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+        { request in
+            log.record(request)
+            let path = request.url?.path ?? ""
+            let (status, body): (Int, Data)
+            if path.hasSuffix("/register") {
+                (status, body) = (201, self.json([
+                    "client_id": "cid-xyz",
+                    "registration_access_token": "reg-tok",
+                    "registration_client_uri": "https://corveil.test/mcp/oauth/register/cid-xyz",
+                    "scope": "orgs.read keys.provision",
+                ]))
+            } else if path.hasSuffix("/token") {
+                (status, body) = (200, self.json([
+                    "access_token": "at-final", "refresh_token": "rt-final",
+                    "token_type": "Bearer", "expires_in": 3600, "scope": "orgs.read",
+                ]))
+            } else {
+                (status, body) = (404, Data())
+            }
+            return (body, HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!)
+        }
+    }
+
+    // MARK: - Fixture
+
+    private struct Harness {
+        let app: any ApplicationProtocol
+        let pending: CorveilPendingAuthStore
+        let calls: CallLog
+        let persisted: PersistBox
+        let opened: OpenBox
+        let devRoot: String
+        func cleanUp() { try? FileManager.default.removeItem(atPath: devRoot) }
+    }
+
+    private func makeHarness() -> Harness {
+        let devRoot = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("corveil-routes-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: devRoot, withIntermediateDirectories: true)
+        let calls = CallLog()
+        let persisted = PersistBox()
+        let opened = OpenBox()
+        let pending = CorveilPendingAuthStore()
+
+        let router = Router(context: CrowHTTPContext.self)
+        CorveilIntegrationRoutes.mount(
+            on: router, boundHost: "127.0.0.1", devRoot: devRoot, httpPort: 8787,
+            pending: pending,
+            client: CorveilOAuthClient(transport: backend(log: calls)),
+            openBrowser: { opened.record($0) },
+            persist: { baseURL, clientID, tokens in
+                persisted.record(baseURL: baseURL, clientID: clientID, tokens: tokens)
+            })
+        let app = Application(
+            router: router,
+            configuration: .init(address: .hostname("127.0.0.1", port: 0), serverName: "crowd-test"))
+        return Harness(
+            app: app, pending: pending, calls: calls, persisted: persisted,
+            opened: opened, devRoot: devRoot)
+    }
+
+    private let jsonHeaders: HTTPFields = [.contentType: "application/json"]
+    private let xff = HTTPField.Name("x-forwarded-for")!
+    private let connectURI = CorveilIntegrationRoutes.connectPath
+    private let callbackURI = CorveilIntegrationRoutes.callbackPath
+
+    private func decodeJSON(_ buffer: ByteBuffer) throws -> [String: Any] {
+        try #require(try JSONSerialization.jsonObject(with: Data(buffer: buffer)) as? [String: Any])
+    }
+
+    // MARK: - Gating: refused
+
+    @Test func connectRefusesProxiedPeer() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        let headers: HTTPFields = [.contentType: "application/json", xff: "203.0.113.9"]
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: connectURI, method: .post, headers: headers,
+                body: ByteBuffer(string: #"{"baseURL":"https://corveil.test"}"#)
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(!h.calls.hitRegister, "the gate must run before any DCR call")
+    }
+
+    @Test func connectRefusesCrossSiteOrigin() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        let headers: HTTPFields = [.contentType: "application/json", .origin: "https://evil.com"]
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: connectURI, method: .post, headers: headers,
+                body: ByteBuffer(string: #"{"baseURL":"https://corveil.test"}"#)
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(!h.calls.hitRegister)
+    }
+
+    @Test func callbackRefusesProxiedPeer() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        let headers: HTTPFields = [xff: "203.0.113.9"]
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: "\(callbackURI)?code=x&state=y", method: .get, headers: headers
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(!h.calls.hitToken, "the gate must run before any token exchange")
+    }
+
+    // MARK: - Connect: happy path
+
+    @Test func connectRegistersOpensBrowserAndReturnsAuthorizeURL() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: connectURI, method: .post, headers: jsonHeaders,
+                body: ByteBuffer(string: #"{"baseURL":"https://corveil.test"}"#)
+            ) { response in
+                #expect(response.status == .ok)
+                let body = try decodeJSON(response.body)
+                let authorizeURL = try #require(body["authorizeURL"] as? String)
+                #expect(authorizeURL.hasPrefix("https://corveil.test/mcp/oauth/authorize?"))
+                #expect(authorizeURL.contains("client_id=cid-xyz"))
+                #expect(authorizeURL.contains("code_challenge_method=S256"))
+            }
+        }
+        #expect(h.calls.hitRegister)
+        #expect(h.pending.count == 1, "an in-flight authorization is recorded")
+        #expect(h.opened.url?.absoluteString.contains("/mcp/oauth/authorize") == true)
+    }
+
+    @Test func connectWithoutBaseURLIsRejected() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: connectURI, method: .post, headers: jsonHeaders,
+                body: ByteBuffer(string: #"{}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+        #expect(!h.calls.hitRegister)
+    }
+
+    // MARK: - Callback: happy path + failures
+
+    /// Seed a pending authorization directly, then drive the callback — the token
+    /// exchange runs, tokens are stored, and the state is consumed (single-use).
+    @Test func callbackExchangesCodeAndStoresTokens() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        h.pending.put(CorveilPendingAuthorization(
+            state: "st-1", codeVerifier: "verifier-1", clientID: "cid-xyz",
+            redirectURI: CorveilOAuthClient.redirectURI(httpPort: 8787),
+            baseURL: "https://corveil.test", registrationAccessToken: "reg-tok",
+            scope: "orgs.read keys.provision", createdAt: Date()))
+
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: "\(callbackURI)?code=auth-code-1&state=st-1", method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                let html = String(buffer: response.body)
+                #expect(html.contains("Connected to Corveil"))
+            }
+        }
+        #expect(h.calls.hitToken)
+        let tokens = try #require(h.persisted.tokens)
+        #expect(tokens.accessToken == "at-final")
+        #expect(tokens.refreshToken == "rt-final")
+        #expect(tokens.registrationAccessToken == "reg-tok")  // carried from the pending record
+        #expect(tokens.accessTokenExpiresAt != nil)
+        #expect(h.persisted.clientID == "cid-xyz")
+        #expect(h.pending.count == 0, "the state is consumed and can't be replayed")
+    }
+
+    @Test func callbackWithUnknownStateIsRejected() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: "\(callbackURI)?code=x&state=never-issued", method: .get
+            ) { response in
+                #expect(response.status == .badRequest)
+                #expect(String(buffer: response.body).contains("expired"))
+            }
+        }
+        #expect(!h.calls.hitToken, "no token exchange for an unrecognized state")
+        #expect(h.persisted.calls == 0)
+    }
+
+    @Test func callbackWithProviderErrorIsRendered() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        try await h.app.test(.live) { client in
+            try await client.execute(
+                uri: "\(callbackURI)?error=access_denied&error_description=User%20said%20no", method: .get
+            ) { response in
+                #expect(response.status == .badRequest)
+                #expect(String(buffer: response.body).contains("User said no"))
+            }
+        }
+        #expect(!h.calls.hitToken)
+    }
+
+    @Test func callbackMissingCodeIsRejected() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        h.pending.put(CorveilPendingAuthorization(
+            state: "st-2", codeVerifier: "v", clientID: "c", redirectURI: "r",
+            baseURL: "https://corveil.test", registrationAccessToken: "reg", scope: "s", createdAt: Date()))
+        try await h.app.test(.live) { client in
+            try await client.execute(uri: "\(callbackURI)?state=st-2", method: .get) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+        #expect(!h.calls.hitToken)
+    }
+
+    // MARK: - Full end-to-end: connect issues the state the callback consumes
+
+    @Test func connectThenCallbackEndToEnd() async throws {
+        let h = makeHarness(); defer { h.cleanUp() }
+        try await h.app.test(.live) { client in
+            // 1) Connect → authorize URL carrying the issued state.
+            var issuedState = ""
+            try await client.execute(
+                uri: connectURI, method: .post, headers: jsonHeaders,
+                body: ByteBuffer(string: #"{"baseURL":"https://corveil.test"}"#)
+            ) { response in
+                #expect(response.status == .ok)
+                let authorizeURL = try #require(try decodeJSON(response.body)["authorizeURL"] as? String)
+                let items = URLComponents(string: authorizeURL)?.queryItems ?? []
+                issuedState = items.first { $0.name == "state" }?.value ?? ""
+                #expect(!issuedState.isEmpty)
+            }
+
+            // 2) The browser redirect comes back to the loopback callback with that
+            //    same state + an authorization code.
+            try await client.execute(
+                uri: "\(callbackURI)?code=code-from-corveil&state=\(issuedState)", method: .get
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains("Connected to Corveil"))
+            }
+        }
+        #expect(h.calls.hitRegister)
+        #expect(h.calls.hitToken)
+        #expect(h.persisted.tokens?.accessToken == "at-final")
+        #expect(h.pending.count == 0)
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilIntegrationRouteTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilIntegrationRouteTests.swift
@@ -237,6 +237,9 @@ import FoundationNetworking
                 #expect(response.status == .ok)
                 let html = String(buffer: response.body)
                 #expect(html.contains("Connected to Corveil"))
+                // The result page is locked down behind escape() (review Green #3).
+                #expect(response.headers[.contentSecurityPolicy]?.contains("default-src 'none'") == true)
+                #expect(response.headers[HTTPField.Name("x-frame-options")!] == "DENY")
             }
         }
         #expect(h.calls.hitToken)

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
@@ -95,6 +95,15 @@ import FoundationNetworking
         #expect(CorveilOAuthClient.Endpoints(baseURL: "not-a-url") == nil)  // no scheme/host
     }
 
+    @Test func endpointsRejectNonHTTPSchemes() {
+        // A non-http(s) base URL is rejected before it can reach the browser or the
+        // transport (review Green #1).
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "file://localhost/x") == nil)
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "javascript://alert.com") == nil)
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "slack://open") == nil)
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "http://corveil.test") != nil)  // http allowed (loopback dev)
+    }
+
     // MARK: - Dynamic Client Registration (RFC 7591)
 
     @Test func registerParsesResponseAndSendsPublicClient() async throws {
@@ -224,6 +233,20 @@ import FoundationNetworking
             _ = try await client.exchangeCode(
                 endpoints: endpoints, clientID: "c", code: "x", codeVerifier: "v", redirectURI: "r")
         }
+    }
+
+    @Test func expiresInOutOfRangeIsIgnoredNotFatal() async throws {
+        // A 2xx token body with an out-of-Int-range `expires_in` (a buggy or hostile
+        // AS) must not trap the daemon: the access token still parses and the expiry
+        // is simply unknown (review Yellow).
+        let client = CorveilOAuthClient(transport: transport { _ in
+            (200, Data(#"{"access_token":"at","refresh_token":"rt","token_type":"Bearer","expires_in":1e20,"scope":"s"}"#.utf8))
+        })
+        let tokens = try await client.exchangeCode(
+            endpoints: endpoints, clientID: "c", code: "x", codeVerifier: "v", redirectURI: "r")
+        #expect(tokens.accessToken == "at")
+        #expect(tokens.expiresIn == nil)
+        #expect(tokens.expiresAt(now: Date()) == nil)
     }
 
     @Test func transportThrowBecomesTransportFailure() async {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
@@ -1,0 +1,382 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+import Testing
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@testable import CrowDaemon
+
+/// Unit coverage for the Corveil OAuth client and the state/persistence around it
+/// (CROW-1119), driven entirely against a stub transport — no live Corveil. The
+/// mounted-route behavior (gating, the loopback callback, end-to-end) lives in
+/// ``CorveilIntegrationRouteTests``.
+@Suite struct CorveilOAuthClientTests {
+
+    // MARK: - Stub transport
+
+    /// Records every request the client makes, in order, for assertions.
+    private final class RequestLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var items: [URLRequest] = []
+        func append(_ request: URLRequest) { lock.lock(); items.append(request); lock.unlock() }
+        var all: [URLRequest] { lock.lock(); defer { lock.unlock() }; return items }
+        var last: URLRequest? { all.last }
+    }
+
+    /// A transport that maps each request to a `(status, jsonBody)` via `respond`,
+    /// recording the request in `log`.
+    private func transport(
+        log: RequestLog? = nil,
+        _ respond: @escaping @Sendable (URLRequest) -> (Int, Data)
+    ) -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+        { request in
+            log?.append(request)
+            let (status, body) = respond(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (body, response)
+        }
+    }
+
+    private func jsonData(_ dict: [String: Any]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: dict)) ?? Data()
+    }
+
+    private func bodyString(_ request: URLRequest?) -> String {
+        request?.httpBody.map { String(decoding: $0, as: UTF8.self) } ?? ""
+    }
+
+    private let endpoints = CorveilOAuthClient.Endpoints(baseURL: "https://corveil.test")!
+
+    // MARK: - PKCE (RFC 7636)
+
+    @Test func pkceChallengeIsS256OfVerifier() {
+        let pkce = CorveilOAuthClient.makePKCE()
+        #expect(pkce.method == "S256")
+        // 32 random bytes → 43 base64url chars (no padding).
+        #expect(pkce.verifier.count == 43)
+        let allowed = CharacterSet(charactersIn:
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        #expect(pkce.verifier.unicodeScalars.allSatisfy { allowed.contains($0) })
+        #expect(pkce.challenge.unicodeScalars.allSatisfy { allowed.contains($0) })
+        // The challenge must be BASE64URL(SHA256(verifier)).
+        #expect(pkce.challenge == CorveilOAuthClient.challenge(for: pkce.verifier))
+    }
+
+    /// The canonical PKCE S256 test vector from RFC 7636 Appendix B pins the
+    /// challenge computation itself.
+    @Test func s256MatchesRFC7636Vector() {
+        #expect(CorveilOAuthClient.challenge(for: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+            == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test func distinctPKCEEachCall() {
+        #expect(CorveilOAuthClient.makePKCE().verifier != CorveilOAuthClient.makePKCE().verifier)
+        #expect(CorveilOAuthClient.makeState() != CorveilOAuthClient.makeState())
+    }
+
+    // MARK: - Endpoints
+
+    @Test func endpointsResolveAgainstBaseURL() {
+        let withSlash = CorveilOAuthClient.Endpoints(baseURL: "https://corveil.test/")
+        #expect(withSlash?.register.absoluteString == "https://corveil.test/mcp/oauth/register")
+        #expect(withSlash?.authorize.absoluteString == "https://corveil.test/mcp/oauth/authorize")
+        #expect(withSlash?.token.absoluteString == "https://corveil.test/mcp/oauth/token")
+        // Without a trailing slash resolves identically.
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "https://corveil.test")?.token.absoluteString
+            == "https://corveil.test/mcp/oauth/token")
+    }
+
+    @Test func endpointsRejectGarbageBaseURL() {
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "") == nil)
+        #expect(CorveilOAuthClient.Endpoints(baseURL: "not-a-url") == nil)  // no scheme/host
+    }
+
+    // MARK: - Dynamic Client Registration (RFC 7591)
+
+    @Test func registerParsesResponseAndSendsPublicClient() async throws {
+        let log = RequestLog()
+        let client = CorveilOAuthClient(transport: transport(log: log) { _ in
+            (201, self.jsonData([
+                "client_id": "crow-client-123",
+                "registration_access_token": "reg-tok-abc",
+                "registration_client_uri": "https://corveil.test/mcp/oauth/register/crow-client-123",
+                "scope": "orgs.read keys.provision",
+            ]))
+        })
+
+        let registration = try await client.register(
+            endpoints: endpoints, redirectURI: "http://127.0.0.1:8787/integrations/corveil/callback")
+
+        #expect(registration.clientID == "crow-client-123")
+        #expect(registration.registrationAccessToken == "reg-tok-abc")
+        #expect(registration.registrationClientURI.hasSuffix("/crow-client-123"))
+
+        let request = try #require(log.last)
+        #expect(request.url?.absoluteString == "https://corveil.test/mcp/oauth/register")
+        #expect(request.httpMethod == "POST")
+        // Public PKCE client with the loopback redirect + refresh grant.
+        let sent = try #require(
+            try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: Any])
+        #expect(sent["token_endpoint_auth_method"] as? String == "none")
+        #expect(sent["redirect_uris"] as? [String] == ["http://127.0.0.1:8787/integrations/corveil/callback"])
+        #expect((sent["grant_types"] as? [String])?.contains("refresh_token") == true)
+        #expect((sent["response_types"] as? [String]) == ["code"])
+    }
+
+    // MARK: - Authorize URL
+
+    @Test func authorizeURLCarriesPKCEAndState() throws {
+        let pkce = CorveilOAuthClient.makePKCE()
+        let url = CorveilOAuthClient.authorizeURL(
+            endpoints: endpoints, clientID: "cid", redirectURI: "http://127.0.0.1:8787/cb",
+            scope: "orgs.read keys.provision", state: "st-123", pkce: pkce)
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let map = Dictionary(items.map { ($0.name, $0.value ?? "") }, uniquingKeysWith: { a, _ in a })
+        #expect(url.absoluteString.hasPrefix("https://corveil.test/mcp/oauth/authorize?"))
+        #expect(map["response_type"] == "code")
+        #expect(map["client_id"] == "cid")
+        #expect(map["redirect_uri"] == "http://127.0.0.1:8787/cb")
+        #expect(map["scope"] == "orgs.read keys.provision")
+        #expect(map["state"] == "st-123")
+        #expect(map["code_challenge"] == pkce.challenge)
+        #expect(map["code_challenge_method"] == "S256")
+    }
+
+    // MARK: - Token exchange (RFC 6749 §4.1.3)
+
+    @Test func exchangeSendsFormAndParsesTokens() async throws {
+        let log = RequestLog()
+        let client = CorveilOAuthClient(transport: transport(log: log) { _ in
+            (200, self.jsonData([
+                "access_token": "at-1", "refresh_token": "rt-1",
+                "token_type": "Bearer", "expires_in": 3600, "scope": "orgs.read",
+            ]))
+        })
+
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let tokens = try await client.exchangeCode(
+            endpoints: endpoints, clientID: "cid", code: "the-code",
+            codeVerifier: "the-verifier", redirectURI: "http://127.0.0.1:8787/cb")
+
+        #expect(tokens.accessToken == "at-1")
+        #expect(tokens.refreshToken == "rt-1")
+        #expect(tokens.expiresIn == 3600)
+        #expect(tokens.expiresAt(now: now) == now.addingTimeInterval(3600))
+
+        let request = try #require(log.last)
+        #expect(request.url?.absoluteString == "https://corveil.test/mcp/oauth/token")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        let form = bodyString(request)
+        #expect(form.contains("grant_type=authorization_code"))
+        #expect(form.contains("code=the-code"))
+        #expect(form.contains("code_verifier=the-verifier"))
+        #expect(form.contains("client_id=cid"))
+    }
+
+    // MARK: - Refresh (RFC 6749 §6)
+
+    @Test func refreshSendsRefreshGrant() async throws {
+        let log = RequestLog()
+        let client = CorveilOAuthClient(transport: transport(log: log) { _ in
+            (200, self.jsonData([
+                "access_token": "at-2", "refresh_token": "rt-2",
+                "token_type": "Bearer", "expires_in": 3600, "scope": "orgs.read",
+            ]))
+        })
+
+        let tokens = try await client.refresh(
+            endpoints: endpoints, clientID: "cid", refreshToken: "rt-1")
+        #expect(tokens.accessToken == "at-2")
+        #expect(tokens.refreshToken == "rt-2")
+
+        let form = bodyString(log.last)
+        #expect(form.contains("grant_type=refresh_token"))
+        #expect(form.contains("refresh_token=rt-1"))
+        #expect(form.contains("client_id=cid"))
+    }
+
+    // MARK: - Error mapping
+
+    @Test func oauthErrorBodyBecomesOAuthFailure() async {
+        let client = CorveilOAuthClient(transport: transport { _ in
+            (400, self.jsonData(["error": "invalid_grant", "error_description": "code expired"]))
+        })
+        await #expect(throws: CorveilOAuthClient.Failure.oauth(error: "invalid_grant", description: "code expired")) {
+            _ = try await client.exchangeCode(
+                endpoints: endpoints, clientID: "c", code: "x", codeVerifier: "v", redirectURI: "r")
+        }
+    }
+
+    @Test func nonOAuthHTTPErrorBecomesHTTPFailure() async {
+        let client = CorveilOAuthClient(transport: transport { _ in (500, Data("boom".utf8)) })
+        await #expect(throws: CorveilOAuthClient.Failure.http(status: 500, body: "boom")) {
+            _ = try await client.refresh(endpoints: endpoints, clientID: "c", refreshToken: "r")
+        }
+    }
+
+    @Test func missingAccessTokenIsMalformed() async {
+        let client = CorveilOAuthClient(transport: transport { _ in (200, self.jsonData(["scope": "x"])) })
+        await #expect(throws: CorveilOAuthClient.Failure.self) {
+            _ = try await client.exchangeCode(
+                endpoints: endpoints, clientID: "c", code: "x", codeVerifier: "v", redirectURI: "r")
+        }
+    }
+
+    @Test func transportThrowBecomesTransportFailure() async {
+        struct Boom: Error {}
+        let client = CorveilOAuthClient(transport: { _ in throw Boom() })
+        await #expect(throws: CorveilOAuthClient.Failure.self) {
+            _ = try await client.register(endpoints: endpoints, redirectURI: "http://127.0.0.1/cb")
+        }
+    }
+
+    // MARK: - Pending-auth store
+
+    private func pending(state: String, at date: Date) -> CorveilPendingAuthorization {
+        CorveilPendingAuthorization(
+            state: state, codeVerifier: "v", clientID: "c", redirectURI: "r",
+            baseURL: "https://corveil.test", registrationAccessToken: "reg", scope: "s", createdAt: date)
+    }
+
+    @Test func pendingStoreConsumeIsSingleUse() {
+        let store = CorveilPendingAuthStore()
+        let now = Date()
+        store.put(pending(state: "abc", at: now))
+        #expect(store.consume(state: "abc", now: now)?.codeVerifier == "v")
+        // A second consume of the same state fails — no replay.
+        #expect(store.consume(state: "abc", now: now) == nil)
+    }
+
+    @Test func pendingStoreRejectsUnknownAndExpired() {
+        let store = CorveilPendingAuthStore(ttl: 60)
+        let now = Date()
+        #expect(store.consume(state: "never-issued", now: now) == nil)
+        store.put(pending(state: "old", at: now.addingTimeInterval(-120)))
+        #expect(store.consume(state: "old", now: now) == nil)  // past TTL
+    }
+
+    @Test func pendingStorePruneDropsExpired() {
+        let store = CorveilPendingAuthStore(ttl: 60)
+        let now = Date()
+        store.put(pending(state: "fresh", at: now))
+        store.put(pending(state: "stale", at: now.addingTimeInterval(-120)))
+        store.prune(now: now)
+        #expect(store.count == 1)
+        #expect(store.consume(state: "fresh", now: now) != nil)
+    }
+
+    // MARK: - Persistence door
+
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("corveil-oauth-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func storeThenUpdateTokensPreservesConnectionShell() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        // A prior connect populated the connected user + org keys (a later step's job).
+        var seeded = AppConfig()
+        seeded.corveilConnection = CorveilConnection(
+            baseURL: "https://old.test", clientID: "old",
+            connectedUser: CorveilConnectedUser(id: "u1", email: "a@b.c", name: "A"),
+            orgKeys: [CorveilOrgKey(orgID: "o1", orgName: "Org", keyID: "k1", keyPrefix: "sk-")])
+        try ConfigStore.saveConfig(seeded, devRoot: devRoot)
+
+        try CorveilConnectionPersistence.store(
+            devRoot: devRoot, baseURL: "https://new.test", clientID: "new",
+            tokens: CorveilOAuthTokens(accessToken: "at", refreshToken: "rt", registrationAccessToken: "reg"))
+
+        let stored = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(stored.baseURL == "https://new.test")
+        #expect(stored.clientID == "new")
+        #expect(stored.oauth.accessToken == "at")
+        // The connected user + org keys a reconnect must not destroy survive.
+        #expect(stored.connectedUser.email == "a@b.c")
+        #expect(stored.orgKeys.first?.keyID == "k1")
+
+        // updateTokens replaces only the oauth block.
+        let updated = try CorveilConnectionPersistence.updateTokens(
+            devRoot: devRoot,
+            tokens: CorveilOAuthTokens(accessToken: "at2", refreshToken: "rt2", registrationAccessToken: "reg"))
+        #expect(updated)
+        let after = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(after.oauth.accessToken == "at2")
+        #expect(after.clientID == "new")  // untouched
+    }
+
+    @Test func updateTokensReturnsFalseWithoutConnection() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let updated = try CorveilConnectionPersistence.updateTokens(
+            devRoot: devRoot, tokens: CorveilOAuthTokens(accessToken: "x"))
+        #expect(!updated)
+    }
+
+    // MARK: - Refresher (load → refresh → store)
+
+    @Test func refresherRenewsAndPersists() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        var seeded = AppConfig()
+        seeded.corveilConnection = CorveilConnection(
+            baseURL: "https://corveil.test", clientID: "cid",
+            oauth: CorveilOAuthTokens(
+                accessToken: "old-at", refreshToken: "old-rt", registrationAccessToken: "reg-keep"))
+        try ConfigStore.saveConfig(seeded, devRoot: devRoot)
+
+        let client = CorveilOAuthClient(transport: transport { _ in
+            (200, self.jsonData([
+                "access_token": "new-at", "refresh_token": "new-rt",
+                "token_type": "Bearer", "expires_in": 3600, "scope": "orgs.read",
+            ]))
+        })
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let tokens = try await CorveilConnectionRefresher.refresh(devRoot: devRoot, client: client, now: now)
+
+        #expect(tokens.accessToken == "new-at")
+        #expect(tokens.refreshToken == "new-rt")
+        #expect(tokens.registrationAccessToken == "reg-keep")  // not part of refresh, carried through
+        #expect(tokens.accessTokenExpiresAt == now.addingTimeInterval(3600))
+        // Persisted.
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection?.oauth.accessToken == "new-at")
+    }
+
+    @Test func refresherRejectsMissingConnectionAndToken() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // No connection at all.
+        await #expect(throws: CorveilConnectionRefresher.RefreshError.self) {
+            _ = try await CorveilConnectionRefresher.refresh(devRoot: devRoot)
+        }
+        // A connection with no refresh token.
+        var seeded = AppConfig()
+        seeded.corveilConnection = CorveilConnection(
+            baseURL: "https://corveil.test", clientID: "cid",
+            oauth: CorveilOAuthTokens(accessToken: "at", refreshToken: ""))
+        try ConfigStore.saveConfig(seeded, devRoot: devRoot)
+        await #expect(throws: CorveilConnectionRefresher.RefreshError.self) {
+            _ = try await CorveilConnectionRefresher.refresh(devRoot: devRoot)
+        }
+    }
+
+    @Test func mergedTokensKeepsRefreshWhenServerOmitsIt() {
+        let existing = CorveilOAuthTokens(
+            accessToken: "a", refreshToken: "keep-me", registrationAccessToken: "reg")
+        let response = CorveilOAuthClient.TokenResponse(
+            accessToken: "a2", refreshToken: "", tokenType: "Bearer", expiresIn: 60, scope: "s")
+        let merged = CorveilConnectionRefresher.mergedTokens(
+            existing: existing, response: response, now: Date(timeIntervalSince1970: 0))
+        #expect(merged.accessToken == "a2")
+        #expect(merged.refreshToken == "keep-me")  // server didn't rotate → keep old
+        #expect(merged.registrationAccessToken == "reg")
+    }
+}


### PR DESCRIPTION
Closes #1119

Net-new OAuth 2.0 client for the Corveil **Connect** flow (epic #1117). Crow had zero OAuth code before this; it now self-registers a public PKCE client against Corveil's own DCR authorization server (`/mcp/oauth/*`) and stores the resulting user-scoped tokens locally.

## What's here
- **`CorveilOAuthClient`** — RFC 7591 Dynamic Client Registration (public client, `token_endpoint_auth_method: none`), RFC 7636 **S256 PKCE**, RFC 6749 authorization-code exchange + refresh-token rotation, against `{base}/mcp/oauth/{register,authorize,token}`. Request/response shapes were verified against the corveil backend (`go/internal/handler/oauth_{register,authorize,token}.go`). Transport is injected, so the whole flow is exercised without a live Corveil.
- **`CorveilConnectionStore`** — a single-use, TTL-bounded pending-authorization store (`state → code_verifier`) that also *is* the `state` validation; the **local-only** `ConfigStore` write door for `corveilConnection`; and a load→refresh→store refresh helper.
- **`CorveilIntegrationRoutes`** (mounted in `CrowDaemon`):
  - `POST /integrations/corveil/connect` — gated `gateOK` (local-direct **+** same-origin CSRF), like the other secret writes. Registers, opens the browser to Corveil, returns the authorize URL.
  - `GET /integrations/corveil/callback` — gated **local-direct** (loopback + no `X-Forwarded-For`), per the ticket. Validates `state`, exchanges the `code` with the PKCE `code_verifier`, stores the tokens, renders a result page.

## Acceptance
- ✅ New `GET /integrations/corveil/callback` in `CorveilIntegrationRoutes.swift`, mounted in `CrowDaemon.swift`, gated local-direct (loopback + no XFF).
- ✅ End-to-end: Connect opens the browser → consent → callback → tokens stored via the local-only config door (`SettingsSecrets` names the OAuth flow as the author of `corveilConnection`, CROW-1118).
- ✅ Access-token refresh works; PKCE `code_verifier`/`state` validated (state via the single-use pending store; verifier presented at exchange; challenge pinned against the RFC 7636 test vector).

## Tests
Client unit coverage (PKCE incl. RFC 7636 vector, DCR, exchange, refresh, OAuth/HTTP/transport error mapping), pending-store / persistence / refresher, and **live-server** route gating + full `connect → callback → stored` end-to-end. All 31 new tests pass.

## Scope
Stays strictly within #1119. Parallel siblings: CLI write verbs (#1120), org listing / one-key-per-org provisioning (#1121), the Integrations UI (#1122), and refresh scheduling / reconnect UX (#1125). The requested scopes (`orgs.read keys.provision`) are what the connected app needs; the backend may downscope until its sibling tickets land.

## Note
Two **pre-existing** `CrowDaemon` test failures — `RPCLanePolicyTests` (`terminal-set` / `corveil-verify` / `corveil-reinstall-skill` declared as ledger writes without a lane) and `WebNotificationCenterTests.bootCatchResetsTheHistory` — are unrelated to this change and reproduce on a clean checkout of the branch base (verified by stashing all of this PR's changes and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
