### PR TITLE
Corveil token health/refresh + reconnect state (CROW-1125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ The local-only write path for the **Corveil OAuth connection** (CROW-1120) — t
 ```
 crow corveil connect [--base-url URL] [--client-id ID] [--user-id ID] [--user-email E] [--user-name N] [--access-token T] [--refresh-token T] [--registration-access-token T] [--access-token-expires-at ISO8601]
                                                 → status payload + {"saved":true}
-crow corveil status                             → {connected, base_url, client_id, connected_user, org_count, has_*_token, access_token_expires_at}
+crow corveil status                             → {connected, state, needs_reconnect, base_url, client_id, connected_user, org_count, has_*_token, access_token_expires_at, last_refresh_at, last_refresh_error}
 crow corveil disconnect                         → {"saved":true,"was_connected":bool}
 crow corveil orgs                               → {"orgs":[{org_id,org_name,key_id,key_prefix,created_at}],"count":N}
 ```
@@ -173,6 +173,7 @@ crow corveil orgs                               → {"orgs":[{org_id,org_name,ke
 - All four are **local-only** on `/rpc`, like `gateway`/`web-password`/`mcp token`: `connect` stores OAuth tokens and `disconnect` clears them, and the two reads are gated alongside the writes so the whole connection is one local-only surface. The CLI is unaffected — it goes over the Unix socket.
 - `connect` is a **merge**: every field is optional, and a blank/omitted one keeps the stored value, so a token refresh can restate only `--access-token` + `--access-token-expires-at`. The merged result needs at least a client id and an access token; `orgKeys` (provisioned by corveil/crow#1121) are preserved.
 - `status`/`orgs` never return a token value — only presence booleans and non-secret metadata.
+- **Token health/refresh (CROW-1125):** a daemon-lifetime watcher renews the access token before it expires. `status.state` is the derived health — `connected` · `expired` (past expiry, refresh not keeping up) · `revoked` (a refresh was rejected `invalid_grant`/`invalid_client` — the grant is dead) · `disconnected` — and `needs_reconnect` is true for `expired`/`revoked`. `last_refresh_at`/`last_refresh_error` expose the watcher's most recent outcome. `revoked`/`disconnected` mean rerun Connect; `expired` self-heals once the daemon can reach Corveil again. The Integrations tab (corveil/crow#1122) keys its Reconnect affordance off the same `needs_reconnect`.
 - `disconnect` clears the local record; revoking the per-org gateway keys on the Corveil side is a separate step (corveil/crow#1121).
 
 ### Job Commands

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -213,7 +213,9 @@ struct ParityGateTests {
                 ],
                 oauth: CorveilOAuthTokens(
                     accessToken: "at", refreshToken: "rt",
-                    registrationAccessToken: "rat", accessTokenExpiresAt: Date()))
+                    registrationAccessToken: "rat", accessTokenExpiresAt: Date()),
+                health: CorveilConnectionHealth(
+                    lastRefreshAt: Date(), lastRefreshError: "probe", needsReconnect: true))
         )
     }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -547,6 +547,11 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
     /// OAuth token material — the secrets. Stripped for transport by
     /// `SettingsSecrets`.
     public var oauth: CorveilOAuthTokens
+    /// Token-refresh health, owned by the background refresher (CROW-1125). Not a
+    /// secret — it carries no token, only the *outcome* of the last refresh — so it
+    /// passes through `SettingsSecrets` untouched and the read-only Integrations
+    /// view can render a "Reconnect" state from it.
+    public var health: CorveilConnectionHealth
 
     /// Whether the connection has enough to be usable — a client id and an access
     /// token. An all-empty block (e.g. a partially-written record) reads as unset.
@@ -555,18 +560,38 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
             && oauth.accessToken.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
+    /// The connection's health as of `now` (CROW-1125), the single fact the
+    /// Integrations tab and `crow corveil status` key their "Reconnect" affordance
+    /// off. Derived, not stored: a background refresh that renews the token moves
+    /// `accessTokenExpiresAt` into the future and flips this back to `.connected`
+    /// with no extra write.
+    ///
+    /// `.revoked` wins over `.expired` — a definitively-rejected grant
+    /// (`health.needsReconnect`, set when a refresh came back `invalid_grant`) is a
+    /// stronger, sooner signal than the clock passing an expiry the refresher might
+    /// still renew. An unknown expiry (`nil`) is treated as not-yet-expired, since a
+    /// token with no stated lifetime is not evidence of a lapse.
+    public func healthState(now: Date = Date()) -> CorveilConnectionState {
+        if isEmpty { return .disconnected }
+        if health.needsReconnect { return .revoked }
+        if let expiry = oauth.accessTokenExpiresAt, expiry <= now { return .expired }
+        return .connected
+    }
+
     public init(
         baseURL: String = "",
         clientID: String = "",
         connectedUser: CorveilConnectedUser = CorveilConnectedUser(),
         orgKeys: [CorveilOrgKey] = [],
-        oauth: CorveilOAuthTokens = CorveilOAuthTokens()
+        oauth: CorveilOAuthTokens = CorveilOAuthTokens(),
+        health: CorveilConnectionHealth = CorveilConnectionHealth()
     ) {
         self.baseURL = baseURL
         self.clientID = clientID
         self.connectedUser = connectedUser
         self.orgKeys = orgKeys
         self.oauth = oauth
+        self.health = health
     }
 
     public init(from decoder: Decoder) throws {
@@ -577,11 +602,33 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
             ?? CorveilConnectedUser()
         orgKeys = try c.decodeIfPresent([CorveilOrgKey].self, forKey: .orgKeys) ?? []
         oauth = try c.decodeIfPresent(CorveilOAuthTokens.self, forKey: .oauth) ?? CorveilOAuthTokens()
+        health = try c.decodeIfPresent(CorveilConnectionHealth.self, forKey: .health)
+            ?? CorveilConnectionHealth()
     }
 
     private enum CodingKeys: String, CodingKey {
-        case baseURL, clientID, connectedUser, orgKeys, oauth
+        case baseURL, clientID, connectedUser, orgKeys, oauth, health
     }
+}
+
+/// The health of a ``CorveilConnection``'s access token, as one of four states
+/// (CROW-1125). Drives the Integrations tab and `crow corveil status`: `.expired`
+/// and `.revoked` are the two that ask the user to **Reconnect**.
+public enum CorveilConnectionState: String, Codable, Sendable, Equatable, CaseIterable {
+    /// No connection is stored.
+    case disconnected
+    /// A usable, non-expired access token — nothing to do.
+    case connected
+    /// The access token is past its expiry and the background refresh has not
+    /// renewed it (offline too long, or refresh failing). Reconnect fixes it.
+    case expired
+    /// A refresh was definitively rejected (`invalid_grant`/`invalid_client`) — the
+    /// stored grant is dead (the user or an admin revoked it, or the refresh token
+    /// lapsed). Only reconnecting issues a fresh grant.
+    case revoked
+
+    /// Whether this state asks the user to reconnect.
+    public var needsReconnect: Bool { self == .expired || self == .revoked }
 }
 
 /// The signed-in Corveil user identity behind a ``CorveilConnection`` (CROW-1118).
