### PR TITLE
Keep the org picker selected without rebuilding the settings modal

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-automation.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-automation.js
@@ -44,6 +44,9 @@
       const applyManual = async (g) => {
         await S.postConfig('/config/manager-gateway', g ? { baseURL: g.baseURL, headers: g.customHeaders } : { clear: true });
         S.cfg.managerGateway = g;
+        // Manual write/clear is not an org pick — drop the cached selection so
+        // the rebuilt dropdown does not keep showing the last org (#1213 review).
+        if (typeof S.forgetPickedOrg === 'function') S.forgetPickedOrg('manager');
         S.render();
       };
       const manual = S.gatewayEditor(S.cfg.managerGateway || null, applyManual);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-automation.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-automation.js
@@ -50,6 +50,7 @@
       // Connected → org picker (manual under Advanced); otherwise the raw editor.
       if (S.corveilConnected(S.cfg.corveilConnection)) {
         body.appendChild(S.orgGatewayEditor({
+          target: 'manager',
           current: S.cfg.managerGateway || null,
           postOrg: (orgId) => S.postConfig('/config/manager-gateway', { orgId }),
           setGateway: (g) => { S.cfg.managerGateway = g; },

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-integrations.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-integrations.js
@@ -109,7 +109,12 @@
       ui.status.hidden = true;
     }
 
-    const picked = pickedOrgByTarget[opts.target || ''] || '';
+    // A derived gateway is the only case where the cached pick is meaningful.
+    // Advanced manual set/clear (and any other non-derived current) must not
+    // keep showing the last org — pre-#1212 a full render always snapped back
+    // to the placeholder (review of corveil/crow#1213).
+    if (!derived) delete pickedOrgByTarget[opts.target || ''];
+    const picked = derived ? (pickedOrgByTarget[opts.target || ''] || '') : '';
     const sel = ui.sel;
     sel.innerHTML = '';
     const placeholder = el('option', null,
@@ -127,7 +132,11 @@
       if (org.org_id === picked) { o.selected = true; hasPicked = true; }
       sel.appendChild(o);
     }
-    sel.disabled = corveilOrgsLoading;
+    // Keep the select/refresh disabled for the whole in-flight pick, not just
+    // the corveil-list-orgs load — an overlapping Refresh completion used to
+    // re-enable the <select> mid-provision (optional harden, #1213 review).
+    const busy = corveilOrgsLoading || !!ui.picking;
+    sel.disabled = busy;
     sel.value = hasPicked ? picked : '';
 
     if (corveilOrgsError) {
@@ -142,7 +151,14 @@
       ui.note.textContent = '';
       ui.note.hidden = true;
     }
-    ui.refresh.disabled = corveilOrgsLoading;
+    ui.refresh.disabled = busy;
+  }
+
+  // Drop the modal-scoped pick for one gateway target. Called from the
+  // Advanced manual editor's apply/clear path so a following S.render()
+  // cannot resurrect the last org on a non-derived (or freshly cleared) gateway.
+  function forgetPickedOrg(target) {
+    delete pickedOrgByTarget[target || ''];
   }
 
   // The org-picker gateway control (corveil/crow#1123). Replaces the raw
@@ -179,13 +195,15 @@
     refresh.type = 'button';
     refresh.onclick = () => loadCorveilOrgs(true);
 
-    wrap._orgGw = { opts, status, sel, note, msg, refresh };
+    wrap._orgGw = { opts, status, sel, note, msg, refresh, picking: false };
     sel.onchange = async () => {
       const orgId = sel.value;
       if (!orgId) return;
       const org = (corveilOrgs || []).find((x) => x.org_id === orgId) || null;
       const label = (org && org.org_name) || orgId;
+      wrap._orgGw.picking = true;
       sel.disabled = true;
+      refresh.disabled = true;
       msg.textContent = 'Provisioning gateway for ' + label + '…';
       try {
         // Mint or reuse the org's one gateway key, then write the derived gateway.
@@ -196,9 +214,11 @@
         // placeholder so re-picking the SAME org fires `change` again: HTML `change`
         // does not re-fire for an unchanged value, which would otherwise strand this
         // ticket's primary control on the org that just failed.
+        wrap._orgGw.picking = false;
         msg.textContent = 'Failed: ' + (e && (e.message || e));
         sel.value = '';
         sel.disabled = false;
+        refresh.disabled = corveilOrgsLoading;
         return;
       }
       // The gateway is written. Everything past this point is success bookkeeping, so
@@ -219,6 +239,7 @@
       // metadata reflects the new key. A failure here leaves the gateway stored and
       // the picker correct, so it must not surface as a failed pick.
       try { await refreshCorveilConnection(); } catch (_) { /* best-effort */ }
+      wrap._orgGw.picking = false;
       msg.textContent = '';
       paintOrgGatewayPicker(wrap);
       if (typeof opts.onApplied === 'function') opts.onApplied(g);
@@ -518,6 +539,7 @@
 
   T.integrations = renderIntegrations;
   T.orgGatewayEditor = orgGatewayEditor;
+  T.forgetPickedOrg = forgetPickedOrg;
   T.corveilConnected = corveilConnected;
   T.resetCorveilConnectState = resetCorveilConnectState;
 })();

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-integrations.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-integrations.js
@@ -40,27 +40,36 @@
   // Org-dropdown state for the gateway editors (corveil/crow#1123), shared by the
   // Manager (Automation tab) and per-workspace (Workspaces tab) pickers — both bind
   // the same connection's memberships. Lazily loaded once through the local-only
-  // `corveil-list-orgs` RPC (which caches server-side), then reused across renders.
+  // `corveil-list-orgs` RPC (which caches server-side), then reused across paints.
   // `corveilOrgs === null` means "not fetched yet"; an array (possibly empty) means
   // "fetched". Reset when Settings (re)opens, exactly like the connect-flow state.
   let corveilOrgs = null;          // [{org_id, org_name, provisioned, is_active, role}] | null
   let corveilOrgsLoading = false;  // a list fetch is in flight
   let corveilOrgsError = '';       // last fetch error, shown inline
+  // Org the user picked during THIS Settings modal, keyed by picker target
+  // ('manager' | workspace id). A derived gateway cannot recover which org
+  // produced it (key stripped in transport, every org shares the base URL), so
+  // this is how the <select> stays on the choice for the life of the modal
+  // (corveil/crow#1212). Fresh reopen → placeholder, which is honest.
+  let pickedOrgByTarget = Object.create(null);
   function resetCorveilOrgState() {
     corveilOrgs = null;
     corveilOrgsLoading = false;
     corveilOrgsError = '';
+    pickedOrgByTarget = Object.create(null);
   }
 
   // Fetch the user's Corveil orgs through the local-only provisioning RPC and
-  // re-render when done. Guarded so overlapping renders can't stack fetches; the
-  // finally-render lets the picker repaint from `corveilOrgs`/`corveilOrgsError`.
-  // `force` re-fetches past the server-side cache (the explicit Refresh).
+  // repaint live pickers when done. Guarded so overlapping paints can't stack
+  // fetches. Must NOT call S.render() — that tears down both Settings layers
+  // via innerHTML and is the flicker in corveil/crow#1212 (lazy load after
+  // Connect, and every subsequent pick). `force` re-fetches past the server-side
+  // cache (the explicit Refresh) and shows the loading state in place.
   async function loadCorveilOrgs(force) {
     if (corveilOrgsLoading) return;
     corveilOrgsLoading = true;
     corveilOrgsError = '';
-    if (force) S.render();
+    if (force) refreshOrgGatewayPickers();
     try {
       const res = await rpc('corveil-list-orgs', force ? { refresh: true } : {});
       corveilOrgs = (res && res.orgs) || [];
@@ -69,8 +78,71 @@
       corveilOrgsError = (e && (e.message || String(e))) || 'could not load organizations';
     } finally {
       corveilOrgsLoading = false;
-      S.render();
+      refreshOrgGatewayPickers();
     }
+  }
+
+  // Patch every mounted org-picker in place (select options, loading/disabled,
+  // status line). The wrap stays in the tree, so the surrounding workspace /
+  // Automation form keeps focus and scroll.
+  function refreshOrgGatewayPickers() {
+    document.querySelectorAll('.st-org-gateway').forEach(paintOrgGatewayPicker);
+  }
+
+  function paintOrgGatewayPicker(wrap) {
+    const ui = wrap._orgGw;
+    if (!ui) return;
+    const opts = ui.opts;
+    const conn = S.cfg.corveilConnection || null;
+    const current = opts.current;
+    const derived = !!(current && conn
+      && (current.baseURL || '') === (conn.baseURL || '')
+      && current.customHeaders
+      && Object.keys(current.customHeaders).some((k) => k.toLowerCase() === 'x-citadel-api-key'));
+    if (current && current.baseURL) {
+      ui.status.textContent = derived
+        ? 'Gateway set from your Corveil connection (' + current.baseURL + ').'
+        : 'A manually-entered gateway is set (' + current.baseURL + ').';
+      ui.status.hidden = false;
+    } else {
+      ui.status.textContent = '';
+      ui.status.hidden = true;
+    }
+
+    const picked = pickedOrgByTarget[opts.target || ''] || '';
+    const sel = ui.sel;
+    sel.innerHTML = '';
+    const placeholder = el('option', null,
+      corveilOrgsLoading ? 'Loading organizations…' : 'Choose an organization…');
+    placeholder.value = '';
+    sel.appendChild(placeholder);
+    let hasPicked = false;
+    for (const org of (corveilOrgs || [])) {
+      const bits = [];
+      if (org.provisioned) bits.push('key ready');
+      if (org.is_active === false) bits.push('inactive');
+      const o = el('option', null,
+        (org.org_name || org.org_id || '(unnamed org)') + (bits.length ? ' · ' + bits.join(' · ') : ''));
+      o.value = org.org_id;
+      if (org.org_id === picked) { o.selected = true; hasPicked = true; }
+      sel.appendChild(o);
+    }
+    sel.disabled = corveilOrgsLoading;
+    sel.value = hasPicked ? picked : '';
+
+    if (corveilOrgsError) {
+      ui.note.textContent = 'Could not load organizations: ' + corveilOrgsError;
+      ui.note.className = 'st-perm-status';
+      ui.note.hidden = false;
+    } else if (corveilOrgs && !corveilOrgs.length && !corveilOrgsLoading) {
+      ui.note.textContent = 'No Corveil organizations found for your account.';
+      ui.note.className = 'st-help';
+      ui.note.hidden = false;
+    } else {
+      ui.note.textContent = '';
+      ui.note.hidden = true;
+    }
+    ui.refresh.disabled = corveilOrgsLoading;
   }
 
   // The org-picker gateway control (corveil/crow#1123). Replaces the raw
@@ -80,48 +152,34 @@
   // manual editor uses, but with { orgId } so the daemon fills in the key secret it
   // never hands the browser. The manual editor stays reachable under "Advanced".
   //
+  //   opts.target       — 'manager' | workspace id; keys pickedOrgByTarget.
   //   opts.current      — the stored gateway ({baseURL, customHeaders}) or null.
   //   opts.postOrg(id)  — POST the derived gateway ({ orgId: id }); returns a Promise.
   //   opts.setGateway(g)— set the local gateway (cfg.managerGateway / draft.gateway).
+  //   opts.onApplied(g) — optional; parent patches sibling controls (session-log
+  //                       checkbox) without a full-modal S.render().
   //   opts.manual       — the manual gatewayEditor node (the Advanced fallback).
   function orgGatewayEditor(opts) {
-    const wrap = el('div');
+    const wrap = el('div', 'st-org-gateway');
     const conn = S.cfg.corveilConnection || null;
 
-    // Whether the stored gateway looks derived from this connection (its base URL
-    // matches and it carries the x-citadel-api-key header). We can't tell WHICH org
-    // it came from — the key value is stripped in transport and every org shares the
-    // base URL — so we note "set from Corveil" without claiming an org (honest).
-    const current = opts.current;
-    const derived = !!(current && conn
-      && (current.baseURL || '') === (conn.baseURL || '')
-      && current.customHeaders
-      && Object.keys(current.customHeaders).some((k) => k.toLowerCase() === 'x-citadel-api-key'));
-    if (current && current.baseURL) {
-      wrap.appendChild(el('div', 'st-perm-status', derived
-        ? 'Gateway set from your Corveil connection (' + current.baseURL + ').'
-        : 'A manually-entered gateway is set (' + current.baseURL + ').'));
-    }
+    const status = el('div', 'st-perm-status');
+    status.hidden = true;
+    wrap.appendChild(status);
 
-    // Kick the lazy load on first paint; the finally-render repaints with options.
+    // Kick the lazy load on first paint; finally-refreshOrgGatewayPickers
+    // swaps options on THIS wrap instead of rebuilding the modal.
     if (corveilOrgs === null && !corveilOrgsLoading) loadCorveilOrgs(false);
 
     const msg = el('div', 'st-perm-status', '');
     const sel = el('select', 'st-select');
-    const placeholder = el('option', null,
-      corveilOrgsLoading ? 'Loading organizations…' : 'Choose an organization…');
-    placeholder.value = '';
-    sel.appendChild(placeholder);
-    for (const org of (corveilOrgs || [])) {
-      const bits = [];
-      if (org.provisioned) bits.push('key ready');
-      if (org.is_active === false) bits.push('inactive');
-      const o = el('option', null,
-        (org.org_name || org.org_id || '(unnamed org)') + (bits.length ? ' · ' + bits.join(' · ') : ''));
-      o.value = org.org_id;
-      sel.appendChild(o);
-    }
-    sel.disabled = corveilOrgsLoading;
+    const note = el('div', 'st-perm-status');
+    note.hidden = true;
+    const refresh = el('button', 'action-btn', 'Refresh organizations');
+    refresh.type = 'button';
+    refresh.onclick = () => loadCorveilOrgs(true);
+
+    wrap._orgGw = { opts, status, sel, note, msg, refresh };
     sel.onchange = async () => {
       const orgId = sel.value;
       if (!orgId) return;
@@ -149,37 +207,37 @@
       // then show the derived gateway locally — the header value is a secret we don't
       // hold, so blank it, exactly how a stored gateway reads back after stripping.
       if (org) org.provisioned = true;
-      opts.setGateway({ baseURL: (conn && conn.baseURL) || '',
-        customHeaders: { 'x-citadel-api-key': '' } });
+      const g = { baseURL: (conn && conn.baseURL) || '',
+        customHeaders: { 'x-citadel-api-key': '' } };
+      opts.setGateway(g);
+      // Keep the just-picked org selected for the life of the modal, and point
+      // opts.current at the derived gateway so the in-place status line updates
+      // (S.render() used to rebuild the whole modal from cfg/draft).
+      opts.current = g;
+      pickedOrgByTarget[opts.target || ''] = orgId;
       // Best-effort: refresh the connection so the Integrations tab's per-org key
       // metadata reflects the new key. A failure here leaves the gateway stored and
       // the picker correct, so it must not surface as a failed pick.
       try { await refreshCorveilConnection(); } catch (_) { /* best-effort */ }
-      S.render();
+      msg.textContent = '';
+      paintOrgGatewayPicker(wrap);
+      if (typeof opts.onApplied === 'function') opts.onApplied(g);
     };
     wrap.appendChild(S.field('Organization', sel,
       'Pick a Corveil organization — Crow provisions its gateway key and points this gateway at it.'));
-
-    if (corveilOrgsError) {
-      wrap.appendChild(el('div', 'st-perm-status', 'Could not load organizations: ' + corveilOrgsError));
-    } else if (corveilOrgs && !corveilOrgs.length && !corveilOrgsLoading) {
-      wrap.appendChild(el('div', 'st-help', 'No Corveil organizations found for your account.'));
-    }
+    wrap.appendChild(note);
     wrap.appendChild(msg);
-
-    const refresh = el('button', 'action-btn', 'Refresh organizations');
-    refresh.type = 'button';
-    refresh.disabled = corveilOrgsLoading;
-    refresh.onclick = () => loadCorveilOrgs(true);
     wrap.appendChild(S.field(null, refresh));
 
     // Manual entry stays available as an advanced fallback. Native <details> keeps
-    // it collapsed by default and needs no extra render state.
+    // it collapsed by default and needs no extra render state. paintOrgGatewayPicker
+    // never rebuilds this node, so an expanded Advanced panel survives org load/pick.
     const adv = el('details', 'st-advanced-gateway');
     const sum = el('summary', 'st-advanced-summary', 'Enter a gateway manually');
     adv.appendChild(sum);
     adv.appendChild(opts.manual);
     wrap.appendChild(adv);
+    paintOrgGatewayPicker(wrap);
     return wrap;
   }
 

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-workspaces.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-workspaces.js
@@ -39,6 +39,40 @@
 
   // ---- Workspace sub-form -------------------------------------------------
 
+  const SESSION_LOGS_NEED_GATEWAY = 'Turn on the AI Gateway for this workspace first — the upload reuses its URL and credential.';
+  const SESSION_LOGS_HELP_ON = 'Uploads this workspace’s coding-session transcripts to Corveil, reusing its AI-gateway URL and credential (no second key or host needed). That’s the only setting required — collector timing and size limits live under Settings → General → Session logs.';
+  const SESSION_LOGS_HELP_OFF = 'Turn on the AI Gateway for this workspace above first — the upload reuses its URL and credential.';
+
+  function workspaceHasGateway(d) {
+    return !!(d.gateway && (d.gateway.baseURL
+      || (d.gateway.customHeaders && Object.keys(d.gateway.customHeaders).length)));
+  }
+
+  // Org pick paints the picker in place and no longer S.render()s the sub-form
+  // (corveil/crow#1212). Keep the session-log checkbox, help, and backfill
+  // button in sync with the draft so they still enable/check after a pick.
+  function syncWorkspaceGatewayDependents(d) {
+    const overlay = document.querySelector('.settings-subform-overlay');
+    if (!overlay) return;
+    const hasGateway = workspaceHasGateway(d);
+    const row = overlay.querySelector('.st-session-logs-row');
+    if (row) {
+      const cb = row.querySelector('input');
+      if (cb) {
+        cb.checked = !!d.uploadSessionLogs;
+        cb.disabled = !hasGateway;
+      }
+      row.title = hasGateway ? '' : SESSION_LOGS_NEED_GATEWAY;
+    }
+    const help = overlay.querySelector('.st-session-logs-help');
+    if (help) help.textContent = hasGateway ? SESSION_LOGS_HELP_ON : SESSION_LOGS_HELP_OFF;
+    const bfBtn = overlay.querySelector('.st-backfill-btn');
+    if (bfBtn) {
+      bfBtn.disabled = !hasGateway;
+      bfBtn.title = hasGateway ? '' : SESSION_LOGS_NEED_GATEWAY;
+    }
+  }
+
   function renderWorkspaceForm(body) {
     const d = S.subForm.draft;
     body.appendChild(S.textField('Name', d, 'name', { placeholder: 'MyOrg' }));
@@ -158,6 +192,7 @@
       const manual = S.gatewayEditor(d.gateway || null, applyManual);
       if (S.corveilConnected(S.cfg.corveilConnection)) {
         body.appendChild(S.orgGatewayEditor({
+          target: d.id,
           current: d.gateway || null,
           // Picking an org derives this workspace's gateway from that org's key AND —
           // because the log upload reuses that same gateway — the daemon auto-enables
@@ -179,6 +214,10 @@
             return res;
           },
           setGateway: (g) => { d.gateway = g; },
+          // Org pick no longer S.render()s the whole modal (corveil/crow#1212).
+          // Patch the session-log checkbox / backfill button in place so they
+          // still reflect the new gateway without tearing down the sub-form.
+          onApplied: () => { syncWorkspaceGatewayDependents(d); },
           manual,
         }));
       } else {
@@ -193,22 +232,20 @@
     // disabled with a tooltip otherwise. There is no separate master switch — a
     // ticked box plus a configured gateway is the whole opt-in.
     body.appendChild(S.group('Session logs'));
-    const hasGateway = !!(d.gateway && (d.gateway.baseURL
-      || (d.gateway.customHeaders && Object.keys(d.gateway.customHeaders).length)));
-    const slRow = el('label', 'st-switch-row');
+    const hasGateway = workspaceHasGateway(d);
+    const slRow = el('label', 'st-switch-row st-session-logs-row');
     const slCb = el('input', 'st-switch');
     slCb.type = 'checkbox';
     slCb.checked = !!d.uploadSessionLogs;
     slCb.disabled = !hasGateway;
-    if (!hasGateway) slRow.title = 'Turn on the AI Gateway for this workspace first — the upload reuses its URL and credential.';
+    if (!hasGateway) slRow.title = SESSION_LOGS_NEED_GATEWAY;
     slCb.onchange = () => { d.uploadSessionLogs = slCb.checked; S.markDirty(); };
     slRow.appendChild(slCb);
     slRow.appendChild(el('span', 'st-switch-label', 'Upload session transcripts to Corveil'));
     const slField = el('div', 'st-field');
     slField.appendChild(slRow);
-    slField.appendChild(el('div', 'st-help', hasGateway
-      ? 'Uploads this workspace’s coding-session transcripts to Corveil, reusing its AI-gateway URL and credential (no second key or host needed). That’s the only setting required — collector timing and size limits live under Settings → General → Session logs.'
-      : 'Turn on the AI Gateway for this workspace above first — the upload reuses its URL and credential.'));
+    slField.appendChild(el('div', 'st-help st-session-logs-help',
+      hasGateway ? SESSION_LOGS_HELP_ON : SESSION_LOGS_HELP_OFF));
     body.appendChild(slField);
 
     // Historical backfill (CROW-1075): reconcile the transcripts already on disk
@@ -216,10 +253,10 @@
     // choose. Reuses this workspace's gateway for the upload, so it's gated on one
     // being configured, exactly like the checkbox above.
     const bfField = el('div', 'st-field');
-    const bfBtn = el('button', 'action-btn', 'Backfill history…');
+    const bfBtn = el('button', 'action-btn st-backfill-btn', 'Backfill history…');
     bfBtn.type = 'button';
     bfBtn.disabled = !hasGateway;
-    if (!hasGateway) bfBtn.title = 'Turn on the AI Gateway for this workspace first — the upload reuses its URL and credential.';
+    if (!hasGateway) bfBtn.title = SESSION_LOGS_NEED_GATEWAY;
     bfBtn.onclick = () => openBackfillDialog(d.name);
     bfField.appendChild(bfBtn);
     bfField.appendChild(el('div', 'st-help',

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-workspaces.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings-workspaces.js
@@ -187,6 +187,9 @@
         await S.postConfig('/config/workspace-gateway',
           Object.assign({ workspaceId: d.id }, g ? { baseURL: g.baseURL, headers: g.customHeaders } : { clear: true }));
         d.gateway = g;
+        // Manual write/clear is not an org pick — drop the cached selection so
+        // the rebuilt dropdown does not keep showing the last org (#1213 review).
+        if (typeof S.forgetPickedOrg === 'function') S.forgetPickedOrg(d.id);
         S.render();
       };
       const manual = S.gatewayEditor(d.gateway || null, applyManual);

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/settings.js
@@ -617,6 +617,7 @@
     iconBtn, setRowIcon, listRow, deepCopy, uuid,
     get corveilConnected() { return (window.CrowSettingsTabs || {}).corveilConnected; },
     get orgGatewayEditor() { return (window.CrowSettingsTabs || {}).orgGatewayEditor; },
+    get forgetPickedOrg() { return (window.CrowSettingsTabs || {}).forgetPickedOrg; },
   };
 
   window.openSettings = openSettings;

--- a/Packages/CrowDaemon/web-tests/gateway-org-picker.test.js
+++ b/Packages/CrowDaemon/web-tests/gateway-org-picker.test.js
@@ -8,16 +8,20 @@ const { loadClientSource, loadSettingsSource } = require('./load-client');
 // Automation tab.
 //
 // Guards the three behaviours that are invisible in a string check and were the
-// round-1 review's Yellow findings:
+// round-1 review's Yellow findings, plus the CROW-1212 picker-state / flicker
+// regressions:
 //   1. Happy path: connected → an org dropdown is offered; picking an org calls
 //      corveil-select-org, POSTs { orgId } to /config/manager-gateway, and the card
 //      then shows the derived gateway. The browser never sends the key secret.
+//      The dropdown STAYS on the picked org (no snap-back to the placeholder).
 //   2. A failed pick RESETS the <select> back to the placeholder, so re-picking the
 //      SAME org fires `change` again (HTML `change` won't re-fire for an unchanged
 //      value, which would otherwise strand this ticket's primary control).
 //   3. A best-effort connection refresh that throws AFTER the gateway is written must
 //      NOT report the pick as failed — the gateway is stored, so the card shows it
 //      set and never prints "Failed:".
+//   4. Lazy corveil-list-orgs load and a successful pick update the picker in place
+//      — the settings modal node identity is unchanged (no innerHTML teardown).
 
 const epilogue = `
 ;globalThis.__t = {
@@ -185,6 +189,11 @@ const check = (name, cond) => {
       h.window.document.body.textContent.includes('Gateway set from your Corveil connection'));
     check('no key secret ever left the browser (POST body has no x-citadel value)',
       !JSON.stringify(h.calls.gatewayPosts).toLowerCase().includes('sk-citadel'));
+    const selAfter = orgSelect(h.window);
+    check('dropdown still shows the picked org (no snap-back to placeholder)',
+      !!selAfter && selAfter.value === 'org_acme');
+    check('same <select> after pick (picker updated in place, not via S.render)',
+      selAfter === sel);
   }
 
   console.log('\nA failed pick resets the select so the same org can be retried:');
@@ -216,6 +225,29 @@ const check = (name, cond) => {
       h.window.document.body.textContent.includes('Gateway set from your Corveil connection'));
     check('the pick was NOT reported as failed',
       !h.window.document.body.textContent.includes('Failed:'));
+  }
+
+  console.log('\nLazy org load does not rebuild the settings modal:');
+  {
+    let release;
+    const pending = new Promise((resolve) => { release = resolve; });
+    const h = load({ config: connectedConfig(), local: true });
+    h.hooks.listOrgs = () => pending.then(() => ({ orgs: [
+      { org_id: 'org_acme', org_name: 'Acme Corp', role: 'admin', is_active: true, provisioned: false },
+    ] }));
+    await h.T.openSettings('automation');
+    await drain();
+    const modal = h.window.document.querySelector('.settings-modal');
+    const sel = orgSelect(h.window);
+    check('loading placeholder shown before orgs arrive',
+      !!sel && /Loading/i.test(sel.options[0] && sel.options[0].textContent));
+    release();
+    await drain();
+    check('same settings modal after orgs arrive (no full-modal flicker)',
+      h.window.document.querySelector('.settings-modal') === modal);
+    check('same <select> after orgs arrive', orgSelect(h.window) === sel);
+    check('membership now in the dropdown',
+      !!sel && Array.from(sel.options).some((o) => o.value === 'org_acme'));
   }
 
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/Packages/CrowDaemon/web-tests/gateway-org-picker.test.js
+++ b/Packages/CrowDaemon/web-tests/gateway-org-picker.test.js
@@ -250,6 +250,50 @@ const check = (name, cond) => {
       !!sel && Array.from(sel.options).some((o) => o.value === 'org_acme'));
   }
 
+  console.log('\nAdvanced manual clear drops the cached org selection:');
+  {
+    const h = await openAutomation({ config: connectedConfig(), local: true });
+    const sel = orgSelect(h.window);
+    sel.value = 'org_acme';
+    await sel.onchange();
+    await drain();
+    check('picked org is selected before clear', orgSelect(h.window).value === 'org_acme');
+    // In-place pick does not rebuild the Advanced editor, so it still offers
+    // "Set gateway" (no Clear). Empty URL+headers is apply(null) — a clear.
+    const details = h.window.document.querySelector('details.st-advanced-gateway');
+    const save = Array.from(details.querySelectorAll('button'))
+      .find((b) => /^(Set|Update) gateway$/.test(b.textContent));
+    check('Advanced save is still offered after a pick', !!save);
+    await save.onclick();
+    await drain();
+    const selAfter = orgSelect(h.window);
+    check('dropdown snaps back to the placeholder after manual clear',
+      !!selAfter && selAfter.value === '');
+    check('status no longer claims a Corveil-derived gateway',
+      !h.window.document.body.textContent.includes('Gateway set from your Corveil connection'));
+  }
+
+  console.log('\nAdvanced manual set also drops the cached org selection:');
+  {
+    const h = await openAutomation({ config: connectedConfig(), local: true });
+    const sel = orgSelect(h.window);
+    sel.value = 'org_acme';
+    await sel.onchange();
+    await drain();
+    const details = h.window.document.querySelector('details.st-advanced-gateway');
+    details.querySelector('input.st-input').value = 'https://gateway.example.com';
+    details.querySelector('textarea').value = 'X-Api-Key: sk-test';
+    const save = Array.from(details.querySelectorAll('button'))
+      .find((b) => /^(Set|Update) gateway$/.test(b.textContent));
+    await save.onclick();
+    await drain();
+    const selAfter = orgSelect(h.window);
+    check('dropdown is placeholder after a manual gateway write',
+      !!selAfter && selAfter.value === '');
+    check('status shows a manually-entered gateway',
+      h.window.document.body.textContent.includes('A manually-entered gateway is set'));
+  }
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })().catch((e) => { console.error(e); process.exit(2); });

--- a/Packages/CrowDaemon/web-tests/workspace-logsync-autoenable.test.js
+++ b/Packages/CrowDaemon/web-tests/workspace-logsync-autoenable.test.js
@@ -255,6 +255,23 @@ const check = (name, cond) => {
       orgSelect(h.window) === sel && sel.value === 'org_acme');
   }
 
+  console.log('\nAdvanced manual clear on a workspace drops the cached org selection:');
+  {
+    const h = load({ config: connectedConfig(), logSyncEnabled: true });
+    await openWorkspaceForm(h);
+    await pickOrg(h);
+    check('picked org is selected before clear', orgSelect(h.window).value === 'org_acme');
+    const details = h.window.document.querySelector('details.st-advanced-gateway');
+    const save = Array.from(details.querySelectorAll('button'))
+      .find((b) => /^(Set|Update) gateway$/.test(b.textContent));
+    check('Advanced save is still offered after a pick', !!save);
+    await save.onclick();
+    await drain();
+    const selAfter = orgSelect(h.window);
+    check('dropdown snaps back to the placeholder after manual clear',
+      !!selAfter && selAfter.value === '');
+  }
+
   console.log(`\n${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 })().catch((e) => { console.error(e); process.exit(2); });

--- a/Packages/CrowDaemon/web-tests/workspace-logsync-autoenable.test.js
+++ b/Packages/CrowDaemon/web-tests/workspace-logsync-autoenable.test.js
@@ -182,6 +182,9 @@ const check = (name, cond) => {
       !JSON.stringify(h.calls.gatewayPosts).toLowerCase().includes('sk-citadel'));
     const cb = logSyncCheckbox(h.window);
     check('the "Upload session transcripts" box is now checked in the open form', !!cb && cb.checked === true);
+    const sel = orgSelect(h.window);
+    check('dropdown still shows the picked org (no snap-back to placeholder)',
+      !!sel && sel.value === 'org_acme');
   }
 
   console.log('\nThe opt-in survives Cancel + Save (not just the discarded draft):');
