### PR TITLE
Extract a shared Claude MCP source reader from the harness Jira bridges

### DIFF
--- a/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityMCPConfigWriter.swift
+++ b/Packages/CrowAntigravity/Sources/CrowAntigravity/AntigravityMCPConfigWriter.swift
@@ -89,13 +89,14 @@ public enum AntigravityMCPConfigWriter {
         writeLock.lock()
         defer { writeLock.unlock() }
 
-        let claudePath = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
+        let claudePath = claudeJSONPath ?? ClaudeMCPSource.defaultPath()
 
         let sourceServer: [String: Any]?
-        switch readClaudeJira(claudeJSONPath: claudePath) {
-        case .found(let entry):
+        switch ClaudeMCPSource.lookupJira(from: claudePath) {
+        case .found(let entry, origin: let origin):
+            if case .project(let key) = origin {
+                CrowLog.info("[AntigravityMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global mcp_config.json")
+            }
             sourceServer = entry
         case .absent:
             sourceServer = nil
@@ -103,6 +104,7 @@ public enum AntigravityMCPConfigWriter {
             CrowLog.info("[AntigravityMCPConfigWriter] \(claudePath) missing/unreadable; leaving Antigravity mcp_config.json untouched")
             return .noSource
         case .unparseable:
+            CrowLog.info("[AntigravityMCPConfigWriter] \(claudePath) exists but is not a JSON object; ignoring")
             return .skippedUnparseable
         }
 
@@ -188,51 +190,10 @@ public enum AntigravityMCPConfigWriter {
     /// names `jira_*` only when a bridge is expected; an Antigravity-primary
     /// host with no Claude Jira MCP keeps the `acli` arm.
     public static func claudeHasJiraServer(claudeJSONPath: String? = nil) -> Bool {
-        let path = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
-        if case .found(let entry) = readClaudeJira(claudeJSONPath: path) {
+        if case .found(let entry, origin: _) = ClaudeMCPSource.lookupJira(from: claudeJSONPath) {
             return translateClaudeServer(entry) != nil
         }
         return false
-    }
-
-    // MARK: - Source
-
-    enum ClaudeJiraLookup {
-        case found([String: Any])
-        /// Parsed cleanly but declares no `jira` — safe to un-mirror.
-        case absent
-        /// Missing or unreadable — do not act.
-        case sourceUnavailable
-        /// Exists but isn't a JSON object.
-        case unparseable
-    }
-
-    /// Root `mcpServers` (user scope) preferred, else the first project-scoped
-    /// `jira` in sorted `projects[<path>].mcpServers` order — same widening
-    /// Cursor uses so Claude's default local-scope `mcp add` isn't missed.
-    static func readClaudeJira(claudeJSONPath: String) -> ClaudeJiraLookup {
-        guard let data = FileManager.default.contents(atPath: claudeJSONPath) else {
-            return .sourceUnavailable
-        }
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            CrowLog.info("[AntigravityMCPConfigWriter] \(claudeJSONPath) exists but is not a JSON object; ignoring")
-            return .unparseable
-        }
-        if let userScoped = (root["mcpServers"] as? [String: Any])?[serverName] as? [String: Any] {
-            return .found(userScoped)
-        }
-        if let projects = root["projects"] as? [String: Any] {
-            for key in projects.keys.sorted() {
-                if let servers = (projects[key] as? [String: Any])?["mcpServers"] as? [String: Any],
-                   let jira = servers[serverName] as? [String: Any] {
-                    CrowLog.info("[AntigravityMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global mcp_config.json")
-                    return .found(jira)
-                }
-            }
-        }
-        return .absent
     }
 
     // MARK: - Translation

--- a/Packages/CrowCodex/Sources/CrowCodex/CodexMCPWriter.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/CodexMCPWriter.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Mirrors the user's Claude Code MCP servers into Codex so a Codex session
@@ -98,25 +99,24 @@ public enum CodexMCPWriter {
 
     // MARK: - Claude parsing
 
-    /// Parse `~/.claude.json`'s `mcpServers` object into translated `Server`s,
+    /// Parse `~/.claude.json`'s user-scope `mcpServers` into translated `Server`s,
     /// dropping any definition Codex can't express (neither `command` nor
     /// `url`). Server order follows JSON key order sorted for determinism.
+    ///
+    /// **Root-only:** project-scoped `projects[<path>].mcpServers` are not
+    /// mirrored — they'd need per-worktree Codex config, which the
+    /// per-worktree-hooks deferral already parks. The narrowing is
+    /// `includeProjectScope: false` on the shared `ClaudeMCPSource` helper
+    /// (CROW-1214), not a second JSON walk.
     static func readClaudeServers(claudeJSONPath: String?) -> [Server] {
-        let path = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
-        guard let data = FileManager.default.contents(atPath: path),
-              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-              let mcp = root["mcpServers"] as? [String: Any]
-        else { return [] }
-
-        var servers: [Server] = []
-        for name in mcp.keys.sorted() {
-            guard let def = mcp[name] as? [String: Any],
-                  let server = translate(name: name, def: def) else { continue }
-            servers.append(server)
+        switch ClaudeMCPSource.load(from: claudeJSONPath) {
+        case .parsed(let snapshot):
+            return snapshot.servers(includeProjectScope: false).compactMap { item in
+                translate(name: item.name, def: item.entry)
+            }
+        case .sourceUnavailable, .unparseable:
+            return []
         }
-        return servers
     }
 
     /// Translate one Claude `mcpServers.<name>` definition into a `Server`.

--- a/Packages/CrowCodex/Tests/CrowCodexTests/CodexMCPWriterTests.swift
+++ b/Packages/CrowCodex/Tests/CrowCodexTests/CodexMCPWriterTests.swift
@@ -257,6 +257,25 @@ struct CodexMCPWriterTests {
         #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.toml").path))
     }
 
+    @Test func installSkipsProjectScopedServers() throws {
+        // CROW-1214: Codex's root-only narrowing is `includeProjectScope: false`
+        // on ClaudeMCPSource, not a second JSON walk. A project-local jira
+        // must not land in the global config.toml.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let claudePath = dir.appendingPathComponent("claude.json").path
+        try JSONSerialization.data(withJSONObject: [
+            "projects": [
+                "/repo": ["mcpServers": ["jira": ["command": "npx"]]],
+            ],
+        ]).write(to: URL(fileURLWithPath: claudePath))
+
+        let added = try CodexMCPWriter.installMCPConfig(codexHome: dir.path, claudeJSONPath: claudePath)
+        #expect(added.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.toml").path))
+    }
+
     @Test func installIsIdempotent() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Packages/CrowCore/Sources/CrowCore/Agent/ClaudeMCPSource.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/ClaudeMCPSource.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// Reads Claude Code's `~/.claude.json` MCP server map so harness writers
+/// (Cursor, OpenCode, Grok, Antigravity, Muse, Codex) share one parse of the
+/// source config (CROW-1214).
+///
+/// Destination translation, atomic 0600 writes, merge-preserve, and
+/// managed-marker/sidecar rules stay in each harness package. This type only
+/// answers: what did Claude declare, and can we trust the read?
+///
+/// **Lookup.** User-scope `mcpServers` wins. When `includeProjectScope` is
+/// true (the default — Claude's `mcp add` writes local scope under
+/// `projects[<path>].mcpServers`), the first project-scoped hit in **sorted**
+/// path order is returned so which server wins is deterministic. Codex passes
+/// `false` to keep its documented root-only narrowing in one place rather
+/// than an implicit fork of the walk.
+///
+/// **Outcomes.** Missing/unreadable, unparseable, and parsed-but-absent are
+/// distinct so callers keep today's fail-open vs fail-closed behavior (a
+/// torn read of the live 2 MB file must not look like "the user removed jira"
+/// and reap a valid bridged copy).
+public enum ClaudeMCPSource {
+
+    /// The server key every Jira bridge looks up — matches the `jira_*` tools
+    /// the launch prompts reference.
+    public static let jiraKey = "jira"
+
+    /// Default source path: `~/.claude.json`. Tests inject a fixture path
+    /// instead; never read the live file from a unit suite (ADR 0012).
+    public static func defaultPath(fileManager: FileManager = .default) -> String {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude.json").path
+    }
+
+    /// Where a server definition was found.
+    public enum Origin: Equatable, Sendable {
+        /// Root `mcpServers` (Claude's `-s user` / user scope).
+        case user
+        /// `projects[<path>].mcpServers` (Claude's default local scope).
+        case project(path: String)
+    }
+
+    /// Parsed `mcpServers` from both scopes. Values that aren't JSON objects
+    /// are dropped so callers always receive a dictionary they can translate.
+    public struct Snapshot {
+        /// Root `mcpServers`, keyed by server name. Empty when the key is absent.
+        public let userServers: [String: [String: Any]]
+        /// `projects[<path>].mcpServers` in sorted-path order. A project whose
+        /// value isn't an object, or that has no `mcpServers` object, is omitted.
+        public let projectServers: [(path: String, servers: [String: [String: Any]])]
+
+        /// User-scope `name` first; else the first project-scoped hit in sorted
+        /// path order. `includeProjectScope: false` is Codex's root-only gate.
+        public func server(
+            named name: String,
+            includeProjectScope: Bool = true
+        ) -> (entry: [String: Any], origin: Origin)? {
+            if let entry = userServers[name] {
+                return (entry, .user)
+            }
+            guard includeProjectScope else { return nil }
+            for (path, servers) in projectServers {
+                if let entry = servers[name] {
+                    return (entry, .project(path: path))
+                }
+            }
+            return nil
+        }
+
+        /// Every named server the caller should consider, user-scope first
+        /// (sorted names). When `includeProjectScope` is true, each project in
+        /// sorted-path order contributes names not already taken — user wins,
+        /// then earlier projects.
+        public func servers(includeProjectScope: Bool = true) -> [(name: String, entry: [String: Any], origin: Origin)] {
+            var seen = Set<String>()
+            var out: [(name: String, entry: [String: Any], origin: Origin)] = []
+            for name in userServers.keys.sorted() {
+                guard let entry = userServers[name] else { continue }
+                seen.insert(name)
+                out.append((name, entry, .user))
+            }
+            guard includeProjectScope else { return out }
+            for (path, servers) in projectServers {
+                for name in servers.keys.sorted() {
+                    guard !seen.contains(name), let entry = servers[name] else { continue }
+                    seen.insert(name)
+                    out.append((name, entry, .project(path: path)))
+                }
+            }
+            return out
+        }
+    }
+
+    /// Result of reading the Claude config file.
+    public enum LoadResult {
+        /// File parsed as a JSON object.
+        case parsed(Snapshot)
+        /// Path does not exist, or exists but could not be read.
+        case sourceUnavailable
+        /// File was read but is not a JSON object (truncated, JSONC, array).
+        case unparseable
+    }
+
+    /// Result of looking up one named server (typically `jira`).
+    public enum Lookup {
+        /// Found a definition at `origin`.
+        case found([String: Any], origin: Origin)
+        /// File parsed cleanly but declares no such server in the requested scopes.
+        case absent
+        /// Missing or unreadable — do not treat as "user removed it".
+        case sourceUnavailable
+        /// Exists but isn't a JSON object.
+        case unparseable
+    }
+
+    /// Read `path` (default `~/.claude.json`) into a snapshot.
+    public static func load(
+        from path: String? = nil,
+        fileManager: FileManager = .default
+    ) -> LoadResult {
+        let resolved = path ?? defaultPath(fileManager: fileManager)
+        guard let data = fileManager.contents(atPath: resolved) else {
+            return .sourceUnavailable
+        }
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .unparseable
+        }
+        return .parsed(Snapshot(
+            userServers: objectMap(root["mcpServers"]),
+            projectServers: projectServers(from: root)))
+    }
+
+    /// Look up one named server. User scope wins; else the first project-scoped
+    /// hit in sorted-path order when `includeProjectScope` is true.
+    public static func lookup(
+        server name: String = jiraKey,
+        includeProjectScope: Bool = true,
+        from path: String? = nil,
+        fileManager: FileManager = .default
+    ) -> Lookup {
+        switch load(from: path, fileManager: fileManager) {
+        case .sourceUnavailable:
+            return .sourceUnavailable
+        case .unparseable:
+            return .unparseable
+        case .parsed(let snapshot):
+            if let hit = snapshot.server(named: name, includeProjectScope: includeProjectScope) {
+                return .found(hit.entry, origin: hit.origin)
+            }
+            return .absent
+        }
+    }
+
+    /// Convenience for the Jira bridges — `lookup(server: "jira", …)`.
+    public static func lookupJira(
+        includeProjectScope: Bool = true,
+        from path: String? = nil,
+        fileManager: FileManager = .default
+    ) -> Lookup {
+        lookup(
+            server: jiraKey,
+            includeProjectScope: includeProjectScope,
+            from: path,
+            fileManager: fileManager)
+    }
+
+    // MARK: - Parse
+
+    private static func objectMap(_ value: Any?) -> [String: [String: Any]] {
+        guard let dict = value as? [String: Any] else { return [:] }
+        var out: [String: [String: Any]] = [:]
+        for (key, val) in dict {
+            if let obj = val as? [String: Any] {
+                out[key] = obj
+            }
+        }
+        return out
+    }
+
+    private static func projectServers(
+        from root: [String: Any]
+    ) -> [(path: String, servers: [String: [String: Any]])] {
+        guard let projects = root["projects"] as? [String: Any] else { return [] }
+        return projects.keys.sorted().compactMap { path in
+            guard let project = projects[path] as? [String: Any] else { return nil }
+            let servers = objectMap(project["mcpServers"])
+            guard !servers.isEmpty else { return nil }
+            return (path, servers)
+        }
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/ClaudeMCPSourceTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ClaudeMCPSourceTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+/// CROW-1214: one parse of `~/.claude.json` for every harness Jira bridge.
+/// Fixtures live under a throwaway temp dir — never the live `~/.claude.json`
+/// (ADR 0012).
+@Suite("ClaudeMCPSource")
+struct ClaudeMCPSourceTests {
+
+    private func tempJSON(_ name: String = ".claude.json") -> (dir: URL, path: String) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-mcp-source-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir, dir.appendingPathComponent(name).path)
+    }
+
+    private func write(_ obj: [String: Any], to path: String) throws {
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: obj).write(to: URL(fileURLWithPath: path))
+    }
+
+    private let jira: [String: Any] = [
+        "command": "jira-mcp",
+        "args": ["--stdio"],
+        "env": ["JIRA_TOKEN": "secret"],
+    ]
+
+    @Test func defaultPathIsDotClaudeJSON() {
+        #expect(ClaudeMCPSource.defaultPath().hasSuffix("/.claude.json"))
+    }
+
+    @Test func findsUserScopedJira() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write(["mcpServers": ["jira": jira, "other": ["command": "x"]]], to: path)
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .found(let entry, origin: .user):
+            #expect(entry["command"] as? String == "jira-mcp")
+            #expect((entry["env"] as? [String: Any])?["JIRA_TOKEN"] as? String == "secret")
+        default:
+            Issue.record("expected user-scoped jira")
+        }
+    }
+
+    @Test func userScopeWinsOverProjectScope() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write([
+            "mcpServers": ["jira": ["command": "user-jira"]],
+            "projects": [
+                "/z/repo": ["mcpServers": ["jira": ["command": "project-jira"]]],
+            ],
+        ], to: path)
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .found(let entry, origin: .user):
+            #expect(entry["command"] as? String == "user-jira")
+        default:
+            Issue.record("user-scope jira must win")
+        }
+    }
+
+    @Test func fallsBackToFirstProjectInSortedKeyOrder() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write([
+            "projects": [
+                "/z/repo": ["mcpServers": ["jira": ["command": "z-jira"]]],
+                "/a/repo": ["mcpServers": ["jira": ["command": "a-jira"]]],
+            ],
+        ], to: path)
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .found(let entry, origin: .project(let projectPath)):
+            #expect(projectPath == "/a/repo", "sorted-key order, not insertion order")
+            #expect(entry["command"] as? String == "a-jira")
+        default:
+            Issue.record("expected project-scoped jira from /a/repo")
+        }
+    }
+
+    @Test func parsedButNoJiraIsAbsent() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write(["mcpServers": ["other": ["command": "x"]]], to: path)
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .absent:
+            break
+        default:
+            Issue.record("parsed config with no jira must be .absent")
+        }
+    }
+
+    @Test func missingFileIsSourceUnavailable() {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .sourceUnavailable:
+            break
+        default:
+            Issue.record("missing file must not look like absent")
+        }
+    }
+
+    @Test func unparseableFileIsUnparseable() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
+        try "{ \"mcpServers\": {".write(toFile: path, atomically: true, encoding: .utf8)
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .unparseable:
+            break
+        default:
+            Issue.record("truncated JSON must be .unparseable, not .absent")
+        }
+    }
+
+    @Test func jsonArrayIsUnparseable() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try "[1, 2, 3]".write(toFile: path, atomically: true, encoding: .utf8)
+
+        switch ClaudeMCPSource.load(from: path) {
+        case .unparseable:
+            break
+        default:
+            Issue.record("a JSON array is not a Claude config object")
+        }
+    }
+
+    @Test func rootOnlyIgnoresProjectScopedServers() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write([
+            "projects": [
+                "/some/repo": ["mcpServers": ["jira": jira]],
+            ],
+        ], to: path)
+
+        switch ClaudeMCPSource.lookupJira(includeProjectScope: false, from: path) {
+        case .absent:
+            break
+        default:
+            Issue.record("Codex root-only narrowing must skip project-scoped jira")
+        }
+
+        switch ClaudeMCPSource.lookupJira(includeProjectScope: true, from: path) {
+        case .found(_, origin: .project):
+            break
+        default:
+            Issue.record("default lookup still finds project-scoped jira")
+        }
+    }
+
+    @Test func loadExposesAllUserServersForCodex() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write([
+            "mcpServers": [
+                "jira": ["command": "npx"],
+                "remote": ["type": "http", "url": "https://mcp.example.com"],
+            ],
+            "projects": [
+                "/repo": ["mcpServers": ["github": ["command": "gh-mcp"]]],
+            ],
+        ], to: path)
+
+        guard case .parsed(let snapshot) = ClaudeMCPSource.load(from: path) else {
+            Issue.record("expected parsed snapshot")
+            return
+        }
+        let rootOnly = snapshot.servers(includeProjectScope: false)
+        #expect(rootOnly.map(\.name) == ["jira", "remote"])
+        #expect(rootOnly.allSatisfy { $0.origin == .user })
+
+        let withProjects = snapshot.servers(includeProjectScope: true)
+        #expect(withProjects.map(\.name) == ["jira", "remote", "github"])
+    }
+
+    @Test func emptyObjectIsAbsentNotUnavailable() throws {
+        let (dir, path) = tempJSON()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write([:], to: path)
+
+        switch ClaudeMCPSource.lookupJira(from: path) {
+        case .absent:
+            break
+        default:
+            Issue.record("{} parsed cleanly with no jira")
+        }
+    }
+}

