### PR TITLE
Add Corveil org listing + one-key-per-org provisioning (CROW-1121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,14 +167,18 @@ crow corveil connect [--base-url URL] [--client-id ID] [--user-id ID] [--user-em
                                                 → status payload + {"saved":true}
 crow corveil status                             → {connected, state, needs_reconnect, base_url, client_id, connected_user, org_count, has_*_token, access_token_expires_at, last_refresh_at, last_refresh_error}
 crow corveil disconnect                         → {"saved":true,"was_connected":bool}
-crow corveil orgs                               → {"orgs":[{org_id,org_name,key_id,key_prefix,created_at}],"count":N}
+crow corveil orgs                               → {"orgs":[{org_id,org_name,key_id,key_prefix,created_at}],"count":N}   the LOCAL provisioned-key metadata
+crow corveil list-orgs [--refresh]              → {"orgs":[{org_id,org_name,role,is_active,provisioned}],"count":N}   the orgs you belong to, cached
+crow corveil select-org --org ID [--name N] [--rotate]  → {"saved":true,"reused":bool,"org":{org_id,org_name,key_id,key_prefix,created_at}}
+crow corveil deselect-org --org ID              → {"saved":true,"removed":bool}
 ```
 
-- All four are **local-only** on `/rpc`, like `gateway`/`web-password`/`mcp token`: `connect` stores OAuth tokens and `disconnect` clears them, and the two reads are gated alongside the writes so the whole connection is one local-only surface. The CLI is unaffected — it goes over the Unix socket.
-- `connect` is a **merge**: every field is optional, and a blank/omitted one keeps the stored value, so a token refresh can restate only `--access-token` + `--access-token-expires-at`. The merged result needs at least a client id and an access token; `orgKeys` (provisioned by corveil/crow#1121) are preserved.
-- `status`/`orgs` never return a token value — only presence booleans and non-secret metadata.
+- All seven are **local-only** on `/rpc`, like `gateway`/`web-password`/`mcp token`: `connect` stores OAuth tokens and `disconnect` clears them, and the reads + the provisioning verbs are gated alongside the writes so the whole connection is one local-only surface. The CLI is unaffected — it goes over the Unix socket.
+- `connect` is a **merge**: every field is optional, and a blank/omitted one keeps the stored value, so a token refresh can restate only `--access-token` + `--access-token-expires-at`. The merged result needs at least a client id and an access token; `orgKeys` + their per-org secrets (provisioned by corveil/crow#1121) are preserved.
+- `status`/`orgs`/`list-orgs`/`select-org`/`deselect-org` never return a token or a key value — only presence booleans and non-secret metadata.
 - **Token health/refresh (CROW-1125):** a daemon-lifetime watcher renews the access token before it expires. `status.state` is the derived health — `connected` · `expired` (past expiry, refresh not keeping up) · `revoked` (a refresh was rejected `invalid_grant`/`invalid_client` — the grant is dead) · `disconnected` — and `needs_reconnect` is true for `expired`/`revoked`. `last_refresh_at`/`last_refresh_error` expose the watcher's most recent outcome. `revoked`/`disconnected` mean rerun Connect; `expired` self-heals once the daemon can reach Corveil again. The Integrations tab (corveil/crow#1122) keys its Reconnect affordance off the same `needs_reconnect`.
-- `disconnect` clears the local record; revoking the per-org gateway keys on the Corveil side is a separate step (corveil/crow#1121).
+- **Org provisioning (CROW-1121):** `list-orgs` lists the orgs you belong to (`GET /api/me/organizations`, cached; `--refresh` re-fetches) and flags which already have a key. `select-org` mints **one** `sk-citadel-…` gateway key per org via `POST /api/keys`, **reusing** the stored one if the org already has a key (`reused:true`, no re-mint — the backend rotates the key on each POST, so re-minting would break bound gateways); `--rotate` forces a fresh key. The key value is stored as a per-org secret in `corveilConnection`; only its metadata is ever printed. `deselect-org` revokes the key server-side and drops the local record (idempotent).
+- `disconnect` clears the local record; revoking the per-org gateway keys on the Corveil side is `deselect-org` (or a dashboard cascade on revoke).
 
 ### Job Commands
 

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/CorveilCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/CorveilCommands.swift
@@ -32,6 +32,9 @@ public struct Corveil: ParsableCommand {
             CorveilStatus.self,
             CorveilDisconnect.self,
             CorveilOrgs.self,
+            CorveilListOrgs.self,
+            CorveilSelectOrg.self,
+            CorveilDeselectOrg.self,
         ]
     )
 
@@ -240,7 +243,9 @@ public struct CorveilOrgs: ParsableCommand {
         discussion: """
         Prints the metadata for each auto-provisioned per-org gateway key — org id \
         and name, key id, display prefix, and mint time — never the key material \
-        itself. Empty until an org is provisioned (corveil/crow#1121).
+        itself. This is the LOCAL record of what has been provisioned; use `corveil \
+        list-orgs` to see every org you could select. Empty until an org is \
+        provisioned with `corveil select-org` (corveil/crow#1121).
         """
     )
 
@@ -248,5 +253,96 @@ public struct CorveilOrgs: ParsableCommand {
 
     public func run() throws {
         printJSON(try rpc("corveil-orgs"))
+    }
+}
+
+// MARK: - Org provisioning (CROW-1121)
+
+/// `crow corveil list-orgs` — list the user's Corveil orgs from the API (cached).
+public struct CorveilListOrgs: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "list-orgs",
+        abstract: "List the Corveil orgs you belong to (local-only)",
+        discussion: """
+        Fetches your Corveil memberships with the connection's OAuth token and \
+        prints each org's id, name, role, active flag, and whether it already has a \
+        provisioned gateway key. The result is cached briefly; pass `--refresh` to \
+        force a re-fetch. This is the list you pick from — `corveil orgs` shows only \
+        the orgs already provisioned locally. Local-only: it acts with a credential, \
+        so it runs over the Unix socket and is refused for remote web clients.
+        """
+    )
+
+    @Flag(name: .long, help: "Bypass the cache and re-fetch the org list from Corveil.")
+    public var refresh: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        var params: [String: JSONValue] = [:]
+        if refresh { params["refresh"] = .bool(true) }
+        printJSON(try rpc("corveil-list-orgs", params: params))
+    }
+}
+
+/// `crow corveil select-org` — provision (or reuse) the one gateway key for an org.
+public struct CorveilSelectOrg: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "select-org",
+        abstract: "Provision or reuse the gateway key for a Corveil org (local-only)",
+        discussion: """
+        Mints exactly one `sk-citadel-…` gateway key for the org, reusing the stored \
+        one if the org already has a key — so every workspace bound to the org shares \
+        it. The key value is stored as a secret; only its metadata (id, prefix, mint \
+        time) is ever printed. Pass `--rotate` to force a fresh key (the old one is \
+        revoked). The org name is taken from `--name` if given, else looked up from \
+        your memberships. Local-only: it mints a credential over the Unix socket and \
+        is refused for remote web clients.
+
+          crow corveil select-org --org <org-id>
+          crow corveil select-org --org <org-id> --rotate
+        """
+    )
+
+    @Option(name: .customLong("org"), help: "Corveil organization id to provision a key for")
+    public var org: String
+
+    @Option(name: .customLong("name"), help: "Org display name to store (looked up if omitted)")
+    public var name: String?
+
+    @Flag(name: .long, help: "Revoke the existing key and mint a fresh one.")
+    public var rotate: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["org_id": .string(org)]
+        let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedName.isEmpty { params["org_name"] = .string(trimmedName) }
+        if rotate { params["rotate"] = .bool(true) }
+        printJSON(try rpc("corveil-select-org", params: params))
+    }
+}
+
+/// `crow corveil deselect-org` — revoke an org's gateway key and drop the record.
+public struct CorveilDeselectOrg: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "deselect-org",
+        abstract: "Revoke a Corveil org's gateway key (local-only)",
+        discussion: """
+        Revokes the org's provisioned gateway key on the Corveil side and removes its \
+        local metadata and stored secret. Idempotent — deselecting an org with no key \
+        is a no-op. Local-only: it acts with a credential over the Unix socket and is \
+        refused for remote web clients.
+        """
+    )
+
+    @Option(name: .customLong("org"), help: "Corveil organization id whose key to revoke")
+    public var org: String
+
+    public init() {}
+
+    public func run() throws {
+        printJSON(try rpc("corveil-deselect-org", params: ["org_id": .string(org)]))
     }
 }

--- a/Packages/CrowCLI/Tests/CrowCLITests/CorveilCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CorveilCommandParsingTests.swift
@@ -23,6 +23,7 @@ struct CorveilCommandParsingTests {
         let names = Corveil.configuration.subcommands.map { $0.configuration.commandName }
         #expect(Set(names) == [
             "verify", "reinstall-skill", "connect", "status", "disconnect", "orgs",
+            "list-orgs", "select-org", "deselect-org",
         ])
     }
 
@@ -61,6 +62,47 @@ struct CorveilCommandParsingTests {
         #expect((try parse(["corveil", "status"]) as? CorveilStatus) != nil)
         #expect((try parse(["corveil", "disconnect"]) as? CorveilDisconnect) != nil)
         #expect((try parse(["corveil", "orgs"]) as? CorveilOrgs) != nil)
+    }
+
+    // MARK: - Org provisioning (CROW-1121)
+
+    @Test("list-orgs sends refresh only when the flag is set")
+    func listOrgsRefreshFlag() throws {
+        let plain = try #require(try parse(["corveil", "list-orgs"]) as? CorveilListOrgs)
+        #expect(plain.refresh == false)
+
+        let refreshed = try #require(
+            try parse(["corveil", "list-orgs", "--refresh"]) as? CorveilListOrgs)
+        #expect(refreshed.refresh == true)
+    }
+
+    @Test("select-org requires --org and maps optional name/rotate")
+    func selectOrgFlags() throws {
+        let minimal = try #require(
+            try parse(["corveil", "select-org", "--org", "org-123"]) as? CorveilSelectOrg)
+        #expect(minimal.org == "org-123")
+        #expect(minimal.name == nil)
+        #expect(minimal.rotate == false)
+
+        let full = try #require(try parse([
+            "corveil", "select-org", "--org", "org-123", "--name", "Acme Inc", "--rotate",
+        ]) as? CorveilSelectOrg)
+        #expect(full.org == "org-123")
+        #expect(full.name == "Acme Inc")
+        #expect(full.rotate == true)
+    }
+
+    @Test("select-org without --org is rejected")
+    func selectOrgRequiresOrg() {
+        #expect(throws: (any Error).self) { _ = try self.parse(["corveil", "select-org"]) }
+    }
+
+    @Test("deselect-org requires --org")
+    func deselectOrgFlags() throws {
+        let deselect = try #require(
+            try parse(["corveil", "deselect-org", "--org", "org-9"]) as? CorveilDeselectOrg)
+        #expect(deselect.org == "org-9")
+        #expect(throws: (any Error).self) { _ = try self.parse(["corveil", "deselect-org"]) }
     }
 
     // MARK: - --path

--- a/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/ParityGateTests.swift
@@ -211,6 +211,7 @@ struct ParityGateTests {
                         orgID: "org1", orgName: "Acme", keyID: "key1",
                         keyPrefix: "sk-citadel-AbC", createdAt: Date())
                 ],
+                orgKeySecrets: ["org1": "sk-citadel-AbCdEfGhIjKl"],
                 oauth: CorveilOAuthTokens(
                     accessToken: "at", refreshToken: "rt",
                     registrationAccessToken: "rat", accessTokenExpiresAt: Date()),
@@ -290,6 +291,10 @@ struct ParityGateTests {
         // presumes writes (CROW-1120).
         "corveil-status",
         "corveil-orgs",
+        // `corveil-list-orgs` lists the user's Corveil orgs from the API (cached) —
+        // a read — but `corveil-list-orgs` is neither `list-`-prefixed nor
+        // `-list`-suffixed, so the heuristic presumes a write (CROW-1121).
+        "corveil-list-orgs",
     ]
 
     /// `isWrite` is hand-set per row, deliberately, because a `get-`/`list-`

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -541,9 +541,21 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
     /// The signed-in Corveil user this connection belongs to.
     public var connectedUser: CorveilConnectedUser
     /// Metadata (never key material) for the one auto-provisioned gateway key per
-    /// Corveil org. The `sk-citadel-…` value itself lives in the generated
-    /// ``WorkspaceGateway`` header, not here.
+    /// Corveil org — org id/name, key id, display prefix, mint time. The
+    /// `sk-citadel-…` value itself is **not** here; it lives in the sibling
+    /// ``orgKeySecrets`` (a secret), from which the generated ``WorkspaceGateway``
+    /// header is populated (corveil/crow#1124). Keeping the metadata free of key
+    /// material means this array is safe to serialize to the read-only web view.
     public var orgKeys: [CorveilOrgKey]
+    /// The `sk-citadel-…` gateway-key value for each provisioned org, keyed by
+    /// Corveil org id — the **secret** half of ``orgKeys`` (CROW-1121). This is the
+    /// source of truth `corveilConnection` holds so a key is minted once per org
+    /// and reused across every workspace bound to it (the backend rotates the key
+    /// on each `POST /api/keys`, so re-minting would silently invalidate bound
+    /// gateways). Stripped for transport by `SettingsSecrets`, exactly like a
+    /// gateway header value and the OAuth tokens; a generated ``WorkspaceGateway``
+    /// (corveil/crow#1124) copies the value into its `x-citadel-api-key` header.
+    public var orgKeySecrets: [String: String]
     /// OAuth token material — the secrets. Stripped for transport by
     /// `SettingsSecrets`.
     public var oauth: CorveilOAuthTokens
@@ -583,6 +595,7 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
         clientID: String = "",
         connectedUser: CorveilConnectedUser = CorveilConnectedUser(),
         orgKeys: [CorveilOrgKey] = [],
+        orgKeySecrets: [String: String] = [:],
         oauth: CorveilOAuthTokens = CorveilOAuthTokens(),
         health: CorveilConnectionHealth = CorveilConnectionHealth()
     ) {
@@ -590,6 +603,7 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
         self.clientID = clientID
         self.connectedUser = connectedUser
         self.orgKeys = orgKeys
+        self.orgKeySecrets = orgKeySecrets
         self.oauth = oauth
         self.health = health
     }
@@ -601,13 +615,14 @@ public struct CorveilConnection: Codable, Sendable, Equatable {
         connectedUser = try c.decodeIfPresent(CorveilConnectedUser.self, forKey: .connectedUser)
             ?? CorveilConnectedUser()
         orgKeys = try c.decodeIfPresent([CorveilOrgKey].self, forKey: .orgKeys) ?? []
+        orgKeySecrets = try c.decodeIfPresent([String: String].self, forKey: .orgKeySecrets) ?? [:]
         oauth = try c.decodeIfPresent(CorveilOAuthTokens.self, forKey: .oauth) ?? CorveilOAuthTokens()
         health = try c.decodeIfPresent(CorveilConnectionHealth.self, forKey: .health)
             ?? CorveilConnectionHealth()
     }
 
     private enum CodingKeys: String, CodingKey {
-        case baseURL, clientID, connectedUser, orgKeys, oauth, health
+        case baseURL, clientID, connectedUser, orgKeys, orgKeySecrets, oauth, health
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -151,6 +151,9 @@ public enum ParityLedger {
         "corveil-status",
         "corveil-disconnect",
         "corveil-orgs",
+        "corveil-list-orgs",
+        "corveil-select-org",
+        "corveil-deselect-org",
     ]
 
     /// Every method reachable through the live router pair — the daemon's
@@ -369,19 +372,27 @@ public enum ParityLedger {
         // Corveil connection — the local-only write path (CROW-1120). The "door"
         // the OAuth client (corveil/crow#1119) and org provisioning
         // (corveil/crow#1121) persist a `CorveilConnection` through, never
-        // `set-config`, because it holds OAuth tokens. All four are local-only on
-        // `/rpc` (RPCWebSocketHandler.localOnlyDenial): the two writes author a
-        // credential, and the two reads are gated alongside them so the connection
+        // `set-config`, because it holds OAuth tokens. All are local-only on
+        // `/rpc` (RPCWebSocketHandler.localOnlyDenial): the writes author a
+        // credential, and the reads are gated alongside them so the connection
         // is one local-only surface — the `mcp-token-list` precedent.
         //
-        // `corveil-status`/`corveil-orgs` return only non-secret connection fields
-        // — never a token — so they are safe reads; they are gated for
-        // surface-coherence, not because they leak. NOT MCP-exported: the surface
-        // is a credential store and the MCP server is read-only.
+        // `corveil-status`/`corveil-orgs`/`corveil-list-orgs` return only
+        // non-secret fields — never a token or key value — so they are safe reads;
+        // they are gated for surface-coherence, not because they leak. NOT
+        // MCP-exported: the surface is a credential store and the MCP server is
+        // read-only.
+        //
+        // `corveil-list-orgs` reads the user's Corveil memberships (cached) with
+        // the OAuth bearer; `corveil-select-org`/`corveil-deselect-org` mint/reuse
+        // and revoke the one per-org gateway key (corveil/crow#1121).
         .write("corveil-connect", cli: "corveil connect"),
         .read("corveil-status", cli: "corveil status"),
         .write("corveil-disconnect", cli: "corveil disconnect"),
         .read("corveil-orgs", cli: "corveil orgs"),
+        .read("corveil-list-orgs", cli: "corveil list-orgs"),
+        .write("corveil-select-org", cli: "corveil select-org"),
+        .write("corveil-deselect-org", cli: "corveil deselect-org"),
 
         // Jobs
         .read("job-list", cli: "job list"),
@@ -738,55 +749,32 @@ public enum ParityLedger {
         // CROW-1120 gave the block its CLI surface: `corveil connect` writes the
         // identity + tokens, `corveil status` reads the non-secret health, `corveil
         // orgs` reads the per-org key metadata, and `corveil disconnect` clears it.
-        // The three token strings stay read-exempt (a secret is never read back,
-        // like `webAuth.hashB64`), and `orgKeys[].*` stay write-exempt (provisioned
-        // by corveil/crow#1121, not by `corveil connect`).
+        // CROW-1121 adds the provisioning verbs: `corveil select-org` mints/reuses
+        // the per-org gateway key (writing `orgKeys[].*` + the secret
+        // `orgKeySecrets` value) and `corveil deselect-org` revokes it. The OAuth
+        // token strings and the per-org key values stay read-exempt (a secret is
+        // never read back, like `webAuth.hashB64`).
 
         .field("corveilConnection.baseURL", read: "corveil status", write: "corveil connect"),
         .field("corveilConnection.clientID", read: "corveil status", write: "corveil connect"),
         .field("corveilConnection.connectedUser.id", read: "corveil status", write: "corveil connect"),
         .field("corveilConnection.connectedUser.email", read: "corveil status", write: "corveil connect"),
         .field("corveilConnection.connectedUser.name", read: "corveil status", write: "corveil connect"),
+        .field("corveilConnection.orgKeys[].orgID", read: "corveil orgs", write: "corveil select-org"),
+        .field("corveilConnection.orgKeys[].orgName", read: "corveil orgs", write: "corveil select-org"),
+        .field("corveilConnection.orgKeys[].keyID", read: "corveil orgs", write: "corveil select-org"),
+        .field("corveilConnection.orgKeys[].keyPrefix", read: "corveil orgs", write: "corveil select-org"),
+        .field("corveilConnection.orgKeys[].createdAt", read: "corveil orgs", write: "corveil select-org"),
         .field(
-            "corveilConnection.orgKeys[].orgID",
-            read: "corveil orgs",
-            writeNoCLI: """
-                Corveil org id for one auto-provisioned gateway key (CROW-1118). \
-                Populated by the local-only org-provisioning step (corveil/crow#1121), \
-                not by `corveil connect`; not user-settable.
-                """),
-        .field(
-            "corveilConnection.orgKeys[].orgName",
-            read: "corveil orgs",
-            writeNoCLI: """
-                Display name of a Corveil org with an auto-provisioned key \
-                (CROW-1118). Populated by the local-only provisioning flow \
-                (corveil/crow#1121); read via `corveil orgs`, not independently set.
-                """),
-        .field(
-            "corveilConnection.orgKeys[].keyID",
-            read: "corveil orgs",
-            writeNoCLI: """
-                Id of the auto-provisioned per-org gateway key — the handle a \
-                disconnect revokes by (CROW-1118). Minted server-side by the \
-                provisioning flow (corveil/crow#1121); not user-settable.
-                """),
-        .field(
-            "corveilConnection.orgKeys[].keyPrefix",
-            read: "corveil orgs",
-            writeNoCLI: """
-                Display prefix of the auto-provisioned per-org key so the UI can tell \
-                keys apart (CROW-1118). Derived from the minted key during \
-                provisioning (corveil/crow#1121); not independently settable.
-                """),
-        .field(
-            "corveilConnection.orgKeys[].createdAt",
-            read: "corveil orgs",
-            writeNoCLI: """
-                Mint timestamp of the per-org gateway key (CROW-1118). Stamped when \
-                the key is provisioned by the local-only flow (corveil/crow#1121); \
-                not user-settable.
-                """),
+            "corveilConnection.orgKeySecrets",
+            readNoCLI: """
+                Per-org `sk-citadel-…` gateway-key values (secret), keyed by org id \
+                (CROW-1121). Never read back by any surface — `corveil orgs` reports \
+                the key metadata only, never the value — so exposing it would defeat \
+                holding a spendable credential locally. Written by `corveil \
+                select-org` and blanked by `SettingsSecrets` for transport.
+                """,
+            write: "corveil select-org"),
         .field(
             "corveilConnection.oauth.accessToken",
             readNoCLI: """

--- a/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
+++ b/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
@@ -12,6 +12,8 @@ import Foundation
 ///   - each `workspaces[].gateway.customHeaders` value (per-workspace gateway auth)
 ///   - `corveilConnection.oauth` token strings (Corveil OAuth access / refresh /
 ///     registration-access tokens — CROW-1118)
+///   - `corveilConnection.orgKeySecrets` values (per-org `sk-citadel-…` gateway
+///     keys — CROW-1121)
 ///
 /// So the web round-trip is deliberately trivial: **strip** the credential values
 /// on the way out (the browser shows names/URLs/username read-only but never the
@@ -61,10 +63,18 @@ public enum SettingsSecrets {
         // what's connected without ever seeing a token. Like a gateway header
         // value, only the secret is blanked, not the surrounding structure — the
         // block still decodes unchanged in shape.
+        //
+        // The per-org gateway-key *values* (`orgKeySecrets`, CROW-1121) are the
+        // same kind of secret as the OAuth tokens: blank the values but keep the
+        // org-id keys, so the read-only view still knows which orgs are
+        // provisioned (the same information `orgKeys` metadata already carries)
+        // without holding a spendable `sk-citadel-…` key.
         if c.corveilConnection != nil {
             c.corveilConnection?.oauth.accessToken = ""
             c.corveilConnection?.oauth.refreshToken = ""
             c.corveilConnection?.oauth.registrationAccessToken = ""
+            let blankedOrgKeys = c.corveilConnection?.orgKeySecrets.mapValues { _ in "" } ?? [:]
+            c.corveilConnection?.orgKeySecrets = blankedOrgKeys
         }
         return c
     }
@@ -99,12 +109,13 @@ public enum SettingsSecrets {
         result.mcpTokens = current?.mcpTokens ?? []
         result.managerGateway = current?.managerGateway
         // Corveil connection (CROW-1118): authored only through the local-only
-        // Connect (OAuth) flow and its CLI verbs (corveil/crow#1120), never
-        // `set-config`. Restore the whole block from `current` — exactly like
-        // `managerGateway` above — so a browser can neither read the OAuth tokens
-        // (blanked by `strippedForTransport`) nor change or clear the connection
-        // through a config save. A nil `current` drops it, so a client can't
-        // introduce a forged connection when no config is stored yet.
+        // Connect (OAuth) flow and its CLI verbs (corveil/crow#1120) plus the
+        // org-provisioning flow (corveil/crow#1121), never `set-config`. Restore
+        // the whole block from `current` — exactly like `managerGateway` above —
+        // so a browser can neither read the OAuth tokens or per-org key values
+        // (both blanked by `strippedForTransport`) nor change or clear the
+        // connection through a config save. A nil `current` drops it, so a client
+        // can't introduce a forged connection when no config is stored yet.
         result.corveilConnection = current?.corveilConnection
         // Session-log collector (CROW-1070): the `logSync` block is now ordinary,
         // non-secret behavior tuning, so — unlike the gateways/tokens above — it is

--- a/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
@@ -39,6 +39,7 @@ import CrowCore
                     keyPrefix: "sk-citadel-AbC",
                     createdAt: Date(timeIntervalSince1970: 1_800_000_000)),
             ],
+            orgKeySecrets: ["org1": "sk-citadel-AbCdEfGhIjKlMnOp"],
             oauth: CorveilOAuthTokens(
                 accessToken: "CORVEIL-ACCESS-SECRET",
                 refreshToken: "CORVEIL-REFRESH-SECRET",
@@ -222,6 +223,9 @@ import CrowCore
         #expect(stripped.corveilConnection?.oauth.accessToken == "")
         #expect(stripped.corveilConnection?.oauth.refreshToken == "")
         #expect(stripped.corveilConnection?.oauth.registrationAccessToken == "")
+        // …as is the per-org gateway-key value, but its org-id key stays so the
+        // read-only view still knows which orgs are provisioned (CROW-1121).
+        #expect(stripped.corveilConnection?.orgKeySecrets["org1"] == "")
         // …but everything the read-only Integrations view needs survives.
         #expect(stripped.corveilConnection?.baseURL == "https://corveil.example")
         #expect(stripped.corveilConnection?.clientID == "crow-client-id")
@@ -242,6 +246,8 @@ import CrowCore
         #expect(!text.contains("CORVEIL-ACCESS-SECRET"))
         #expect(!text.contains("CORVEIL-REFRESH-SECRET"))
         #expect(!text.contains("CORVEIL-REG-SECRET"))
+        // The per-org `sk-citadel-…` key value is a secret too and must not ship.
+        #expect(!text.contains("sk-citadel-AbCdEfGhIjKlMnOp"))
     }
 
     @Test func preserveRestoresCorveilConnectionAndIgnoresBrowserEdits() {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilAPIClient.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilAPIClient.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking  // URLRequest/URLResponse/URLSession live here on Linux
+#endif
+
+/// The Corveil REST client backing org listing + one-key-per-org provisioning
+/// (CROW-1121).
+///
+/// Where ``CorveilOAuthClient`` speaks the OAuth `/mcp/oauth/*` protocol to get a
+/// user-scoped bearer, this client uses that bearer against the constrained
+/// `/api/*` surface the backend opened for the Crow connected app
+/// (RadiusMethod/corveil#2704, #2706):
+///   - **list orgs** — `GET {base}/api/me/organizations` (scope `orgs.read`) →
+///     the memberships the org dropdown renders.
+///   - **provision key** — `POST {base}/api/keys` (scope `keys.provision`) → mints
+///     one `sk-citadel-…` gateway key in a named org. The backend enforces **one
+///     active key per (org, user, client)**: each mint deactivates the prior key
+///     this client made for the user in that org. So a caller must reuse a stored
+///     key and only re-POST to rotate — re-minting silently invalidates the old
+///     value (``CorveilOrgProvisioner`` is where that reuse lives).
+///   - **revoke key** — `DELETE {base}/api/keys/{id}` (scope `keys.provision`) →
+///     soft-deactivates a key this client minted; `404` if it is already gone or
+///     was minted by someone else.
+///
+/// It performs **no I/O beyond HTTP** and holds no state — the access-token
+/// freshness, the org-list cache, and the config write live in
+/// ``CorveilOrgProvisioner``. `transport` is injected so tests drive the whole
+/// flow against a stub without a live Corveil, exactly like ``CorveilOAuthClient``.
+struct CorveilAPIClient: Sendable {
+    /// Performs one HTTP round-trip. Defaults to `URLSession.shared` in ``live``.
+    var transport: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    /// The production client, backed by `URLSession`.
+    static let live = CorveilAPIClient(
+        transport: { try await URLSession.shared.data(for: $0) })
+
+    // MARK: - Errors
+
+    /// Every way an API call can fail, with enough detail to render a diagnostic.
+    enum Failure: Error, Equatable, CustomStringConvertible {
+        /// The base URL couldn't be turned into the `/api/*` endpoints.
+        case invalidBaseURL(String)
+        /// The transport threw (DNS, TLS, connection refused, …).
+        case transport(String)
+        /// The bearer was rejected (401/403) — the token expired or lacks a scope.
+        /// Split out because it is the one failure a caller acts on differently
+        /// (reconnect / refresh) rather than surfacing verbatim.
+        case unauthorized(status: Int, message: String)
+        /// A structured API error body (`{"error":{"message":…,"type":…}}`).
+        case api(status: Int, type: String, message: String)
+        /// A non-2xx response that did not carry a structured error body.
+        case http(status: Int, body: String)
+        /// A 2xx response whose body didn't decode / lacked a required field.
+        case malformedResponse(String)
+
+        var description: String {
+            switch self {
+            case .invalidBaseURL(let url): return "invalid Corveil base URL: \(url)"
+            case .transport(let message): return "network error: \(message)"
+            case .unauthorized(let status, let message):
+                return "Corveil rejected the connection (HTTP \(status)): \(message)"
+            case .api(let status, let type, let message):
+                return "Corveil returned HTTP \(status) (\(type)): \(message)"
+            case .http(let status, let body):
+                return "Corveil returned HTTP \(status): \(body.prefix(200))"
+            case .malformedResponse(let detail): return "unexpected Corveil response: \(detail)"
+            }
+        }
+    }
+
+    // MARK: - Endpoints
+
+    /// The `/api/*` endpoints, resolved against a Corveil base URL.
+    struct Endpoints: Sendable, Equatable {
+        let organizations: URL
+        let keys: URL
+        private let root: URL
+
+        /// Resolve from a base URL like `https://app.corveil.example`. A trailing
+        /// slash is tolerated. Returns nil unless the URL is an `http`/`https` URL
+        /// with a host, so a `file://` or custom-scheme base URL is rejected here
+        /// rather than reaching the transport — the same guard ``CorveilOAuthClient``
+        /// applies.
+        init?(baseURL: String) {
+            let trimmed = baseURL.trimmingCharacters(in: .whitespaces)
+            guard let root = URL(string: trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed),
+                  let scheme = root.scheme?.lowercased(), scheme == "http" || scheme == "https",
+                  root.host != nil
+            else { return nil }
+            self.root = root
+            organizations = root.appendingPathComponent("api/me/organizations")
+            keys = root.appendingPathComponent("api/keys")
+        }
+
+        /// `DELETE /api/keys/{id}` for a specific key id. The id is path-escaped so
+        /// a hostile/odd id can't break out of the path.
+        func key(id: String) -> URL {
+            root.appendingPathComponent("api/keys").appendingPathComponent(id)
+        }
+    }
+
+    // MARK: - Models
+
+    /// One Corveil org the user belongs to — the shape `GET /api/me/organizations`
+    /// returns (`{organization_id, organization_name, role, is_active, …}`), pared
+    /// to what the dropdown and provisioning need.
+    struct Organization: Sendable, Equatable {
+        let id: String
+        let name: String
+        let role: String
+        let isActive: Bool
+    }
+
+    /// A freshly-minted gateway key. `value` is the full `sk-citadel-…` secret,
+    /// present only on creation; `prefix` is the display prefix.
+    struct ProvisionedKey: Sendable, Equatable {
+        let id: String
+        let prefix: String
+        let value: String
+        let createdAt: Date?
+    }
+
+    // MARK: - Operations
+
+    /// `GET /api/me/organizations` — every org the bearer's user belongs to.
+    func listOrganizations(baseURL: String, accessToken: String) async throws -> [Organization] {
+        let endpoints = try resolve(baseURL)
+        var request = URLRequest(url: endpoints.organizations)
+        request.httpMethod = "GET"
+        authorize(&request, accessToken)
+
+        let json = try await sendExpectingJSON(request)
+        guard let rows = json["organizations"] as? [[String: Any]] else {
+            throw Failure.malformedResponse("organizations response had no organizations array")
+        }
+        return rows.compactMap(Self.decodeOrganization)
+    }
+
+    /// `POST /api/keys` — mint one gateway key in `orgID`. The backend auto-resolves
+    /// a team and tags the key to this client, and returns the full `sk-citadel-…`
+    /// value exactly once, here.
+    func provisionKey(
+        baseURL: String, accessToken: String, orgID: String, name: String
+    ) async throws -> ProvisionedKey {
+        let endpoints = try resolve(baseURL)
+        var request = URLRequest(url: endpoints.keys)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        authorize(&request, accessToken)
+        let body: [String: Any] = ["organization_id": orgID, "name": name]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        let json = try await sendExpectingJSON(request)
+        guard let id = json["id"] as? String, !id.isEmpty else {
+            throw Failure.malformedResponse("key response had no id")
+        }
+        guard let value = json["key"] as? String, !value.isEmpty else {
+            // `key` is only set on creation; its absence means we didn't get a
+            // usable key back and must not persist a keyless record.
+            throw Failure.malformedResponse("key response had no key value")
+        }
+        return ProvisionedKey(
+            id: id,
+            prefix: (json["key_prefix"] as? String) ?? "",
+            value: value,
+            createdAt: Self.parseTimestamp(json["created_at"]))
+    }
+
+    /// `DELETE /api/keys/{id}` — revoke a key this client minted. A `404` means the
+    /// key is already gone (revoked elsewhere, or never existed), which is success
+    /// for a caller whose goal is "this key no longer exists".
+    func revokeKey(baseURL: String, accessToken: String, keyID: String) async throws {
+        let endpoints = try resolve(baseURL)
+        var request = URLRequest(url: endpoints.key(id: keyID))
+        request.httpMethod = "DELETE"
+        authorize(&request, accessToken)
+
+        do {
+            _ = try await sendExpectingJSON(request, allowEmptyBody: true)
+        } catch Failure.api(let status, _, _) where status == 404 {
+            return  // already gone — the desired end state
+        } catch Failure.http(let status, _) where status == 404 {
+            return
+        }
+    }
+
+    // MARK: - Decoding helpers
+
+    private static func decodeOrganization(_ row: [String: Any]) -> Organization? {
+        guard let id = row["organization_id"] as? String, !id.isEmpty else { return nil }
+        return Organization(
+            id: id,
+            name: (row["organization_name"] as? String) ?? "",
+            role: (row["role"] as? String) ?? "",
+            isActive: (row["is_active"] as? Bool) ?? false)
+    }
+
+    /// Corveil timestamps are RFC 3339 strings. Accept both the plain and the
+    /// fractional-seconds shapes (a single `ISO8601DateFormatter` accepts only
+    /// one), mirroring `CorveilConnectionRPC.parseExpiry`.
+    private static func parseTimestamp(_ value: Any?) -> Date? {
+        guard let string = value as? String, !string.isEmpty else { return nil }
+        let plain = ISO8601DateFormatter()
+        if let date = plain.date(from: string) { return date }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: string)
+    }
+
+    // MARK: - HTTP plumbing
+
+    private func resolve(_ baseURL: String) throws -> Endpoints {
+        guard let endpoints = Endpoints(baseURL: baseURL) else {
+            throw Failure.invalidBaseURL(baseURL)
+        }
+        return endpoints
+    }
+
+    private func authorize(_ request: inout URLRequest, _ accessToken: String) {
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+    }
+
+    /// Run `request`, map transport/HTTP/API failures to ``Failure``, and return
+    /// the decoded JSON object on 2xx. `allowEmptyBody` tolerates a 2xx with no
+    /// JSON body (some DELETEs), returning an empty dictionary.
+    private func sendExpectingJSON(
+        _ request: URLRequest, allowEmptyBody: Bool = false
+    ) async throws -> [String: Any] {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await transport(request)
+        } catch {
+            throw Failure.transport(error.localizedDescription)
+        }
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+
+        guard (200...299).contains(status) else {
+            // The backend's error body is `{"error":{"message":…,"type":…}}`
+            // (OpenAI-shaped). Surface 401/403 as `.unauthorized` so a caller can
+            // distinguish "reconnect" from a plain request error.
+            let (type, message) = Self.errorFields(object)
+            if status == 401 || status == 403 {
+                throw Failure.unauthorized(status: status, message: message ?? "not authorized")
+            }
+            if let message {
+                throw Failure.api(status: status, type: type ?? "error", message: message)
+            }
+            throw Failure.http(status: status, body: String(decoding: data, as: UTF8.self))
+        }
+        if let object { return object }
+        if allowEmptyBody { return [:] }
+        throw Failure.malformedResponse("response body was not a JSON object")
+    }
+
+    /// Pull `error.message` / `error.type` out of an OpenAI-shaped error body.
+    private static func errorFields(_ object: [String: Any]?) -> (type: String?, message: String?) {
+        guard let error = object?["error"] as? [String: Any] else { return (nil, nil) }
+        return (error["type"] as? String, error["message"] as? String)
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilAPIClient.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilAPIClient.swift
@@ -93,11 +93,24 @@ struct CorveilAPIClient: Sendable {
             keys = root.appendingPathComponent("api/keys")
         }
 
-        /// `DELETE /api/keys/{id}` for a specific key id. The id is path-escaped so
-        /// a hostile/odd id can't break out of the path.
+        /// `DELETE /api/keys/{id}` for a specific key id. Callers validate `id` is a
+        /// single safe path segment first (``isSafeKeyID``): `appendingPathComponent`
+        /// does not encode `/` and does not collapse `..`, so an id like `../me` would
+        /// otherwise resolve to a different endpoint. Key ids are backend-issued
+        /// UUIDs, so this is defense-in-depth against a hostile `baseURL`.
         func key(id: String) -> URL {
             root.appendingPathComponent("api/keys").appendingPathComponent(id)
         }
+    }
+
+    /// Whether a key id is a single, safe URL path segment. Rejects the sequences
+    /// `appendingPathComponent` mishandles — path separators and `..` traversal —
+    /// plus empty/whitespace. Backend key ids are UUIDs; anything else is anomalous.
+    static func isSafeKeyID(_ id: String) -> Bool {
+        !id.trimmingCharacters(in: .whitespaces).isEmpty
+            && !id.contains("/")
+            && !id.contains("\\")
+            && !id.contains("..")
     }
 
     // MARK: - Models
@@ -172,6 +185,11 @@ struct CorveilAPIClient: Sendable {
     /// for a caller whose goal is "this key no longer exists".
     func revokeKey(baseURL: String, accessToken: String, keyID: String) async throws {
         let endpoints = try resolve(baseURL)
+        guard Self.isSafeKeyID(keyID) else {
+            // An id carrying `/` or `..` could target a different endpoint via
+            // `appendingPathComponent`; refuse rather than issue the request.
+            throw Failure.malformedResponse("unsafe key id")
+        }
         var request = URLRequest(url: endpoints.key(id: keyID))
         request.httpMethod = "DELETE"
         authorize(&request, accessToken)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionRPCSupport.swift
@@ -75,9 +75,10 @@ enum CorveilConnectionRPC {
     /// Build the connection to persist by merging `input` over `stored`.
     ///
     /// Non-blank fields overwrite; blank or absent fields keep the stored value
-    /// (or empty when nothing is stored). `orgKeys` are always carried over
-    /// untouched — they are provisioned by a separate flow (corveil/crow#1121),
-    /// and a token refresh through this door must not drop them.
+    /// (or empty when nothing is stored). `orgKeys` **and** their secret
+    /// `orgKeySecrets` are always carried over untouched — they are provisioned by
+    /// a separate flow (corveil/crow#1121), and a token refresh through this door
+    /// must not drop the shared per-org gateway keys.
     ///
     /// Rejects a merged result that lacks a client id **or** an access token. This
     /// is deliberately stricter than `CorveilConnection.isEmpty`, which is an AND
@@ -101,6 +102,7 @@ enum CorveilConnectionRPC {
                 email: pick(input.userEmail, base.connectedUser.email),
                 name: pick(input.userName, base.connectedUser.name)),
             orgKeys: base.orgKeys,
+            orgKeySecrets: base.orgKeySecrets,
             oauth: CorveilOAuthTokens(
                 accessToken: pick(input.accessToken, base.oauth.accessToken),
                 refreshToken: pick(input.refreshToken, base.oauth.refreshToken),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
@@ -189,15 +189,28 @@ enum CorveilConnectionPersistence {
     /// into whatever is stored now — so a token refresh that landed between the
     /// mint and this write is preserved, and re-selecting an org replaces its key
     /// in place rather than appending a duplicate.
-    static func upsertOrgKey(devRoot: String, orgKey: CorveilOrgKey, secret: String) throws {
+    ///
+    /// Returns whether the key was written. **Disconnect-wins:** if no connection is
+    /// stored — because a `corveil-disconnect` cleared it while this mint was in
+    /// flight (`select-org` and `disconnect` sit in different `/rpc` lanes, so they
+    /// overlap) — this refuses to create one, exactly like `updateTokens` /
+    /// `recordRefreshSuccess` / `removeOrg`. Materializing a `CorveilConnection` here
+    /// would leave a "zombie" block that reads as disconnected (`isEmpty` checks only
+    /// the client id + access token) yet holds a spendable `sk-citadel-…` in
+    /// `orgKeySecrets`, which the next `corveil-connect` merge would silently inherit.
+    /// The caller (`CorveilOrgProvisioner.provision`) revokes the now-orphaned key
+    /// when this returns false.
+    @discardableResult
+    static func upsertOrgKey(devRoot: String, orgKey: CorveilOrgKey, secret: String) throws -> Bool {
         try ConfigStore.withConfigLock {
             var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-            var connection = config.corveilConnection ?? CorveilConnection()
+            guard var connection = config.corveilConnection else { return false }
             connection.orgKeys.removeAll { $0.orgID == orgKey.orgID }
             connection.orgKeys.append(orgKey)
             connection.orgKeySecrets[orgKey.orgID] = secret
             config.corveilConnection = connection
             try ConfigStore.saveConfig(config, devRoot: devRoot)
+            return true
         }
     }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
@@ -182,6 +182,43 @@ enum CorveilConnectionPersistence {
             return true
         }
     }
+
+    /// Store (or replace) the one provisioned gateway key for an org: its metadata
+    /// in `orgKeys` and its `sk-citadel-…` value in the secret `orgKeySecrets`
+    /// (corveil/crow#1121). Read-modify-write under the shared config lock, merging
+    /// into whatever is stored now — so a token refresh that landed between the
+    /// mint and this write is preserved, and re-selecting an org replaces its key
+    /// in place rather than appending a duplicate.
+    static func upsertOrgKey(devRoot: String, orgKey: CorveilOrgKey, secret: String) throws {
+        try ConfigStore.withConfigLock {
+            var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            var connection = config.corveilConnection ?? CorveilConnection()
+            connection.orgKeys.removeAll { $0.orgID == orgKey.orgID }
+            connection.orgKeys.append(orgKey)
+            connection.orgKeySecrets[orgKey.orgID] = secret
+            config.corveilConnection = connection
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+        }
+    }
+
+    /// Drop an org's provisioned key metadata and secret (a deselect). Returns
+    /// whether anything was actually removed, so the caller can distinguish "cleared
+    /// a key" from "nothing was there". Leaves the rest of the connection intact.
+    @discardableResult
+    static func removeOrg(devRoot: String, orgID: String) throws -> Bool {
+        try ConfigStore.withConfigLock {
+            var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+            guard var connection = config.corveilConnection else { return false }
+            let hadKey = connection.orgKeys.contains { $0.orgID == orgID }
+            let hadSecret = connection.orgKeySecrets[orgID] != nil
+            guard hadKey || hadSecret else { return false }
+            connection.orgKeys.removeAll { $0.orgID == orgID }
+            connection.orgKeySecrets[orgID] = nil
+            config.corveilConnection = connection
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+            return true
+        }
+    }
 }
 
 // MARK: - Refresh

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilConnectionStore.swift
@@ -190,21 +190,28 @@ enum CorveilConnectionPersistence {
     /// mint and this write is preserved, and re-selecting an org replaces its key
     /// in place rather than appending a duplicate.
     ///
-    /// Returns whether the key was written. **Disconnect-wins:** if no connection is
-    /// stored — because a `corveil-disconnect` cleared it while this mint was in
-    /// flight (`select-org` and `disconnect` sit in different `/rpc` lanes, so they
-    /// overlap) — this refuses to create one, exactly like `updateTokens` /
-    /// `recordRefreshSuccess` / `removeOrg`. Materializing a `CorveilConnection` here
-    /// would leave a "zombie" block that reads as disconnected (`isEmpty` checks only
-    /// the client id + access token) yet holds a spendable `sk-citadel-…` in
-    /// `orgKeySecrets`, which the next `corveil-connect` merge would silently inherit.
-    /// The caller (`CorveilOrgProvisioner.provision`) revokes the now-orphaned key
-    /// when this returns false.
+    /// Returns whether the key was written. **Reconnect-wins** (mirrors
+    /// ``recordRefreshSuccess``): the write is refused unless the stored connection
+    /// is still the same grant that minted — its `clientID` must equal
+    /// `expectedClientID`. `select-org` and `connect`/`disconnect` sit in different
+    /// `/rpc` lanes (and browser Connect is HTTP, un-laned), so they overlap; if a
+    /// disconnect cleared the block or a reconnect — even as a **different account**,
+    /// which gets a fresh DCR client id — replaced it while this mint was in flight,
+    /// writing here would attach a spendable `sk-citadel-…` to a connection that
+    /// didn't make it (`isEmpty` can't catch that; a different live connection is not
+    /// empty). Using the client id, not the refresh token, means a concurrent token
+    /// refresh (same client id) still lands. The caller
+    /// (``CorveilOrgProvisioner/provision``) revokes the now-orphaned key when this
+    /// returns false.
     @discardableResult
-    static func upsertOrgKey(devRoot: String, orgKey: CorveilOrgKey, secret: String) throws -> Bool {
+    static func upsertOrgKey(
+        devRoot: String, expectedClientID: String, orgKey: CorveilOrgKey, secret: String
+    ) throws -> Bool {
         try ConfigStore.withConfigLock {
             var config = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-            guard var connection = config.corveilConnection else { return false }
+            guard var connection = config.corveilConnection,
+                  connection.clientID == expectedClientID
+            else { return false }
             connection.orgKeys.removeAll { $0.orgID == orgKey.orgID }
             connection.orgKeys.append(orgKey)
             connection.orgKeySecrets[orgKey.orgID] = secret

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
@@ -110,10 +110,10 @@ enum CorveilOrgProvisioner {
     /// `force == true` (rotate), a fresh key is minted; the backend deactivates the
     /// prior one as part of the mint, so the stored record is simply replaced.
     ///
-    /// `orgName` is the display name to store. `nil` (or empty) means "look it up
-    /// from the user's memberships" — done lazily on the mint path only, which also
-    /// validates `orgID` is a real membership. A caller that already knows the name
-    /// (the UI) passes it to skip that lookup.
+    /// `orgName` is a display-name override to store. It never bypasses validation:
+    /// the mint path always confirms `orgID` is one of the user's memberships
+    /// (a cached lookup) and falls back to the membership's own name when `orgName`
+    /// is nil or empty. A reuse skips this lookup entirely.
     static func provision(
         devRoot: String,
         orgID: String,
@@ -137,9 +137,11 @@ enum CorveilOrgProvisioner {
             return SelectOutcome(orgKey: existing, reused: true)
         }
 
-        // Mint path. Resolve the display name now — from `orgName` if the caller
-        // supplied one, else from the membership list (which also validates that
-        // `orgID` is an org the user actually belongs to).
+        // Mint path. Always validate `orgID` against the user's memberships (a
+        // cheap cached lookup) before minting a spendable key — `--name` is only a
+        // display override, never a way to skip the membership check. The backend
+        // enforces membership too, but validating locally gives a clear error and
+        // never mints for an org the user doesn't belong to.
         let resolvedName = try await resolvedOrgName(
             explicit: orgName, orgID: orgID, connection: connection, token: token,
             cache: cache, apiClient: apiClient, now: now)
@@ -151,14 +153,25 @@ enum CorveilOrgProvisioner {
             keyID: key.id,
             keyPrefix: key.prefix,
             createdAt: key.createdAt ?? now)
-        try CorveilConnectionPersistence.upsertOrgKey(
+        // Disconnect-wins: if a `corveil-disconnect` cleared the connection while the
+        // mint was in flight, the persist is refused (returns false) rather than
+        // resurrecting a zombie connection that holds the key. The key is now
+        // orphaned server-side, so revoke it best-effort and fail the select — never
+        // report success for a key that isn't stored.
+        let stored = try CorveilConnectionPersistence.upsertOrgKey(
             devRoot: devRoot, orgKey: orgKey, secret: key.value)
+        guard stored else {
+            try? await apiClient.revokeKey(
+                baseURL: connection.baseURL, accessToken: token, keyID: key.id)
+            throw ProvisionError.notConnected
+        }
         return SelectOutcome(orgKey: orgKey, reused: false)
     }
 
-    /// The display name to store for a mint: the caller-supplied one wins; otherwise
-    /// look it up in the user's memberships (cached), which also validates that
-    /// `orgID` is one the user belongs to (else `.unknownOrg`).
+    /// The display name to store for a mint. Always fetches the user's memberships
+    /// (cached) to validate that `orgID` is one they belong to (else `.unknownOrg`).
+    /// A caller-supplied `explicit` name overrides the membership's display name but
+    /// does **not** skip that validation — it is display-only.
     private static func resolvedOrgName(
         explicit: String?,
         orgID: String,
@@ -168,16 +181,14 @@ enum CorveilOrgProvisioner {
         apiClient: CorveilAPIClient,
         now: Date
     ) async throws -> String {
-        if let explicit, !explicit.trimmingCharacters(in: .whitespaces).isEmpty {
-            return explicit.trimmingCharacters(in: .whitespaces)
-        }
         let orgs = try await cachedOrganizations(
             connection: connection, token: token, cache: cache,
             apiClient: apiClient, now: now, forceRefresh: false)
         guard let match = orgs.first(where: { $0.id == orgID }) else {
             throw ProvisionError.unknownOrg(orgID)
         }
-        return match.name
+        let trimmed = explicit?.trimmingCharacters(in: .whitespaces) ?? ""
+        return trimmed.isEmpty ? match.name : trimmed
     }
 
     // MARK: - Deprovision (deselect)

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
@@ -1,0 +1,233 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+
+/// Org listing + one-key-per-org provisioning (CROW-1121) — the coordinator that
+/// sits between the pure HTTP ``CorveilAPIClient`` and the local-only
+/// ``CorveilConnection`` config, plus the small in-memory cache the org dropdown
+/// reads through.
+///
+/// This is the "on org selection, mint/reuse exactly one gateway key per org"
+/// half of the epic (corveil/crow#1117). The invariants it enforces:
+///   - **one key per org, reused** — a select for an org that already has a stored
+///     key returns it without a network call, so every workspace bound to the org
+///     shares the one `sk-citadel-…` value. This matters because the backend
+///     deactivates the prior key on each `POST /api/keys`
+///     (RadiusMethod/corveil#2706), so re-minting would silently break bound
+///     gateways.
+///   - **rotate = one POST** — `force: true` re-mints; the backend revokes the old
+///     key as part of the mint, so the coordinator just replaces the stored record.
+///   - **deselect = revoke + forget** — `DELETE /api/keys/{id}` (404 tolerated),
+///     then drop the metadata and secret. No dangling local key.
+///
+/// The UI that decides *when* to select/deselect is a sibling ticket
+/// (corveil/crow#1123); the `WorkspaceGateway` generated from the stored secret is
+/// another (corveil/crow#1124). This ticket is only the mechanism, exposed through
+/// the `corveil-list-orgs` / `corveil-select-org` / `corveil-deselect-org` RPCs.
+enum CorveilOrgProvisioner {
+
+    /// How long before an access token's expiry we proactively refresh, so a call
+    /// doesn't race the boundary.
+    static let refreshSkew: TimeInterval = 60
+
+    /// Name attached to a minted key. The backend accepts any name and defaults an
+    /// empty one; a fixed, recognizable value keeps the Corveil dashboard legible
+    /// about who minted the key.
+    static let keyName = "Crow gateway"
+
+    /// Everything that can stop a provisioning call before it reaches the network.
+    enum ProvisionError: Error, CustomStringConvertible, Equatable {
+        /// No usable connection: none stored, or one lacking an access token / base
+        /// URL. The caller should run the Connect flow first.
+        case notConnected
+        /// The named org is not one of the user's Corveil memberships.
+        case unknownOrg(String)
+
+        var description: String {
+            switch self {
+            case .notConnected:
+                return "no usable Corveil connection — connect to Corveil first"
+            case .unknownOrg(let id):
+                return "organization \(id) is not one of your Corveil memberships"
+            }
+        }
+    }
+
+    /// The result of a select: the stored key metadata, and whether it was reused
+    /// (no mint) or freshly provisioned.
+    struct SelectOutcome: Sendable, Equatable {
+        let orgKey: CorveilOrgKey
+        let reused: Bool
+    }
+
+    // MARK: - List
+
+    /// The user's Corveil orgs, served from `cache` when fresh and re-fetched
+    /// otherwise. `forceRefresh` bypasses the cache (the UI's explicit refresh).
+    static func listOrganizations(
+        devRoot: String,
+        cache: CorveilOrgListCache,
+        apiClient: CorveilAPIClient = .live,
+        oauthClient: CorveilOAuthClient = .live,
+        now: Date = Date(),
+        forceRefresh: Bool = false
+    ) async throws -> [CorveilAPIClient.Organization] {
+        let (connection, token) = try await validAccessToken(
+            devRoot: devRoot, oauthClient: oauthClient, now: now)
+        let key = Self.cacheKey(connection)
+        if !forceRefresh, let cached = cache.get(key: key, now: now) {
+            return cached
+        }
+        let orgs = try await apiClient.listOrganizations(baseURL: connection.baseURL, accessToken: token)
+        cache.set(orgs, key: key, now: now)
+        return orgs
+    }
+
+    // MARK: - Provision (select / rotate)
+
+    /// Mint or reuse the one gateway key for `orgID`.
+    ///
+    /// With `force == false` (a plain select), an org that already has a stored key
+    /// and secret is returned untouched — no network call, no new key. With
+    /// `force == true` (rotate), a fresh key is minted; the backend deactivates the
+    /// prior one as part of the mint, so the stored record is simply replaced.
+    static func provision(
+        devRoot: String,
+        orgID: String,
+        orgName: String,
+        apiClient: CorveilAPIClient = .live,
+        oauthClient: CorveilOAuthClient = .live,
+        now: Date = Date(),
+        force: Bool = false
+    ) async throws -> SelectOutcome {
+        let (connection, token) = try await validAccessToken(
+            devRoot: devRoot, oauthClient: oauthClient, now: now)
+
+        // Reuse: a stored key with a non-empty id and secret is the shared per-org
+        // key. Re-minting would rotate it server-side and orphan bound gateways.
+        if !force,
+           let existing = connection.orgKeys.first(where: { $0.orgID == orgID }),
+           !existing.keyID.isEmpty,
+           let secret = connection.orgKeySecrets[orgID], !secret.isEmpty {
+            return SelectOutcome(orgKey: existing, reused: true)
+        }
+
+        let key = try await apiClient.provisionKey(
+            baseURL: connection.baseURL, accessToken: token, orgID: orgID, name: keyName)
+        let orgKey = CorveilOrgKey(
+            orgID: orgID,
+            orgName: orgName,
+            keyID: key.id,
+            keyPrefix: key.prefix,
+            createdAt: key.createdAt ?? now)
+        try CorveilConnectionPersistence.upsertOrgKey(
+            devRoot: devRoot, orgKey: orgKey, secret: key.value)
+        return SelectOutcome(orgKey: orgKey, reused: false)
+    }
+
+    // MARK: - Deprovision (deselect)
+
+    /// Revoke `orgID`'s key server-side and drop its local metadata + secret.
+    /// Returns whether anything was removed. A revoke `404` is treated as success
+    /// (the key is already gone), so a deselect always converges on "no key".
+    @discardableResult
+    static func deprovision(
+        devRoot: String,
+        orgID: String,
+        apiClient: CorveilAPIClient = .live,
+        oauthClient: CorveilOAuthClient = .live,
+        now: Date = Date()
+    ) async throws -> Bool {
+        let (connection, token) = try await validAccessToken(
+            devRoot: devRoot, oauthClient: oauthClient, now: now)
+
+        let keyID = connection.orgKeys.first(where: { $0.orgID == orgID })?.keyID ?? ""
+        if !keyID.isEmpty {
+            try await apiClient.revokeKey(baseURL: connection.baseURL, accessToken: token, keyID: keyID)
+        }
+        return try CorveilConnectionPersistence.removeOrg(devRoot: devRoot, orgID: orgID)
+    }
+
+    // MARK: - Token freshness
+
+    /// Load the stored connection and return it with a usable access token,
+    /// refreshing proactively when the token is at/near expiry and a refresh token
+    /// is available. A refresh failure is swallowed — the (possibly stale) token is
+    /// still tried, and a genuinely dead token surfaces as `.unauthorized` from the
+    /// API call, which is the signal the reconnect UX (corveil/crow#1125) acts on.
+    private static func validAccessToken(
+        devRoot: String,
+        oauthClient: CorveilOAuthClient,
+        now: Date
+    ) async throws -> (connection: CorveilConnection, token: String) {
+        guard var connection = ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection,
+              !connection.isEmpty
+        else { throw ProvisionError.notConnected }
+
+        let expired = connection.oauth.accessTokenExpiresAt
+            .map { $0 <= now.addingTimeInterval(refreshSkew) } ?? false
+        let refreshable = !connection.oauth.refreshToken.trimmingCharacters(in: .whitespaces).isEmpty
+            && CorveilOAuthClient.Endpoints(baseURL: connection.baseURL) != nil
+        if expired && refreshable {
+            _ = try? await CorveilConnectionRefresher.refresh(
+                devRoot: devRoot, client: oauthClient, now: now)
+            if let reloaded = ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection {
+                connection = reloaded
+            }
+        }
+
+        let token = connection.oauth.accessToken.trimmingCharacters(in: .whitespaces)
+        let baseURL = connection.baseURL.trimmingCharacters(in: .whitespaces)
+        guard !token.isEmpty, !baseURL.isEmpty else { throw ProvisionError.notConnected }
+        return (connection, token)
+    }
+
+    /// Cache identity — the org list belongs to one (base URL, user). A reconnect
+    /// as a different user changes the key, so stale memberships never leak across.
+    private static func cacheKey(_ connection: CorveilConnection) -> String {
+        "\(connection.baseURL)\u{1}\(connection.connectedUser.id)"
+    }
+}
+
+/// A tiny TTL cache for one user's Corveil org list (CROW-1121). Lock-guarded so
+/// the concurrent `/rpc` handlers share one instance; keyed on (base URL, user) so
+/// a reconnect as a different user is a miss rather than a leak. Holds only the
+/// membership list — the "which org is provisioned" flag is derived live from the
+/// stored connection, never cached.
+final class CorveilOrgListCache: @unchecked Sendable {
+    /// Long enough that opening the dropdown twice doesn't re-hit the API, short
+    /// enough that a newly-added org membership shows up on its own before long.
+    static let defaultTTL: TimeInterval = 5 * 60
+
+    private let lock = NSLock()
+    private var key: String?
+    private var orgs: [CorveilAPIClient.Organization] = []
+    private var fetchedAt = Date.distantPast
+    private let ttl: TimeInterval
+
+    init(ttl: TimeInterval = defaultTTL) { self.ttl = ttl }
+
+    /// The cached orgs when the key matches and the entry is within its TTL, else
+    /// nil (a miss the caller re-fetches on).
+    func get(key: String, now: Date = Date()) -> [CorveilAPIClient.Organization]? {
+        lock.lock(); defer { lock.unlock() }
+        guard self.key == key, now.timeIntervalSince(fetchedAt) <= ttl else { return nil }
+        return orgs
+    }
+
+    func set(_ orgs: [CorveilAPIClient.Organization], key: String, now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        self.key = key
+        self.orgs = orgs
+        self.fetchedAt = now
+    }
+
+    /// Drop the entry — used when the connection is cleared, so the next list
+    /// re-fetches rather than serving a disconnected user's orgs.
+    func invalidate() {
+        lock.lock(); defer { lock.unlock() }
+        key = nil
+        orgs = []
+        fetchedAt = .distantPast
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
@@ -42,6 +42,10 @@ enum CorveilOrgProvisioner {
         case notConnected
         /// The named org is not one of the user's Corveil memberships.
         case unknownOrg(String)
+        /// The stored connection changed (disconnected, or reconnected as a
+        /// different DCR client) while a key was being minted, so the mint was
+        /// rolled back rather than attached to a connection that didn't make it.
+        case connectionChanged
 
         var description: String {
             switch self {
@@ -49,6 +53,9 @@ enum CorveilOrgProvisioner {
                 return "no usable Corveil connection — connect to Corveil first"
             case .unknownOrg(let id):
                 return "organization \(id) is not one of your Corveil memberships"
+            case .connectionChanged:
+                return "the Corveil connection changed while provisioning — "
+                    + "the key was rolled back; reconnect and try again"
             }
         }
     }
@@ -153,17 +160,21 @@ enum CorveilOrgProvisioner {
             keyID: key.id,
             keyPrefix: key.prefix,
             createdAt: key.createdAt ?? now)
-        // Disconnect-wins: if a `corveil-disconnect` cleared the connection while the
-        // mint was in flight, the persist is refused (returns false) rather than
-        // resurrecting a zombie connection that holds the key. The key is now
-        // orphaned server-side, so revoke it best-effort and fail the select — never
-        // report success for a key that isn't stored.
+        // Disconnect/reconnect-wins: the persist is refused (returns false) unless
+        // the stored connection is still the SAME grant that minted — same client
+        // id. If a `corveil-disconnect` cleared it, or a reconnect / a different
+        // account's Connect replaced it (fresh DCR client id) while the mint was in
+        // flight, the key would otherwise be planted on a connection that didn't
+        // make it. On refusal the key is orphaned server-side, so revoke it
+        // best-effort and fail the select — never report success for a key that
+        // isn't stored, and never attach it to the wrong connection.
         let stored = try CorveilConnectionPersistence.upsertOrgKey(
-            devRoot: devRoot, orgKey: orgKey, secret: key.value)
+            devRoot: devRoot, expectedClientID: connection.clientID,
+            orgKey: orgKey, secret: key.value)
         guard stored else {
             try? await apiClient.revokeKey(
                 baseURL: connection.baseURL, accessToken: token, keyID: key.id)
-            throw ProvisionError.notConnected
+            throw ProvisionError.connectionChanged
         }
         return SelectOutcome(orgKey: orgKey, reused: false)
     }
@@ -262,11 +273,12 @@ enum CorveilOrgProvisioner {
     }
 }
 
-/// A tiny TTL cache for one user's Corveil org list (CROW-1121). Lock-guarded so
-/// the concurrent `/rpc` handlers share one instance; keyed on (base URL, user) so
-/// a reconnect as a different user is a miss rather than a leak. Holds only the
-/// membership list — the "which org is provisioned" flag is derived live from the
-/// stored connection, never cached.
+/// A tiny TTL cache for one connection's Corveil org list (CROW-1121). Lock-guarded
+/// so the concurrent `/rpc` handlers share one instance; keyed on (base URL, DCR
+/// client id) — see ``CorveilOrgProvisioner/cacheKey(_:)`` — so a reconnect (which
+/// gets a fresh client id) is a miss rather than a leak. Holds only the membership
+/// list — the "which org is provisioned" flag is derived live from the stored
+/// connection, never cached.
 final class CorveilOrgListCache: @unchecked Sendable {
     /// Long enough that opening the dropdown twice doesn't re-hit the API, short
     /// enough that a newly-added org membership shows up on its own before long.

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CorveilOrgProvisioner.swift
@@ -74,6 +74,22 @@ enum CorveilOrgProvisioner {
     ) async throws -> [CorveilAPIClient.Organization] {
         let (connection, token) = try await validAccessToken(
             devRoot: devRoot, oauthClient: oauthClient, now: now)
+        return try await cachedOrganizations(
+            connection: connection, token: token, cache: cache,
+            apiClient: apiClient, now: now, forceRefresh: forceRefresh)
+    }
+
+    /// Serve the org list through the cache given an already-resolved
+    /// connection + token. Shared by `listOrganizations` and the mint path's name
+    /// resolution so both hit one cache under one key.
+    private static func cachedOrganizations(
+        connection: CorveilConnection,
+        token: String,
+        cache: CorveilOrgListCache,
+        apiClient: CorveilAPIClient,
+        now: Date,
+        forceRefresh: Bool
+    ) async throws -> [CorveilAPIClient.Organization] {
         let key = Self.cacheKey(connection)
         if !forceRefresh, let cached = cache.get(key: key, now: now) {
             return cached
@@ -88,13 +104,21 @@ enum CorveilOrgProvisioner {
     /// Mint or reuse the one gateway key for `orgID`.
     ///
     /// With `force == false` (a plain select), an org that already has a stored key
-    /// and secret is returned untouched — no network call, no new key. With
+    /// and secret is returned untouched — **no network call at all**, not even the
+    /// membership lookup: a stored key is already known-good, and a reuse must not
+    /// fail on a transient outage or a token that only breaks on refresh. With
     /// `force == true` (rotate), a fresh key is minted; the backend deactivates the
     /// prior one as part of the mint, so the stored record is simply replaced.
+    ///
+    /// `orgName` is the display name to store. `nil` (or empty) means "look it up
+    /// from the user's memberships" — done lazily on the mint path only, which also
+    /// validates `orgID` is a real membership. A caller that already knows the name
+    /// (the UI) passes it to skip that lookup.
     static func provision(
         devRoot: String,
         orgID: String,
-        orgName: String,
+        orgName: String?,
+        cache: CorveilOrgListCache,
         apiClient: CorveilAPIClient = .live,
         oauthClient: CorveilOAuthClient = .live,
         now: Date = Date(),
@@ -105,6 +129,7 @@ enum CorveilOrgProvisioner {
 
         // Reuse: a stored key with a non-empty id and secret is the shared per-org
         // key. Re-minting would rotate it server-side and orphan bound gateways.
+        // Returns before ANY network call — no mint, and no name lookup.
         if !force,
            let existing = connection.orgKeys.first(where: { $0.orgID == orgID }),
            !existing.keyID.isEmpty,
@@ -112,17 +137,47 @@ enum CorveilOrgProvisioner {
             return SelectOutcome(orgKey: existing, reused: true)
         }
 
+        // Mint path. Resolve the display name now — from `orgName` if the caller
+        // supplied one, else from the membership list (which also validates that
+        // `orgID` is an org the user actually belongs to).
+        let resolvedName = try await resolvedOrgName(
+            explicit: orgName, orgID: orgID, connection: connection, token: token,
+            cache: cache, apiClient: apiClient, now: now)
         let key = try await apiClient.provisionKey(
             baseURL: connection.baseURL, accessToken: token, orgID: orgID, name: keyName)
         let orgKey = CorveilOrgKey(
             orgID: orgID,
-            orgName: orgName,
+            orgName: resolvedName,
             keyID: key.id,
             keyPrefix: key.prefix,
             createdAt: key.createdAt ?? now)
         try CorveilConnectionPersistence.upsertOrgKey(
             devRoot: devRoot, orgKey: orgKey, secret: key.value)
         return SelectOutcome(orgKey: orgKey, reused: false)
+    }
+
+    /// The display name to store for a mint: the caller-supplied one wins; otherwise
+    /// look it up in the user's memberships (cached), which also validates that
+    /// `orgID` is one the user belongs to (else `.unknownOrg`).
+    private static func resolvedOrgName(
+        explicit: String?,
+        orgID: String,
+        connection: CorveilConnection,
+        token: String,
+        cache: CorveilOrgListCache,
+        apiClient: CorveilAPIClient,
+        now: Date
+    ) async throws -> String {
+        if let explicit, !explicit.trimmingCharacters(in: .whitespaces).isEmpty {
+            return explicit.trimmingCharacters(in: .whitespaces)
+        }
+        let orgs = try await cachedOrganizations(
+            connection: connection, token: token, cache: cache,
+            apiClient: apiClient, now: now, forceRefresh: false)
+        guard let match = orgs.first(where: { $0.id == orgID }) else {
+            throw ProvisionError.unknownOrg(orgID)
+        }
+        return match.name
     }
 
     // MARK: - Deprovision (deselect)
@@ -182,10 +237,17 @@ enum CorveilOrgProvisioner {
         return (connection, token)
     }
 
-    /// Cache identity — the org list belongs to one (base URL, user). A reconnect
-    /// as a different user changes the key, so stale memberships never leak across.
+    /// Cache identity — the org list belongs to one connection, identified by its
+    /// OAuth **client id**. The browser Connect flow self-registers a fresh client
+    /// per connect (DCR issues a new `client_id` each time), so a disconnect +
+    /// reconnect — even as the same user, certainly as a different one — changes
+    /// this key and misses the cache. This is the cross-path guarantee against
+    /// serving a previous account's memberships: it holds no matter which disconnect
+    /// path (RPC or the HTTP `POST /config/corveil-connection` clear) ran, and does
+    /// not depend on `connectedUser.id`, which the Connect persist path leaves empty.
+    /// `baseURL` is folded in as defensive disambiguation.
     private static func cacheKey(_ connection: CorveilConnection) -> String {
-        "\(connection.baseURL)\u{1}\(connection.connectedUser.id)"
+        "\(connection.baseURL)\u{1}\(connection.clientID)"
     }
 }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -2096,6 +2096,9 @@ func makeCommandRouter(
     handlers.merge(makeMCPTokenHandlers(devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeCorveilHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeCorveilConnectionHandlers(devRoot: devRoot)) { existing, _ in existing }
+    handlers.merge(
+        makeCorveilProvisioningHandlers(cache: CorveilOrgListCache(), devRoot: devRoot)
+    ) { existing, _ in existing }
     handlers.merge(makeBackfillHandlers(devRoot: devRoot)) { existing, _ in existing }
     return CommandRouter(handlers: handlers, fallback: fallback)
 }
@@ -2458,6 +2461,117 @@ private func makeCorveilConnectionHandlers(devRoot: String) -> [String: CommandR
             return CorveilConnectionRPC.orgsJSON(config.corveilConnection)
         },
     ]
+}
+
+/// The `corveil-list-orgs` / `corveil-select-org` / `corveil-deselect-org` verb
+/// group — org listing + one-key-per-org provisioning (CROW-1121).
+///
+/// These reach the network with the stored OAuth bearer: `corveil-list-orgs`
+/// reads the user's Corveil memberships (served through a shared TTL cache), and
+/// the two writes mint/reuse and revoke the one per-org gateway key via
+/// ``CorveilOrgProvisioner``. All three are local-only on `/rpc`
+/// (``RPCWebSocketHandler/localOnlyDenial``): they act with a credential the
+/// browser must never drive, exactly like the connection verbs beside them. The
+/// cache is passed in (constructed once in ``makeCommandRouter``) so it survives
+/// across calls.
+///
+/// Its own function for the type-checker-budget reason `makeMCPTokenHandlers`
+/// states, and it must stay in this file so `scripts/check-cli-parity.sh` can grep
+/// the registrations.
+private func makeCorveilProvisioningHandlers(
+    cache: CorveilOrgListCache, devRoot: String
+) -> [String: CommandRouter.Handler] {
+    [
+        // List the user's Corveil orgs (cached). Each row is annotated with whether
+        // it currently has a provisioned key, so the dropdown can mark selections
+        // without a second call.
+        "corveil-list-orgs": { params in
+            let forceRefresh = params["refresh"]?.boolValue ?? false
+            let orgs = try await corveilMapErrors {
+                try await CorveilOrgProvisioner.listOrganizations(
+                    devRoot: devRoot, cache: cache, forceRefresh: forceRefresh)
+            }
+            let provisioned = Set(
+                (ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection?.orgKeys ?? [])
+                    .map(\.orgID))
+            let rows = orgs.map { org -> JSONValue in
+                .object([
+                    "org_id": .string(org.id),
+                    "org_name": .string(org.name),
+                    "role": .string(org.role),
+                    "is_active": .bool(org.isActive),
+                    "provisioned": .bool(provisioned.contains(org.id)),
+                ])
+            }
+            return ["orgs": .array(rows), "count": .int(rows.count)]
+        },
+        // Select an org: mint or reuse its one gateway key. `rotate` re-mints
+        // (the backend revokes the prior key as part of the mint).
+        "corveil-select-org": { params in
+            guard let orgID = params["org_id"]?.stringValue?.trimmingCharacters(in: .whitespaces),
+                  !orgID.isEmpty
+            else { throw DaemonRPCError.invalidParams("org_id is required") }
+            let rotate = params["rotate"]?.boolValue ?? false
+            let explicitName =
+                params["org_name"]?.stringValue?.trimmingCharacters(in: .whitespaces) ?? ""
+            let outcome = try await corveilMapErrors {
+                let orgName = try await resolveCorveilOrgName(
+                    explicit: explicitName, orgID: orgID, cache: cache, devRoot: devRoot)
+                return try await CorveilOrgProvisioner.provision(
+                    devRoot: devRoot, orgID: orgID, orgName: orgName, force: rotate)
+            }
+            let formatter = ISO8601DateFormatter()
+            return [
+                "saved": .bool(true),
+                "reused": .bool(outcome.reused),
+                "org": .object([
+                    "org_id": .string(outcome.orgKey.orgID),
+                    "org_name": .string(outcome.orgKey.orgName),
+                    "key_id": .string(outcome.orgKey.keyID),
+                    "key_prefix": .string(outcome.orgKey.keyPrefix),
+                    "created_at": outcome.orgKey.createdAt
+                        .map { .string(formatter.string(from: $0)) } ?? .null,
+                ]),
+            ]
+        },
+        // Deselect an org: revoke its key server-side and drop the local record.
+        "corveil-deselect-org": { params in
+            guard let orgID = params["org_id"]?.stringValue?.trimmingCharacters(in: .whitespaces),
+                  !orgID.isEmpty
+            else { throw DaemonRPCError.invalidParams("org_id is required") }
+            let removed = try await corveilMapErrors {
+                try await CorveilOrgProvisioner.deprovision(devRoot: devRoot, orgID: orgID)
+            }
+            return ["saved": .bool(true), "removed": .bool(removed)]
+        },
+    ]
+}
+
+/// Resolve an org's display name for storage: the caller-supplied `--name` wins;
+/// otherwise look it up in the user's memberships (cached), which also validates
+/// that the org id is one the user actually belongs to.
+private func resolveCorveilOrgName(
+    explicit: String, orgID: String, cache: CorveilOrgListCache, devRoot: String
+) async throws -> String {
+    if !explicit.isEmpty { return explicit }
+    let orgs = try await CorveilOrgProvisioner.listOrganizations(devRoot: devRoot, cache: cache)
+    guard let match = orgs.first(where: { $0.id == orgID }) else {
+        throw CorveilOrgProvisioner.ProvisionError.unknownOrg(orgID)
+    }
+    return match.name
+}
+
+/// Map provisioning + Corveil API failures to `DaemonRPCError` so a CLI/web caller
+/// gets a clear message. All are operational (network, auth, not-connected), not
+/// bad params, so they surface as `applicationError`.
+private func corveilMapErrors<T>(_ body: () async throws -> T) async throws -> T {
+    do {
+        return try await body()
+    } catch let error as CorveilOrgProvisioner.ProvisionError {
+        throw DaemonRPCError.applicationError(error.description)
+    } catch let error as CorveilAPIClient.Failure {
+        throw DaemonRPCError.applicationError(error.description)
+    }
 }
 
 /// The binary a `corveil-*` call should act on: the caller's `path`, else the

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -163,6 +163,10 @@ func makeCommandRouter(
     // is off (there'd be no DB to rebuild from).
     rebuildScorecard: (@MainActor @Sendable () async -> Void)? = nil,
     versionUpdateService: VersionUpdateService? = nil,
+    // The Corveil org-list cache (CROW-1121), shared between the connection verbs
+    // (so `corveil-disconnect` can invalidate it) and the provisioning verbs.
+    // Injectable so a test can observe the invalidation; one per router otherwise.
+    corveilOrgCache: CorveilOrgListCache = CorveilOrgListCache(),
     fallback: CommandRouter? = nil
 ) -> CommandRouter {
     // Serializes review kickoffs (see start-review) — one per router instance.
@@ -2095,9 +2099,9 @@ func makeCommandRouter(
     handlers.merge(makeWorkspaceHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeMCPTokenHandlers(devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeCorveilHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
-    handlers.merge(makeCorveilConnectionHandlers(devRoot: devRoot)) { existing, _ in existing }
+    handlers.merge(makeCorveilConnectionHandlers(cache: corveilOrgCache, devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(
-        makeCorveilProvisioningHandlers(cache: CorveilOrgListCache(), devRoot: devRoot)
+        makeCorveilProvisioningHandlers(cache: corveilOrgCache, devRoot: devRoot)
     ) { existing, _ in existing }
     handlers.merge(makeBackfillHandlers(devRoot: devRoot)) { existing, _ in existing }
     return CommandRouter(handlers: handlers, fallback: fallback)
@@ -2413,7 +2417,9 @@ private func makeCorveilHandlers(
 /// Decoding, the secret-safe merge, and the response shapes live in
 /// ``CorveilConnectionRPC`` so this and the browser's
 /// `POST /config/corveil-connection` (``SecretRoutes``) cannot drift.
-private func makeCorveilConnectionHandlers(devRoot: String) -> [String: CommandRouter.Handler] {
+private func makeCorveilConnectionHandlers(
+    cache: CorveilOrgListCache, devRoot: String
+) -> [String: CommandRouter.Handler] {
     [
         // Store or update the connection. A blank/absent field keeps the stored
         // value — an access-token refresh need not restate the refresh token — and
@@ -2447,12 +2453,18 @@ private func makeCorveilConnectionHandlers(devRoot: String) -> [String: CommandR
         // Clear the whole connection. The cascade key-revocation on the Corveil
         // side is a separate concern (corveil/crow#1121, backend); this removes the
         // local block so gateway resolution and the log collector stop using it.
+        // Invalidate the org-list cache too, so a reconnect as a different account
+        // never sees the prior user's memberships before the entry ages out (the
+        // cache is also keyed on the fresh-per-connect client id, which is the
+        // guarantee for the HTTP disconnect path that can't reach this cache).
         "corveil-disconnect": { _ in
-            try mutateConfig(devRoot: devRoot) { config -> [String: JSONValue] in
+            let result = try mutateConfig(devRoot: devRoot) { config -> [String: JSONValue] in
                 let wasConnected = !(config.corveilConnection?.isEmpty ?? true)
                 config.corveilConnection = nil
                 return ["saved": .bool(true), "was_connected": .bool(wasConnected)]
             }
+            cache.invalidate()
+            return result
         },
         // The per-org gateway-key metadata (never key material). See
         // `CorveilConnectionRPC.orgsJSON`.
@@ -2515,10 +2527,13 @@ private func makeCorveilProvisioningHandlers(
             let explicitName =
                 params["org_name"]?.stringValue?.trimmingCharacters(in: .whitespaces) ?? ""
             let outcome = try await corveilMapErrors {
-                let orgName = try await resolveCorveilOrgName(
-                    explicit: explicitName, orgID: orgID, cache: cache, devRoot: devRoot)
-                return try await CorveilOrgProvisioner.provision(
-                    devRoot: devRoot, orgID: orgID, orgName: orgName, force: rotate)
+                // `orgName` nil → the provisioner looks it up (and validates the org
+                // is a real membership) only when it actually mints; a reuse skips
+                // that lookup entirely.
+                try await CorveilOrgProvisioner.provision(
+                    devRoot: devRoot, orgID: orgID,
+                    orgName: explicitName.isEmpty ? nil : explicitName,
+                    cache: cache, force: rotate)
             }
             let formatter = ISO8601DateFormatter()
             return [
@@ -2545,20 +2560,6 @@ private func makeCorveilProvisioningHandlers(
             return ["saved": .bool(true), "removed": .bool(removed)]
         },
     ]
-}
-
-/// Resolve an org's display name for storage: the caller-supplied `--name` wins;
-/// otherwise look it up in the user's memberships (cached), which also validates
-/// that the org id is one the user actually belongs to.
-private func resolveCorveilOrgName(
-    explicit: String, orgID: String, cache: CorveilOrgListCache, devRoot: String
-) async throws -> String {
-    if !explicit.isEmpty { return explicit }
-    let orgs = try await CorveilOrgProvisioner.listOrganizations(devRoot: devRoot, cache: cache)
-    guard let match = orgs.first(where: { $0.id == orgID }) else {
-        throw CorveilOrgProvisioner.ProvisionError.unknownOrg(orgID)
-    }
-    return match.name
 }
 
 /// Map provisioning + Corveil API failures to `DaemonRPCError` so a CLI/web caller

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -137,6 +137,15 @@ enum RPCLanePolicy {
         // lane, like every other read.
         "corveil-connect": .fixed(.config),
         "corveil-disconnect": .fixed(.config),
+        // Org provisioning (CROW-1121) mints/revokes a per-org key over the
+        // network before its small config write, so it must NOT sit on `.config`
+        // (a slow round-trip would park every Settings save). Keyed on the org so
+        // two selects for one org can't double-mint, while different orgs and
+        // config writes proceed in parallel; the config write itself is still
+        // serialized by `ConfigStore.withConfigLock`. `corveil-list-orgs` is a
+        // read and takes no lane.
+        "corveil-select-org": .on("org_id"),
+        "corveil-deselect-org": .on("org_id"),
         "job-add": .fixed(.config),
         "job-edit": .fixed(.config),
         "job-enable": .fixed(.config),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -369,6 +369,15 @@ enum RPCWebSocketHandler {
             // breaks. The browser's own write door is `POST /config/corveil-connection`
             // in `SecretRoutes`, gated the same way.
             return "Corveil connection management is local-only"
+        case "corveil-list-orgs", "corveil-select-org", "corveil-deselect-org":
+            // Org listing + one-key-per-org provisioning (CROW-1121). All three act
+            // with the stored OAuth bearer — a credential — against Corveil: listing
+            // the user's orgs and minting/revoking the per-org gateway key. A remote
+            // peer must no more drive a key mint than it may read the token that
+            // authorizes it, so these are gated exactly like the connection verbs
+            // above. The read-only Integrations view gets nothing from these; it
+            // reads provisioned-org metadata through the stripped `get-config`.
+            return "Corveil org provisioning is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
             return "set-config binaries is local-only"

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilAPIClientTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilAPIClientTests.swift
@@ -192,4 +192,28 @@ import FoundationNetworking
             try await api.revokeKey(baseURL: self.base, accessToken: "tok", keyID: "key-123")
         }
     }
+
+    @Test func revokeKeyRejectsAPathTraversingKeyIDWithoutSendingARequest() async throws {
+        let log = RequestLog()
+        let api = client(log: log) { _ in (200, Data()) }
+        // `appendingPathComponent` neither encodes `/` nor collapses `..`, so an id
+        // like `../me` would target a different endpoint. Reject before any request.
+        for badID in ["../me", "a/b", "..", "keys/../secrets", ""] {
+            await #expect(throws: CorveilAPIClient.Failure.self) {
+                try await api.revokeKey(baseURL: self.base, accessToken: "tok", keyID: badID)
+            }
+        }
+        #expect(log.all.isEmpty, "an unsafe key id must never reach the network")
+    }
+
+    @Test func isSafeKeyIDAcceptsUUIDsAndRejectsTraversal() {
+        #expect(CorveilAPIClient.isSafeKeyID("3fa85f64-5717-4562-b3fc-2c963f66afa6"))
+        #expect(CorveilAPIClient.isSafeKeyID("key-123"))
+        #expect(!CorveilAPIClient.isSafeKeyID(""))
+        #expect(!CorveilAPIClient.isSafeKeyID("   "))
+        #expect(!CorveilAPIClient.isSafeKeyID("a/b"))
+        #expect(!CorveilAPIClient.isSafeKeyID(".."))
+        #expect(!CorveilAPIClient.isSafeKeyID("../me"))
+        #expect(!CorveilAPIClient.isSafeKeyID("a\\b"))
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilAPIClientTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilAPIClientTests.swift
@@ -1,0 +1,195 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+import Testing
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@testable import CrowDaemon
+
+/// Unit coverage for the Corveil REST client (CROW-1121), driven against a stub
+/// transport — no live Corveil. The reuse/rotate/revoke coordination on top of it
+/// lives in ``CorveilOrgProvisionerTests``.
+@Suite struct CorveilAPIClientTests {
+
+    // MARK: - Stub transport
+
+    private final class RequestLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var items: [URLRequest] = []
+        func append(_ request: URLRequest) { lock.lock(); items.append(request); lock.unlock() }
+        var all: [URLRequest] { lock.lock(); defer { lock.unlock() }; return items }
+        var last: URLRequest? { all.last }
+    }
+
+    private func client(
+        log: RequestLog? = nil,
+        _ respond: @escaping @Sendable (URLRequest) -> (Int, Data)
+    ) -> CorveilAPIClient {
+        CorveilAPIClient(transport: { request in
+            log?.append(request)
+            let (status, body) = respond(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (body, response)
+        })
+    }
+
+    private func jsonData(_ value: Any) -> Data {
+        (try? JSONSerialization.data(withJSONObject: value)) ?? Data()
+    }
+
+    private func bodyJSON(_ request: URLRequest?) -> [String: Any] {
+        guard let data = request?.httpBody,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return obj
+    }
+
+    private let base = "https://corveil.test"
+
+    // MARK: - Endpoints
+
+    @Test func endpointsRejectNonHTTPBaseURL() {
+        #expect(CorveilAPIClient.Endpoints(baseURL: "file:///etc/passwd") == nil)
+        #expect(CorveilAPIClient.Endpoints(baseURL: "javascript://x") == nil)
+        #expect(CorveilAPIClient.Endpoints(baseURL: "") == nil)
+    }
+
+    @Test func endpointsResolveUnderBaseURLToleratingTrailingSlash() throws {
+        let e = try #require(CorveilAPIClient.Endpoints(baseURL: "https://corveil.test/"))
+        #expect(e.organizations.absoluteString == "https://corveil.test/api/me/organizations")
+        #expect(e.keys.absoluteString == "https://corveil.test/api/keys")
+        #expect(e.key(id: "abc").absoluteString == "https://corveil.test/api/keys/abc")
+    }
+
+    // MARK: - List organizations
+
+    @Test func listOrganizationsParsesMembershipRows() async throws {
+        let log = RequestLog()
+        let api = client(log: log) { _ in
+            (200, self.jsonData([
+                "organizations": [
+                    ["organization_id": "org1", "organization_name": "Acme",
+                     "role": "admin", "is_active": true],
+                    ["organization_id": "org2", "organization_name": "Beta",
+                     "role": "member", "is_active": false],
+                ],
+            ]))
+        }
+        let orgs = try await api.listOrganizations(baseURL: base, accessToken: "tok")
+        #expect(orgs.count == 2)
+        #expect(orgs[0] == .init(id: "org1", name: "Acme", role: "admin", isActive: true))
+        #expect(orgs[1].isActive == false)
+        // Bearer auth is sent.
+        #expect(log.last?.value(forHTTPHeaderField: "Authorization") == "Bearer tok")
+        #expect(log.last?.url?.absoluteString == "https://corveil.test/api/me/organizations")
+    }
+
+    @Test func listOrganizationsSkipsRowsWithNoOrgID() async throws {
+        let api = client { _ in
+            (200, self.jsonData(["organizations": [
+                ["organization_name": "No ID"],
+                ["organization_id": "org1", "organization_name": "Acme"],
+            ]]))
+        }
+        let orgs = try await api.listOrganizations(baseURL: base, accessToken: "tok")
+        #expect(orgs.map(\.id) == ["org1"])
+    }
+
+    @Test func listOrganizationsMissingArrayIsMalformed() async throws {
+        let api = client { _ in (200, self.jsonData(["something": "else"])) }
+        await #expect(throws: CorveilAPIClient.Failure.self) {
+            _ = try await api.listOrganizations(baseURL: self.base, accessToken: "tok")
+        }
+    }
+
+    // MARK: - Provision key
+
+    @Test func provisionKeySendsOrgAndParsesKey() async throws {
+        let log = RequestLog()
+        let api = client(log: log) { _ in
+            (200, self.jsonData([
+                "id": "key-123",
+                "key_prefix": "sk-citadel-AbC",
+                "key": "sk-citadel-AbCdEfGhIjKlMnOp",
+                "created_at": "2026-01-02T03:04:05Z",
+            ]))
+        }
+        let key = try await api.provisionKey(
+            baseURL: base, accessToken: "tok", orgID: "org1", name: "Crow gateway")
+        #expect(key.id == "key-123")
+        #expect(key.prefix == "sk-citadel-AbC")
+        #expect(key.value == "sk-citadel-AbCdEfGhIjKlMnOp")
+        #expect(key.createdAt != nil)
+        // Request shape.
+        #expect(log.last?.httpMethod == "POST")
+        #expect(log.last?.url?.absoluteString == "https://corveil.test/api/keys")
+        let body = bodyJSON(log.last)
+        #expect(body["organization_id"] as? String == "org1")
+        #expect(body["name"] as? String == "Crow gateway")
+    }
+
+    @Test func provisionKeyWithoutKeyValueIsMalformed() async throws {
+        // `key` is only present on creation; a response lacking it must not persist
+        // a keyless record.
+        let api = client { _ in
+            (200, self.jsonData(["id": "key-123", "key_prefix": "sk-citadel-AbC"]))
+        }
+        await #expect(throws: CorveilAPIClient.Failure.self) {
+            _ = try await api.provisionKey(
+                baseURL: self.base, accessToken: "tok", orgID: "org1", name: "x")
+        }
+    }
+
+    @Test func unauthorizedIsSurfacedDistinctly() async throws {
+        let api = client { _ in
+            (403, self.jsonData(["error": ["message": "missing scope", "type": "permission_denied"]]))
+        }
+        await #expect(throws: CorveilAPIClient.Failure.unauthorized(status: 403, message: "missing scope")) {
+            _ = try await api.provisionKey(
+                baseURL: self.base, accessToken: "tok", orgID: "org1", name: "x")
+        }
+    }
+
+    @Test func structuredAPIErrorIsSurfaced() async throws {
+        let api = client { _ in
+            (409, self.jsonData(["error": ["message": "no team", "type": "no_team"]]))
+        }
+        await #expect(throws: CorveilAPIClient.Failure.api(status: 409, type: "no_team", message: "no team")) {
+            _ = try await api.provisionKey(
+                baseURL: self.base, accessToken: "tok", orgID: "org1", name: "x")
+        }
+    }
+
+    // MARK: - Revoke key
+
+    @Test func revokeKeySendsDelete() async throws {
+        let log = RequestLog()
+        let api = client(log: log) { _ in
+            (200, self.jsonData(["status": "ok", "message": "API key revoked"]))
+        }
+        try await api.revokeKey(baseURL: base, accessToken: "tok", keyID: "key-123")
+        #expect(log.last?.httpMethod == "DELETE")
+        #expect(log.last?.url?.absoluteString == "https://corveil.test/api/keys/key-123")
+    }
+
+    @Test func revokeKeyTolerates404AsAlreadyGone() async throws {
+        let api = client { _ in
+            (404, self.jsonData(["error": ["message": "API key not found", "type": "not_found"]]))
+        }
+        // No throw — a missing key is the desired end state for a revoke.
+        try await api.revokeKey(baseURL: base, accessToken: "tok", keyID: "gone")
+    }
+
+    @Test func revokeKeyRethrowsNon404Failures() async throws {
+        let api = client { _ in
+            (500, self.jsonData(["error": ["message": "boom", "type": "internal_error"]]))
+        }
+        await #expect(throws: CorveilAPIClient.Failure.self) {
+            try await api.revokeKey(baseURL: self.base, accessToken: "tok", keyID: "key-123")
+        }
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
@@ -89,6 +89,25 @@ import Testing
         #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
     }
 
+    @Test @MainActor func disconnectInvalidatesTheOrgListCache() async throws {
+        // `corveil-disconnect` must clear the org-list cache (CROW-1121) so a
+        // reconnect as a different account never serves the prior user's memberships
+        // out of a warm cache. Drive the real router with a cache we control.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let cache = CorveilOrgListCache()
+        cache.set(
+            [.init(id: "org1", name: "Acme", role: "admin", isActive: true)], key: "warm")
+        #expect(cache.get(key: "warm") != nil)
+
+        let router = makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: devRoot, cockpit: nil, corveilOrgCache: cache)
+        _ = await call(router, "corveil-disconnect")
+
+        #expect(cache.get(key: "warm") == nil, "disconnect must invalidate the org-list cache")
+    }
+
     @Test @MainActor func connectRefreshPreservesStoredSecretsAndOrgKeys() async throws {
         // A refresh sends only a new access token + expiry; the refresh token,
         // registration token, identity and provisioned org keys must survive.

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilConnectionRPCTests.swift
@@ -241,6 +241,7 @@ import Testing
             baseURL: "https://corveil.example.com",
             clientID: "crow-client-1",
             orgKeys: [CorveilOrgKey(orgID: "org1", keyID: "key1")],
+            orgKeySecrets: ["org1": "sk-citadel-secret"],
             oauth: CorveilOAuthTokens(accessToken: "at-old", refreshToken: "rt-keep"))
         // Only a new access token; blanks/absent keep the rest.
         let input = CorveilConnectionRPC.Input(accessToken: "at-new")
@@ -249,6 +250,9 @@ import Testing
         #expect(merged.oauth.refreshToken == "rt-keep")
         #expect(merged.clientID == "crow-client-1")
         #expect(merged.orgKeys.count == 1)
+        // A token refresh through this door must NOT drop the provisioned per-org
+        // key metadata or its secret (corveil/crow#1121).
+        #expect(merged.orgKeySecrets["org1"] == "sk-citadel-secret")
     }
 
     @Test func mergeRequiresBothClientIdAndAccessToken() {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
@@ -254,21 +254,18 @@ import FoundationNetworking
         }
     }
 
-    // MARK: - Provision: disconnect racing the mint
+    // MARK: - Provision: a concurrent write racing the mint
 
-    @Test func disconnectDuringMintDoesNotResurrectTheConnectionOrLeakTheKey() async throws {
-        // `select-org` (lane .on org_id) and `disconnect` (lane .fixed .config) can
-        // overlap. If a disconnect clears the connection while the mint HTTP call is
-        // in flight, the freshly minted `sk-citadel-…` must NOT be written back onto
-        // a resurrected zombie connection — it must be revoked and the select must
-        // fail. (The Red finding's regression test.)
-        let devRoot = tempDevRoot()
-        defer { try? FileManager.default.removeItem(atPath: devRoot) }
-        try seedConnection(devRoot: devRoot)
+    /// Drive a `provision` whose mint, mid-flight (during the `POST /api/keys`),
+    /// runs `midMint(devRoot)` to mutate the stored connection — simulating a
+    /// concurrent disconnect or reconnect that lands in the window between mint and
+    /// persist. Returns the error thrown (if any) and how many revoke DELETEs ran.
+    private func provisionRacingAMint(
+        devRoot: String,
+        orgID: String = "org1",
+        midMint: @escaping @Sendable (String) -> Void
+    ) async -> (error: Error?, deletes: Int) {
         let deletes = Counter()
-
-        // A client whose mint, mid-flight, simulates a concurrent disconnect
-        // clearing the stored connection, then returns the freshly minted key.
         let client = CorveilAPIClient(transport: { request in
             let method = request.httpMethod ?? "GET"
             let path = request.url?.path ?? ""
@@ -280,10 +277,7 @@ import FoundationNetworking
                     "role": "admin", "is_active": true,
                 ]]]
             } else if method == "POST", path.hasSuffix("/api/keys") {
-                // The disconnect lands during the mint.
-                var cfg = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
-                cfg.corveilConnection = nil
-                try? ConfigStore.saveConfig(cfg, devRoot: devRoot)
+                midMint(devRoot)  // the concurrent disconnect/reconnect lands here
                 body = [
                     "id": "key-orphan", "key_prefix": "sk-citadel-orph",
                     "key": "sk-citadel-LEAKED", "created_at": "2026-01-02T03:04:05Z",
@@ -299,17 +293,67 @@ import FoundationNetworking
             let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
             return (data, response)
         })
-
-        await #expect(throws: CorveilOrgProvisioner.ProvisionError.notConnected) {
+        var thrown: Error?
+        do {
             _ = try await CorveilOrgProvisioner.provision(
-                devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
-                apiClient: client, oauthClient: self.neverCalledOAuth())
+                devRoot: devRoot, orgID: orgID, orgName: "Acme", cache: CorveilOrgListCache(),
+                apiClient: client, oauthClient: neverCalledOAuth())
+        } catch {
+            thrown = error
+        }
+        return (thrown, deletes.value)
+    }
+
+    @Test func disconnectDuringMintDoesNotResurrectTheConnectionOrLeakTheKey() async throws {
+        // A `corveil-disconnect` clears the connection while the mint is in flight.
+        // The freshly minted `sk-citadel-…` must NOT be written back onto a
+        // resurrected zombie connection — it must be revoked and the select fail.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+
+        let (error, deletes) = await provisionRacingAMint(devRoot: devRoot) { root in
+            var cfg = ConfigStore.loadConfig(devRoot: root) ?? AppConfig()
+            cfg.corveilConnection = nil
+            try? ConfigStore.saveConfig(cfg, devRoot: root)
         }
 
+        #expect(error as? CorveilOrgProvisioner.ProvisionError == .connectionChanged)
         // No zombie connection, and no spendable secret left on disk.
         #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
-        // The orphaned key was revoked.
-        #expect(deletes.value == 1, "the orphaned key must be revoked when the write is refused")
+        #expect(deletes == 1, "the orphaned key must be revoked when the write is refused")
+    }
+
+    @Test func reconnectAsADifferentAccountDuringMintDoesNotInheritTheKey() async throws {
+        // The subtler race: a DIFFERENT account connects mid-mint (fresh DCR client
+        // id). The nil-guard doesn't catch this — a different live connection is not
+        // empty — so the write must also refuse on a client-id mismatch, or account
+        // B inherits account A's minted key.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)  // mints under clientID "client-1"
+        let baseURL = base
+
+        let (error, deletes) = await provisionRacingAMint(devRoot: devRoot) { root in
+            var cfg = ConfigStore.loadConfig(devRoot: root) ?? AppConfig()
+            cfg.corveilConnection = CorveilConnection(
+                baseURL: baseURL,
+                clientID: "client-2",  // a fresh DCR registration — a different grant
+                connectedUser: CorveilConnectedUser(id: "u2", email: "b@corp.com", name: "B"),
+                oauth: CorveilOAuthTokens(
+                    accessToken: "at2", refreshToken: "rt2",
+                    accessTokenExpiresAt: Date(timeIntervalSinceNow: 3600)))
+            try? ConfigStore.saveConfig(cfg, devRoot: root)
+        }
+
+        #expect(error as? CorveilOrgProvisioner.ProvisionError == .connectionChanged)
+        let conn = try #require(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection)
+        #expect(conn.clientID == "client-2", "the reconnected account is left untouched")
+        #expect(conn.orgKeys.isEmpty, "the other account's key metadata is not attached")
+        #expect(
+            conn.orgKeySecrets["org1"] == nil,
+            "the minted secret never lands on a different connection")
+        #expect(deletes == 1, "the orphaned key is revoked")
     }
 
     @Test func provisionTwiceKeepsExactlyOneKeyPerOrg() async throws {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
@@ -145,6 +145,15 @@ import FoundationNetworking
         })
     }
 
+    /// A thread-safe counter for observing calls from an async transport closure
+    /// (the lock is taken inside the synchronous `increment`, never from `async`).
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value = 0
+        var value: Int { lock.lock(); defer { lock.unlock() }; return _value }
+        func increment() { lock.lock(); _value += 1; lock.unlock() }
+    }
+
     // MARK: - Provision: mint
 
     @Test func provisionMintsAndStoresKeyPlusSecret() async throws {
@@ -210,18 +219,20 @@ import FoundationNetworking
         #expect(api.posts == 1)
     }
 
-    @Test func mintWithNameSkipsTheMembershipLookup() async throws {
+    @Test func mintWithNameValidatesMembershipButUsesTheNameForDisplay() async throws {
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         try seedConnection(devRoot: devRoot)
         let api = APIStub()
 
+        // A supplied `--name` is display-only: it overrides the stored name but does
+        // NOT skip the membership validation.
         let outcome = try await CorveilOrgProvisioner.provision(
             devRoot: devRoot, orgID: "org1", orgName: "Custom Name", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth())
 
         #expect(outcome.orgKey.orgName == "Custom Name")
-        #expect(api.lists == 0, "a supplied name skips GET /api/me/organizations")
+        #expect(api.lists == 1, "membership is always validated, even with a supplied name")
         #expect(api.posts == 1)
     }
 
@@ -229,14 +240,76 @@ import FoundationNetworking
         let devRoot = tempDevRoot()
         defer { try? FileManager.default.removeItem(atPath: devRoot) }
         try seedConnection(devRoot: devRoot)
-        let api = APIStub()  // memberships list only contains "org1"
 
-        await #expect(throws: CorveilOrgProvisioner.ProvisionError.unknownOrg("ghost")) {
-            _ = try await CorveilOrgProvisioner.provision(
-                devRoot: devRoot, orgID: "ghost", orgName: nil, cache: CorveilOrgListCache(),
-                apiClient: api.client(), oauthClient: self.neverCalledOAuth())
+        // Both with and without a supplied name, an org the user doesn't belong to
+        // is rejected locally and never minted — `--name` can't smuggle it past.
+        for name in [String?.none, "Ghost Corp"] {
+            let api = APIStub()  // memberships list only contains "org1"
+            await #expect(throws: CorveilOrgProvisioner.ProvisionError.unknownOrg("ghost")) {
+                _ = try await CorveilOrgProvisioner.provision(
+                    devRoot: devRoot, orgID: "ghost", orgName: name, cache: CorveilOrgListCache(),
+                    apiClient: api.client(), oauthClient: self.neverCalledOAuth())
+            }
+            #expect(api.posts == 0, "an org the user doesn't belong to is never minted")
         }
-        #expect(api.posts == 0, "an org the user doesn't belong to is never minted")
+    }
+
+    // MARK: - Provision: disconnect racing the mint
+
+    @Test func disconnectDuringMintDoesNotResurrectTheConnectionOrLeakTheKey() async throws {
+        // `select-org` (lane .on org_id) and `disconnect` (lane .fixed .config) can
+        // overlap. If a disconnect clears the connection while the mint HTTP call is
+        // in flight, the freshly minted `sk-citadel-…` must NOT be written back onto
+        // a resurrected zombie connection — it must be revoked and the select must
+        // fail. (The Red finding's regression test.)
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let deletes = Counter()
+
+        // A client whose mint, mid-flight, simulates a concurrent disconnect
+        // clearing the stored connection, then returns the freshly minted key.
+        let client = CorveilAPIClient(transport: { request in
+            let method = request.httpMethod ?? "GET"
+            let path = request.url?.path ?? ""
+            var status = 200
+            var body: [String: Any] = [:]
+            if path.hasSuffix("/api/me/organizations") {
+                body = ["organizations": [[
+                    "organization_id": "org1", "organization_name": "Acme",
+                    "role": "admin", "is_active": true,
+                ]]]
+            } else if method == "POST", path.hasSuffix("/api/keys") {
+                // The disconnect lands during the mint.
+                var cfg = ConfigStore.loadConfig(devRoot: devRoot) ?? AppConfig()
+                cfg.corveilConnection = nil
+                try? ConfigStore.saveConfig(cfg, devRoot: devRoot)
+                body = [
+                    "id": "key-orphan", "key_prefix": "sk-citadel-orph",
+                    "key": "sk-citadel-LEAKED", "created_at": "2026-01-02T03:04:05Z",
+                ]
+            } else if method == "DELETE" {
+                deletes.increment()
+                body = ["status": "ok", "message": "revoked"]
+            } else {
+                status = 404
+            }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+            return (data, response)
+        })
+
+        await #expect(throws: CorveilOrgProvisioner.ProvisionError.notConnected) {
+            _ = try await CorveilOrgProvisioner.provision(
+                devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
+                apiClient: client, oauthClient: self.neverCalledOAuth())
+        }
+
+        // No zombie connection, and no spendable secret left on disk.
+        #expect(ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection == nil)
+        // The orphaned key was revoked.
+        #expect(deletes.value == 1, "the orphaned key must be revoked when the write is refused")
     }
 
     @Test func provisionTwiceKeepsExactlyOneKeyPerOrg() async throws {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
@@ -1,0 +1,360 @@
+import CrowCore
+import CrowPersistence
+import Foundation
+import Testing
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@testable import CrowDaemon
+
+/// The provisioning coordinator (CROW-1121): reuse-not-remint, rotate, revoke,
+/// no-duplicate-keys, the org-list cache, and proactive token refresh — all
+/// against stub API + OAuth transports over a temp devRoot.
+@Suite struct CorveilOrgProvisionerTests {
+
+    // MARK: - Fixtures
+
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("corveil-prov-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private let base = "https://corveil.test"
+
+    /// Seed a usable connection with a non-expired access token.
+    private func seedConnection(
+        devRoot: String,
+        orgKeys: [CorveilOrgKey] = [],
+        orgKeySecrets: [String: String] = [:],
+        expiresAt: Date? = Date(timeIntervalSinceNow: 3600),
+        refreshToken: String = "rt"
+    ) throws {
+        var config = AppConfig()
+        config.corveilConnection = CorveilConnection(
+            baseURL: base,
+            clientID: "client-1",
+            connectedUser: CorveilConnectedUser(id: "u1", email: "a@b.c", name: "A"),
+            orgKeys: orgKeys,
+            orgKeySecrets: orgKeySecrets,
+            oauth: CorveilOAuthTokens(
+                accessToken: "at", refreshToken: refreshToken,
+                registrationAccessToken: "reg", accessTokenExpiresAt: expiresAt))
+        try ConfigStore.saveConfig(config, devRoot: devRoot)
+    }
+
+    private func storedConnection(_ devRoot: String) -> CorveilConnection? {
+        ConfigStore.loadConfig(devRoot: devRoot)?.corveilConnection
+    }
+
+    // MARK: - API stub
+
+    /// Records requests and serves per-endpoint canned responses, so tests can
+    /// count mints/revokes and assert reuse skipped the network. All state is
+    /// mutated inside a synchronous, lock-guarded `handle` — the async transport
+    /// closure only calls it (an `NSLock` cannot be taken from an async context).
+    private final class APIStub: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _posts = 0
+        private var _deletes = 0
+        private var _lists = 0
+        private var _lastBearer: String?
+        private var mintCounter = 0
+
+        var posts: Int { lock.lock(); defer { lock.unlock() }; return _posts }
+        var deletes: Int { lock.lock(); defer { lock.unlock() }; return _deletes }
+        var lists: Int { lock.lock(); defer { lock.unlock() }; return _lists }
+        var lastBearer: String? { lock.lock(); defer { lock.unlock() }; return _lastBearer }
+
+        private func handle(_ request: URLRequest) -> (Int, Data) {
+            lock.lock(); defer { lock.unlock() }
+            _lastBearer = request.value(forHTTPHeaderField: "Authorization")
+            let method = request.httpMethod ?? "GET"
+            let path = request.url?.path ?? ""
+            var status = 200
+            var body: [String: Any] = [:]
+            if path.hasSuffix("/api/me/organizations") {
+                _lists += 1
+                body = ["organizations": [
+                    ["organization_id": "org1", "organization_name": "Acme",
+                     "role": "admin", "is_active": true],
+                ]]
+            } else if method == "POST", path.hasSuffix("/api/keys") {
+                _posts += 1
+                mintCounter += 1
+                body = [
+                    "id": "key-\(mintCounter)",
+                    "key_prefix": "sk-citadel-p\(mintCounter)",
+                    "key": "sk-citadel-secret-\(mintCounter)",
+                    "created_at": "2026-01-02T03:04:05Z",
+                ]
+            } else if method == "DELETE" {
+                _deletes += 1
+                body = ["status": "ok", "message": "revoked"]
+            } else {
+                status = 404
+            }
+            let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+            return (status, data)
+        }
+
+        func client() -> CorveilAPIClient {
+            CorveilAPIClient(transport: { request in
+                let (status, data) = self.handle(request)
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+                return (data, response)
+            })
+        }
+    }
+
+    /// An OAuth client stub that answers the refresh (token) endpoint. Records
+    /// whether it was called so the "refresh only when expired" path is testable.
+    private final class OAuthStub: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _refreshed = 0
+        var refreshed: Int { lock.lock(); defer { lock.unlock() }; return _refreshed }
+
+        private func recordAndBody() -> Data {
+            lock.lock(); defer { lock.unlock() }
+            _refreshed += 1
+            let body: [String: Any] = [
+                "access_token": "refreshed-at", "refresh_token": "new-rt",
+                "token_type": "Bearer", "expires_in": 3600,
+            ]
+            return (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        }
+
+        func client() -> CorveilOAuthClient {
+            CorveilOAuthClient(transport: { request in
+                let data = self.recordAndBody()
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (data, response)
+            })
+        }
+    }
+
+    private func neverCalledOAuth() -> CorveilOAuthClient {
+        CorveilOAuthClient(transport: { _ in
+            Issue.record("OAuth refresh should not have been called")
+            throw CorveilOAuthClient.Failure.transport("unexpected")
+        })
+    }
+
+    // MARK: - Provision: mint
+
+    @Test func provisionMintsAndStoresKeyPlusSecret() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+
+        let outcome = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(outcome.reused == false)
+        #expect(api.posts == 1)
+        let conn = try #require(storedConnection(devRoot))
+        #expect(conn.orgKeys.count == 1)
+        #expect(conn.orgKeys.first?.orgID == "org1")
+        #expect(conn.orgKeys.first?.keyID == "key-1")
+        #expect(conn.orgKeys.first?.orgName == "Acme")
+        // The secret is stored — and is the value the mint returned.
+        #expect(conn.orgKeySecrets["org1"] == "sk-citadel-secret-1")
+    }
+
+    // MARK: - Provision: reuse (no duplicate)
+
+    @Test func provisionReusesExistingKeyWithoutMinting() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(
+            devRoot: devRoot,
+            orgKeys: [CorveilOrgKey(orgID: "org1", orgName: "Acme", keyID: "existing", keyPrefix: "sk-citadel-x")],
+            orgKeySecrets: ["org1": "sk-citadel-existing-value"])
+        let api = APIStub()
+
+        let outcome = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(outcome.reused == true)
+        #expect(outcome.orgKey.keyID == "existing")
+        #expect(api.posts == 0, "reuse must not mint a new key")
+        // Stored value is untouched — the shared key survives.
+        #expect(storedConnection(devRoot)?.orgKeySecrets["org1"] == "sk-citadel-existing-value")
+    }
+
+    @Test func provisionTwiceKeepsExactlyOneKeyPerOrg() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+
+        _ = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+        let second = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(second.reused == true)
+        #expect(api.posts == 1, "the second select reuses, not re-mints")
+        #expect(storedConnection(devRoot)?.orgKeys.count == 1)
+    }
+
+    // MARK: - Rotate
+
+    @Test func provisionForceRotatesToAFreshKeyReplacingTheOld() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(
+            devRoot: devRoot,
+            orgKeys: [CorveilOrgKey(orgID: "org1", orgName: "Acme", keyID: "old", keyPrefix: "sk-citadel-old")],
+            orgKeySecrets: ["org1": "sk-citadel-old-value"])
+        let api = APIStub()
+
+        let outcome = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: neverCalledOAuth(), force: true)
+
+        #expect(outcome.reused == false)
+        #expect(api.posts == 1)
+        let conn = try #require(storedConnection(devRoot))
+        // Exactly one key, and it's the new one (the backend revokes the old on mint).
+        #expect(conn.orgKeys.count == 1)
+        #expect(conn.orgKeys.first?.keyID == "key-1")
+        #expect(conn.orgKeySecrets["org1"] == "sk-citadel-secret-1")
+    }
+
+    // MARK: - Deprovision
+
+    @Test func deprovisionRevokesAndRemoves() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(
+            devRoot: devRoot,
+            orgKeys: [CorveilOrgKey(orgID: "org1", orgName: "Acme", keyID: "key-1", keyPrefix: "sk-citadel-p1")],
+            orgKeySecrets: ["org1": "sk-citadel-secret-1"])
+        let api = APIStub()
+
+        let removed = try await CorveilOrgProvisioner.deprovision(
+            devRoot: devRoot, orgID: "org1",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(removed == true)
+        #expect(api.deletes == 1)
+        let conn = try #require(storedConnection(devRoot))
+        #expect(conn.orgKeys.isEmpty)
+        #expect(conn.orgKeySecrets["org1"] == nil)
+    }
+
+    @Test func deprovisionOfUnprovisionedOrgIsANoOp() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+
+        let removed = try await CorveilOrgProvisioner.deprovision(
+            devRoot: devRoot, orgID: "org1",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(removed == false)
+        #expect(api.deletes == 0, "nothing to revoke")
+    }
+
+    // MARK: - Not connected
+
+    @Test func provisionWithoutConnectionThrows() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // No connection seeded.
+        await #expect(throws: CorveilOrgProvisioner.ProvisionError.notConnected) {
+            _ = try await CorveilOrgProvisioner.provision(
+                devRoot: devRoot, orgID: "org1", orgName: "Acme",
+                apiClient: APIStub().client(), oauthClient: self.neverCalledOAuth())
+        }
+    }
+
+    // MARK: - List + cache
+
+    @Test func listOrganizationsCachesWithinTTL() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+        let cache = CorveilOrgListCache()
+
+        let first = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(), oauthClient: neverCalledOAuth())
+        let second = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(first == second)
+        #expect(api.lists == 1, "the second list is served from cache")
+    }
+
+    @Test func listOrganizationsForceRefreshBypassesCache() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+        let cache = CorveilOrgListCache()
+
+        _ = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(), oauthClient: neverCalledOAuth())
+        _ = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(),
+            oauthClient: neverCalledOAuth(), forceRefresh: true)
+
+        #expect(api.lists == 2)
+    }
+
+    @Test func expiredEntryIsAMiss() async throws {
+        let cache = CorveilOrgListCache(ttl: 60)
+        let now = Date()
+        cache.set([.init(id: "org1", name: "Acme", role: "admin", isActive: true)], key: "k", now: now)
+        #expect(cache.get(key: "k", now: now.addingTimeInterval(30)) != nil)
+        #expect(cache.get(key: "k", now: now.addingTimeInterval(120)) == nil)
+        // A different key never matches.
+        #expect(cache.get(key: "other", now: now) == nil)
+    }
+
+    // MARK: - Token refresh
+
+    @Test func expiredAccessTokenIsRefreshedBeforeProvisioning() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // Token already expired, but a refresh token is present.
+        try seedConnection(devRoot: devRoot, expiresAt: Date(timeIntervalSinceNow: -10))
+        let api = APIStub()
+        let oauth = OAuthStub()
+
+        _ = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: oauth.client())
+
+        #expect(oauth.refreshed >= 1, "an expired token triggers a refresh")
+        // The refreshed token was persisted and used as the bearer for the mint.
+        #expect(storedConnection(devRoot)?.oauth.accessToken == "refreshed-at")
+        #expect(api.lastBearer == "Bearer refreshed-at")
+    }
+
+    @Test func freshTokenIsNotRefreshed() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)  // expires in an hour
+        let api = APIStub()
+
+        _ = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(api.lastBearer == "Bearer at")
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilOrgProvisionerTests.swift
@@ -154,7 +154,7 @@ import FoundationNetworking
         let api = APIStub()
 
         let outcome = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth())
 
         #expect(outcome.reused == false)
@@ -179,15 +179,64 @@ import FoundationNetworking
             orgKeySecrets: ["org1": "sk-citadel-existing-value"])
         let api = APIStub()
 
+        // No `--name` given: a reuse must still make ZERO network calls — not even
+        // the membership lookup — so it can't fail on a transient outage.
         let outcome = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: nil, cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth())
 
         #expect(outcome.reused == true)
         #expect(outcome.orgKey.keyID == "existing")
         #expect(api.posts == 0, "reuse must not mint a new key")
+        #expect(api.lists == 0, "reuse must not even look up the org name")
         // Stored value is untouched — the shared key survives.
         #expect(storedConnection(devRoot)?.orgKeySecrets["org1"] == "sk-citadel-existing-value")
+    }
+
+    // MARK: - Provision: name resolution
+
+    @Test func mintWithoutNameLooksUpTheOrgNameFromMemberships() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+
+        let outcome = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: nil, cache: CorveilOrgListCache(),
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(outcome.orgKey.orgName == "Acme", "name resolved from the membership list")
+        #expect(api.lists == 1)
+        #expect(api.posts == 1)
+    }
+
+    @Test func mintWithNameSkipsTheMembershipLookup() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()
+
+        let outcome = try await CorveilOrgProvisioner.provision(
+            devRoot: devRoot, orgID: "org1", orgName: "Custom Name", cache: CorveilOrgListCache(),
+            apiClient: api.client(), oauthClient: neverCalledOAuth())
+
+        #expect(outcome.orgKey.orgName == "Custom Name")
+        #expect(api.lists == 0, "a supplied name skips GET /api/me/organizations")
+        #expect(api.posts == 1)
+    }
+
+    @Test func mintForANonMembershipThrowsWithoutMinting() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try seedConnection(devRoot: devRoot)
+        let api = APIStub()  // memberships list only contains "org1"
+
+        await #expect(throws: CorveilOrgProvisioner.ProvisionError.unknownOrg("ghost")) {
+            _ = try await CorveilOrgProvisioner.provision(
+                devRoot: devRoot, orgID: "ghost", orgName: nil, cache: CorveilOrgListCache(),
+                apiClient: api.client(), oauthClient: self.neverCalledOAuth())
+        }
+        #expect(api.posts == 0, "an org the user doesn't belong to is never minted")
     }
 
     @Test func provisionTwiceKeepsExactlyOneKeyPerOrg() async throws {
@@ -197,10 +246,10 @@ import FoundationNetworking
         let api = APIStub()
 
         _ = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth())
         let second = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth())
 
         #expect(second.reused == true)
@@ -220,7 +269,7 @@ import FoundationNetworking
         let api = APIStub()
 
         let outcome = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth(), force: true)
 
         #expect(outcome.reused == false)
@@ -276,7 +325,7 @@ import FoundationNetworking
         // No connection seeded.
         await #expect(throws: CorveilOrgProvisioner.ProvisionError.notConnected) {
             _ = try await CorveilOrgProvisioner.provision(
-                devRoot: devRoot, orgID: "org1", orgName: "Acme",
+                devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
                 apiClient: APIStub().client(), oauthClient: self.neverCalledOAuth())
         }
     }
@@ -325,6 +374,57 @@ import FoundationNetworking
         #expect(cache.get(key: "other", now: now) == nil)
     }
 
+    @Test func invalidateClearsTheEntry() {
+        let cache = CorveilOrgListCache()
+        cache.set([.init(id: "org1", name: "Acme", role: "admin", isActive: true)], key: "k")
+        #expect(cache.get(key: "k") != nil)
+        cache.invalidate()
+        #expect(cache.get(key: "k") == nil, "invalidate must drop the entry (disconnect hook)")
+    }
+
+    @Test func orgCacheIsKeyedOnClientIdSoAReconnectMisses() async throws {
+        // The browser Connect flow leaves `connectedUser.id` empty and self-registers
+        // a FRESH client id per DCR. The cache must key on the client id, not the
+        // (empty) user id — otherwise a disconnect + reconnect as a different account
+        // on the same host would be served the previous user's memberships. This is
+        // the Yellow finding's regression test.
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let cache = CorveilOrgListCache()
+        let api = APIStub()
+
+        func connect(clientID: String) throws {
+            var config = AppConfig()
+            config.corveilConnection = CorveilConnection(
+                baseURL: base,
+                clientID: clientID,
+                connectedUser: CorveilConnectedUser(),  // empty, as after a browser Connect
+                oauth: CorveilOAuthTokens(
+                    accessToken: "at", refreshToken: "rt",
+                    accessTokenExpiresAt: Date(timeIntervalSinceNow: 3600)))
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+        }
+
+        // Connect as client A → one fetch, cached.
+        try connect(clientID: "client-A")
+        _ = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(), oauthClient: neverCalledOAuth())
+        #expect(api.lists == 1)
+
+        // Same client id (a plain token refresh keeps it) → cache hit, no new fetch.
+        _ = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(), oauthClient: neverCalledOAuth())
+        #expect(api.lists == 1, "the same client id serves the cached list")
+
+        // Reconnect as a DIFFERENT client id (fresh DCR, still-empty user id) → miss.
+        try connect(clientID: "client-B")
+        _ = try await CorveilOrgProvisioner.listOrganizations(
+            devRoot: devRoot, cache: cache, apiClient: api.client(), oauthClient: neverCalledOAuth())
+        #expect(
+            api.lists == 2,
+            "a fresh client id must miss the cache, not leak the prior account's orgs")
+    }
+
     // MARK: - Token refresh
 
     @Test func expiredAccessTokenIsRefreshedBeforeProvisioning() async throws {
@@ -336,7 +436,7 @@ import FoundationNetworking
         let oauth = OAuthStub()
 
         _ = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: oauth.client())
 
         #expect(oauth.refreshed >= 1, "an expired token triggers a refresh")
@@ -352,7 +452,7 @@ import FoundationNetworking
         let api = APIStub()
 
         _ = try await CorveilOrgProvisioner.provision(
-            devRoot: devRoot, orgID: "org1", orgName: "Acme",
+            devRoot: devRoot, orgID: "org1", orgName: "Acme", cache: CorveilOrgListCache(),
             apiClient: api.client(), oauthClient: neverCalledOAuth())
 
         #expect(api.lastBearer == "Bearer at")

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -995,6 +995,15 @@ import CrowPersistence
             #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
                 == "Corveil connection management is local-only")
         }
+
+        // The org listing + provisioning verbs (CROW-1121) act with the stored OAuth
+        // bearer — listing memberships, minting/revoking the per-org gateway key — so
+        // they are gated local-only alongside the connection verbs.
+        for method in ["corveil-list-orgs", "corveil-select-org", "corveil-deselect-org"] {
+            let req = JSONRPCRequest(id: 1, method: method, params: ["org_id": .string("org1")])
+            #expect(RPCWebSocketHandler.localOnlyDenial(for: req, devRoot: tempDevRoot())
+                == "Corveil org provisioning is local-only")
+        }
     }
 
     @Test func logsyncMethodsAreNotLocalOnly() {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -880,7 +880,7 @@ crow corveil disconnect
 
 #### `crow corveil orgs`
 
-List the per-org gateway-key metadata — org id and name, key id, display prefix, and mint time — never the key material itself (that lives in the generated gateway header). Empty until an org is provisioned (corveil/crow#1121).
+List the per-org gateway-key metadata — org id and name, key id, display prefix, and mint time — never the key material itself (the `sk-citadel-…` value is stored as a per-org secret and copied into the generated gateway header). This is the LOCAL record of what has been provisioned; use `crow corveil list-orgs` to see every org you could select. Empty until an org is provisioned with `crow corveil select-org` (corveil/crow#1121).
 
 ```bash
 crow corveil orgs
@@ -891,6 +891,50 @@ crow corveil orgs
            "key_prefix": "sk-citadel-AbC", "created_at": "2026-01-01T00:00:00Z"}],
  "count": 1}
 ```
+
+### Org listing + one-key-per-org provisioning (CROW-1121)
+
+Using the connection's OAuth bearer, list the orgs you belong to and provision exactly one gateway key per org. All three are local-only — they act with a credential over the Unix socket and are refused for remote web clients. The `sk-citadel-…` key value is stored as a per-org secret in `corveilConnection`; only its metadata is ever printed.
+
+#### `crow corveil list-orgs`
+
+List the Corveil orgs you belong to (`GET /api/me/organizations`), served through a short-lived cache. Each row carries whether that org already has a provisioned key, so the picker can mark selections without a second call. Pass `--refresh` to bypass the cache and re-fetch.
+
+```bash
+crow corveil list-orgs
+crow corveil list-orgs --refresh
+```
+
+```json
+{"orgs": [{"org_id": "org1", "org_name": "Acme", "role": "admin",
+           "is_active": true, "provisioned": true}],
+ "count": 1}
+```
+
+#### `crow corveil select-org`
+
+Mint or reuse the one gateway key for an org. An org that already has a stored key is returned untouched (`"reused": true`) — no new key — so every workspace bound to the org shares it; the backend rotates the key on each mint, so re-minting would break bound gateways. Pass `--rotate` to force a fresh key (the old one is revoked). The org name is taken from `--name` when given, else looked up from your memberships.
+
+```bash
+crow corveil select-org --org org1
+crow corveil select-org --org org1 --name "Acme" --rotate
+```
+
+```json
+{"saved": true, "reused": false,
+ "org": {"org_id": "org1", "org_name": "Acme", "key_id": "key1",
+         "key_prefix": "sk-citadel-AbC", "created_at": "2026-01-01T00:00:00Z"}}
+```
+
+#### `crow corveil deselect-org`
+
+Revoke an org's gateway key on the Corveil side (`DELETE /api/keys/{id}`) and drop its local metadata and stored secret. Idempotent — deselecting an org with no key returns `"removed": false`.
+
+```bash
+crow corveil deselect-org --org org1
+```
+
+- Returns `{"saved": true, "removed": <bool>}`. A revoke that finds the key already gone (404) still succeeds — the end state is "no key".
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,9 +39,12 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow complete-session`](#crow-complete-session) | Mark a session completed |
 | [`crow corveil`](#crow-corveil) | Verify the Corveil CLI binary and manage the Corveil connection |
 | [`crow corveil connect`](#crow-corveil-connect) | Store or update the Corveil connection (local-only) |
+| [`crow corveil deselect-org`](#crow-corveil-deselect-org) | Revoke a Corveil org's gateway key (local-only) |
 | [`crow corveil disconnect`](#crow-corveil-disconnect) | Clear the Corveil connection (local-only) |
+| [`crow corveil list-orgs`](#crow-corveil-list-orgs) | List the Corveil orgs you belong to (local-only) |
 | [`crow corveil orgs`](#crow-corveil-orgs) | List the connection's per-org gateway keys (local-only) |
 | [`crow corveil reinstall-skill`](#crow-corveil-reinstall-skill) | Reinstall every embedded slash command from the corveil binary |
+| [`crow corveil select-org`](#crow-corveil-select-org) | Provision or reuse the gateway key for a Corveil org (local-only) |
 | [`crow corveil status`](#crow-corveil-status) | Show the Corveil connection state (local-only) |
 | [`crow corveil verify`](#crow-corveil-verify) | Run `corveil --version` and report what came back |
 | [`crow create-manager`](#crow-create-manager) | Create an additional Manager session |
@@ -529,10 +532,10 @@ crow complete-session --session <session>
 Verify the Corveil CLI binary and manage the Corveil connection.
 
 ```
-crow corveil <verify|reinstall-skill|connect|status|disconnect|orgs>
+crow corveil <verify|reinstall-skill|connect|status|disconnect|orgs|list-orgs|select-org|deselect-org>
 ```
 
-Subcommands: [`verify`](#crow-corveil-verify), [`reinstall-skill`](#crow-corveil-reinstall-skill), [`connect`](#crow-corveil-connect), [`status`](#crow-corveil-status), [`disconnect`](#crow-corveil-disconnect), [`orgs`](#crow-corveil-orgs).
+Subcommands: [`verify`](#crow-corveil-verify), [`reinstall-skill`](#crow-corveil-reinstall-skill), [`connect`](#crow-corveil-connect), [`status`](#crow-corveil-status), [`disconnect`](#crow-corveil-disconnect), [`orgs`](#crow-corveil-orgs), [`list-orgs`](#crow-corveil-list-orgs), [`select-org`](#crow-corveil-select-org), [`deselect-org`](#crow-corveil-deselect-org).
 
 ---
 
@@ -566,6 +569,22 @@ The merged connection must have at least a client id and an access token. Tokens
 
 ---
 
+## `crow corveil deselect-org`
+
+Revoke a Corveil org's gateway key (local-only).
+
+```
+crow corveil deselect-org --org <org>
+```
+
+Revokes the org's provisioned gateway key on the Corveil side and removes its local metadata and stored secret. Idempotent — deselecting an org with no key is a no-op. Local-only: it acts with a credential over the Unix socket and is refused for remote web clients.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--org` | `<org>` | yes | Corveil organization id whose key to revoke |
+
+---
+
 ## `crow corveil disconnect`
 
 Clear the Corveil connection (local-only).
@@ -578,6 +597,22 @@ Removes the stored connection block, so gateway resolution and the log collector
 
 ---
 
+## `crow corveil list-orgs`
+
+List the Corveil orgs you belong to (local-only).
+
+```
+crow corveil list-orgs [--refresh]
+```
+
+Fetches your Corveil memberships with the connection's OAuth token and prints each org's id, name, role, active flag, and whether it already has a provisioned gateway key. The result is cached briefly; pass `--refresh` to force a re-fetch. This is the list you pick from — `corveil orgs` shows only the orgs already provisioned locally. Local-only: it acts with a credential, so it runs over the Unix socket and is refused for remote web clients.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--refresh` | — | no | Bypass the cache and re-fetch the org list from Corveil. |
+
+---
+
 ## `crow corveil orgs`
 
 List the connection's per-org gateway keys (local-only).
@@ -586,7 +621,7 @@ List the connection's per-org gateway keys (local-only).
 crow corveil orgs
 ```
 
-Prints the metadata for each auto-provisioned per-org gateway key — org id and name, key id, display prefix, and mint time — never the key material itself. Empty until an org is provisioned (corveil/crow#1121).
+Prints the metadata for each auto-provisioned per-org gateway key — org id and name, key id, display prefix, and mint time — never the key material itself. This is the LOCAL record of what has been provisioned; use `corveil list-orgs` to see every org you could select. Empty until an org is provisioned with `corveil select-org` (corveil/crow#1121).
 
 ---
 
@@ -605,6 +640,29 @@ A run also updates the launch-time corveil warning: succeeding clears it, a per-
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--path` | `<path>` | no | Binary to act on. Defaults to the path in Settings → General → Corveil CLI. |
+
+---
+
+## `crow corveil select-org`
+
+Provision or reuse the gateway key for a Corveil org (local-only).
+
+```
+crow corveil select-org --org <org> [--name <name>] [--rotate]
+```
+
+Mints exactly one `sk-citadel-…` gateway key for the org, reusing the stored one if the org already has a key — so every workspace bound to the org shares it. The key value is stored as a secret; only its metadata (id, prefix, mint time) is ever printed. Pass `--rotate` to force a fresh key (the old one is revoked). The org name is taken from `--name` if given, else looked up from your memberships. Local-only: it mints a credential over the Unix socket and is refused for remote web clients.
+
+```
+crow corveil select-org --org <org-id>
+crow corveil select-org --org <org-id> --rotate
+```
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| `--org` | `<org>` | yes | Corveil organization id to provision a key for |
+| `--name` | `<name>` | no | Org display name to store (looked up if omitted) |
+| `--rotate` | — | no | Revoke the existing key and mint a fresh one. |
 
 ---
 


### PR DESCRIPTION
Closes #1121

Part of the first-class Corveil integration epic (#1117). Builds on the OAuth connection (#1128), the local-only write path (#1129), and the `corveilConnection` model (#1127).

## What this adds

Using the connection's OAuth bearer, list the user's Corveil orgs and, on org selection, mint or reuse **exactly one** gateway key per org.

- **`CorveilAPIClient`** — pure-HTTP client (injected transport, mirrors `CorveilOAuthClient`) for the three constrained endpoints the backend opened for Crow (`RadiusMethod/corveil#2704`, `#2706`):
  - `GET /api/me/organizations` → the memberships list
  - `POST /api/keys` → mint one `sk-citadel-…` key in a named org
  - `DELETE /api/keys/{id}` → revoke (404 tolerated as "already gone")
- **`CorveilOrgProvisioner` + `CorveilOrgListCache`** — the coordination on top:
  - **reuse, don't re-mint** — a select for an org that already has a stored key returns it with no network call. This is load-bearing: the backend deactivates the prior key on every `POST /api/keys`, so re-minting would silently invalidate every workspace bound to the old value.
  - **rotate** (`--rotate`) — force a fresh key; the backend revokes the old one as part of the mint.
  - **deselect** — revoke server-side, then drop the local metadata + secret.
  - a short TTL cache for the org list (acceptance: "populates the org list (cached)"), and proactive access-token refresh when the token is at/near expiry.
- **Secret storage** — the `sk-citadel-…` value is stored per-org in `corveilConnection.orgKeySecrets`, stripped for transport by `SettingsSecrets` (like the OAuth tokens) and preserved across a token-refresh merge. `orgKeys[]` stays pure display metadata.
- **Surface** — RPCs `corveil-list-orgs` / `corveil-select-org` / `corveil-deselect-org` and the `crow corveil list-orgs` / `select-org` / `deselect-org` verbs, all local-only (they act with a credential), with lane rules, parity-ledger rows, and reference + CLAUDE.md docs.

## Scope

Strictly the provisioning mechanism. The org-dropdown UI (#1123), the `WorkspaceGateway` generated from the stored secret (#1124), and the token health/reconnect UX (#1125) are sibling tickets and are not touched here.

## Acceptance

- ✅ `GET /api/me/organizations` populates the org list (cached) — `corveil list-orgs`, `CorveilOrgListCache`.
- ✅ Selecting an org mints one `sk-citadel-…` key via `POST /api/keys`, reused across workspaces bound to that org; value stored as a per-org secret.
- ✅ Deselect/rotate cleanly re-provisions or revokes; no duplicate keys per org.

## Testing

- `CorveilAPIClientTests` — parse, bearer auth, structured/401 error mapping, revoke-404 tolerance.
- `CorveilOrgProvisionerTests` — reuse (no re-mint), exactly-one-key-per-org, rotate, revoke + remove, no-op deselect, not-connected, cache TTL/miss, expired-token refresh.
- `SettingsSecretsTests`, `CorveilConnectionRPCTests`, `CorveilCommandParsingTests`, and the parity/lane/local-only/docs gates.

All package suites green (`CrowCore`, `CrowCLI`, `CrowDaemon`) except one pre-existing flake unrelated to this change (`WebNotificationCenterTests.bootCatchResetsTheHistory`, a web-asset test that also fails on the base commit in a multi-suite run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)