### PR TITLE
Find GitHub PRs by Closes #N, not only the worktree branch

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/PRLinkReconciler.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/PRLinkReconciler.swift
@@ -7,12 +7,13 @@ import CrowProvider
 /// Session ↔ PR link detection and reconciliation, extracted from
 /// `IssueTracker` (CROW-1094). The reactive `applySessionPRLinks` pass attaches
 /// links from the viewer-PR payload; `reconcileMissingPRLinks` queries providers
-/// directly by (repoSlug, branch) or ticket key for sessions still missing a
-/// `.pr` link. Writes links through the shared, injected `JSONStore`
-/// (ADR 0012 / #728) and `appState` via an unowned back-reference. Pure decision
-/// helpers stay `nonisolated static` for unit testing. `public` because the
-/// session-capability predicates `canAddMergeLabel` / `canSetProjectStatus` are
-/// cross-module API (re-exposed under the old `IssueTracker.` spelling).
+/// directly by (repoSlug, branch), Jira ticket key, or GitHub `Closes #N`
+/// (CROW-1221) for sessions still missing a `.pr` link. Writes links through
+/// the shared, injected `JSONStore` (ADR 0012 / #728) and `appState` via an
+/// unowned back-reference. Pure decision helpers stay `nonisolated static` for
+/// unit testing. `public` because the session-capability predicates
+/// `canAddMergeLabel` / `canSetProjectStatus` are cross-module API (re-exposed
+/// under the old `IssueTracker.` spelling).
 @MainActor
 public final class PRLinkReconciler {
     private unowned let owner: IssueTracker
@@ -244,7 +245,9 @@ public final class PRLinkReconciler {
         }
 
         // Jira-tasked sessions: find the PR by the ticket key it references,
-        // since the PR branch won't match the worktree branch. Feeds the same
+        // since the PR branch won't match the worktree branch. GitHub-tasked
+        // sessions: find the PR by `Closes #N` when the registered branch is
+        // missing, empty, or renamed (CROW-1221). Feeds the same
         // `decideReconcileLinks` so a key-found and branch-found PR for one
         // session resolve to a single best pick.
         matches.append(contentsOf: await fetchPRsByKeyForReconcile(candidates: keyCandidates))
@@ -304,11 +307,18 @@ public final class PRLinkReconciler {
         return out
     }
 
-    /// Build key-based reconcile candidates: Jira-tasked sessions missing a PR
-    /// link, whose PR is discoverable by the ticket key (e.g. `MAXX-6859`)
-    /// rather than by branch. Gated on a Jira ticket URL so GitHub/GitLab-tasked
-    /// sessions are untouched (they keep pure branch matching). Runs on
-    /// MainActor; safe to read appState directly.
+    /// Build key-based reconcile candidates for sessions missing a `.pr` link.
+    ///
+    /// - **Jira:** ticket key (`MAXX-6859`) from the browse URL or, for
+    ///   task-only trackers, from the worktree branch. Still needs a worktree
+    ///   to resolve `repoSlug` from the git remote — Jira URLs have no GitHub
+    ///   slug.
+    /// - **GitHub:** issue number (`#473`) from `ticketNumber` / `ticketURL`.
+    ///   `owner/repo` comes from the issue URL when present, so a missing
+    ///   worktree no longer drops the session (CROW-1221). GitLab stays on
+    ///   branch matching.
+    ///
+    /// Runs on MainActor; safe to read appState directly.
     private func buildReconcileKeyCandidates() -> [ReconcileKeyCandidate] {
         var out: [ReconcileKeyCandidate] = []
         for session in appState.sessions {
@@ -319,7 +329,7 @@ public final class PRLinkReconciler {
             guard !links.contains(where: { $0.linkType == .pr }) else { continue }
 
             let wts = appState.worktrees(for: session.id)
-            guard let primaryWt = wts.first(where: { $0.isPrimary }) ?? wts.first else { continue }
+            let primaryWt = wts.first(where: { $0.isPrimary }) ?? wts.first
 
             // Resolve the ticket key: prefer a Jira ticket URL, else derive it
             // from the worktree branch (e.g. `feature/max-monorepo-maxx-7035-…`
@@ -330,39 +340,110 @@ public final class PRLinkReconciler {
             // a lowercased branch can't distinguish a real Jira project ("maxx")
             // from an ordinary word/repo segment ("api"), so a GitHub/GitLab
             // issue branch like `feature/acme-api-197-fix` would yield a bogus
-            // "API-197" key. Those sessions resolve via the branch path instead.
+            // "API-197" key. Those sessions resolve via the GitHub issue-number
+            // path (below) or the branch path.
             let urlKey = session.ticketURL.flatMap {
                 Validation.isJiraSpec($0) ? Validation.jiraKey(from: $0) : nil
             }
             let branchKey = (session.provider?.isTaskOnly == true)
-                ? Validation.ticketKey(fromBranch: primaryWt.branch) : nil
-            guard let key = urlKey ?? branchKey else { continue }
+                ? primaryWt.flatMap { Validation.ticketKey(fromBranch: $0.branch) } : nil
+            if let key = urlKey ?? branchKey {
+                // Jira still needs a worktree: the browse URL has no GitHub slug.
+                guard let primaryWt else { continue }
+                let info = resolveRepoInfo(worktree: primaryWt)
+                guard !info.slug.isEmpty else { continue }
 
-            let info = resolveRepoInfo(worktree: primaryWt)
-            guard !info.slug.isEmpty else { continue }
+                let (provider, gitlabHost) = Self.resolveReconcileProvider(
+                    codeProvider: session.codeProvider,
+                    provider: session.provider,
+                    host: info.host
+                )
+                if provider == .gitlab, gitlabHost == nil { continue }
 
-            let (provider, gitlabHost) = Self.resolveReconcileProvider(
-                codeProvider: session.codeProvider,
-                provider: session.provider,
-                host: info.host
-            )
-            if provider == .gitlab, gitlabHost == nil { continue }
+                out.append(ReconcileKeyCandidate(
+                    sessionID: session.id,
+                    provider: provider,
+                    repoSlug: info.slug,
+                    key: key,
+                    gitlabHost: gitlabHost
+                ))
+                continue
+            }
 
-            out.append(ReconcileKeyCandidate(
+            // GitHub issue-number path — worktree optional when ticketURL
+            // already encodes owner/repo (CROW-1221).
+            let info = primaryWt.map { resolveRepoInfo(worktree: $0) }
+            if let cand = Self.githubIssueKeyCandidate(
                 sessionID: session.id,
-                provider: provider,
-                repoSlug: info.slug,
-                key: key,
-                gitlabHost: gitlabHost
-            ))
+                ticketURL: session.ticketURL,
+                ticketNumber: session.ticketNumber,
+                provider: session.provider,
+                codeProvider: session.codeProvider,
+                worktreeSlug: info?.slug ?? "",
+                worktreeHost: info?.host ?? ""
+            ) {
+                out.append(cand)
+            }
         }
         return out
     }
 
-    /// Resolve PR links for Jira-tasked sessions by searching the code repo for
-    /// the ticket key. GitHub only today (the `CodeBackend` default returns no
-    /// matches for providers without text PR search). Best-effort: a backend
-    /// error skips the cycle rather than dropping links.
+    /// Pure builder for a GitHub-tasked `#<ticketNumber>` reconcile candidate.
+    /// Returns nil for Jira (task-only), GitLab, missing number, or when neither
+    /// the issue URL nor a worktree can supply `owner/repo`. Prefers the slug
+    /// parsed from `ticketURL` so a session with no registered worktree still
+    /// reconciles (CROW-1221 / #1218).
+    nonisolated static func githubIssueKeyCandidate(
+        sessionID: UUID,
+        ticketURL: String?,
+        ticketNumber: Int?,
+        provider: Provider?,
+        codeProvider: Provider?,
+        worktreeSlug: String,
+        worktreeHost: String
+    ) -> ReconcileKeyCandidate? {
+        if provider?.isTaskOnly == true || provider == .gitlab { return nil }
+        if let url = ticketURL, !url.contains("github.com") { return nil }
+
+        guard let number = githubIssueNumber(ticketURL: ticketURL, ticketNumber: ticketNumber) else {
+            return nil
+        }
+
+        let urlSlug = repoSlug(fromTicketURL: ticketURL ?? "")
+        let slug = urlSlug.isEmpty ? worktreeSlug : urlSlug
+        guard !slug.isEmpty else { return nil }
+        let host = urlSlug.isEmpty ? worktreeHost : "github.com"
+
+        let (resolved, gitlabHost) = resolveReconcileProvider(
+            codeProvider: codeProvider, provider: provider, host: host)
+        guard resolved == .github else { return nil }
+
+        return ReconcileKeyCandidate(
+            sessionID: sessionID,
+            provider: .github,
+            repoSlug: slug,
+            key: "#\(number)",
+            gitlabHost: gitlabHost
+        )
+    }
+
+    /// Issue number for GitHub-tasked reconcile: `ticketNumber` when set,
+    /// otherwise the `/issues/<n>` tail of a github.com ticket URL (query and
+    /// fragment stripped). Ignores `/pull/<n>` URLs — those are PRs, not tickets.
+    nonisolated static func githubIssueNumber(ticketURL: String?, ticketNumber: Int?) -> Int? {
+        if let ticketNumber, ticketNumber > 0 { return ticketNumber }
+        guard let url = ticketURL, url.contains("github.com") else { return nil }
+        guard let range = url.range(of: "/issues/", options: .caseInsensitive) else { return nil }
+        let rest = url[range.upperBound...]
+        let digits = rest.prefix { $0.isNumber }
+        guard let n = Int(digits), n > 0 else { return nil }
+        return n
+    }
+
+    /// Resolve PR links by searching the code repo for a ticket key (`MAXX-6859`)
+    /// or GitHub issue number (`#473`). GitHub only today (the `CodeBackend`
+    /// default returns no matches for providers without text PR search).
+    /// Best-effort: a backend error skips the cycle rather than dropping links.
     private func fetchPRsByKeyForReconcile(candidates: [ReconcileKeyCandidate]) async -> [ReconcileBranchMatch] {
         let github = candidates.filter { $0.provider == .github }
         guard !github.isEmpty, let backend = providerManager.codeBackend(for: .github) else { return [] }
@@ -615,6 +696,17 @@ public final class PRLinkReconciler {
     /// URL can't be parsed. Distinct from `extractSlug(fromRemote:)`, which
     /// parses git *remote* URLs (no `/pull/...` suffix).
     nonisolated static func repoSlug(fromPRURL url: String) -> String {
+        repoSlug(fromWebURL: url, stoppingAt: ["pull", "merge_requests", "-"])
+    }
+
+    /// Same as `repoSlug(fromPRURL:)` but also stops at `issues`, so a GitHub
+    /// ticket URL (`https://github.com/owner/repo/issues/473`) yields `owner/repo`
+    /// without needing a worktree remote (CROW-1221).
+    nonisolated static func repoSlug(fromTicketURL url: String) -> String {
+        repoSlug(fromWebURL: url, stoppingAt: ["pull", "merge_requests", "-", "issues"])
+    }
+
+    private nonisolated static func repoSlug(fromWebURL url: String, stoppingAt markers: Set<String>) -> String {
         let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let range = trimmed.range(of: #"^https?://[^/]+/"#, options: .regularExpression) else {
             return ""
@@ -622,7 +714,7 @@ public final class PRLinkReconciler {
         let path = String(trimmed[range.upperBound...])
         var segments: [String] = []
         for segment in path.split(separator: "/").map(String.init) {
-            if segment == "pull" || segment == "merge_requests" || segment == "-" { break }
+            if markers.contains(segment) { break }
             segments.append(segment)
         }
         return segments.joined(separator: "/")
@@ -719,6 +811,34 @@ extension IssueTracker {
 
     nonisolated static func repoSlug(fromPRURL url: String) -> String {
         PRLinkReconciler.repoSlug(fromPRURL: url)
+    }
+
+    nonisolated static func repoSlug(fromTicketURL url: String) -> String {
+        PRLinkReconciler.repoSlug(fromTicketURL: url)
+    }
+
+    nonisolated static func githubIssueKeyCandidate(
+        sessionID: UUID,
+        ticketURL: String?,
+        ticketNumber: Int?,
+        provider: Provider?,
+        codeProvider: Provider?,
+        worktreeSlug: String,
+        worktreeHost: String
+    ) -> ReconcileKeyCandidate? {
+        PRLinkReconciler.githubIssueKeyCandidate(
+            sessionID: sessionID,
+            ticketURL: ticketURL,
+            ticketNumber: ticketNumber,
+            provider: provider,
+            codeProvider: codeProvider,
+            worktreeSlug: worktreeSlug,
+            worktreeHost: worktreeHost
+        )
+    }
+
+    nonisolated static func githubIssueNumber(ticketURL: String?, ticketNumber: Int?) -> Int? {
+        PRLinkReconciler.githubIssueNumber(ticketURL: ticketURL, ticketNumber: ticketNumber)
     }
 
     public nonisolated static func canAddMergeLabel(session: Session, providerManager: ProviderManager) -> Bool {

--- a/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReconcileTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/IssueTrackerReconcileTests.swift
@@ -486,3 +486,231 @@ struct IssueTrackerReconcileKeyScenarioTests {
         #expect(Set(final.map(\.url)).count == final.count)
     }
 }
+
+@Suite("IssueTracker ticket-URL slug extraction (CROW-1221)")
+struct IssueTrackerTicketSlugTests {
+    @Test func parsesGitHubIssueURL() {
+        #expect(
+            IssueTracker.repoSlug(fromTicketURL: "https://github.com/corveil/shell-crm/issues/473")
+                == "corveil/shell-crm"
+        )
+    }
+
+    @Test func parsesGitHubIssueURLWithQueryAndFragment() {
+        #expect(
+            IssueTracker.repoSlug(fromTicketURL: "https://github.com/org/repo/issues/42?tab=comments")
+                == "org/repo"
+        )
+        #expect(
+            IssueTracker.repoSlug(fromTicketURL: "https://github.com/org/repo/issues/42#issuecomment-1")
+                == "org/repo"
+        )
+    }
+
+    @Test func stillParsesPRURLs() {
+        #expect(
+            IssueTracker.repoSlug(fromTicketURL: "https://github.com/owner/repo/pull/123")
+                == "owner/repo"
+        )
+    }
+
+    @Test func returnsEmptyForUnrecognized() {
+        #expect(IssueTracker.repoSlug(fromTicketURL: "") == "")
+        #expect(IssueTracker.repoSlug(fromTicketURL: "github.com/org/repo/issues/1") == "")
+    }
+}
+
+@Suite("IssueTracker GitHub issue-number candidate (CROW-1221)")
+struct IssueTrackerGitHubIssueCandidateTests {
+
+    private let sid = UUID()
+
+    private func candidate(
+        ticketURL: String?,
+        ticketNumber: Int?,
+        provider: Provider?,
+        codeProvider: Provider? = nil,
+        worktreeSlug: String = "",
+        worktreeHost: String = ""
+    ) -> IssueTracker.ReconcileKeyCandidate? {
+        IssueTracker.githubIssueKeyCandidate(
+            sessionID: sid,
+            ticketURL: ticketURL,
+            ticketNumber: ticketNumber,
+            provider: provider,
+            codeProvider: codeProvider,
+            worktreeSlug: worktreeSlug,
+            worktreeHost: worktreeHost
+        )
+    }
+
+    @Test func slugFromTicketURLDoesNotNeedWorktree() {
+        // The #1218 session: ticket URL encodes owner/repo, no registered worktree.
+        let cand = candidate(
+            ticketURL: "https://github.com/corveil/shell-crm/issues/473",
+            ticketNumber: 473,
+            provider: .github
+        )
+        #expect(cand?.repoSlug == "corveil/shell-crm")
+        #expect(cand?.key == "#473")
+        #expect(cand?.provider == .github)
+        #expect(cand?.sessionID == sid)
+    }
+
+    @Test func fallsBackToWorktreeSlugWhenURLMissing() {
+        let cand = candidate(
+            ticketURL: nil,
+            ticketNumber: 473,
+            provider: .github,
+            worktreeSlug: "corveil/shell-crm",
+            worktreeHost: "github.com"
+        )
+        #expect(cand?.repoSlug == "corveil/shell-crm")
+        #expect(cand?.key == "#473")
+    }
+
+    @Test func prefersTicketURLSlugOverWorktree() {
+        let cand = candidate(
+            ticketURL: "https://github.com/corveil/shell-crm/issues/473",
+            ticketNumber: 473,
+            provider: .github,
+            worktreeSlug: "other/repo",
+            worktreeHost: "github.com"
+        )
+        #expect(cand?.repoSlug == "corveil/shell-crm")
+    }
+
+    @Test func numberFromURLWhenTicketNumberNil() {
+        #expect(
+            IssueTracker.githubIssueNumber(
+                ticketURL: "https://github.com/org/repo/issues/42?tab=comments",
+                ticketNumber: nil
+            ) == 42
+        )
+        let cand = candidate(
+            ticketURL: "https://github.com/org/repo/issues/42?tab=comments",
+            ticketNumber: nil,
+            provider: .github
+        )
+        #expect(cand?.key == "#42")
+    }
+
+    @Test func skipsJiraTaskOnly() {
+        #expect(candidate(
+            ticketURL: "https://acme.atlassian.net/browse/MAXX-6859",
+            ticketNumber: 6859,
+            provider: .jira,
+            codeProvider: .github,
+            worktreeSlug: "rm/max-monorepo"
+        ) == nil)
+    }
+
+    @Test func skipsGitLab() {
+        #expect(candidate(
+            ticketURL: "https://gitlab.com/org/repo/-/issues/7",
+            ticketNumber: 7,
+            provider: .gitlab,
+            worktreeSlug: "org/repo"
+        ) == nil)
+    }
+
+    @Test func skipsWhenNeitherURLNorWorktreeYieldsSlug() {
+        #expect(candidate(
+            ticketURL: nil,
+            ticketNumber: 473,
+            provider: .github
+        ) == nil)
+    }
+
+    @Test func skipsPullURLWithoutTicketNumber() {
+        #expect(
+            IssueTracker.githubIssueNumber(
+                ticketURL: "https://github.com/org/repo/pull/99",
+                ticketNumber: nil
+            ) == nil
+        )
+        #expect(candidate(
+            ticketURL: "https://github.com/org/repo/pull/99",
+            ticketNumber: nil,
+            provider: .github
+        ) == nil)
+    }
+
+    @Test func skipsMissingNumber() {
+        #expect(candidate(
+            ticketURL: "https://github.com/org/repo",
+            ticketNumber: nil,
+            provider: .github,
+            worktreeSlug: "org/repo"
+        ) == nil)
+    }
+}
+
+// CROW-1221: GitHub-tasked session whose worktree branch was renamed still
+// attaches the PR whose body says `Closes #473`. Contested across two issue
+// numbers still drops (same #520 rule).
+@Suite("IssueTracker reconcile GitHub issue scenario (CROW-1221)")
+struct IssueTrackerReconcileGitHubIssueScenarioTests {
+
+    private func keyCandidate(_ sid: UUID, _ key: String) -> IssueTracker.ReconcileKeyCandidate {
+        IssueTracker.ReconcileKeyCandidate(
+            sessionID: sid, provider: .github, repoSlug: "corveil/shell-crm", key: key, gitlabHost: nil
+        )
+    }
+
+    @Test func closesIssueNumberResolvesPRAndContestedDrops() {
+        let s473 = UUID()  // ticket 473 → PR #478 (Closes #473)
+        let s999 = UUID()  // ticket 999 → no PR; must not inherit #478
+
+        let candidates = [
+            keyCandidate(s473, "#473"),
+            keyCandidate(s999, "#999"),
+        ]
+        let kc473 = KeyCandidate(repoSlug: "corveil/shell-crm", key: "#473")
+        let backendMatches = [
+            KeyPRMatch(
+                candidate: kc473, number: 478,
+                url: "https://github.com/corveil/shell-crm/pull/478",
+                state: "OPEN", updatedAt: nil
+            )
+        ]
+
+        let fanned = IssueTracker.fanOutKeyMatches(backendMatches, across: candidates)
+        let decided = IssueTracker.decideReconcileLinks(matches: fanned)
+        let identity = [s473: "#473", s999: "#999"]
+        let final = IssueTracker.dedupeContestedPRs(decided, identityBySession: identity)
+
+        let bySession = Dictionary(grouping: final, by: { $0.sessionID })
+        #expect(bySession[s473]?.map(\.number) == [478])
+        #expect(bySession[s999] == nil)
+    }
+
+    @Test func contestedPRAcrossDistinctIssueNumbersDropsBoth() {
+        let s473 = UUID(); let s999 = UUID()
+        let url = "https://github.com/corveil/shell-crm/pull/478"
+        let out = IssueTracker.dedupeContestedPRs(
+            [
+                IssueTracker.ReconcileBranchMatch(
+                    sessionID: s473, number: 478, url: url, state: "OPEN", updatedAt: nil),
+                IssueTracker.ReconcileBranchMatch(
+                    sessionID: s999, number: 478, url: url, state: "OPEN", updatedAt: nil),
+            ],
+            identityBySession: [s473: "#473", s999: "#999"]
+        )
+        #expect(out.isEmpty)
+    }
+
+    @Test func picksOpenPROverMergedForSameIssue() {
+        let s = UUID()
+        let picks = IssueTracker.decideReconcileLinks(matches: [
+            IssueTracker.ReconcileBranchMatch(
+                sessionID: s, number: 10, url: "u10", state: "MERGED",
+                updatedAt: Date(timeIntervalSince1970: 500)),
+            IssueTracker.ReconcileBranchMatch(
+                sessionID: s, number: 478, url: "u478", state: "OPEN",
+                updatedAt: Date(timeIntervalSince1970: 100)),
+        ])
+        #expect(picks.count == 1)
+        #expect(picks[0].number == 478)
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -296,10 +296,11 @@ public struct BranchPRMatch: Sendable {
     }
 }
 
-/// Input to `CodeBackend.findPRsMatchingKeys` — one (repo, key) tuple, where
-/// `key` is a ticket key (e.g. a Jira key `MAXX-6859`) expected to appear in a
-/// PR's title/body/branch. Lets reconcile recover PR links for task-only
-/// trackers (Jira) whose PR branch doesn't match the session's worktree branch.
+/// Input to `CodeBackend.findPRsMatchingKeys` — one (repo, key) tuple.
+/// `key` is either a Jira ticket key (`MAXX-6859`, matched in title/head) or a
+/// GitHub issue number (`#473`, matched via Closes/Fixes/Resolves in title/body).
+/// Lets reconcile recover PR links when the registered worktree branch does
+/// not match the PR head.
 public struct KeyCandidate: Sendable, Hashable {
     public let repoSlug: String
     public let key: String

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -333,10 +333,11 @@ public struct GitHubCodeBackend: CodeBackend {
         return Self.parseRecentPRsResponse(output, parsed: parsed)
     }
 
-    /// Search each repo for PRs whose title/body references `key` (e.g. a Jira
-    /// key like `MAXX-6859`). One `gh pr list --search` call per candidate
-    /// (the candidate set is small — only Jira-tasked sessions missing a PR
-    /// link). Best-effort per repo: a failing repo is skipped, not fatal.
+    /// Search each repo for PRs whose title/body references `key`. `key` is
+    /// either a Jira ticket key (`MAXX-6859`) or a GitHub issue number (`#473`).
+    /// One `gh pr list --search` call per candidate (the set is small — sessions
+    /// missing a PR link). Best-effort per repo: a failing repo is skipped, not
+    /// fatal.
     public func findPRsMatchingKeys(_ candidates: [KeyCandidate]) async throws -> [KeyPRMatch] {
         var out: [KeyPRMatch] = []
         for c in candidates {
@@ -355,9 +356,22 @@ public struct GitHubCodeBackend: CodeBackend {
             } catch {
                 continue
             }
-            out.append(contentsOf: Self.parseKeyPRMatches(output, candidate: c))
+            if Self.isGitHubIssueKey(c.key) {
+                out.append(contentsOf: Self.parseGitHubIssuePRMatches(output, candidate: c))
+            } else {
+                out.append(contentsOf: Self.parseKeyPRMatches(output, candidate: c))
+            }
         }
         return out
+    }
+
+    /// A GitHub issue-number key is `#` plus digits (`#473`). Distinct from a
+    /// Jira key (`MAXX-6859`) so the two post-filters cannot be confused.
+    static func isGitHubIssueKey(_ key: String) -> Bool {
+        guard key.first == "#" else { return false }
+        let digits = key.dropFirst()
+        guard !digits.isEmpty, digits.allSatisfy(\.isNumber), let n = Int(digits) else { return false }
+        return n > 0
     }
 
     /// Parse `gh pr list --json …` output into `KeyPRMatch`es. Post-filters to
@@ -384,6 +398,53 @@ public struct GitHubCodeBackend: CodeBackend {
             ))
         }
         return matches