@@ -697,6 +744,51 @@ public struct CorveilOAuthTokens: Codable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case accessToken, refreshToken, registrationAccessToken, accessTokenExpiresAt
+    }
+}
+
+/// Token-refresh health for a ``CorveilConnection`` (CROW-1125) — the outcome of
+/// the background refresher's most recent attempt. Not a secret (no token, just
+/// booleans/timestamps/a message), so it is **not** stripped for transport and the
+/// read-only Integrations view can render it.
+///
+/// Owned by the refresher, not the user: `store`/`connect` reset it to a fresh
+/// healthy default whenever new tokens land (replacing the tokens invalidates any
+/// prior observation), and the refresher updates it in place — success clears it
+/// and stamps `lastRefreshAt`; a definitive rejection sets `needsReconnect`; a
+/// transient failure records only `lastRefreshError`. Decodes tolerantly so a
+/// connection written before this field existed loads as healthy.
+public struct CorveilConnectionHealth: Codable, Sendable, Equatable {
+    /// When a background refresh last succeeded. `nil` = none has run since the
+    /// tokens were (re)connected.
+    public var lastRefreshAt: Date?
+    /// Why the last refresh attempt failed, or `nil` when the last attempt
+    /// succeeded (or none has run). Diagnostic only — cleared on the next success.
+    public var lastRefreshError: String?
+    /// Set when a refresh was rejected in a way that means the stored grant is dead
+    /// (`invalid_grant`/`invalid_client`), so the user must reconnect. A transient
+    /// network failure leaves this alone; a success clears it.
+    public var needsReconnect: Bool
+
+    public init(
+        lastRefreshAt: Date? = nil,
+        lastRefreshError: String? = nil,
+        needsReconnect: Bool = false
+    ) {
+        self.lastRefreshAt = lastRefreshAt
+        self.lastRefreshError = lastRefreshError
+        self.needsReconnect = needsReconnect
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        lastRefreshAt = try c.decodeIfPresent(Date.self, forKey: .lastRefreshAt)
+        lastRefreshError = try c.decodeIfPresent(String.self, forKey: .lastRefreshError)
+        needsReconnect = try c.decodeIfPresent(Bool.self, forKey: .needsReconnect) ?? false
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case lastRefreshAt, lastRefreshError, needsReconnect
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -816,5 +816,36 @@ public enum ParityLedger {
             "corveilConnection.oauth.accessTokenExpiresAt",
             read: "corveil status",
             write: "corveil connect"),
+
+        // Token health — server-computed by the background refresher (CROW-1125),
+        // read via `corveil status`, never user-settable. The refresher owns these:
+        // a reconnect resets them and each refresh tick updates them, so — like the
+        // server-assigned `jobs[].lastRunAt` — they carry a write exemption while
+        // staying readable.
+        .field(
+            "corveilConnection.health.lastRefreshAt",
+            read: "corveil status",
+            writeNoCLI: """
+                When the background token refresher last succeeded (CROW-1125). \
+                Stamped by the refresher on each successful renewal and reset on \
+                reconnect; not user-settable — a manual write would misreport health.
+                """),
+        .field(
+            "corveilConnection.health.lastRefreshError",
+            read: "corveil status",
+            writeNoCLI: """
+                Why the last background token refresh failed (CROW-1125), or absent \
+                after a success. A diagnostic the refresher owns and clears on the \
+                next success; not something a user sets.
+                """),
+        .field(
+            "corveilConnection.health.needsReconnect",
+            read: "corveil status",
+            writeNoCLI: """
+                Whether the stored grant was definitively rejected (invalid_grant / \
+                invalid_client) so the user must reconnect (CROW-1125). Latched by \
+                the background refresher and cleared only by a reconnect; deriving it \
+                is the refresher's job, not a CLI write.
+                """),
     ]
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -1271,3 +1271,52 @@ import Testing
     #expect(!CorveilConnection(clientID: "cid").isEmpty)
     #expect(!CorveilConnection(oauth: CorveilOAuthTokens(accessToken: "at")).isEmpty)
 }
+
+// MARK: - Corveil connection health (CROW-1125)
+
+@Test func corveilHealthStateDerivesTheFourStates() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    func conn(expiresAt: Date?, needsReconnect: Bool = false) -> CorveilConnection {
+        CorveilConnection(
+            clientID: "cid",
+            oauth: CorveilOAuthTokens(accessToken: "at", accessTokenExpiresAt: expiresAt),
+            health: CorveilConnectionHealth(needsReconnect: needsReconnect))
+    }
+
+    // No connection / empty → disconnected.
+    #expect(CorveilConnection().healthState(now: now) == .disconnected)
+    // A token still in the future → connected.
+    #expect(conn(expiresAt: now.addingTimeInterval(3600)).healthState(now: now) == .connected)
+    // An unknown expiry is not evidence of a lapse → connected.
+    #expect(conn(expiresAt: nil).healthState(now: now) == .connected)
+    // Past its expiry → expired.
+    #expect(conn(expiresAt: now.addingTimeInterval(-1)).healthState(now: now) == .expired)
+    // A latched reconnect wins even when the clock hasn't reached expiry.
+    #expect(
+        conn(expiresAt: now.addingTimeInterval(3600), needsReconnect: true)
+            .healthState(now: now) == .revoked)
+
+    // Only expired/revoked ask the user to reconnect.
+    #expect(!CorveilConnectionState.connected.needsReconnect)
+    #expect(!CorveilConnectionState.disconnected.needsReconnect)
+    #expect(CorveilConnectionState.expired.needsReconnect)
+    #expect(CorveilConnectionState.revoked.needsReconnect)
+}
+
+@Test func corveilHealthDecodesTolerantlyAndRoundTrips() throws {
+    // A connection written before `health` existed loads as healthy.
+    let legacy = #"{"clientID":"cid","oauth":{"accessToken":"at"}}"#.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(CorveilConnection.self, from: legacy)
+    #expect(decoded.health == CorveilConnectionHealth())
+    #expect(!decoded.health.needsReconnect)
+
+    // And a populated health round-trips.
+    let now = Date(timeIntervalSince1970: 1_500_000)
+    let connection = CorveilConnection(
+        clientID: "cid",
+        oauth: CorveilOAuthTokens(accessToken: "at"),
+        health: CorveilConnectionHealth(lastRefreshAt: now, lastRefreshError: "boom", needsReconnect: true))
+    let reencoded = try JSONDecoder().decode(
+        CorveilConnection.self, from: try JSONEncoder().encode(connection))
+    #expect(reencoded == connection)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
@@ -43,7 +43,11 @@ import CrowCore
                 accessToken: "CORVEIL-ACCESS-SECRET",
                 refreshToken: "CORVEIL-REFRESH-SECRET",
                 registrationAccessToken: "CORVEIL-REG-SECRET",
-                accessTokenExpiresAt: Date(timeIntervalSince1970: 1_900_000_000)))
+                accessTokenExpiresAt: Date(timeIntervalSince1970: 1_900_000_000)),
+            health: CorveilConnectionHealth(
+                lastRefreshAt: Date(timeIntervalSince1970: 1_850_000_000),
+                lastRefreshError: "invalid_grant",
+                needsReconnect: true))
         return c
     }
 
