### PR TITLE
Default gateway binding + log-sync on for managed workspaces

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/ManagedWorkspaceDefaults.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ManagedWorkspaceDefaults.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Managed / design-partner workspace creation defaults (CROW-2841).
+///
+/// The Governance story promises "one auditable request plane" that includes
+/// Builder (Crow). But a workspace created with session log-sync off (today's
+/// default) and no AI-gateway binding leaves no Corveil record at all — nothing
+/// forces either connection. For the workspaces we *operate for customers* —
+/// managed / design-partner installs — that audit-plane claim must be true by
+/// default: harness traffic routes through the org's gateway, and transcripts
+/// upload as session artifacts (feeding the Builder evidence ledger, #2838).
+///
+/// **"Managed / design-partner" is not a separate edition flag.** It is derived
+/// from the state that already distinguishes an operated install from a
+/// self-hosted OSS one: a first-class Corveil connection (ADR 0020) with a single
+/// provisioned org whose gateway can be derived. A self-hosted OSS Crow never
+/// connects, so it never matches and keeps today's opt-in (off) defaults — exactly
+/// the behavior the ticket asks to preserve. This is the smallest possible signal:
+/// no new config field, no new CLI verb, no parity-ledger surface.
+///
+/// Only *newly created* workspaces are defaulted, and only where the operator has
+/// not already made a choice — an existing workspace, or one whose gateway is
+/// already set, is never touched, so a later opt-out (untick the box, clear the
+/// gateway) always sticks.
+///
+/// **The bound gateway is a credential** (it carries the org's `sk-citadel-…` key
+/// inline). It is copied from a value the operator already authored through the
+/// local-only Connect / org-provisioning flow, and it never crosses the wire:
+/// every response path strips it (``WorkspaceRPC.workspaceJSON`` shows only the
+/// base URL; ``SettingsSecrets.strippedForTransport`` blanks the header values).
+/// So this materializes the operator's own managed policy on the daemon host — it
+/// does not accept a credential from, or reveal one to, a caller.
+public enum ManagedWorkspaceDefaults {
+    /// Bind a freshly-created workspace to the managed org gateway and, when
+    /// `enableUpload` is set, opt it into session log-sync (CROW-2841).
+    ///
+    /// The gateway is only written when the workspace has none of its own, so a
+    /// caller that already bound one wins. `enableUpload` is kept separate from the
+    /// gateway so the `workspace-add` CLI path can honor an explicit
+    /// `--upload-session-logs false` while still binding the gateway — they are two
+    /// distinct audit items (#11 gateway, #23 log-sync), and opting out of upload
+    /// should not also unbind the gateway.
+    ///
+    /// - Returns: whether anything changed.
+    @discardableResult
+    public static func apply(
+        to workspace: inout WorkspaceInfo, gateway: WorkspaceGateway, enableUpload: Bool
+    ) -> Bool {
+        let before = workspace
+        if workspace.gateway?.isEmpty ?? true { workspace.gateway = gateway }
+        if enableUpload { workspace.uploadSessionLogs = true }
+        return workspace != before
+    }
+
+    /// Apply managed creation defaults to every workspace in `config` that is new
+    /// relative to `previousWorkspaceIDs` — the `set-config` (web) write path,
+    /// where a just-added workspace arrives with no gateway (the web can't author
+    /// one) and `uploadSessionLogs` false.
+    ///
+    /// A no-op on a self-hosted OSS install (``AppConfig/managedWorkspaceGateway()``
+    /// returns nil). New managed workspaces get both on unconditionally: a
+    /// gateway-less new workspace's log-sync checkbox is disabled in the web form,
+    /// so there is no explicit choice to override, and the next save sees the
+    /// workspace as existing (its id is now in `previousWorkspaceIDs`) and leaves
+    /// it alone — so a subsequent untick sticks.
+    public static func applyToNewWorkspaces(
+        in config: inout AppConfig, previousWorkspaceIDs: Set<UUID>
+    ) {
+        guard let gateway = config.managedWorkspaceGateway() else { return }
+        for index in config.workspaces.indices
+        where !previousWorkspaceIDs.contains(config.workspaces[index].id) {
+            apply(to: &config.workspaces[index], gateway: gateway, enableUpload: true)
+        }
+    }
+}
+
+extension AppConfig {
+    /// The AI gateway a newly-created managed / design-partner workspace binds to
+    /// by default (CROW-2841), or `nil` when this install is self-hosted OSS or the
+    /// choice is ambiguous.
+    ///
+    /// "Managed" is the state of being connected to Corveil (ADR 0020) with exactly
+    /// one provisioned org whose gateway can be derived (a stored `sk-citadel-…`
+    /// key + a base URL — ``CorveilConnection/derivedGateway(orgID:)``). The
+    /// resolution is deliberately conservative:
+    ///
+    ///   - **No connection** → nil. A self-hosted OSS Crow never connects, so it
+    ///     keeps today's opt-in defaults untouched.
+    ///   - **Zero derivable orgs** → nil. Connected but no org key yet: there is no
+    ///     gateway to bind, and log-sync without one uploads nothing anyway.
+    ///   - **More than one derivable org** → nil. Which org a new workspace belongs
+    ///     to is ambiguous, and binding the wrong org would route a customer's
+    ///     traffic through another's gateway — so we don't guess; the operator
+    ///     binds per workspace, exactly as before this default existed.
+    ///
+    /// Health is intentionally not consulted: the org gateway key is a separate
+    /// credential from the OAuth grant, so an expired/revoked *connection* can still
+    /// have a usable gateway key.
+    public func managedWorkspaceGateway() -> WorkspaceGateway? {
+        guard let connection = corveilConnection, !connection.isEmpty else { return nil }
+        let derivable = connection.orgKeys.compactMap { connection.derivedGateway(orgID: $0.orgID) }
+        guard derivable.count == 1 else { return nil }
+        return derivable.first
+    }
+}

