### PR TITLE
Skip same-size SIGWINCH on session switch and tab refocus

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -414,7 +414,9 @@ body {
   padding: 0 8px;
   min-height: 34px;
 }
-#tabbar:empty { display: none; }
+/* CROW-1162: keep the 34px slot even with no tabs (Manager). Collapsing it
+   on Manager ↔ work switches is a real row of TUI geometry → SIGWINCH. */
+#tabbar:empty { display: flex; }
 .tab {
   display: flex;
   align-items: center;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/grid.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/grid.js
@@ -109,9 +109,39 @@ function gridVisibleSessions() {
 
 function leaveGridView() {
   stopGridPolling();
-  disposeUnusedGridTerms([]);
   const root = document.getElementById('board');
   if (root) delete root.dataset.gridKey;
+  // CROW-1162: disposing up to 16 xterm instances is heavy. Do it after the
+  // live session attach paints, not on the same turn as `selectSession`.
+  scheduleGridTeardown();
+}
+
+function cancelGridTeardown() {
+  gridTeardownGen += 1;
+  if (gridTeardownTimer != null) {
+    clearTimeout(gridTeardownTimer);
+    gridTeardownTimer = null;
+  }
+}
+
+function scheduleGridTeardown() {
+  const gen = ++gridTeardownGen;
+  if (gridTeardownTimer != null) {
+    clearTimeout(gridTeardownTimer);
+    gridTeardownTimer = null;
+  }
+  const ids = [...gridTerms.keys()];
+  const tearDown = () => {
+    gridTeardownTimer = null;
+    if (gen !== gridTeardownGen) return;
+    if (selectedBoard === 'grid') return;
+    for (const id of ids) disposeGridTerm(id);
+  };
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(tearDown, { timeout: 400 });
+  } else {
+    gridTeardownTimer = setTimeout(tearDown, 0);
+  }
 }
 
 function stopGridPolling() {
@@ -124,7 +154,7 @@ function startGridPolling() {
     if (selectedBoard !== 'grid') { stopGridPolling(); return; }
     if (typeof document !== 'undefined' && document.hidden) return;
     refreshGridSnapshots();
-  }, 800);
+  }, GRID_POLL_MS);
 }
 
 function disposeGridTerm(id) {
@@ -143,6 +173,7 @@ function disposeUnusedGridTerms(keepIds) {
 }
 
 function renderSessionGrid(root) {
+  cancelGridTeardown();
   root.classList.add('session-grid-board');
   const { visible, pages, roster } = gridVisibleSessions();
   const visIds = visible.map((s) => s.id);
@@ -279,7 +310,7 @@ function updateGridCellHeaders() {
 
 function mountGridTerm(sessionId, host) {
   if (typeof Terminal !== 'function') {
-    gridTerms.set(sessionId, { term: null, host: host, lastSnap: '', cols: 0, rows: 0 });
+    gridTerms.set(sessionId, { term: null, host: host, lastSnap: '', cols: 0, rows: 0, lastScale: NaN });
     return;
   }
   const term = new Terminal({
@@ -292,14 +323,21 @@ function mountGridTerm(sessionId, host) {
     allowTransparency: true,
   });
   term.open(host);
-  gridTerms.set(sessionId, { term: term, host: host, lastSnap: '', cols: 0, rows: 0 });
+  gridTerms.set(sessionId, { term: term, host: host, lastSnap: '', cols: 0, rows: 0, lastScale: NaN });
 }
 
 function observeGridTerm(sessionId, wrap) {
   const pane = gridTerms.get(sessionId);
   if (!pane || !window.ResizeObserver) return;
   try { if (pane.ro) pane.ro.disconnect(); } catch (_) {}
-  pane.ro = new ResizeObserver(() => scaleGridTerm(sessionId));
+  pane.ro = new ResizeObserver(() => {
+    if (pane.scaleScheduled) return;
+    pane.scaleScheduled = true;
+    requestAnimationFrame(() => {
+      pane.scaleScheduled = false;
+      scaleGridTerm(sessionId);
+    });
+  });
   pane.ro.observe(wrap);
 }
 
@@ -314,6 +352,8 @@ function scaleGridTerm(sessionId) {
   const tw = screen.offsetWidth || pane.term.element.offsetWidth || 1;
   const th = screen.offsetHeight || pane.term.element.offsetHeight || 1;
   const s = Math.min(cw / tw, ch / th);
+  if (pane.lastScale === s) return;
+  pane.lastScale = s;
   screen.style.transformOrigin = 'top left';
   screen.style.transform = 'scale(' + s + ')';
 }
@@ -345,7 +385,10 @@ function paintGridSnapshot(id, row) {
   const rows = Math.max(1, Number(row.rows) || 24);
   if (pane.term) {
     try {
-      if (pane.term.cols !== cols || pane.term.rows !== rows) pane.term.resize(cols, rows);
+      if (pane.term.cols !== cols || pane.term.rows !== rows) {
+        pane.term.resize(cols, rows);
+        pane.lastScale = NaN;
+      }
       pane.term.write(row.snapshot);
     } catch (_) { /* xterm not ready */ }
     scaleGridTerm(id);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/session.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/session.js
@@ -674,18 +674,17 @@ async function refreshTerminals() {
 function renderTabs() {
   const bar = document.getElementById('tabbar');
   bar.innerHTML = '';
-  // #680: managers are a single terminal — no tabs, no "+", no "×". Leaving
-  // #tabbar empty lets the `#tabbar:empty { display:none }` rule (app.css)
-  // collapse it so no empty strip sits above the manager terminal. (This also
-  // moots the stale-tab naming bug: a renamed manager session has no tab to go
-  // stale, since tabs are labeled from the terminal name, not the session name.)
+  // #680: managers are a single terminal — no tabs, no "+", no "×". The bar
+  // stays empty so there is no stale tab label, but CROW-1162 keeps the 34px
+  // slot (`#tabbar:empty { display:flex }`) so Manager ↔ work switches don't
+  // SIGWINCH the agent by collapsing/expanding the tab strip.
   const sel = sessions.find((x) => x.id === selectedId);
   if (sel && sel.kind === 'manager') {
     // #680: managers have no tabs. But the Manager window is a common CROW-804
     // "stuck alt-screen / 5000-line" case, and with no tab there'd be no ⚠ or
     // Recreate. Surface a slim warning strip with a Recreate action when the
-    // Manager terminal is degraded; otherwise leave #tabbar empty so it stays
-    // collapsed. Recreate routes through restartManager (SessionService).
+    // Manager terminal is degraded; otherwise leave #tabbar empty (the slot
+    // still reserves 34px). Recreate routes through restartManager (SessionService).
     const degraded = terminals.find((t) => t.scrollback_degraded);
     if (degraded) {
       const strip = el('div', 'degraded-strip');

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar.js
@@ -26,6 +26,10 @@ const boardData = { tickets: null, reviews: null, allowlist: null, scorecard: nu
 // the wall; remaining slots auto-fill with active/in-review sessions. Caps at
 // 16 cells per page so a cell stays large enough to read.
 const GRID_PAGE_SIZE = 16;
+// CROW-1162: 16 xterm paints on an 800 ms cadence contended with the live
+// session's fit/reflow. 1500 ms is still a watch wall, just not a main-thread
+// storm; the first paint on enter is still immediate (`refreshGridSnapshots`).
+const GRID_POLL_MS = 1500;
 const GRID_PINS_KEY = 'crow.grid.pins';
 let gridPinnedIds = [];
 let gridPage = 0;
@@ -36,6 +40,8 @@ let gridPage = 0;
 // "from the grid".
 let sessionCameFromGrid = false;
 let gridPollTimer = null;
+let gridTeardownGen = 0;
+let gridTeardownTimer = null;
 const gridTerms = new Map(); // sessionId → { term, host, lastSnap, cols, rows }
 
 // Last-known sidebar layout (sessions + ticket/review badge counts) so first

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/terminal.js
@@ -437,9 +437,10 @@ function ensureTerminal() {
   enableFileDrop(document.getElementById('terminal'));
   window.addEventListener('resize', fitTerminal);
   // #667: on regaining focus/visibility, this surface reclaims ownership of the
-  // shared tmux window size (re-asserts even if unchanged) — so "window-size
-  // latest" converges to "the surface you most recently focused." Registered
-  // once (ensureTerminal is `if (term) return` guarded).
+  // shared tmux window size — so "window-size latest" converges to "the surface
+  // you most recently focused." Same-size reclaim uses `if_needed` so it does
+  // not SIGWINCH the agent (CROW-1162). Registered once (ensureTerminal is
+  // `if (term) return` guarded).
   window.addEventListener('focus', takeTerminalOwnership);
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) takeTerminalOwnership();
@@ -924,9 +925,18 @@ function applyTermFit() {
   if (term.cols === lastTermCols && term.rows === lastTermRows) return;
   lastTermCols = term.cols;
   lastTermRows = term.rows;
-  if (termWs && termWs.readyState === WebSocket.OPEN) {
-    termWs.send(JSON.stringify({ type: 'resize', rows: term.rows, cols: term.cols }));
-  }
+  sendTermResize(false);
+}
+
+// Push cols/rows to the PTY. `ifNeeded` (CROW-1162) asks the daemon to skip the
+// ioctl when the tmux window is already this size, so a tab-refocus can reclaim
+// `window-size latest` without a same-size SIGWINCH. Ordinary fits (the grid
+// actually changed) always ioctl.
+function sendTermResize(ifNeeded) {
+  if (!termWs || termWs.readyState !== WebSocket.OPEN) return;
+  const msg = { type: 'resize', rows: term.rows, cols: term.cols };
+  if (ifNeeded) msg.if_needed = true;
+  termWs.send(JSON.stringify(msg));
 }
 
 // Coalesce a burst of resize/observer events into a single fit per frame. Used
@@ -942,13 +952,24 @@ function fitTerminal() {
 // #667: on regaining focus, re-assert this surface's size so it becomes tmux's
 // "latest" client and reclaims the shared window size from whatever background
 // surface last touched it — even if this surface's own grid didn't change (which
-// applyTermFit's lastTermCols/lastTermRows dedup would otherwise swallow). Reset
-// the dedup, then fit; the reset + the visible/focused state let applyTermFit
-// send the resize frame. Wired to window `focus` and document `visibilitychange`.
+// applyTermFit's lastTermCols/lastTermRows dedup would otherwise swallow).
+//
+// CROW-1162: do NOT reset the dedup and force a same-size ioctl. TIOCSWINSZ
+// always becomes tmux MSG_RESIZE, which redraws the client and SIGWINCHes the
+// agent TUI even when cols/rows are unchanged. Fit locally; if the grid moved,
+// send a real resize; if it didn't, send `if_needed` so the daemon ioctl's only
+// when the *window* (another surface) actually differs. Wired to window `focus`
+// and document `visibilitychange`.
 function takeTerminalOwnership() {
-  lastTermCols = 0;
-  lastTermRows = 0;
-  applyTermFit();
+  if (!term || !fitAddon) return;
+  if (document.hidden || !document.hasFocus()) return;
+  const node = document.getElementById('terminal');
+  if (!node || !node.isConnected || node.clientWidth < 1 || node.clientHeight < 1) return;
+  try { fitAddon.fit(); } catch (_) { return; }
+  const same = term.cols === lastTermCols && term.rows === lastTermRows;
+  lastTermCols = term.cols;
+  lastTermRows = term.rows;
+  sendTermResize(same);
 }
 
 // Same leading sequence as `TerminalCockpit.replayFrame` (CROW-606): home, clear
@@ -1292,6 +1313,10 @@ function switchAgentWindow(win) {
   // and no new PTY, so this stays clear of the CROW-1035 caret jump and CROW-1048
   // chrome stacking a full reload would reintroduce; a same-size switch fits to
   // identical cols/rows, so applyTermFit sends no SIGWINCH (#637).
+  //
+  // CROW-1162: this is the same coalesced `fitTerminal` the container
+  // ResizeObserver uses, so a post-switch layout settle does not double-fire a
+  // PTY resize — both collapse to one applyTermFit per animation frame.
   fitTerminal();
   updateTerminalScrollbar();
   // Do not arm CROW-1027 here. In-place switch has no new PTY and no

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalCockpit.swift
@@ -131,6 +131,27 @@ struct TerminalCockpit: Sendable {
         _ = try? controller.run(["select-window", "-t", "\(group):\(index)"])
     }
 
+    /// Current window size of a grouped view, for CROW-1162's `if_needed` resize
+    /// (skip the PTY ioctl when the window is already the requested size).
+    func windowSize(group: String) -> (cols: Int, rows: Int)? {
+        guard let raw = try? controller.displayMessage(
+            target: group, format: "#{window_width} #{window_height}")
+        else { return nil }
+        return Self.parseColsRows(raw)
+    }
+
+    /// Parse `"cols rows"` from `display-message`. Pure so the skip-ioctl gate
+    /// is unit-testable without tmux.
+    static func parseColsRows(_ raw: String) -> (cols: Int, rows: Int)? {
+        let parts = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+        guard parts.count >= 2,
+              let cols = Int(parts[0]), let rows = Int(parts[1]),
+              cols > 0, rows > 0
+        else { return nil }
+        return (cols, rows)
+    }
+
     /// How many lines of pane history to replay on (re)connect. Wired to
     /// `TmuxBackend.scrollbackHistoryLimit` — the same value baked into the tmux
     /// `history-limit` (crow-tmux.conf) and the xterm.js client scrollback
@@ -235,13 +256,11 @@ struct TerminalCockpit: Sendable {
         var cols = 80
         var rows = 24
         if let dim = try? controller.displayMessage(
-            target: target, format: "#{pane_width} #{pane_height}")
+            target: target, format: "#{pane_width} #{pane_height}"),
+           let parsed = Self.parseColsRows(dim)
         {
-            let parts = dim.split(whereSeparator: { $0.isWhitespace })
-            if parts.count >= 2, let c = Int(parts[0]), let r = Int(parts[1]), c > 0, r > 0 {
-                cols = min(c, 400)
-                rows = min(r, 200)
-            }
+            cols = min(parsed.cols, 400)
+            rows = min(parsed.rows, 200)
         }
         return GridPaneSnapshot(snapshot: framed, cols: cols, rows: rows)
     }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TerminalWebSocket.swift
@@ -87,9 +87,21 @@ enum TerminalWebSocket {
                         case "resize":
                             // Floor at 1×1 so a zero/negative request can't drive a
                             // degenerate tmux resize (CROW-581 review).
+                            let rows = max(1, control.rows ?? 24)
+                            let cols = max(1, control.cols ?? 80)
+                            // CROW-1162: a tab-refocus sends `if_needed` to reclaim
+                            // `window-size latest` without a same-size TIOCSWINSZ
+                            // (which always SIGWINCHes the agent TUI). Skip the
+                            // ioctl when the window is already this size; if
+                            // another surface reshaped it, fall through.
+                            if control.if_needed == true,
+                               let current = cockpit.windowSize(group: group),
+                               current.cols == cols, current.rows == rows {
+                                break
+                            }
                             pty.resize(
-                                rows: UInt16(clamping: max(1, control.rows ?? 24)),
-                                cols: UInt16(clamping: max(1, control.cols ?? 80)))
+                                rows: UInt16(clamping: rows),
+                                cols: UInt16(clamping: cols))
                         case "select-window":
                             // Switch this browser's grouped view to the window; other
                             // clients (incl. the desktop app) keep their own view.
@@ -166,4 +178,8 @@ private struct TerminalControl: Decodable {
     /// switches send this — the live attach already has the frame and replay
     /// races it (CROW-1035). Omitted or `true` keeps connect/reload/heal behavior.
     let replay: Bool?
+    /// When `true`, skip the PTY ioctl if the tmux window is already this size
+    /// so a tab-refocus can reclaim `window-size latest` without a same-size
+    /// SIGWINCH (CROW-1162). Omitted/`false` always resizes (ordinary fit).
+    let if_needed: Bool?
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/TerminalReplayTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/TerminalReplayTests.swift
@@ -86,4 +86,19 @@ import Testing
         let text = TerminalCockpit.plainPreviewText(from: "line1\n\u{1b}[31mred\u{1b}[0m\n\n")
         #expect(text == "line1\nred")
     }
+
+    /// CROW-1162: `if_needed` resize skips the PTY ioctl when the window is
+    /// already this size. Parsing is the gate; garbage / zeros must not skip.
+    @Test func parseColsRowsAcceptsPositivePairs() {
+        #expect(TerminalCockpit.parseColsRows("120 40").map { [$0.cols, $0.rows] } == [120, 40])
+        #expect(TerminalCockpit.parseColsRows("  80\t24\n").map { [$0.cols, $0.rows] } == [80, 24])
+    }
+
+    @Test func parseColsRowsRejectsGarbage() {
+        #expect(TerminalCockpit.parseColsRows("") == nil)
+        #expect(TerminalCockpit.parseColsRows("120") == nil)
+        #expect(TerminalCockpit.parseColsRows("0 40") == nil)
+        #expect(TerminalCockpit.parseColsRows("-1 24") == nil)
+        #expect(TerminalCockpit.parseColsRows("wide tall") == nil)
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -798,4 +798,36 @@ import Testing
                 "the \(token.dropLast()) token app.js reads for xterm's slider must be defined (CROW-1020)")
         }
     }
+
+    /// CROW-1162: tab refocus must not reset the fit dedup and force a same-size
+    /// SIGWINCH. Ownership reclaim goes through `sendTermResize(same)` so the
+    /// daemon can skip the ioctl when the window already matches.
+    @Test func takeTerminalOwnershipReclaimsWithoutZeroingDedup() throws {
+        let source = try Self.webClientJS()
+        let body = Self.stripComments(String(try Self.functionBody("takeTerminalOwnership", in: source)))
+        #expect(
+            !body.contains("lastTermCols = 0"),
+            "zeroing the dedup re-sends a same-size resize on every tab focus (CROW-1162)")
+        #expect(
+            body.contains("sendTermResize(same)"),
+            "same-size reclaim must still tell the daemon (if_needed) so another surface's size can be taken back")
+        let send = Self.stripComments(String(try Self.functionBody("sendTermResize", in: source)))
+        #expect(
+            send.contains("if_needed"),
+            "the reclaim frame must carry if_needed so TerminalWebSocket can skip TIOCSWINSZ")
+    }
+
+    /// CROW-1162: an empty Manager tab bar must keep its 34px slot. Collapsing it
+    /// with `:empty { display:none }` is a real row of agent TUI geometry on
+    /// every Manager ↔ work switch.
+    @Test func emptyTabbarKeepsItsSlot() throws {
+        let css = Self.stripComments(try Self.webAsset("app.css"))
+        let empty = try Self.ruleBody(openedBy: "#tabbar:empty {", in: css)
+        #expect(
+            empty.contains("display: flex"),
+            "an empty #tabbar must remain in flex layout so Manager chrome matches work (CROW-1162)")
+        #expect(
+            !empty.contains("display: none"),
+            "display:none on :empty is the Manager ↔ work SIGWINCH (CROW-1162)")
+    }
 }

--- a/Packages/CrowDaemon/web-tests/README.md
+++ b/Packages/CrowDaemon/web-tests/README.md
@@ -87,7 +87,7 @@ and opening ours; and non-keydown / unmodified keys passing through untouched.
 
 ## `session-switch-attach.test.js` — agent tab/session switch (CROW-1035)
 
-Drives `attachWindow` against a fake xterm + a live `/terminal` socket. Coverage: switching to a Claude (alt-buffer) or Cursor (inline agent) surface is in-place — no new WebSocket, `clearTermBuffer` + `select-window` with `replay: false` on the existing socket, neither agent class arms the CROW-1027 heal on that path (no PTY resize; a second replay stacks Cursor chrome, CROW-1048); a plain shell still takes the #673 full reload; re-clicking the attached window is a no-op; a missing socket only records `attachedWindow`. Connect/reload still heals a one-screen attach (`terminal-reload.test.js`).
+Drives `attachWindow` against a fake xterm + a live `/terminal` socket. Coverage: switching to a Claude (alt-buffer) or Cursor (inline agent) surface is in-place — no new WebSocket, `clearTermBuffer` + `select-window` with `replay: false` on the existing socket, neither agent class arms the CROW-1027 heal on that path (no PTY resize; a second replay stacks Cursor chrome, CROW-1048); a plain shell still takes the #673 full reload; re-clicking the attached window is a no-op; a missing socket only records `attachedWindow`. Connect/reload still heals a one-screen attach (`terminal-reload.test.js`). CROW-1162: tab refocus sends `if_needed` rather than zeroing the fit dedup, so a same-size reclaim does not SIGWINCH; a real geometry change still ioctl's; an ordinary same-size `applyTermFit` stays silent.
 
 ## `terminal-reload.test.js` — header ↻ Reload button (CROW-979)
 
@@ -207,14 +207,15 @@ Drives `gridRoster` / pin helpers / `renderSessionGrid` against mock sessions.
 Coverage: column count (1 / 2×2 / 3×3 / 4×4), pinned-first roster with
 active auto-fill and activity sort, pin persist + reorder in `localStorage`,
 the Grid nav pill, Pin/Unpin on the session menu, `#/grid` routing, empty
-state copy, and cell DOM (pinned class, name, column count). CROW-1163:
+state copy, and cell DOM (pinned class, name, column count). CROW-1162: poll
+interval is 1500 ms, `leaveGridView` defers xterm dispose off the live-attach
+turn, and `scaleGridTerm` skips an unchanged CSS scale. CROW-1163:
 grid-cell clicks pass `{ fromGrid: true }`, `selectSession` sets/clears
 `sessionCameFromGrid`, the `‹ Grid` header control renders only then, and
 Escape returns to `#/grid` from app chrome — never while the xterm textarea
 has focus, while a lightbox is open, in place of closing a context menu, or
 when the session switcher is bound to an Escape prefix (`esc+tab`).
 Snapshot painting is skipped — jsdom has no xterm.js, matching a failed asset fetch.
-
 ## Run
 
 Tests must not evaluate a single concern file in isolation: `load-client.js`

--- a/Packages/CrowDaemon/web-tests/grid.test.js
+++ b/Packages/CrowDaemon/web-tests/grid.test.js
@@ -11,6 +11,7 @@ const { loadClientSource } = require('./load-client');
 const epilogue = `
 ;globalThis.__t = {
   GRID_PAGE_SIZE: () => GRID_PAGE_SIZE,
+  GRID_POLL_MS: () => GRID_POLL_MS,
   gridColsForCount: (n) => gridColsForCount(n),
   gridRoster: (list, pins) => gridRoster(list, pins),
   gridActivityRank: (s) => gridActivityRank(s),
@@ -42,6 +43,9 @@ const epilogue = `
   parseRoute: (h) => parseRoute(h),
   routeToHash: (r) => routeToHash(r),
   GRID_PINS_KEY: () => GRID_PINS_KEY,
+  leaveGridView(){ return leaveGridView(); },
+  scaleGridTerm: (id) => scaleGridTerm(id),
+  get gridTerms(){ return gridTerms; },
   spySelectSession(sink) {
     selectSession = async function (id, opts) { sink.push({ id, opts: opts || null }); };
   },
@@ -92,9 +96,13 @@ function load() {
     return { send() {}, close() {},
       set onopen(v) {}, set onmessage(v) {}, set onclose(v) {}, set onerror(v) {} };
   };
-  window.setInterval = () => 0;
-  window.setTimeout = () => 0;
-  window.requestAnimationFrame = () => 0;
+  window.__timeouts = [];
+  window.__intervals = [];
+  window.setInterval = (fn, ms) => { window.__intervals.push({ fn, ms }); return window.__intervals.length; };
+  window.setTimeout = (fn, ms) => { window.__timeouts.push({ fn, ms: ms || 0 }); return window.__timeouts.length; };
+  window.clearTimeout = (id) => { if (id > 0) window.__timeouts[id - 1] = null; };
+  window.requestAnimationFrame = (fn) => { fn(); return 1; };
+  window.requestIdleCallback = undefined;
   const realGet = window.document.getElementById.bind(window.document);
   window.document.getElementById = (id) => realGet(id) || window.document.createElement('div');
   const ctx = dom.getInternalVMContext();
@@ -180,6 +188,50 @@ console.log('\npage size:');
 {
   const T = load();
   check('page size is 16', T.GRID_PAGE_SIZE() === 16);
+  check('poll interval is 1500ms (CROW-1162)', T.GRID_POLL_MS() === 1500);
+}
+
+console.log('\nCROW-1162: leaveGridView defers xterm dispose off the attach path:');
+{
+  const T = load();
+  let disposed = 0;
+  T.gridTerms.set('keep', {
+    term: { dispose() { disposed += 1; } },
+    host: T.document.createElement('div'),
+    lastSnap: '',
+    ro: { disconnect() {} },
+  });
+  T.selectedBoard = 'tickets';
+  T.leaveGridView();
+  check('terms survive the selectSession turn', T.gridTerms.has('keep') && disposed === 0);
+  for (const t of T.window.__timeouts) { if (t) t.fn(); }
+  check('dispose runs on the deferred turn', disposed === 1 && !T.gridTerms.has('keep'));
+}
+
+console.log('\nCROW-1162: scaleGridTerm skips an unchanged transform:');
+{
+  const T = load();
+  const host = T.document.createElement('div');
+  const wrap = T.document.createElement('div');
+  wrap.appendChild(host);
+  Object.defineProperty(wrap, 'clientWidth', { value: 200 });
+  Object.defineProperty(wrap, 'clientHeight', { value: 100 });
+  const screen = T.document.createElement('div');
+  screen.className = 'xterm';
+  host.appendChild(screen);
+  Object.defineProperty(screen, 'offsetWidth', { value: 400 });
+  Object.defineProperty(screen, 'offsetHeight', { value: 200 });
+  T.gridTerms.set('scaled', {
+    term: { element: screen, cols: 80, rows: 24 },
+    host: host,
+    lastSnap: '',
+    lastScale: NaN,
+  });
+  T.scaleGridTerm('scaled');
+  check('first scale writes the transform', screen.style.transform === 'scale(0.5)');
+  screen.style.transform = 'scale(9)'; // poison: a skip must not rewrite
+  T.scaleGridTerm('scaled');
+  check('second scale with the same ratio is a no-op', screen.style.transform === 'scale(9)');
 }
 
 console.log('\nnav pill:');

--- a/Packages/CrowDaemon/web-tests/session-switch-attach.test.js
+++ b/Packages/CrowDaemon/web-tests/session-switch-attach.test.js
@@ -26,6 +26,14 @@ const epilogue = `
   updateTerminalScrollbar(){ return updateTerminalScrollbar(); },
   get fitScheduled(){ return fitScheduled; },
   set fitScheduled(v){ fitScheduled = v; },
+  get lastTermCols(){ return lastTermCols; },
+  set lastTermCols(v){ lastTermCols = v; },
+  get lastTermRows(){ return lastTermRows; },
+  set lastTermRows(v){ lastTermRows = v; },
+  get fitAddon(){ return fitAddon; },
+  set fitAddon(v){ fitAddon = v; },
+  applyTermFit(){ return applyTermFit(); },
+  takeTerminalOwnership(){ return takeTerminalOwnership(); },
   SCROLLBACK_HEAL_MS,
   SCROLLBACK_HEAL_MAX,
   TERM_BUFFER_CLEAR,
@@ -228,6 +236,58 @@ console.log('\nCROW-1091: switching in a surface with no history leaves no stale
   T.attachWindow(claude.window);
   check('the stale scrollbar class is cleared on switch', !wrap.classList.contains('has-scrollback'));
   check('still an in-place select-window', selectWindowCount(sock) === 1);
+}
+
+function resizePayloads(sock) {
+  return sock.sent.map((d) => {
+    try { return JSON.parse(d); } catch (_) { return null; }
+  }).filter((m) => m && m.type === 'resize');
+}
+
+function armFitSurface(cols, rows) {
+  const node = window.document.getElementById('terminal');
+  Object.defineProperty(node, 'clientWidth', { configurable: true, value: 800 });
+  Object.defineProperty(node, 'clientHeight', { configurable: true, value: 600 });
+  window.document.hasFocus = () => true;
+  Object.defineProperty(window.document, 'hidden', { configurable: true, get: () => false });
+  const t = fakeTerm();
+  t.cols = cols;
+  t.rows = rows;
+  T.term = t;
+  T.fitAddon = { fit() {} };
+  T.lastTermCols = cols;
+  T.lastTermRows = rows;
+  return openSocket();
+}
+
+console.log('\nCROW-1162: tab refocus reclaims ownership without a same-size SIGWINCH:');
+{
+  const sock = armFitSurface(120, 40);
+  T.takeTerminalOwnership();
+  const resizes = resizePayloads(sock);
+  check('same-size refocus still sends a resize frame (so the daemon can become latest)', resizes.length === 1);
+  check('the frame is marked if_needed so the daemon can skip the ioctl', resizes[0].if_needed === true);
+  check('cols/rows are unchanged', resizes[0].cols === 120 && resizes[0].rows === 40);
+  check('dedup counters were not zeroed', T.lastTermCols === 120 && T.lastTermRows === 40);
+}
+
+console.log('\nCROW-1162: refocus after a real geometry change still SIGWINCHes:');
+{
+  const sock = armFitSurface(120, 40);
+  T.term.cols = 100;
+  T.term.rows = 30;
+  T.takeTerminalOwnership();
+  const resizes = resizePayloads(sock);
+  check('changed size sends a resize', resizes.length === 1);
+  check('changed size is a hard ioctl, not if_needed', resizes[0].if_needed === undefined);
+  check('payload is the new grid', resizes[0].cols === 100 && resizes[0].rows === 30);
+}
+
+console.log('\nCROW-1162: an ordinary same-size applyTermFit still sends nothing:');
+{
+  const sock = armFitSurface(80, 24);
+  T.applyTermFit();
+  check('deduped fit is silent', resizePayloads(sock).length === 0);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #1162

## Summary

Switching sessions or refocusing a tab was SIGWINCHing the agent TUI because a same-size `resize` frame always became `TIOCSWINSZ`, and the session grid made that worse by disposing 16 xterms on the live-attach turn.

- Tab refocus still reclaims `window-size latest`, but sends `if_needed` so the daemon skips the ioctl when the window is already that size.
- The empty Manager tab bar keeps its 34px slot so Manager ↔ work no longer changes pane geometry by collapsing the strip.
- Grid polling is 1500ms, CSS scale is skipped when unchanged, and `leaveGridView` defers xterm dispose off `selectSession`.

## Test plan

- [x] `node Packages/CrowDaemon/web-tests/session-switch-attach.test.js` (incl. CROW-1162 refocus cases)
- [x] `node Packages/CrowDaemon/web-tests/grid.test.js` (deferred dispose + scale skip)
- [x] CrowDaemon Swift tests for `parseColsRows`, `takeTerminalOwnership`, and `#tabbar:empty`
- [ ] Click between two work sessions of similar chrome — agent TUI should not reflow
- [ ] Click away from the Crow tab and back — same, no reflow
- [ ] Phone/desktop both attached at different sizes — focusing the desktop still takes the window size
- [ ] Open the session grid, click a cell — attach should feel snappy; wall tears down after idle


Made with [Cursor](https://cursor.com)