### PR TITLE
Add local-only write path + CLI verbs for the Corveil connection (CROW-1120)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,23 @@ crow corveil reinstall-skill [--path PATH]     → {"ok":bool,"message":"Skill r
 - A reinstall also updates the launch-time corveil warning: succeeding clears it, failing replaces it.
 - Both are **local-only** on `/rpc` (they execute a path on the daemon host), like `gateway`/`web-password`/`mcp token`. The CLI is unaffected — it goes over the Unix socket.
 
+### Corveil connection
+
+The local-only write path for the **Corveil OAuth connection** (CROW-1120) — the source of truth an Integrations → Corveil setup writes, from which the AI gateway + log-shipping configs are generated. It is the "door" the browser Connect flow (corveil/crow#1119) and org provisioning (corveil/crow#1121) persist a `corveilConnection` through, never `set-config`, because it holds OAuth tokens.
+
+```
+crow corveil connect [--base-url URL] [--client-id ID] [--user-id ID] [--user-email E] [--user-name N] [--access-token T] [--refresh-token T] [--registration-access-token T] [--access-token-expires-at ISO8601]
+                                                → status payload + {"saved":true}
+crow corveil status                             → {connected, base_url, client_id, connected_user, org_count, has_*_token, access_token_expires_at}
+crow corveil disconnect                         → {"saved":true,"was_connected":bool}
+crow corveil orgs                               → {"orgs":[{org_id,org_name,key_id,key_prefix,created_at}],"count":N}
+```
+
+- All four are **local-only** on `/rpc`, like `gateway`/`web-password`/`mcp token`: `connect` stores OAuth tokens and `disconnect` clears them, and the two reads are gated alongside the writes so the whole connection is one local-only surface. The CLI is unaffected — it goes over the Unix socket.
+- `connect` is a **merge**: every field is optional, and a blank/omitted one keeps the stored value, so a token refresh can restate only `--access-token` + `--access-token-expires-at`. The merged result needs at least a client id and an access token; `orgKeys` (provisioned by corveil/crow#1121) are preserved.
+- `status`/`orgs` never return a token value — only presence booleans and non-secret metadata.
+- `disconnect` clears the local record; revoking the per-org gateway keys on the Corveil side is a separate step (corveil/crow#1121).
+
 ### Job Commands
 
 Scheduled prompt-sets scoped to one repo in a workspace (CROW-604) — the Jobs sidebar, as CLI verbs. Jobs are addressed by UUID; `crow job list` prints them. Mutations hit the app's live config, so the scheduler and Settings UI see them immediately.

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/CorveilCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/CorveilCommands.swift
@@ -3,22 +3,36 @@ import CrowCore
 import CrowIPC
 import Foundation
 
-/// The `crow corveil` verb family (CROW-1011).
+/// The `crow corveil` verb family.
 ///
-/// Settings → Corveil CLI's **Verify** and **Reinstall skill** buttons, as CLI
-/// verbs. Both act on `defaults.binaries["corveil"]` — the path Settings stores
-/// — unless `--path` names another, which is how you check a binary before
-/// committing it to config.
+/// Two groups under one command:
 ///
-/// The RPCs behind these are local-only on `/rpc`
-/// (``RPCWebSocketHandler.localOnlyDenial``) because they execute a path on the
-/// daemon host. That is no obstacle here: `crow` reaches the daemon over its
-/// 0600 Unix socket, so a CLI caller is local by construction (ADR 0002).
+/// - **CLI binary** (CROW-1011): Settings → Corveil CLI's **Verify** and
+///   **Reinstall skill** buttons, as verbs. Both act on
+///   `defaults.binaries["corveil"]` — the path Settings stores — unless `--path`
+///   names another, which is how you check a binary before committing it.
+/// - **Connection** (CROW-1120): `connect` / `status` / `disconnect` / `orgs`
+///   manage the local-only Corveil OAuth connection — the "door" the browser
+///   Connect flow (corveil/crow#1119) and org provisioning (corveil/crow#1121)
+///   persist a `CorveilConnection` through.
+///
+/// The RPCs behind every one of these are local-only on `/rpc`
+/// (``RPCWebSocketHandler.localOnlyDenial``): the binary verbs execute a path on
+/// the daemon host, and the connection verbs read and write OAuth tokens. That is
+/// no obstacle here: `crow` reaches the daemon over its 0600 Unix socket, so a CLI
+/// caller is local by construction (ADR 0002).
 public struct Corveil: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "corveil",
-        abstract: "Verify the configured Corveil CLI binary, and reinstall its skill",
-        subcommands: [CorveilVerify.self, CorveilReinstallSkill.self]
+        abstract: "Verify the Corveil CLI binary and manage the Corveil connection",
+        subcommands: [
+            CorveilVerify.self,
+            CorveilReinstallSkill.self,
+            CorveilConnect.self,
+            CorveilStatus.self,
+            CorveilDisconnect.self,
+            CorveilOrgs.self,
+        ]
     )
 
     public init() {}
@@ -87,5 +101,152 @@ public struct CorveilReinstallSkill: ParsableCommand {
 
     public func run() throws {
         printJSON(try rpc("corveil-reinstall-skill", params: pathOption.params))
+    }
+}
+
+// MARK: - Connection (CROW-1120)
+
+/// `crow corveil connect` — store or update the Corveil OAuth connection.
+///
+/// The local-only write path: it persists the identity + tokens the browser
+/// Connect flow (corveil/crow#1119) produces. Every field is optional and a blank
+/// or omitted one keeps whatever is stored, so a plain access-token refresh need
+/// not restate the refresh token — the same "blank keeps the stored secret"
+/// contract `crow gateway set` has. The merged connection must end up with at
+/// least a client id and an access token.
+public struct CorveilConnect: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "connect",
+        abstract: "Store or update the Corveil connection (local-only)",
+        discussion: """
+        Writes the OAuth connection Crow uses to reach Corveil — the door the \
+        browser Connect flow persists through. Every field is optional; a blank or \
+        omitted one keeps whatever is already stored, so a token refresh can update \
+        just the access token and its expiry:
+
+          crow corveil connect --access-token "$AT" --access-token-expires-at 2026-01-01T00:00:00Z
+
+        The merged connection must have at least a client id and an access token. \
+        Tokens passed on the command line are visible to local `ps` and shell \
+        history; the browser Connect flow is the primary writer. Local-only: this \
+        runs over the Unix socket and is refused for remote web clients, because \
+        the tokens are credentials.
+        """
+    )
+
+    @Option(name: .customLong("base-url"), help: "Corveil API base URL")
+    public var baseURL: String?
+
+    @Option(name: .customLong("client-id"), help: "OAuth client id (from Dynamic Client Registration)")
+    public var clientID: String?
+
+    @Option(name: .customLong("user-id"), help: "Connected Corveil user id")
+    public var userID: String?
+
+    @Option(name: .customLong("user-email"), help: "Connected Corveil user email")
+    public var userEmail: String?
+
+    @Option(name: .customLong("user-name"), help: "Connected Corveil user display name")
+    public var userName: String?
+
+    @Option(name: .customLong("access-token"), help: "OAuth access token (secret)")
+    public var accessToken: String?
+
+    @Option(name: .customLong("refresh-token"), help: "OAuth refresh token (secret)")
+    public var refreshToken: String?
+
+    @Option(
+        name: .customLong("registration-access-token"),
+        help: "RFC 7592 registration access token (secret)")
+    public var registrationAccessToken: String?
+
+    @Option(
+        name: .customLong("access-token-expires-at"),
+        help: "Access-token expiry as an ISO-8601 timestamp (e.g. 2026-01-01T00:00:00Z)")
+    public var accessTokenExpiresAt: String?
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("corveil-connect", params: params))
+    }
+
+    /// The connection fields as RPC params, dropping every blank/omitted one so
+    /// the daemon's merge keeps the stored value rather than clearing it — an
+    /// empty string is not the same as "not provided".
+    var params: [String: JSONValue] {
+        var params: [String: JSONValue] = [:]
+        func put(_ key: String, _ value: String?) {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !trimmed.isEmpty else { return }
+            params[key] = .string(trimmed)
+        }
+        put("base_url", baseURL)
+        put("client_id", clientID)
+        put("user_id", userID)
+        put("user_email", userEmail)
+        put("user_name", userName)
+        put("access_token", accessToken)
+        put("refresh_token", refreshToken)
+        put("registration_access_token", registrationAccessToken)
+        put("access_token_expires_at", accessTokenExpiresAt)
+        return params
+    }
+}
+
+/// `crow corveil status` — report the connection state without any secret.
+public struct CorveilStatus: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show the Corveil connection state (local-only)",
+        discussion: """
+        Reports whether a connection exists and its non-secret fields — base URL, \
+        client id, connected user, org count, access-token expiry, and presence \
+        booleans for the tokens. It never prints a token value.
+        """
+    )
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("corveil-status"))
+    }
+}
+
+/// `crow corveil disconnect` — clear the stored connection.
+public struct CorveilDisconnect: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "disconnect",
+        abstract: "Clear the Corveil connection (local-only)",
+        discussion: """
+        Removes the stored connection block, so gateway resolution and the log \
+        collector stop using it. Revoking the per-org gateway keys on the Corveil \
+        side is a separate step (corveil/crow#1121); this clears the local record.
+        """
+    )
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("corveil-disconnect"))
+    }
+}
+
+/// `crow corveil orgs` — list the connection's per-org gateway-key metadata.
+public struct CorveilOrgs: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "orgs",
+        abstract: "List the connection's per-org gateway keys (local-only)",
+        discussion: """
+        Prints the metadata for each auto-provisioned per-org gateway key — org id \
+        and name, key id, display prefix, and mint time — never the key material \
+        itself. Empty until an org is provisioned (corveil/crow#1121).
+        """
+    )
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("corveil-orgs"))
     }
 }

