### PR TITLE
Rotate launchd's crowd.log by reopening the capture fds

### DIFF
--- a/Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift
+++ b/Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift
@@ -246,6 +246,12 @@ public struct LaunchdAutostart: AutostartService {
             "ThrottleInterval": 10,
             "ProcessType": "Background",
             "EnvironmentVariables": ["PATH": loginPath()],
+            // launchd keeps these fds open for the process lifetime. CrowLog's
+            // drain thread size-caps the file at CrowLog.maxBytes and dup2s a
+            // new open over stdout/stderr so writes follow the rename
+            // (CROW-1197). Do not drop these keys: leftover print() and runtime
+            // writes would otherwise vanish, and crowd-automation.log must not
+            // absorb that volume.
             "StandardOutPath": logURL.path,
             "StandardErrorPath": logURL.path,
         ]

--- a/Packages/CrowAutostart/Tests/CrowAutostartTests/LaunchdAutostartTests.swift
+++ b/Packages/CrowAutostart/Tests/CrowAutostartTests/LaunchdAutostartTests.swift
@@ -132,6 +132,8 @@ private func readPlist(_ service: LaunchdAutostart) throws -> [String: Any] {
     #expect(plist["ProgramArguments"] as? [String] == [binary, "--host", "127.0.0.1", "--http-port", "8787"])
     #expect(plist["RunAtLoad"] as? Bool == true)
     #expect(plist["ProcessType"] as? String == "Background")
+    // Capture stays on crowd.log; CrowLog reopens the fds after a size-capped
+    // rename so launchd's inherited fds actually follow (CROW-1197).
     #expect(plist["StandardOutPath"] as? String == service.logURL.path)
     #expect(plist["StandardErrorPath"] as? String == service.logURL.path)
     // The PATH launchd hands an agent is too bare for git/gh/tmux.

--- a/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowLog.swift
@@ -43,11 +43,21 @@ import Glibc
 /// `error(_:)` deliberately do **not** touch that file — it is a decision log,
 /// and general traffic would evict the auto-merge trail it exists to preserve.
 ///
+/// Under launchd, stdout and stderr are the same path
+/// (`~/Library/Logs/crow/crowd.log`). launchd keeps that fd open for the process
+/// lifetime, so a rename alone would leave subsequent writes on the old inode
+/// (the file on disk looks rotated, then grows forever under a new name). The
+/// drain thread therefore size-caps `crowd.log` with the same `maxBytes` /
+/// one-generation / 0o600 policy and `dup2`s a freshly opened fd over stdout
+/// and stderr so later writes follow. A tty (dev-mode
+/// `scripts/daemon-run.sh`) is left alone — `fstat` sees a non-regular file.
+///
 /// Per ADR 0012 a test process never writes to the live log directory: the
 /// destination is resolved on the *caller's* thread at enqueue (see `emit`), so
 /// `configure(directory:)` is a strict happens-before for every later line.
 public enum CrowLog {
-    /// Rotate the automation file once it exceeds this size (bytes).
+    /// Rotate `crowd.log` and `crowd-automation.log` once either exceeds this
+    /// size (bytes). One policy, two files — never mix their traffic.
     static let maxBytes: Int = 5 * 1024 * 1024
 
     /// Maximum lines held while the sink is blocked. Past this, lines are
@@ -245,7 +255,9 @@ public enum CrowLog {
                     appendToAutomationFile(directory: dir, line: "\(stamp) \(record.message)\n")
                 }
             }
-            // The only blocking call in this loop, and no lock is held across it.
+            // Rotate launchd's capture file *before* the blocking write so this
+            // batch lands on the new inode. No lock is held across either call.
+            rotateCaptureIfNeeded()
             writeAll(out, to: STDERR_FILENO)
 
             cond.lock()
@@ -315,17 +327,109 @@ public enum CrowLog {
         try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
     }
 
-    private static func rotateIfNeeded(url: URL) {
+    /// Rename `url` to `url.1` once it exceeds `maxBytes`. Returns whether the
+    /// rename happened, so the capture-fd path can `dup2` a new open only then.
+    @discardableResult
+    private static func rotateIfNeeded(url: URL) -> Bool {
         let fm = FileManager.default
         guard let attrs = try? fm.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? Int, size > maxBytes else { return }
+              let size = attrs[.size] as? Int, size > maxBytes else { return false }
         let rotated = url.appendingPathExtension("1")
         try? fm.removeItem(at: rotated)
-        try? fm.moveItem(at: url, to: rotated)
+        do {
+            try fm.moveItem(at: url, to: rotated)
+        } catch {
+            return false
+        }
         // The rotated generation holds the same data as the active file, so it
         // keeps the same owner-only permissions (a move preserves them, but the
         // active file may predate this hardening).
         try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: rotated.path)
+        return true
+    }
+
+    // MARK: - launchd capture file (drain thread; CROW-1197)
+
+    /// Size-cap the file behind stderr when it is launchd's `crowd.log`, and
+    /// retarget stdout/stderr onto a new open so writes follow the rename.
+    ///
+    /// Default fds are the process stdio; tests pass dedicated fds opened on a
+    /// temp `crowd.log` so this never has to steal the test runner's stderr.
+    static func rotateCaptureIfNeeded(
+        stderrFD: Int32 = STDERR_FILENO,
+        stdoutFD: Int32 = STDOUT_FILENO
+    ) {
+        var st = stat()
+        guard fstat(stderrFD, &st) == 0 else { return }
+        // A tty / pipe / socket is the inner-loop case: leave it alone.
+        guard (st.st_mode & S_IFMT) == S_IFREG else { return }
+        guard let path = filePath(of: stderrFD) else { return }
+        guard URL(fileURLWithPath: path).lastPathComponent == "crowd.log" else { return }
+
+        // launchd creates this 0644 via umask. Re-applied every drain so a
+        // rotated-and-reopened inode cannot drift, matching the automation file.
+        _ = fchmod(stderrFD, 0o600)
+
+        guard st.st_size > off_t(maxBytes) else { return }
+
+        var outStat = stat()
+        let retargetStdout = fstat(stdoutFD, &outStat) == 0
+            && (outStat.st_mode & S_IFMT) == S_IFREG
+            && outStat.st_dev == st.st_dev
+            && outStat.st_ino == st.st_ino
+
+        let url = URL(fileURLWithPath: path)
+        guard rotateIfNeeded(url: url) else { return }
+        reopenStdio(onto: path, stderrFD: stderrFD, stdoutFD: stdoutFD, retargetStdout: retargetStdout)
+    }
+
+    /// `dup2` a newly created `crowd.log` over the capture fds. `O_APPEND` is
+    /// mandatory: launchd may have given stdout and stderr separate opens of the
+    /// same path, and independent offsets would clobber each other.
+    private static func reopenStdio(
+        onto path: String,
+        stderrFD: Int32,
+        stdoutFD: Int32,
+        retargetStdout: Bool
+    ) {
+        let dir = URL(fileURLWithPath: path).deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+
+        let fd = path.withCString { open($0, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0o600) }
+        guard fd >= 0 else { return }
+        defer { close(fd) }
+        _ = fchmod(fd, 0o600)
+        _ = dup2(fd, stderrFD)
+        if retargetStdout {
+            _ = dup2(fd, stdoutFD)
+        }
+    }
+
+    /// Path of an open fd. Darwin's `F_GETPATH`; Linux `/proc/self/fd/N`.
+    private static func filePath(of fd: Int32) -> String? {
+        #if canImport(Darwin)
+        var buf = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        let rc = buf.withUnsafeMutableBufferPointer { ptr -> Int32 in
+            guard let base = ptr.baseAddress else { return -1 }
+            return fcntl(fd, F_GETPATH, base)
+        }
+        guard rc == 0 else { return nil }
+        return String(decoding: buf.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+        #elseif canImport(Glibc)
+        var buf = [CChar](repeating: 0, count: 4096)
+        let n = "/proc/self/fd/\(fd)".withCString { cPath in
+            buf.withUnsafeMutableBufferPointer { ptr -> Int in
+                guard let base = ptr.baseAddress else { return -1 }
+                return readlink(cPath, base, ptr.count - 1)
+            }
+        }
+        guard n > 0 else { return nil }
+        return String(decoding: buf.prefix(n).map { UInt8(bitPattern: $0) }, as: UTF8.self)
+        #else
+        return nil
+        #endif
     }
 
     // MARK: - Directory resolution (callers hold `dirLock`)

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowLogTests.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Testing
 @testable import CrowCore
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 /// `CrowLog` is the durable automation log added for CROW-782, and since
 /// CROW-874 the process-wide non-blocking sink. Every test here points the sink
@@ -196,6 +201,150 @@ struct CrowLogTests {
             iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             #expect(iso.date(from: parts[0]) != nil)
             #expect(parts[1] == "[automation] auto-merge: pr=42 skipped reason=checks-pending")
+        }
+    }
+
+    // MARK: - CROW-1197 (launchd crowd.log rotation)
+
+    /// Open `url` twice (launchd gives stdout and stderr separate opens of the
+    /// same path) and return the fds. Caller closes them.
+    private func openCapturePair(_ url: URL) throws -> (err: Int32, out: Int32) {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let flags = O_WRONLY | O_CREAT | O_APPEND
+        let errFD = url.path.withCString { open($0, flags, 0o600) }
+        let outFD = url.path.withCString { open($0, flags, 0o600) }
+        try #require(errFD >= 0 && outFD >= 0)
+        return (errFD, outFD)
+    }
+
+    private func seedFile(_ url: URL, contents: String) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func posixPermissions(_ path: String) throws -> Int16 {
+        let perms = try #require(
+            (try FileManager.default.attributesOfItem(atPath: path))[.posixPermissions] as? NSNumber)
+        return perms.int16Value
+    }
+
+    @Test func oversizedCrowdLogRotatesAndReopensStdio() throws {
+        // Dedicated fds, not the process stderr: the drain writes there, and
+        // stealing it would swallow the test runner. Same rename + dup2 the
+        // drain calls on STDERR_FILENO / STDOUT_FILENO under launchd.
+        try withTempLogDirectory { dir in
+            let url = dir.appendingPathComponent("crowd.log")
+            try seedFile(url, contents: String(repeating: "y", count: CrowLog.maxBytes + 1))
+
+            let pair = try openCapturePair(url)
+            defer { close(pair.err); close(pair.out) }
+
+            CrowLog.rotateCaptureIfNeeded(stderrFD: pair.err, stdoutFD: pair.out)
+
+            let rotated = url.appendingPathExtension("1")
+            #expect(FileManager.default.fileExists(atPath: rotated.path))
+            let active = try String(contentsOf: url, encoding: .utf8)
+            #expect(active.isEmpty)
+            #expect(try String(contentsOf: rotated, encoding: .utf8).hasPrefix("yyy"))
+            #expect(try posixPermissions(url.path) == 0o600)
+            #expect(try posixPermissions(rotated.path) == 0o600)
+
+            // Subsequent writes follow the new inode, not the rotated generation.
+            let probe = Array("post-rotate\n".utf8)
+            #expect(probe.withUnsafeBufferPointer { write(pair.err, $0.baseAddress, $0.count) } > 0)
+            #expect(probe.withUnsafeBufferPointer { write(pair.out, $0.baseAddress, $0.count) } > 0)
+            let after = try String(contentsOf: url, encoding: .utf8)
+            #expect(after.contains("post-rotate"))
+            #expect(!((try String(contentsOf: rotated, encoding: .utf8)).contains("post-rotate")))
+        }
+    }
+
+    @Test func undersizedCrowdLogIsNotRotatedButIsOwnerOnly() throws {
+        try withTempLogDirectory { dir in
+            let url = dir.appendingPathComponent("crowd.log")
+            try seedFile(url, contents: "small\n")
+            // Seed 0644 so the drain's chmod is what makes it owner-only.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o644], ofItemAtPath: url.path)
+
+            let pair = try openCapturePair(url)
+            defer { close(pair.err); close(pair.out) }
+
+            CrowLog.rotateCaptureIfNeeded(stderrFD: pair.err, stdoutFD: pair.out)
+
+            #expect(!FileManager.default.fileExists(atPath: url.appendingPathExtension("1").path))
+            #expect(try String(contentsOf: url, encoding: .utf8) == "small\n")
+            #expect(try posixPermissions(url.path) == 0o600)
+        }
+    }
+
+    @Test func oversizedNonCrowdLogIsNotRotated() throws {
+        // Safety: a redirected test-runner log or a tty-backed file that happens
+        // to be large must not be renamed just because we fstat a regular file.
+        try withTempLogDirectory { dir in
+            let url = dir.appendingPathComponent("other.log")
+            try seedFile(url, contents: String(repeating: "z", count: CrowLog.maxBytes + 1))
+
+            let pair = try openCapturePair(url)
+            defer { close(pair.err); close(pair.out) }
+
+            CrowLog.rotateCaptureIfNeeded(stderrFD: pair.err, stdoutFD: pair.out)
+
+            #expect(!FileManager.default.fileExists(atPath: url.appendingPathExtension("1").path))
+            #expect(try String(contentsOf: url, encoding: .utf8).hasPrefix("zzz"))
+        }
+    }
+
+    @Test func crowdLogRotationDoesNotTouchTheAutomationFile() throws {
+        try withTempLogDirectory { dir in
+            let url = dir.appendingPathComponent("crowd.log")
+            try seedFile(url, contents: String(repeating: "y", count: CrowLog.maxBytes + 1))
+
+            let pair = try openCapturePair(url)
+            defer { close(pair.err); close(pair.out) }
+
+            CrowLog.rotateCaptureIfNeeded(stderrFD: pair.err, stdoutFD: pair.out)
+
+            #expect(!FileManager.default.fileExists(atPath: CrowLog.fileURL.path))
+        }
+    }
+
+    @Test func drainRotatesAnOversizedCrowdLogBehindStderr() throws {
+        // End-to-end: the drain's default fds are 1 and 2, so this briefly
+        // retargets them at a temp crowd.log. The suite is serialized and
+        // flush is a barrier, so the runner's stderr is restored before the
+        // next test.
+        try withTempLogDirectory { dir in
+            let url = dir.appendingPathComponent("crowd.log")
+            try seedFile(url, contents: String(repeating: "y", count: CrowLog.maxBytes + 1))
+
+            let savedErr = dup(STDERR_FILENO)
+            let savedOut = dup(STDOUT_FILENO)
+            try #require(savedErr >= 0 && savedOut >= 0)
+            defer {
+                _ = dup2(savedErr, STDERR_FILENO)
+                _ = dup2(savedOut, STDOUT_FILENO)
+                close(savedErr)
+                close(savedOut)
+            }
+
+            let pair = try openCapturePair(url)
+            _ = dup2(pair.err, STDERR_FILENO)
+            _ = dup2(pair.out, STDOUT_FILENO)
+            close(pair.err)
+            close(pair.out)
+
+            CrowLog.info("after rotation via drain")
+            #expect(CrowLog.flush(timeout: 5))
+
+            let rotated = url.appendingPathExtension("1")
+            #expect(FileManager.default.fileExists(atPath: rotated.path))
+            let active = try String(contentsOf: url, encoding: .utf8)
+            #expect(active.contains("after rotation via drain"))
+            #expect(active.count < CrowLog.maxBytes)
+            #expect(try String(contentsOf: rotated, encoding: .utf8).hasPrefix("yyy"))
         }
     }
 }

