### PR TITLE
Bump GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -23,13 +23,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Trust workspace for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/org.swift.swiftpm
           key: swift-build-Linux-${{ hashFiles('Package.swift', 'Packages/*/Package.swift') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Container runs as root; the checkout is owned by a different uid, so
       # git refuses to operate on it until it's marked safe. generate-build-info
@@ -45,7 +45,7 @@ jobs:
         run: bash scripts/generate-build-info.sh
 
       - name: Restore SwiftPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/org.swift.swiftpm
           key: swift-build-Linux-${{ hashFiles('Package.swift', 'Packages/*/Package.swift') }}
@@ -109,7 +109,7 @@ jobs:
       # died partway yields a smaller table, never a wrong one.
       - name: Upload coverage summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-summary-linux
           path: coverage/
@@ -129,7 +129,7 @@ jobs:
     name: Catalog & Parity Gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: CLI/RPC control-plane parity (CROW-807)
         run: bash scripts/check-cli-parity.sh
@@ -158,7 +158,7 @@ jobs:
       # lockfile pins the deps, this pins the runtime they run on. Placed
       # immediately before the step that needs it so the shell gates above keep
       # the environment they've always had.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
 
@@ -175,7 +175,7 @@ jobs:
     name: Desktop (Tauri) Build
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -194,14 +194,14 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16"
 
       - name: Restore SwiftPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: swift-build-macOS-${{ hashFiles('Package.swift', 'Packages/*/Package.swift') }}
@@ -219,7 +219,7 @@ jobs:
     name: Shell Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check scripts
         run: shellcheck scripts/*.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload coverage summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-summary-macos
           path: coverage/
@@ -49,7 +49,7 @@ jobs:
     name: Shell Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check scripts
         run: shellcheck scripts/*.sh
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -114,7 +114,7 @@ jobs:
         with:
           targets: aarch64-apple-darwin, x86_64-apple-darwin
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: crow-${{ env.CROW_VERSION }}-macos-universal
           path: |
@@ -212,7 +212,7 @@ jobs:
 
       - name: Create GitHub Release
         if: github.event_name != 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             crow-${{ env.CROW_VERSION }}-macos-universal.tar.gz


### PR DESCRIPTION
Closes #1203

## Summary
- Pin `actions/checkout`, `actions/cache`, `actions/setup-node`, and `actions/upload-artifact` from `@v4` (Node 20) to `@v5` (Node 24) in `ci.yml`, `cache-warm.yml`, and `release.yml`.
- Pin `softprops/action-gh-release` from `@v2` to `@v3`.
- Workflow inputs are unchanged. `setup-node@v5` auto-cache only fires when `package.json` has a `packageManager` field; neither Crow `package.json` has one, and the desktop job already sets `cache: npm` explicitly.

## Test plan
- [ ] CI on this PR runs green (Linux packages, parity/jsdom, desktop, universal-build, shellcheck) with no Node 20 deprecation annotations on the bumped actions.
- [ ] Cache restore/save still works for SwiftPM keys (`swift-build-Linux-*` / `swift-build-macOS-*`).
- [ ] Coverage summary artifacts still upload (`if-no-files-found: ignore`).
- [ ] If a self-hosted signing runner is in use (`CROW_SIGNING_RUNS_ON`), confirm it is Actions Runner ≥ 2.327.1 before the next `v*` tag cut.


Made with [Cursor](https://cursor.com)