### PR TITLE
Infer a missing SessionWorktree from the managed terminal cwd

### DIFF
--- a/Packages/CrowEngine/Sources/CrowEngine/EngineTerminalRPCHandlers.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/EngineTerminalRPCHandlers.swift
@@ -162,6 +162,19 @@ func makeEngineTerminalHandlers(
                 }
                 capturedAppState.terminals[sessionID, default: []].append(terminal)
                 capturedStore.mutate { $0.terminals.append(terminal) }
+                // CROW-1219: if this is a managed agent terminal and the
+                // session still has no worktree row, the cwd we just
+                // persisted is enough to reconstruct one. Poll recovery
+                // covers already-running sessions; this catches the
+                // bootstrap race at create time.
+                if isManaged {
+                    _ = MissingWorktreeRecovery.recoverIfNeeded(
+                        sessionID: sessionID,
+                        appState: capturedAppState,
+                        store: capturedStore,
+                        devRoot: devRoot
+                    )
+                }
                 if trackReadiness {
                     TerminalRouter.trackReadiness(for: terminal)
                 }

--- a/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/IssueTracker.swift
@@ -445,6 +445,17 @@ public final class IssueTracker {
 
     public func refresh() async {
         guard !isRefreshing else { return }
+
+        // CROW-1219: local git + store only — does not create a checkout, and
+        // does not need GitHub. Runs even when the poll is rate-limited so
+        // `primaryWorktree(for:)` / merge labels recover without waiting on
+        // `gh`. Sync on MainActor (no await) so a second refresh cannot
+        // double-append.
+        if let devRoot = ConfigStore.loadDevRoot() {
+            _ = MissingWorktreeRecovery.recoverAll(
+                appState: appState, store: store, devRoot: devRoot)
+        }
+
         guard shouldPoll() else {
             if let suspendedUntil {
                 print("[IssueTracker] skipping refresh — rate-limited until \(suspendedUntil)")

--- a/Packages/CrowEngine/Sources/CrowEngine/MissingWorktreeRecovery.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/MissingWorktreeRecovery.swift
@@ -1,0 +1,95 @@
+import Foundation
+import CrowCore
+import CrowGit
+import CrowPersistence
+
+/// Register a `SessionWorktree` row from a managed terminal's cwd when a
+/// work session has none (CROW-1219).
+///
+/// A work session can already be running with a checkout on disk while Crow's
+/// store has no row — PR auto-link, merge labels, and `primaryWorktree(for:)`
+/// all no-op until someone runs `crow add-worktree` by hand. The terminal cwd
+/// is enough to reconstruct repo, path, and branch. This never creates a git
+/// worktree; `add-worktree` already treats an existing `{path}/.git` as
+/// metadata-only, and that is the failure mode here too.
+enum MissingWorktreeRecovery {
+    /// Scan every session and persist a primary worktree for each eligible
+    /// work session that still has none. Returns the rows that were added.
+    @MainActor
+    static func recoverAll(appState: AppState, store: JSONStore, devRoot: String) -> [SessionWorktree] {
+        var added: [SessionWorktree] = []
+        for session in appState.sessions {
+            if let wt = inferredWorktree(session: session, appState: appState, devRoot: devRoot) {
+                added.append(wt)
+            }
+        }
+        persist(added, appState: appState, store: store)
+        return added
+    }
+
+    /// Recover a single session — the `new-terminal` hook. No-ops when the
+    /// session is ineligible or already has a worktree.
+    @MainActor
+    static func recoverIfNeeded(
+        sessionID: UUID,
+        appState: AppState,
+        store: JSONStore,
+        devRoot: String
+    ) -> SessionWorktree? {
+        guard let session = appState.sessions.first(where: { $0.id == sessionID }) else {
+            return nil
+        }
+        guard let wt = inferredWorktree(session: session, appState: appState, devRoot: devRoot) else {
+            return nil
+        }
+        persist([wt], appState: appState, store: store)
+        return wt
+    }
+
+    @MainActor
+    private static func inferredWorktree(
+        session: Session,
+        appState: AppState,
+        devRoot: String
+    ) -> SessionWorktree? {
+        // Jobs, reviews, and Managers get their rows at creation (or, for
+        // Managers, never). Explore is still `kind == .work`; a missing row
+        // there is the same bootstrap gap, and inferring is harmless because
+        // we only register a checkout that already exists.
+        guard session.kind == .work else { return nil }
+        guard appState.worktrees(for: session.id).isEmpty else { return nil }
+
+        let terminals = appState.terminals(for: session.id)
+        guard let cwd = terminals.first(where: { $0.isManaged && !$0.cwd.isEmpty })?.cwd else {
+            return nil
+        }
+        guard let inferred = WorktreeInference.infer(cwd: cwd, devRoot: devRoot) else {
+            return nil
+        }
+        CrowLog.info(
+            "[Crow] inferred missing worktree for session \(session.id.uuidString) "
+                + "at \(inferred.worktreePath) (\(inferred.branch))"
+        )
+        return SessionWorktree(
+            sessionID: session.id,
+            repoName: inferred.repoName,
+            repoPath: inferred.repoPath,
+            worktreePath: inferred.worktreePath,
+            branch: inferred.branch,
+            isPrimary: true
+        )
+    }
+
+    @MainActor
+    private static func persist(
+        _ worktrees: [SessionWorktree],
+        appState: AppState,
+        store: JSONStore
+    ) {
+        guard !worktrees.isEmpty else { return }
+        for wt in worktrees {
+            appState.worktrees[wt.sessionID, default: []].append(wt)
+        }
+        store.mutate { $0.worktrees.append(contentsOf: worktrees) }
+    }
+}

--- a/Packages/CrowEngine/Tests/CrowEngineTests/MissingWorktreeRecoveryTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/MissingWorktreeRecoveryTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import Testing
+import CrowCore
+import CrowPersistence
+import CrowGit
+@testable import CrowEngine
+
+/// CROW-1219: a work session with a managed terminal whose cwd is a git
+/// worktree, but no `SessionWorktree` row, should grow a primary row so PR
+/// linking and `primaryWorktree(for:)` can match.
+@Suite("Missing worktree recovery")
+@MainActor
+struct MissingWorktreeRecoveryTests {
+
+    @Test("registers a primary worktree from the managed terminal cwd")
+    func registersFromManagedCwd() throws {
+        let fixture = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let (appState, store, session) = seed(
+            kind: .work,
+            terminals: [managed(cwd: fixture.worktree.path)]
+        )
+        let added = MissingWorktreeRecovery.recoverAll(
+            appState: appState, store: store, devRoot: fixture.root.path)
+
+        #expect(added.count == 1)
+        let wt = try #require(appState.primaryWorktree(for: session.id))
+        #expect(wt.isPrimary)
+        #expect(wt.repoName == "shell-crm")
+        #expect(std(wt.repoPath) == std(fixture.mainClone.path))
+        #expect(std(wt.worktreePath) == std(fixture.worktree.path))
+        #expect(wt.branch == "feature/x")
+        #expect(store.data.worktrees.contains { $0.id == wt.id })
+    }
+
+    @Test("does not invent a second worktree when one already exists")
+    func skipsWhenWorktreeExists() throws {
+        let fixture = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let existing = SessionWorktree(
+            sessionID: UUID(), repoName: "already", repoPath: fixture.mainClone.path,
+            worktreePath: fixture.worktree.path, branch: "feature/existing", isPrimary: true
+        )
+        let (appState, store, session) = seed(
+            kind: .work,
+            worktrees: [existing],
+            terminals: [managed(cwd: fixture.worktree.path)]
+        )
+
+        let added = MissingWorktreeRecovery.recoverAll(
+            appState: appState, store: store, devRoot: fixture.root.path)
+        #expect(added.isEmpty)
+        #expect(appState.worktrees(for: session.id).count == 1)
+        #expect(appState.worktrees(for: session.id)[0].branch == "feature/existing")
+    }
+
+    @Test("skips job, review, and manager sessions")
+    func skipsNonWorkKinds() throws {
+        let fixture = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        for kind: SessionKind in [.job, .review, .manager] {
+            let (appState, store, session) = seed(
+                kind: kind,
+                terminals: [managed(cwd: fixture.worktree.path)]
+            )
+            let added = MissingWorktreeRecovery.recoverAll(
+                appState: appState, store: store, devRoot: fixture.root.path)
+            #expect(added.isEmpty, "kind \(kind.rawValue) should stay worktree-less")
+            #expect(appState.worktrees(for: session.id).isEmpty)
+        }
+    }
+
+    @Test("ignores an unmanaged terminal")
+    func skipsUnmanagedTerminal() throws {
+        let fixture = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let (appState, store, session) = seed(
+            kind: .work,
+            terminals: [
+                SessionTerminal(
+                    sessionID: UUID(), name: "Shell", cwd: fixture.worktree.path, isManaged: false
+                )
+            ]
+        )
+
+        let added = MissingWorktreeRecovery.recoverAll(
+            appState: appState, store: store, devRoot: fixture.root.path)
+        #expect(added.isEmpty)
+        #expect(appState.worktrees(for: session.id).isEmpty)
+    }
+
+    @Test("recoverIfNeeded is a no-op when the session already has a worktree")
+    func recoverIfNeededIsIdempotent() throws {
+        let fixture = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let (appState, store, session) = seed(
+            kind: .work,
+            terminals: [managed(cwd: fixture.worktree.path)]
+        )
+        let first = MissingWorktreeRecovery.recoverIfNeeded(
+            sessionID: session.id, appState: appState, store: store, devRoot: fixture.root.path)
+        #expect(first != nil)
+        let second = MissingWorktreeRecovery.recoverIfNeeded(
+            sessionID: session.id, appState: appState, store: store, devRoot: fixture.root.path)
+        #expect(second == nil)
+        #expect(appState.worktrees(for: session.id).count == 1)
+    }
+
+    @Test("an explore work session is still recovered")
+    func recoversExploreWorkSession() throws {
+        // Explore is a tag on `.work`, not a separate kind. A missing row is
+        // the same bootstrap gap; inferring a checkout that already exists is
+        // not inventing a second tree.
+        let fixture = try makeRepoWithWorktree()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let appState = AppState()
+        let store = JSONStore(directory: URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-1219-explore-\(UUID().uuidString)"))
+        let session = Session(name: "explore", kind: .work, isExplore: true)
+        appState.sessions = [session]
+        appState.terminals[session.id] = [
+            SessionTerminal(
+                sessionID: session.id, name: "Claude Code",
+                cwd: fixture.worktree.path, isManaged: true)
+        ]
+
+        let added = MissingWorktreeRecovery.recoverAll(
+            appState: appState, store: store, devRoot: fixture.root.path)
+        #expect(added.count == 1)
+        #expect(appState.primaryWorktree(for: session.id)?.isPrimary == true)
+    }
+
+    // MARK: - Helpers
+
+    private func seed(
+        kind: SessionKind,
+        worktrees: [SessionWorktree] = [],
+        terminals: [SessionTerminal]
+    ) -> (AppState, JSONStore, Session) {
+        let appState = AppState()
+        let store = JSONStore(directory: URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-1219-\(UUID().uuidString)"))
+        let session = Session(name: "s", kind: kind)
+        appState.sessions = [session]
+        if !worktrees.isEmpty {
+            appState.worktrees[session.id] = worktrees.map {
+                SessionWorktree(
+                    sessionID: session.id, repoName: $0.repoName, repoPath: $0.repoPath,
+                    worktreePath: $0.worktreePath, branch: $0.branch, isPrimary: $0.isPrimary)
+            }
+        }
+        appState.terminals[session.id] = terminals.map {
+            SessionTerminal(
+                sessionID: session.id, name: $0.name, cwd: $0.cwd, isManaged: $0.isManaged)
+        }
+        return (appState, store, session)
+    }
+
+    private func managed(cwd: String) -> SessionTerminal {
+        SessionTerminal(sessionID: UUID(), name: "Claude Code", cwd: cwd, isManaged: true)
+    }
+
+    private struct Fixture {
+        let root: URL
+        let mainClone: URL
+        let worktree: URL
+    }
+
+    private func makeRepoWithWorktree() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-1219-\(UUID().uuidString)")
+        let mainClone = root.appendingPathComponent("corveil/shell-crm")
+        try FileManager.default.createDirectory(at: mainClone, withIntermediateDirectories: true)
+        _ = try git(["init", "--initial-branch=main", mainClone.path])
+        _ = try git(["-C", mainClone.path, "config", "user.email", "t@example.com"])
+        _ = try git(["-C", mainClone.path, "config", "user.name", "T"])
+        _ = try git(["-C", mainClone.path, "config", "commit.gpgsign", "false"])
+        try Data("x".utf8).write(to: mainClone.appendingPathComponent("README"))
+        _ = try git(["-C", mainClone.path, "add", "README"])
+        _ = try git(["-C", mainClone.path, "commit", "-m", "init"])
+        _ = try git(["-C", mainClone.path, "remote", "add", "origin",
+                      "git@github.com:corveil/shell-crm.git"])
+
+        let worktree = root.appendingPathComponent("corveil/shell-crm-473-open-geo-enrichment")
+        _ = try git(["-C", mainClone.path, "worktree", "add", worktree.path, "-b", "feature/x"])
+        return Fixture(root: root, mainClone: mainClone, worktree: worktree)
+    }
+
+    private func git(_ args: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let out = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let text = String(decoding: out, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "git", code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: text]
+            )
+        }
+        return text
+    }
+
+    private func std(_ path: String) -> String {
+        (path as NSString).standardizingPath
+    }
+}

--- a/Packages/CrowGit/Sources/CrowGit/WorktreeInference.swift
+++ b/Packages/CrowGit/Sources/CrowGit/WorktreeInference.swift
@@ -1,0 +1,126 @@
+import Foundation
+import CrowCore
+
+/// Reconstruct a `SessionWorktree`'s fields from an on-disk checkout (CROW-1219).
+///
+/// `add-worktree` records metadata only when `{path}/.git` already exists; this
+/// helper is the other half of that failure mode — a session whose managed
+/// terminal cwd *is* a git worktree, but whose store has no row. It never
+/// creates a checkout.
+public enum WorktreeInference {
+    public struct Result: Sendable, Equatable {
+        public let repoName: String
+        public let repoPath: String
+        public let worktreePath: String
+        public let branch: String
+
+        public init(repoName: String, repoPath: String, worktreePath: String, branch: String) {
+            self.repoName = repoName
+            self.repoPath = repoPath
+            self.worktreePath = worktreePath
+            self.branch = branch
+        }
+    }
+
+    /// Infer repo name, main-clone path, worktree path, and branch from `cwd`.
+    ///
+    /// Returns `nil` when `cwd` is outside `devRoot`, is not a git checkout,
+    /// HEAD is detached / option-shaped, or the main clone would sit outside
+    /// `devRoot`. Does not invent a row for a path that is not already a
+    /// checkout — the git tree must exist.
+    public static func infer(cwd: String, devRoot: String) -> Result? {
+        let worktreePath = (cwd as NSString).standardizingPath
+        guard !worktreePath.isEmpty else { return nil }
+        guard Validation.isPathWithinRoot(worktreePath, root: devRoot) else { return nil }
+        // The Manager's cwd is `devRoot` itself. A work session whose
+        // managed terminal landed there is not a recoverable checkout.
+        let stdRoot = (devRoot as NSString).standardizingPath
+        guard worktreePath != stdRoot else { return nil }
+
+        let gitMarker = (worktreePath as NSString).appendingPathComponent(".git")
+        guard FileManager.default.fileExists(atPath: gitMarker) else { return nil }
+
+        guard let branch = git(["-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD"]) else {
+            return nil
+        }
+        // Detached HEAD prints `HEAD`. A leading dash would be parsed as an
+        // option by later `git` invocations (same guard as `add-worktree`).
+        guard !branch.isEmpty, branch != "HEAD", !branch.hasPrefix("-") else { return nil }
+
+        let repoPath: String
+        if let main = resolveMainClone(worktreePath: worktreePath) {
+            repoPath = main
+        } else {
+            // `.git` is a directory — this *is* the main clone (or a
+            // worktree whose gitdir chain we could not read). Either way the
+            // checkout itself is the repo path, matching review-session rows.
+            repoPath = worktreePath
+        }
+        guard Validation.isPathWithinRoot(repoPath, root: devRoot) else { return nil }
+
+        // Prefer the origin slug's last segment (`shell-crm`); fall back to
+        // the main clone's folder name, which is the `{workspace}/{repo}`
+        // convention `setup.sh` and `discoverRepos` already use.
+        let origin = git(["-C", worktreePath, "remote", "get-url", "origin"])
+        let repoName = RepoRemote.parse(origin ?? "")?.repo
+            ?? (repoPath as NSString).lastPathComponent
+        guard !repoName.isEmpty else { return nil }
+
+        return Result(
+            repoName: repoName,
+            repoPath: repoPath,
+            worktreePath: worktreePath,
+            branch: branch
+        )
+    }
+
+    /// The main clone backing a linked worktree, or `nil` when `worktreePath`
+    /// is itself the main clone (or not a shape we understand).
+    ///
+    /// Asks git for `--git-common-dir` rather than parsing `gitdir:` by hand:
+    /// the poll path can afford a subprocess, and git's own answer is the
+    /// source of truth for "where is the shared dir".
+    public static func resolveMainClone(worktreePath: String) -> String? {
+        let raw = git([
+            "-C", worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir",
+        ]) ?? git(["-C", worktreePath, "rev-parse", "--git-common-dir"])
+        guard let raw else { return nil }
+
+        let commonDir: String
+        if raw.hasPrefix("/") {
+            commonDir = (raw as NSString).standardizingPath
+        } else {
+            commonDir = ((worktreePath as NSString).appendingPathComponent(raw) as NSString)
+                .standardizingPath
+        }
+        guard (commonDir as NSString).lastPathComponent == ".git" else { return nil }
+        let main = ((commonDir as NSString).deletingLastPathComponent as NSString).standardizingPath
+        guard !main.isEmpty, main != "/" else { return nil }
+        let stdWorktree = (worktreePath as NSString).standardizingPath
+        if main == stdWorktree { return nil }
+        return main
+    }
+
+    private static func git(_ args: [String]) -> String? {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        process.environment = ShellEnvironment.shared.env
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        process.standardInput = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+            ?? ""
+        let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/CrowGit/Tests/CrowGitTests/WorktreeInferenceTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/WorktreeInferenceTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import CrowGit
+import CrowCore
+
+@Suite("WorktreeInference")
+struct WorktreeInferenceTests {
+
+    @Test("infers repo, main clone, path, and branch from a linked worktree")
+    func infersFromLinkedWorktree() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "my-folder",
+            origin: "git@github.com:corveil/shell-crm.git",
+            branch: "feature/shell-crm-473-open-geo-enrichment"
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try #require(WorktreeInference.infer(
+            cwd: fixture.worktree.path, devRoot: fixture.root.path))
+
+        #expect(result.repoName == "shell-crm")
+        #expect(std(result.repoPath) == std(fixture.mainClone.path))
+        #expect(std(result.worktreePath) == std(fixture.worktree.path))
+        #expect(result.branch == "feature/shell-crm-473-open-geo-enrichment")
+    }
+
+    @Test("falls back to the clone folder name when origin is missing")
+    func fallsBackToFolderNameWithoutOrigin() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "shell-crm", origin: nil, branch: "feature/x")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try #require(WorktreeInference.infer(
+            cwd: fixture.worktree.path, devRoot: fixture.root.path))
+        #expect(result.repoName == "shell-crm")
+        #expect(result.branch == "feature/x")
+    }
+
+    @Test("a main clone uses itself as repoPath")
+    func mainCloneUsesItself() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "crow", origin: "https://github.com/corveil/crow.git", branch: "feature/x")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try #require(WorktreeInference.infer(
+            cwd: fixture.mainClone.path, devRoot: fixture.root.path))
+        #expect(result.repoName == "crow")
+        #expect(std(result.repoPath) == std(fixture.mainClone.path))
+        #expect(std(result.worktreePath) == std(fixture.mainClone.path))
+        #expect(result.branch == "main")
+    }
+
+    @Test("cwd outside devRoot is rejected")
+    func rejectsPathOutsideDevRoot() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "crow", origin: nil, branch: "feature/x")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let elsewhere = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-infer-outside-\(UUID().uuidString)")
+        #expect(WorktreeInference.infer(cwd: fixture.worktree.path, devRoot: elsewhere.path) == nil)
+    }
+
+    @Test("a plain directory is not a worktree")
+    func rejectsPlainDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-infer-plain-\(UUID().uuidString)")
+        let dir = root.appendingPathComponent("ws/not-a-repo")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(WorktreeInference.infer(cwd: dir.path, devRoot: root.path) == nil)
+    }
+
+    @Test("cwd equal to devRoot is rejected even if it is a git repo")
+    func rejectsDevRootItself() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "crow", origin: nil, branch: "feature/x")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        #expect(WorktreeInference.infer(
+            cwd: fixture.mainClone.path, devRoot: fixture.mainClone.path) == nil)
+    }
+
+    @Test("resolveMainClone agrees with git on a linked worktree")
+    func resolveMainCloneAgreesWithGit() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "crow", origin: nil, branch: "feature/x")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        #expect(WorktreeInference.resolveMainClone(worktreePath: fixture.worktree.path)
+                == std(fixture.mainClone.path))
+        #expect(WorktreeInference.resolveMainClone(worktreePath: fixture.mainClone.path) == nil)
+    }
+
+    @Test("https origin URLs yield the repo segment")
+    func parsesHTTPSOrigin() throws {
+        let fixture = try makeRepoWithWorktree(
+            repoFolder: "ignored",
+            origin: "https://github.com/corveil/crow.git",
+            branch: "feature/x"
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try #require(WorktreeInference.infer(
+            cwd: fixture.worktree.path, devRoot: fixture.root.path))
+        #expect(result.repoName == "crow")
+    }
+
+    // MARK: - Fixtures
+
+    private struct Fixture {
+        let root: URL
+        let mainClone: URL
+        let worktree: URL
+    }
+
+    private func makeRepoWithWorktree(
+        repoFolder: String,
+        origin: String?,
+        branch: String
+    ) throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crow-infer-\(UUID().uuidString)")
+        let mainClone = root.appendingPathComponent("ws").appendingPathComponent(repoFolder)
+        try FileManager.default.createDirectory(at: mainClone, withIntermediateDirectories: true)
+        _ = try git(["init", "--initial-branch=main", mainClone.path])
+        _ = try git(["-C", mainClone.path, "config", "user.email", "t@example.com"])
+        _ = try git(["-C", mainClone.path, "config", "user.name", "T"])
+        _ = try git(["-C", mainClone.path, "config", "commit.gpgsign", "false"])
+        try Data("x".utf8).write(to: mainClone.appendingPathComponent("README"))
+        _ = try git(["-C", mainClone.path, "add", "README"])
+        _ = try git(["-C", mainClone.path, "commit", "-m", "init"])
+        if let origin {
+            _ = try git(["-C", mainClone.path, "remote", "add", "origin", origin])
+        }
+
+        let worktree = root.appendingPathComponent("ws").appendingPathComponent("\(repoFolder)-1-slug")
+        _ = try git(["-C", mainClone.path, "worktree", "add", worktree.path, "-b", branch])
+        return Fixture(root: root, mainClone: mainClone, worktree: worktree)
+    }
+
+    private func git(_ args: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let out = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let text = String(decoding: out, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "git", code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: text]
+            )
+        }
+        return text
+    }
+
+    private func std(_ path: String) -> String {
+        (path as NSString).standardizingPath
+    }
+}


### PR DESCRIPTION
Closes #1219

## Summary
- If a work session has no `SessionWorktree` row, recover one from the managed terminal's cwd by reading `HEAD` and `origin` — metadata only, the checkout already exists.
- Runs on every board poll (even when GitHub is rate-limited) so the same tick's PR auto-link can match, and again on managed `new-terminal` so a bootstrap miss is repaired at create time.
- Gated on `kind == .work` and an empty worktree list, so jobs, reviews, and Managers stay worktree-less on purpose.

## Test plan
- [ ] `swift test --package-path Packages/CrowGit --filter WorktreeInference`
- [ ] `swift test --package-path Packages/CrowEngine --filter MissingWorktreeRecovery`
- [ ] On a work session with a managed terminal cwd that is a git worktree and no store row, wait one poll (or create a managed terminal) and confirm `crow list-worktrees` shows a primary row; PR auto-link / merge label then match.


Made with [Cursor](https://cursor.com)