--- a/Packages/CrowCore/Sources/CrowCore/ManagedWorkspaceDefaults.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ManagedWorkspaceDefaults.swift
@@ -18,10 +18,13 @@ import Foundation
 /// the behavior the ticket asks to preserve. This is the smallest possible signal:
 /// no new config field, no new CLI verb, no parity-ledger surface.
 ///
-/// Only *newly created* workspaces are defaulted, and only where the operator has
-/// not already made a choice — an existing workspace, or one whose gateway is
-/// already set, is never touched, so a later opt-out (untick the box, clear the
-/// gateway) always sticks.
+/// Only *newly created* workspaces are defaulted, and only ones not already in the
+/// stored config — an existing workspace is never re-touched, so a later opt-out
+/// (untick the box, clear the gateway) always sticks. A brand-new workspace never
+/// carries an operator-authored gateway (neither `workspace-add` nor the web can
+/// set one at creation), so the managed gateway is bound unconditionally; a
+/// pre-existing value on a new workspace can only be an untrusted `set-config`
+/// blob, which must not become an upload destination (see ``apply``).
 ///
 /// **The bound gateway is a credential** (it carries the org's `sk-citadel-…` key
 /// inline). It is copied from a value the operator already authored through the
@@ -34,12 +37,19 @@ public enum ManagedWorkspaceDefaults {
     /// Bind a freshly-created workspace to the managed org gateway and, when
     /// `enableUpload` is set, opt it into session log-sync (CROW-2841).
     ///
-    /// The gateway is only written when the workspace has none of its own, so a
-    /// caller that already bound one wins. `enableUpload` is kept separate from the
-    /// gateway so the `workspace-add` CLI path can honor an explicit
-    /// `--upload-session-logs false` while still binding the gateway — they are two
-    /// distinct audit items (#11 gateway, #23 log-sync), and opting out of upload
-    /// should not also unbind the gateway.
+    /// The managed gateway is bound **unconditionally**, overwriting any value the
+    /// workspace arrived with. A freshly-created workspace never carries an
+    /// operator-authored gateway — neither `workspace-add` (no gateway field) nor
+    /// the web (which can't author one at creation) sets one — so a pre-existing
+    /// value can only be an untrusted `set-config` blob. Enabling log-sync onto it
+    /// would redirect the transcript upload to a destination Crow never bound
+    /// (`LogSyncCollector` reuses `WorkspaceInfo.gateway` for both), so the helper
+    /// only ever pairs log-sync with the gateway it just wrote (CROW-2841 review).
+    ///
+    /// `enableUpload` is kept separate from the gateway so the `workspace-add` CLI
+    /// path can honor an explicit `--upload-session-logs false` while still binding
+    /// the gateway — they are two distinct audit items (#11 gateway, #23 log-sync),
+    /// and opting out of upload should not also unbind the gateway.
     ///
     /// - Returns: whether anything changed.
     @discardableResult
@@ -47,7 +57,7 @@ public enum ManagedWorkspaceDefaults {
         to workspace: inout WorkspaceInfo, gateway: WorkspaceGateway, enableUpload: Bool
     ) -> Bool {
         let before = workspace
-        if workspace.gateway?.isEmpty ?? true { workspace.gateway = gateway }
+        workspace.gateway = gateway
         if enableUpload { workspace.uploadSessionLogs = true }
         return workspace != before
     }

--- a/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
+++ b/Packages/CrowCore/Sources/CrowCore/SettingsSecrets.swift
@@ -88,8 +88,13 @@ public enum SettingsSecrets {
     ///
     /// Per-workspace gateways are matched to `current` by workspace `id`. A
     /// workspace present in `incoming` but not in `current` (e.g. one just added
-    /// from the web) keeps whatever gateway it arrived with — which is `nil`,
-    /// since the web can't author a gateway.
+    /// from the web) is forced to **no gateway**: the web can't author one at
+    /// creation, and the secure per-workspace gateway route matches an existing id,
+    /// so a non-nil gateway on a new id can only be a crafted blob. Enforcing that
+    /// here — rather than trusting the incoming value — stops a remote `set-config`
+    /// from planting a plaintext key that the managed-defaults path (CROW-2841)
+    /// would then opt into log-sync, redirecting transcripts to a destination Crow
+    /// never bound.
     public static func preservingSecrets(incoming: AppConfig, current: AppConfig?) -> AppConfig {
         var result = incoming
         result.jiraCredential = current?.jiraCredential
@@ -128,9 +133,14 @@ public enum SettingsSecrets {
                 current.workspaces.map { ($0.id, $0.gateway) },
                 uniquingKeysWith: { first, _ in first })
             result.workspaces = result.workspaces.map { workspace in
-                guard let storedGateway = currentGatewaysByID[workspace.id] else { return workspace }
                 var w = workspace
-                w.gateway = storedGateway
+                // Known id → restore its stored gateway; unknown id (a just-added
+                // workspace) → force nil, never trusting the incoming value (see the
+                // doc comment above). `currentGatewaysByID[id]` is a double optional
+                // (`WorkspaceGateway??`): `?? nil` collapses both "id absent" and
+                // "id present with a nil gateway" to nil, and yields the stored
+                // gateway when present.
+                w.gateway = currentGatewaysByID[workspace.id] ?? nil
                 return w
             }
         } else {

--- a/Packages/CrowCore/Tests/CrowCoreTests/ManagedWorkspaceDefaultsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ManagedWorkspaceDefaultsTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+import CrowCore
+
+/// Unit coverage for the managed / design-partner workspace creation defaults
+/// (CROW-2841): the pure resolution of "is this install managed, and which org
+/// gateway does a new workspace bind to?" plus the field application. The
+/// end-to-end wiring through `workspace-add` / `set-config` is pinned separately in
+/// `CrowDaemonTests.ManagedWorkspaceDefaultsHandlerTests`.
+@Suite struct ManagedWorkspaceDefaultsTests {
+    private let orgGateway = WorkspaceGateway(
+        baseURL: "https://gw.corveil.example",
+        customHeaders: ["x-citadel-api-key": "sk-citadel-key0"])
+
+    /// A connected install with `orgCount` provisioned orgs, each with a usable key.
+    private func managed(orgCount: Int) -> AppConfig {
+        var c = AppConfig()
+        c.corveilConnection = CorveilConnection(
+            baseURL: "https://gw.corveil.example",
+            clientID: "cid",
+            orgKeys: (0..<orgCount).map { CorveilOrgKey(orgID: "org-\($0)", orgName: "Org \($0)") },
+            orgKeySecrets: Dictionary(
+                uniqueKeysWithValues: (0..<orgCount).map { ("org-\($0)", "sk-citadel-key\($0)") }),
+            oauth: CorveilOAuthTokens(accessToken: "at"))
+        return c
+    }
+
+    // MARK: - managedWorkspaceGateway
+
+    @Test func ossInstallHasNoManagedGateway() {
+        // No Corveil connection at all — the self-hosted OSS case the ticket
+        // preserves untouched.
+        #expect(AppConfig().managedWorkspaceGateway() == nil)
+    }
+
+    @Test func singleProvisionedOrgYieldsItsDerivedGateway() throws {
+        let gateway = try #require(managed(orgCount: 1).managedWorkspaceGateway())
+        #expect(gateway.baseURL == "https://gw.corveil.example")
+        #expect(gateway.customHeaders == ["x-citadel-api-key": "sk-citadel-key0"])
+    }
+
+    @Test func zeroProvisionedOrgsIsNotManaged() {
+        // Connected, but no org key minted yet — there is no gateway to bind, and
+        // log-sync without one would upload nothing.
+        var c = AppConfig()
+        c.corveilConnection = CorveilConnection(
+            baseURL: "https://gw.corveil.example", clientID: "cid",
+            oauth: CorveilOAuthTokens(accessToken: "at"))
+        #expect(c.managedWorkspaceGateway() == nil)
+    }
+
+    @Test func multipleProvisionedOrgsAreAmbiguous() {
+        // Binding the wrong org would route a customer's traffic through another's
+        // gateway, so we refuse to guess.
+        #expect(managed(orgCount: 2).managedWorkspaceGateway() == nil)
+    }
+
+    @Test func orgWithoutAStoredKeyIsNotDerivable() {
+        // Metadata present but no `sk-citadel-…` secret → no derivable gateway.
+        var c = AppConfig()
+        c.corveilConnection = CorveilConnection(
+            baseURL: "https://gw.corveil.example", clientID: "cid",
+            orgKeys: [CorveilOrgKey(orgID: "org-0", orgName: "Org 0")],
+            orgKeySecrets: [:],
+            oauth: CorveilOAuthTokens(accessToken: "at"))
+        #expect(c.managedWorkspaceGateway() == nil)
+    }
+
+    @Test func oneDerivableOrgAmongUnprovisionedOnesStillResolves() throws {
+        // Two org rows, only one carries a stored key → unambiguous.
+        var c = AppConfig()
+        c.corveilConnection = CorveilConnection(
+            baseURL: "https://gw.corveil.example", clientID: "cid",
+            orgKeys: [CorveilOrgKey(orgID: "org-0", orgName: "A"),
+                      CorveilOrgKey(orgID: "org-1", orgName: "B")],
+            orgKeySecrets: ["org-1": "sk-citadel-only"],
+            oauth: CorveilOAuthTokens(accessToken: "at"))
+        let gateway = try #require(c.managedWorkspaceGateway())
+        #expect(gateway.customHeaders == ["x-citadel-api-key": "sk-citadel-only"])
+    }
+
+    // MARK: - apply (single workspace)
+
+    @Test func applyBindsGatewayAndEnablesUpload() {
+        var ws = WorkspaceInfo(name: "Acme")
+        let changed = ManagedWorkspaceDefaults.apply(
+            to: &ws, gateway: orgGateway, enableUpload: true)
+        #expect(changed)
+        #expect(ws.gateway == orgGateway)
+        #expect(ws.uploadSessionLogs)
+    }
+
+    @Test func applyHonorsExplicitUploadOptOutButStillBindsGateway() {
+        // #11 (gateway) and #23 (log-sync) are distinct audit items: opting out of
+        // upload must not also unbind the gateway.
+        var ws = WorkspaceInfo(name: "Acme")
+        ManagedWorkspaceDefaults.apply(to: &ws, gateway: orgGateway, enableUpload: false)
+        #expect(ws.gateway == orgGateway)
+        #expect(ws.uploadSessionLogs == false)
+    }
+
+    @Test func applyDoesNotClobberAnExistingGateway() {
+        let existing = WorkspaceGateway(baseURL: "https://other", customHeaders: ["X": "y"])
+        var ws = WorkspaceInfo(name: "Acme", gateway: existing)
+        ManagedWorkspaceDefaults.apply(to: &ws, gateway: orgGateway, enableUpload: true)
+        #expect(ws.gateway == existing)
+        #expect(ws.uploadSessionLogs)
+    }
+
+    // MARK: - applyToNewWorkspaces (set-config path)
+
+    @Test func newWorkspacesGetDefaultsExistingOnesAreUntouched() {
+        var config = managed(orgCount: 1)
+        let existing = WorkspaceInfo(name: "Existing")  // no gateway, upload off
+        let brandNew = WorkspaceInfo(name: "New")
+        config.workspaces = [existing, brandNew]
+
+        ManagedWorkspaceDefaults.applyToNewWorkspaces(
+            in: &config, previousWorkspaceIDs: [existing.id])
+
+        let after = Dictionary(uniqueKeysWithValues: config.workspaces.map { ($0.name, $0) })
+        #expect(after["Existing"]?.gateway == nil)
+        #expect(after["Existing"]?.uploadSessionLogs == false)
+        #expect(after["New"]?.gateway?.customHeaders == ["x-citadel-api-key": "sk-citadel-key0"])
+        #expect(after["New"]?.uploadSessionLogs == true)
+    }
+
+    @Test func applyToNewWorkspacesIsNoOpForOSS() {
+        var config = AppConfig()
+        config.workspaces = [WorkspaceInfo(name: "New")]
+        ManagedWorkspaceDefaults.applyToNewWorkspaces(in: &config, previousWorkspaceIDs: [])
+        #expect(config.workspaces[0].gateway == nil)
+        #expect(config.workspaces[0].uploadSessionLogs == false)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/ManagedWorkspaceDefaultsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ManagedWorkspaceDefaultsTests.swift
@@ -99,11 +99,15 @@ import CrowCore
         #expect(ws.uploadSessionLogs == false)
     }
 
-    @Test func applyDoesNotClobberAnExistingGateway() {
-        let existing = WorkspaceGateway(baseURL: "https://other", customHeaders: ["X": "y"])
-        var ws = WorkspaceInfo(name: "Acme", gateway: existing)
+    @Test func applyOverwritesAnIncomingGatewayWithTheManagedOne() {
+        // A brand-new workspace never carries an operator-authored gateway, so a
+        // pre-existing value can only be an untrusted set-config blob — the managed
+        // gateway must win, so log-sync is never enabled onto a caller's gateway.
+        let planted = WorkspaceGateway(
+            baseURL: "https://evil.example", customHeaders: ["x-citadel-api-key": "sk-attacker"])
+        var ws = WorkspaceInfo(name: "Acme", gateway: planted)
         ManagedWorkspaceDefaults.apply(to: &ws, gateway: orgGateway, enableUpload: true)
-        #expect(ws.gateway == existing)
+        #expect(ws.gateway == orgGateway)
         #expect(ws.uploadSessionLogs)
     }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SettingsSecretsTests.swift
@@ -146,6 +146,23 @@ import CrowCore
         #expect(merged.managerGateway == current.managerGateway)
     }
 
+    @Test func preserveDropsAGatewayPlantedOnANewWorkspaceID() {
+        // The web can't author a gateway on a just-added workspace, so a non-nil
+        // gateway on an id NOT in `current` can only be a crafted set-config blob —
+        // it must be dropped, not trusted, or the managed-defaults path (CROW-2841)
+        // could opt that workspace into log-sync upload to a caller-chosen
+        // destination.
+        let current = configWithSecrets()  // one existing workspace with a gateway
+        var incoming = SettingsSecrets.strippedForTransport(current)
+        var planted = WorkspaceInfo(name: "Planted")
+        planted.gateway = WorkspaceGateway(
+            baseURL: "https://evil.example", customHeaders: ["x-citadel-api-key": "sk-attacker"])
+        incoming.workspaces.append(planted)
+
+        let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+        #expect(merged.workspaces.first { $0.name == "Planted" }?.gateway == nil)
+    }
+
     @Test func preserveWithNilCurrentDropsCredentials() {
         // App down and no config file yet: there's nothing to restore, so drop
         // any credential shell the browser echoed back rather than persist a

--- a/Packages/CrowDaemon/Sources/CrowDaemon/SnapshotRPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/SnapshotRPCHandlers.swift
@@ -246,7 +246,15 @@ func makeSnapshotHandlers(
             do {
                 merged = try ConfigStore.withConfigLock {
                     let current = ConfigStore.loadConfig(devRoot: devRoot)
-                    let m = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+                    var m = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+                    // CROW-2841: a workspace just added from the web arrives with no
+                    // gateway (the web can't author one). On a managed / design-partner
+                    // install, default each genuinely-new workspace to the org gateway
+                    // + session log-sync so the audit plane is true by default — a
+                    // no-op for self-hosted OSS, and never for a workspace that already
+                    // existed (so a later opt-out sticks).
+                    ManagedWorkspaceDefaults.applyToNewWorkspaces(
+                        in: &m, previousWorkspaceIDs: Set((current?.workspaces ?? []).map(\.id)))
                     try ConfigStore.saveConfig(m, devRoot: devRoot)
                     return m
                 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/WorkspaceRPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/WorkspaceRPCHandlers.swift
@@ -52,6 +52,17 @@ func makeWorkspaceHandlers(
                     // any field added to `WorkspaceInfo` later.
                     var workspace = WorkspaceInfo(name: name)
                     try WorkspaceRPC.applyPatch(params, to: &workspace, name: name)
+                    // CROW-2841: on a managed / design-partner install (connected to
+                    // Corveil with a single provisioned org), a new workspace defaults
+                    // to that org's gateway + session log-sync so the audit plane is
+                    // true by default. Self-hosted OSS has no connection, so this is a
+                    // no-op there. An explicit `--upload-session-logs` is honored; the
+                    // gateway (a distinct audit item) is always bound.
+                    if let managedGateway = config.managedWorkspaceGateway() {
+                        let explicitUpload = (params["upload_session_logs"] ?? .null) != .null
+                        ManagedWorkspaceDefaults.apply(
+                            to: &workspace, gateway: managedGateway, enableUpload: !explicitUpload)
+                    }
                     config.workspaces.append(workspace)
                     return workspace
                 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/DaemonSecurityTests.swift
@@ -1436,10 +1436,14 @@ import CrowPersistence
         // granular verbs stay un-gated too — the remote-reachable surface here is
         // strictly smaller than the whole-config blob it replaces.
         //
-        // What would justify gating — the per-workspace AI gateway — is *excluded*
-        // rather than gated: no `workspace-*` method writes it, and
-        // `workspaceJSON` reduces it to a flag plus a base URL. Authoring the
-        // credential stays with `gateway-set`, which is gated.
+        // The per-workspace AI gateway is still never *authored from the wire*:
+        // `workspaceJSON` reduces it to a flag plus a base URL, and a manual gateway
+        // credential stays with the gated `gateway-set`. `workspace-add` does now
+        // write one derived value — the managed org gateway a managed/design-partner
+        // install binds a new workspace to (CROW-2841) — but that key is copied from
+        // the operator-authored, local-only `corveilConnection`, never from the
+        // request, and is stripped from the response. A remote caller can trigger
+        // the bind but can neither supply nor read the credential.
         //
         // This test is what enforces that decision — `localOnlyDenial`'s
         // `default:` would silently swallow a later change of heart. Deliberate:

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/ManagedWorkspaceDefaultsHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/ManagedWorkspaceDefaultsHandlerTests.swift
@@ -165,4 +165,55 @@ import CrowPersistence
         #expect(stored.gateway == nil)
         #expect(stored.uploadSessionLogs == false)
     }
+
+    // MARK: - set-config, hostile blobs (CROW-2841 review)
+
+    @Test @MainActor func setConfigOverwritesACraftedGatewayOnANewManagedWorkspace() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(managedConfig(), devRoot: devRoot)
+
+        // A crafted blob plants a hostile gateway on a brand-new workspace id — the
+        // web never authors one there, so `preservingSecrets` must not trust it and
+        // the managed bind must win, or log-sync would redirect to the attacker.
+        var incoming = AppConfig()
+        var planted = WorkspaceInfo(name: "New")
+        planted.gateway = WorkspaceGateway(
+            baseURL: "https://evil.example", customHeaders: ["x-citadel-api-key": "sk-attacker"])
+        incoming.workspaces = [planted]
+        let json = try #require(String(data: JSONEncoder().encode(incoming), encoding: .utf8))
+
+        let resp = await call("set-config", ["config": .string(json)], devRoot: devRoot)
+        #expect(resp.error == nil)
+
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway?.baseURL == "https://gw.corveil.example")
+        #expect(stored.gateway?.customHeaders == ["x-citadel-api-key": "sk-citadel-AbCdEf"])
+        #expect(stored.uploadSessionLogs)
+    }
+
+    @Test @MainActor func setConfigDropsACraftedGatewayOnOSSSoNothingUploads() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // An OSS install with a stored (empty) config, so the `current != nil` merge
+        // branch runs — the one that must nil a new id's gateway.
+        try ConfigStore.saveConfig(AppConfig(), devRoot: devRoot)
+
+        // Crafted: a planted gateway AND a pre-flipped log-sync flag on a new id.
+        var incoming = AppConfig()
+        var planted = WorkspaceInfo(name: "New")
+        planted.gateway = WorkspaceGateway(
+            baseURL: "https://evil.example", customHeaders: ["x-citadel-api-key": "sk-attacker"])
+        planted.uploadSessionLogs = true
+        incoming.workspaces = [planted]
+        let json = try #require(String(data: JSONEncoder().encode(incoming), encoding: .utf8))
+
+        let resp = await call("set-config", ["config": .string(json)], devRoot: devRoot)
+        #expect(resp.error == nil)
+
+        // The gateway is dropped, so the collector has no destination even though the
+        // crafted flag persisted — the exfil target is gone.
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway == nil)
+    }
 }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/ManagedWorkspaceDefaultsHandlerTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/ManagedWorkspaceDefaultsHandlerTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowGit
+import CrowIPC
+import CrowPersistence
+@testable import CrowDaemon
+
+/// End-to-end coverage of the CROW-2841 managed / design-partner workspace
+/// creation defaults, through the real router against a temp `config.json`.
+///
+/// A new workspace on a managed install (a Corveil connection with one provisioned
+/// org) defaults to that org's gateway + session log-sync, so the audit plane is
+/// true by default; a self-hosted OSS install (no connection) keeps today's
+/// opt-in-off behavior. Both creation surfaces are exercised: `workspace-add` (the
+/// CLI path) and `set-config` (the web "Add workspace" path, which ships the whole
+/// config). The pure resolution logic is pinned in
+/// `CrowCoreTests.ManagedWorkspaceDefaultsTests`.
+@Suite struct ManagedWorkspaceDefaultsHandlerTests {
+    private func tempDevRoot() -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crowd-managed-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @MainActor
+    private func call(
+        _ method: String, _ params: [String: JSONValue] = [:], devRoot: String
+    ) async -> JSONRPCResponse {
+        let router = makeCommandRouter(
+            appState: AppState(), store: JSONStore.temporary(), git: GitManager(),
+            devRoot: devRoot, cockpit: nil)
+        return await router.handle(request: JSONRPCRequest(id: 1, method: method, params: params))
+    }
+
+    private func workspaces(_ devRoot: String) -> [WorkspaceInfo] {
+        ConfigStore.loadConfig(devRoot: devRoot)?.workspaces ?? []
+    }
+
+    private func named(_ devRoot: String) -> [String: WorkspaceInfo] {
+        Dictionary(uniqueKeysWithValues: workspaces(devRoot).map { ($0.name, $0) })
+    }
+
+    /// A managed install: connected to Corveil with a single provisioned org whose
+    /// gateway derives to `https://gw.corveil.example` + `sk-citadel-AbCdEf`.
+    private func managedConfig() -> AppConfig {
+        var c = AppConfig()
+        c.corveilConnection = CorveilConnection(
+            baseURL: "https://gw.corveil.example",
+            clientID: "cid",
+            orgKeys: [CorveilOrgKey(orgID: "org-1", orgName: "Acme")],
+            orgKeySecrets: ["org-1": "sk-citadel-AbCdEf"],
+            oauth: CorveilOAuthTokens(accessToken: "at"))
+        return c
+    }
+
+    // MARK: - workspace-add (CLI path)
+
+    @Test @MainActor func addOnManagedInstallBindsGatewayAndEnablesLogSync() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(managedConfig(), devRoot: devRoot)
+
+        let resp = await call("workspace-add", ["name": .string("Acme")], devRoot: devRoot)
+        #expect(resp.error == nil)
+        // The response reports the binding without ever exposing the key.
+        #expect(resp.result?["workspace"]?.objectValue?["gateway_set"] == .bool(true))
+        #expect(resp.result?["workspace"]?.objectValue?["upload_session_logs"] == .bool(true))
+
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway?.baseURL == "https://gw.corveil.example")
+        #expect(stored.gateway?.customHeaders == ["x-citadel-api-key": "sk-citadel-AbCdEf"])
+        #expect(stored.uploadSessionLogs)
+    }
+
+    @Test @MainActor func addOnOSSInstallLeavesDefaultsOff() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        // No config at all — the fresh OSS install.
+
+        let resp = await call("workspace-add", ["name": .string("Acme")], devRoot: devRoot)
+        #expect(resp.error == nil)
+
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway == nil)
+        #expect(stored.uploadSessionLogs == false)
+    }
+
+    @Test @MainActor func addRespectsExplicitUploadOptOutButStillBindsGateway() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        try ConfigStore.saveConfig(managedConfig(), devRoot: devRoot)
+
+        let resp = await call(
+            "workspace-add",
+            ["name": .string("Acme"), "upload_session_logs": .bool(false)],
+            devRoot: devRoot)
+        #expect(resp.error == nil)
+
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway?.customHeaders == ["x-citadel-api-key": "sk-citadel-AbCdEf"])
+        #expect(stored.uploadSessionLogs == false)  // explicit --upload-session-logs false honored
+    }
+
+    @Test @MainActor func addWithMultipleProvisionedOrgsIsAmbiguousSoOff() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+        var config = managedConfig()
+        config.corveilConnection?.orgKeys.append(CorveilOrgKey(orgID: "org-2", orgName: "Beta"))
+        config.corveilConnection?.orgKeySecrets["org-2"] = "sk-citadel-Second"
+        try ConfigStore.saveConfig(config, devRoot: devRoot)
+
+        _ = await call("workspace-add", ["name": .string("Acme")], devRoot: devRoot)
+
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway == nil)
+        #expect(stored.uploadSessionLogs == false)
+    }
+
+    // MARK: - set-config (web path)
+
+    @Test @MainActor func setConfigDefaultsANewManagedWorkspaceOnly() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        // Stored: a managed install with one existing workspace the operator has
+        // deliberately not opted into anything.
+        var stored = managedConfig()
+        let existing = WorkspaceInfo(name: "Existing")
+        stored.workspaces = [existing]
+        try ConfigStore.saveConfig(stored, devRoot: devRoot)
+
+        // Incoming, as a browser sends it: the existing workspace plus a brand-new
+        // one, connection secrets stripped (restored server-side by preservingSecrets).
+        var incoming = AppConfig()
+        incoming.workspaces = [existing, WorkspaceInfo(name: "New")]
+        let json = try #require(String(data: JSONEncoder().encode(incoming), encoding: .utf8))
+
+        let resp = await call("set-config", ["config": .string(json)], devRoot: devRoot)
+        #expect(resp.error == nil)
+
+        let after = named(devRoot)
+        // The genuinely-new workspace is bound + opted in.
+        #expect(after["New"]?.gateway?.customHeaders == ["x-citadel-api-key": "sk-citadel-AbCdEf"])
+        #expect(after["New"]?.uploadSessionLogs == true)
+        // The pre-existing workspace is left exactly as the operator had it, so a
+        // prior opt-out is never re-flipped.
+        #expect(after["Existing"]?.gateway == nil)
+        #expect(after["Existing"]?.uploadSessionLogs == false)
+    }
+
+    @Test @MainActor func setConfigOnOSSInstallLeavesNewWorkspaceOff() async throws {
+        let devRoot = tempDevRoot()
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        var incoming = AppConfig()
+        incoming.workspaces = [WorkspaceInfo(name: "New")]
+        let json = try #require(String(data: JSONEncoder().encode(incoming), encoding: .utf8))
+
+        let resp = await call("set-config", ["config": .string(json)], devRoot: devRoot)
+        #expect(resp.error == nil)
+
+        let stored = try #require(workspaces(devRoot).first)
+        #expect(stored.gateway == nil)
+        #expect(stored.uploadSessionLogs == false)
+    }
+}

