### PR TITLE
Rename Tauri crate so the crow sidecar can bundle

### DIFF
--- a/crow-desktop/src-tauri/Cargo.lock
+++ b/crow-desktop/src-tauri/Cargo.lock
@@ -568,7 +568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
-name = "crow"
+name = "crow-desktop"
 version = "0.1.0"
 dependencies = [
  "libc",

--- a/crow-desktop/src-tauri/Cargo.toml
+++ b/crow-desktop/src-tauri/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-name = "crow"
+# Not `crow`: Tauri forbids an externalBin sidecar whose base name equals the
+# Cargo package name, and we ship a `crow` CLI sidecar (CROW-1195).
+# productName/identifier stay Crow / com.corveil.crow — this is crate-only.
+name = "crow-desktop"
 version = "0.1.0"
 description = "Crow desktop shell — a native window over the crowd daemon and its web UI."
 authors = ["dhilgaertner", "dgershman"]

--- a/crow-desktop/src-tauri/src/lib.rs
+++ b/crow-desktop/src-tauri/src/lib.rs
@@ -394,6 +394,34 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     #[test]
+    fn crate_name_does_not_collide_with_sidecar_names() {
+        // Tauri's build.rs errors with "Cannot define a sidecar with the same
+        // name as the Cargo package name" — that is what blocked the v0.2.0
+        // Crow.app release job (CROW-1195). cargo test never runs `tauri build`,
+        // so assert the invariant here.
+        let pkg = env!("CARGO_PKG_NAME");
+        let conf = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.sidecar.conf.json"),
+        )
+        .expect("tauri.sidecar.conf.json");
+        let json: serde_json::Value = serde_json::from_str(&conf).expect("sidecar json");
+        let bins = json["bundle"]["externalBin"]
+            .as_array()
+            .expect("bundle.externalBin");
+        for b in bins {
+            let path = b.as_str().expect("externalBin entry is a string");
+            let name = Path::new(path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(path);
+            assert_ne!(
+                pkg, name,
+                "Tauri forbids a sidecar named {name:?} when the crate is also {pkg:?} (CROW-1195)"
+            );
+        }
+    }
+
+    #[test]
     fn links_a_real_sha() {
         assert_eq!(
             crow_commit_url("2a24aeb3").as_deref(),


### PR DESCRIPTION
Closes #1195

## Summary
- Rename the Tauri desktop crate `crow` → `crow-desktop` so it no longer collides with the `binaries/crow` sidecar Tauri forbids matching the Cargo package name.
- `productName` stays `Crow` and `identifier` stays `com.corveil.crow`; sidecar staging (`prepare-desktop-sidecar.sh`) and `externalBin` paths are unchanged.
- Add a `cargo test` assertion that the crate name is not any sidecar base name, so this stays visible to the Desktop CI job (the release `tauri build` is still the only job that actually bundles sidecars).

## Test plan
- [x] `cargo test --manifest-path crow-desktop/src-tauri/Cargo.toml` (8 passed, including the new collision test)
- [ ] PR Desktop (Tauri) Build job goes green
- [ ] After merge, cut a fresh prerelease tag (`v0.2.0-rc.3`) and confirm Build Crow.app (crowd sidecar) → sign/notarize → release is green end-to-end


Made with [Cursor](https://cursor.com)