--- a/Packages/CrowCLI/Tests/CrowCLITests/CorveilCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CorveilCommandParsingTests.swift
@@ -21,7 +21,46 @@ struct CorveilCommandParsingTests {
     func registered() throws {
         #expect(CrowCommand.configuration.subcommands.contains { $0 == Corveil.self })
         let names = Corveil.configuration.subcommands.map { $0.configuration.commandName }
-        #expect(Set(names) == ["verify", "reinstall-skill"])
+        #expect(Set(names) == [
+            "verify", "reinstall-skill", "connect", "status", "disconnect", "orgs",
+        ])
+    }
+
+    // MARK: - Connection (CROW-1120)
+
+    @Test("connect maps its flags to snake_case params and drops blanks")
+    func connectMapsFlags() throws {
+        let connect = try #require(try parse([
+            "corveil", "connect",
+            "--base-url", "https://corveil.example.com",
+            "--client-id", "crow-client-1",
+            "--user-email", "dev@example.com",
+            "--access-token", "at-secret",
+            "--access-token-expires-at", "2026-01-01T00:00:00Z",
+        ]) as? CorveilConnect)
+        let params = connect.params
+        #expect(params["base_url"]?.stringValue == "https://corveil.example.com")
+        #expect(params["client_id"]?.stringValue == "crow-client-1")
+        #expect(params["user_email"]?.stringValue == "dev@example.com")
+        #expect(params["access_token"]?.stringValue == "at-secret")
+        #expect(params["access_token_expires_at"]?.stringValue == "2026-01-01T00:00:00Z")
+        // Nothing sent for the flags that were omitted — a blank must not clear a
+        // stored value.
+        #expect(params["refresh_token"] == nil)
+        #expect(params["user_name"] == nil)
+    }
+
+    @Test("connect with no flags sends no params, so the daemon rejects an empty write")
+    func connectWithoutFlagsSendsNothing() throws {
+        let connect = try #require(try parse(["corveil", "connect"]) as? CorveilConnect)
+        #expect(connect.params.isEmpty)
+    }
+
+    @Test("The read/clear verbs parse and take no arguments")
+    func readAndClearVerbsParse() throws {
+        #expect((try parse(["corveil", "status"]) as? CorveilStatus) != nil)
+        #expect((try parse(["corveil", "disconnect"]) as? CorveilDisconnect) != nil)
+        #expect((try parse(["corveil", "orgs"]) as? CorveilOrgs) != nil)
     }
 
     // MARK: - --path

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -283,6 +283,11 @@ struct ParityGateTests {
         // read — but its name isn't `get-`/`list-` prefixed, so the heuristic
         // presumes a write (CROW-1075).
         "backfill-scan",
+        // `corveil-status` / `corveil-orgs` read the Corveil connection state — no
+        // mutation — but their names aren't `get-`/`list-` shaped, so the heuristic
+        // presumes writes (CROW-1120).
+        "corveil-status",
+        "corveil-orgs",
     ]
 
     /// `isWrite` is hand-set per row, deliberately, because a `get-`/`list-`

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -147,6 +147,10 @@ public enum ParityLedger {
         "mcp-token-revoke",
         "corveil-verify",
         "corveil-reinstall-skill",
+        "corveil-connect",
+        "corveil-status",
+        "corveil-disconnect",
+        "corveil-orgs",
     ]
 
     /// Every method reachable through the live router pair — the daemon's