--- a/docs/adr/0017-non-blocking-logging.md
+++ b/docs/adr/0017-non-blocking-logging.md
@@ -76,8 +76,12 @@ Two sites also passed a 64-bit `Int` to `%d`, which worked only by ABI accident.
   `TmuxBackend.captureDiagnostics`) arrive whole on stderr but truncated in the unified
   log.
 - **A dedicated thread, permanently.** It is parked on a condition variable when idle.
-- **`~/Library/Logs/crow/crowd.log` still has no rotation** — launchd writes it by stream
-  redirection, and each line is now slightly longer. Pre-existing, but worth a ticket.
+- **`crowd.log` rotation reopens launchd's capture fds.** launchd holds stdout/stderr
+  open for the process lifetime, so a rename alone would leave writes on the old inode.
+  The drain thread size-caps the file at 5 MB (one `…log.1` generation, 0o600) and
+  `dup2`s a new open over fd 1/2 so later writes follow. A tty is left alone so
+  `scripts/daemon-run.sh` still prints to the terminal. `crowd-automation.log` stays a
+  decision log — general traffic is not mixed into it.
 
 ## Alternatives considered
 
@@ -98,15 +102,22 @@ Two sites also passed a 64-bit `Int` to `%d`, which worked only by ABI accident.
 - **Redirecting stderr to a file by default outside launchd.** Narrows the window but does
   not close it (a full disk or a stalled network mount still blocks), and it takes the
   daemon's output away from the terminal a developer is watching.