--- a/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift
@@ -216,7 +216,12 @@ public func makeEngineRouter(_ ctx: EngineContext) -> CommandRouter {
                 // them back — mirror the daemon handler so this surface stays safe
                 // if it ever becomes web-facing (review #3).
                 let current = await loadConfigForRPC()?.1
-                let merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+                var merged = SettingsSecrets.preservingSecrets(incoming: incoming, current: current)
+                // CROW-2841: default a genuinely-new workspace to the managed org
+                // gateway + session log-sync on a managed / design-partner install
+                // (no-op for self-hosted OSS). Mirrors the daemon `set-config` handler.
+                ManagedWorkspaceDefaults.applyToNewWorkspaces(
+                    in: &merged, previousWorkspaceIDs: Set((current?.workspaces ?? []).map(\.id)))
                 guard let saved = await applyConfigForRPC(merged) else {
                     throw RPCError.applicationError("Config not loaded yet")
                 }

--- a/docs/adr/0023-managed-workspace-defaults.md
+++ b/docs/adr/0023-managed-workspace-defaults.md
@@ -65,9 +65,13 @@ never connects, so it never matches and its opt-in-off defaults are untouched.
   inline. It is copied from a value the operator already authored through the
   local-only Connect / org-provisioning flow, and it never crosses the wire — every
   response path strips it (`WorkspaceRPC.workspaceJSON` shows only the base URL;
-  `SettingsSecrets.strippedForTransport` blanks header values). So creation from a
-  remote authenticated peer materializes the operator's own managed policy on the
-  daemon host; it neither accepts a credential from, nor reveals one to, the caller.
+  `SettingsSecrets.strippedForTransport` blanks header values). A new workspace also
+  never *keeps* a caller-supplied gateway: `preservingSecrets` nils the gateway on a
+  new (unknown) id, and the managed default overwrites unconditionally — so log-sync
+  is only ever paired with the gateway Crow itself derived, never one a crafted
+  `set-config` blob planted. So creation from a remote authenticated peer
+  materializes the operator's own managed policy on the daemon host; it neither
+  accepts a credential from, nor reveals one to, the caller.
 
 ## Alternatives considered
 