@@ -362,6 +366,23 @@ public enum ParityLedger {
         .write("corveil-verify", cli: "corveil verify"),
         .write("corveil-reinstall-skill", cli: "corveil reinstall-skill"),
 
+        // Corveil connection — the local-only write path (CROW-1120). The "door"
+        // the OAuth client (corveil/crow#1119) and org provisioning
+        // (corveil/crow#1121) persist a `CorveilConnection` through, never
+        // `set-config`, because it holds OAuth tokens. All four are local-only on
+        // `/rpc` (RPCWebSocketHandler.localOnlyDenial): the two writes author a
+        // credential, and the two reads are gated alongside them so the connection
+        // is one local-only surface — the `mcp-token-list` precedent.
+        //
+        // `corveil-status`/`corveil-orgs` return only non-secret connection fields
+        // — never a token — so they are safe reads; they are gated for
+        // surface-coherence, not because they leak. NOT MCP-exported: the surface
+        // is a credential store and the MCP server is read-only.
+        .write("corveil-connect", cli: "corveil connect"),
+        .read("corveil-status", cli: "corveil status"),
+        .write("corveil-disconnect", cli: "corveil disconnect"),
+        .read("corveil-orgs", cli: "corveil orgs"),
+
         // Jobs
         .read("job-list", cli: "job list"),
         .read("job-get", cli: "job get"),
@@ -425,7 +446,8 @@ public enum ParityLedger {
     /// that already have verbs are covered: `telemetry`, `cleanup`, `sidebar`,
     /// `notifications`, gateways and jobs, `defaults` since CROW-810, agent
     /// selection since CROW-811, `workspaces[].*` since CROW-809, the automation
-    /// toggles since CROW-812 and `terminal.*` since CROW-1085. What the web
+    /// toggles since CROW-812, `terminal.*` since CROW-1085 and
+    /// `corveilConnection.*` since CROW-1120 (`crow corveil`). What the web
     /// Settings tab still owns exclusively is `jiraCredential.*`; the `webAuth`
     /// hash and salt are writable but readable nowhere.
     ///
@@ -704,117 +726,95 @@ public enum ParityLedger {
                 `jiraCredential.username`; no verb exists yet.
                 """),
 
-        // MARK: Exempt — Corveil connection (CROW-1118)
+        // MARK: Corveil connection — `crow corveil` (CROW-1118 model, CROW-1120 verbs)
         //
         // The whole `corveilConnection` block is authored only through the
-        // local-only Connect (OAuth) flow and its CLI verbs (corveil/crow#1120),
-        // never `set-config` — the same local-only constraint as `managerGateway`
-        // / `jiraCredential`. The three OAuth token strings are additionally
-        // blanked by `SettingsSecrets` on the way to a browser and restored on the
-        // way back, so they never leave the machine and a web round-trip can't
-        // clear them. Verbs land in corveil/crow#1120; until then the block has no
-        // CLI surface at all.
+        // local-only Connect (OAuth) flow and its CLI verbs, never `set-config` —
+        // the same local-only constraint as `managerGateway` / `jiraCredential`.
+        // The three OAuth token strings are additionally blanked by
+        // `SettingsSecrets` on the way to a browser and restored on the way back,
+        // so they never leave the machine and a web round-trip can't clear them.
+        //
+        // CROW-1120 gave the block its CLI surface: `corveil connect` writes the
+        // identity + tokens, `corveil status` reads the non-secret health, `corveil
+        // orgs` reads the per-org key metadata, and `corveil disconnect` clears it.
+        // The three token strings stay read-exempt (a secret is never read back,
+        // like `webAuth.hashB64`), and `orgKeys[].*` stay write-exempt (provisioned
+        // by corveil/crow#1121, not by `corveil connect`).
 
-        .field(
-            "corveilConnection.baseURL",
-            noCLI: """
-                Corveil API base URL of the active Connect (OAuth) integration \
-                (CROW-1118). Authored only by the local-only Connect flow; CLI verbs \
-                land in corveil/crow#1120.
-                """),
-        .field(
-            "corveilConnection.clientID",
-            noCLI: """
-                OAuth client id Crow self-registered via Dynamic Client Registration \
-                (CROW-1118). Written only by the local-only Connect flow; no \
-                `set-config` path.
-                """),
-        .field(
-            "corveilConnection.connectedUser.id",
-            noCLI: """
-                Corveil user id behind the connection (CROW-1118). Fetched during the \
-                local-only Connect flow and shown read-only; no CLI verb yet \
-                (corveil/crow#1120).
-                """),
-        .field(
-            "corveilConnection.connectedUser.email",
-            noCLI: """
-                Connected Corveil user email (CROW-1118). Read-only display of \
-                connection identity, authored by the local-only Connect flow; verbs \
-                in corveil/crow#1120.
-                """),
-        .field(
-            "corveilConnection.connectedUser.name",
-            noCLI: """
-                Connected Corveil user display name (CROW-1118). Read-only display, \
-                authored by the local-only Connect flow; no `set-config` path \
-                (corveil/crow#1120).
-                """),
+        .field("corveilConnection.baseURL", read: "corveil status", write: "corveil connect"),
+        .field("corveilConnection.clientID", read: "corveil status", write: "corveil connect"),
+        .field("corveilConnection.connectedUser.id", read: "corveil status", write: "corveil connect"),
+        .field("corveilConnection.connectedUser.email", read: "corveil status", write: "corveil connect"),
+        .field("corveilConnection.connectedUser.name", read: "corveil status", write: "corveil connect"),
         .field(
             "corveilConnection.orgKeys[].orgID",
-            noCLI: """
+            read: "corveil orgs",
+            writeNoCLI: """
                 Corveil org id for one auto-provisioned gateway key (CROW-1118). \
-                Populated by the local-only org-provisioning step (corveil/crow#1121); \
-                not user-settable.
+                Populated by the local-only org-provisioning step (corveil/crow#1121), \
+                not by `corveil connect`; not user-settable.
                 """),
         .field(
             "corveilConnection.orgKeys[].orgName",
-            noCLI: """
+            read: "corveil orgs",
+            writeNoCLI: """
                 Display name of a Corveil org with an auto-provisioned key \
-                (CROW-1118). Populated by the local-only Connect / provisioning flow; \
-                no CLI verb yet.
+                (CROW-1118). Populated by the local-only provisioning flow \
+                (corveil/crow#1121); read via `corveil orgs`, not independently set.
                 """),
         .field(
             "corveilConnection.orgKeys[].keyID",
-            noCLI: """
+            read: "corveil orgs",
+            writeNoCLI: """
                 Id of the auto-provisioned per-org gateway key — the handle a \
-                disconnect revokes by (CROW-1118). Minted server-side; not \
-                user-settable (corveil/crow#1121).
+                disconnect revokes by (CROW-1118). Minted server-side by the \
+                provisioning flow (corveil/crow#1121); not user-settable.
                 """),
         .field(
             "corveilConnection.orgKeys[].keyPrefix",
-            noCLI: """
+            read: "corveil orgs",
+            writeNoCLI: """
                 Display prefix of the auto-provisioned per-org key so the UI can tell \
-                keys apart (CROW-1118). Derived from the minted key; not \
-                independently settable.
+                keys apart (CROW-1118). Derived from the minted key during \
+                provisioning (corveil/crow#1121); not independently settable.
                 """),
         .field(
             "corveilConnection.orgKeys[].createdAt",
-            noCLI: """
+            read: "corveil orgs",
+            writeNoCLI: """
                 Mint timestamp of the per-org gateway key (CROW-1118). Stamped when \
                 the key is provisioned by the local-only flow (corveil/crow#1121); \
                 not user-settable.
                 """),
         .field(
             "corveilConnection.oauth.accessToken",
-            noCLI: """
-                User-scoped OAuth access token (secret). Blanked by \
-                `SettingsSecrets.strippedForTransport` and restored from the stored \
-                config on `set-config`, so it never reaches a browser and a round-trip \
-                can't clear it. Written only by the local-only Corveil OAuth client \
-                (corveil/crow#1120).
-                """),
+            readNoCLI: """
+                User-scoped OAuth access token (secret). Never read back by any \
+                surface — `corveil status` reports only that a token is present — so \
+                exposing it would defeat holding a credential locally. Written by \
+                `corveil connect` (the OAuth client's door, corveil/crow#1119).
+                """,
+            write: "corveil connect"),
         .field(
             "corveilConnection.oauth.refreshToken",
-            noCLI: """
-                OAuth refresh token (secret). Same secret-safe transport as the access \
-                token — stripped for a browser, restored on the way back — and written \
-                only by the local-only Corveil OAuth client (corveil/crow#1120).
-                """),
+            readNoCLI: """
+                OAuth refresh token (secret). Never read back — same reason as the \
+                access token above; `corveil status` reports presence only. Written \
+                by `corveil connect`, and blanked by `SettingsSecrets` for transport.
+                """,
+            write: "corveil connect"),
         .field(
             "corveilConnection.oauth.registrationAccessToken",
-            noCLI: """
+            readNoCLI: """
                 RFC 7592 registration access token that manages Crow's own DCR client \
-                (secret). Stripped for transport and restored from the stored config; \
-                authored only by the local-only Corveil OAuth client \
-                (corveil/crow#1120).
-                """),
+                (secret). Never read back by any surface; written by `corveil connect` \
+                and stripped for transport by `SettingsSecrets`.
+                """,
+            write: "corveil connect"),
         .field(
             "corveilConnection.oauth.accessTokenExpiresAt",
-            noCLI: """
-                Access-token expiry that drives refresh (CROW-1118). Written with the \
-                tokens by the local-only Corveil OAuth client (corveil/crow#1120); \
-                read-only connection-health display, with no `set-config` write path.
-                """),
+            read: "corveil status",
+            write: "corveil connect"),
     ]
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
@@ -79,11 +79,14 @@ enum CorveilConnectionRPC {
     /// untouched — they are provisioned by a separate flow (corveil/crow#1121),
     /// and a token refresh through this door must not drop them.
     ///
-    /// Rejects a merged result that is still empty (no client id and no access
-    /// token, per ``CorveilConnection/isEmpty``): a connection with neither is not
-    /// a connection, and storing one would leave a block that reads as
-    /// connected-but-broken. A caller that means to remove the connection uses
-    /// disconnect, not an all-blank connect.
+    /// Rejects a merged result that lacks a client id **or** an access token. This
+    /// is deliberately stricter than `CorveilConnection.isEmpty`, which is an AND
+    /// (blank client id *and* blank token) and so would accept a half-filled
+    /// connection — a client-id-only connect would be stored as a live connection
+    /// that `statusJSON` reports as `connected: true` with `has_access_token:
+    /// false`. Both fields are the documented contract, here and in the CLI and
+    /// the reference. A caller that means to remove the connection uses disconnect,
+    /// not an all-blank connect.
     static func merge(_ input: Input, into stored: CorveilConnection?) throws -> CorveilConnection {
         func pick(_ incoming: String?, _ current: String) -> String {
             let trimmed = incoming?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -104,7 +107,9 @@ enum CorveilConnectionRPC {
                 registrationAccessToken: pick(
                     input.registrationAccessToken, base.oauth.registrationAccessToken),
                 accessTokenExpiresAt: input.accessTokenExpiresAt ?? base.oauth.accessTokenExpiresAt))
-        if result.isEmpty {
+        let hasClientID = !result.clientID.trimmingCharacters(in: .whitespaces).isEmpty
+        let hasAccessToken = !result.oauth.accessToken.trimmingCharacters(in: .whitespaces).isEmpty
+        guard hasClientID, hasAccessToken else {
             throw Invalid("a Corveil connection needs at least a client id and an access token")
         }
         return result
@@ -113,9 +118,9 @@ enum CorveilConnectionRPC {
     /// Decode `corveil-connect` params into an ``Input``.
     ///
     /// `access_token_expires_at` is an ISO-8601 string — the shape `corveil-status`
-    /// emits — parsed here; a present-but-unparseable value is rejected rather
-    /// than silently dropped, since a caller who bothered to send an expiry meant
-    /// something by it.
+    /// emits — parsed by ``parseExpiry(_:)``; a present-but-unparseable value is
+    /// rejected rather than silently dropped, since a caller who bothered to send
+    /// an expiry meant something by it.
     static func decodeInput(_ params: [String: JSONValue]) throws -> Input {
         var input = Input()
         input.baseURL = params["base_url"]?.stringValue
@@ -126,15 +131,36 @@ enum CorveilConnectionRPC {
         input.accessToken = params["access_token"]?.stringValue
         input.refreshToken = params["refresh_token"]?.stringValue
         input.registrationAccessToken = params["registration_access_token"]?.stringValue
-        if let raw = params["access_token_expires_at"]?.stringValue,
-           !raw.trimmingCharacters(in: .whitespaces).isEmpty {
-            guard let date = ISO8601DateFormatter().date(from: raw) else {
-                throw Invalid(
-                    "access_token_expires_at must be an ISO-8601 timestamp (e.g. 2026-01-01T00:00:00Z)")
-            }
-            input.accessTokenExpiresAt = date
-        }
+        input.accessTokenExpiresAt = try parseExpiry(params["access_token_expires_at"]?.stringValue)
         return input
+    }
+
+    /// Parse an optional ISO-8601 access-token expiry, shared by both doors (the
+    /// CLI RPC and the HTTP POST) so a later format change can't drift the two
+    /// parsers. A nil or blank value is "not provided" — keep whatever is stored;
+    /// a present value that won't parse is rejected rather than silently dropped.
+    ///
+    /// Accepts both the plain `2026-01-01T00:00:00Z` shape `statusJSON` emits and
+    /// the fractional-seconds shape a browser's `Date.toISOString()` produces
+    /// (`…00.000Z`). A single `ISO8601DateFormatter` accepts only one of the two,
+    /// so try both (CROW-1120 review).
+    static func parseExpiry(_ raw: String?) throws -> Date? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespaces), !trimmed.isEmpty else {
+            return nil
+        }
+        guard let date = parseISO8601(trimmed) else {
+            throw Invalid(
+                "the access-token expiry must be an ISO-8601 timestamp (e.g. 2026-01-01T00:00:00Z)")
+        }
+        return date
+    }
+
+    private static func parseISO8601(_ value: String) -> Date? {
+        let plain = ISO8601DateFormatter()
+        if let date = plain.date(from: value) { return date }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value)
     }
 
     /// The `corveil-status` payload: connection health, no secrets. Whether a

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
@@ -1,0 +1,186 @@
+import CrowCore
+import CrowIPC
+import Foundation
+
+/// Param decoding, secret-safe merge, and response encoding for the
+/// `corveil-connect` / `corveil-status` / `corveil-disconnect` / `corveil-orgs`
+/// RPC methods (CROW-1120) — the CLI-facing analog of the
+/// `POST /config/corveil-connection` HTTP body in ``SecretRoutes``.
+///
+/// This is the local-only **write path** the epic (corveil/crow#1117) calls "the
+/// door": the Corveil OAuth client (corveil/crow#1119) and the org-provisioning
+/// flow (corveil/crow#1121) persist a ``CorveilConnection`` *through* here, never
+/// through `set-config`, because the block holds OAuth tokens. Mirrors
+/// ``SecretsRPC`` (gateways) and ``MCPTokenRPC`` (bearer tokens): two doors — the
+/// RPC over the Unix socket and the HTTP POST for the browser — share this one
+/// implementation, so the CLI and the Settings UI cannot drift on what a blank
+/// field means or when a connection is rejected.
+///
+/// All four methods are local-only on `/rpc`
+/// (``RPCWebSocketHandler/localOnlyDenial(for:devRoot:)``). The two writes author
+/// a credential; the two reads carry no secret but are gated alongside them, so
+/// the whole connection is one local-only surface — the same choice `mcp-token-list`
+/// makes beside the mint/revoke it lists. The non-secret fields a remote browser
+/// needs for a read-only Integrations view still reach it through the stripped
+/// `get-config` (``SettingsSecrets``), so nothing web breaks.
+enum CorveilConnectionRPC {
+
+    /// A rejected request, surfaced verbatim by both doors.
+    struct Invalid: Error {
+        let message: String
+        init(_ message: String) { self.message = message }
+    }
+
+    /// The fields a `corveil-connect` (or the HTTP set) carries. Every field is
+    /// optional: an absent or blank one keeps whatever is stored, so the OAuth
+    /// client can refresh just the access token + expiry without restating the
+    /// refresh/registration tokens — the same "a blank value keeps the stored
+    /// secret" contract a gateway header value has.
+    struct Input {
+        var baseURL: String?
+        var clientID: String?
+        var userID: String?
+        var userEmail: String?
+        var userName: String?
+        var accessToken: String?
+        var refreshToken: String?
+        var registrationAccessToken: String?
+        /// Already parsed to a `Date` by whichever door decoded it (ISO-8601 over
+        /// the wire). `nil` keeps the stored expiry.
+        var accessTokenExpiresAt: Date?
+
+        init(
+            baseURL: String? = nil,
+            clientID: String? = nil,
+            userID: String? = nil,
+            userEmail: String? = nil,
+            userName: String? = nil,
+            accessToken: String? = nil,
+            refreshToken: String? = nil,
+            registrationAccessToken: String? = nil,
+            accessTokenExpiresAt: Date? = nil
+        ) {
+            self.baseURL = baseURL
+            self.clientID = clientID
+            self.userID = userID
+            self.userEmail = userEmail
+            self.userName = userName
+            self.accessToken = accessToken
+            self.refreshToken = refreshToken
+            self.registrationAccessToken = registrationAccessToken
+            self.accessTokenExpiresAt = accessTokenExpiresAt
+        }
+    }
+
+    /// Build the connection to persist by merging `input` over `stored`.
+    ///
+    /// Non-blank fields overwrite; blank or absent fields keep the stored value
+    /// (or empty when nothing is stored). `orgKeys` are always carried over
+    /// untouched — they are provisioned by a separate flow (corveil/crow#1121),
+    /// and a token refresh through this door must not drop them.
+    ///
+    /// Rejects a merged result that is still empty (no client id and no access
+    /// token, per ``CorveilConnection/isEmpty``): a connection with neither is not
+    /// a connection, and storing one would leave a block that reads as
+    /// connected-but-broken. A caller that means to remove the connection uses
+    /// disconnect, not an all-blank connect.
+    static func merge(_ input: Input, into stored: CorveilConnection?) throws -> CorveilConnection {
+        func pick(_ incoming: String?, _ current: String) -> String {
+            let trimmed = incoming?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? current : trimmed
+        }
+        let base = stored ?? CorveilConnection()
+        let result = CorveilConnection(
+            baseURL: pick(input.baseURL, base.baseURL),
+            clientID: pick(input.clientID, base.clientID),
+            connectedUser: CorveilConnectedUser(
+                id: pick(input.userID, base.connectedUser.id),
+                email: pick(input.userEmail, base.connectedUser.email),
+                name: pick(input.userName, base.connectedUser.name)),
+            orgKeys: base.orgKeys,
+            oauth: CorveilOAuthTokens(
+                accessToken: pick(input.accessToken, base.oauth.accessToken),
+                refreshToken: pick(input.refreshToken, base.oauth.refreshToken),
+                registrationAccessToken: pick(
+                    input.registrationAccessToken, base.oauth.registrationAccessToken),
+                accessTokenExpiresAt: input.accessTokenExpiresAt ?? base.oauth.accessTokenExpiresAt))
+        if result.isEmpty {
+            throw Invalid("a Corveil connection needs at least a client id and an access token")
+        }
+        return result
+    }
+
+    /// Decode `corveil-connect` params into an ``Input``.
+    ///
+    /// `access_token_expires_at` is an ISO-8601 string — the shape `corveil-status`
+    /// emits — parsed here; a present-but-unparseable value is rejected rather
+    /// than silently dropped, since a caller who bothered to send an expiry meant
+    /// something by it.
+    static func decodeInput(_ params: [String: JSONValue]) throws -> Input {
+        var input = Input()
+        input.baseURL = params["base_url"]?.stringValue
+        input.clientID = params["client_id"]?.stringValue
+        input.userID = params["user_id"]?.stringValue
+        input.userEmail = params["user_email"]?.stringValue
+        input.userName = params["user_name"]?.stringValue
+        input.accessToken = params["access_token"]?.stringValue
+        input.refreshToken = params["refresh_token"]?.stringValue
+        input.registrationAccessToken = params["registration_access_token"]?.stringValue
+        if let raw = params["access_token_expires_at"]?.stringValue,
+           !raw.trimmingCharacters(in: .whitespaces).isEmpty {
+            guard let date = ISO8601DateFormatter().date(from: raw) else {
+                throw Invalid(
+                    "access_token_expires_at must be an ISO-8601 timestamp (e.g. 2026-01-01T00:00:00Z)")
+            }
+            input.accessTokenExpiresAt = date
+        }
+        return input
+    }
+
+    /// The `corveil-status` payload: connection health, no secrets. Whether a
+    /// connection exists, its base URL / client id / connected user / org count /
+    /// access-token expiry, and *presence* booleans for the tokens — never a
+    /// token value. Safe to paste into a ticket, like `gateway-get` without
+    /// `reveal`.
+    static func statusJSON(_ connection: CorveilConnection?) -> [String: JSONValue] {
+        guard let connection, !connection.isEmpty else {
+            return ["connected": .bool(false)]
+        }
+        let formatter = ISO8601DateFormatter()
+        let user = connection.connectedUser
+        return [
+            "connected": .bool(true),
+            "base_url": .string(connection.baseURL),
+            "client_id": .string(connection.clientID),
+            "connected_user": .object([
+                "id": .string(user.id),
+                "email": .string(user.email),
+                "name": .string(user.name),
+            ]),
+            "org_count": .int(connection.orgKeys.count),
+            "has_access_token": .bool(!connection.oauth.accessToken.isEmpty),
+            "has_refresh_token": .bool(!connection.oauth.refreshToken.isEmpty),
+            "has_registration_access_token": .bool(!connection.oauth.registrationAccessToken.isEmpty),
+            "access_token_expires_at": connection.oauth.accessTokenExpiresAt
+                .map { .string(formatter.string(from: $0)) } ?? .null,
+        ]
+    }
+
+    /// The `corveil-orgs` payload: the per-org gateway-key metadata (never key
+    /// material — the `sk-citadel-…` value lives in the generated
+    /// ``WorkspaceGateway`` header, not here). Empty when nothing is connected or
+    /// no org has been provisioned yet (corveil/crow#1121).
+    static func orgsJSON(_ connection: CorveilConnection?) -> [String: JSONValue] {
+        let formatter = ISO8601DateFormatter()
+        let orgs = (connection?.orgKeys ?? []).map { key -> JSONValue in
+            .object([
+                "org_id": .string(key.orgID),
+                "org_name": .string(key.orgName),
+                "key_id": .string(key.keyID),
+                "key_prefix": .string(key.keyPrefix),
+                "created_at": key.createdAt.map { .string(formatter.string(from: $0)) } ?? .null,
+            ])
+        }
+        return ["orgs": .array(orgs), "count": .int(orgs.count)]
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2095,6 +2095,7 @@ func makeCommandRouter(
     handlers.merge(makeWorkspaceHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeMCPTokenHandlers(devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeCorveilHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
+    handlers.merge(makeCorveilConnectionHandlers(devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeBackfillHandlers(devRoot: devRoot)) { existing, _ in existing }
     return CommandRouter(handlers: handlers, fallback: fallback)
 }
@@ -2382,6 +2383,79 @@ private func makeCorveilHandlers(
                 "path": .string(outcome.path),
                 "skill_path": .string(CorveilCLI.commandsDir(devRoot: devRoot)),
             ]
+        },
+    ]
+}
+
+/// The `corveil-connect` / `corveil-status` / `corveil-disconnect` /
+/// `corveil-orgs` verb group — the local-only write path for the Corveil
+/// connection (CROW-1120), the "door" from the epic (corveil/crow#1117) that the
+/// OAuth client (corveil/crow#1119) and org provisioning (corveil/crow#1121)
+/// persist a ``CorveilConnection`` through, never through `set-config`, because
+/// the block holds OAuth tokens.
+///
+/// Its own function for the type-checker-budget reason `makeMCPTokenHandlers`
+/// states, and it must stay in this file so `scripts/check-cli-parity.sh` can
+/// grep the registrations.
+///
+/// All four are local-only on `/rpc`
+/// (``RPCWebSocketHandler/localOnlyDenial(for:devRoot:)``). `corveil-connect`
+/// writes OAuth tokens and `corveil-disconnect` clears the connection — both
+/// author a credential, like `gateway-set`. The two reads carry no secret but are
+/// gated alongside the writes, so the entire connection is one local-only surface
+/// — the choice `mcp-token-list` makes beside the mint/revoke it lists. Not
+/// MCP-exported: the surface is a credential store, and the MCP server is
+/// read-only over `MCPToolCatalog`'s allowlist.
+///
+/// Decoding, the secret-safe merge, and the response shapes live in
+/// ``CorveilConnectionRPC`` so this and the browser's
+/// `POST /config/corveil-connection` (``SecretRoutes``) cannot drift.
+private func makeCorveilConnectionHandlers(devRoot: String) -> [String: CommandRouter.Handler] {
+    [
+        // Store or update the connection. A blank/absent field keeps the stored
+        // value — an access-token refresh need not restate the refresh token — and
+        // the merged result must have at least a client id and an access token.
+        // `orgKeys` are preserved (provisioned by corveil/crow#1121).
+        "corveil-connect": { params in
+            let input: CorveilConnectionRPC.Input
+            do {
+                input = try CorveilConnectionRPC.decodeInput(params)
+            } catch let error as CorveilConnectionRPC.Invalid {
+                throw DaemonRPCError.invalidParams(error.message)
+            }
+            return try mutateConfig(devRoot: devRoot) { config -> [String: JSONValue] in
+                let merged: CorveilConnection
+                do {
+                    merged = try CorveilConnectionRPC.merge(input, into: config.corveilConnection)
+                } catch let error as CorveilConnectionRPC.Invalid {
+                    throw RPCError.invalidParams(error.message)
+                }
+                config.corveilConnection = merged
+                var result = CorveilConnectionRPC.statusJSON(merged)
+                result["saved"] = .bool(true)
+                return result
+            }
+        },
+        // Connection health — no secret. See `CorveilConnectionRPC.statusJSON`.
+        "corveil-status": { _ in
+            let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            return CorveilConnectionRPC.statusJSON(config.corveilConnection)
+        },
+        // Clear the whole connection. The cascade key-revocation on the Corveil
+        // side is a separate concern (corveil/crow#1121, backend); this removes the
+        // local block so gateway resolution and the log collector stop using it.
+        "corveil-disconnect": { _ in
+            try mutateConfig(devRoot: devRoot) { config -> [String: JSONValue] in
+                let wasConnected = !(config.corveilConnection?.isEmpty ?? true)
+                config.corveilConnection = nil
+                return ["saved": .bool(true), "was_connected": .bool(wasConnected)]
+            }
+        },
+        // The per-org gateway-key metadata (never key material). See
+        // `CorveilConnectionRPC.orgsJSON`.
+        "corveil-orgs": { _ in
+            let config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            return CorveilConnectionRPC.orgsJSON(config.corveilConnection)
         },
     ]
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -119,6 +119,7 @@ enum RPCLanePolicy {
         "telemetry-set": .fixed(.config),
         "cleanup-set": .fixed(.config),
         "ui-set": .fixed(.config),
+        "terminal-set": .fixed(.config),
         "notifications-set": .fixed(.config),
         "workspace-add": .fixed(.config),
         "workspace-edit": .fixed(.config),
@@ -131,6 +132,11 @@ enum RPCLanePolicy {
         // append (CROW-1004).
         "mcp-token-mint": .fixed(.config),
         "mcp-token-revoke": .fixed(.config),
+        // Corveil connection writes (CROW-1120) — they write config.json, so they
+        // share its lane. The two reads (`corveil-status`/`corveil-orgs`) take no
+        // lane, like every other read.
+        "corveil-connect": .fixed(.config),
+        "corveil-disconnect": .fixed(.config),
         "job-add": .fixed(.config),
         "job-edit": .fixed(.config),
         "job-enable": .fixed(.config),
@@ -145,6 +151,17 @@ enum RPCLanePolicy {
         // Already single-flight: a second caller awaits the in-flight compare
         // instead of spawning another `gh auth token` subprocess + GitHub call.
         "version-update-check": .concurrent,
+
+        // MARK: Corveil CLI binary (CROW-1011)
+        // Both run `defaults.binaries["corveil"]` in a detached subprocess and
+        // write nothing to config.json. `verify` orders nothing; `reinstall-skill`
+        // writes the embedded skill files idempotently (same content each run) and
+        // updates a MainActor warning, so two at once cannot corrupt state. Stated
+        // concurrent rather than omitted, so the ledger gate can tell "decided"
+        // from "forgotten" — these predate the gate and were the latter until
+        // CROW-1120.
+        "corveil-verify": .concurrent,
+        "corveil-reinstall-skill": .concurrent,
 
         // MARK: Job runs
         // Not `.config`: these await a full worktree + tmux spawn, and parking

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -357,6 +357,18 @@ enum RPCWebSocketHandler {
             // / `open-terminal` are gated on the same argument: a remote session
             // does not get to spawn host processes.
             return "corveil verify and reinstall are local-only"
+        case "corveil-connect", "corveil-status", "corveil-disconnect", "corveil-orgs":
+            // The Corveil connection write path (CROW-1120). `corveil-connect`
+            // stores OAuth tokens and `corveil-disconnect` clears the connection —
+            // both author a credential, exactly like `gateway-set`. The two reads
+            // carry no secret, but are gated alongside the writes so the whole
+            // connection is one local-only surface, the same way `mcp-token-list`
+            // is gated beside the mint/revoke it lists. A remote browser that needs
+            // a read-only Integrations view still gets the non-secret fields
+            // through the stripped `get-config` (`SettingsSecrets`), so nothing web
+            // breaks. The browser's own write door is `POST /config/corveil-connection`
+            // in `SecretRoutes`, gated the same way.
+            return "Corveil connection management is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
             return "set-config binaries is local-only"

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
@@ -223,16 +223,13 @@ enum SecretRoutes {
             }
 
             // Parse expiry (ISO-8601) up front so a bad value is a 400, not a
-            // silent drop — matching the RPC's `decodeInput`.
-            var expiresAt: Date?
-            if let raw = body.accessTokenExpiresAt?.trimmingCharacters(in: .whitespaces),
-               !raw.isEmpty {
-                guard let date = ISO8601DateFormatter().date(from: raw) else {
-                    return json(
-                        ["error": "accessTokenExpiresAt must be an ISO-8601 timestamp"],
-                        status: .badRequest)
-                }
-                expiresAt = date
+            // silent drop. Shared with the RPC's `decodeInput` through
+            // `parseExpiry`, so the two doors accept exactly the same shapes.
+            let expiresAt: Date?
+            do {
+                expiresAt = try CorveilConnectionRPC.parseExpiry(body.accessTokenExpiresAt)
+            } catch let error as CorveilConnectionRPC.Invalid {
+                return json(["error": error.message], status: .badRequest)
             }
             let input = CorveilConnectionRPC.Input(
                 baseURL: body.baseURL,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SecretRoutes.swift
@@ -188,6 +188,95 @@ enum SecretRoutes {
                     status: .internalServerError)
             }
         }
+
+        // Set or clear the Corveil connection (CROW-1120). Local-only (see type
+        // doc) — the block holds OAuth tokens, so a remote peer must not author or
+        // clear it. This is the browser's half of the write path; the CLI's is the
+        // `corveil-connect` / `corveil-disconnect` RPC. Both share the decode +
+        // secret-safe merge in `CorveilConnectionRPC`, so the Integrations tab and
+        // `crow corveil` cannot drift on what a blank field means.
+        router.post("/config/corveil-connection") { request, context -> Response in
+            guard gateOK(request, context, boundHost: boundHost) else {
+                return json(["error": "local-only"], status: .forbidden)
+            }
+            guard let body = await decode(CorveilConnectionBody.self, request) else {
+                return json(["error": "a JSON body is required"], status: .badRequest)
+            }
+
+            // Disconnect: drop the whole block. Gateway resolution and the log
+            // collector stop using it on the next read.
+            if body.clear == true {
+                do {
+                    let wasConnected = try ConfigStore.withConfigLock { () -> Bool in
+                        var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+                        let was = !(c.corveilConnection?.isEmpty ?? true)
+                        c.corveilConnection = nil
+                        try ConfigStore.saveConfig(c, devRoot: devRoot)
+                        return was
+                    }
+                    return json(["saved": true, "connected": false, "was_connected": wasConnected])
+                } catch {
+                    return json(
+                        ["error": "failed to save: \(error.localizedDescription)"],
+                        status: .internalServerError)
+                }
+            }
+
+            // Parse expiry (ISO-8601) up front so a bad value is a 400, not a
+            // silent drop — matching the RPC's `decodeInput`.
+            var expiresAt: Date?
+            if let raw = body.accessTokenExpiresAt?.trimmingCharacters(in: .whitespaces),
+               !raw.isEmpty {
+                guard let date = ISO8601DateFormatter().date(from: raw) else {
+                    return json(
+                        ["error": "accessTokenExpiresAt must be an ISO-8601 timestamp"],
+                        status: .badRequest)
+                }
+                expiresAt = date
+            }
+            let input = CorveilConnectionRPC.Input(
+                baseURL: body.baseURL,
+                clientID: body.clientID,
+                userID: body.userId,
+                userEmail: body.userEmail,
+                userName: body.userName,
+                accessToken: body.accessToken,
+                refreshToken: body.refreshToken,
+                registrationAccessToken: body.registrationAccessToken,
+                accessTokenExpiresAt: expiresAt)
+            do {
+                try ConfigStore.withConfigLock {
+                    var c = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+                    c.corveilConnection = try CorveilConnectionRPC.merge(
+                        input, into: c.corveilConnection)
+                    try ConfigStore.saveConfig(c, devRoot: devRoot)
+                }
+                return json(["saved": true, "connected": true])
+            } catch let error as CorveilConnectionRPC.Invalid {
+                return json(["error": error.message], status: .badRequest)
+            } catch {
+                return json(
+                    ["error": "failed to save: \(error.localizedDescription)"],
+                    status: .internalServerError)
+            }
+        }
+    }
+
+    /// Body of `POST /config/corveil-connection`. All fields optional; a blank or
+    /// absent token keeps the stored secret (matching the gateway route's
+    /// blank-value contract). `clear: true` disconnects. `accessTokenExpiresAt` is
+    /// an ISO-8601 string.
+    struct CorveilConnectionBody: Decodable {
+        let baseURL: String?
+        let clientID: String?
+        let userId: String?
+        let userEmail: String?
+        let userName: String?
+        let accessToken: String?
+        let refreshToken: String?
+        let registrationAccessToken: String?
+        let accessTokenExpiresAt: String?
+        let clear: Bool?
     }
 
     /// Body of `POST /config/mcp-tokens`. One shape for both actions — `mint` reads

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
@@ -138,6 +138,22 @@ import Testing
         #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
     }
 
+    @Test @MainActor func connectRejectsAHalfFilledConnection() async throws {
+        // The reviewer's reproduction: a client-id-only (or token-only) connect
+        // must not be stored as a live-but-broken connection (CROW-1120 review).
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let clientOnly = await call(router, "corveil-connect", ["client_id": .string("crow-client-1")])
+        #expect(clientOnly.error?.code == RPCErrorCode.invalidParams)
+
+        let tokenOnly = await call(router, "corveil-connect", ["access_token": .string("at")])
+        #expect(tokenOnly.error?.code == RPCErrorCode.invalidParams)
+
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+    }
+
     @Test @MainActor func connectRejectsMalformedExpiry() async throws {
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
@@ -235,15 +251,26 @@ import Testing
         #expect(merged.orgKeys.count == 1)
     }
 
-    @Test func mergeRejectsAResultWithNoClientOrToken() {
-        #expect(throws: CorveilConnectionRPC.Invalid.self) {
-            _ = try CorveilConnectionRPC.merge(CorveilConnectionRPC.Input(), into: nil)
+    @Test func mergeRequiresBothClientIdAndAccessToken() {
+        // `CorveilConnection.isEmpty` is an AND, so a half-filled connection is not
+        // "empty" — but it is not usable either. The merge must reject any result
+        // missing a client id or an access token, matching the error/CLI/docs.
+        let cases: [CorveilConnectionRPC.Input] = [
+            CorveilConnectionRPC.Input(),                                         // neither
+            CorveilConnectionRPC.Input(baseURL: "https://corveil.example.com"),   // base URL only
+            CorveilConnectionRPC.Input(clientID: "crow-client-1"),               // client id only
+            CorveilConnectionRPC.Input(accessToken: "at"),                        // token only
+        ]
+        for input in cases {
+            #expect(throws: CorveilConnectionRPC.Invalid.self) {
+                _ = try CorveilConnectionRPC.merge(input, into: nil)
+            }
         }
-        // A base URL alone is still not a connection.
-        #expect(throws: CorveilConnectionRPC.Invalid.self) {
-            _ = try CorveilConnectionRPC.merge(
-                CorveilConnectionRPC.Input(baseURL: "https://corveil.example.com"), into: nil)
-        }
+        // Both → accepted.
+        let ok = try? CorveilConnectionRPC.merge(
+            CorveilConnectionRPC.Input(clientID: "crow-client-1", accessToken: "at"), into: nil)
+        #expect(ok?.clientID == "crow-client-1")
+        #expect(ok?.oauth.accessToken == "at")
     }
 
     @Test func decodeInputParsesISOExpiryAndRejectsGarbage() throws {
@@ -259,6 +286,20 @@ import Testing
             _ = try CorveilConnectionRPC.decodeInput([
                 "access_token_expires_at": .string("nonsense"),
             ])
+        }
+    }
+
+    @Test func expiryParsesBothPlainAndFractionalSeconds() throws {
+        // A browser's `Date.toISOString()` emits milliseconds; both the plain shape
+        // `statusJSON` writes and the fractional one must parse (CROW-1120 review).
+        for stamp in ["2026-01-01T00:00:00Z", "2026-01-01T00:00:00.000Z"] {
+            #expect(try CorveilConnectionRPC.parseExpiry(stamp) != nil, "\(stamp) should parse")
+        }
+        // Absent / blank keeps the stored value (nil, no throw); garbage throws.
+        #expect(try CorveilConnectionRPC.parseExpiry(nil) == nil)
+        #expect(try CorveilConnectionRPC.parseExpiry("  ") == nil)
+        #expect(throws: CorveilConnectionRPC.Invalid.self) {
+            _ = try CorveilConnectionRPC.parseExpiry("2026-01-01")
         }
     }
 

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
@@ -1,0 +1,293 @@
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+import Foundation
+import Testing
+
+@testable import CrowDaemon
+
+/// The `corveil-connect` / `corveil-status` / `corveil-disconnect` /
+/// `corveil-orgs` RPC methods — the CLI's local-only write path for the Corveil
+/// connection (CROW-1120).
+///
+/// These go through the real router and read back from disk, so they cover the
+/// handlers, the secret-safe merge in `CorveilConnectionRPC`, and
+/// `CorveilConnection`'s tolerant decode in one pass.
+@Suite struct CorveilConnectionRPCTests {
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crowd-corveil-conn-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @MainActor private func router(devRoot: String) -> CommandRouter {
+        makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: devRoot, cockpit: nil)
+    }
+
+    private func call(
+        _ router: CommandRouter, _ method: String, _ params: [String: JSONValue] = [:]
+    ) async -> JSONRPCResponse {
+        await router.handle(request: JSONRPCRequest(id: 1, method: method, params: params))
+    }
+
+    @Test @MainActor func connectStatusDisconnectRoundTrip() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        // Nothing connected yet.
+        let before = await call(router, "corveil-status")
+        #expect(before.result?["connected"] == .bool(false))
+
+        let connect = await call(router, "corveil-connect", [
+            "base_url": .string("https://corveil.example.com"),
+            "client_id": .string("crow-client-1"),
+            "user_id": .string("u1"),
+            "user_email": .string("dev@example.com"),
+            "user_name": .string("Dev"),
+            "access_token": .string("at-secret"),
+            "refresh_token": .string("rt-secret"),
+            "registration_access_token": .string("rat-secret"),
+            "access_token_expires_at": .string("2026-01-01T00:00:00Z"),
+        ])
+        #expect(connect.error == nil)
+        #expect(connect.result?["saved"] == .bool(true))
+        #expect(connect.result?["connected"] == .bool(true))
+
+        // It reached disk with the tokens intact.
+        let stored = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(stored.baseURL == "https://corveil.example.com")
+        #expect(stored.clientID == "crow-client-1")
+        #expect(stored.connectedUser.email == "dev@example.com")
+        #expect(stored.oauth.accessToken == "at-secret")
+        #expect(stored.oauth.refreshToken == "rt-secret")
+        #expect(stored.oauth.registrationAccessToken == "rat-secret")
+
+        // Status reports health without ever handing back a token value.
+        let status = await call(router, "corveil-status")
+        #expect(status.result?["connected"] == .bool(true))
+        #expect(status.result?["base_url"] == .string("https://corveil.example.com"))
+        #expect(status.result?["client_id"] == .string("crow-client-1"))
+        #expect(status.result?["org_count"] == .int(0))
+        #expect(status.result?["has_access_token"] == .bool(true))
+        #expect(status.result?["has_refresh_token"] == .bool(true))
+        #expect(status.result?["has_registration_access_token"] == .bool(true))
+        #expect(status.result?["access_token_expires_at"]?.stringValue?.isEmpty == false)
+        // No secret anywhere in the payload.
+        let flattened = "\(status.result ?? [:])"
+        #expect(!flattened.contains("at-secret"))
+        #expect(!flattened.contains("rt-secret"))
+        #expect(!flattened.contains("rat-secret"))
+
+        let disconnect = await call(router, "corveil-disconnect")
+        #expect(disconnect.result?["saved"] == .bool(true))
+        #expect(disconnect.result?["was_connected"] == .bool(true))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+    }
+
+    @Test @MainActor func connectRefreshPreservesStoredSecretsAndOrgKeys() async throws {
+        // A refresh sends only a new access token + expiry; the refresh token,
+        // registration token, identity and provisioned org keys must survive.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let seeded = CorveilConnection(
+            baseURL: "https://corveil.example.com",
+            clientID: "crow-client-1",
+            connectedUser: CorveilConnectedUser(id: "u1", email: "dev@example.com", name: "Dev"),
+            orgKeys: [
+                CorveilOrgKey(
+                    orgID: "org1", orgName: "Acme", keyID: "key1",
+                    keyPrefix: "sk-citadel-AbC", createdAt: Date(timeIntervalSince1970: 1))
+            ],
+            oauth: CorveilOAuthTokens(
+                accessToken: "at-old", refreshToken: "rt-keep",
+                registrationAccessToken: "rat-keep"))
+        try ConfigStore.saveConfig(AppConfig(corveilConnection: seeded), devRoot: devRoot)
+        let router = router(devRoot: devRoot)
+
+        let refresh = await call(router, "corveil-connect", [
+            "access_token": .string("at-new"),
+            "access_token_expires_at": .string("2027-06-01T12:00:00Z"),
+        ])
+        #expect(refresh.error == nil)
+
+        let stored = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(stored.oauth.accessToken == "at-new")           // updated
+        #expect(stored.oauth.refreshToken == "rt-keep")         // preserved
+        #expect(stored.oauth.registrationAccessToken == "rat-keep")
+        #expect(stored.clientID == "crow-client-1")             // preserved
+        #expect(stored.connectedUser.email == "dev@example.com")
+        #expect(stored.orgKeys.count == 1)                      // provisioning survives a refresh
+        #expect(stored.orgKeys.first?.keyID == "key1")
+    }
+
+    @Test @MainActor func connectRejectsAnEmptyConnection() async throws {
+        // No client id, no access token, nothing stored → not a connection.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let response = await call(router, "corveil-connect", [
+            "base_url": .string("https://corveil.example.com"),
+        ])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+    }
+
+    @Test @MainActor func connectRejectsMalformedExpiry() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let response = await call(router, "corveil-connect", [
+            "client_id": .string("crow-client-1"),
+            "access_token": .string("at"),
+            "access_token_expires_at": .string("not-a-date"),
+        ])
+        #expect(response.error?.code == RPCErrorCode.invalidParams)
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+    }
+
+    @Test @MainActor func orgsListsStoredKeysWithoutKeyMaterial() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let connection = CorveilConnection(
+            clientID: "crow-client-1",
+            orgKeys: [
+                CorveilOrgKey(orgID: "org1", orgName: "Acme", keyID: "key1", keyPrefix: "sk-citadel-AbC"),
+                CorveilOrgKey(orgID: "org2", orgName: "Globex", keyID: "key2", keyPrefix: "sk-citadel-XyZ"),
+            ],
+            oauth: CorveilOAuthTokens(accessToken: "at"))
+        try ConfigStore.saveConfig(AppConfig(corveilConnection: connection), devRoot: devRoot)
+        let router = router(devRoot: devRoot)
+
+        let orgs = await call(router, "corveil-orgs")
+        #expect(orgs.result?["count"] == .int(2))
+        let list = try #require(orgs.result?["orgs"]?.arrayValue)
+        #expect(list.count == 2)
+        #expect(list.first?.objectValue?["org_name"] == .string("Acme"))
+        #expect(list.first?.objectValue?["key_prefix"] == .string("sk-citadel-AbC"))
+    }
+
+    @Test @MainActor func disconnectWhenNothingConnectedIsANoOpReceipt() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let router = router(devRoot: devRoot)
+
+        let response = await call(router, "corveil-disconnect")
+        #expect(response.result?["saved"] == .bool(true))
+        #expect(response.result?["was_connected"] == .bool(false))
+    }
+
+    @Test @MainActor func connectRefusesToOverwriteAnUndecodableConfig() async throws {
+        // Same guard as the gateway/web-password writers (CROW-814): a corrupt
+        // config.json must not be silently replaced with defaults + a connection.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let claudeDir = (devRoot as NSString).appendingPathComponent(".claude")
+        try FileManager.default.createDirectory(atPath: claudeDir, withIntermediateDirectories: true)
+        let configPath = (claudeDir as NSString).appendingPathComponent("config.json")
+        let corrupt = #"{"workspaces": "not-an-array"}"#
+        try corrupt.write(toFile: configPath, atomically: true, encoding: .utf8)
+        let router = router(devRoot: devRoot)
+
+        let response = await call(router, "corveil-connect", [
+            "client_id": .string("crow-client-1"),
+            "access_token": .string("at"),
+        ])
+        #expect(response.error?.code == RPCErrorCode.applicationError)
+        #expect(try String(contentsOfFile: configPath, encoding: .utf8) == corrupt)
+    }
+}
+
+/// Unit coverage for the decode / merge / encode helpers behind those handlers.
+@Suite struct CorveilConnectionRPCSupportTests {
+    @Test func mergeFreshSetsProvidedFields() throws {
+        let input = CorveilConnectionRPC.Input(
+            baseURL: "https://corveil.example.com",
+            clientID: "crow-client-1",
+            userEmail: "dev@example.com",
+            accessToken: "at")
+        let merged = try CorveilConnectionRPC.merge(input, into: nil)
+        #expect(merged.baseURL == "https://corveil.example.com")
+        #expect(merged.clientID == "crow-client-1")
+        #expect(merged.connectedUser.email == "dev@example.com")
+        #expect(merged.oauth.accessToken == "at")
+        #expect(merged.orgKeys.isEmpty)
+    }
+
+    @Test func mergeBlankFieldsKeepStoredValues() throws {
+        let stored = CorveilConnection(
+            baseURL: "https://corveil.example.com",
+            clientID: "crow-client-1",
+            orgKeys: [CorveilOrgKey(orgID: "org1", keyID: "key1")],
+            oauth: CorveilOAuthTokens(accessToken: "at-old", refreshToken: "rt-keep"))
+        // Only a new access token; blanks/absent keep the rest.
+        let input = CorveilConnectionRPC.Input(accessToken: "at-new")
+        let merged = try CorveilConnectionRPC.merge(input, into: stored)
+        #expect(merged.oauth.accessToken == "at-new")
+        #expect(merged.oauth.refreshToken == "rt-keep")
+        #expect(merged.clientID == "crow-client-1")
+        #expect(merged.orgKeys.count == 1)
+    }
+
+    @Test func mergeRejectsAResultWithNoClientOrToken() {
+        #expect(throws: CorveilConnectionRPC.Invalid.self) {
+            _ = try CorveilConnectionRPC.merge(CorveilConnectionRPC.Input(), into: nil)
+        }
+        // A base URL alone is still not a connection.
+        #expect(throws: CorveilConnectionRPC.Invalid.self) {
+            _ = try CorveilConnectionRPC.merge(
+                CorveilConnectionRPC.Input(baseURL: "https://corveil.example.com"), into: nil)
+        }
+    }
+
+    @Test func decodeInputParsesISOExpiryAndRejectsGarbage() throws {
+        let input = try CorveilConnectionRPC.decodeInput([
+            "client_id": .string("crow-client-1"),
+            "access_token": .string("at"),
+            "access_token_expires_at": .string("2026-01-01T00:00:00Z"),
+        ])
+        #expect(input.clientID == "crow-client-1")
+        #expect(input.accessTokenExpiresAt != nil)
+
+        #expect(throws: CorveilConnectionRPC.Invalid.self) {
+            _ = try CorveilConnectionRPC.decodeInput([
+                "access_token_expires_at": .string("nonsense"),
+            ])
+        }
+    }
+
+    @Test func statusJSONReportsDisconnectedForNilAndEmpty() {
+        #expect(CorveilConnectionRPC.statusJSON(nil)["connected"] == .bool(false))
+        #expect(CorveilConnectionRPC.statusJSON(CorveilConnection())["connected"] == .bool(false))
+    }
+
+    @Test func statusJSONNeverExposesTokenValues() {
+        let connection = CorveilConnection(
+            clientID: "crow-client-1",
+            oauth: CorveilOAuthTokens(
+                accessToken: "at-secret", refreshToken: "rt-secret",
+                registrationAccessToken: "rat-secret"))
+        let json = CorveilConnectionRPC.statusJSON(connection)
+        #expect(json["connected"] == .bool(true))
+        #expect(json["has_access_token"] == .bool(true))
+        let flattened = "\(json)"
+        #expect(!flattened.contains("at-secret"))
+        #expect(!flattened.contains("rt-secret"))
+        #expect(!flattened.contains("rat-secret"))
+    }
+
+    @Test func orgsJSONMapsKeysAndEmptyForNil() {
+        #expect(CorveilConnectionRPC.orgsJSON(nil)["count"] == .int(0))
+        let connection = CorveilConnection(
+            orgKeys: [CorveilOrgKey(orgID: "org1", orgName: "Acme", keyID: "key1", keyPrefix: "sk-citadel-AbC")])
+        let json = CorveilConnectionRPC.orgsJSON(connection)
+        #expect(json["count"] == .int(1))
+        #expect(json["orgs"]?.arrayValue?.first?.objectValue?["org_id"] == .string("org1"))
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -980,6 +980,23 @@ import CrowPersistence
                 == "MCP token management is local-only")
         }
     }