@@ -226,6 +230,10 @@ import CrowCore
         #expect(
             stripped.corveilConnection?.oauth.accessTokenExpiresAt
                 == Date(timeIntervalSince1970: 1_900_000_000))
+        // Token health is not a secret, so it survives stripping — the read-only
+        // Integrations view renders its "Reconnect" state from it (CROW-1125).
+        #expect(stripped.corveilConnection?.health.needsReconnect == true)
+        #expect(stripped.corveilConnection?.health.lastRefreshError == "invalid_grant")
     }
 
     @Test func strippedCorveilTokensNeverAppearInTheSerializedConfig() throws {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
@@ -106,7 +106,12 @@ enum CorveilConnectionRPC {
                 refreshToken: pick(input.refreshToken, base.oauth.refreshToken),
                 registrationAccessToken: pick(
                     input.registrationAccessToken, base.oauth.registrationAccessToken),
-                accessTokenExpiresAt: input.accessTokenExpiresAt ?? base.oauth.accessTokenExpiresAt))
+                accessTokenExpiresAt: input.accessTokenExpiresAt ?? base.oauth.accessTokenExpiresAt),
+            // Reset health explicitly (CROW-1125): a (re)connect through this door is
+            // a fresh grant, so any prior `needsReconnect`/error observation is stale
+            // — carrying `base.health` over would leave a just-reconnected connection
+            // showing "Reconnect". The refresher re-populates it on its next tick.
+            health: CorveilConnectionHealth())
         let hasClientID = !result.clientID.trimmingCharacters(in: .whitespaces).isEmpty
         let hasAccessToken = !result.oauth.accessToken.trimmingCharacters(in: .whitespaces).isEmpty
         guard hasClientID, hasAccessToken else {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
@@ -168,14 +168,29 @@ enum CorveilConnectionRPC {
     /// access-token expiry, and *presence* booleans for the tokens — never a
     /// token value. Safe to paste into a ticket, like `gateway-get` without
     /// `reveal`.
-    static func statusJSON(_ connection: CorveilConnection?) -> [String: JSONValue] {
-        guard let connection, !connection.isEmpty else {
-            return ["connected": .bool(false)]
-        }
+    ///
+    /// Since CROW-1125 it also reports token health: `state` is one of
+    /// `disconnected` / `connected` / `expired` / `revoked`, `needs_reconnect` is
+    /// the derived "the user must click Reconnect" flag (true for `expired` and
+    /// `revoked`), and `last_refresh_at` / `last_refresh_error` expose the
+    /// background refresher's most recent outcome. `now` is injectable so the
+    /// expiry→state derivation is deterministic in tests.
+    static func statusJSON(_ connection: CorveilConnection?, now: Date = Date()) -> [String: JSONValue] {
         let formatter = ISO8601DateFormatter()
+        let state = connection?.healthState(now: now) ?? .disconnected
+        guard let connection, !connection.isEmpty else {
+            return [
+                "connected": .bool(false),
+                "state": .string(state.rawValue),
+                "needs_reconnect": .bool(state.needsReconnect),
+            ]
+        }
         let user = connection.connectedUser
+        let health = connection.health
         return [
             "connected": .bool(true),
+            "state": .string(state.rawValue),
+            "needs_reconnect": .bool(state.needsReconnect),
             "base_url": .string(connection.baseURL),
             "client_id": .string(connection.clientID),
             "connected_user": .object([
@@ -189,6 +204,9 @@ enum CorveilConnectionRPC {
             "has_registration_access_token": .bool(!connection.oauth.registrationAccessToken.isEmpty),
             "access_token_expires_at": connection.oauth.accessTokenExpiresAt
                 .map { .string(formatter.string(from: $0)) } ?? .null,
+            "last_refresh_at": health.lastRefreshAt
+                .map { .string(formatter.string(from: $0)) } ?? .null,
+            "last_refresh_error": health.lastRefreshError.map { .string($0) } ?? .null,
         ]
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
@@ -103,6 +103,11 @@ enum CorveilConnectionPersistence {
             connection.baseURL = baseURL
             connection.clientID = clientID
             connection.oauth = tokens
+            // Fresh tokens make any prior refresh observation stale: a reconnect
+            // after a revocation must clear `needsReconnect`, or the UI would keep
+            // asking the user to reconnect a connection that just succeeded
+            // (CROW-1125). The refresher re-populates health on its next tick.
+            connection.health = CorveilConnectionHealth()
             config.corveilConnection = connection
             try ConfigStore.saveConfig(config, devRoot: devRoot)
         }
@@ -117,6 +122,47 @@ enum CorveilConnectionPersistence {
             var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
             guard var connection = config.corveilConnection else { return false }
             connection.oauth = tokens
+            config.corveilConnection = connection
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+            return true
+        }
+    }
+
+    /// Persist a successful background refresh (CROW-1125): replace the OAuth block
+    /// and stamp the connection **healthy** — `lastRefreshAt = now`, no error, no
+    /// pending reconnect. Reloads inside the config lock, so a disconnect that
+    /// raced the in-flight refresh wins (returns false rather than resurrecting the
+    /// connection).
+    @discardableResult
+    static func recordRefreshSuccess(
+        devRoot: String, tokens: CorveilOAuthTokens, now: Date
+    ) throws -> Bool {
+        try ConfigStore.withConfigLock {
+            var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            guard var connection = config.corveilConnection else { return false }
+            connection.oauth = tokens
+            connection.health = CorveilConnectionHealth(
+                lastRefreshAt: now, lastRefreshError: nil, needsReconnect: false)
+            config.corveilConnection = connection
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+            return true
+        }
+    }
+
+    /// Persist a failed background refresh (CROW-1125): record `error`, and — only
+    /// for a definitive grant rejection — latch `needsReconnect`. The tokens and
+    /// `lastRefreshAt` are left untouched (a transient failure must not erase a
+    /// still-valid token), and `needsReconnect` is never *cleared* here — only a
+    /// success or a reconnect clears it. Same disconnect-wins reload as above.
+    @discardableResult
+    static func recordRefreshFailure(
+        devRoot: String, error: String, needsReconnect: Bool
+    ) throws -> Bool {
+        try ConfigStore.withConfigLock {
+            var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            guard var connection = config.corveilConnection else { return false }
+            connection.health.lastRefreshError = error
+            if needsReconnect { connection.health.needsReconnect = true }
             config.corveilConnection = connection
             try ConfigStore.saveConfig(config, devRoot: devRoot)
             return true

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
@@ -130,16 +130,23 @@ enum CorveilConnectionPersistence {
 
     /// Persist a successful background refresh (CROW-1125): replace the OAuth block
     /// and stamp the connection **healthy** — `lastRefreshAt = now`, no error, no
-    /// pending reconnect. Reloads inside the config lock, so a disconnect that
-    /// raced the in-flight refresh wins (returns false rather than resurrecting the
-    /// connection).
+    /// pending reconnect.
+    ///
+    /// Reloads inside the config lock and writes only if the stored grant is still
+    /// the one this refresh presented (`expectedRefreshToken` == the stored refresh
+    /// token). A disconnect (connection now nil) or a **reconnect** that landed
+    /// while the token HTTP call was in flight therefore wins — returns false rather
+    /// than clobbering the fresh grant with tokens minted from the old refresh
+    /// token. Reconnect-wins, the sibling of disconnect-wins.
     @discardableResult
     static func recordRefreshSuccess(
-        devRoot: String, tokens: CorveilOAuthTokens, now: Date
+        devRoot: String, expectedRefreshToken: String, tokens: CorveilOAuthTokens, now: Date
     ) throws -> Bool {
         try ConfigStore.withConfigLock {
             var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-            guard var connection = config.corveilConnection else { return false }
+            guard var connection = config.corveilConnection,
+                  connection.oauth.refreshToken == expectedRefreshToken
+            else { return false }
             connection.oauth = tokens
             connection.health = CorveilConnectionHealth(
                 lastRefreshAt: now, lastRefreshError: nil, needsReconnect: false)
@@ -153,14 +160,21 @@ enum CorveilConnectionPersistence {
     /// for a definitive grant rejection — latch `needsReconnect`. The tokens and
     /// `lastRefreshAt` are left untouched (a transient failure must not erase a
     /// still-valid token), and `needsReconnect` is never *cleared* here — only a
-    /// success or a reconnect clears it. Same disconnect-wins reload as above.
+    /// success or a reconnect clears it.
+    ///
+    /// Same reconnect-wins guard as `recordRefreshSuccess`: writes only if the
+    /// stored grant is still the one this refresh presented. Without it, an
+    /// `invalid_grant` on the *old* refresh token would mark a connection the user
+    /// just reconnected as revoked.
     @discardableResult
     static func recordRefreshFailure(
-        devRoot: String, error: String, needsReconnect: Bool
+        devRoot: String, expectedRefreshToken: String, error: String, needsReconnect: Bool
     ) throws -> Bool {
         try ConfigStore.withConfigLock {
             var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-            guard var connection = config.corveilConnection else { return false }
+            guard var connection = config.corveilConnection,
+                  connection.oauth.refreshToken == expectedRefreshToken
+            else { return false }
             connection.health.lastRefreshError = error
             if needsReconnect { connection.health.needsReconnect = true }
             config.corveilConnection = connection

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilTokenRefreshWatcher.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilTokenRefreshWatcher.swift
@@ -1,0 +1,117 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+
+/// The background half of Corveil token health (CROW-1125): a daemon-lifetime loop
+/// that renews the stored access token **before** it expires, and records the
+/// outcome as connection health so the Integrations tab and `crow corveil status`
+/// can surface a clear "Reconnect" state.
+///
+/// This is the scheduler the reusable ``CorveilConnectionRefresher`` primitive was
+/// built for (corveil/crow#1119 left "when to call it" to this ticket). Each
+/// ``tick(devRoot:client:now:)`` is one self-contained pass — load the connection,
+/// decide whether a refresh is due, refresh, and persist tokens + health — so it is
+/// driven from an ordinary `while` loop in ``CrowDaemon`` (like the pending-auth
+/// prune) and unit-tested directly against a stub transport, no timer involved.
+///
+/// It never throws: a refresh that fails leaves the previous token in place and is
+/// retried next tick. The distinction that matters is *why* it failed — a
+/// definitively-rejected grant (`invalid_grant`/`invalid_client`) latches
+/// `needsReconnect`, while a transient network error only records a diagnostic and
+/// tries again — because only the former is the user's to fix by reconnecting.
+enum CorveilTokenRefreshWatcher {
+    /// How often the loop wakes. Matches the neighboring prune cadence; small
+    /// relative to `refreshMargin` so a due token is always caught before it lapses.
+    static let tickInterval: TimeInterval = 300  // 5 minutes
+
+    /// Refresh once the access token is within this window of expiring. Larger than
+    /// `tickInterval`, so at least one tick lands inside the window before expiry —
+    /// the "refresh before expiry" the ticket requires. An already-expired token is
+    /// (still) due, so a daemon that was down through an expiry catches up on boot.
+    static let refreshMargin: TimeInterval = 600  // 10 minutes
+
+    /// What one ``tick`` did — for logging and tests.
+    enum Outcome: Equatable {
+        /// No connection stored, or it has no access token.
+        case noConnection
+        /// A connection exists but can't be refreshed here (no refresh token, or no
+        /// usable base URL). If it is also past expiry, `healthState` still reports
+        /// `.expired`; the watcher simply has nothing to do.
+        case notRefreshable
+        /// The token is not yet within the refresh window (or its expiry is unknown,
+        /// which can't be scheduled against) — nothing to do this tick.
+        case notDue
+        /// The token was refreshed and persisted; health reset to connected.
+        case refreshed
+        /// A refresh was attempted and failed. `needsReconnect` is true only for a
+        /// definitive grant rejection (the connection is now `.revoked`).
+        case failed(needsReconnect: Bool)
+    }
+
+    /// Whether a stored connection is due for a proactive refresh at `now`: it has a
+    /// known expiry that is within `margin` of now (or already past). An unknown
+    /// expiry is never "due" — a token with no stated lifetime is not scheduled
+    /// against, and refreshing it blindly every tick would be wasteful.
+    static func isDue(
+        _ connection: CorveilConnection, now: Date, margin: TimeInterval = refreshMargin
+    ) -> Bool {
+        guard let expiry = connection.oauth.accessTokenExpiresAt else { return false }
+        return expiry.timeIntervalSince(now) <= margin
+    }
+
+    /// One refresh pass. Never throws — a failure is recorded as health and retried
+    /// on the next tick.
+    @discardableResult
+    static func tick(
+        devRoot: String,
+        client: CorveilOAuthClient = .live,
+        now: Date = Date()
+    ) async -> Outcome {
+        guard let connection = ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection,
+              !connection.isEmpty
+        else { return .noConnection }
+
+        let refreshToken = connection.oauth.refreshToken.trimmingCharacters(in: .whitespaces)
+        guard !refreshToken.isEmpty,
+              let endpoints = CorveilOAuthClient.Endpoints(baseURL: connection.baseURL)
+        else { return .notRefreshable }
+
+        guard isDue(connection, now: now) else { return .notDue }
+
+        do {
+            let response = try await client.refresh(
+                endpoints: endpoints, clientID: connection.clientID, refreshToken: refreshToken)
+            let tokens = CorveilConnectionRefresher.mergedTokens(
+                existing: connection.oauth, response: response, now: now)
+            try CorveilConnectionPersistence.recordRefreshSuccess(
+                devRoot: devRoot, tokens: tokens, now: now)
+            return .refreshed
+        } catch {
+            let revoked = isGrantRejection(error)
+            _ = try? CorveilConnectionPersistence.recordRefreshFailure(
+                devRoot: devRoot, error: describe(error), needsReconnect: revoked)
+            return .failed(needsReconnect: revoked)
+        }
+    }
+
+    /// Whether an error from the token endpoint means the stored grant is dead — the
+    /// user must reconnect — as opposed to a transient failure worth retrying.
+    ///
+    /// Only the two OAuth error codes that name a bad grant qualify (RFC 6749 §5.2):
+    /// `invalid_grant` (the refresh token is expired, revoked, or was already
+    /// rotated away) and `invalid_client` (the registered client is gone). Every
+    /// other OAuth error, and every transport/HTTP/parse failure, is treated as
+    /// transient — a 5xx or a dropped connection must not push a working connection
+    /// into a "Reconnect" state.
+    static func isGrantRejection(_ error: Error) -> Bool {
+        guard case let CorveilOAuthClient.Failure.oauth(code, _) = error else { return false }
+        switch code.lowercased() {
+        case "invalid_grant", "invalid_client": return true
+        default: return false
+        }
+    }
+
+    private static func describe(_ error: Error) -> String {
+        (error as? CorveilOAuthClient.Failure)?.description ?? error.localizedDescription
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilTokenRefreshWatcher.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilTokenRefreshWatcher.swift
@@ -43,6 +43,10 @@ enum CorveilTokenRefreshWatcher {
         case notDue
         /// The token was refreshed and persisted; health reset to connected.
         case refreshed
+        /// A refresh completed but a reconnect (or disconnect) landed while the token
+        /// HTTP call was in flight, so the result was discarded rather than clobber
+        /// the newer grant. Nothing was written — reconnect-wins.
+        case superseded
         /// A refresh was attempted and failed. `needsReconnect` is true only for a
         /// definitive grant rejection (the connection is now `.revoked`).
         case failed(needsReconnect: Bool)
@@ -78,19 +82,26 @@ enum CorveilTokenRefreshWatcher {
 
         guard isDue(connection, now: now) else { return .notDue }
 
+        // The exact stored refresh token identifies this grant. A reconnect while the
+        // HTTP call is in flight replaces it, and the persist below no-ops on the
+        // mismatch (reconnect-wins), so a stale success/failure can't touch the new
+        // grant.
+        let presentedGrant = connection.oauth.refreshToken
+
         do {
             let response = try await client.refresh(
                 endpoints: endpoints, clientID: connection.clientID, refreshToken: refreshToken)
             let tokens = CorveilConnectionRefresher.mergedTokens(
                 existing: connection.oauth, response: response, now: now)
-            try CorveilConnectionPersistence.recordRefreshSuccess(
-                devRoot: devRoot, tokens: tokens, now: now)
-            return .refreshed
+            let written = try CorveilConnectionPersistence.recordRefreshSuccess(
+                devRoot: devRoot, expectedRefreshToken: presentedGrant, tokens: tokens, now: now)
+            return written ? .refreshed : .superseded
         } catch {
             let revoked = isGrantRejection(error)
-            _ = try? CorveilConnectionPersistence.recordRefreshFailure(
-                devRoot: devRoot, error: describe(error), needsReconnect: revoked)
-            return .failed(needsReconnect: revoked)
+            let written = (try? CorveilConnectionPersistence.recordRefreshFailure(
+                devRoot: devRoot, expectedRefreshToken: presentedGrant,
+                error: describe(error), needsReconnect: revoked)) ?? false
+            return written ? .failed(needsReconnect: revoked) : .superseded
         }
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -572,11 +572,12 @@ public enum CrowDaemon {
         // expires, and latch a "Reconnect" state (surfaced by `crow corveil status`
         // and the Integrations tab) when a refresh is definitively rejected. Each
         // tick reloads the connection, so it needs no reactive config wiring; a
-        // no-op tick when nothing is connected costs one disk read.
+        // no-op tick when nothing is connected costs one disk read. Ticks first,
+        // then sleeps, so an already-expired token is caught at boot rather than one
+        // interval later.
         let corveilRefreshDevRoot = options.devRoot
         Task {
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(CorveilTokenRefreshWatcher.tickInterval))
                 let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: corveilRefreshDevRoot)
                 switch outcome {
                 case .refreshed:
@@ -584,9 +585,10 @@ public enum CrowDaemon {
                 case .failed(let needsReconnect):
                     log("Corveil token refresh failed"
                         + (needsReconnect ? " — connection revoked, reconnect required" : " (will retry)"))
-                case .noConnection, .notRefreshable, .notDue:
+                case .noConnection, .notRefreshable, .notDue, .superseded:
                     break  // routine; no log
                 }
+                try? await Task.sleep(for: .seconds(CorveilTokenRefreshWatcher.tickInterval))
             }
         }
         // Read-only MCP for off-box clients (CROW-1004). Authenticates with a scoped

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -568,6 +568,27 @@ public enum CrowDaemon {
         CorveilIntegrationRoutes.mount(
             on: httpRouter, boundHost: options.host, devRoot: options.devRoot,
             httpPort: options.httpPort, pending: corveilPendingAuth)
+        // Corveil token health (CROW-1125): renew the stored access token before it
+        // expires, and latch a "Reconnect" state (surfaced by `crow corveil status`
+        // and the Integrations tab) when a refresh is definitively rejected. Each
+        // tick reloads the connection, so it needs no reactive config wiring; a
+        // no-op tick when nothing is connected costs one disk read.
+        let corveilRefreshDevRoot = options.devRoot
+        Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(CorveilTokenRefreshWatcher.tickInterval))
+                let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: corveilRefreshDevRoot)
+                switch outcome {
+                case .refreshed:
+                    log("Corveil access token refreshed")
+                case .failed(let needsReconnect):
+                    log("Corveil token refresh failed"
+                        + (needsReconnect ? " — connection revoked, reconnect required" : " (will retry)"))
+                case .noConnection, .notRefreshable, .notDue:
+                    break  // routine; no log
+                }
+            }
+        }
         // Read-only MCP for off-box clients (CROW-1004). Authenticates with a scoped
         // bearer token minted by `crow mcp token mint`, NOT the web-session cookie —
         // `/mcp` is listed in `WebAuthMiddleware.isAuthExempt` for that reason, and

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
@@ -306,6 +306,50 @@ import Testing
     @Test func statusJSONReportsDisconnectedForNilAndEmpty() {
         #expect(CorveilConnectionRPC.statusJSON(nil)["connected"] == .bool(false))
         #expect(CorveilConnectionRPC.statusJSON(CorveilConnection())["connected"] == .bool(false))
+        // Even disconnected, the shape carries the state fields the UI keys off.
+        #expect(CorveilConnectionRPC.statusJSON(nil)["state"] == .string("disconnected"))
+        #expect(CorveilConnectionRPC.statusJSON(nil)["needs_reconnect"] == .bool(false))
+    }
+
+    // A live connection whose token is comfortably in the future (CROW-1125).
+    private func liveConnection(
+        expiresAt: Date?, health: CorveilConnectionHealth = CorveilConnectionHealth()
+    ) -> CorveilConnection {
+        CorveilConnection(
+            clientID: "crow-client-1",
+            oauth: CorveilOAuthTokens(
+                accessToken: "at", refreshToken: "rt", accessTokenExpiresAt: expiresAt),
+            health: health)
+    }
+
+    @Test func statusJSONReportsConnectedStateWhenTokenIsFresh() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let json = CorveilConnectionRPC.statusJSON(
+            liveConnection(expiresAt: now.addingTimeInterval(3600)), now: now)
+        #expect(json["state"] == .string("connected"))
+        #expect(json["needs_reconnect"] == .bool(false))
+    }
+
+    @Test func statusJSONReportsExpiredStateOncePastExpiry() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let json = CorveilConnectionRPC.statusJSON(
+            liveConnection(expiresAt: now.addingTimeInterval(-60)), now: now)
+        #expect(json["state"] == .string("expired"))
+        #expect(json["needs_reconnect"] == .bool(true))
+    }
+
+    @Test func statusJSONReportsRevokedWhenHealthLatchedIt() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        // Revoked wins even though the clock hasn't reached expiry yet.
+        let json = CorveilConnectionRPC.statusJSON(
+            liveConnection(
+                expiresAt: now.addingTimeInterval(3600),
+                health: CorveilConnectionHealth(
+                    lastRefreshError: "invalid_grant", needsReconnect: true)),
+            now: now)
+        #expect(json["state"] == .string("revoked"))
+        #expect(json["needs_reconnect"] == .bool(true))
+        #expect(json["last_refresh_error"] == .string("invalid_grant"))
     }
 
     @Test func statusJSONNeverExposesTokenValues() {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
@@ -402,4 +402,203 @@ import FoundationNetworking
         #expect(merged.refreshToken == "keep-me")  // server didn't rotate → keep old
         #expect(merged.registrationAccessToken == "reg")
     }
+
+    // MARK: - Health persistence + reconnect state (CROW-1125)
+
+    /// Seed a config with one connection whose token expires at `expiresAt`.
+    private func seed(
+        devRoot: String, expiresAt: Date?,
+        refreshToken: String = "old-rt",
+        health: CorveilConnectionHealth = CorveilConnectionHealth()
+    ) throws {
+        var config = AppConfig()
+        config.corveilConnection = CorveilConnection(
+            baseURL: "https://corveil.test", clientID: "cid",
+            oauth: CorveilOAuthTokens(
+                accessToken: "old-at", refreshToken: refreshToken,
+                registrationAccessToken: "reg-keep", accessTokenExpiresAt: expiresAt),
+            health: health)
+        try ConfigStore.saveConfig(config, devRoot: devRoot)
+    }
+
+    private func storedHealth(_ devRoot: String) -> CorveilConnectionHealth? {
+        ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection?.health
+    }
+
+    @Test func storeResetsHealthSoAReconnectClearsNeedsReconnect() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seed(
+            devRoot: devRoot, expiresAt: Date(),
+            health: CorveilConnectionHealth(lastRefreshError: "invalid_grant", needsReconnect: true))
+
+        try CorveilConnectionPersistence.store(
+            devRoot: devRoot, baseURL: "https://corveil.test", clientID: "cid",
+            tokens: CorveilOAuthTokens(accessToken: "fresh", refreshToken: "fresh-rt"))
+
+        let health = try #require(storedHealth(devRoot))
+        #expect(!health.needsReconnect)
+        #expect(health.lastRefreshError == nil)
+    }
+
+    @Test func recordRefreshSuccessStampsHealthy() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seed(
+            devRoot: devRoot, expiresAt: Date(),
+            health: CorveilConnectionHealth(lastRefreshError: "boom", needsReconnect: true))
+        let now = Date(timeIntervalSince1970: 3_000_000)
+
+        let ok = try CorveilConnectionPersistence.recordRefreshSuccess(
+            devRoot: devRoot, tokens: CorveilOAuthTokens(accessToken: "new-at"), now: now)
+        #expect(ok)
+        let health = try #require(storedHealth(devRoot))
+        #expect(health.lastRefreshAt == now)
+        #expect(health.lastRefreshError == nil)
+        #expect(!health.needsReconnect)
+    }
+
+    @Test func recordRefreshFailureLatchesReconnectOnlyWhenAsked() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seed(devRoot: devRoot, expiresAt: Date())
+
+        // A transient failure records the message but does not latch reconnect.
+        #expect(try CorveilConnectionPersistence.recordRefreshFailure(
+            devRoot: devRoot, error: "network down", needsReconnect: false))
+        var health = try #require(storedHealth(devRoot))
+        #expect(health.lastRefreshError == "network down")
+        #expect(!health.needsReconnect)
+
+        // A definitive rejection latches it.
+        #expect(try CorveilConnectionPersistence.recordRefreshFailure(
+            devRoot: devRoot, error: "invalid_grant", needsReconnect: true))
+        health = try #require(storedHealth(devRoot))
+        #expect(health.needsReconnect)
+
+        // A later transient failure must not *clear* the latch.
+        #expect(try CorveilConnectionPersistence.recordRefreshFailure(
+            devRoot: devRoot, error: "flaky again", needsReconnect: false))
+        #expect(try #require(storedHealth(devRoot)).needsReconnect)
+    }
+
+    @Test func recordRefreshReturnsFalseWithoutConnection() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        #expect(try !CorveilConnectionPersistence.recordRefreshSuccess(
+            devRoot: devRoot, tokens: CorveilOAuthTokens(accessToken: "x"), now: Date()))
+        #expect(try !CorveilConnectionPersistence.recordRefreshFailure(
+            devRoot: devRoot, error: "x", needsReconnect: true))
+    }
+
+    // MARK: - Watcher (schedule + classify)
+
+    @Test func isDueSchedulesAgainstTheRefreshMargin() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        func conn(_ expiresAt: Date?) -> CorveilConnection {
+            CorveilConnection(oauth: CorveilOAuthTokens(accessTokenExpiresAt: expiresAt))
+        }
+        // Unknown expiry is never scheduled.
+        #expect(!CorveilTokenRefreshWatcher.isDue(conn(nil), now: now))
+        // Comfortably in the future → not due.
+        #expect(!CorveilTokenRefreshWatcher.isDue(conn(now.addingTimeInterval(3600)), now: now))
+        // Inside the 10-minute window → due.
+        #expect(CorveilTokenRefreshWatcher.isDue(conn(now.addingTimeInterval(120)), now: now))
+        // Already expired → still due (catch-up).
+        #expect(CorveilTokenRefreshWatcher.isDue(conn(now.addingTimeInterval(-60)), now: now))
+    }
+
+    @Test func isGrantRejectionOnlyForDeadGrants() {
+        typealias F = CorveilOAuthClient.Failure
+        #expect(CorveilTokenRefreshWatcher.isGrantRejection(F.oauth(error: "invalid_grant", description: nil)))
+        #expect(CorveilTokenRefreshWatcher.isGrantRejection(F.oauth(error: "invalid_client", description: nil)))
+        // A server hiccup or a slow-down is transient, not a reason to reconnect.
+        #expect(!CorveilTokenRefreshWatcher.isGrantRejection(F.oauth(error: "temporarily_unavailable", description: nil)))
+        #expect(!CorveilTokenRefreshWatcher.isGrantRejection(F.http(status: 503, body: "")))
+        #expect(!CorveilTokenRefreshWatcher.isGrantRejection(F.transport("connection refused")))
+    }
+
+    @Test func watcherRefreshesADueTokenAndStampsHealth() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(120))  // within margin
+
+        let client = CorveilOAuthClient(transport: transport { _ in
+            (200, self.jsonData([
+                "access_token": "new-at", "refresh_token": "new-rt",
+                "token_type": "Bearer", "expires_in": 3600, "scope": "orgs.read",
+            ]))
+        })
+        let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, client: client, now: now)
+        #expect(outcome == .refreshed)
+
+        let connection = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(connection.oauth.accessToken == "new-at")
+        #expect(connection.oauth.accessTokenExpiresAt == now.addingTimeInterval(3600))
+        #expect(connection.health.lastRefreshAt == now)
+        #expect(!connection.health.needsReconnect)
+        #expect(connection.healthState(now: now.addingTimeInterval(1)) == .connected)
+    }
+
+    @Test func watcherSkipsAFreshToken() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(3600))  // far future
+
+        let log = RequestLog()
+        let client = CorveilOAuthClient(transport: transport(log: log) { _ in (200, Data()) })
+        let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, client: client, now: now)
+        #expect(outcome == .notDue)
+        #expect(log.all.isEmpty)  // never hit the network
+        // Token untouched.
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection?.oauth.accessToken == "old-at")
+    }
+
+    @Test func watcherLatchesReconnectOnInvalidGrant() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(-30))  // expired → due
+
+        let client = CorveilOAuthClient(transport: transport { _ in
+            (400, self.jsonData(["error": "invalid_grant", "error_description": "token revoked"]))
+        })
+        let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, client: client, now: now)
+        #expect(outcome == .failed(needsReconnect: true))
+
+        let connection = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(connection.health.needsReconnect)
+        #expect(connection.oauth.accessToken == "old-at")  // stale token left in place
+        #expect(connection.healthState(now: now) == .revoked)
+    }
+
+    @Test func watcherKeepsRetryingOnTransientError() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(-30))
+
+        let client = CorveilOAuthClient(transport: transport { _ in (503, Data("upstream".utf8)) })
+        let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, client: client, now: now)
+        #expect(outcome == .failed(needsReconnect: false))
+
+        let connection = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(!connection.health.needsReconnect)  // a 5xx is not the user's to fix
+        #expect(connection.health.lastRefreshError != nil)
+        // Still just "expired" (clock), not "revoked".
+        #expect(connection.healthState(now: now) == .expired)
+    }
+
+    @Test func watcherNoOpsWithoutAConnectionOrRefreshToken() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // Nothing stored.
+        #expect(await CorveilTokenRefreshWatcher.tick(devRoot: devRoot) == .noConnection)
+        // A connection with no refresh token cannot be refreshed here.
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(-30), refreshToken: "")
+        #expect(await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, now: now) == .notRefreshable)
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOAuthClientTests.swift
@@ -450,7 +450,8 @@ import FoundationNetworking
         let now = Date(timeIntervalSince1970: 3_000_000)
 
         let ok = try CorveilConnectionPersistence.recordRefreshSuccess(
-            devRoot: devRoot, tokens: CorveilOAuthTokens(accessToken: "new-at"), now: now)
+            devRoot: devRoot, expectedRefreshToken: "old-rt",
+            tokens: CorveilOAuthTokens(accessToken: "new-at"), now: now)
         #expect(ok)
         let health = try #require(storedHealth(devRoot))
         #expect(health.lastRefreshAt == now)