+    }
+
+    /// Parse `gh pr list --json …` for a GitHub issue-number candidate (`#473`).
+    /// Unlike the Jira-key filter, a match in the **body** is the whole point:
+    /// Crow's workspace skill writes `Closes #N` there. Require a GitHub closing
+    /// keyword (`close[sd]?` / `fix(e[sd])?` / `resolve[sd]?`) so a passing
+    /// "related to #473" does not attach a phantom PR (#520 analog, CROW-1221).
+    static func parseGitHubIssuePRMatches(_ output: String, candidate: KeyCandidate) -> [KeyPRMatch] {
+        guard let issueNumber = Int(candidate.key.dropFirst()), issueNumber > 0,
+              let data = output.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        var matches: [KeyPRMatch] = []
+        for node in arr {
+            guard let number = node["number"] as? Int,
+                  let url = node["url"] as? String,
+                  let state = node["state"] as? String else { continue }
+            let title = node["title"] as? String ?? ""
+            let body = node["body"] as? String ?? ""
+            guard prReferencesGitHubIssue(
+                title: title, body: body, repoSlug: candidate.repoSlug, number: issueNumber
+            ) else { continue }
+            let updatedAt = IssueDate.parse(node["updatedAt"] as? String)
+            matches.append(KeyPRMatch(
+                candidate: candidate, number: number, url: url, state: state, updatedAt: updatedAt
+            ))
+        }
+        return matches
+    }
+
+    /// Whether `title`/`body` reference GitHub issue `number` with a closing
+    /// keyword GitHub itself honors: close/closes/closed, fix/fixes/fixed,
+    /// resolve/resolves/resolved, optional colon, then `#N`, `owner/repo#N`,
+    /// or `https://github.com/owner/repo/issues/N`. Bare `#N` without a keyword
+    /// is not enough — that is how "related to #473" attached the wrong PR.
+    static func prReferencesGitHubIssue(
+        title: String, body: String, repoSlug: String, number: Int
+    ) -> Bool {
+        let n = String(number)
+        let escapedSlug = NSRegularExpression.escapedPattern(for: repoSlug)
+        let keyword = #"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*"#
+        let haystack = title + "\n" + body
+        let patterns = [
+            keyword + "#\(n)\\b",
+            keyword + "https?://github\\.com/\(escapedSlug)/issues/\(n)\\b",
+            keyword + "\(escapedSlug)#\(n)\\b",
+        ]
+        return patterns.contains { haystack.range(of: $0, options: .regularExpression) != nil }
     }
 
     // MARK: - enableAutoMerge / updateBranch