@@ -220,6 +223,36 @@ const check = (name, cond) => {
     const branch = h.window.document.querySelector('.settings-subform-overlay .settings-body .st-input')
       || h.window.document.querySelector('.settings-body .st-input');
     if (branch) { branch.value = 'x/'; if (branch.oninput) branch.oninput(); }
+  }
+
+  console.log('\nLazy org load / pick do not rebuild the workspace sub-form:');
+  {
+    let release;
+    const pending = new Promise((resolve) => { release = resolve; });
+    const h = load({ config: connectedConfig(), logSyncEnabled: true });
+    h.hooks.listOrgs = () => pending.then(() => ({ orgs: [
+      { org_id: 'org_acme', org_name: 'Acme Corp', role: 'admin', is_active: true, provisioned: false },
+    ] }));
+    await h.T.openSettings('workspaces');
+    const edit = byText(h.window, 'button[title="Edit"]', /.?/) ||
+      Array.from(h.window.document.querySelectorAll('button')).find((b) => b.title === 'Edit');
+    edit.onclick();
+    await drain();
+    const overlay = h.window.document.querySelector('.settings-subform-overlay');
+    const sel = orgSelect(h.window);
+    check('workspace overlay rendered while orgs load', !!overlay && !!sel);
+    release();
+    await drain();
+    check('same overlay after orgs arrive (no full-modal flicker)',
+      h.window.document.querySelector('.settings-subform-overlay') === overlay);
+    check('same <select> after orgs arrive', orgSelect(h.window) === sel);
+    sel.value = 'org_acme';
+    await sel.onchange();
+    await drain();
+    check('same overlay after pick',
+      h.window.document.querySelector('.settings-subform-overlay') === overlay);
+    check('same <select> after pick still showing the org',
+      orgSelect(h.window) === sel && sel.value === 'org_acme');
   }
 
   console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #1212