@@ -465,20 +466,20 @@ import FoundationNetworking
 
         // A transient failure records the message but does not latch reconnect.
         #expect(try CorveilConnectionPersistence.recordRefreshFailure(
-            devRoot: devRoot, error: "network down", needsReconnect: false))
+            devRoot: devRoot, expectedRefreshToken: "old-rt", error: "network down", needsReconnect: false))
         var health = try #require(storedHealth(devRoot))
         #expect(health.lastRefreshError == "network down")
         #expect(!health.needsReconnect)
 
         // A definitive rejection latches it.
         #expect(try CorveilConnectionPersistence.recordRefreshFailure(
-            devRoot: devRoot, error: "invalid_grant", needsReconnect: true))
+            devRoot: devRoot, expectedRefreshToken: "old-rt", error: "invalid_grant", needsReconnect: true))
         health = try #require(storedHealth(devRoot))
         #expect(health.needsReconnect)
 
         // A later transient failure must not *clear* the latch.
         #expect(try CorveilConnectionPersistence.recordRefreshFailure(
-            devRoot: devRoot, error: "flaky again", needsReconnect: false))
+            devRoot: devRoot, expectedRefreshToken: "old-rt", error: "flaky again", needsReconnect: false))
         #expect(try #require(storedHealth(devRoot)).needsReconnect)
     }
 