--- a/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
@@ -79,11 +79,11 @@ public protocol CodeBackend: Sendable {
     func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch]
 
     /// For each `(repoSlug, key)` candidate, search the repo for PRs that
-    /// reference `key` (e.g. a Jira key `MAXX-6859`) in their title/body/branch
-    /// and return the recent matches. Used by reconcile to link PRs for
-    /// task-only trackers (Jira) whose PR branch doesn't match the session's
-    /// worktree branch — branch matching can't find those. The default
-    /// implementation returns `[]` (no key search); GitHub overrides it.
+    /// reference `key` — a Jira key (`MAXX-6859`) in title/head, or a GitHub
+    /// issue number (`#473`) via Closes/Fixes/Resolves in title/body — and
+    /// return the recent matches. Used by reconcile when the PR head does not
+    /// match the session's worktree branch. The default implementation returns
+    /// `[]` (no key search); GitHub overrides it.
     func findPRsMatchingKeys(_ candidates: [KeyCandidate]) async throws -> [KeyPRMatch]
 
     /// Add the `crow:merge` auto-merge label to the PR at `prURL`.
@@ -132,8 +132,8 @@ public protocol CodeBackend: Sendable {
 public extension CodeBackend {
     /// Default: no key-based PR search. Backends that can search PRs by text
     /// (GitHub) override this; others (GitLab today, Corveil stub) inherit the
-    /// no-op so a Jira-key reconcile pass degrades to "no matches" rather than
-    /// forcing every conformer to implement it.
+    /// no-op so a Jira-key / GitHub-issue reconcile pass degrades to "no matches"
+    /// rather than forcing every conformer to implement it.
     func findPRsMatchingKeys(_ candidates: [KeyCandidate]) async throws -> [KeyPRMatch] { [] }
 
     /// Default: no default-branch commit scan. GitHub overrides this; others

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -1332,6 +1332,85 @@ final class BackendsTests: XCTestCase {
         XCTAssertTrue(matches.isEmpty)
     }
 
+    func testGitHubIssueKeyShape() {
+        XCTAssertTrue(GitHubCodeBackend.isGitHubIssueKey("#473"))
+        XCTAssertTrue(GitHubCodeBackend.isGitHubIssueKey("#1"))
+        XCTAssertFalse(GitHubCodeBackend.isGitHubIssueKey("MAXX-6859"))
+        XCTAssertFalse(GitHubCodeBackend.isGitHubIssueKey("473"))
+        XCTAssertFalse(GitHubCodeBackend.isGitHubIssueKey("#"))
+        XCTAssertFalse(GitHubCodeBackend.isGitHubIssueKey("#0"))
+        XCTAssertFalse(GitHubCodeBackend.isGitHubIssueKey("#47a"))
+    }
+
+    func testGitHubCodeBackendFindPRsMatchingIssueNumberClosesInBody() async throws {
+        // CROW-1221: a GitHub-tasked session finds the PR by `Closes #473` in
+        // the body even when the head branch was renamed. Jira's title/head
+        // filter would have dropped this.
+        let fake = FakeShellRunner()
+        let json = """
+        [
+          {"number":478,"url":"https://github.com/corveil/shell-crm/pull/478","state":"OPEN","updatedAt":"2026-01-02T00:00:00Z","title":"feat: reconcile","headRefName":"feature/renamed-head","body":"Closes #473"},
+          {"number":479,"url":"https://github.com/corveil/shell-crm/pull/479","state":"OPEN","updatedAt":"2026-01-03T00:00:00Z","title":"unrelated","headRefName":"feature/other","body":"related to #473"},
+          {"number":480,"url":"https://github.com/corveil/shell-crm/pull/480","state":"MERGED","updatedAt":"2026-01-01T00:00:00Z","title":"Fixes #4730 overflow","headRefName":"feature/overflow","body":""},
+          {"number":481,"url":"https://github.com/corveil/shell-crm/pull/481","state":"OPEN","updatedAt":"2026-01-04T00:00:00Z","title":"Fixes #473 keyboard","headRefName":"feature/kb","body":""}
+        ]
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let matches = try await backend.findPRsMatchingKeys([
+            KeyCandidate(repoSlug: "corveil/shell-crm", key: "#473")
+        ])
+        XCTAssertEqual(Set(matches.map(\.number)), [478, 481])
+        let args = fake.calls[0].args
+        XCTAssertEqual(Array(args.prefix(3)), ["gh", "pr", "list"])
+        XCTAssertTrue(args.contains("#473 in:title,body"))
+        XCTAssertTrue(args.contains("corveil/shell-crm"))
+    }
+
+    func testParseGitHubIssuePRMatchesHonorsClosingKeywords() {
+        let candidate = KeyCandidate(repoSlug: "org/repo", key: "#42")
+        func json(_ n: Int, title: String, body: String) -> String {
+            """
+            [{"number":\(n),"url":"https://github.com/org/repo/pull/\(n)","state":"OPEN","updatedAt":"2026-01-01T00:00:00Z","title":"\(title)","headRefName":"x","body":"\(body)"}]
+            """
+        }
+
+        XCTAssertEqual(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(1, title: "n", body: "Closes #42"), candidate: candidate
+            ).map(\.number), [1])
+        XCTAssertEqual(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(2, title: "n", body: "Fixes: #42"), candidate: candidate
+            ).map(\.number), [2])
+        XCTAssertEqual(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(3, title: "n", body: "Resolved #42"), candidate: candidate
+            ).map(\.number), [3])
+        XCTAssertEqual(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(4, title: "n", body: "Closes https://github.com/org/repo/issues/42"),
+                candidate: candidate
+            ).map(\.number), [4])
+        XCTAssertEqual(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(5, title: "n", body: "Fixes org/repo#42"), candidate: candidate
+            ).map(\.number), [5])
+        XCTAssertTrue(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(6, title: "n", body: "related to #42"), candidate: candidate
+            ).isEmpty)
+        XCTAssertTrue(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(7, title: "n", body: "Closes #41"), candidate: candidate
+            ).isEmpty)
+        XCTAssertTrue(
+            GitHubCodeBackend.parseGitHubIssuePRMatches(
+                json(8, title: "n", body: "Closes https://github.com/other/repo/issues/42"),
+                candidate: candidate
+            ).isEmpty)
+    }
+
     // MARK: - GitLab backends
 
     func testGitLabTaskBackendDeclaresNoCapabilities() {


### PR DESCRIPTION
## Summary
- GitHub-tasked work sessions now reconcile a missing `.pr` link by searching the repo for PRs that `Closes`/`Fixes`/`Resolves` `#<ticketNumber>`, instead of only matching the registered worktree branch.
- `owner/repo` is parsed from `ticketURL` when present, so a session with no worktree (the #1218 case) can still find the PR. Hits go through the existing 1:1 pick and `#520` contested-PR dedupe. Jira stays on the ticket-key path; GitLab stays on branch matching.

## Test plan
- [ ] GitHub-tasked session with `ticketURL` + `ticketNumber`, no worktree, PR body `Closes #N` → `.pr` link attaches on the next poll
- [ ] Same session with a renamed PR head (branch match misses) → still attaches via `Closes #N`
- [ ] Session that already has a `.pr` link is left alone
- [ ] Two sessions on different issue numbers that both match one PR → neither gets it
- [ ] Jira-tasked sessions still match on ticket key in title/head, not body-only mentions

Closes #1221

Made with [Cursor](https://cursor.com)