+
+    @Test func corveilConnectionMethodsAreLocalOnly() {
+        // `corveil-connect` stores OAuth tokens and `corveil-disconnect` clears the
+        // connection — both author a credential, like `gateway-set`. The two reads
+        // carry no secret but are gated alongside the writes so the whole
+        // connection is one local-only surface, matching how `mcp-token-list` is
+        // gated beside the mint/revoke it lists (CROW-1120).
+        for method in ["corveil-connect", "corveil-status", "corveil-disconnect", "corveil-orgs"] {
+            let req = JSONRPCRequest(id: 1, method: method, params: [
+                "client_id": .string("crow-client-1"),
+                "access_token": .string("at"),
+            ])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
+                == "Corveil connection management is local-only")
+        }
+    }
+
     @Test func logsyncMethodsAreNotLocalOnly() {
         // CROW-1070 removed the credential + opt-in from the `logSync` block — it
         // now holds only behavior knobs (retention / quiet period / upload cap), and

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretRoutesCorveilConnectionGatingTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/SecretRoutesCorveilConnectionGatingTests.swift
@@ -1,0 +1,131 @@
+import CrowCore
+import CrowEngine
+import CrowPersistence
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import Testing
+
+@testable import CrowDaemon
+
+// MARK: - `POST /config/corveil-connection` is local-only (CROW-1120)
+
+/// The browser's half of the Corveil connection write path carries the same
+/// gating as the gateway / web-password / MCP-token routes it sits beside in
+/// `SecretRoutes`: a proxied/remote session — even a logged-in one — is refused,
+/// and a cross-site Origin is refused even from a local peer. The OAuth tokens it
+/// writes are credentials, so a remote peer must not author or clear the
+/// connection.
+///
+/// Driven end to end through the mounted route over a real loopback server, so a
+/// refactor that drops `gateOK` fails here. Each forbidden case additionally
+/// asserts nothing was persisted.
+@Suite struct SecretRoutesCorveilConnectionGatingTests {
+
+    private func makeDevRoot() throws -> String {
+        let devRoot = NSTemporaryDirectory().appending("corveil-conn-route-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: devRoot, withIntermediateDirectories: true)
+        return devRoot
+    }
+
+    private func makeApp(devRoot: String) -> some ApplicationProtocol {
+        let router = Router(context: CrowHTTPContext.self)
+        SecretRoutes.mount(on: router, boundHost: "127.0.0.1", devRoot: devRoot)
+        return Application(
+            router: router,
+            configuration: .init(address: .hostname("127.0.0.1", port: 0), serverName: "crowd-test"))
+    }
+
+    private let jsonHeaders: HTTPFields = [.contentType: "application/json"]
+    private let xff = HTTPField.Name("x-forwarded-for")!
+
+    private func connectBody() -> ByteBuffer {
+        ByteBuffer(string: #"{"clientID":"crow-client-1","accessToken":"at-secret"}"#)
+    }
+
+    // MARK: - Allowed
+
+    @Test func localDirectPeerMaySetAndClear() async throws {
+        let devRoot = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try await makeApp(devRoot: devRoot).test(.live) { client in
+            try await client.execute(
+                uri: "/config/corveil-connection", method: .post, headers: jsonHeaders,
+                body: connectBody()
+            ) { response in
+                #expect(response.status == .ok)
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(buffer: response.body))
+                        as? [String: Any])
+                #expect(json["saved"] as? Bool == true)
+                #expect(json["connected"] as? Bool == true)
+            }
+        }
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection?.oauth.accessToken == "at-secret")
+
+        // Clear.
+        try await makeApp(devRoot: devRoot).test(.live) { client in
+            try await client.execute(
+                uri: "/config/corveil-connection", method: .post, headers: jsonHeaders,
+                body: ByteBuffer(string: #"{"clear":true}"#)
+            ) { response in
+                #expect(response.status == .ok)
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(buffer: response.body))
+                        as? [String: Any])
+                #expect(json["connected"] as? Bool == false)
+            }
+        }
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+    }
+
+    @Test func anEmptyConnectionIsRejected() async throws {
+        let devRoot = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try await makeApp(devRoot: devRoot).test(.live) { client in
+            try await client.execute(
+                uri: "/config/corveil-connection", method: .post, headers: jsonHeaders,
+                body: ByteBuffer(string: #"{"baseURL":"https://corveil.example.com"}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+    }
+
+    // MARK: - Refused
+
+    @Test func proxiedPeerIsForbidden() async throws {
+        let devRoot = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let headers: HTTPFields = [.contentType: "application/json", xff: "203.0.113.9"]
+        try await makeApp(devRoot: devRoot).test(.live) { client in
+            try await client.execute(
+                uri: "/config/corveil-connection", method: .post, headers: headers,
+                body: connectBody()
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil,
+                "the gate must run before any write")
+    }
+
+    @Test func crossSiteOriginIsForbidden() async throws {
+        let devRoot = try makeDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let headers: HTTPFields = [.contentType: "application/json", .origin: "https://evil.com"]
+        try await makeApp(devRoot: devRoot).test(.live) { client in
+            try await client.execute(
+                uri: "/config/corveil-connection", method: .post, headers: headers,
+                body: connectBody()
+            ) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil,
+                "the gate must run before any write")
+    }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -827,6 +827,65 @@ crow corveil reinstall-skill --path ~/src/corveil/bin/corveil
 - The loop this serves is "I just rebuilt corveil locally; install its new embedded skills." Each skill installs independently — one that fails doesn't abort the rest, and `message` names the ones that didn't install (`ok` is then `false`).
 - A run also updates the launch-time corveil warning: succeeding clears it, a per-skill failure replaces it. There is one answer to "is corveil broken?", not a startup one and a button one.
 
+### The Corveil connection
+
+`connect` / `status` / `disconnect` / `orgs` manage the **Corveil OAuth connection** — the source of truth an Integrations → Corveil setup writes, from which the AI gateway and log-shipping configs are generated (CROW-1120). This is the local-only **write path** the browser Connect flow (corveil/crow#1119) and org provisioning (corveil/crow#1121) persist through; it never travels via `set-config`, because the block holds OAuth tokens.
+
+All four are **local-only** on `/rpc`, like the gateway and web-password verbs: `connect` stores tokens and `disconnect` clears them, and the two reads are gated alongside the writes so the whole connection is one local-only surface. From the CLI that is no obstacle — the Unix socket is local by construction.
+
+#### `crow corveil connect`
+
+Store or update the connection. Every field is optional; a blank or omitted one keeps whatever is already stored, so a token refresh can update just the access token and its expiry without restating the refresh token — the same blank-keeps-the-secret contract [`crow gateway set`](#crow-gateway-get--set--clear) has. The merged connection must end up with at least a client id and an access token; `orgKeys` (provisioned separately) are preserved.
+
+```bash
+crow corveil connect --base-url https://corveil.example.com --client-id crow-client-1 \
+  --access-token "$AT" --refresh-token "$RT" --access-token-expires-at 2026-01-01T00:00:00Z
+# A refresh restates only what changed:
+crow corveil connect --access-token "$AT" --access-token-expires-at 2027-06-01T12:00:00Z
+```
+
+- Options: `--base-url`, `--client-id`, `--user-id`, `--user-email`, `--user-name`, `--access-token`, `--refresh-token`, `--registration-access-token`, `--access-token-expires-at` (ISO-8601).
+- Tokens passed on the command line are visible to local `ps` and shell history; the browser Connect flow is the primary writer. The response is the same non-secret payload as `crow corveil status`, plus `"saved": true`.
+
+#### `crow corveil status`
+
+Report the connection state — no secret. Whether a connection exists, its base URL, client id, connected user, org count, access-token expiry, and presence booleans for the tokens. It never prints a token value, so the output is safe to paste into a ticket.
+
+```bash
+crow corveil status
+```
+
+```json
+{"connected": true, "base_url": "https://corveil.example.com", "client_id": "crow-client-1",
+ "connected_user": {"id": "u1", "email": "dev@example.com", "name": "Dev"},
+ "org_count": 2, "has_access_token": true, "has_refresh_token": true,
+ "has_registration_access_token": true, "access_token_expires_at": "2026-01-01T00:00:00Z"}
+```
+
+#### `crow corveil disconnect`
+
+Clear the stored connection so gateway resolution and the log collector stop using it. Revoking the per-org gateway keys on the Corveil side is a separate step (corveil/crow#1121); this removes the local record.
+
+```bash
+crow corveil disconnect
+```
+
+- Returns `{"saved": true, "was_connected": <bool>}`. Safe to run when nothing is connected — `was_connected` is then `false`.
+
+#### `crow corveil orgs`
+
+List the per-org gateway-key metadata — org id and name, key id, display prefix, and mint time — never the key material itself (that lives in the generated gateway header). Empty until an org is provisioned (corveil/crow#1121).
+
+```bash
+crow corveil orgs
+```
+
+```json
+{"orgs": [{"org_id": "org1", "org_name": "Acme", "key_id": "key1",
+           "key_prefix": "sk-citadel-AbC", "created_at": "2026-01-01T00:00:00Z"}],
+ "count": 1}
+```
+
 ---
 
 ## Automation Commands

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,8 +37,12 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow cleanup set`](#crow-cleanup-set) | Change automatic session cleanup |
 | [`crow close-terminal`](#crow-close-terminal) | Close a terminal tab in a session |
 | [`crow complete-session`](#crow-complete-session) | Mark a session completed |
-| [`crow corveil`](#crow-corveil) | Verify the configured Corveil CLI binary, and reinstall its skill |
+| [`crow corveil`](#crow-corveil) | Verify the Corveil CLI binary and manage the Corveil connection |
+| [`crow corveil connect`](#crow-corveil-connect) | Store or update the Corveil connection (local-only) |
+| [`crow corveil disconnect`](#crow-corveil-disconnect) | Clear the Corveil connection (local-only) |
+| [`crow corveil orgs`](#crow-corveil-orgs) | List the connection's per-org gateway keys (local-only) |
 | [`crow corveil reinstall-skill`](#crow-corveil-reinstall-skill) | Reinstall every embedded slash command from the corveil binary |
+| [`crow corveil status`](#crow-corveil-status) | Show the Corveil connection state (local-only) |
 | [`crow corveil verify`](#crow-corveil-verify) | Run `corveil --version` and report what came back |
 | [`crow create-manager`](#crow-create-manager) | Create an additional Manager session |
 | [`crow defaults`](#crow-defaults) | View or change workspace and automation defaults |
@@ -522,13 +526,67 @@ crow complete-session --session <session>
 
 ## `crow corveil`
 
-Verify the configured Corveil CLI binary, and reinstall its skill.
+Verify the Corveil CLI binary and manage the Corveil connection.
 
 ```
-crow corveil <verify|reinstall-skill>
+crow corveil <verify|reinstall-skill|connect|status|disconnect|orgs>
 ```
 
-Subcommands: [`verify`](#crow-corveil-verify), [`reinstall-skill`](#crow-corveil-reinstall-skill).
+Subcommands: [`verify`](#crow-corveil-verify), [`reinstall-skill`](#crow-corveil-reinstall-skill), [`connect`](#crow-corveil-connect), [`status`](#crow-corveil-status), [`disconnect`](#crow-corveil-disconnect), [`orgs`](#crow-corveil-orgs).
+
+---
+
+## `crow corveil connect`
+
+Store or update the Corveil connection (local-only).
+
+```
+crow corveil connect [--base-url <base-url>] [--client-id <client-id>] [--user-id <user-id>] [--user-email <user-email>] [--user-name <user-name>] [--access-token <access-token>] [--refresh-token <refresh-token>] [--registration-access-token <registration-access-token>] [--access-token-expires-at <access-token-expires-at>]
+```
+
+Writes the OAuth connection Crow uses to reach Corveil — the door the browser Connect flow persists through. Every field is optional; a blank or omitted one keeps whatever is already stored, so a token refresh can update just the access token and its expiry:
+
+```
+crow corveil connect --access-token "$AT" --access-token-expires-at 2026-01-01T00:00:00Z
+```
+
+The merged connection must have at least a client id and an access token. Tokens passed on the command line are visible to local `ps` and shell history; the browser Connect flow is the primary writer. Local-only: this runs over the Unix socket and is refused for remote web clients, because the tokens are credentials.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--base-url` | `<base-url>` | no | Corveil API base URL |
+| `--client-id` | `<client-id>` | no | OAuth client id (from Dynamic Client Registration) |
+| `--user-id` | `<user-id>` | no | Connected Corveil user id |
+| `--user-email` | `<user-email>` | no | Connected Corveil user email |
+| `--user-name` | `<user-name>` | no | Connected Corveil user display name |
+| `--access-token` | `<access-token>` | no | OAuth access token (secret) |
+| `--refresh-token` | `<refresh-token>` | no | OAuth refresh token (secret) |
+| `--registration-access-token` | `<registration-access-token>` | no | RFC 7592 registration access token (secret) |
+| `--access-token-expires-at` | `<access-token-expires-at>` | no | Access-token expiry as an ISO-8601 timestamp (e.g. 2026-01-01T00:00:00Z) |
+
+---
+
+## `crow corveil disconnect`
+
+Clear the Corveil connection (local-only).
+
+```
+crow corveil disconnect
+```
+
+Removes the stored connection block, so gateway resolution and the log collector stop using it. Revoking the per-org gateway keys on the Corveil side is a separate step (corveil/crow#1121); this clears the local record.
+
+---
+
+## `crow corveil orgs`
+
+List the connection's per-org gateway keys (local-only).
+
+```
+crow corveil orgs
+```
+
+Prints the metadata for each auto-provisioned per-org gateway key — org id and name, key id, display prefix, and mint time — never the key material itself. Empty until an org is provisioned (corveil/crow#1121).
 
 ---
 
@@ -547,6 +605,18 @@ A run also updates the launch-time corveil warning: succeeding clears it, a per-
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--path` | `<path>` | no | Binary to act on. Defaults to the path in Settings → General → Corveil CLI. |
+
+---
+
+## `crow corveil status`
+
+Show the Corveil connection state (local-only).
+
+```
+crow corveil status
+```
+
+Reports whether a connection exists and its non-secret fields — base URL, client id, connected user, org count, access-token expiry, and presence booleans for the tokens. It never prints a token value.
 
 ---
 


### PR DESCRIPTION
Closes #1120

Part of epic #1117 (first-class Corveil integration). The Corveil connection (CROW-1118) holds OAuth tokens, so — like the AI gateways, the web password and MCP tokens — it must be authored only through **local-only doors**, never `set-config`. This ticket adds that write path plus its CLI surface: the "door" the OAuth client (#1119) and org provisioning (#1121) persist a `corveilConnection` through.

## What's here

**Two doors, one implementation**
- `POST /config/corveil-connection` in `SecretRoutes` (`gateOK` = Origin + `isLocalDirect`) — the browser's door.
- Four RPCs — `corveil-connect` / `corveil-status` / `corveil-disconnect` / `corveil-orgs` — the CLI's door over the Unix socket.
- Decoding, the secret-safe **merge** (a blank field keeps the stored secret, so a token refresh needn't restate the refresh token; `orgKeys` are preserved), and the non-secret response shapes live in `CorveilConnectionRPC`, so the two doors can't drift.

**Local-only gating**
- All four RPCs are on `localOnlyDenial` (+ the `ParityLedger.localOnlyRPCMethods` mirror, pinned in both directions by `LocalOnlyRPCGateTests`). The two writes author a credential; the two reads are gated alongside them so the whole connection is one local-only surface — the `mcp-token-list` precedent. `status`/`orgs` never return a token value.

**Parity plumbing** (the build fails otherwise)
- `RPCLanePolicy`: `corveil-connect`/`corveil-disconnect` share the config lane; the reads take none. Also classifies three writes the Darwin-only lane gate never caught in the Linux PR lane — `terminal-set` (CROW-1085) and `corveil-verify` / `corveil-reinstall-skill` (CROW-1011).
- `ParityLedger`: 4 `rpcMethods` rows + 4 `localOnlyRPCMethods` entries; the `corveilConnection.*` config-field rows move from `noCLI` to their new verbs (token values stay read-exempt; `orgKeys[].*` stay write-exempt, provisioned by #1121).

**CLI** — `crow corveil connect | status | disconnect | orgs`, alongside the existing `verify`/`reinstall-skill`.

**Docs & tests**
- `docs/cli.md` regenerated; `docs/cli-reference.md` + `CLAUDE.md` written up.
- New tests: `CorveilConnectionRPC` unit + end-to-end round-trip, the POST route's gating (proxied/cross-origin refused before any write), and the local-only gate.

## Scope note
This is the write-path "door" only. The OAuth flow itself (DCR/PKCE/callback/refresh) is #1119, and org listing + key provisioning is #1121 — both persist through the door added here.

## Testing
- `scripts/check-cli-parity.sh` ✅ (113 methods)
- CrowCLI suite ✅ (387 tests — parity, docs-drift, parsing)
- CrowIPC `MCPLedgerExportTests` ✅
- CrowDaemon lane / ledger / security / new corveil suites ✅
- One unrelated pre-existing failure remains in the worktree: `WebNotificationCenterTests.bootCatchResetsTheHistory` asserts a whitespace pattern in the frontend `app.js`, which this PR does not touch (unchanged from HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)