@@ -486,9 +487,26 @@ import FoundationNetworking
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         #expect(try !CorveilConnectionPersistence.recordRefreshSuccess(
-            devRoot: devRoot, tokens: CorveilOAuthTokens(accessToken: "x"), now: Date()))
+            devRoot: devRoot, expectedRefreshToken: "rt",
+            tokens: CorveilOAuthTokens(accessToken: "x"), now: Date()))
         #expect(try !CorveilConnectionPersistence.recordRefreshFailure(
-            devRoot: devRoot, error: "x", needsReconnect: true))
+            devRoot: devRoot, expectedRefreshToken: "rt", error: "x", needsReconnect: true))
+    }
+
+    @Test func recordRefreshNoOpsWhenTheGrantWasReplaced() throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seed(devRoot: devRoot, expiresAt: Date(), refreshToken: "current-rt")
+
+        // A stale write presenting a superseded refresh token touches nothing.
+        #expect(try !CorveilConnectionPersistence.recordRefreshSuccess(
+            devRoot: devRoot, expectedRefreshToken: "stale-rt",
+            tokens: CorveilOAuthTokens(accessToken: "stale-at"), now: Date()))
+        #expect(try !CorveilConnectionPersistence.recordRefreshFailure(
+            devRoot: devRoot, expectedRefreshToken: "stale-rt", error: "invalid_grant", needsReconnect: true))
+        let connection = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(connection.oauth.accessToken == "old-at")  // untouched
+        #expect(!connection.health.needsReconnect)          // not falsely revoked
     }
 
     // MARK: - Watcher (schedule + classify)
