### PR TITLE
Stop awaiting board polls on MainActor

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/AutoMergeController.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/AutoMergeController.swift
@@ -615,7 +615,17 @@ final class AutoMergeController {
         // PR, so asking for `viewerLastReviewedAt` here would spend query
         // budget on a field that is structurally always nil. Only the
         // review-session path needs it.
-        let result = await owner.boardPoller.fetchStalePRStates(urls: [prURL], viewerLogin: "")
+        let providerManager = owner.providerManager
+        let result = await Task.detached {
+            await BoardPoller.fetchStalePRStates(
+                urls: [prURL],
+                viewerLogin: "",
+                providerManager: providerManager
+            )
+        }.value
+        for event in result.events {
+            owner.applyGitHubBackendEvent(event)
+        }
         var byURL = Dictionary(result.prs.map { ($0.url, $0) }, uniquingKeysWith: IssueTracker.mergePRRecords)
 
         // Read-your-write: `backend.addMergeLabel` threw on failure, so the

--- a/Packages/CrowEngine/Sources/CrowEngine/BoardPoller.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/BoardPoller.swift
@@ -11,7 +11,11 @@ import CrowProvider
 /// log-rate-limit bookkeeping; reaches the shared warnings + rate-limit sink,
 /// the auto-create callback/toggle, `appState`, `providerManager`, and the
 /// shared `JSONStore` through an unowned back-reference to the tracker.
-/// `refresh()` still drives every method here, in the current order.
+///
+/// Provider I/O is `nonisolated` (`fetchOffActor`) so `refresh()` can snapshot
+/// on the state actor, await GitHub/GitLab/Jira off MainActor, and apply in
+/// one hop (CROW-1179). `refresh()` still drives every method here, in the
+/// current order.
 @MainActor
 final class BoardPoller {
     private unowned let owner: IssueTracker
@@ -185,6 +189,44 @@ final class BoardPoller {
         let rateLimit: GitHubRateLimit?
     }
 
+    /// Side effects the GitHub fetch must not apply itself — they mutate
+    /// `@MainActor` warning / rate-limit state. Collected off-actor and
+    /// applied in the single hop back (CROW-1179).
+    enum GitHubBackendEvent: Sendable, Equatable {
+        case insufficientScope(String)
+        case rateLimited(stderr: String)
+        case samlRestricted
+        case failed(operation: String, message: String)
+        case reportScopeWarning(String)
+        case clearScopeWarning
+        case reportSAMLWarning
+        case clearSAMLWarning
+    }
+
+    /// Everything the off-actor poll needs from `AppState` / config.
+    /// Snapshotted on MainActor in milliseconds; contains no live actor refs.
+    struct BoardPollSnapshot: Sendable {
+        let hasGitHub: Bool
+        let gitLabHosts: [String]
+        /// Workspace Jira configs **without** a resolved `Authorization`
+        /// header. `op read` for `op://` tokens is blocking (semaphore, up to
+        /// 15s) and must not run on MainActor — `fetchOffActor` resolves it.
+        let jiraConfigsWithoutAuth: [JiraConfig]
+        let jiraCredential: JiraCredential?
+        /// PR URLs linked to active/paused/inReview sessions. Stale follow-up
+        /// subtracts the open-viewer set after the GitHub query returns.
+        let sessionPRURLs: [String]
+    }
+
+    /// Assembled board payload. `refresh()` assigns this in one MainActor hop.
+    struct BoardPollFetch: Sendable {
+        var issues: [AssignedIssue]
+        var doneCount: Int
+        var ghResult: ConsolidatedGitHubResponse?
+        var githubEvents: [GitHubBackendEvent]
+        var staleFetch: StalePRFetchResult
+    }
+
     // MARK: - PR Dedup
 
     /// State-rank precedence used when the same PR URL appears in multiple
@@ -315,10 +357,14 @@ final class BoardPoller {
     /// via the GitHub backends. Issues + PRs go in parallel — the GitHub
     /// backend issues two GraphQL calls in flight at once (one for assigned
     /// issues, one for PRs + reviews).
-    func runConsolidatedGitHubQuery() async -> ConsolidatedGitHubResponse? {
-        let taskBackend = providerManager.taskBackend(for: .github)
-        let codeBackend = providerManager.codeBackend(for: .github)!
-
+    ///
+    /// `nonisolated` so the GraphQL round-trip and JSON parse run off
+    /// MainActor (CROW-1179). Warning / rate-limit side effects are returned
+    /// as events for the apply hop.
+    nonisolated static func runConsolidatedGitHubQuery(
+        taskBackend: TaskBackend,
+        codeBackend: CodeBackend
+    ) async -> (ConsolidatedGitHubResponse?, [GitHubBackendEvent]) {
         async let assignedAsync = taskBackend.listAssigned()
         async let monitoredAsync = codeBackend.listMonitoredPRs()
 
@@ -327,27 +373,26 @@ final class BoardPoller {
         do {
             assigned = try await assignedAsync
         } catch {
-            owner.handleGitHubBackendError(error, operation: "listAssigned")
             // Drain the second task so we don't leak an unawaited future.
             _ = try? await monitoredAsync
-            return nil
+            return (nil, githubEvents(from: error, operation: "listAssigned"))
         }
         do {
             monitored = try await monitoredAsync
         } catch {
-            owner.handleGitHubBackendError(error, operation: "listMonitoredPRs")
-            return nil
+            return (nil, githubEvents(from: error, operation: "listMonitoredPRs"))
         }
 
+        var events: [GitHubBackendEvent] = []
         if let scope = assigned.missingScope {
             // listAssigned silently degrades on INSUFFICIENT_SCOPES (drops
             // projectItems) and reports the scope here so the warning UI
             // stays lit instead of getting cleared on the next poll. This
             // preserves the prior `owner.reportScopeWarning("read:project")`
             // behavior the consolidated query had inline.
-            owner.reportScopeWarning(scope)
+            events.append(.reportScopeWarning(scope))
         } else {
-            owner.clearScopeWarning()
+            events.append(.clearScopeWarning)
         }
 
         // The backends recover accessible-org data on SAML enforcement and
@@ -355,11 +400,11 @@ final class BoardPoller {
         // assembled above. Light the one-time warning while any org stays
         // blocked; clear it once a clean poll returns.
         if assigned.samlRestricted || monitored.samlRestricted {
-            owner.reportSAMLWarning()
+            events.append(.reportSAMLWarning)
         } else {
-            owner.clearSAMLWarning()
+            events.append(.clearSAMLWarning)
         }
-        return ConsolidatedGitHubResponse(
+        let response = ConsolidatedGitHubResponse(
             openIssues: assigned.open,
             closedIssues: assigned.closed,
             closedTotalCount: assigned.closedTotalCount,
@@ -369,16 +414,28 @@ final class BoardPoller {
             viewerLogin: monitored.viewerLogin,
             rateLimit: assigned.rateLimit ?? monitored.rateLimit
         )
+        return (response, events)
+    }
+
+    nonisolated static func githubEvents(from error: Error, operation: String) -> [GitHubBackendEvent] {
+        switch error {
+        case ProviderError.insufficientScope(let scope):
+            return [.insufficientScope(scope)]
+        case ProviderError.rateLimited(let stderr):
+            return [.rateLimited(stderr: stderr)]
+        case ProviderError.samlRestricted(_):
+            return [.samlRestricted]
+        default:
+            return [.failed(operation: operation, message: error.localizedDescription)]
+        }
     }
 
     // MARK: - Stale PR Follow-up
 
-    /// PR URLs linked to active/paused/inReview sessions that are NOT in
-    /// `openPRURLs`. These are the PRs we need to fetch state for to surface
-    /// merged/closed status on the badge and drive auto-complete.
-    /// Completed sessions are skipped — their badge state is set in-memory
-    /// during the cycle they auto-complete and is preserved thereafter.
-    func collectStalePRURLs(excluding openPRURLs: Set<String>) -> [String] {
+    /// PR URLs linked to active/paused/inReview sessions. Snapshotted on
+    /// MainActor before the off-actor fetch; stale follow-up subtracts the
+    /// open-viewer set once GitHub returns.
+    func collectSessionPRURLs() -> [String] {
         var urls: Set<String> = []
         for session in appState.sessions where !session.isManager {
             switch session.status {
@@ -388,20 +445,28 @@ final class BoardPoller {
                 continue
             }
             for link in appState.links(for: session.id) where link.linkType == .pr {
-                if !openPRURLs.contains(link.url) {
-                    urls.insert(link.url)
-                }
+                urls.insert(link.url)
             }
         }
         return Array(urls)
     }
 
+    /// PR URLs linked to active/paused/inReview sessions that are NOT in
+    /// `openPRURLs`. These are the PRs we need to fetch state for to surface
+    /// merged/closed status on the badge and drive auto-complete.
+    /// Completed sessions are skipped — their badge state is set in-memory
+    /// during the cycle they auto-complete and is preserved thereafter.
+    func collectStalePRURLs(excluding openPRURLs: Set<String>) -> [String] {
+        collectSessionPRURLs().filter { !openPRURLs.contains($0) }
+    }
+
     /// Result of a stale-PR follow-up: any PRs successfully fetched, plus
     /// whether every provider call returned cleanly. `complete == false`
     /// signals downstream auto-completion to treat the cycle as degraded.
-    struct StalePRFetchResult {
+    struct StalePRFetchResult: Sendable {
         var prs: [ViewerPR]
         var complete: Bool
+        var events: [GitHubBackendEvent] = []
     }
 
     /// Fetch state for a small set of PRs/MRs that are linked to a session
@@ -420,7 +485,11 @@ final class BoardPoller {
     /// `viewer.pullRequests(first: 50)`, or one in a SAML-restricted org (a
     /// permanent hole in that connection), reaches the UI only through here, so
     /// without `statusCheckRollup` it could never show CI state at all.
-    func fetchStalePRStates(urls: [String], viewerLogin: String) async -> StalePRFetchResult {
+    nonisolated static func fetchStalePRStates(
+        urls: [String],
+        viewerLogin: String,
+        providerManager: ProviderManager
+    ) async -> StalePRFetchResult {
         // Bucket URLs by (provider, host). GitLab self-hosted needs the host so the
         // backend pins the right GITLAB_HOST env var.
         var githubRefs: [PRRef] = []
@@ -451,6 +520,7 @@ final class BoardPoller {
 
         var prs: [ViewerPR] = []
         var complete = true
+        var events: [GitHubBackendEvent] = []
 
         if !githubRefs.isEmpty {
             let backend = providerManager.codeBackend(for: .github)!
@@ -468,7 +538,7 @@ final class BoardPoller {
                     prs.append(rec)
                 }
             } catch {
-                owner.handleGitHubBackendError(error, operation: "prStates(github)")
+                events.append(contentsOf: githubEvents(from: error, operation: "prStates(github)"))
                 complete = false
             }
         }
@@ -490,7 +560,7 @@ final class BoardPoller {
             }
         }
 
-        return StalePRFetchResult(prs: prs, complete: complete)
+        return StalePRFetchResult(prs: prs, complete: complete, events: events)
     }
 
     /// Copy `pr` with a different `url`. Used by the stale-PR follow-up to
@@ -628,8 +698,7 @@ final class BoardPoller {
     /// half (#697) so GitLab-backed workspaces feed the done-count badge.
     /// Best-effort: degrades to an empty listing on failure, mirroring the
     /// Jira / Corveil paths.
-    func fetchGitLabIssues(host: String) async -> AssignedListing {
-        let backend = providerManager.taskBackend(for: .gitlab, host: host)
+    nonisolated static func fetchGitLabIssues(host: String, backend: TaskBackend) async -> AssignedListing {
         do {
             return try await backend.listAssigned(includeClosed: true)
         } catch {
@@ -641,7 +710,7 @@ final class BoardPoller {
     /// Hard cap on how many GitLab issues get the (up to 2 REST calls each)
     /// related-MR lookup per host per poll, so one large assigned-issue queue
     /// can't stall the ~60s cycle or burn API quota (#751 review).
-    private static let maxGitLabMREnrich = 25
+    nonisolated private static let maxGitLabMREnrich = 25
 
     /// Attach linked-MR state + CI checks to open GitLab issues for the board's
     /// inline PR badges (#751). GitLab has no consolidated issue↔MR query like
@@ -650,10 +719,12 @@ final class BoardPoller {
     /// GitLab reports have zero MRs (`merge_requests_count == 0`) skip the round
     /// trip entirely, and the rest are capped at `maxGitLabMREnrich`. Any
     /// failure leaves the fields nil and the card degrades gracefully.
-    func enrichGitLabMRStatus(_ issues: [AssignedIssue], host: String) async -> [AssignedIssue] {
-        guard let backend = providerManager.codeBackend(for: .gitlab, host: host) as? GitLabCodeBackend else {
-            return issues
-        }
+    nonisolated static func enrichGitLabMRStatus(
+        _ issues: [AssignedIssue],
+        host: String,
+        backend: GitLabCodeBackend?
+    ) async -> [AssignedIssue] {
+        guard let backend else { return issues }
         var result = issues
         var budget = Self.maxGitLabMREnrich
         var skippedForBudget = 0
@@ -680,8 +751,7 @@ final class BoardPoller {
     /// recently-Done half (#536) so tickets in their mapped Done status surface
     /// in the board's Done section. Best-effort: degrades to an empty listing on
     /// failure, mirroring the GitLab / Corveil paths.
-    func fetchJiraIssues(config: JiraConfig) async -> AssignedListing {
-        let backend = providerManager.taskBackend(for: .jira, jira: config)
+    nonisolated static func fetchJiraIssues(config: JiraConfig, backend: TaskBackend) async -> AssignedListing {
         do {
             return try await backend.listAssigned(includeClosed: true)
         } catch {
@@ -702,6 +772,153 @@ final class BoardPoller {
         let openIDs = Set(listing.open.map(\.id))
         let uniqueDone = listing.closed.filter { !openIDs.contains($0.id) }
         return (listing.open + uniqueDone, listing.closedTotalCount)
+    }
+
+    // MARK: - Off-actor poll (CROW-1179)
+
+    /// Snapshot the poll inputs from live `AppState` / config. Milliseconds;
+    /// no provider I/O. Jira `op://` tokens stay unresolved.
+    func captureSnapshot(config: AppConfig) -> BoardPollSnapshot {
+        let hasGitHub = config.workspaces.contains(where: { $0.derivedTaskProvider == "github" })
+        var gitLabHosts: [String] = []
+        for ws in config.workspaces where ws.derivedTaskProvider == "gitlab" {
+            if let host = ws.host, !gitLabHosts.contains(host) {
+                gitLabHosts.append(host)
+            }
+        }
+        var jiraConfigs: [JiraConfig] = []
+        for ws in config.workspaces where ws.derivedTaskProvider == "jira" {
+            let cfg = JiraConfig(
+                site: ws.jiraSite,
+                projectKey: ws.jiraProjectKey,
+                jql: ws.jiraJQL,
+                statusMap: ws.jiraStatusMap
+            )
+            if !jiraConfigs.contains(cfg) { jiraConfigs.append(cfg) }
+        }
+        return BoardPollSnapshot(
+            hasGitHub: hasGitHub,
+            gitLabHosts: gitLabHosts,
+            jiraConfigsWithoutAuth: jiraConfigs,
+            jiraCredential: config.jiraCredential,
+            sessionPRURLs: collectSessionPRURLs()
+        )
+    }
+
+    /// Match viewer's open PRs onto assigned issues by
+    /// `closingIssuesReferences` (repo + number). Pure over the GitHub
+    /// payload so it can run off MainActor with the rest of the fetch.
+    nonisolated static func enrichOpenIssuesWithViewerPRs(
+        _ openIssues: [AssignedIssue],
+        viewerPRs: [ViewerPR]
+    ) -> [AssignedIssue] {
+        var openIssues = openIssues
+        for pr in viewerPRs where pr.state == "OPEN" {
+            for linked in pr.linkedIssueReferences {
+                if let idx = openIssues.firstIndex(where: {
+                    $0.provider == .github && $0.number == linked.number && $0.repo == linked.repo
+                }) {
+                    openIssues[idx].prNumber = pr.number
+                    openIssues[idx].prURL = pr.url
+                    // Surface PR health inline on the board (#751): PRRecord
+                    // already carries these from monitoredPRsQuery, so no
+                    // extra fetch. A draft PR reports "draft"; otherwise the
+                    // normalized state lowercased ("open"/"merged"/"closed").
+                    openIssues[idx].prState = pr.isDraft ? "draft" : pr.state.lowercased()
+                    openIssues[idx].checksState = pr.checksState.isEmpty ? nil : pr.checksState
+                    openIssues[idx].failedCheckNames = pr.failedCheckNames.isEmpty ? nil : pr.failedCheckNames
+                }
+            }
+        }
+        return openIssues
+    }
+
+    /// Run GitHub GraphQL, GitLab, Jira, and the stale-PR follow-up off
+    /// MainActor. `refresh()` awaits this from a detached task, then applies
+    /// `BoardPollFetch` in one hop.
+    nonisolated static func fetchOffActor(
+        snapshot: BoardPollSnapshot,
+        providerManager: ProviderManager
+    ) async -> BoardPollFetch {
+        var allIssues: [AssignedIssue] = []
+        var doneCount = 0
+        var githubEvents: [GitHubBackendEvent] = []
+
+        let ghResult: ConsolidatedGitHubResponse?
+        if snapshot.hasGitHub {
+            let (response, events) = await runConsolidatedGitHubQuery(
+                taskBackend: providerManager.taskBackend(for: .github),
+                codeBackend: providerManager.codeBackend(for: .github)!
+            )
+            githubEvents.append(contentsOf: events)
+            ghResult = response
+        } else {
+            ghResult = nil
+        }
+
+        if let ghResult {
+            let openIssues = enrichOpenIssuesWithViewerPRs(
+                ghResult.openIssues, viewerPRs: ghResult.viewerPRs)
+            allIssues.append(contentsOf: openIssues)
+            let openIDs = Set(openIssues.map(\.id))
+            let uniqueDone = ghResult.closedIssues.filter { !openIDs.contains($0.id) }
+            allIssues.append(contentsOf: uniqueDone)
+            doneCount += ghResult.closedTotalCount
+        }
+
+        for host in snapshot.gitLabHosts {
+            let listing = await fetchGitLabIssues(
+                host: host,
+                backend: providerManager.taskBackend(for: .gitlab, host: host)
+            )
+            let merged = mergeListing(listing)
+            let gitlabCode = providerManager.codeBackend(for: .gitlab, host: host) as? GitLabCodeBackend
+            let enriched = await enrichGitLabMRStatus(merged.issues, host: host, backend: gitlabCode)
+            allIssues.append(contentsOf: enriched)
+            doneCount += merged.doneCount
+        }
+
+        // Resolve the shared Jira REST credential once (it may shell `op read`)
+        // off MainActor, then thread it into every config.
+        let jiraAuthorization = snapshot.jiraCredential.flatMap { JiraCredentialResolver.resolve($0) }
+        for cfg in snapshot.jiraConfigsWithoutAuth {
+            let authed = JiraConfig(
+                site: cfg.site,
+                projectKey: cfg.projectKey,
+                jql: cfg.jql,
+                statusMap: cfg.statusMap,
+                authorization: jiraAuthorization
+            )
+            let listing = await fetchJiraIssues(
+                config: authed,
+                backend: providerManager.taskBackend(for: .jira, jira: authed)
+            )
+            let merged = mergeListing(listing)
+            allIssues.append(contentsOf: merged.issues)
+            doneCount += merged.doneCount
+        }
+
+        var staleFetch = StalePRFetchResult(prs: [], complete: true)
+        if let ghResult {
+            let openPRURLs = Set(ghResult.viewerPRs.map(\.url))
+            let staleCandidateURLs = snapshot.sessionPRURLs.filter { !openPRURLs.contains($0) }
+            if !staleCandidateURLs.isEmpty {
+                staleFetch = await fetchStalePRStates(
+                    urls: staleCandidateURLs,
+                    viewerLogin: ghResult.viewerLogin,
+                    providerManager: providerManager
+                )
+                githubEvents.append(contentsOf: staleFetch.events)
+            }
+        }
+
+        return BoardPollFetch(
+            issues: allIssues,
+            doneCount: doneCount,
+            ghResult: ghResult,
+            githubEvents: githubEvents,
+            staleFetch: staleFetch
+        )
     }
 }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -14,6 +14,10 @@ import CrowProvider
 /// piggyback on those two responses — no per-session `gh` calls. The
 /// `rateLimit` block on each response feeds `AppState.githubRateLimit`,
 /// and a soft threshold + 403 detection suspend polling when quotas are low.
+///
+/// `refresh()` snapshots `AppState`/config on MainActor, runs provider I/O
+/// off the actor (`BoardPoller.fetchOffActor`), and applies results in one
+/// hop so a 5–10s GraphQL poll cannot starve CLI RPCs (CROW-1179).
 @MainActor
 public final class IssueTracker {
     let appState: AppState
@@ -464,218 +468,25 @@ public final class IssueTracker {
         guard let devRoot = ConfigStore.loadDevRoot(),
               let config = ConfigStore.loadConfig(devRoot: devRoot) else { return }
 
-        // Iterate by **task** provider — a workspace's tickets may live somewhere
-        // other than its code host (ADR 0005). A Jira-task / GitHub-code workspace
-        // contributes Jira issues here but still uses the GitHub code path below.
-        let hasGitHub = config.workspaces.contains(where: { $0.derivedTaskProvider == "github" })
-        var gitLabHosts: [String] = []
-        for ws in config.workspaces where ws.derivedTaskProvider == "gitlab" {
-            if let host = ws.host, !gitLabHosts.contains(host) {
-                gitLabHosts.append(host)
-            }
-        }
-        // Collect distinct Jira queries (the site/JQL/project triple is what
-        // actually varies). Resolve the shared Jira REST credential once (it may
-        // shell `op read`) and thread it into every config so the board read-back
-        // can list assigned issues over REST instead of acli (#533).
-        let jiraAuthorization = config.jiraCredential.flatMap { JiraCredentialResolver.resolve($0) }
-        var jiraConfigs: [JiraConfig] = []
-        for ws in config.workspaces where ws.derivedTaskProvider == "jira" {
-            let cfg = JiraConfig(site: ws.jiraSite, projectKey: ws.jiraProjectKey, jql: ws.jiraJQL, statusMap: ws.jiraStatusMap, authorization: jiraAuthorization)
-            if !jiraConfigs.contains(cfg) { jiraConfigs.append(cfg) }
-        }
+        // Snapshot on the state actor (milliseconds). Provider I/O — including
+        // Jira `op read` — runs off MainActor so CLI RPCs can hop on while a
+        // 5–10s GraphQL poll is in flight (CROW-1179). `isRefreshing` stays
+        // true across the hop so a second poll cannot tear `appState`.
+        let snapshot = boardPoller.captureSnapshot(config: config)
+        let providerManager = self.providerManager
+        let fetch = await Task.detached(priority: .utility) {
+            await BoardPoller.fetchOffActor(snapshot: snapshot, providerManager: providerManager)
+        }.value
 
-        var allIssues: [AssignedIssue] = []
-        // Recently-done count, accumulated across every provider this refresh.
-        // Each provider contributes its 24h closed/Done window; assigned once
-        // at the end so a non-GitHub (e.g. Jira-only) workspace updates it too
-        // instead of leaving a stale value from a prior GitHub-backed refresh.
-        var doneCount = 0
+        applyFetchedBoard(fetch, config: config)
 
-        // GitHub — one consolidated GraphQL query
-        let ghResult: ConsolidatedGitHubResponse? = hasGitHub ? await boardPoller.runConsolidatedGitHubQuery() : nil
-        if let ghResult {
-            if let rl = ghResult.rateLimit { appState.githubRateLimit = rl }
-
-            var openIssues = ghResult.openIssues
-            // Match viewer's open PRs to issues by closingIssuesReferences (repo + number)
-            for pr in ghResult.viewerPRs where pr.state == "OPEN" {
-                for linked in pr.linkedIssueReferences {
-                    if let idx = openIssues.firstIndex(where: {
-                        $0.provider == .github && $0.number == linked.number && $0.repo == linked.repo
-                    }) {
-                        openIssues[idx].prNumber = pr.number
-                        openIssues[idx].prURL = pr.url
-                        // Surface PR health inline on the board (#751): PRRecord
-                        // already carries these from monitoredPRsQuery, so no
-                        // extra fetch. A draft PR reports "draft"; otherwise the
-                        // normalized state lowercased ("open"/"merged"/"closed").
-                        openIssues[idx].prState = pr.isDraft ? "draft" : pr.state.lowercased()
-                        openIssues[idx].checksState = pr.checksState.isEmpty ? nil : pr.checksState
-                        openIssues[idx].failedCheckNames = pr.failedCheckNames.isEmpty ? nil : pr.failedCheckNames
-                    }
-                }
-            }
-            allIssues.append(contentsOf: openIssues)
-
-            let openIDs = Set(openIssues.map(\.id))
-            let uniqueDone = ghResult.closedIssues.filter { !openIDs.contains($0.id) }
-            allIssues.append(contentsOf: uniqueDone)
-            doneCount += ghResult.closedTotalCount
-        }
-
-        // GitLab — one call per host; includes the recently-closed half (#697)
-        // so GitLab-backed workspaces count toward doneIssuesLast24h, mirroring
-        // GitHub's open + deduped-closed merge.
-        for host in gitLabHosts {
-            let merged = Self.mergeListing(await boardPoller.fetchGitLabIssues(host: host))
-            let enriched = await boardPoller.enrichGitLabMRStatus(merged.issues, host: host)
-            allIssues.append(contentsOf: enriched)
-            doneCount += merged.doneCount
-        }
-
-        // Jira — one search per distinct config (best-effort, like GitLab).
-        // Include the recently-Done half (#536): a Jira ticket in its mapped
-        // Done status is a workflow status, not a closed issue, so it only lands
-        // in the board's Done section once its `.done`-mapped issue reaches
-        // `assignedIssues`. Mirror GitHub's open + deduped-closed merge.
-        for cfg in jiraConfigs {
-            let listing = await boardPoller.fetchJiraIssues(config: cfg)
-            let merged = Self.mergeListing(listing)
-            allIssues.append(contentsOf: merged.issues)
-            doneCount += merged.doneCount
-        }
-
-        appState.assignedIssues = allIssues
-        appState.doneIssuesLast24h = doneCount
-
-        let ticketExcludePatterns = config.defaults.excludeTicketRepos
-        let autoCreateCandidates = ticketExcludePatterns.isEmpty
-            ? allIssues
-            : allIssues.filter { !repoMatchesPatterns($0.repo, patterns: ticketExcludePatterns) }
-        boardPoller.detectAutoCreateCandidates(issues: autoCreateCandidates)
-
-        if let ghResult {
-            // Session PR link detection runs against open PRs only — we only
-            // ever want to attach a fresh link when there's an open PR.
-            reconciler.applySessionPRLinks(viewerPRs: ghResult.viewerPRs)
-
-            // For sessions with an existing .pr link whose PR isn't in the open
-            // viewer set, fetch the state in one batched aliased query. This
-            // surfaces merged/closed state without pulling MERGED/CLOSED PRs
-            // for every viewer (which routinely returned 100 PRs / ~86 KB).
-            let openPRURLs = Set(ghResult.viewerPRs.map(\.url))
-            let staleCandidateURLs = boardPoller.collectStalePRURLs(excluding: openPRURLs)
-            // `complete == false` means at least one provider's follow-up errored
-            // (rate limit, exit != 0, parse failure). We thread that through to
-            // auto-complete so "PR missing from payload" doesn't get treated as
-            // "PR is closed" on a degraded response. Partial-success is allowed:
-            // PRs from the working provider still flow through so merged badges
-            // can flip even if the other provider failed.
-            let staleFetch = staleCandidateURLs.isEmpty
-                ? StalePRFetchResult(prs: [], complete: true)
-                : await boardPoller.fetchStalePRStates(urls: staleCandidateURLs, viewerLogin: ghResult.viewerLogin)
-            let stalePRs = staleFetch.prs
-            let prDataComplete = staleFetch.complete
-            let allKnownPRs = Self.dedupedByURL(ghResult.viewerPRs + stalePRs)
-
-            applyPRStatuses(viewerPRs: allKnownPRs)
-            attribution.updatePRAttributions(viewerPRs: allKnownPRs)
-
-            // Rework signals (#694): capture file lists for fresh merges,
-            // stamp reverts, then post-merge fixes — in that order, so a
-            // revert never double-counts as a fix (heuristic rule 4).
-            await attribution.captureChangedFilesForNewMerges()
-            await attribution.scanDefaultBranchesForReverts()
-            attribution.detectPostMergeFixes()
-
-            // Review requests (search result) + cross-reference with review sessions
-            appState.isLoadingReviews = true
-            var reviews = ghResult.reviewRequests
-            for i in reviews.indices {
-                if let session = appState.reviewSessions.first(where: {
-                    appState.links(for: $0.id).contains(where: { $0.linkType == .pr && $0.url == reviews[i].url })
-                }) {
-                    reviews[i].reviewSessionID = session.id
-                }
-            }
-            let allCurrentIDs = Set(reviews.map(\.id))
-            let reviewExcludePatterns = config.effectiveExcludeReviewRepos
-            if !reviewExcludePatterns.isEmpty {
-                reviews = reviews.filter { !repoMatchesPatterns($0.repo, patterns: reviewExcludePatterns) }
-            }
-            let ignoreLabels = config.defaults.ignoreReviewLabels
-            if !ignoreLabels.isEmpty {
-                let lowerLabels = Set(ignoreLabels.map { $0.lowercased() })
-                reviews = reviews.filter { request in
-                    !request.labels.contains(where: { lowerLabels.contains($0.name.lowercased()) })
-                }
-            }
-            let currentIDs = Set(reviews.map(\.id))
-            let newIDs = currentIDs.subtracting(previousReviewRequestIDs)
-            previousReviewRequestIDs = allCurrentIDs
-            if !isFirstFetch && !newIDs.isEmpty {
-                let newRequests = reviews.filter { newIDs.contains($0.id) }
-                onNewReviewRequests?(newRequests)
-            }
-            isFirstFetch = false
-            appState.reviewRequests = reviews
-            // How many requested reviews the filters swallowed (CROW-982). The
-            // board shows this so "No review requests" can't be mistaken for
-            // "GitHub is asking nothing of me" — the #953 failure mode, where
-            // `ignoreReviewLabels` hid live requests and the board looked empty.
-            appState.hiddenReviewCount = max(0, allCurrentIDs.count - reviews.count)
-
-            // The post-request half of the board (CROW-982, widened by
-            // CROW-990). Cross-referenced against review sessions on the same
-            // rule as the requested queue, so a PR you reviewed that still has a
-            // live session renders under In review rather than jumping straight
-            // to a finished heading. Repo/label filters are applied at
-            // serialization time via `filteredReviewedPRs` — the same place the
-            // requested queue is filtered — so the two lists can't drift apart
-            // on which repos are visible.
-            //
-            // Deliberately outside the notification path: a submitted review is
-            // work finished, not work arriving, and chiming `reviewRequested`
-            // for it would be a lie.
-            var reviewed = ghResult.reviewedPRs
-            for i in reviewed.indices {
-                if let session = appState.reviewSessions.first(where: {
-                    appState.links(for: $0.id).contains(where: { $0.linkType == .pr && $0.url == reviewed[i].url })
-                }) {
-                    reviewed[i].reviewSessionID = session.id
-                }
-            }
-            // A PR can legitimately be in both searches (you reviewed it, then
-            // the author pushed and re-requested). The requested queue owns it
-            // in that case — it is asking for something — so drop the duplicate
-            // here rather than letting it render in two groups at once.
-            //
-            // This can only ever discard an *open* row: the requested search is
-            // `review-requested:@me state:open`, so a merged or closed PR is
-            // never in `requestedURLs` and a Recently completed row cannot be
-            // swallowed by a stale request.
-            let requestedURLs = Set(reviews.map(\.url))
-            appState.reviewedPRs = reviewed.filter { !requestedURLs.contains($0.url) }
-            appState.isLoadingReviews = false
-
-            onReviewRequestsRefreshed?(reviews)
-
-            completion.syncInReviewSessions(issues: allIssues)
-            completion.autoCompleteFinishedSessions(
-                openIssues: allIssues.filter { $0.state == "open" },
-                closedIssueURLs: Set(ghResult.closedIssues.map(\.url)),
-                viewerPRs: allKnownPRs,
-                prDataComplete: prDataComplete
-            )
-            completion.autoCompleteFinishedReviews(
-                openReviewPRURLs: Set(reviews.map(\.url)),
-                prsByURL: Dictionary(allKnownPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords),
-                reviewRequestsByPRURL: Dictionary(reviews.map { ($0.url, $0) }, uniquingKeysWith: { lhs, _ in lhs }),
-                prDataComplete: prDataComplete
-            )
-
-            clearRateLimitWarning()
+        // Rework signals (#694): capture file lists for fresh merges,
+        // stamp reverts, then post-merge fixes — in that order, so a
+        // revert never double-counts as a fix (heuristic rule 4). Runs
+        // after the apply hop so attributions are already written; the
+        // fetches themselves hop off MainActor.
+        if fetch.ghResult != nil {
+            await captureReworkSignals()
         }
 
         // Reconcile any session still missing a .pr link by querying the
@@ -695,6 +506,140 @@ public final class IssueTracker {
         logRefreshSummary(elapsed: Date().timeIntervalSince(startedAt))
     }
 
+    /// One MainActor hop: warnings, `assignedIssues`, PR maps, rate-limit,
+    /// auto-create, auto-complete. No provider I/O.
+    private func applyFetchedBoard(_ fetch: BoardPoller.BoardPollFetch, config: AppConfig) {
+        for event in fetch.githubEvents {
+            applyGitHubBackendEvent(event)
+        }
+
+        let allIssues = fetch.issues
+        appState.assignedIssues = allIssues
+        appState.doneIssuesLast24h = fetch.doneCount
+
+        let ticketExcludePatterns = config.defaults.excludeTicketRepos
+        let autoCreateCandidates = ticketExcludePatterns.isEmpty
+            ? allIssues
+            : allIssues.filter { !repoMatchesPatterns($0.repo, patterns: ticketExcludePatterns) }
+        boardPoller.detectAutoCreateCandidates(issues: autoCreateCandidates)
+
+        guard let ghResult = fetch.ghResult else { return }
+
+        if let rl = ghResult.rateLimit { appState.githubRateLimit = rl }
+
+        // Session PR link detection runs against open PRs only — we only
+        // ever want to attach a fresh link when there's an open PR.
+        reconciler.applySessionPRLinks(viewerPRs: ghResult.viewerPRs)
+
+        // `complete == false` means at least one provider's follow-up errored
+        // (rate limit, exit != 0, parse failure). We thread that through to
+        // auto-complete so "PR missing from payload" doesn't get treated as
+        // "PR is closed" on a degraded response. Partial-success is allowed:
+        // PRs from the working provider still flow through so merged badges
+        // can flip even if the other provider failed.
+        let staleFetch = fetch.staleFetch
+        let allKnownPRs = Self.dedupedByURL(ghResult.viewerPRs + staleFetch.prs)
+
+        applyPRStatuses(viewerPRs: allKnownPRs)
+        attribution.updatePRAttributions(viewerPRs: allKnownPRs)
+
+        // Review requests (search result) + cross-reference with review sessions
+        appState.isLoadingReviews = true
+        var reviews = ghResult.reviewRequests
+        for i in reviews.indices {
+            if let session = appState.reviewSessions.first(where: {
+                appState.links(for: $0.id).contains(where: { $0.linkType == .pr && $0.url == reviews[i].url })
+            }) {
+                reviews[i].reviewSessionID = session.id
+            }
+        }
+        let allCurrentIDs = Set(reviews.map(\.id))
+        let reviewExcludePatterns = config.effectiveExcludeReviewRepos
+        if !reviewExcludePatterns.isEmpty {
+            reviews = reviews.filter { !repoMatchesPatterns($0.repo, patterns: reviewExcludePatterns) }
+        }
+        let ignoreLabels = config.defaults.ignoreReviewLabels
+        if !ignoreLabels.isEmpty {
+            let lowerLabels = Set(ignoreLabels.map { $0.lowercased() })
+            reviews = reviews.filter { request in
+                !request.labels.contains(where: { lowerLabels.contains($0.name.lowercased()) })
+            }
+        }
+        let currentIDs = Set(reviews.map(\.id))
+        let newIDs = currentIDs.subtracting(previousReviewRequestIDs)
+        previousReviewRequestIDs = allCurrentIDs
+        if !isFirstFetch && !newIDs.isEmpty {
+            let newRequests = reviews.filter { newIDs.contains($0.id) }
+            onNewReviewRequests?(newRequests)
+        }
+        isFirstFetch = false
+        appState.reviewRequests = reviews
+        // How many requested reviews the filters swallowed (CROW-982). The
+        // board shows this so "No review requests" can't be mistaken for
+        // "GitHub is asking nothing of me" — the #953 failure mode, where
+        // `ignoreReviewLabels` hid live requests and the board looked empty.
+        appState.hiddenReviewCount = max(0, allCurrentIDs.count - reviews.count)
+
+        // The post-request half of the board (CROW-982, widened by
+        // CROW-990). Cross-referenced against review sessions on the same
+        // rule as the requested queue, so a PR you reviewed that still has a
+        // live session renders under In review rather than jumping straight
+        // to a finished heading. Repo/label filters are applied at
+        // serialization time via `filteredReviewedPRs` — the same place the
+        // requested queue is filtered — so the two lists can't drift apart
+        // on which repos are visible.
+        //
+        // Deliberately outside the notification path: a submitted review is
+        // work finished, not work arriving, and chiming `reviewRequested`
+        // for it would be a lie.
+        var reviewed = ghResult.reviewedPRs
+        for i in reviewed.indices {
+            if let session = appState.reviewSessions.first(where: {
+                appState.links(for: $0.id).contains(where: { $0.linkType == .pr && $0.url == reviewed[i].url })
+            }) {
+                reviewed[i].reviewSessionID = session.id
+            }
+        }
+        // A PR can legitimately be in both searches (you reviewed it, then
+        // the author pushed and re-requested). The requested queue owns it
+        // in that case — it is asking for something — so drop the duplicate
+        // here rather than letting it render in two groups at once.
+        //
+        // This can only ever discard an *open* row: the requested search is
+        // `review-requested:@me state:open`, so a merged or closed PR is
+        // never in `requestedURLs` and a Recently completed row cannot be
+        // swallowed by a stale request.
+        let requestedURLs = Set(reviews.map(\.url))
+        appState.reviewedPRs = reviewed.filter { !requestedURLs.contains($0.url) }
+        appState.isLoadingReviews = false
+
+        onReviewRequestsRefreshed?(reviews)
+
+        completion.syncInReviewSessions(issues: allIssues)
+        completion.autoCompleteFinishedSessions(
+            openIssues: allIssues.filter { $0.state == "open" },
+            closedIssueURLs: Set(ghResult.closedIssues.map(\.url)),
+            viewerPRs: allKnownPRs,
+            prDataComplete: staleFetch.complete
+        )
+        completion.autoCompleteFinishedReviews(
+            openReviewPRURLs: Set(reviews.map(\.url)),
+            prsByURL: Dictionary(allKnownPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords),
+            reviewRequestsByPRURL: Dictionary(reviews.map { ($0.url, $0) }, uniquingKeysWith: { lhs, _ in lhs }),
+            prDataComplete: staleFetch.complete
+        )
+
+        clearRateLimitWarning()
+    }
+
+    /// Rework-signal fetches (#694) stay after the apply hop so a revert
+    /// never double-counts as a fix. They hop off MainActor internally.
+    private func captureReworkSignals() async {
+        await attribution.captureChangedFilesForNewMerges()
+        await attribution.scanDefaultBranchesForReverts()
+        attribution.detectPostMergeFixes()
+    }
+
 
     private func logRefreshSummary(elapsed: TimeInterval) {
         let elapsedStr = String(format: "%.2fs", elapsed)
@@ -712,19 +657,29 @@ public final class IssueTracker {
     /// Untyped errors get a console line and otherwise propagate as "this
     /// cycle is degraded" via the caller's nil-return.
     func handleGitHubBackendError(_ error: Error, operation: String) {
-        switch error {
-        case ProviderError.insufficientScope(let scope):
+        for event in BoardPoller.githubEvents(from: error, operation: operation) {
+            applyGitHubBackendEvent(event)
+        }
+    }
+
+    func applyGitHubBackendEvent(_ event: BoardPoller.GitHubBackendEvent) {
+        switch event {
+        case .insufficientScope(let scope), .reportScopeWarning(let scope):
             reportScopeWarning(scope)
-        case ProviderError.rateLimited(let stderr):
+        case .clearScopeWarning:
+            clearScopeWarning()
+        case .rateLimited(let stderr):
             _ = handleGraphQLRateLimit(stderr: stderr)
-        case ProviderError.samlRestricted:
+        case .samlRestricted, .reportSAMLWarning:
             // `findRecentPRsForBranches` doesn't recover partial data; route
             // its SAML failures to the same one-time warning instead of
             // spamming the console each cycle. (`prStates` recovers its
             // accessible aliases since #894, so it no longer lands here.)
             reportSAMLWarning()
-        default:
-            print("[IssueTracker] \(operation) failed: \(error.localizedDescription)")
+        case .clearSAMLWarning:
+            clearSAMLWarning()
+        case .failed(let operation, let message):
+            print("[IssueTracker] \(operation) failed: \(message)")
         }
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/PRAttributionRecorder.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/PRAttributionRecorder.swift
@@ -378,10 +378,12 @@ final class PRAttributionRecorder {
             changedFilesFetchAttempted.insert(attribution.prURL)
             let files: [String]
             do {
-                files = try await backend.fetchPRChangedFiles(
-                    repoSlug: attribution.repoNameWithOwner,
-                    prNumber: attribution.prNumber
-                )
+                files = try await Task.detached {
+                    try await backend.fetchPRChangedFiles(
+                        repoSlug: attribution.repoNameWithOwner,
+                        prNumber: attribution.prNumber
+                    )
+                }.value
             } catch {
                 CrowLog.info("[Crow] fetchPRChangedFiles failed for \(attribution.prURL): \(error.localizedDescription)")
                 continue
@@ -423,7 +425,9 @@ final class PRAttributionRecorder {
         for repo in repos.sorted() {
             let commits: [CommitInfo]
             do {
-                commits = try await backend.fetchRecentDefaultBranchCommits(repoSlug: repo, since: since)
+                commits = try await Task.detached {
+                    try await backend.fetchRecentDefaultBranchCommits(repoSlug: repo, since: since)
+                }.value
             } catch {
                 CrowLog.info("[Crow] fetchRecentDefaultBranchCommits failed for \(repo): \(error.localizedDescription)")
                 continue

--- a/Packages/CrowEngine/Sources/CrowEngine/PRLinkReconciler.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/PRLinkReconciler.swift
@@ -367,7 +367,9 @@ public final class PRLinkReconciler {
         let github = candidates.filter { $0.provider == .github }
         guard !github.isEmpty, let backend = providerManager.codeBackend(for: .github) else { return [] }
         do {
-            let matches = try await backend.findPRsMatchingKeys(Self.dedupedKeyCandidates(github))
+            let matches = try await Task.detached {
+                try await backend.findPRsMatchingKeys(Self.dedupedKeyCandidates(github))
+            }.value
             return Self.fanOutKeyMatches(matches, across: github)
         } catch {
             owner.handleGitHubBackendError(error, operation: "findPRsMatchingKeys(github)")
@@ -422,9 +424,11 @@ public final class PRLinkReconciler {
         guard !candidates.isEmpty else { return [] }
         let backend = providerManager.codeBackend(for: .github)!
         do {
-            let matches = try await backend.findRecentPRsForBranches(
-                Self.dedupedBranchCandidates(candidates)
-            )
+            let matches = try await Task.detached {
+                try await backend.findRecentPRsForBranches(
+                    Self.dedupedBranchCandidates(candidates)
+                )
+            }.value
             return Self.fanOutMatches(matches, across: candidates)
         } catch {
             owner.handleGitHubBackendError(error, operation: "findRecentPRsForBranches(github)")
@@ -440,9 +444,11 @@ public final class PRLinkReconciler {
         guard !candidates.isEmpty else { return [] }
         let backend = providerManager.codeBackend(for: .gitlab, host: host)!
         do {
-            let matches = try await backend.findRecentPRsForBranches(
-                Self.dedupedBranchCandidates(candidates)
-            )
+            let matches = try await Task.detached {
+                try await backend.findRecentPRsForBranches(
+                    Self.dedupedBranchCandidates(candidates)
+                )
+            }.value
             return Self.fanOutMatches(matches, across: candidates)
         } catch {
             print("[IssueTracker] Reconcile via backend failed for host \(host): \(error.localizedDescription.prefix(200))")

--- a/Packages/CrowEngine/Tests/CrowEngineTests/BoardPollOffMainActorTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/BoardPollOffMainActorTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowProvider
+@testable import CrowEngine
+
+/// CROW-1179: provider I/O for the board poll must not run on MainActor.
+/// The shell runner records whether `run` executed on the main thread; a
+/// `@MainActor` `BoardPoller` method would inherit that isolation and
+/// `Thread.isMainThread` would be true (the `sample` stack the ticket cites).
+@Suite("Board poll provider I/O is off MainActor (CROW-1179)")
+struct BoardPollOffMainActorTests {
+
+    /// Records the calling thread and fails the command immediately so the
+    /// test does not depend on a real `gh` payload. Thread inspection lives
+    /// in a synchronous helper because `Thread.isMainThread` is unavailable
+    /// from `async` contexts.
+    final class RecordingShellRunner: ShellRunner, @unchecked Sendable {
+        private nonisolated(unsafe) var _sawMain = false
+        private let entered = DispatchSemaphore(value: 0)
+
+        var sawMainThread: Bool { _sawMain }
+
+        func waitUntilEntered() {
+            entered.wait()
+        }
+
+        func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+            recordIfMain()
+            entered.signal()
+            throw ShellRunnerError.nonZeroExit(exitCode: 1, output: "recorded")
+        }
+
+        private func recordIfMain() {
+            if Thread.isMainThread { _sawMain = true }
+        }
+    }
+
+    @Test func consolidatedGitHubQueryDoesNotRunOnMainThread() async {
+        let runner = RecordingShellRunner()
+        let task = GitHubTaskBackend(shellRunner: runner)
+        let code = GitHubCodeBackend(shellRunner: runner)
+
+        async let fetch = BoardPoller.runConsolidatedGitHubQuery(
+            taskBackend: task, codeBackend: code)
+        await Task.detached { runner.waitUntilEntered() }.value
+        #expect(
+            !runner.sawMainThread,
+            "runConsolidatedGitHubQuery still inherited MainActor isolation (CROW-1179)"
+        )
+        _ = await fetch
+    }
+
+    @Test func fetchOffActorDoesNotRunOnMainThread() async {
+        let runner = RecordingShellRunner()
+        let providerManager = ProviderManager(shellRunner: runner)
+        let snapshot = BoardPoller.BoardPollSnapshot(
+            hasGitHub: true,
+            gitLabHosts: [],
+            jiraConfigsWithoutAuth: [],
+            jiraCredential: nil,
+            sessionPRURLs: []
+        )
+
+        async let fetch = BoardPoller.fetchOffActor(
+            snapshot: snapshot, providerManager: providerManager)
+        await Task.detached { runner.waitUntilEntered() }.value
+        #expect(
+            !runner.sawMainThread,
+            "fetchOffActor still inherited MainActor isolation (CROW-1179)"
+        )
+
+        let hopStart = Date()
+        await MainActor.run {}
+        #expect(Date().timeIntervalSince(hopStart) < 0.1)
+
+        let result = await fetch
+        #expect(result.ghResult == nil)
+        #expect(result.issues.isEmpty)
+    }
+
+    @Test func overlappingFetchesDoNotShareMutablePollerState() async {
+        // fetchOffActor is a pure static over a Sendable snapshot — two
+        // concurrent polls cannot tear appState because they write nothing.
+        // IssueTracker.refresh still serializes the apply hop with isRefreshing.
+        let runner = RecordingShellRunner()
+        let providerManager = ProviderManager(shellRunner: runner)
+        let snapshot = BoardPoller.BoardPollSnapshot(
+            hasGitHub: true,
+            gitLabHosts: [],
+            jiraConfigsWithoutAuth: [],
+            jiraCredential: nil,
+            sessionPRURLs: []
+        )
+        async let a = BoardPoller.fetchOffActor(
+            snapshot: snapshot, providerManager: providerManager)
+        async let b = BoardPoller.fetchOffActor(
+            snapshot: snapshot, providerManager: providerManager)
+        let first = await a
+        let second = await b
+        #expect(first.issues.isEmpty)
+        #expect(second.issues.isEmpty)
+        #expect(first.staleFetch.complete)
+        #expect(second.staleFetch.complete)
+    }
+
+    @Test func enrichOpenIssuesCopiesViewerPRHealthOntoTheMatchingIssue() {
+        let issue = AssignedIssue(
+            id: "github:corveil/crow#1179",
+            number: 1179,
+            title: "board poll",
+            state: "open",
+            url: "https://github.com/corveil/crow/issues/1179",
+            repo: "corveil/crow",
+            provider: .github
+        )
+        let pr = PRRecord(
+            number: 42,
+            url: "https://github.com/corveil/crow/pull/42",
+            state: "OPEN",
+            isDraft: false,
+            repoNameWithOwner: "corveil/crow",
+            linkedIssueReferences: [LinkedIssueRef(number: 1179, repo: "corveil/crow")],
+            checksState: "FAILURE",
+            failedCheckNames: ["ci"]
+        )
+        let enriched = BoardPoller.enrichOpenIssuesWithViewerPRs([issue], viewerPRs: [pr])
+        #expect(enriched[0].prNumber == 42)
+        #expect(enriched[0].prURL == pr.url)
+        #expect(enriched[0].prState == "open")
+        #expect(enriched[0].checksState == "FAILURE")
+        #expect(enriched[0].failedCheckNames == ["ci"])
+    }
+
+    @Test func githubEventsMapTypedProviderErrors() {
+        let scope = BoardPoller.githubEvents(
+            from: ProviderError.insufficientScope("read:project"),
+            operation: "listAssigned"
+        )
+        #expect(scope == [.insufficientScope("read:project")])
+
+        let rate = BoardPoller.githubEvents(
+            from: ProviderError.rateLimited("rate limit exceeded"),
+            operation: "listAssigned"
+        )
+        #expect(rate == [.rateLimited(stderr: "rate limit exceeded")])
+    }
+}


### PR DESCRIPTION
Closes #1179

## Summary
- Snapshot `AppState` / config on the state actor, then run GitHub GraphQL, GitLab, Jira (`op read` included), and the stale-PR follow-up **off** MainActor via `BoardPoller.fetchOffActor`.
- Apply issues, PR maps, rate-limit, auto-create, and auto-complete in **one** MainActor hop. `isRefreshing` stays set across the hop so overlapping polls cannot tear `appState`.
- Do not bump the CLI 30s timeout — `list-sessions` / `new-session` no longer queue behind a 5–10s GraphQL poll.

## Test plan
- [ ] With the Crow web UI open and a board poll in flight, `crow list-sessions` and `crow new-session --name …` return in well under 30s.
- [ ] `sample` during a refresh no longer shows GraphQL/`BoardPoller` stacks on `com.apple.main-thread` for seconds.
- [ ] Auto-merge / auto-rebase / ticket board still update after a poll (apply hop still runs).
- [ ] Two overlapping polls cannot tear `appState` (guard / single-apply still serializes writes).


Made with [Cursor](https://cursor.com)