--- a/Packages/CrowCursor/Sources/CrowCursor/CursorMCPConfigWriter.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorMCPConfigWriter.swift
@@ -112,7 +112,7 @@ public enum CursorMCPConfigWriter {
         claudeJSONPath: String? = nil,
         cursorMCPPath: String? = nil
     ) {
-        let claudePath = claudeJSONPath ?? home(".claude.json")
+        let claudePath = claudeJSONPath ?? ClaudeMCPSource.defaultPath()
         let cursorPath = cursorMCPPath ?? home(".cursor/mcp.json")
 
         // Serialize the whole read-modify-write: the bridge fires unsynchronized
@@ -127,13 +127,18 @@ public enum CursorMCPConfigWriter {
         // file → do NOT touch cursor's config, or a bad read would delete a
         // valid bridged entry).
         let jiraEntry: [String: Any]
-        switch readClaudeJira(claudeJSONPath: claudePath) {
-        case .found(let entry):
+        switch ClaudeMCPSource.lookupJira(from: claudePath) {
+        case .found(let entry, origin: let origin):
+            if case .project(let key) = origin {
+                // Visibility: a project-scoped Claude MCP token is about to
+                // be promoted into Cursor's *global* config (every session).
+                CrowLog.info("[CursorMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global ~/.cursor/mcp.json")
+            }
             jiraEntry = entry
         case .absent:
             reapManagedJira(cursorMCPPath: cursorPath)
             return
-        case .sourceUnavailable:
+        case .sourceUnavailable, .unparseable:
             CrowLog.info("[CursorMCPConfigWriter] \(claudePath) missing/unreadable; leaving ~/.cursor/mcp.json untouched")
             return
         }
@@ -200,51 +205,6 @@ public enum CursorMCPConfigWriter {
             atomicWriteJSON(root, to: cursorMCPPath)
         }
         CrowLog.info("[CursorMCPConfigWriter] Reaped bridged `jira` MCP from \(cursorMCPPath) — no longer in Claude's config")
-    }
-
-    /// Outcome of looking for a `jira` server in Claude's config.
-    private enum ClaudeJiraLookup {
-        /// Found a `jira` server (user or project scope).
-        case found([String: Any])
-        /// `~/.claude.json` parsed cleanly but declares no `jira` anywhere —
-        /// the only signal that means "the user removed it" (safe to reap).
-        case absent
-        /// Missing, unreadable, or unparseable — do not act; a transient read
-        /// failure must not trigger a destructive reap.
-        case sourceUnavailable
-    }
-
-    /// Look for a `jira` server in Claude's config: root `mcpServers` (user
-    /// scope) preferred, else `projects[<path>].mcpServers` (local scope,
-    /// Claude's default). Project keys are scanned in **sorted** order so which
-    /// server wins is deterministic when multiple projects declare `jira`.
-    ///
-    /// Note the scope widening: a *project-local* Claude MCP is promoted into
-    /// Cursor's *global* `~/.cursor/mcp.json`, so a token scoped to one repo
-    /// becomes available to every Cursor session on the machine — the tradeoff
-    /// for MCP reachability across worktrees.
-    private static func readClaudeJira(claudeJSONPath: String) -> ClaudeJiraLookup {
-        guard let data = FileManager.default.contents(atPath: claudeJSONPath) else {
-            return .sourceUnavailable  // missing or unreadable
-        }
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return .sourceUnavailable  // unparseable (e.g. truncated/interleaved read)
-        }
-        if let userScoped = (root["mcpServers"] as? [String: Any])?[serverKey] as? [String: Any] {
-            return .found(userScoped)
-        }
-        if let projects = root["projects"] as? [String: Any] {
-            for key in projects.keys.sorted() {
-                if let servers = (projects[key] as? [String: Any])?["mcpServers"] as? [String: Any],
-                   let jira = servers[serverKey] as? [String: Any] {
-                    // Visibility: a project-scoped Claude MCP token is about to
-                    // be promoted into Cursor's *global* config (every session).
-                    CrowLog.info("[CursorMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global ~/.cursor/mcp.json")
-                    return .found(jira)
-                }
-            }
-        }
-        return .absent  // parsed fine, no jira in any scope
     }
 
     private static func home(_ relative: String) -> String {

--- a/Packages/CrowGrok/Sources/CrowGrok/GrokMCPConfigWriter.swift
+++ b/Packages/CrowGrok/Sources/CrowGrok/GrokMCPConfigWriter.swift
@@ -84,13 +84,14 @@ public enum GrokMCPConfigWriter {
         writeLock.lock()
         defer { writeLock.unlock() }
 
-        let claudePath = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
+        let claudePath = claudeJSONPath ?? ClaudeMCPSource.defaultPath()
 
         let sourceServer: [String: Any]?
-        switch readClaudeJira(claudeJSONPath: claudePath) {
-        case .found(let entry):
+        switch ClaudeMCPSource.lookupJira(from: claudePath) {
+        case .found(let entry, origin: let origin):
+            if case .project(let key) = origin {
+                CrowLog.info("[GrokMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global Grok config.toml")
+            }
             sourceServer = entry
         case .absent:
             sourceServer = nil
@@ -98,6 +99,7 @@ public enum GrokMCPConfigWriter {
             CrowLog.info("[GrokMCPConfigWriter] \(claudePath) missing/unreadable; leaving Grok config.toml untouched")
             return .noSource
         case .unparseable:
+            CrowLog.info("[GrokMCPConfigWriter] \(claudePath) exists but is not a JSON object; ignoring")
             return .skippedUnparseable
         }
 
@@ -177,51 +179,10 @@ public enum GrokMCPConfigWriter {
     /// `jira_*` only when a bridge is expected; a Grok-primary host with no
     /// Claude Jira MCP keeps the `acli` arm.
     public static func claudeHasJiraServer(claudeJSONPath: String? = nil) -> Bool {
-        let path = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
-        if case .found(let entry) = readClaudeJira(claudeJSONPath: path) {
+        if case .found(let entry, origin: _) = ClaudeMCPSource.lookupJira(from: claudeJSONPath) {
             return translateClaudeServer(name: serverName, def: entry) != nil
         }
         return false
-    }
-
-    // MARK: - Source
-
-    enum ClaudeJiraLookup {
-        case found([String: Any])
-        /// Parsed cleanly but declares no `jira` — safe to un-mirror.
-        case absent
-        /// Missing or unreadable — do not act.
-        case sourceUnavailable
-        /// Exists but isn't a JSON object.
-        case unparseable
-    }
-
-    /// Root `mcpServers` (user scope) preferred, else the first project-scoped
-    /// `jira` in sorted `projects[<path>].mcpServers` order — same widening
-    /// Cursor uses so Claude's default local-scope `mcp add` isn't missed.
-    static func readClaudeJira(claudeJSONPath: String) -> ClaudeJiraLookup {
-        guard let data = FileManager.default.contents(atPath: claudeJSONPath) else {
-            return .sourceUnavailable
-        }
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            CrowLog.info("[GrokMCPConfigWriter] \(claudeJSONPath) exists but is not a JSON object; ignoring")
-            return .unparseable
-        }
-        if let userScoped = (root["mcpServers"] as? [String: Any])?[serverName] as? [String: Any] {
-            return .found(userScoped)
-        }
-        if let projects = root["projects"] as? [String: Any] {
-            for key in projects.keys.sorted() {
-                if let servers = (projects[key] as? [String: Any])?["mcpServers"] as? [String: Any],
-                   let jira = servers[serverName] as? [String: Any] {
-                    CrowLog.info("[GrokMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global Grok config.toml")
-                    return .found(jira)
-                }
-            }
-        }
-        return .absent
     }
 
     // MARK: - Translation

--- a/Packages/CrowMuse/Sources/CrowMuse/MuseMCPConfigWriter.swift
+++ b/Packages/CrowMuse/Sources/CrowMuse/MuseMCPConfigWriter.swift
@@ -104,13 +104,14 @@ public enum MuseMCPConfigWriter {
         writeLock.lock()
         defer { writeLock.unlock() }
 
-        let claudePath = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
+        let claudePath = claudeJSONPath ?? ClaudeMCPSource.defaultPath()
 
         let sourceServer: [String: Any]?
-        switch readClaudeJira(claudeJSONPath: claudePath) {
-        case .found(let entry):
+        switch ClaudeMCPSource.lookupJira(from: claudePath) {
+        case .found(let entry, origin: let origin):
+            if case .project(let key) = origin {
+                CrowLog.info("[MuseMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global Muse settings.json")
+            }
             sourceServer = entry
         case .absent:
             sourceServer = nil
@@ -118,6 +119,7 @@ public enum MuseMCPConfigWriter {
             CrowLog.info("[MuseMCPConfigWriter] \(claudePath) missing/unreadable; leaving Muse settings.json untouched")
             return .noSource
         case .unparseable:
+            CrowLog.info("[MuseMCPConfigWriter] \(claudePath) exists but is not a JSON object; ignoring")
             return .skippedUnparseable
         }
 
@@ -207,51 +209,10 @@ public enum MuseMCPConfigWriter {
     /// `jira_*` only when a bridge is expected; a Muse-primary host with no
     /// Claude Jira MCP keeps the `acli` arm.
     public static func claudeHasJiraServer(claudeJSONPath: String? = nil) -> Bool {
-        let path = claudeJSONPath
-            ?? FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude.json").path
-        if case .found(let entry) = readClaudeJira(claudeJSONPath: path) {
+        if case .found(let entry, origin: _) = ClaudeMCPSource.lookupJira(from: claudeJSONPath) {
             return translateClaudeServer(entry) != nil
         }
         return false
-    }
-
-    // MARK: - Source
-
-    enum ClaudeJiraLookup {
-        case found([String: Any])
-        /// Parsed cleanly but declares no `jira` — safe to un-mirror.
-        case absent
-        /// Missing or unreadable — do not act.
-        case sourceUnavailable
-        /// Exists but isn't a JSON object.
-        case unparseable
-    }
-
-    /// Root `mcpServers` (user scope) preferred, else the first project-scoped
-    /// `jira` in sorted `projects[<path>].mcpServers` order — same widening
-    /// Cursor uses so Claude's default local-scope `mcp add` isn't missed.
-    static func readClaudeJira(claudeJSONPath: String) -> ClaudeJiraLookup {
-        guard let data = FileManager.default.contents(atPath: claudeJSONPath) else {
-            return .sourceUnavailable
-        }
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            CrowLog.info("[MuseMCPConfigWriter] \(claudeJSONPath) exists but is not a JSON object; ignoring")
-            return .unparseable
-        }
-        if let userScoped = (root["mcpServers"] as? [String: Any])?[serverName] as? [String: Any] {
-            return .found(userScoped)
-        }
-        if let projects = root["projects"] as? [String: Any] {
-            for key in projects.keys.sorted() {
-                if let servers = (projects[key] as? [String: Any])?["mcpServers"] as? [String: Any],
-                   let jira = servers[serverName] as? [String: Any] {
-                    CrowLog.info("[MuseMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global Muse settings.json")
-                    return .found(jira)
-                }
-            }
-        }
-        return .absent
     }
 
     // MARK: - Translation

--- a/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
+++ b/Packages/CrowOpenCode/Sources/CrowOpenCode/OpenCodeMCPConfigWriter.swift
@@ -81,15 +81,25 @@ public enum OpenCodeMCPConfigWriter {
     ) -> Outcome {
         let fm = FileManager.default
 
-        // 1. Read the source `jira` server from the Claude config. Distinguish
-        //    "absent" (→ un-mirror) from "present but untranslatable" (→ leave
-        //    the mirror alone) from "unparseable" (→ refuse).
-        let claudePath = claudeJSONPath
-            ?? fm.homeDirectoryForCurrentUser.appendingPathComponent(".claude.json").path
+        // 1. Read the source `jira` server via the shared Claude parse
+        //    (CROW-1214). Distinguish "absent" (→ un-mirror) from "present but
+        //    untranslatable" (→ leave the mirror alone) from "unparseable"
+        //    (→ refuse). Missing/unreadable stays fail-open (treat as absent).
+        let claudePath = claudeJSONPath ?? ClaudeMCPSource.defaultPath()
         let sourceServer: [String: Any]?
-        switch readClaudeJiraServer(claudeJSONPath: claudePath) {
-        case .success(let server): sourceServer = server
-        case .unparseable: return .skippedUnparseable
+        switch ClaudeMCPSource.lookupJira(from: claudePath) {
+        case .found(let entry, origin: let origin):
+            if case .project(let key) = origin {
+                CrowLog.info("[OpenCodeMCPConfigWriter] Promoting project-scoped `jira` MCP from \(key) into global opencode.json")
+            }
+            sourceServer = entry
+        case .absent, .sourceUnavailable:
+            // Missing ~/.claude.json historically reads as "no jira" (fail-open
+            // un-mirror). Parsed-but-absent is the same outcome for the caller.
+            sourceServer = nil
+        case .unparseable:
+            CrowLog.info("[OpenCodeMCPConfigWriter] \(claudePath) exists but is not a JSON object; ignoring")
+            return .skippedUnparseable
         }
 
         // 2. Load the Crow-owned `opencode.json` (if any).
@@ -256,29 +266,6 @@ public enum OpenCodeMCPConfigWriter {
         } catch {
             CrowLog.info("[OpenCodeMCPConfigWriter] Failed to write mirror record \(path): \(error.localizedDescription)")
         }
-    }
-
-    // MARK: - Source
-
-    enum ClaudeReadResult {
-        case success([String: Any]?)
-        case unparseable
-    }
-
-    /// The `mcpServers.jira` object from `~/.claude.json`, or `nil` when absent.
-    /// A file that exists but isn't a JSON object is reported as `.unparseable`
-    /// so the caller refuses to proceed (rather than silently overwriting).
-    static func readClaudeJiraServer(claudeJSONPath: String) -> ClaudeReadResult {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: claudeJSONPath) else { return .success(nil) }
-        guard let data = fm.contents(atPath: claudeJSONPath),
-              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-        else {
-            CrowLog.info("[OpenCodeMCPConfigWriter] \(claudeJSONPath) exists but is not a JSON object; ignoring")
-            return .unparseable
-        }
-        let servers = root["mcpServers"] as? [String: Any]
-        return .success(servers?[serverName] as? [String: Any])
     }
 
     // MARK: - Translation

--- a/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
+++ b/Packages/CrowOpenCode/Tests/CrowOpenCodeTests/OpenCodeMCPConfigWriterTests.swift
@@ -338,4 +338,33 @@ struct OpenCodeMCPConfigWriterTests {
         let jira = try #require((root["mcp"] as? [String: Any])?["jira"] as? [String: Any])
         #expect(jira["url"] as? String == "https://mine.example.net")
     }
+
+    @Test func promotesProjectScopedClaudeJira() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-mcp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let claude = tmp.appendingPathComponent(".claude.json")
+        try JSONSerialization.data(withJSONObject: [
+            "projects": [
+                "/some/repo": [
+                    "mcpServers": ["jira": ["command": "uvx", "args": ["mcp-atlassian"]]],
+                ],
+            ],
+        ]).write(to: claude)
+
+        let configHome = tmp.appendingPathComponent("opencode")
+        try FileManager.default.createDirectory(at: configHome, withIntermediateDirectories: true)
+        let outcome = OpenCodeMCPConfigWriter.installGlobalMCPConfig(
+            configHome: configHome.path,
+            claudeJSONPath: claude.path,
+            mirrorRecordPath: tmp.appendingPathComponent("mirror.json").path)
+        #expect(outcome == .registered)
+        let root = try #require(
+            FileManager.default.contents(atPath: configHome.appendingPathComponent("opencode.json").path)
+                .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        let jira = try #require((root["mcp"] as? [String: Any])?["jira"] as? [String: Any])
+        #expect(jira["command"] as? [String] == ["uvx", "mcp-atlassian"])
+    }
 }


### PR DESCRIPTION
Closes #1214

## Summary
- Add `ClaudeMCPSource` in CrowCore so every harness Jira bridge shares one parse of `~/.claude.json` (user-scope first, then the first project-scoped server in sorted-key order).
- Distinguish missing/unreadable vs unparseable vs parsed-but-absent so each writer keeps today's fail-open vs fail-closed behavior; Codex's root-only narrowing is `includeProjectScope: false` instead of a second JSON walk.
- Destination writers still own translation, atomic 0600 writes, merge-preserve, and managed-marker/sidecar rules.

## Test plan
- [ ] `swift test --package-path Packages/CrowCore --filter ClaudeMCPSource` covers user-scope, project-scope (sorted keys), missing, unparseable, and Codex root-only.
- [ ] Cursor / OpenCode / Grok / Antigravity / Muse / Codex MCP writer suites still pin merge-preserve and don't-clobber-user-authored.
- [ ] `git grep readClaudeJira` is empty; `readClaudeServers` is a thin `ClaudeMCPSource` wrapper with no local `mcpServers` / `projects` walk.


Made with [Cursor](https://cursor.com)