@@ -589,6 +607,59 @@ import FoundationNetworking
         #expect(connection.health.lastRefreshError != nil)
         // Still just "expired" (clock), not "revoked".
         #expect(connection.healthState(now: now) == .expired)
+    }
+
+    // The Connect path this ticket exists to serve: a reconnect completes while the
+    // watcher's refresh of the *old* grant is in flight. The stub performs the
+    // reconnect at the moment of the HTTP call, so the persist that follows finds a
+    // different stored grant — and must leave the fresh grant alone (reconnect-wins).
+    @Test func watcherSuccessSupersededByAReconnectMidFlight() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(-30), refreshToken: "old-rt")
+
+        let client = CorveilOAuthClient(transport: transport { _ in
+            // A reconnect lands while this refresh is "in flight".
+            try? CorveilConnectionPersistence.store(
+                devRoot: devRoot, baseURL: "https://corveil.test", clientID: "cid",
+                tokens: CorveilOAuthTokens(accessToken: "fresh-at", refreshToken: "fresh-rt"))
+            return (200, self.jsonData([
+                "access_token": "stale-at", "refresh_token": "stale-rt",
+                "token_type": "Bearer", "expires_in": 3600, "scope": "orgs.read",
+            ]))
+        })
+        let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, client: client, now: now)
+        #expect(outcome == .superseded)
+
+        // The fresh grant is intact — not clobbered by tokens minted from old-rt.
+        let connection = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(connection.oauth.accessToken == "fresh-at")
+        #expect(connection.oauth.refreshToken == "fresh-rt")
+        #expect(!connection.health.needsReconnect)
+    }
+
+    @Test func watcherRevocationSupersededByAReconnectMidFlight() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let now = Date(timeIntervalSince1970: 5_000_000)
+        try seed(devRoot: devRoot, expiresAt: now.addingTimeInterval(-30), refreshToken: "old-rt")
+
+        let client = CorveilOAuthClient(transport: transport { _ in
+            try? CorveilConnectionPersistence.store(
+                devRoot: devRoot, baseURL: "https://corveil.test", clientID: "cid",
+                tokens: CorveilOAuthTokens(accessToken: "fresh-at", refreshToken: "fresh-rt"))
+            // The *old* refresh token is rejected — but the user just reconnected.
+            return (400, self.jsonData(["error": "invalid_grant", "error_description": "token revoked"]))
+        })
+        let outcome = await CorveilTokenRefreshWatcher.tick(devRoot: devRoot, client: client, now: now)
+        #expect(outcome == .superseded)
+
+        // The just-reconnected connection must NOT be marked revoked.
+        let connection = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(connection.oauth.accessToken == "fresh-at")
+        #expect(!connection.health.needsReconnect)
+        #expect(connection.healthState(now: now.addingTimeInterval(1)) == .connected)
     }
 
     @Test func watcherNoOpsWithoutAConnectionOrRefreshToken() async throws {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -851,16 +851,22 @@ crow corveil connect --access-token "$AT" --access-token-expires-at 2027-06-01T1
 
 Report the connection state — no secret. Whether a connection exists, its base URL, client id, connected user, org count, access-token expiry, and presence booleans for the tokens. It never prints a token value, so the output is safe to paste into a ticket.
 
+Since CROW-1125 it also reports token health. A background refresher renews the access token before it expires; `state` is the derived health — one of `connected`, `expired` (past expiry, refresh not keeping up), `revoked` (a refresh was rejected with `invalid_grant`/`invalid_client` — the grant is dead), or `disconnected` — and `needs_reconnect` is the "the user must Reconnect" flag (true for `expired` and `revoked`). `last_refresh_at` / `last_refresh_error` expose the refresher's most recent outcome. This is the same signal the Integrations tab keys its Reconnect affordance off.
+
 ```bash
 crow corveil status
 ```
 
 ```json
-{"connected": true, "base_url": "https://corveil.example.com", "client_id": "crow-client-1",
+{"connected": true, "state": "connected", "needs_reconnect": false,
+ "base_url": "https://corveil.example.com", "client_id": "crow-client-1",
  "connected_user": {"id": "u1", "email": "dev@example.com", "name": "Dev"},
  "org_count": 2, "has_access_token": true, "has_refresh_token": true,
- "has_registration_access_token": true, "access_token_expires_at": "2026-01-01T00:00:00Z"}
+ "has_registration_access_token": true, "access_token_expires_at": "2026-01-01T00:00:00Z",
+ "last_refresh_at": "2025-12-31T23:00:00Z", "last_refresh_error": null}
 ```
+
+A disconnected or revoked connection is the cue to reconnect (rerun the browser Connect flow); the refresher recovers an `expired` one on its own once it can reach Corveil again.
 
 #### `crow corveil disconnect`
 


### PR DESCRIPTION
Closes #1125

Part of the first-class Corveil integration epic (#1117). Builds on the OAuth client (#1119) and the local-only connection write path (#1120): wires the background refresh loop and the health/reconnect state those left to this ticket.

## What

**Background refresh before expiry.** `CorveilTokenRefreshWatcher` runs for the daemon's lifetime (5-min cadence, like the pending-auth prune). Each tick loads the stored connection and, when the access token is within 10 min of expiry (margin > cadence, so a due token is always caught first), refreshes it through the existing `CorveilConnectionRefresher` primitive and persists the rotated tokens.

**A clear Reconnect state.** The watcher records the outcome as connection health:
- a definitively-rejected grant (`invalid_grant` / `invalid_client`) **latches** `needsReconnect` → state `revoked`;
- a transient network / 5xx error only records a diagnostic and retries next tick — it must not push a working connection into "Reconnect";
- success clears health and stamps `lastRefreshAt`.

`CorveilConnection.healthState(now:)` derives one of `connected` / `expired` (past expiry, refresh not keeping up) / `revoked` / `disconnected` (revoked wins over a clock expiry, since it's the sooner, definitive signal). `crow corveil status` now returns `state`, `needs_reconnect`, `last_refresh_at`, `last_refresh_error` alongside the existing non-secret fields.

**Available to the Integrations tab.** `CorveilConnectionHealth` carries no token, so it passes through `SettingsSecrets` untouched — the read-only Integrations view (#1122) reads `health.needsReconnect` + the token expiry from the stripped config and keys its Reconnect affordance off the same signal. (This PR does not build that tab — #1122 owns the UI.)

## Notes / scope
- Health is server-computed and owned by the refresher: reset to healthy on any (re)connect (replacing tokens invalidates a prior observation), updated in place by the watcher. Parity ledger rows for the three fields are read-via-`corveil status`, write-exempt.
- Revocation surfaces at the next scheduled refresh (near expiry) — refresh rotates the refresh token, so probing every tick regardless of expiry would churn tokens; margin-based refresh is the correct mechanism. Gateway-failure-driven detection is out of scope (#1124).

## Tests
- Watcher: refreshes a due token + stamps health; skips a fresh token (no network); `invalid_grant` → `revoked` with the stale token left in place; 5xx → retry, not revoked; no-connection / no-refresh-token no-ops; `isDue` / `isGrantRejection` units.
- Persistence: `recordRefreshSuccess`/`recordRefreshFailure` (latch-only-when-asked, never clears on transient), `store` resets health, disconnect-wins reload.
- Model: `healthState` across all four states, tolerant decode of a pre-health connection, round-trip; `SettingsSecrets` keeps health through a strip.
- Status payload state fields; parity gate (ledger ⇔ AppConfig) and `make parity` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)