--- a/docs/adr/0023-managed-workspace-defaults.md
+++ b/docs/adr/0023-managed-workspace-defaults.md
@@ -1,0 +1,94 @@
+# 0023 — Managed / design-partner workspaces default gateway binding + log-sync on
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Deciders:** @dhilgaertner
+
+## Context
+
+The Governance story promises "one auditable request plane" that includes Builder
+(Crow). But a workspace created with session log-sync off (today's default, ADR
+0020 / CROW-1070) and no AI-gateway binding leaves **no** Corveil record at all:
+harness traffic doesn't route through the org's gateway, and no transcript uploads
+as a session artifact. Nothing forces either connection, so the audit-plane claim is
+aspirational rather than true by default — and the Builder evidence ledger (#2838)
+only has `AgentSession` records for workspaces that happened to opt in.
+
+Andy's call (audit items #11 + #23, filed as
+[corveil/corveil#2841](https://github.com/corveil/corveil/issues/2841)): for the
+workspaces **we operate for customers** — managed / design-partner installs — both
+should be **on by default**. Self-hosted OSS Crow must keep today's opt-in (off)
+defaults, so this cannot be an unconditional behavior change.
+
+That raises the real question: *how does Crow know it is a managed / design-partner
+install rather than a self-hosted OSS one?* There was no edition flag, and adding
+one (a new `AppConfig` field + CLI verb + web control) is a lot of surface for a
+distinction the config already encodes.
+
+## Decision
+
+**"Managed / design-partner" is derived from the first-class Corveil connection
+(ADR 0020), not a new flag.** A workspace is created with the org gateway bound and
+`uploadSessionLogs` on **iff** the install has a connected `corveilConnection` with
+exactly one provisioned org whose gateway can be derived. A self-hosted OSS Crow
+never connects, so it never matches and its opt-in-off defaults are untouched.
+
+- The single provisioned org's `CorveilConnection.derivedGateway(orgID:)` is bound
+  as the new workspace's `gateway`, and `uploadSessionLogs` is set true — the same
+  "org binding ⇒ log-sync on" pairing the org picker already applies
+  (`SecretRoutes.orgSelectionEnablesLogSync`, corveil/crow#1124), now at creation
+  time.
+- Applied at both creation surfaces: `workspace-add` (CLI) and `set-config` (the
+  web "Add workspace" path), sharing one Core helper (`ManagedWorkspaceDefaults`).
+- Only **new** workspaces, and only where the field is unset: an existing workspace
+  is never re-flipped, and `workspace-add` honors an explicit
+  `--upload-session-logs false` (the gateway, a distinct audit item, still binds).
+- Resolution is conservative: zero derivable orgs (connected, none provisioned) or
+  more than one (ambiguous — binding the wrong org would route a customer's traffic
+  through another's gateway) both fall back to no default.
+
+## Consequences
+
+- **Easier:** the audit-plane claim is true by default on the installs where it
+  matters, with **zero** new config surface — no `AppConfig` field, no CLI verb, no
+  parity-ledger row, no new web control. The Builder evidence ledger (#2838) gains
+  `AgentSession` coverage automatically as managed workspaces are created.
+- **To live with — implicit signal:** connecting Corveil and provisioning an org
+  changes workspace-creation defaults. That is the intent ("true by default once
+  operating within Corveil"), it is reversible (untick the box / clear the gateway),
+  and it never touches existing workspaces — but it is a behavior a reader must know
+  is connection-derived, hence this ADR.
+- **To live with — ambiguity is a no-op:** a design partner with two provisioned
+  orgs gets no auto-binding and picks per workspace, exactly as before. Safe over
+  clever: we never guess which org a workspace belongs to.
+- **Credential handling:** the bound gateway carries the org's `sk-citadel-…` key
+  inline. It is copied from a value the operator already authored through the
+  local-only Connect / org-provisioning flow, and it never crosses the wire — every
+  response path strips it (`WorkspaceRPC.workspaceJSON` shows only the base URL;
+  `SettingsSecrets.strippedForTransport` blanks header values). So creation from a
+  remote authenticated peer materializes the operator's own managed policy on the
+  daemon host; it neither accepts a credential from, nor reveals one to, the caller.
+
+## Alternatives considered
+
+- **A new explicit edition flag** (`defaults.managedWorkspaceDefaults`, or a
+  connection field). Rejected: it is the larger surface the ticket asks to avoid
+  ("propose the smallest one"), and it *still* has to resolve "which org" from the
+  connection — so the connection is the real signal regardless.
+- **A build / edition compile flag.** Rejected: managed vs OSS is a runtime
+  deployment property, not a build one; the same binary serves both.
+- **Retroactively flipping existing managed workspaces on.** Rejected: it would
+  clobber a deliberate opt-out. "Default" means at creation, not a migration.
+- **Binding at gateway-resolution time instead of storing the gateway.** Rejected:
+  the log collector reads the materialized `WorkspaceInfo.gateway` for its upload
+  credential, so the binding must be stored, not resolved lazily.
+
+## References
+
+- PR: (this change) — Refs [corveil/corveil#2841](https://github.com/corveil/corveil/issues/2841)
+- Related ADRs: [0020](./0020-first-class-corveil-integration.md) (first-class
+  Corveil integration — the connection this derives from)
+- Code: `Packages/CrowCore/Sources/CrowCore/ManagedWorkspaceDefaults.swift`,
+  `Packages/CrowDaemon/Sources/CrowDaemon/WorkspaceRPCHandlers.swift`
+  (`workspace-add`), `Packages/CrowDaemon/Sources/CrowDaemon/SnapshotRPCHandlers.swift`
+  + `Packages/CrowEngine/Sources/CrowEngine/EngineRouter.swift` (`set-config`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,3 +59,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0020 | [Corveil is a first-class integration, not a manual gateway](./0020-first-class-corveil-integration.md) | Accepted | 2026-08-27 |
 | 0021 | [Signed + notarized macOS CLI releases](./0021-signed-notarized-macos-releases.md) | Accepted | 2026-08-28 |
 | 0022 | [Session grid cells are read-only capture-pane snapshots](./0022-session-grid-snapshots.md) | Accepted | 2026-08-28 |
+| 0023 | [Managed / design-partner workspaces default gateway binding + log-sync on](./0023-managed-workspace-defaults.md) | Accepted | 2026-09-01 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,14 @@ For a **Corveil** gateway, the recommended path is not a hand-entered `x-citadel
 - **Local-only, like every other credential.** The whole `corveilConnection` surface — Connect, org selection, and the migration verbs below — is authored only over the local Unix socket / a local-direct browser POST; a remote web session gets a read-only view (tokens and key values stripped). See [Gateways & Secrets](cli-reference.md#gateways--secrets).
 - Drive it from the CLI with `crow corveil connect` / `status` / `list-orgs` / `select-org` (see the [CLI reference](cli-reference.md#the-corveil-connection)).
 
+### Managed / design-partner workspace defaults
+
+On an install we operate for a customer, the audit-plane claim must be true *by default* — so a **newly created** workspace defaults both the org **gateway binding** and **session log-sync** on (CROW-2841, [ADR 0023](adr/0023-managed-workspace-defaults.md)). This is derived from the connection, not a separate flag:
+
+- **When it applies:** the install has a connected `corveilConnection` with **exactly one** provisioned org whose gateway can be derived. That org's `baseURL` + `x-citadel-api-key` is bound as the new workspace's `gateway`, and `uploadSessionLogs` is turned on — so harness traffic routes through the org's gateway and transcripts upload as session artifacts, feeding the [Builder evidence ledger](https://github.com/corveil/corveil/issues/2838), with nothing to configure.
+- **Self-hosted OSS is unchanged.** No Corveil connection ⇒ no managed org ⇒ today's opt-in (off) defaults, untouched.
+- **Conservative and reversible.** Zero provisioned orgs, or **more than one** (ambiguous — we won't guess which org a workspace belongs to), fall back to no default. Only *new* workspaces are affected — an existing one is never re-flipped, `crow workspace add --upload-session-logs false` is honored (the gateway still binds — a distinct audit item), and you can always untick the box / `crow gateway clear` afterward.
+
 ### Migrating manual gateways to the connection
 
 If you configured Corveil the old way — a `gateway` with a hand-entered `x-citadel-api-key` header — you can bring that key under the connection without disrupting the running session (CROW-1126):


### PR DESCRIPTION
## Summary

Managed / design-partner workspaces now default **both** the per-workspace AI-gateway binding **and** session log-sync **ON** at creation, so the Governance "one auditable request plane" claim is true by default for the installs we operate for customers. Self-hosted OSS Crow is unchanged.

> **Ticket lives in `corveil/corveil`, code lives here.** This implements [corveil/corveil#2841](https://github.com/corveil/corveil/issues/2841) (Andy's call, audit items #11 + #23). Cross-repo, so `Refs` — it links but won't auto-close.

## How "managed / design-partner" is signaled

There was no edition flag, and adding one is a lot of surface for a distinction the config already encodes. So **it's derived from the first-class Corveil connection** ([ADR 0020](../blob/main/docs/adr/0020-first-class-corveil-integration.md)), not a new flag:

| Install state | Result |
|---|---|
| No `corveilConnection` (self-hosted OSS) | **Unchanged** — today's opt-in (off) defaults |
| Connected, **exactly one** provisioned org with a derivable gateway | New workspace binds that org's gateway + `uploadSessionLogs = true` |
| Connected, **zero** or **more than one** provisioned org | No default (ambiguous — we won't guess which org a workspace belongs to) |

This needs **no new `AppConfig` field, CLI verb, or parity-ledger surface** — it reuses `WorkspaceInfo.gateway` + `uploadSessionLogs` and `CorveilConnection.derivedGateway(orgID:)`, extending the existing "org binding ⇒ log-sync on" pairing (`SecretRoutes.orgSelectionEnablesLogSync`) to *creation time*.

## What changed

- **New Core helper** `ManagedWorkspaceDefaults` + `AppConfig.managedWorkspaceGateway()` — the pure "is this managed, and which org gateway?" resolution and field application.
- **Both creation surfaces**, sharing that helper:
  - `workspace-add` (CLI) — honors an explicit `--upload-session-logs false`; the gateway (a *distinct* audit item, #11 vs #23) still binds.
  - `set-config` (web "Add workspace", which ships the whole config) — only for genuinely-**new** workspace ids, so a later opt-out is never re-flipped, and gateway-less new web workspaces (the web can't author a gateway) get bound server-side.
- **Docs:** [ADR 0023](../blob/feature/crow-2841-managed-workspace-defaults/docs/adr/0023-managed-workspace-defaults.md) records the decision; a `configuration.md` note explains it for operators.

## Security

The bound gateway carries the org's `sk-citadel-…` key inline, but it's **copied from a value the operator already authored through the local-only Connect / org-provisioning flow** and **never crosses the wire** — every response path strips it (`WorkspaceRPC.workspaceJSON` shows only the base URL; `SettingsSecrets.strippedForTransport` blanks header values). So creation from a remote authenticated peer materializes the operator's own managed policy on the daemon host; it neither accepts a credential from, nor reveals one to, the caller.

## Side effect

Materially improves the **Builder evidence ledger** ([corveil/corveil#2838](https://github.com/corveil/corveil/issues/2838)): `AgentSession` records only exist for workspaces that upload logs, and this makes that the default on managed installs.

## Tests

- `CrowCoreTests/ManagedWorkspaceDefaultsTests` (11) — the pure resolution + application: OSS ⇒ nil, single org ⇒ derived gateway, zero/multiple ⇒ nil, explicit opt-out respected, existing workspaces untouched.
- `CrowDaemonTests/ManagedWorkspaceDefaultsHandlerTests` (6) — end-to-end through the real router for `workspace-add` **and** `set-config`: managed ⇒ both on, OSS ⇒ both off, explicit `--upload-session-logs false` honored (gateway still binds), ambiguous multi-org ⇒ off, new-only for `set-config`.

CLI/RPC parity (`scripts/check-cli-parity.sh`) and the config-field parity gates pass unchanged (no new field/verb).

Refs corveil/corveil#2841

🤖 Generated with [Claude Code](https://claude.com/claude-code)