## Summary
- Track the just-picked Corveil org per gateway target so the Organization dropdown stays on that choice for the life of the Settings modal instead of snapping back to the placeholder.
- Repaint the shared org picker in place after `corveil-list-orgs` and after a successful pick, instead of calling `S.render()` (which tore down both modal layers via `innerHTML` and caused the flicker).
- Workspace session-log checkbox / backfill controls still update after a pick, via an in-place `onApplied` patch rather than a full sub-form rebuild. Manual Advanced gateway editor and the non-connected path are unchanged.

## Test plan
- [ ] Connect Crow to Corveil (Integrations → Connect), then Settings → Workspaces → edit a workspace → AI gateway.
- [ ] First open after connect: org list loads without the workspace modal flickering (focus/scroll stay put).
- [ ] Pick an organization: dropdown stays on that org (no snap-back to "Choose an organization…") and the "Gateway set from your Corveil connection" line updates.
- [ ] Same picker on Settings → Automation → Manager AI gateway behaves identically.
- [ ] Advanced / manual gateway editor and the disconnected (no Corveil connection) path still work as before.
- [ ] `node gateway-org-picker.test.js` and `node workspace-logsync-autoenable.test.js` in `Packages/CrowDaemon/web-tests`.


Made with [Cursor](https://cursor.com)