### PR TITLE
Add custom notification sound files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,16 +276,18 @@ crow quick-action --session <uuid> --action fixConflicts|addressChanges|fixCheck
 Reads and writes `AppConfig.notifications` — the same settings as Settings → Notifications.
 
 ```
-crow notifications get [--event <name>]                → {"notifications":{globals, events, available_sounds, config_readable}}
+crow notifications get [--event <name>]                → {"notifications":{globals, events, available_sounds, custom_sounds, config_readable}}
 crow notifications set [--global-mute|--no-global-mute] [--sound-enabled|--no-sound-enabled]
                        [--system-notifications-enabled|--no-system-notifications-enabled]
 crow notifications set --event <name> [--event-enabled|--no-event-enabled]
                        [--event-sound-enabled|--no-event-sound-enabled]
                        [--event-system-notification-enabled|--no-event-system-notification-enabled]
                        [--event-sound-name <Sound>]     → {"notifications":{...},"saved":true}
+crow notifications add-sound <path> [--name NAME]      → {"sound":{name,file,url},"saved":true}
+crow notifications remove-sound <name>                 → {"removed":true,"name":"..."}
 ```
 
-Events: `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoMergeBlocked`, `autoRebasePushed`, `autoRebaseConflicts`, `autoRebaseStuck`, `configReloaded`. Sounds: the 14 built-ins listed under `available_sounds` (case-insensitive).
+Events: `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoMergeBlocked`, `autoRebasePushed`, `autoRebaseConflicts`, `autoRebaseStuck`, `configReloaded`. Sounds: the 14 built-ins listed under `available_sounds`, plus any custom files in `~/Library/Application Support/crow/sounds/` (`.wav` / `.mp3` / `.aiff`, 2 MB cap). `--event-sound-name` accepts either, case-insensitively. `add-sound` is local-only (it copies a host path); Settings → Notifications uploads via HTTP instead. Removing a custom sound keeps the name in config; playback falls back to a default if the file is gone.
 
 Notifications cascade — one fires only if `globalMute` is off, the global category toggle is on, **and** the per-event toggle is on. Omitted flags leave their stored value alone; every `--event-*` flag requires `--event`.
 