+- **A `newsyslog.d` plist, or giving `CrowLog` its own `crowd.log` and dropping
+  launchd `StandardOutPath`.** newsyslog still needs the process to reopen the fd (or
+  SIGUSR1/HUP) and splits the 5 MB policy out of Crow. Dropping launchd capture would
+  miss leftover `print()` and runtime writes; feeding that volume into
+  `crowd-automation.log` would evict the auto-merge trail. Rotation next to
+  `rotateIfNeeded` plus `dup2` keeps one policy and the existing capture.
 
 ## References
 
-- Issue: [#874](https://github.com/corveil/crow/issues/874)
+- Issue: [#874](https://github.com/corveil/crow/issues/874), [#1197](https://github.com/corveil/crow/issues/1197)
 - Related ADRs: [0007](./0007-linux-ci-swift.md) (CrowCore builds on Linux, so `import os`
   is `#if canImport(Darwin)`-fenced), [0009](./0009-crowd-sole-authority-clients-only.md)
   (why the main actor is shared by every client), [0012](./0012-tests-never-touch-live-data.md)
   (the log directory resolves to a temp dir under a test runner)
 - Code: `Packages/CrowCore/Sources/CrowCore/CrowLog.swift`,
+  `Packages/CrowAutostart/Sources/CrowAutostart/LaunchdAutostart.swift`,
   `scripts/check-no-nslog.sh`,
   `Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift` (the bounded-drain
   half of the same defect class),


### PR DESCRIPTION
Closes #1197

## Summary
- Size-cap `~/Library/Logs/crow/crowd.log` at the same 5 MB / one-generation / `0o600` policy as `crowd-automation.log`.
- After the rename, `CrowLog`'s drain thread `dup2`s a new open over stdout/stderr so launchd's inherited fds actually follow — a path-only rotate would keep writing the old inode.
- Leave the LaunchAgent `StandardOutPath`/`StandardErrorPath` on `crowd.log` (so leftover `print()` and runtime writes stay captured) and keep general traffic out of the automation decision log.
- Update ADR 0017's leftover "worth a ticket" bullet.

## Test plan
- [x] `swift test --package-path Packages/CrowCore --filter CrowLogTests` (rotation, reopen, 0o600, skip non-`crowd.log`, drain-path, no automation-file mixing)
- [x] `swift test --package-path Packages/CrowAutostart` (plist still points both capture keys at `crowd.log`)
- [ ] Under autostart, confirm `~/Library/Logs/crow/crowd.log` rotates to `crowd.log.1` once past 5 MB and new lines land in the fresh `crowd.log` (not `.1`)
- [ ] Dev-mode `scripts/daemon-run.sh` still prints to the terminal (tty is not rotated)


Made with [Cursor](https://cursor.com)