--- a/Packages/CrowCLI/Package.swift
+++ b/Packages/CrowCLI/Package.swift
@@ -20,8 +20,8 @@ let package = Package(
             dependencies: [
                 "CrowIPC",
                 // Lets `crow notifications` validate against the canonical
-                // NotificationEvent cases and builtInSounds instead of keeping
-                // its own copy of either list (CROW-813).
+                // NotificationEvent cases, builtInSounds, and the custom sound
+                // library instead of keeping its own copy (CROW-813 / CROW-1147).
                 "CrowCore",
                 "CrowCodex",
                 "CrowAutostart",

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/NotificationCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/NotificationCommands.swift
@@ -26,7 +26,10 @@ public struct Notifications: ParsableCommand {
         on. Global flags apply to every event; the --event-* flags apply to the \
         single event named by --event.
         """,
-        subcommands: [NotificationsGet.self, NotificationsSet.self]
+        subcommands: [
+            NotificationsGet.self, NotificationsSet.self,
+            NotificationsAddSound.self, NotificationsRemoveSound.self,
+        ]
     )
 
     public init() {}
@@ -37,11 +40,12 @@ public struct NotificationsGet: ParsableCommand {
         commandName: "get",
         abstract: "Show notification settings",
         discussion: """
-        Lists the global toggles, every event's effective settings, and the \
-        built-in sound names. Events absent from config.json are reported with \
-        the defaults they will actually fire with. --event narrows the event \
-        list to one entry; the global toggles are always included, since they \
-        can be the reason an event never fires.
+        Lists the global toggles, every event's effective settings, the \
+        built-in sound names, and any custom sounds in the library. Events \
+        absent from config.json are reported with the defaults they will \
+        actually fire with. --event narrows the event list to one entry; the \
+        global toggles are always included, since they can be the reason an \
+        event never fires.
         """
     )
 
@@ -65,8 +69,9 @@ public struct NotificationsSet: ParsableCommand {
         discussion: """
         Only the provided flags change; everything else keeps its value. Each \
         toggle takes a --flag / --no-flag pair. The --event-* flags require \
-        --event and apply to that event alone. --event-sound-name accepts the \
-        built-in sounds listed by `crow notifications get` (case-insensitive).
+        --event and apply to that event alone. --event-sound-name accepts a \
+        built-in or custom sound listed by `crow notifications get` \
+        (case-insensitive).
         """
     )
 
@@ -95,7 +100,7 @@ public struct NotificationsSet: ParsableCommand {
     @Flag(inversion: .prefixedNo, exclusivity: .exclusive,
           help: "Whether this event posts a system notification")
     var eventSystemNotificationEnabled: Bool?
-    @Option(name: .customLong("event-sound-name"), help: "Sound for this event (a built-in sound name)")
+    @Option(name: .customLong("event-sound-name"), help: "Sound for this event (a built-in or custom sound name)")
     var eventSoundName: String?
 
     public init() {}
@@ -142,6 +147,77 @@ public struct NotificationsSet: ParsableCommand {
         // so the RPC stays self-sufficient for non-CLI callers.
         if let eventSoundName { params["event_sound_name"] = .string(eventSoundName) }
         let result = try rpc("notifications-set", params: params)
+        printJSON(result)
+    }
+}
+
+public struct NotificationsAddSound: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "add-sound",
+        abstract: "Add a custom notification sound",
+        discussion: """
+        Copies a .wav, .mp3, or .aiff file into Crow's sound library \
+        (~/Library/Application Support/crow/sounds/). The stem becomes the \
+        name shown in Settings and accepted by --event-sound-name. Dropping a \
+        file into that directory also works — get lists whatever is there.
+        """
+    )
+
+    @Argument(help: "Path to a .wav, .mp3, or .aiff file")
+    var path: String
+
+    @Option(name: .long, help: "Display name (defaults to the file's name)")
+    var name: String?
+
+    public init() {}
+
+    public func validate() throws {
+        _ = try resolvedSoundFilePath(path)
+        if let name {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard CustomSoundLibrary.sanitizeStem(trimmed) != nil else {
+                throw ValidationError("--name is empty or contains no usable characters.")
+            }
+        }
+    }
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["path": .string(try resolvedSoundFilePath(path))]
+        if let name {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { params["name"] = .string(trimmed) }
+        }
+        let result = try rpc("notifications-add-sound", params: params)
+        printJSON(result)
+    }
+}
+
+public struct NotificationsRemoveSound: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "remove-sound",
+        abstract: "Remove a custom notification sound",
+        discussion: """
+        Deletes the file from the sound library. Events that still name it keep \
+        the reference in config.json; playback falls back to a default until \
+        you pick another sound.
+        """
+    )
+
+    @Argument(help: "Custom sound name (as listed by notifications get)")
+    var name: String
+
+    public init() {}
+
+    public func validate() throws {
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError("name must not be blank.")
+        }
+    }
+
+    public func run() throws {
+        let result = try rpc("notifications-remove-sound", params: [
+            "name": .string(name.trimmingCharacters(in: .whitespacesAndNewlines)),
+        ])
         printJSON(result)
     }
 }

--- a/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Validation.swift
@@ -59,16 +59,43 @@ func validateJobName(_ value: String) throws {
     }
 }
 
-/// Validate that a notification sound is one of the built-in sounds, matching
-/// the Settings UI's sound picker (which only offers those). Delegates to
+/// Validate that a notification sound is a built-in or a custom library name.
+/// Custom names are read from the live sounds directory so a name the daemon
+/// will accept also passes here. Delegates to
 /// `NotificationSettings.canonicalSoundName` — the same predicate the
 /// `notifications-set` handler enforces with — so the two can't drift.
 ///
-/// - Throws: `ValidationError` listing the built-in sounds when unmatched.
-func validateNotificationSound(_ value: String) throws {
-    guard NotificationSettings.canonicalSoundName(value) != nil else {
-        throw ValidationError("'\(value)' is not a built-in sound. Expected one of: \(NotificationSettings.builtInSounds.joined(separator: ", "))")
+/// - Throws: `ValidationError` listing built-ins (and custom names when any
+///   exist) when unmatched.
+func validateNotificationSound(_ value: String, customNames: [String]? = nil) throws {
+    let names = customNames ?? CustomSoundLibrary.live.names
+    guard NotificationSettings.canonicalSoundName(value, customNames: names) != nil else {
+        let extras = names.isEmpty ? "" : "; custom: \(names.joined(separator: ", "))"
+        throw ValidationError("'\(value)' is not an available sound. Expected one of: \(NotificationSettings.builtInSounds.joined(separator: ", "))\(extras)")
     }
+}
+
+/// Resolve `crow notifications add-sound` to an absolute readable path and
+/// check the extension locally. Tilde-expanded and relative-to-cwd, matching
+/// `--binary`: the daemon receives an absolute path and does not share the
+/// caller's working directory.
+///
+/// - Throws: `ValidationError` for a missing file or unsupported extension.
+func resolvedSoundFilePath(_ value: String) throws -> String {
+    var path = value.trimmingCharacters(in: .whitespaces)
+    if path == "~" || path.hasPrefix("~/") {
+        path = NSString(string: path).expandingTildeInPath
+    }
+    let url = URL(fileURLWithPath: path).standardizedFileURL
+    var isDir: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), !isDir.boolValue else {
+        throw ValidationError("'\(value)' is not a readable file.")
+    }
+    let ext = url.pathExtension.lowercased()
+    guard CustomSoundLibrary.allowedExtensions.contains(ext) else {
+        throw ValidationError("'\(value)' is not a supported sound. Expected .wav, .mp3, or .aiff.")
+    }
+    return url.path
 }
 
 /// Validate that at least one optional field is provided for set-ticket.

--- a/Packages/CrowCLI/Tests/CrowCLITests/NotificationCommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/NotificationCommandParsingTests.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 import Testing
 import CrowCore
 @testable import CrowCLILib
@@ -11,6 +12,25 @@ import CrowCore
     #expect(get is NotificationsGet)
     let set = try Notifications.parseAsRoot(["set", "--global-mute"])
     #expect(set is NotificationsSet)
+    let wav = try writeTempWav()
+    defer { try? FileManager.default.removeItem(at: wav) }
+    let add = try Notifications.parseAsRoot(["add-sound", wav.path])
+    #expect(add is NotificationsAddSound)
+    let remove = try Notifications.parseAsRoot(["remove-sound", "Office-Bell"])
+    #expect(remove is NotificationsRemoveSound)
+}
+
+/// A tiny on-disk .wav so `add-sound` parse can satisfy `validate()` (existence
+/// + extension). Magic bytes are the daemon's job.
+private func writeTempWav() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("crow-cli-sound-\(UUID().uuidString).wav")
+    try Data("RIFF".utf8).write(to: url) // contents unused at parse time
+    // Pad so it's not empty; extension is what validate checks.
+    var data = Data("RIFF".utf8)
+    data.append(Data(repeating: 0, count: 12))
+    try data.write(to: url)
+    return url
 }
 
 // MARK: - get
@@ -188,6 +208,42 @@ private func setParseError(_ args: [String]) -> String {
 }
 
 @Test func validateNotificationSoundRejectsUnknown() {
-    #expect(throws: (any Error).self) { try validateNotificationSound("Nope") }
-    #expect(throws: (any Error).self) { try validateNotificationSound("") }
+    #expect(throws: (any Error).self) { try validateNotificationSound("Nope", customNames: []) }
+    #expect(throws: (any Error).self) { try validateNotificationSound("", customNames: []) }
+}
+
+@Test func validateNotificationSoundAcceptsCustomNames() throws {
+    try validateNotificationSound("Office-Bell", customNames: ["Office-Bell"])
+    try validateNotificationSound("office-bell", customNames: ["Office-Bell"])
+}
+
+// MARK: - add-sound / remove-sound
+
+@Test func notificationsAddSoundParsesPathAndName() throws {
+    let wav = try writeTempWav()
+    defer { try? FileManager.default.removeItem(at: wav) }
+    let cmd = try NotificationsAddSound.parse([wav.path, "--name", "Office Bell"])
+    #expect(cmd.path == wav.path)
+    #expect(cmd.name == "Office Bell")
+}
+
+@Test func notificationsAddSoundRejectsMissingFile() {
+    #expect(throws: (any Error).self) {
+        _ = try NotificationsAddSound.parse(["/no/such/crow-sound.wav"])
+    }
+}
+
+@Test func notificationsAddSoundRejectsUnsupportedExtension() throws {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("crow-cli-sound-\(UUID().uuidString).txt")
+    try Data("x".utf8).write(to: url)
+    defer { try? FileManager.default.removeItem(at: url) }
+    #expect(throws: (any Error).self) {
+        _ = try NotificationsAddSound.parse([url.path])
+    }
+}
+
+@Test func notificationsRemoveSoundParsesName() throws {
+    let cmd = try NotificationsRemoveSound.parse(["Office-Bell"])
+    #expect(cmd.name == "Office-Bell")
 }

--- a/Packages/CrowCore/Sources/CrowCore/Models/CustomSoundLibrary.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/CustomSoundLibrary.swift
@@ -1,0 +1,309 @@
+import Foundation
+
+/// One user-supplied notification sound, stored as a file under the library
+/// directory. `name` is what pickers and `--event-sound-name` use; `file` is
+/// the on-disk filename; `url` is the web path the client fetches to play it.
+///
+/// Bytes never enter `config.json` — per-event `soundName` holds this `name`
+/// as a reference, the same way built-in macOS sound names are stored.
+public struct CustomSound: Sendable, Equatable {
+    public var name: String
+    public var file: String
+    public var url: String
+
+    public init(name: String, file: String, url: String) {
+        self.name = name
+        self.file = file
+        self.url = url
+    }
+}
+
+/// Why adding or removing a custom sound failed. Messages are shown verbatim
+/// by the CLI and the Settings upload row.
+public enum CustomSoundError: Error, LocalizedError, Equatable {
+    case fileNotFound(String)
+    case unsupportedFormat
+    case tooLarge(maxBytes: Int)
+    case invalidName
+    case nameConflict(String)
+    case notAudio
+    case missing(String)
+    case io(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let path):
+            return "'\(path)' is not a readable file."
+        case .unsupportedFormat:
+            return "Unsupported sound format. Expected .wav, .mp3, or .aiff."
+        case .tooLarge(let max):
+            return "Sound file is too large. Maximum size is \(max / (1024 * 1024)) MB."
+        case .invalidName:
+            return "Sound name is empty or contains no usable characters."
+        case .nameConflict(let name):
+            return "'\(name)' already exists as a sound name. Pick a different name, or remove the existing one first."
+        case .notAudio:
+            return "File does not look like a .wav, .mp3, or .aiff audio file."
+        case .missing(let name):
+            return "No custom sound named '\(name)'."
+        case .io(let message):
+            return message
+        }
+    }
+}
+
+/// On-disk library of custom notification sounds.
+///
+/// Lives at `~/Library/Application Support/crow/sounds/` (or the platform
+/// equivalent). The directory is the source of truth — dropping a valid file
+/// in is enough for it to show up in `available_sounds` on the next get.
+/// Uploads (Settings) and `crow notifications add-sound` copy into it.
+///
+/// Tests **must** construct one with an explicit temporary `directory:` —
+/// never `.live` — so they cannot read or write the user's library (ADR 0012).
+public struct CustomSoundLibrary: Sendable {
+    /// Extensions accepted for upload, drop-in, and HTTP serve.
+    public static let allowedExtensions: Set<String> = ["wav", "mp3", "aiff", "aif"]
+
+    /// Cap for a single custom sound (2 MB). Notification chimes are short;
+    /// this also stays well under what a Settings upload should ship.
+    public static let maxBytes = 2 * 1024 * 1024
+
+    /// Web path prefix the client fetches. Kept here so the RPC listing and
+    /// the HTTP route cannot drift.
+    public static let urlPrefix = "/sounds/"
+
+    public let directory: URL
+
+    public init(directory: URL) {
+        self.directory = directory
+    }
+
+    /// Production library under Application Support. Tests must not use this —
+    /// pass a unique temp directory instead.
+    public static var live: CustomSoundLibrary {
+        CustomSoundLibrary(directory: defaultDirectory)
+    }
+
+    /// `~/Library/Application Support/crow/sounds/` (macOS) or the platform
+    /// Application Support equivalent. Created on first add, not on list.
+    public static var defaultDirectory: URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("crow", isDirectory: true)
+            .appendingPathComponent("sounds", isDirectory: true)
+    }
+
+    /// A unique temp directory for tests. Caller is responsible for cleanup.
+    public static func temporary() -> CustomSoundLibrary {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-test-sounds-\(UUID().uuidString)", isDirectory: true)
+        return CustomSoundLibrary(directory: dir)
+    }
+
+    // MARK: - Listing
+
+    /// Valid audio files in the library, sorted by display name.
+    /// Hidden files, wrong extensions, built-in-name collisions, and duplicate
+    /// stems (first wins) are skipped.
+    public func list() -> [CustomSound] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var seen = Set<String>()
+        var sounds: [CustomSound] = []
+        for url in entries.sorted(by: { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }) {
+            let file = url.lastPathComponent
+            guard Self.isSafeFileName(file) else { continue }
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDir), !isDir.boolValue else { continue }
+            guard Self.fileSize(url) <= Self.maxBytes else { continue }
+            let name = (file as NSString).deletingPathExtension
+            guard !name.isEmpty else { continue }
+            let key = name.lowercased()
+            // Built-ins win the picker; a dropped Glass.wav must not duplicate them.
+            if NotificationSettings.canonicalSoundName(name) != nil { continue }
+            guard seen.insert(key).inserted else { continue }
+            sounds.append(CustomSound(name: name, file: file, url: Self.url(for: file)))
+        }
+        return sounds.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    /// Display names currently in the library.
+    public var names: [String] { list().map(\.name) }
+
+    /// Look up a custom sound by display name (case-insensitive).
+    public func sound(named raw: String) -> CustomSound? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return list().first { $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }
+    }
+
+    /// Resolve a stored `soundName` to a custom file URL for serving, or nil
+    /// when it isn't a custom sound (built-in, missing, or unsafe).
+    public func fileURL(named raw: String) -> URL? {
+        guard let sound = sound(named: raw) else { return nil }
+        return resolvedFile(sound.file)
+    }
+
+    /// Resolve a served filename to a regular file still inside `directory`.
+    public func resolvedFile(_ file: String) -> URL? {
+        guard Self.isSafeFileName(file) else { return nil }
+        let candidate = directory.appendingPathComponent(file)
+        guard let url = Self.resolvedPathInside(dir: directory, file: candidate) else { return nil }
+        guard Self.fileSize(url) <= Self.maxBytes else { return nil }
+        return url
+    }
+
+    // MARK: - Add / remove
+
+    /// Copy `source` into the library. `requestedName` overrides the stem.
+    public func add(from source: URL, requestedName: String? = nil) throws -> CustomSound {
+        let path = source.path
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue else {
+            throw CustomSoundError.fileNotFound(path)
+        }
+        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+        if let size = attrs?[.size] as? Int, size > Self.maxBytes {
+            throw CustomSoundError.tooLarge(maxBytes: Self.maxBytes)
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: source)
+        } catch {
+            throw CustomSoundError.fileNotFound(path)
+        }
+        return try add(data: data, filename: source.lastPathComponent, requestedName: requestedName)
+    }
+
+    /// Store `data` as a new library entry. Used by the HTTP upload route.
+    public func add(data: Data, filename: String, requestedName: String? = nil) throws -> CustomSound {
+        guard !data.isEmpty else { throw CustomSoundError.notAudio }
+        guard data.count <= Self.maxBytes else {
+            throw CustomSoundError.tooLarge(maxBytes: Self.maxBytes)
+        }
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard Self.allowedExtensions.contains(ext) else {
+            throw CustomSoundError.unsupportedFormat
+        }
+        guard Self.looksLikeAudio(data, ext: ext) else {
+            throw CustomSoundError.notAudio
+        }
+        let trimmedRequested = requestedName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stemSource = (trimmedRequested?.isEmpty == false ? trimmedRequested : nil)
+            ?? (filename as NSString).deletingPathExtension
+        guard let stem = Self.sanitizeStem(stemSource) else {
+            throw CustomSoundError.invalidName
+        }
+        if let builtIn = NotificationSettings.canonicalSoundName(stem) {
+            throw CustomSoundError.nameConflict(builtIn)
+        }
+        if let existing = sound(named: stem) {
+            throw CustomSoundError.nameConflict(existing.name)
+        }
+        // Normalize aif → aiff so served names stay in the documented set.
+        let storedExt = ext == "aif" ? "aiff" : ext
+        let file = "\(stem).\(storedExt)"
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try data.write(to: directory.appendingPathComponent(file), options: .atomic)
+        } catch {
+            throw CustomSoundError.io(error.localizedDescription)
+        }
+        return CustomSound(name: stem, file: file, url: Self.url(for: file))
+    }
+
+    /// Delete the file for `name`. Events that still reference it keep the
+    /// name in config; playback falls back to a default when the file is gone.
+    public func remove(name raw: String) throws {
+        guard let sound = sound(named: raw) else {
+            throw CustomSoundError.missing(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        let url = directory.appendingPathComponent(sound.file)
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            throw CustomSoundError.io(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Guards
+
+    /// A bare audio filename: non-empty, no separators, no `..`, allowed ext.
+    public static func isSafeFileName(_ name: String) -> Bool {
+        !name.isEmpty && !name.contains("/") && !name.contains("\\") && !name.contains("..")
+            && allowedExtensions.contains((name as NSString).pathExtension.lowercased())
+    }
+
+    /// Stem used as the display / `--event-sound-name` value: `[A-Za-z0-9_-]`,
+    /// spaces become hyphens, 1–64 chars. Nil when nothing usable remains.
+    public static func sanitizeStem(_ raw: String) -> String? {
+        let spaced = raw.replacingOccurrences(of: " ", with: "-")
+        let allowed = CharacterSet(charactersIn:
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        let cleaned = String(String.UnicodeScalarView(spaced.unicodeScalars.filter { allowed.contains($0) }))
+        let trimmed = cleaned.trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(64))
+    }
+
+    /// Magic-byte sniff so a renamed `.txt` can't be stored as `.wav` and then
+    /// served from the daemon origin.
+    public static func looksLikeAudio(_ data: Data, ext: String) -> Bool {
+        guard data.count >= 12 else { return false }
+        switch ext {
+        case "wav":
+            return data.starts(with: Array("RIFF".utf8))
+                && data.dropFirst(8).starts(with: Array("WAVE".utf8))
+        case "aiff", "aif":
+            return data.starts(with: Array("FORM".utf8))
+                && (data.dropFirst(8).starts(with: Array("AIFF".utf8))
+                    || data.dropFirst(8).starts(with: Array("AIFC".utf8)))
+        case "mp3":
+            if data.starts(with: Array("ID3".utf8)) { return true }
+            return data[0] == 0xFF && (data[1] & 0xE0) == 0xE0
+        default:
+            return false
+        }
+    }
+
+    /// File size in bytes, or `Int.max` when unknown so callers skip it.
+    public static func fileSize(_ url: URL) -> Int {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        if let n = attrs?[.size] as? NSNumber { return n.intValue }
+        if let n = attrs?[.size] as? Int { return n }
+        return Int.max
+    }
+
+    public static func url(for file: String) -> String {
+        let encoded = file.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file
+        return urlPrefix + encoded
+    }
+
+    public static func contentType(for file: String) -> String {
+        switch (file as NSString).pathExtension.lowercased() {
+        case "wav": return "audio/wav"
+        case "mp3": return "audio/mpeg"
+        case "aiff", "aif": return "audio/aiff"
+        default: return "application/octet-stream"
+        }
+    }
+
+    /// Resolve `file` (following symlinks) and return it only when the final
+    /// path is still under `dir`. Mirrors `Artifacts.resolvedPathInside`.
+    public static func resolvedPathInside(dir: URL, file: URL) -> URL? {
+        let root = dir.resolvingSymlinksInPath().standardizedFileURL.path
+        let resolved = file.resolvingSymlinksInPath().standardizedFileURL.path
+        guard resolved == root || resolved.hasPrefix(root + "/") else { return nil }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: resolved, isDirectory: &isDir), !isDir.boolValue else {
+            return nil
+        }
+        return URL(fileURLWithPath: resolved)
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/Models/NotificationSettings.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/NotificationSettings.swift
@@ -85,16 +85,21 @@ public struct NotificationSettings: Codable, Sendable, Equatable {
         eventSettings[event] ?? EventNotificationConfig(soundName: event.defaultSound)
     }
 
-    /// Resolve a user-supplied sound name to its canonical `builtInSounds`
-    /// spelling, or nil when it isn't a built-in sound.
+    /// Resolve a user-supplied sound name to its canonical spelling, or nil
+    /// when it isn't a built-in and isn't in `customNames`.
     ///
     /// Single source of truth for the `--event-sound-name` rule: the CLI calls it
     /// for fast local feedback and the `notifications-set` handler calls it again
     /// as the authoritative check, so the two can't drift (CROW-813). Matching is
     /// case-insensitive so `crow notifications set --event-sound-name hero` works.
-    public static func canonicalSoundName(_ raw: String) -> String? {
+    /// Built-ins win over a custom name that collides (add-sound refuses that
+    /// collision, but a dropped file could still create one).
+    public static func canonicalSoundName(_ raw: String, customNames: [String] = []) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return builtInSounds.first { $0.caseInsensitiveCompare(trimmed) == .orderedSame }
+        if let builtIn = builtInSounds.first(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return builtIn
+        }
+        return customNames.first { $0.caseInsensitiveCompare(trimmed) == .orderedSame }
     }
 }
 
@@ -109,7 +114,8 @@ public struct EventNotificationConfig: Codable, Sendable, Equatable {
     /// Whether to post a macOS system notification.
     public var systemNotificationEnabled: Bool
 
-    /// Name of the sound to play (macOS system sound name or path to custom file).
+    /// Sound to play: a built-in name (`Glass`, `Hero`, …) or a custom library
+    /// name. Bytes live in Application Support, not here.
     public var soundName: String
 
     public init(

--- a/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Parity/ParityLedger.swift
@@ -156,6 +156,7 @@ public enum ParityLedger {
         "corveil-deselect-org",
         "corveil-detect-gateways",
         "corveil-link-gateway",
+        "notifications-add-sound",
     ]
 
     /// Every method reachable through the live router pair — the daemon's
@@ -316,6 +317,8 @@ public enum ParityLedger {
         .write("version-update-check", cli: "version check"),
         .read("notifications-get", cli: "notifications get"),
         .write("notifications-set", cli: "notifications set"),
+        .write("notifications-add-sound", cli: "notifications add-sound"),
+        .write("notifications-remove-sound", cli: "notifications remove-sound"),
         .read(
             "get-config",
             noCLI: """

--- a/Packages/CrowCore/Tests/CrowCoreTests/CustomSoundLibraryTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CustomSoundLibraryTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Suite("Custom sound library")
+struct CustomSoundLibraryTests {
+    private func library() -> CustomSoundLibrary {
+        CustomSoundLibrary.temporary()
+    }
+
+    private func cleanup(_ lib: CustomSoundLibrary) {
+        try? FileManager.default.removeItem(at: lib.directory)
+    }
+
+    // MARK: - add
+
+    @Test func addCopiesWavAndListsIt() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-src-\(UUID().uuidString).wav")
+        try TestAudio.wav.write(to: source)
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let sound = try lib.add(from: source)
+        #expect(sound.file.hasSuffix(".wav"))
+        #expect(sound.url.hasPrefix(CustomSoundLibrary.urlPrefix))
+        #expect(lib.list().map(\.name) == [sound.name])
+        #expect(lib.sound(named: sound.name)?.file == sound.file)
+        #expect(!sound.name.isEmpty)
+    }
+
+    @Test func addUsesRequestedNameAndSanitizes() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+
+        let sound = try lib.add(data: TestAudio.wav, filename: "ding.wav", requestedName: "Office Bell!")
+        #expect(sound.name == "Office-Bell")
+        #expect(sound.file == "Office-Bell.wav")
+        #expect(sound.url == "/sounds/Office-Bell.wav")
+    }
+
+    @Test func addNormalizesAifToAiff() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        let sound = try lib.add(data: TestAudio.aiff, filename: "tone.aif")
+        #expect(sound.file == "tone.aiff")
+        #expect(CustomSoundLibrary.contentType(for: sound.file) == "audio/aiff")
+    }
+
+    @Test func addRejectsUnsupportedExtension() {
+        let lib = library()
+        defer { cleanup(lib) }
+        #expect(throws: CustomSoundError.unsupportedFormat) {
+            try lib.add(data: TestAudio.wav, filename: "beep.txt")
+        }
+    }
+
+    @Test func addRejectsNonAudioBytes() {
+        let lib = library()
+        defer { cleanup(lib) }
+        #expect(throws: CustomSoundError.notAudio) {
+            try lib.add(data: Data("not audio".utf8), filename: "beep.wav")
+        }
+    }
+
+    @Test func addRejectsTooLarge() {
+        let lib = library()
+        defer { cleanup(lib) }
+        var data = TestAudio.wav
+        data.append(Data(repeating: 0, count: CustomSoundLibrary.maxBytes))
+        #expect(throws: CustomSoundError.tooLarge(maxBytes: CustomSoundLibrary.maxBytes)) {
+            try lib.add(data: data, filename: "huge.wav")
+        }
+    }
+
+    @Test func addRejectsBuiltInNameCollision() {
+        let lib = library()
+        defer { cleanup(lib) }
+        #expect(throws: CustomSoundError.nameConflict("Glass")) {
+            try lib.add(data: TestAudio.wav, filename: "x.wav", requestedName: "glass")
+        }
+    }
+
+    @Test func addRejectsDuplicateCustomName() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        _ = try lib.add(data: TestAudio.wav, filename: "a.wav", requestedName: "Chime")
+        #expect(throws: CustomSoundError.nameConflict("Chime")) {
+            try lib.add(data: TestAudio.mp3, filename: "b.mp3", requestedName: "chime")
+        }
+    }
+
+    @Test func addRejectsEmptySanitizedName() {
+        let lib = library()
+        defer { cleanup(lib) }
+        #expect(throws: CustomSoundError.invalidName) {
+            try lib.add(data: TestAudio.wav, filename: "x.wav", requestedName: "!!!")
+        }
+    }
+
+    @Test func addFromMissingPath() {
+        let lib = library()
+        defer { cleanup(lib) }
+        let missing = URL(fileURLWithPath: "/no/such/crow-sound-\(UUID().uuidString).wav")
+        #expect(throws: CustomSoundError.fileNotFound(missing.path)) {
+            try lib.add(from: missing)
+        }
+    }
+
+    // MARK: - list / drop-in
+
+    @Test func listPicksUpDroppedFilesAndSkipsBuiltInNames() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        try FileManager.default.createDirectory(at: lib.directory, withIntermediateDirectories: true)
+        try TestAudio.wav.write(to: lib.directory.appendingPathComponent("Dropped.wav"))
+        try TestAudio.wav.write(to: lib.directory.appendingPathComponent("Glass.wav"))
+        try Data("nope".utf8).write(to: lib.directory.appendingPathComponent("notes.txt"))
+
+        let names = lib.list().map(\.name)
+        #expect(names == ["Dropped"])
+    }
+
+    @Test func listSkipsOversizedDroppedFiles() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        try FileManager.default.createDirectory(at: lib.directory, withIntermediateDirectories: true)
+        try TestAudio.wav.write(to: lib.directory.appendingPathComponent("ok.wav"))
+        let huge = Data(repeating: 0, count: CustomSoundLibrary.maxBytes + 1)
+        try huge.write(to: lib.directory.appendingPathComponent("huge.wav"))
+        #expect(lib.list().map(\.name) == ["ok"])
+        #expect(lib.resolvedFile("huge.wav") == nil)
+    }
+
+    // MARK: - remove
+
+    @Test func removeDeletesTheFile() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        let sound = try lib.add(data: TestAudio.wav, filename: "gone.wav", requestedName: "Gone")
+        try lib.remove(name: "gone")
+        #expect(lib.list().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: lib.directory.appendingPathComponent(sound.file).path))
+    }
+
+    @Test func removeMissingName() {
+        let lib = library()
+        defer { cleanup(lib) }
+        #expect(throws: CustomSoundError.missing("Nope")) {
+            try lib.remove(name: "Nope")
+        }
+    }
+
+    // MARK: - guards
+
+    @Test func isSafeFileName() {
+        #expect(CustomSoundLibrary.isSafeFileName("chime.wav"))
+        #expect(CustomSoundLibrary.isSafeFileName("a.MP3"))
+        #expect(CustomSoundLibrary.isSafeFileName("tone.aiff"))
+        #expect(!CustomSoundLibrary.isSafeFileName("../secret.wav"))
+        #expect(!CustomSoundLibrary.isSafeFileName("sub/dir.wav"))
+        #expect(!CustomSoundLibrary.isSafeFileName("notes.txt"))
+        #expect(!CustomSoundLibrary.isSafeFileName(""))
+    }
+
+    @Test func sanitizeStem() {
+        #expect(CustomSoundLibrary.sanitizeStem("Office Bell") == "Office-Bell")
+        #expect(CustomSoundLibrary.sanitizeStem("  --x--  ") == "x")
+        #expect(CustomSoundLibrary.sanitizeStem("!!!") == nil)
+        #expect(CustomSoundLibrary.sanitizeStem(String(repeating: "a", count: 80))?.count == 64)
+    }
+
+    @Test func looksLikeAudio() {
+        #expect(CustomSoundLibrary.looksLikeAudio(TestAudio.wav, ext: "wav"))
+        #expect(CustomSoundLibrary.looksLikeAudio(TestAudio.mp3, ext: "mp3"))
+        #expect(CustomSoundLibrary.looksLikeAudio(TestAudio.aiff, ext: "aiff"))
+        #expect(!CustomSoundLibrary.looksLikeAudio(Data("RIFF....NOTWAVE".utf8), ext: "wav"))
+        #expect(!CustomSoundLibrary.looksLikeAudio(Data("short".utf8), ext: "wav"))
+    }
+
+    @Test func resolvedPathRejectsEscapingSymlink() throws {
+        let lib = library()
+        defer { cleanup(lib) }
+        try FileManager.default.createDirectory(at: lib.directory, withIntermediateDirectories: true)
+
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-sound-secret-\(UUID().uuidString).txt")
+        try Data("SECRET".utf8).write(to: outside)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        let link = lib.directory.appendingPathComponent("shot.wav")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+        #expect(lib.resolvedFile("shot.wav") == nil)
+
+        let real = lib.directory.appendingPathComponent("ok.wav")
+        try TestAudio.wav.write(to: real)
+        #expect(lib.resolvedFile("ok.wav") != nil)
+        #expect(lib.resolvedFile("../ok.wav") == nil)
+    }
+}
+
+enum TestAudio {
+    static var wav: Data {
+        var d = Data()
+        d.append(contentsOf: Array("RIFF".utf8))
+        d.append(contentsOf: [36, 0, 0, 0])
+        d.append(contentsOf: Array("WAVE".utf8))
+        d.append(contentsOf: Array("fmt ".utf8))
+        d.append(contentsOf: [16, 0, 0, 0, 1, 0, 1, 0, 0x44, 0xAC, 0, 0, 0x88, 0x58, 1, 0, 2, 0, 16, 0])
+        d.append(contentsOf: Array("data".utf8))
+        d.append(contentsOf: [0, 0, 0, 0])
+        return d
+    }
+
+    static var mp3: Data {
+        var d = Data(Array("ID3".utf8))
+        d.append(contentsOf: [0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        d.append(contentsOf: [0xFF, 0xFB])
+        d.append(Data(repeating: 0, count: 32))
+        return d
+    }
+
+    static var aiff: Data {
+        var d = Data()
+        d.append(contentsOf: Array("FORM".utf8))
+        d.append(contentsOf: [0, 0, 0, 4])
+        d.append(contentsOf: Array("AIFF".utf8))
+        return d
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/NotificationSettingsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/NotificationSettingsTests.swift
@@ -166,6 +166,14 @@ import Testing
     #expect(NotificationSettings.canonicalSoundName("/System/Library/Sounds/Glass.aiff") == nil)
 }
 
+@Test func canonicalSoundNameAcceptsCustomNames() {
+    #expect(NotificationSettings.canonicalSoundName("Office-Bell", customNames: ["Office-Bell"]) == "Office-Bell")
+    #expect(NotificationSettings.canonicalSoundName("office-bell", customNames: ["Office-Bell"]) == "Office-Bell")
+    #expect(NotificationSettings.canonicalSoundName("Nope", customNames: ["Office-Bell"]) == nil)
+    // Built-ins still win when a custom name collides.
+    #expect(NotificationSettings.canonicalSoundName("glass", customNames: ["Glass-Custom"]) == "Glass")
+}
+
 // MARK: - builtInSounds
 
 @Test func builtInSoundsNonEmpty() {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CrowDaemon.swift
@@ -496,11 +496,13 @@ public enum CrowDaemon {
             return makeEngineRouter(ctx)
         }
 
+        let soundLibrary = CustomSoundLibrary.live
         let commandRouter = makeCommandRouter(
             appState: appState, store: store, git: git, devRoot: options.devRoot,
             cockpit: cockpit, tracker: tracker, allowList: allowList,
             sessionService: sessionService, autoRespond: autoRespond, jobScheduler: jobScheduler,
             rebuildScorecard: rebuildScorecard, versionUpdateService: versionUpdateService,
+            soundLibrary: soundLibrary,
             fallback: engineFallback)
 
         // Unix socket — lets the existing `crow` CLI talk to the daemon. By
@@ -605,6 +607,8 @@ public enum CrowDaemon {
         // Per-session generated images (diagrams/screenshots an agent dropped
         // in the scratch dir), served read-only + sandboxed (CROW-593).
         Artifacts.mount(on: httpRouter, boundHost: options.host)
+        CustomSoundRoutes.mount(
+            on: httpRouter, boundHost: options.host, library: soundLibrary)
         if let webDir = options.webDir {
             log("serving web UI live from \(webDir) (edit + refresh, no rebuild)")
         }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/CustomSoundRoutes.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/CustomSoundRoutes.swift
@@ -1,0 +1,87 @@
+import Foundation
+import CrowCore
+import HTTPTypes
+import Hummingbird
+import NIOCore
+
+/// Serves custom notification sounds from the Application Support `sounds/`
+/// library and accepts Settings uploads (CROW-1147).
+///
+/// `GET /sounds/:file` is the playback path the web client (and the Tauri
+/// desktop wrapper) fetches. `POST /sounds` is the Settings "Upload sound"
+/// write — binary, so it sits here rather than on `/rpc` (1 MB frame cap).
+/// Both sit behind `WebAuthMiddleware`; the write side additionally requires a
+/// same-origin request (anti-CSRF), matching `Artifacts`.
+enum CustomSoundRoutes {
+    /// Mount serve + upload. `library` is injected so tests never touch the
+    /// live Application Support directory (ADR 0012).
+    static func mount(
+        on router: Router<CrowHTTPContext>,
+        boundHost: String,
+        library: CustomSoundLibrary
+    ) {
+        router.get("/sounds/:file") { _, context -> Response in
+            guard let file = context.parameters.get("file"),
+                  CustomSoundLibrary.isSafeFileName(file) else {
+                return Response(status: .badRequest)
+            }
+            guard let resolved = library.resolvedFile(file),
+                  let data = try? Data(contentsOf: resolved) else {
+                return Response(status: .notFound)
+            }
+            return Response(
+                status: .ok,
+                headers: [
+                    .contentType: CustomSoundLibrary.contentType(for: file),
+                    .cacheControl: "no-store",
+                    HTTPField.Name("x-content-type-options")!: "nosniff",
+                ],
+                body: .init(byteBuffer: ByteBuffer(bytes: data)))
+        }
+
+        router.post("/sounds") { request, context -> Response in
+            guard WebSocketOriginGuard.isAllowedOrigin(
+                request.headers[.origin],
+                boundHost: boundHost,
+                forwardedHost: request.headers[HTTPField.Name("x-forwarded-host")!],
+                peerIsLoopback: WebAuthGuard.isLoopbackPeer(context.remoteAddress)) else {
+                return Response(status: .forbidden)
+            }
+            let filename = request.headers[HTTPField.Name("x-filename")!]
+                .flatMap { $0.removingPercentEncoding ?? $0 }
+                ?? "sound.wav"
+            guard let buffer = try? await request.body.collect(upTo: CustomSoundLibrary.maxBytes) else {
+                return json(
+                    ["error": "Sound file is too large. Maximum size is \(CustomSoundLibrary.maxBytes / (1024 * 1024)) MB."],
+                    status: .init(code: 413))
+            }
+            let data = Data(buffer.readableBytesView)
+            do {
+                let sound = try library.add(data: data, filename: filename)
+                return json([
+                    "name": sound.name,
+                    "file": sound.file,
+                    "url": sound.url,
+                ])
+            } catch let error as CustomSoundError {
+                let status: HTTPResponse.Status
+                switch error {
+                case .tooLarge: status = .init(code: 413)
+                case .io: status = .internalServerError
+                default: status = .badRequest
+                }
+                return json(["error": error.localizedDescription], status: status)
+            } catch {
+                return json(["error": error.localizedDescription], status: .internalServerError)
+            }
+        }
+    }
+
+    private static func json(_ dict: [String: Any], status: HTTPResponse.Status = .ok) -> Response {
+        let data = (try? JSONSerialization.data(withJSONObject: dict)) ?? Data("{}".utf8)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json; charset=utf-8"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data)))
+    }
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCHandlers.swift
@@ -48,6 +48,7 @@ func makeCommandRouter(
     // (so `corveil-disconnect` can invalidate it) and the provisioning verbs.
     // Injectable so a test can observe the invalidation; one per router otherwise.
     corveilOrgCache: CorveilOrgListCache = CorveilOrgListCache(),
+    soundLibrary: CustomSoundLibrary = .live,
     fallback: CommandRouter? = nil
 ) -> CommandRouter {
     // Serializes review kickoffs (see start-review) — one per router instance.
@@ -78,7 +79,9 @@ func makeCommandRouter(
             jobScheduler: jobScheduler, tracker: tracker, devRoot: devRoot)
     ) { existing, _ in existing }
     handlers.merge(
-        makeSettingsHandlers(versionUpdateService: versionUpdateService, devRoot: devRoot)
+        makeSettingsHandlers(
+            versionUpdateService: versionUpdateService, devRoot: devRoot,
+            soundLibrary: soundLibrary)
     ) { existing, _ in existing }
     handlers.merge(makeWorkspaceHandlers(appState: appState, devRoot: devRoot)) { existing, _ in existing }
     handlers.merge(makeMCPTokenHandlers(devRoot: devRoot)) { existing, _ in existing }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -121,6 +121,8 @@ enum RPCLanePolicy {
         "ui-set": .fixed(.config),
         "terminal-set": .fixed(.config),
         "notifications-set": .fixed(.config),
+        "notifications-add-sound": .fixed(.config),
+        "notifications-remove-sound": .fixed(.config),
         "workspace-add": .fixed(.config),
         "workspace-edit": .fixed(.config),
         "workspace-remove": .fixed(.config),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCWebSocketHandler.swift
@@ -254,11 +254,13 @@ enum RPCWebSocketHandler {
     /// are likewise un-gated (same jobs-array surface; today only the CLI, which is
     /// always local, uses them).
     ///
-    /// `notifications-get` / `notifications-set` are un-gated for the same reason
-    /// (CROW-813): they read and write `AppConfig.notifications`, which carries no
-    /// secrets and is already remotely editable through un-gated `set-config` —
-    /// Settings → Notifications is a core web surface. Gating only the CLI's path
-    /// to it would be inconsistent, not safer.
+    /// `notifications-get` / `notifications-set` / `notifications-remove-sound`
+    /// are un-gated for the same reason (CROW-813 / CROW-1147): they read and
+    /// write `AppConfig.notifications` (or delete a named library file), which
+    /// carries no secrets and is already remotely editable through un-gated
+    /// `set-config` — Settings → Notifications is a core web surface. Gating
+    /// only the CLI's path to it would be inconsistent, not safer.
+    /// `notifications-add-sound` *is* gated: it copies a host filesystem path.
     ///
     /// The tmux-maintenance methods (`restart-manager`, `restart-tmux-server`,
     /// `reload-tmux-config`, `launch-agent`, `retry-readiness`) are also NOT gated,
@@ -386,6 +388,12 @@ enum RPCWebSocketHandler {
             // connection verbs above. Both are gated so the whole migration surface
             // stays part of the one local-only Corveil connection surface.
             return "Corveil gateway migration is local-only"
+        case "notifications-add-sound":
+            // Copies a file from a path on the daemon host into the sound library
+            // (CROW-1147). A remote `/rpc` peer must not read arbitrary host
+            // paths. The web Settings upload uses `POST /sounds` instead, which
+            // carries bytes rather than a path.
+            return "notifications-add-sound is local-only"
         case "set-config":
             guard setConfigTouchesPrivilegedFields(request, devRoot: devRoot) else { return nil }
             return "set-config binaries is local-only"

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.js
@@ -399,6 +399,13 @@ async function loadUIConfig() {
     uiConfig.wheelScrollLines = Math.max(1, Number(t.wheelScrollLines) || 3);
     uiConfig.agentWheelNotches = Math.max(1, Number(t.agentWheelNotches) || 1);
     uiConfig.notifications = parseNotificationSettings(cfg.notifications);
+    try {
+      const nr = await rpc('notifications-get');
+      const custom = (nr && nr.notifications && nr.notifications.custom_sounds) || [];
+      if (window.crowSound && window.crowSound.setCustomSounds) {
+        window.crowSound.setCustomSounds(custom);
+      }
+    } catch (_) { /* custom sounds stay empty; built-in synth still works */ }
     // Presence of the (secret-stripped) webAuth block means a web password is set.
     uiConfig.webPasswordSet = !!cfg.webAuth;
     // Host capability: whether the VS Code `code` CLI is installed. Gates the
@@ -530,6 +537,7 @@ const SOUND_TONES = {
 
 const crowSound = (() => {
   let ctx = null;
+  let customByName = {}; // lowercased name → url
   function ensure() {
     const AC = window.AudioContext || window.webkitAudioContext;
     if (!AC) return null;
@@ -537,7 +545,7 @@ const crowSound = (() => {
     if (ctx.state === 'suspended') ctx.resume(); // no-op once unlocked
     return ctx;
   }
-  function play(name) {
+  function playSynth(name) {
     const c = ensure();
     if (!c) return;
     const recipe = SOUND_TONES[name] || SOUND_TONES._default;
@@ -554,8 +562,33 @@ const crowSound = (() => {
       osc.start(t0); osc.stop(t0 + dur + 0.03);
     }
   }
-  return { play, unlock: ensure };
+  function playFile(url, fallbackName) {
+    try {
+      const audio = new Audio(url);
+      audio.onerror = () => playSynth(fallbackName || 'Glass');
+      const p = audio.play();
+      if (p && p.catch) p.catch(() => playSynth(fallbackName || 'Glass'));
+    } catch (_) {
+      playSynth(fallbackName || 'Glass');
+    }
+  }
+  function play(name, fallbackName) {
+    const url = customByName[String(name || '').toLowerCase()];
+    if (url) { playFile(url, fallbackName || 'Glass'); return; }
+    // Built-in names synthesize; a missing/deleted custom file falls back
+    // to the event default (or Glass) rather than a generic beep.
+    if (SOUND_TONES[name]) { playSynth(name); return; }
+    playSynth(fallbackName || 'Glass');
+  }
+  function setCustomSounds(list) {
+    customByName = {};
+    for (const s of list || []) {
+      if (s && s.name && s.url) customByName[String(s.name).toLowerCase()] = s.url;
+    }
+  }
+  return { play, unlock: ensure, setCustomSounds };
 })();
+window.crowSound = crowSound;
 
 // Web Audio starts suspended until a user gesture (autoplay policy) — unlock on
 // the first interaction so event chimes play thereafter.
@@ -583,7 +616,8 @@ function playEventSound(event, key) {
   const now = Date.now();
   if (_lastSoundAt[k] && now - _lastSoundAt[k] < 2000) return;
   _lastSoundAt[k] = now;
-  crowSound.play(cfg.soundName || DEFAULT_EVENT_SOUND[event] || 'Glass');
+  crowSound.play(cfg.soundName || DEFAULT_EVENT_SOUND[event] || 'Glass',
+    DEFAULT_EVENT_SOUND[event] || 'Glass');
 }
 
 // Manual test hook. crowTestSound() plays each event once (staggered);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.css
@@ -174,6 +174,9 @@
 .st-sound-row { display: flex; gap: 8px; align-items: center; }
 .st-sound-row .st-select { flex: 1; }
 .st-sound-row .st-input { flex: 1; }
+.st-sound-lib { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+.st-sound-lib-row { display: flex; gap: 8px; align-items: center; }
+.st-sound-lib-name { flex: 1; font-size: 13px; }
 .st-perm-status { font-size: 12px; color: var(--text-muted); }
 .st-switch {
   appearance: none; -webkit-appearance: none;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -88,6 +88,10 @@
     'Basso', 'Blow', 'Bottle', 'Frog', 'Funk', 'Glass', 'Hero', 'Morse',
     'Ping', 'Pop', 'Purr', 'Sosumi', 'Submarine', 'Tink',
   ];
+  // Built-ins plus custom library names, filled from `notifications-get` when
+  // Settings opens. Falls back to BUILT_IN_SOUNDS if that RPC fails.
+  let availableSounds = BUILT_IN_SOUNDS.slice();
+  let customSounds = []; // [{name, file, url}]
   // The app plays macOS system sounds (NSSound) that don't exist in a browser,
   // so the web preview synthesizes a short distinct tone per name via Web Audio
   // — an approximation, no bundled assets (CROW-593). Each recipe is a list of
@@ -111,6 +115,10 @@
   };
   let _audioCtx = null;
   function previewSound(name) {
+    if (window.crowSound && typeof window.crowSound.play === 'function') {
+      window.crowSound.play(name);
+      return;
+    }
     const AC = window.AudioContext || window.webkitAudioContext;
     if (!AC) return;
     try {
@@ -178,6 +186,22 @@
     // local browser may change it (CROW-769).
     try { const ar2 = await fetch('/autostart'); autostart = ar2.ok ? await ar2.json() : null; }
     catch (_) { autostart = null; }
+    // Custom sound library (CROW-1147). get-config does not scan the sounds
+    // directory, so this is a second read — same payload the CLI `notifications
+    // get` prints.
+    try {
+      const nr = await rpc('notifications-get');
+      const n = (nr && nr.notifications) || {};
+      availableSounds = Array.isArray(n.available_sounds) && n.available_sounds.length
+        ? n.available_sounds : BUILT_IN_SOUNDS.slice();
+      customSounds = Array.isArray(n.custom_sounds) ? n.custom_sounds : [];
+      if (window.crowSound && window.crowSound.setCustomSounds) {
+        window.crowSound.setCustomSounds(customSounds);
+      }
+    } catch (_) {
+      availableSounds = BUILT_IN_SOUNDS.slice();
+      customSounds = [];
+    }
     dirty = false;
     subForm = null;
     resetCorveilConnectState();
@@ -875,12 +899,109 @@
 
   // ---- Notifications ------------------------------------------------------
 
+  // Custom sound library (CROW-1147). Upload and remove apply immediately —
+  // they write the Application Support sounds/ dir, not config.json — so they
+  // do not mark the form dirty. Choosing a custom name in a picker still does.
+  function customSoundLibrary() {
+    const wrap = el('div', 'st-sound-lib');
+    if (customSounds.length === 0) {
+      wrap.appendChild(el('div', 'st-help', 'No custom sounds yet.'));
+    } else {
+      for (const sound of customSounds) {
+        const row = el('div', 'st-sound-lib-row');
+        row.appendChild(el('span', 'st-sound-lib-name', sound.name));
+        const preview = el('button', 'action-btn', '▶ Preview');
+        preview.type = 'button';
+        preview.onclick = () => previewSound(sound.name);
+        const del = el('button', 'action-btn', 'Remove');
+        del.type = 'button';
+        del.onclick = () => removeCustomSound(sound.name);
+        row.appendChild(preview);
+        row.appendChild(del);
+        wrap.appendChild(row);
+      }
+    }
+    const actions = el('div', 'st-sound-row');
+    const input = el('input');
+    input.type = 'file';
+    input.accept = '.wav,.mp3,.aiff,.aif,audio/wav,audio/mpeg,audio/aiff';
+    input.style.display = 'none';
+    input.onchange = () => {
+      const file = input.files && input.files[0];
+      input.value = '';
+      if (file) uploadCustomSound(file);
+    };
+    const btn = el('button', 'action-btn', 'Upload sound');
+    btn.type = 'button';
+    btn.onclick = () => input.click();
+    actions.appendChild(btn);
+    actions.appendChild(input);
+    wrap.appendChild(actions);
+    return field('Custom sounds', wrap,
+      'WAV, MP3, or AIFF, up to 2 MB. Stored on this machine and playable in the web app. Dropping a file into ~/Library/Application Support/crow/sounds/ also works.');
+  }
+
+  async function uploadCustomSound(file) {
+    try {
+      const res = await fetch('/sounds', {
+        method: 'POST',
+        headers: { 'X-Filename': encodeURIComponent(file.name) },
+        body: file,
+        credentials: 'same-origin',
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alertModal(body.error || ('Upload failed (' + res.status + ')'));
+        return;
+      }
+      applySoundLibraryFromUpload(body);
+    } catch (err) {
+      alertModal('Upload failed: ' + (err.message || err));
+    }
+  }
+
+  async function removeCustomSound(name) {
+    if (!(await confirmModal('Remove “' + name + '”? Events that use it will fall back to a default sound.',
+        { title: 'Remove sound', okLabel: 'Remove', danger: true }))) return;
+    try {
+      const res = await rpc('notifications-remove-sound', { name: name });
+      applySoundLibraryFromGet(res && res.notifications);
+    } catch (err) {
+      alertModal('Remove failed: ' + (err.message || err));
+    }
+  }
+
+  function applySoundLibraryFromUpload(sound) {
+    if (!sound || !sound.name) return;
+    customSounds = customSounds.filter((s) => s.name !== sound.name).concat([sound]);
+    if (availableSounds.indexOf(sound.name) < 0) availableSounds = availableSounds.concat([sound.name]);
+    if (window.crowSound && window.crowSound.setCustomSounds) {
+      window.crowSound.setCustomSounds(customSounds);
+    }
+    render();
+  }
+
+  function applySoundLibraryFromGet(n) {
+    if (!n) return;
+    availableSounds = Array.isArray(n.available_sounds) && n.available_sounds.length
+      ? n.available_sounds : BUILT_IN_SOUNDS.slice();
+    customSounds = Array.isArray(n.custom_sounds) ? n.custom_sounds : [];
+    if (window.crowSound && window.crowSound.setCustomSounds) {
+      window.crowSound.setCustomSounds(customSounds);
+    }
+    render();
+  }
+
   // Sound selector with an inline preview button (Web Audio synth, see
   // previewSound). Bound to conf.soundName like the desktop picker (CROW-593).
   function soundField(conf) {
     const wrap = el('div', 'st-sound-row');
     const sel = el('select', 'st-select');
-    for (const s of BUILT_IN_SOUNDS) {
+    const names = availableSounds.slice();
+    // Keep a stored custom/missing name selectable so Save doesn't silently
+    // rewrite it to the first built-in.
+    if (conf.soundName && names.indexOf(conf.soundName) < 0) names.push(conf.soundName);
+    for (const s of names) {
       const o = el('option', null, s);
       o.value = s;
       if (conf.soundName === s) o.selected = true;
@@ -893,7 +1014,7 @@
     wrap.appendChild(sel);
     wrap.appendChild(btn);
     return field('Sound', wrap,
-      'Preview is a synthesized approximation; the desktop app plays the actual macOS system sound.');
+      'Preview of a built-in is a synthesized approximation; custom sounds play the uploaded file.');
   }
 
   function renderNotifications(body) {
@@ -904,6 +1025,7 @@
     body.appendChild(toggleField('Enable sound', n, 'soundEnabled'));
     body.appendChild(toggleField('Enable system notifications', n, 'systemNotificationsEnabled'));
     body.appendChild(browserNotifRow());
+    body.appendChild(customSoundLibrary());
 
     for (const [raw, conf] of ensureAllEvents(n)) {
       body.appendChild(group(EVENT_LABELS[raw] || raw));

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SettingsRPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SettingsRPCHandlers.swift
@@ -11,7 +11,8 @@ import Foundation
 /// Extracted from `makeCommandRouter`'s dictionary literal (CROW-1134).
 func makeSettingsHandlers(
     versionUpdateService: VersionUpdateService?,
-    devRoot: String
+    devRoot: String,
+    soundLibrary: CustomSoundLibrary = .live
 ) -> [String: CommandRouter.Handler] {
     // The explicit annotation is load-bearing, not decoration: a large
     // dictionary of closures without a contextual type blows Swift's
@@ -292,7 +293,8 @@ func makeSettingsHandlers(
                 let event = try params["event"].map { try NotificationRPC.decodeEvent($0) }
                 let (config, readable) = loadConfigReportingReadability(devRoot: devRoot)
                 return ["notifications": NotificationRPC.settingsJSON(
-                    config.notifications, only: event, configReadable: readable)]
+                    config.notifications, only: event, configReadable: readable,
+                    customSounds: soundLibrary.list())]
             }
         },
         "notifications-set": { params in
@@ -304,8 +306,9 @@ func makeSettingsHandlers(
                 let eventEnabled = params["event_enabled"]?.boolValue
                 let eventSoundEnabled = params["event_sound_enabled"]?.boolValue
                 let eventSystemEnabled = params["event_system_notification_enabled"]?.boolValue
+                let customNames = soundLibrary.names
                 let eventSoundName = try params["event_sound_name"].map {
-                    try NotificationRPC.decodeSoundName($0)
+                    try NotificationRPC.decodeSoundName($0, customNames: customNames)
                 }
 
                 let hasEventField = eventEnabled != nil || eventSoundEnabled != nil
@@ -350,8 +353,61 @@ func makeSettingsHandlers(
                     return config.notifications
                 }
                 return [
-                    "notifications": NotificationRPC.settingsJSON(settings, only: event),
+                    "notifications": NotificationRPC.settingsJSON(
+                        settings, only: event, customSounds: soundLibrary.list()),
                     "saved": .bool(true),
+                ]
+            }
+        },
+
+        // Custom notification sounds (CROW-1147). Files live under Application
+        // Support, not in config.json — add copies a host path (CLI, local-only);
+        // remove deletes by name (web Settings + CLI). The web upload itself is
+        // HTTP POST /sounds, because a sound can exceed the 1 MB /rpc frame.
+        "notifications-add-sound": { params in
+            try await mapRPCError {
+                guard let raw = params["path"]?.stringValue,
+                      !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw RPCError.invalidParams("path required")
+                }
+                let path = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard path.hasPrefix("/") else {
+                    throw RPCError.invalidParams(
+                        "path must be absolute (it is resolved by the daemon, not your shell)")
+                }
+                let name = params["name"]?.stringValue
+                do {
+                    let sound = try soundLibrary.add(
+                        from: URL(fileURLWithPath: path), requestedName: name)
+                    let (config, _) = loadConfigReportingReadability(devRoot: devRoot)
+                    return [
+                        "sound": NotificationRPC.customSoundJSON(sound),
+                        "notifications": NotificationRPC.settingsJSON(
+                            config.notifications, customSounds: soundLibrary.list()),
+                        "saved": .bool(true),
+                    ]
+                } catch let error as CustomSoundError {
+                    throw RPCError.invalidParams(error.localizedDescription)
+                }
+            }
+        },
+        "notifications-remove-sound": { params in
+            try await mapRPCError {
+                guard let raw = params["name"]?.stringValue,
+                      !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw RPCError.invalidParams("name required")
+                }
+                do {
+                    try soundLibrary.remove(name: raw)
+                } catch let error as CustomSoundError {
+                    throw RPCError.invalidParams(error.localizedDescription)
+                }
+                let (config, _) = loadConfigReportingReadability(devRoot: devRoot)
+                return [
+                    "removed": .bool(true),
+                    "name": .string(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+                    "notifications": NotificationRPC.settingsJSON(
+                        config.notifications, customSounds: soundLibrary.list()),
                 ]
             }
         },

--- a/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/StaticAssets.swift
@@ -166,6 +166,7 @@ enum StaticAssets {
         // today, but explicit so a future default-src tightening can't break install.
         "manifest-src 'self'",
         "connect-src 'self'",
+        "media-src 'self'",
         "worker-src 'self' blob:",
         "object-src 'none'",
         "base-uri 'none'",

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CustomSoundRoutesTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CustomSoundRoutesTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import Testing
+@testable import CrowDaemon
+import CrowCore
+
+@Suite("Custom sound HTTP routes")
+struct CustomSoundRoutesTests {
+    private func makeApp(_ library: CustomSoundLibrary) -> some ApplicationProtocol {
+        let router = Router(context: CrowHTTPContext.self)
+        CustomSoundRoutes.mount(on: router, boundHost: "127.0.0.1", library: library)
+        return Application(router: router)
+    }
+
+    @Test func getServesUploadedWav() async throws {
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        let sound = try lib.add(data: NotificationTestAudio.wav, filename: "chime.wav", requestedName: "Chime")
+
+        try await makeApp(lib).test(.router) { client in
+            try await client.execute(uri: sound.url, method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.headers[.contentType] == "audio/wav")
+                #expect(response.headers[.cacheControl] == "no-store")
+                #expect(response.body.readableBytes == NotificationTestAudio.wav.count)
+            }
+        }
+    }
+
+    @Test func getRejectsTraversal() async throws {
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        try await makeApp(lib).test(.router) { client in
+            try await client.execute(uri: "/sounds/../Package.swift", method: .get) { response in
+                #expect(response.status == .badRequest || response.status == .notFound)
+            }
+            try await client.execute(uri: "/sounds/notes.txt", method: .get) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+    }
+
+    @Test func postUploadsAndGetServes() async throws {
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        try await makeApp(lib).test(.router) { client in
+            try await client.execute(
+                uri: "/sounds",
+                method: .post,
+                headers: [HTTPField.Name("x-filename")!: "Office Bell.wav"],
+                body: ByteBuffer(bytes: NotificationTestAudio.wav)
+            ) { response in
+                #expect(response.status == .ok)
+                let json = try #require(
+                    try JSONSerialization.jsonObject(with: Data(buffer: response.body)) as? [String: Any]
+                )
+                #expect(json["name"] as? String == "Office-Bell")
+                #expect(json["file"] as? String == "Office-Bell.wav")
+                #expect(json["url"] as? String == "/sounds/Office-Bell.wav")
+            }
+            try await client.execute(uri: "/sounds/Office-Bell.wav", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.headers[.contentType] == "audio/wav")
+            }
+        }
+    }
+
+    @Test func postRejectsNonAudio() async throws {
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        try await makeApp(lib).test(.router) { client in
+            try await client.execute(
+                uri: "/sounds",
+                method: .post,
+                headers: [HTTPField.Name("x-filename")!: "notes.wav"],
+                body: ByteBuffer(bytes: Array("not a wav".utf8))
+            ) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+    }
+
+    @Test func postRejectsUnsupportedExtension() async throws {
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        try await makeApp(lib).test(.router) { client in
+            try await client.execute(
+                uri: "/sounds",
+                method: .post,
+                headers: [HTTPField.Name("x-filename")!: "notes.txt"],
+                body: ByteBuffer(bytes: NotificationTestAudio.wav)
+            ) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+    }
+}

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -877,7 +877,8 @@ import CrowPersistence
         // routing is the whole point of the probe (CROW-593).
         #expect(!MW.isAuthExempt(path: "/auth/check"))
         for path in ["/", "/index.html", "/app.js", "/rpc",
-                     "/config/web-password", "/config/manager-gateway"] {
+                     "/config/web-password", "/config/manager-gateway",
+                     "/sounds", "/sounds/chime.wav"] {
             #expect(!MW.isAuthExempt(path: path), "\(path) must be gated")
         }
     }
@@ -913,6 +914,7 @@ import CrowPersistence
             "default-src 'self'",
             "script-src 'self' 'wasm-unsafe-eval'",   // xterm's Sixel wasm, no arbitrary eval
             "connect-src 'self'",                      // same-origin /rpc + /terminal WS only
+            "media-src 'self'",                        // custom notification sounds (CROW-1147)
             "object-src 'none'",
             "base-uri 'none'",
             "frame-ancestors 'none'",                  // no clickjacking
@@ -1311,6 +1313,20 @@ import CrowPersistence
             "global_mute": .bool(true),
         ])
         #expect(RPCWebSocketHandler.localOnlyDenial(for: set, devRoot: devRoot) == nil)
+
+        // remove-sound deletes a named library file — same trust as set.
+        let remove = JSONRPCRequest(id: 3, method: "notifications-remove-sound", params: [
+            "name": .string("Office-Bell"),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: remove, devRoot: devRoot) == nil)
+
+        // add-sound copies a host path, so it stays local-only. The web upload
+        // is POST /sounds, not this RPC.
+        let add = JSONRPCRequest(id: 4, method: "notifications-add-sound", params: [
+            "path": .string("/tmp/ding.wav"),
+        ])
+        #expect(RPCWebSocketHandler.localOnlyDenial(for: add, devRoot: devRoot)
+            == "notifications-add-sound is local-only")
     }
 
     @Test func agentRPCsAreAllowedRemotely() throws {

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/NotificationRoutesTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/NotificationRoutesTests.swift
@@ -20,13 +20,14 @@ import CrowPersistence
     }
 
     @MainActor
-    private func router(devRoot: String) -> CommandRouter {
+    private func router(devRoot: String, soundLibrary: CustomSoundLibrary = .temporary()) -> CommandRouter {
         makeCommandRouter(
             appState: AppState(),
             store: JSONStore.temporary(),
             git: GitManager(),
             devRoot: devRoot,
-            cockpit: nil)
+            cockpit: nil,
+            soundLibrary: soundLibrary)
     }
 
     private func notifications(_ result: [String: JSONValue]?) throws -> [String: JSONValue] {
@@ -323,5 +324,106 @@ import CrowPersistence
 
         #expect(resp.error != nil)
         #expect(try String(contentsOf: configURL, encoding: .utf8) == corrupt)
+    }
+
+    // MARK: - custom sounds (CROW-1147)
+
+    @Test func getListsCustomSoundsNextToBuiltIns() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        _ = try lib.add(data: NotificationTestAudio.wav, filename: "office.wav", requestedName: "Office-Bell")
+
+        let resp = await router(devRoot: devRoot, soundLibrary: lib)
+            .handle(request: JSONRPCRequest(id: 1, method: "notifications-get"))
+
+        #expect(resp.error == nil)
+        let object = try notifications(resp.result)
+        let available = try #require(object["available_sounds"]?.arrayValue)
+        #expect(available.contains(.string("Glass")))
+        #expect(available.contains(.string("Office-Bell")))
+        let custom = try #require(object["custom_sounds"]?.arrayValue)
+        #expect(custom.count == 1)
+        #expect(custom[0].objectValue?["name"]?.stringValue == "Office-Bell")
+        #expect(custom[0].objectValue?["url"]?.stringValue == "/sounds/Office-Bell.wav")
+    }
+
+    @Test func setAcceptsACustomSoundName() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        _ = try lib.add(data: NotificationTestAudio.wav, filename: "office.wav", requestedName: "Office-Bell")
+
+        let resp = await router(devRoot: devRoot, soundLibrary: lib).handle(request: JSONRPCRequest(
+            id: 1, method: "notifications-set", params: [
+                "event": .string("taskComplete"),
+                "event_sound_name": .string("office-bell"),
+            ]))
+
+        #expect(resp.error == nil)
+        let stored = try #require(ConfigStore.loadConfig(devRoot: devRoot))
+        #expect(stored.notifications.eventSettings[.taskComplete]?.soundName == "Office-Bell")
+    }
+
+    @Test func addSoundCopiesIntoTheLibrary() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-add-\(UUID().uuidString).wav")
+        try NotificationTestAudio.wav.write(to: source)
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let resp = await router(devRoot: devRoot, soundLibrary: lib).handle(request: JSONRPCRequest(
+            id: 1, method: "notifications-add-sound", params: [
+                "path": .string(source.path),
+                "name": .string("Desk Bell"),
+            ]))
+
+        #expect(resp.error == nil)
+        #expect(resp.result?["saved"]?.boolValue == true)
+        #expect(resp.result?["sound"]?.objectValue?["name"]?.stringValue == "Desk-Bell")
+        #expect(lib.sound(named: "Desk-Bell") != nil)
+    }
+
+    @Test func addSoundRejectsRelativePath() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let resp = await router(devRoot: devRoot).handle(request: JSONRPCRequest(
+            id: 1, method: "notifications-add-sound", params: ["path": .string("ding.wav")]))
+        #expect(resp.error != nil)
+    }
+
+    @Test func removeSoundDeletesTheFile() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        let lib = CustomSoundLibrary.temporary()
+        defer { try? FileManager.default.removeItem(at: lib.directory) }
+        _ = try lib.add(data: NotificationTestAudio.wav, filename: "gone.wav", requestedName: "Gone")
+
+        let resp = await router(devRoot: devRoot, soundLibrary: lib).handle(request: JSONRPCRequest(
+            id: 1, method: "notifications-remove-sound", params: ["name": .string("gone")]))
+
+        #expect(resp.error == nil)
+        #expect(resp.result?["removed"]?.boolValue == true)
+        #expect(lib.list().isEmpty)
+    }
+}
+
+/// Minimal RIFF/WAVE bytes for route tests. Sniffed by `CustomSoundLibrary`, not played.
+enum NotificationTestAudio {
+    static var wav: Data {
+        var d = Data()
+        d.append(contentsOf: Array("RIFF".utf8))
+        d.append(contentsOf: [36, 0, 0, 0])
+        d.append(contentsOf: Array("WAVE".utf8))
+        d.append(contentsOf: Array("fmt ".utf8))
+        d.append(contentsOf: [16, 0, 0, 0, 1, 0, 1, 0, 0x44, 0xAC, 0, 0, 0x88, 0x58, 1, 0, 2, 0, 16, 0])
+        d.append(contentsOf: Array("data".utf8))
+        d.append(contentsOf: [0, 0, 0, 0])
+        return d
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/NotificationRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/NotificationRPCSupport.swift
@@ -21,24 +21,40 @@ public enum NotificationRPC {
         return event
     }
 
-    /// Resolve a sound name to its canonical `builtInSounds` spelling.
+    /// Resolve a sound name to its canonical built-in spelling, or to a custom
+    /// library name from `customNames`.
     ///
-    /// The Settings UI's sound picker only offers the built-ins, so the CLI is
-    /// held to the same set. Note this is a *write*-side rule only —
-    /// `settingsJSON` echoes a stored custom `soundName` untouched, since the
-    /// model documents that field as "system sound name or path to custom file".
+    /// Write-side only — `settingsJSON` echoes a stored `soundName` untouched,
+    /// including a path leftover from before custom sounds were a first-class
+    /// library, so a missing file never fails a read.
     ///
-    /// - Throws: `RPCError.invalidParams` listing the built-ins when unmatched.
-    public static func decodeSoundName(_ value: JSONValue?) throws -> String {
+    /// - Throws: `RPCError.invalidParams` listing built-ins (and custom names
+    ///   when any exist) when unmatched.
+    public static func decodeSoundName(
+        _ value: JSONValue?,
+        customNames: [String] = []
+    ) throws -> String {
         guard let raw = value?.stringValue else {
             throw RPCError.invalidParams("event_sound_name must be a string")
         }
-        guard let canonical = NotificationSettings.canonicalSoundName(raw) else {
+        guard let canonical = NotificationSettings.canonicalSoundName(raw, customNames: customNames) else {
+            let extras = customNames.isEmpty
+                ? ""
+                : "; custom: \(customNames.joined(separator: ", "))"
             throw RPCError.invalidParams(
-                "'\(raw)' is not a built-in sound. Expected one of: \(NotificationSettings.builtInSounds.joined(separator: ", "))"
+                "'\(raw)' is not an available sound. Expected one of: \(NotificationSettings.builtInSounds.joined(separator: ", "))\(extras)"
             )
         }
         return canonical
+    }
+
+    /// One custom-sound record as RPC JSON (`name` / `file` / `url`).
+    public static func customSoundJSON(_ sound: CustomSound) -> JSONValue {
+        .object([
+            "name": .string(sound.name),
+            "file": .string(sound.file),
+            "url": .string(sound.url),
+        ])
     }
 
     /// Canonical notification-settings JSON for RPC responses: snake_case
@@ -62,7 +78,8 @@ public enum NotificationRPC {
     public static func settingsJSON(
         _ settings: NotificationSettings,
         only: NotificationEvent? = nil,
-        configReadable: Bool = true
+        configReadable: Bool = true,
+        customSounds: [CustomSound] = []
     ) -> JSONValue {
         let events = only.map { [$0] } ?? NotificationEvent.allCases
         var eventsObject: [String: JSONValue] = [:]
@@ -75,12 +92,15 @@ public enum NotificationRPC {
                 "sound_name": .string(config.soundName),
             ])
         }
+        let available = NotificationSettings.builtInSounds.map { JSONValue.string($0) }
+            + customSounds.map { .string($0.name) }
         return .object([
             "global_mute": .bool(settings.globalMute),
             "sound_enabled": .bool(settings.soundEnabled),
             "system_notifications_enabled": .bool(settings.systemNotificationsEnabled),
             "events": .object(eventsObject),
-            "available_sounds": .array(NotificationSettings.builtInSounds.map { .string($0) }),
+            "available_sounds": .array(available),
+            "custom_sounds": .array(customSounds.map(customSoundJSON)),
             "config_readable": .bool(configReadable),
         ])
     }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/NotificationRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/NotificationRPCSupportTests.swift
@@ -55,6 +55,14 @@ struct NotificationRPCSupportTests {
         #expect(throws: RPCError.self) { _ = try NotificationRPC.decodeSoundName(nil) }
     }
 
+    @Test func decodeSoundNameAcceptsCustomNames() throws {
+        #expect(try NotificationRPC.decodeSoundName(
+            .string("office-bell"), customNames: ["Office-Bell"]) == "Office-Bell")
+        #expect(throws: RPCError.self) {
+            _ = try NotificationRPC.decodeSoundName(.string("Nope"), customNames: ["Office-Bell"])
+        }
+    }
+
     // MARK: - settingsJSON
 
     @Test func settingsJSONListsEveryEventAsAnObject() throws {
@@ -65,6 +73,7 @@ struct NotificationRPCSupportTests {
         #expect(object["system_notifications_enabled"]?.boolValue == true)
         #expect(object["config_readable"]?.boolValue == true)
         #expect(object["available_sounds"]?.arrayValue?.count == NotificationSettings.builtInSounds.count)
+        #expect(object["custom_sounds"]?.arrayValue?.isEmpty == true)
 
         // An object keyed by raw value, NOT the flat alternating array that
         // JSONEncoder produces for a dictionary keyed by a non-CodingKey enum.
@@ -115,6 +124,17 @@ struct NotificationRPCSupportTests {
         let config = try #require(events["taskComplete"]?.objectValue)
 
         #expect(config["sound_name"]?.stringValue == "/Users/me/Sounds/custom.aiff")
+    }
+
+    @Test func settingsJSONMergesCustomSoundsIntoAvailable() throws {
+        let custom = CustomSound(name: "Office-Bell", file: "Office-Bell.wav", url: "/sounds/Office-Bell.wav")
+        let object = try #require(
+            NotificationRPC.settingsJSON(NotificationSettings(), customSounds: [custom]).objectValue)
+        let available = try #require(object["available_sounds"]?.arrayValue)
+        #expect(available.last == .string("Office-Bell"))
+        let listed = try #require(object["custom_sounds"]?.arrayValue)
+        #expect(listed.count == 1)
+        #expect(listed[0].objectValue?["url"]?.stringValue == "/sounds/Office-Bell.wav")
     }
 
     @Test func settingsJSONReportsUnreadableConfig() throws {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1390,7 +1390,7 @@ The twelve events are `taskComplete`, `agentWaiting`, `reviewRequested`, `change
 
 ### `crow notifications get`
 
-Show the global toggles, every event's effective settings, the built-in sound names, and whether the config was readable. Events absent from `config.json` are reported with the defaults they will actually fire with.
+Show the global toggles, every event's effective settings, the built-in and custom sound names, and whether the config was readable. Events absent from `config.json` are reported with the defaults they will actually fire with.
 
 ```bash
 crow notifications get
@@ -1418,6 +1418,9 @@ Returns:
       }
     },
     "available_sounds": ["Basso", "Blow", "..."],
+    "custom_sounds": [
+      {"name": "Office-Bell", "file": "Office-Bell.wav", "url": "/sounds/Office-Bell.wav"}
+    ],
     "config_readable": true
   }
 }
@@ -1444,7 +1447,7 @@ crow notifications set --event checksFailing --event-sound-name Hero --no-event-
 | `--event-enabled` / `--no-event-enabled`   | no       | Whether this event notifies at all                              |
 | `--event-sound-enabled` / `--no-…`         | no       | Whether this event plays a sound                                |
 | `--event-system-notification-enabled` / `--no-…` | no | Whether this event posts a system notification                  |
-| `--event-sound-name`                       | no       | Sound for this event — a built-in name, matched case-insensitively |
+| `--event-sound-name`                       | no       | Sound for this event — a built-in or custom name, matched case-insensitively |
 
 Returns the resulting settings in the same shape as `get`, plus `"saved": true`.
 
@@ -1452,9 +1455,28 @@ Notes:
 
 - Every toggle is a `--flag` / `--no-flag` pair; **omitting** it leaves the stored value alone. `--flag --no-flag` together is rejected rather than silently resolved.
 - The global toggle is `--system-notifications-enabled` (plural) and the per-event one is `--event-system-notification-enabled` (singular). The flag names mirror the config field names, which differ the same way.
-- `--event-sound-name` accepts only the built-in sounds listed under `available_sounds`, matching the Settings sound picker. A config that already stores a custom sound path keeps it — reads never validate — but the CLI won't set a new one.
+- `--event-sound-name` accepts the names listed under `available_sounds` (the 14 built-ins plus any custom sounds in the library), matching the Settings sound picker. A config that already stores a missing custom name or a leftover file path keeps it — reads never validate — and playback falls back to a default until you pick another sound.
 - Only the event you name is written to `config.json`. Events you never touch stay absent and keep following the current defaults — a globals-only `set` leaves `eventSettings` alone entirely.
 - Each write seeds the entry from the event's real default before applying your flags, so `set` never has to be told a sound just to change a toggle. Hand-editing has no such help: an event entry written without `soundName` falls back to `Glass` rather than that event's default (see [configuration.md](configuration.md#notifications)).
+
+### `crow notifications add-sound`
+
+Copy a `.wav`, `.mp3`, or `.aiff` file (up to 2 MB) into Crow's sound library (`~/Library/Application Support/crow/sounds/`). Local-only — the daemon reads a path on the host. The Settings tab uploads bytes over HTTP instead.
+
+```bash
+crow notifications add-sound ~/Music/office-bell.wav
+crow notifications add-sound ~/Music/ding.wav --name "Office Bell"
+```
+
+The stem (or `--name`) becomes the value `--event-sound-name` and the Settings picker accept. Dropping a valid file into the sounds directory also lists it on the next `get`.
+
+### `crow notifications remove-sound`
+
+Delete a custom sound from the library by name. Events that still reference it keep the name in `config.json`; playback falls back to a default until you pick another.
+
+```bash
+crow notifications remove-sound Office-Bell
+```
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,7 +98,9 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow new-session`](#crow-new-session) | Create a new session |
 | [`crow new-terminal`](#crow-new-terminal) | Create a terminal tab inside Crow (tmux) |
 | [`crow notifications`](#crow-notifications) | Read and write notification settings |
+| [`crow notifications add-sound`](#crow-notifications-add-sound) | Add a custom notification sound |
 | [`crow notifications get`](#crow-notifications-get) | Show notification settings |
+| [`crow notifications remove-sound`](#crow-notifications-remove-sound) | Remove a custom notification sound |
 | [`crow notifications set`](#crow-notifications-set) | Change notification settings |
 | [`crow open-in-vscode`](#crow-open-in-vscode) | Open the session's worktree in VS Code on the host |
 | [`crow open-terminal`](#crow-open-terminal) | Open a macOS Terminal.app window at the session's worktree (host GUI) |
@@ -1510,12 +1512,29 @@ crow new-terminal --session <session> --cwd <cwd> [--name <name>] [--command <co
 Read and write notification settings.
 
 ```
-crow notifications <get|set>
+crow notifications <get|set|add-sound|remove-sound>
 ```
 
 Notifications cascade: a notification fires only if globalMute is off, the matching global category toggle is on, AND the per-event toggle is on. Global flags apply to every event; the --event-* flags apply to the single event named by --event.
 
-Subcommands: [`get`](#crow-notifications-get), [`set`](#crow-notifications-set).
+Subcommands: [`get`](#crow-notifications-get), [`set`](#crow-notifications-set), [`add-sound`](#crow-notifications-add-sound), [`remove-sound`](#crow-notifications-remove-sound).
+
+---
+
+## `crow notifications add-sound`
+
+Add a custom notification sound.
+
+```
+crow notifications add-sound <path> [--name <name>]
+```
+
+Copies a .wav, .mp3, or .aiff file into Crow's sound library (~/Library/Application Support/crow/sounds/). The stem becomes the name shown in Settings and accepted by --event-sound-name. Dropping a file into that directory also works — get lists whatever is there.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| _(positional)_ | `<path>` | yes | Path to a .wav, .mp3, or .aiff file |
+| `--name` | `<name>` | no | Display name (defaults to the file's name) |
 
 ---
 
@@ -1527,11 +1546,27 @@ Show notification settings.
 crow notifications get [--event <event>]
 ```
 
-Lists the global toggles, every event's effective settings, and the built-in sound names. Events absent from config.json are reported with the defaults they will actually fire with. --event narrows the event list to one entry; the global toggles are always included, since they can be the reason an event never fires.
+Lists the global toggles, every event's effective settings, the built-in sound names, and any custom sounds in the library. Events absent from config.json are reported with the defaults they will actually fire with. --event narrows the event list to one entry; the global toggles are always included, since they can be the reason an event never fires.
 
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--event` | `<event>` | no | Restrict the event list to one event. Values: `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoMergeBlocked`, `autoRebasePushed`, `autoRebaseConflicts`, `autoRebaseStuck`, `configReloaded`. |
+
+---
+
+## `crow notifications remove-sound`
+
+Remove a custom notification sound.
+
+```
+crow notifications remove-sound <name>
+```
+
+Deletes the file from the sound library. Events that still name it keep the reference in config.json; playback falls back to a default until you pick another sound.
+
+| Flag | Value | Required | Description |
+| --- | --- | --- | --- |
+| _(positional)_ | `<name>` | yes | Custom sound name (as listed by notifications get) |
 
 ---
 
@@ -1543,7 +1578,7 @@ Change notification settings.
 crow notifications set [--global-mute|--no-global-mute] [--sound-enabled|--no-sound-enabled] [--system-notifications-enabled|--no-system-notifications-enabled] [--event <event>] [--event-enabled|--no-event-enabled] [--event-sound-enabled|--no-event-sound-enabled] [--event-system-notification-enabled|--no-event-system-notification-enabled] [--event-sound-name <event-sound-name>]
 ```
 
-Only the provided flags change; everything else keeps its value. Each toggle takes a --flag / --no-flag pair. The --event-* flags require --event and apply to that event alone. --event-sound-name accepts the built-in sounds listed by `crow notifications get` (case-insensitive).
+Only the provided flags change; everything else keeps its value. Each toggle takes a --flag / --no-flag pair. The --event-* flags require --event and apply to that event alone. --event-sound-name accepts a built-in or custom sound listed by `crow notifications get` (case-insensitive).
 
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
@@ -1554,7 +1589,7 @@ Only the provided flags change; everything else keeps its value. Each toggle tak
 | `--event-enabled`, `--no-event-enabled` | — | no | Whether this event notifies at all |
 | `--event-sound-enabled`, `--no-event-sound-enabled` | — | no | Whether this event plays a sound |
 | `--event-system-notification-enabled`, `--no-event-system-notification-enabled` | — | no | Whether this event posts a system notification |
-| `--event-sound-name` | `<event-sound-name>` | no | Sound for this event (a built-in sound name) |
+| `--event-sound-name` | `<event-sound-name>` | no | Sound for this event (a built-in or custom sound name) |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -406,7 +406,7 @@ Notifications cascade — one fires only if `globalMute` is off, the matching gl
 - **`systemNotificationsEnabled`** (default: `true`) — global system-notification toggle.
 - **`eventSettings`** — per-event overrides, holding only the events you've actually changed. Any event you omit follows the current defaults, so leaving events out is the way to stay on Crow's defaults as they evolve. Neither Crow nor `crow notifications set` will backfill the rest.
 
-The twelve events are `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoMergeBlocked`, `autoRebasePushed`, `autoRebaseConflicts`, `autoRebaseStuck`, and `configReloaded`. The 14 built-in sounds are `Basso`, `Blow`, `Bottle`, `Frog`, `Funk`, `Glass`, `Hero`, `Morse`, `Ping`, `Pop`, `Purr`, `Sosumi`, `Submarine`, and `Tink`.
+The twelve events are `taskComplete`, `agentWaiting`, `reviewRequested`, `changesRequested`, `checksFailing`, `autoWorkspaceCreated`, `autoMergeEnabled`, `autoMergeBlocked`, `autoRebasePushed`, `autoRebaseConflicts`, `autoRebaseStuck`, and `configReloaded`. The 14 built-in sounds are `Basso`, `Blow`, `Bottle`, `Frog`, `Funk`, `Glass`, `Hero`, `Morse`, `Ping`, `Pop`, `Purr`, `Sosumi`, `Submarine`, and `Tink`. Custom sounds live as files in `~/Library/Application Support/crow/sounds/` (`.wav` / `.mp3` / `.aiff`, 2 MB); their names appear in `available_sounds` next to the built-ins. Per-event `soundName` stores that name as a reference — never the file bytes. A missing custom file falls back to a default at playback. Add via Settings → Notifications → Upload sound, `crow notifications add-sound <path>`, or by dropping a file into that directory.
 
 Three things to know before hand-editing:
 


### PR DESCRIPTION
Closes #1147

## Summary
- Users can add custom `.wav` / `.mp3` / `.aiff` files (2 MB cap) to a global library at `~/Library/Application Support/crow/sounds/`.
- Custom names appear in `available_sounds` next to the 14 built-ins and are accepted by `--event-sound-name`. Config stores the name, not the file bytes.
- Settings → Notifications has Upload / Preview / Remove. The web client (and Tauri desktop wrapper) plays custom files from `GET /sounds/:file`; a missing file falls back to the event default.

## Test plan
- [ ] Upload a short `.wav` from Settings → Notifications, preview it, assign it to an event, and Save
- [ ] Trigger that event in the web UI and confirm the uploaded file plays (not a synth approximation)
- [ ] `crow notifications add-sound <path> --name Office-Bell` then `crow notifications set --event taskComplete --event-sound-name Office-Bell`
- [ ] Remove the sound (Settings or `remove-sound`); the event keeps the name and playback falls back
- [ ] Reject a `.txt` renamed to `.wav` and a file over 2 MB
- [ ] Dropping a valid file into the sounds directory shows up on the next `notifications get`


Made with [Cursor](https://cursor.com)