### PR TITLE
Scratch follow-up: drop idea copy, nav pill, submit explore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ crow job duplicate --id <job-uuid>              → {"job":{...}}   the copy sta
 
 ### Todo Commands
 
-Durable pre-ticket ideas (CROW-1231) — the Scratch sidebar. Capture in Crow, then promote into a Manager / ticket / work session. Lives in the shared `JSONStore` (not `config.json`) and is **not** reaped by session cleanup.
+Durable Scratch items (CROW-1231) — the Scratch sidebar. Capture in Crow, then promote into a Manager / ticket / work session. Lives in the shared `JSONStore` (not `config.json`) and is **not** reaped by session cleanup.
 
 ```
 crow todo add "text" [--tag a,b] [--priority p1|p2|p3|p4] [--note "..."]

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/TodoCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/TodoCommands.swift
@@ -2,15 +2,15 @@ import ArgumentParser
 import CrowIPC
 import Foundation
 
-/// Parent command for the durable pre-ticket Scratch list: `crow todo <subcommand>`.
+/// Parent command for the durable Scratch list: `crow todo <subcommand>`.
 ///
-/// Capture an idea in Crow, then promote it into a Manager / ticket / work
+/// Capture an item in Crow, then promote it into a Manager / ticket / work
 /// session. Mutations hit the daemon's injected `JSONStore` — the same store
 /// sessions live in — and are exempt from the session retention reaper.
 public struct Todo: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "todo",
-        abstract: "Capture and promote pre-ticket ideas",
+        abstract: "Capture and promote Scratch items",
         subcommands: [
             TodoAdd.self,
             TodoList.self,
@@ -35,10 +35,10 @@ public struct Todo: ParsableCommand {
 public struct TodoAdd: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "add",
-        abstract: "Capture a pre-ticket idea"
+        abstract: "Capture a Scratch item"
     )
 
-    @Argument(help: "Idea text")
+    @Argument(help: "Item text")
     var text: String
     @Option(name: .long, help: "Comma-separated tags")
     var tag: String?
@@ -119,7 +119,7 @@ public struct TodoEdit: ParsableCommand {
     )
 
     @Option(name: .long, help: "Todo UUID") var id: String
-    @Option(name: .long, help: "Replacement idea text") var text: String?
+    @Option(name: .long, help: "Replacement item text") var text: String?
     @Option(name: .long, help: "Replacement note") var note: String?
     @Option(name: .long, help: "Priority: p1, p2, p3, or p4") var priority: String?
     @Option(name: .customLong("add-tag"), parsing: .singleValue, help: "Tag to add (repeatable)")
@@ -324,7 +324,7 @@ public struct TodoTalk: ParsableCommand {
         printJSON(try rpc("todo-talk", params: [
             "todo_id": .string(id),
             "text": .string(text),
-        ]))
+        ], timeoutSeconds: 90))
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -393,6 +393,13 @@ public final class AppState {
         _sessionState.removeValue(forKey: sessionID)
     }
 
+    /// Reset live hook signals for a session whose agent pane was torn down
+    /// and relaunched. No-op when the session never had hook state (do not
+    /// instantiate an empty wrapper just to clear it).
+    public func resetHookStateForAgentRelaunch(sessionID: UUID) {
+        existingHookState(for: sessionID)?.resetForAgentRelaunch()
+    }
+
     /// Snapshot every session's color-driving hook state for persistence (#367).
     public func allHookStateSnapshots() -> [UUID: PersistedHookState] {
         _sessionState.mapValues { $0.persistedSnapshot }
@@ -895,6 +902,18 @@ public final class SessionHookState {
     /// graded waste.
     public func noteCompactionEvent(_ eventName: String) {
         if eventName == Self.compactionEventName { compactionCount += 1 }
+    }
+
+    /// Drop live agent signals so a relaunched pane cannot look "already
+    /// announced" from the previous process's SessionStart (CROW-1233).
+    /// Analytics / compaction counts stay — those are session-lifetime, not
+    /// this TUI instance. Callers: `restartManager`, `recreateTerminalSurface`.
+    public func resetForAgentRelaunch() {
+        activityState = .idle
+        pendingNotification = nil
+        lastToolActivity = nil
+        hookEvents = []
+        lastTopLevelStopAt = nil
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/HookEventTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/HookEventTests.swift
@@ -30,3 +30,37 @@ import Testing
     #expect(event.eventName == "Notification")
     #expect(event.summary == "Task complete")
 }
+
+@Test @MainActor func resetForAgentRelaunchDropsLiveSignalsAndKeepsAnalytics() {
+    let sessionID = UUID()
+    let state = SessionHookState()
+    state.activityState = .working
+    state.pendingNotification = HookNotification(message: "n", notificationType: "permission")
+    state.hookEvents = [
+        HookEvent(sessionID: sessionID, eventName: "SessionStart", summary: "up"),
+        HookEvent(sessionID: sessionID, eventName: "Stop", summary: "done"),
+    ]
+    state.lastTopLevelStopAt = Date()
+    state.compactionCount = 3
+    state.resetForAgentRelaunch()
+    #expect(state.hookEvents.isEmpty)
+    #expect(state.activityState == .idle)
+    #expect(state.pendingNotification == nil)
+    #expect(state.lastToolActivity == nil)
+    #expect(state.lastTopLevelStopAt == nil)
+    #expect(state.compactionCount == 3)
+}
+
+@Test @MainActor func resetHookStateForAgentRelaunchIsANoOpWhenEmpty() {
+    let app = AppState()
+    let sid = UUID()
+    app.resetHookStateForAgentRelaunch(sessionID: sid)
+    #expect(app.existingHookState(for: sid) == nil)
+
+    let state = app.hookState(for: sid)
+    state.activityState = .waiting
+    state.hookEvents = [HookEvent(sessionID: sid, eventName: "SessionStart", summary: "up")]
+    app.resetHookStateForAgentRelaunch(sessionID: sid)
+    #expect(state.activityState == .idle)
+    #expect(state.hookEvents.isEmpty)
+}

--- a/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/RPCLanePolicy.swift
@@ -190,7 +190,7 @@ enum RPCLanePolicy {
         // cannot tear. Explore/work/talk type into a Manager (new, primary,
         // or the item's linked explore Manager), so they share the manager
         // lane with `create-manager` / `work-on-issue` / `send` — otherwise
-        // a talk can interleave with seedExploreBrief or work-on-issue and
+        // a talk can interleave with sendToManager or work-on-issue and
         // corrupt the prompt.
         "todo-add": .concurrent,
         "todo-edit": .on("todo_id"),

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -833,16 +833,6 @@ body.update-banner-visible #back-to-sidebar {
 }
 .tickets-card:hover { border-color: var(--border-strong); }
 .tickets-card.selected { border-color: var(--gold); }
-.scratch-card { min-height: 48px; }
-.scratch-card .tickets-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.scratch-card .tickets-title { grid-column: unset; text-align: left; }
-.scratch-head-spacer { display: none; }
-.scratch-count {
-  min-width: 18px; height: 18px; padding: 0 5px; border-radius: 9px;
-  background: var(--gold); color: var(--bg); font-size: 11px; font-weight: 700;
-  display: inline-flex; align-items: center; justify-content: center;
-}
-.scratch-sub { color: var(--text-muted); font-size: 11px; padding: 2px 2px 0; }
 .scratch-capture { display: flex; gap: 8px; margin: 8px 0 16px; }
 .scratch-input {
   flex: 1; min-width: 0; padding: 8px 10px; border-radius: 8px;
@@ -1000,9 +990,10 @@ button.scratch-link:hover { border-color: var(--blue); }
 .tk-dot { width: 7px; height: 7px; border-radius: 50%; }
 .tk-n { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-/* Left-column nav rows (CROW-917): row 1 Grid/Reviews/Scorecard, row 2 the
-   full-width Manager pill. Each .nav-pills-row is its own non-wrapping flex line so
-   groups never reflow; the "+" and Select buttons live in the right icon column. */
+/* Left-column nav rows (CROW-917 / CROW-1233): row 1 Grid/Reviews/Scorecard/Scratch,
+   row 2 the full-width Manager pill. Each .nav-pills-row is its own non-wrapping
+   flex line so groups never reflow; the "+" and Select buttons live in the right
+   icon column. */
 .nav-pills-row { display: flex; gap: 6px; }
 .nav-pill {
   flex: 1 1 auto; min-width: 0; display: flex; align-items: center; justify-content: center; gap: 5px;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/boards.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/boards.js
@@ -1359,7 +1359,7 @@ function reviewCard(r) {
   return card;
 }
 
-// ===== Scratch / pre-ticket ideas (CROW-1231) =====
+// ===== Scratch (CROW-1231 / CROW-1233) =====
 let scratchShowClosed = false;
 
 function renderScratchBoard(root) {
@@ -1377,7 +1377,7 @@ function renderScratchBoard(root) {
   const capture = el('form', 'scratch-capture');
   const input = document.createElement('input');
   input.className = 'scratch-input';
-  input.placeholder = 'Capture an idea…';
+  input.placeholder = 'Capture to Scratch…';
   input.autocomplete = 'off';
   const submit = el('button', 'action-btn action-primary', 'Capture');
   submit.type = 'submit';
@@ -1406,7 +1406,7 @@ function renderScratchBoard(root) {
   const visible = todos.filter((t) => scratchShowClosed || (t.state !== 'done' && t.state !== 'dropped'));
   if (!visible.length) {
     root.appendChild(el('div', 'board-note',
-      todos.length ? 'No open ideas — capture one above, or Show done.' : 'No ideas yet. Capture one above; Explore opens a Manager without filing a ticket.'));
+      todos.length ? 'Nothing open — capture one above, or Show done.' : 'Scratch is empty. Capture one above; Explore opens a Manager without filing a ticket.'));
     return;
   }
   for (const item of visible) root.appendChild(scratchRow(item));

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/rpc.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/rpc.js
@@ -41,6 +41,7 @@ const RPC_TIMEOUTS_MS = {
   'list-tickets': 60000,
   'list-reviews': 60000,
   'todo-explore': 90000,
+  'todo-talk': 90000,
   'todo-ticket': 60000,
   'todo-work': 60000,
   'get-state': 60000,

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar.js
@@ -455,23 +455,15 @@ async function bulkDeleteSelected() {
   if (failed) alertModal(failed + ' session(s) could not be deleted.');
 }
 
-// Tickets summary card: title + refresh + 5 status mini-counts. Click opens the
-// Ticket Board (TicketBoardSidebarRow).
-function scratchCard() {
-  const card = el('div', 'tickets-card scratch-card' + (selectedBoard === 'scratch' ? ' selected' : ''));
-  card.onclick = () => selectBoard('scratch');
-  const head = el('div', 'tickets-head');
-  head.appendChild(el('span', 'tickets-title', 'Scratch'));
-  head.appendChild(el('span', 'scratch-head-spacer'));
+function scratchPill() {
+  const pill = navPill('Scratch', selectedBoard === 'scratch', () => selectBoard('scratch'));
   const count = scratchOpenCount();
   if (count) {
-    const badge = el('span', 'scratch-count', String(count));
-    badge.title = count + ' open idea' + (count === 1 ? '' : 's');
-    head.appendChild(badge);
+    const badge = el('span', 'pill-badge', String(count));
+    badge.title = count + ' open item' + (count === 1 ? '' : 's');
+    pill.appendChild(badge);
   }
-  card.appendChild(head);
-  card.appendChild(el('div', 'scratch-sub', 'Pre-ticket ideas'));
-  return card;
+  return pill;
 }
 
 function scratchOpenCount() {
@@ -479,6 +471,8 @@ function scratchOpenCount() {
   return todos.filter((t) => t.state !== 'done' && t.state !== 'dropped').length;
 }
 
+// Tickets summary card: title + refresh + 5 status mini-counts. Click opens the
+// Ticket Board (TicketBoardSidebarRow).
 function ticketsCard() {
   const card = el('div', 'tickets-card' + (selectedBoard === 'tickets' ? ' selected' : ''));
   card.onclick = () => selectBoard('tickets');
@@ -656,14 +650,14 @@ function sidebarIconColumn() {
   return col;
 }
 
-// Left sidebar-top stack (CROW-917): the Tickets card over two nav-pill rows —
-// row 1 Grid · Reviews · Scorecard, row 2 the full-width Manager pill.
+// Left sidebar-top stack (CROW-917 / CROW-1233): the Tickets card over two
+// nav-pill rows — row 1 Grid · Reviews · Scorecard · Scratch, row 2 the
+// full-width Manager pill.
 function sidebarLeftStack() {
   const wrap = el('div', 'sidebar-left');
   wrap.appendChild(ticketsCard());
-  wrap.appendChild(scratchCard());
 
-  // Row 1: Grid · Reviews · Scorecard (each its own non-wrapping flex line).
+  // Row 1: Grid · Reviews · Scorecard · Scratch (each its own non-wrapping flex line).
   const row1 = el('div', 'nav-pills-row');
   row1.appendChild(navPill('Grid', selectedBoard === 'grid', () => selectBoard('grid')));
   const rev = navPill('Reviews', selectedBoard === 'reviews', () => selectBoard('reviews'));
@@ -671,6 +665,7 @@ function sidebarLeftStack() {
   if (unseen) rev.appendChild(el('span', 'pill-badge', String(unseen)));
   row1.appendChild(rev);
   row1.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
+  row1.appendChild(scratchPill());
   wrap.appendChild(row1);
 
   // Row 2: the primary Manager pill, spanning the full left-column width. Only

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TodoRPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TodoRPCHandlers.swift
@@ -172,7 +172,9 @@ private func exploreTodo(
             appState.sessions.contains { $0.id == existing && $0.kind == .manager }
         }
         if alive {
-            let seeded = await seedExploreBrief(item: item, sessionID: existing, appState: appState)
+            let seeded = await sendToManager(
+                sessionID: existing, text: TodoRPC.exploreBrief(for: item),
+                appState: appState, waitForAgent: false)
             if item.state != .exploring {
                 item.state = .exploring
                 item.updatedAt = Date()
@@ -202,7 +204,9 @@ private func exploreTodo(
         return (id, display)
     }
 
-    let seeded = await seedExploreBrief(item: item, sessionID: sessionID, appState: appState)
+    let seeded = await sendToManager(
+        sessionID: sessionID, text: TodoRPC.exploreBrief(for: item),
+        appState: appState, waitForAgent: true)
     item.links.append(TodoLink(type: .session, sessionID: sessionID, label: name))
     item.state = .exploring
     item.updatedAt = Date()
@@ -221,22 +225,64 @@ private func exploreTodo(
     return result
 }
 
-/// Wait for the Manager pane, then paste the explore brief. Managers do not
-/// track readiness the way work sessions do, so we wait for the terminal row
-/// and a short settle rather than a sentinel.
-private func seedExploreBrief(
-    item: TodoItem, sessionID: UUID, appState: AppState
+/// Wait for the Manager pane (and, on a fresh launch, for the agent to
+/// announce via SessionStart), paste `text`, then retry a bare Enter if
+/// the agent stayed idle. Managers do not track `TerminalReadiness` the
+/// way work sessions do, so SessionStart + a composer settle is the
+/// "ready to submit" signal (#1233 / #264 / #272). `seeded`/`sent`
+/// still mean "we delivered to a live pane", not "the agent started
+/// working" — the retry is what closes the "words in the box, agent
+/// idle" gap.
+private func sendToManager(
+    sessionID: UUID,
+    text: String,
+    appState: AppState,
+    waitForAgent: Bool
 ) async -> Bool {
     var terminal: SessionTerminal?
-    for _ in 0..<20 {
+    for _ in 0..<TodoRPC.managerTerminalPolls {
         terminal = await MainActor.run { appState.terminals[sessionID]?.first }
         if terminal != nil { break }
-        try? await Task.sleep(nanoseconds: 250_000_000)
+        try? await Task.sleep(nanoseconds: TodoRPC.managerTerminalPollNanos)
     }
     guard let terminal else { return false }
-    try? await Task.sleep(nanoseconds: 2_000_000_000)
+
+    var announced = await MainActor.run {
+        TodoRPC.agentHasAnnounced(
+            hookEventCount: appState.hookState(for: sessionID).hookEvents.count)
+    }
+    let alreadyAnnounced = announced
+    if !announced {
+        let polls = waitForAgent
+            ? TodoRPC.agentAnnouncePolls
+            : TodoRPC.existingAgentAnnouncePolls
+        for _ in 0..<polls {
+            announced = await MainActor.run {
+                TodoRPC.agentHasAnnounced(
+                    hookEventCount: appState.hookState(for: sessionID).hookEvents.count)
+            }
+            if announced { break }
+            try? await Task.sleep(nanoseconds: TodoRPC.agentAnnouncePollNanos)
+        }
+    }
+    try? await Task.sleep(nanoseconds: alreadyAnnounced
+        ? TodoRPC.alreadyUpSettleNanos
+        : TodoRPC.composerSettleNanos)
+
+    var payload = text
+    if !payload.hasSuffix("\n") { payload += "\n" }
     await MainActor.run {
-        TerminalRouter.send(terminal, text: TodoRPC.exploreBrief(for: item))
+        TerminalRouter.send(terminal, text: payload)
+    }
+
+    try? await Task.sleep(nanoseconds: TodoRPC.submitConfirmNanos)
+    let activity = await MainActor.run {
+        appState.hookState(for: sessionID).activityState
+    }
+    if TodoRPC.shouldRetryEnter(activity: activity, agentAnnounced: announced) {
+        await MainActor.run {
+            TerminalRouter.send(terminal, text: "\n")
+        }
     }
     return true
 }
@@ -346,15 +392,13 @@ private func talkTodo(
     guard let sessionID = item.linkedSessionID else {
         throw RPCError.applicationError("Explore this item first (`crow todo explore`)")
     }
-    guard var text = params["text"]?.stringValue, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    guard let text = params["text"]?.stringValue, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         throw RPCError.invalidParams("text is required")
     }
-    if !text.hasSuffix("\n") { text += "\n" }
-    try await MainActor.run {
-        guard let terminal = appState.terminals[sessionID]?.first else {
-            throw DaemonRPCError.applicationError("The linked Manager has no terminal")
-        }
-        TerminalRouter.send(terminal, text: text)
+    let sent = await sendToManager(
+        sessionID: sessionID, text: text, appState: appState, waitForAgent: false)
+    guard sent else {
+        throw RPCError.applicationError("The linked Manager has no terminal")
     }
     return ["todo": TodoRPC.todoJSON(item), "sent": .bool(true), "session_id": .string(sessionID.uuidString)]
 }

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TodoRPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TodoRPCHandlers.swift
@@ -5,8 +5,8 @@ import CrowPersistence
 import CrowProvider
 import Foundation
 
-/// Scratch / pre-ticket idea list (CROW-1231). Mutations go through the
-/// injected `JSONStore` via `TodoRepository` — never a throwaway store.
+/// Scratch list (CROW-1231). Mutations go through the injected `JSONStore`
+/// via `TodoRepository` — never a throwaway store.
 func makeTodoHandlers(
     appState: AppState,
     store: JSONStore,
@@ -247,20 +247,19 @@ private func sendToManager(
     }
     guard let terminal else { return false }
 
-    var announced = await MainActor.run {
-        TodoRPC.agentHasAnnounced(
-            hookEventCount: appState.hookState(for: sessionID).hookEvents.count)
+    func hookEventNames() async -> [String] {
+        await MainActor.run {
+            appState.hookState(for: sessionID).hookEvents.map(\.eventName)
+        }
     }
+    var announced = TodoRPC.agentHasAnnounced(hookEventNames: await hookEventNames())
     let alreadyAnnounced = announced
     if !announced {
         let polls = waitForAgent
             ? TodoRPC.agentAnnouncePolls
             : TodoRPC.existingAgentAnnouncePolls
         for _ in 0..<polls {
-            announced = await MainActor.run {
-                TodoRPC.agentHasAnnounced(
-                    hookEventCount: appState.hookState(for: sessionID).hookEvents.count)
-            }
+            announced = TodoRPC.agentHasAnnounced(hookEventNames: await hookEventNames())
             if announced { break }
             try? await Task.sleep(nanoseconds: TodoRPC.agentAnnouncePollNanos)
         }

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -628,6 +628,23 @@ import Testing
             "the relocated Select toggle needs its .nav-select styles")
     }
 
+    /// CROW-1233: Scratch is a fourth nav pill on the Grid/Reviews/Scorecard
+    /// row, not a Tickets-style card stacked under Tickets.
+    @Test func scratchIsANavPillNotACardUnderTickets() throws {
+        let js = try Self.webClientJS()
+        let stack = try Self.stripComments(String(Self.functionBody("sidebarLeftStack", in: js)))
+        #expect(
+            stack.contains("scratchPill") && !stack.contains("scratchCard"),
+            "sidebarLeftStack must render Scratch via scratchPill, not a second tickets-card")
+        #expect(
+            try Self.functionBody("scratchPill", in: js).contains("'Scratch'"),
+            "scratchPill must label the pill Scratch")
+        let css = try Self.webAsset("app.css")
+        #expect(
+            !css.contains(".scratch-card") && !css.contains(".scratch-sub"),
+            "the Scratch-as-card CSS is dead once Scratch is a nav pill")
+    }
+
     /// CROW-917/922: layout decisions with no other pin, verified to regress silently
     /// (reverting any leaves every suite green). CROW-922 made the right column's icon
     /// buttons natural-size (`flex: 0 0 auto`) with a `min-height` floor above the WCAG

--- a/Packages/CrowDaemon/web-tests/grid.test.js
+++ b/Packages/CrowDaemon/web-tests/grid.test.js
@@ -240,6 +240,8 @@ console.log('\nnav pill:');
   const pills = [...stack.querySelectorAll('.nav-pill .pill-label')].map((n) => n.textContent);
   check('Grid is a nav pill', pills.indexOf('Grid') !== -1);
   check('Grid sits before Reviews', pills.indexOf('Grid') < pills.indexOf('Reviews'));
+  check('Scratch is a nav pill', pills.indexOf('Scratch') !== -1);
+  check('Scratch sits after Scorecard', pills.indexOf('Scorecard') < pills.indexOf('Scratch'));
 }
 
 console.log('\ncontext menu Pin to grid:');

--- a/Packages/CrowDaemon/web-tests/rpc-timeout.test.js
+++ b/Packages/CrowDaemon/web-tests/rpc-timeout.test.js
@@ -132,6 +132,8 @@ const deliver = (msg) => cur().deliver(msg);
   check('quick-action 60s', T.rpcTimeoutFor('quick-action') === 60000);
   check('get-state 60s', T.rpcTimeoutFor('get-state') === 60000);
   check('batch-work-on-issues 60s', T.rpcTimeoutFor('batch-work-on-issues') === 60000);
+  check('todo-explore 90s', T.rpcTimeoutFor('todo-explore') === 90000);
+  check('todo-talk 90s', T.rpcTimeoutFor('todo-talk') === 90000);
 
   console.log('\nTimeout rejects tagged and RETAINS the pending entry:');
   await reset();

--- a/Packages/CrowDaemon/web-tests/scratch.test.js
+++ b/Packages/CrowDaemon/web-tests/scratch.test.js
@@ -9,7 +9,7 @@ const epilogue = `
   set selectedBoard(v){ selectedBoard = v; },
   set rpc(v){ rpc = v; },
   renderBoard(){ return renderBoard(); },
-  scratchCard(){ return scratchCard(); },
+  sidebarLeftStack(){ return sidebarLeftStack(); },
   scratchOpenCount(){ return scratchOpenCount(); },
 };
 `;
@@ -63,7 +63,7 @@ T.renderBoard();
 const board = window.document.getElementById('board');
 check('board title', board.textContent.includes('Scratch'));
 check('capture form', !!board.querySelector('.scratch-capture'));
-check('idea text', board.textContent.includes('native scratch list'));
+check('item text', board.textContent.includes('native scratch list'));
 check('state chip', board.textContent.includes('captured'));
 check('Explore action', board.textContent.includes('Explore'));
 check('Ticket action', board.textContent.includes('Ticket'));
@@ -89,16 +89,26 @@ check('Work enabled once a ticket exists', ticketedWork && !ticketedWork.disable
 T.boardData.scratch = { todos: [item] };
 T.renderBoard();
 
-const card = T.scratchCard();
-check('sidebar card label', card.textContent.includes('Scratch'));
+const stack = T.sidebarLeftStack();
+const pills = [...stack.querySelectorAll('.nav-pill .pill-label')].map((n) => n.textContent);
+check('Scratch is a nav pill', pills.indexOf('Scratch') !== -1);
+check('Scratch sits after Scorecard', pills.indexOf('Scorecard') < pills.indexOf('Scratch'));
+check('Scratch is not a Tickets-style card', !stack.querySelector('.scratch-card'));
 check('open count', T.scratchOpenCount() === 1);
+const scratchPill = [...stack.querySelectorAll('.nav-pill')].find((p) => p.querySelector('.pill-label')?.textContent === 'Scratch');
+check('open-count badge on the pill', scratchPill && scratchPill.textContent.includes('1'));
 
 item.state = 'done';
 T.boardData.scratch = { todos: [item] };
 check('done items are not open', T.scratchOpenCount() === 0);
 
 T.renderBoard();
-check('hides done by default', !board.textContent.includes('native scratch list') || board.textContent.includes('No open ideas'));
+check('hides done by default', !board.textContent.includes('native scratch list') || board.textContent.includes('Nothing open'));
+check('empty state does not say idea', !board.textContent.toLowerCase().includes('idea'));
+T.boardData.scratch = { todos: [] };
+T.renderBoard();
+check('blank-board copy does not say idea', !board.textContent.toLowerCase().includes('idea'));
+check('capture placeholder', board.querySelector('.scratch-input')?.placeholder === 'Capture to Scratch…');
 
 if (failed) { console.log('\n' + failed + ' failed'); process.exit(1); }
 console.log('\nscratch board ok');

--- a/Packages/CrowEngine/Sources/CrowEngine/ManagerSessionController.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/ManagerSessionController.swift
@@ -139,6 +139,10 @@ final class ManagerSessionController {
         }
 
         appState.managerProcessExited = false
+        // The pane is gone; drop the previous process's SessionStart so
+        // sendToManager cannot treat stale hookEvents as "composer ready"
+        // (CROW-1233 review).
+        appState.resetHookStateForAgentRelaunch(sessionID: managerID)
         CrowLog.info("[CrowTelemetry manager:restart]")
 
         // Session row still exists, so this only recreates the terminal.

--- a/Packages/CrowEngine/Sources/CrowEngine/SessionSurfaceController.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/SessionSurfaceController.swift
@@ -490,6 +490,9 @@ final class SessionSurfaceController {
         // degraded window so its (now-duplicate) agent doesn't linger.
         applyRehydrationResult(sessionID: sessionID, original: seed, updated: updated)
         if let oldIndex { TmuxBackend.shared.killWindow(index: oldIndex) }
+        // Replacement window relaunches the agent. Drop the previous TUI's
+        // SessionStart so Explore/Talk wait for the new one (CROW-1233 review).
+        appState.resetHookStateForAgentRelaunch(sessionID: sessionID)
         return true
     }
 

--- a/Packages/CrowEngine/Sources/CrowEngine/TodoRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/TodoRPCSupport.swift
@@ -18,7 +18,7 @@ public enum TodoRPC {
         return id
     }
 
-    /// Extract and trim the idea text. Rejects missing or whitespace-only.
+    /// Extract and trim the item text. Rejects missing or whitespace-only.
     public static func decodeText(_ value: JSONValue?) throws -> String {
         guard let text = value?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
               !text.isEmpty else {
@@ -134,20 +134,20 @@ public enum TodoRPC {
             .split(whereSeparator: { $0.isNewline || $0.isWhitespace })
             .joined(separator: " ")
         let trimmed = String(collapsed.prefix(80))
-        if trimmed.isEmpty { return "explore-idea" }
+        if trimmed.isEmpty { return "Scratch" }
         if Validation.isValidSessionName(trimmed) { return trimmed }
         let stripped = String(trimmed.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) })
         let fallback = String(stripped.prefix(Validation.maxSessionNameLength))
-        return fallback.isEmpty ? "explore-idea" : fallback
+        return fallback.isEmpty ? "Scratch" : fallback
     }
 
     /// The prompt pasted into the exploring Manager. Read/explain only — this
-    /// is the pre-ticket sibling of `/crow-workspace --explore`.
+    /// is the Scratch sibling of `/crow-workspace --explore`.
     public static func exploreBrief(for item: TodoItem) -> String {
         var lines = [
-            "This is a pre-ticket idea from Crow Scratch. Explore it. Do not file a ticket, create a worktree, or start a work session unless I ask.",
+            "This is from Crow Scratch. Explore it. Do not file a ticket, create a worktree, or start a work session unless I ask.",
             "",
-            "## Idea",
+            "## Item",
             item.text,
         ]
         if !item.note.isEmpty {
@@ -163,7 +163,7 @@ public enum TodoRPC {
         return lines.joined(separator: "\n") + "\n"
     }
 
-    /// Body filed with `todo ticket` — the idea plus its note, tagged as
+    /// Body filed with `todo ticket` — the item plus its note, tagged as
     /// originating in Scratch so the trail is visible on the provider too.
     public static func ticketBody(for item: TodoItem) -> String {
         var parts: [String] = []
@@ -173,5 +173,53 @@ public enum TodoRPC {
         }
         parts.append("Filed from Crow Scratch.")
         return parts.joined(separator: "\n\n")
+    }
+
+    // MARK: - Manager prompt delivery (CROW-1233)
+
+    /// Polls waiting for the Manager pane to exist (20 × 250ms).
+    public static let managerTerminalPolls = 20
+    public static let managerTerminalPollNanos: UInt64 = 250_000_000
+
+    /// After the agent announces (SessionStart), Cursor's composer still
+    /// needs a beat before Enter is accepted (#1233 / #272).
+    public static let composerSettleNanos: UInt64 = 1_500_000_000
+    /// Already-running Manager (Talk / re-Explore after SessionStart): skip
+    /// the long composer settle — the TUI is already focused.
+    public static let alreadyUpSettleNanos: UInt64 = 200_000_000
+
+    /// Fresh Manager launch: wait up to 30s (60 × 500ms) for SessionStart.
+    public static let agentAnnouncePolls = 60
+    /// Existing Manager (Talk / re-Explore): shorter wait — the TUI is
+    /// usually already up, but Explore may have just spawned it.
+    public static let existingAgentAnnouncePolls = 16
+    public static let agentAnnouncePollNanos: UInt64 = 500_000_000
+
+    /// After paste+Enter, wait this long for `.working`/`.waiting` before
+    /// retrying a bare Enter. Too short and a slow UserPromptSubmit looks
+    /// like a dropped Enter; a second Enter would re-submit leftover text
+    /// (#631).
+    public static let submitConfirmNanos: UInt64 = 2_000_000_000
+
+    /// Whether hook events have arrived for this Manager — SessionStart
+    /// means the agent TUI is up enough to fire hooks, which is the
+    /// closest "composer ready" signal Managers have (they do not track
+    /// `TerminalReadiness` the way work sessions do).
+    public static func agentHasAnnounced(hookEventCount: Int) -> Bool {
+        hookEventCount > 0
+    }
+
+    /// Retry a bare Enter only when the agent announced itself and then
+    /// stayed idle after the paste — "words in the box, agent idle".
+    /// Skip the retry when hooks never fired (don't double-submit an
+    /// agent that accepted Enter but has no hook pipeline).
+    public static func shouldRetryEnter(
+        activity: AgentActivityState, agentAnnounced: Bool
+    ) -> Bool {
+        guard agentAnnounced else { return false }
+        switch activity {
+        case .working, .waiting: return false
+        case .idle, .done: return true
+        }
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/TodoRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/TodoRPCSupport.swift
@@ -201,12 +201,14 @@ public enum TodoRPC {
     /// (#631).
     public static let submitConfirmNanos: UInt64 = 2_000_000_000
 
-    /// Whether hook events have arrived for this Manager — SessionStart
-    /// means the agent TUI is up enough to fire hooks, which is the
-    /// closest "composer ready" signal Managers have (they do not track
-    /// `TerminalReadiness` the way work sessions do).
-    public static func agentHasAnnounced(hookEventCount: Int) -> Bool {
-        hookEventCount > 0
+    /// Whether this Manager's *current* agent TUI has announced itself.
+    /// Keys off `SessionStart` specifically — any other event (or a leftover
+    /// count from a previous pane after `recreate-terminal` / `restartManager`)
+    /// is not "composer ready". Managers do not track `TerminalReadiness`.
+    public static let sessionStartEventName = "SessionStart"
+
+    public static func agentHasAnnounced(hookEventNames: [String]) -> Bool {
+        hookEventNames.contains(sessionStartEventName)
     }
 
     /// Retry a bare Enter only when the agent announced itself and then

--- a/Packages/CrowEngine/Tests/CrowEngineTests/TodoRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/TodoRPCSupportTests.swift
@@ -77,7 +77,7 @@ struct TodoRPCSupportTests {
 
     @Test func managerNameCollapsesWhitespaceAndFallsBack() {
         #expect(TodoRPC.managerName(from: "  native   scratch\nlist ") == "native scratch list")
-        #expect(TodoRPC.managerName(from: "   ") == "explore-idea")
+        #expect(TodoRPC.managerName(from: "   ") == "Scratch")
         #expect(TodoRPC.managerName(from: String(repeating: "x", count: 90)).count == 80)
     }
 
@@ -85,7 +85,9 @@ struct TodoRPCSupportTests {
         let item = TodoItem(text: "try this", tags: ["ios"], priority: "p2")
         let brief = TodoRPC.exploreBrief(for: item)
         #expect(brief.hasSuffix("\n"))
-        #expect(brief.contains("## Idea"))
+        #expect(brief.contains("## Item"))
+        #expect(!brief.contains("## Idea"))
+        #expect(!brief.localizedCaseInsensitiveContains("idea"))
         #expect(brief.contains("try this"))
         #expect(!brief.contains("## Notes"))
         #expect(brief.contains("Tags: ios"))
@@ -99,5 +101,15 @@ struct TodoRPCSupportTests {
         #expect(body.contains("details"))
         #expect(body.contains("Tags: web"))
         #expect(body.contains("Filed from Crow Scratch."))
+    }
+
+    @Test func shouldRetryEnterOnlyWhenAnnouncedAndIdle() {
+        #expect(TodoRPC.shouldRetryEnter(activity: .idle, agentAnnounced: true))
+        #expect(TodoRPC.shouldRetryEnter(activity: .done, agentAnnounced: true))
+        #expect(!TodoRPC.shouldRetryEnter(activity: .working, agentAnnounced: true))
+        #expect(!TodoRPC.shouldRetryEnter(activity: .waiting, agentAnnounced: true))
+        #expect(!TodoRPC.shouldRetryEnter(activity: .idle, agentAnnounced: false))
+        #expect(TodoRPC.agentHasAnnounced(hookEventCount: 1))
+        #expect(!TodoRPC.agentHasAnnounced(hookEventCount: 0))
     }
 }

--- a/Packages/CrowEngine/Tests/CrowEngineTests/TodoRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/TodoRPCSupportTests.swift
@@ -109,7 +109,9 @@ struct TodoRPCSupportTests {
         #expect(!TodoRPC.shouldRetryEnter(activity: .working, agentAnnounced: true))
         #expect(!TodoRPC.shouldRetryEnter(activity: .waiting, agentAnnounced: true))
         #expect(!TodoRPC.shouldRetryEnter(activity: .idle, agentAnnounced: false))
-        #expect(TodoRPC.agentHasAnnounced(hookEventCount: 1))
-        #expect(!TodoRPC.agentHasAnnounced(hookEventCount: 0))
+        #expect(TodoRPC.agentHasAnnounced(hookEventNames: ["SessionStart"]))
+        #expect(TodoRPC.agentHasAnnounced(hookEventNames: ["UserPromptSubmit", "SessionStart"]))
+        #expect(!TodoRPC.agentHasAnnounced(hookEventNames: []))
+        #expect(!TodoRPC.agentHasAnnounced(hookEventNames: ["UserPromptSubmit"]))
     }
 }

--- a/Packages/CrowIPC/Sources/CrowIPC/MCP/MCPToolCatalog.swift
+++ b/Packages/CrowIPC/Sources/CrowIPC/MCP/MCPToolCatalog.swift
@@ -366,7 +366,7 @@ public enum MCPToolCatalog {
         name: "list_todos",
         title: "List Crow Scratch items",
         description: """
-            Pre-ticket ideas captured in Crow Scratch. Filter by state or tag. \
+            Items captured in Crow Scratch. Filter by state or tag. \
             Each row includes its provenance trail (explore session, filed ticket, PR).
             """,
         inputSchema: .object([
@@ -431,7 +431,7 @@ public enum MCPToolCatalog {
             }
             guard UUID(uuidString: todoID) != nil else {
                 throw MCPToolInputError(
-                    "todo_id must be a UUID (got \"\(todoID)\") — use the id from list_todos, not the idea text")
+                    "todo_id must be a UUID (got \"\(todoID)\") — use the id from list_todos, not the item text")
             }
             let result = try await invoke("todo-get", ["todo_id": .string(todoID)])
             return .object(result)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -645,7 +645,7 @@ crow job duplicate --id <job-uuid>
 
 ## Todo Commands
 
-Pre-ticket ideas (CROW-1231) — the Scratch sidebar. Capture in Crow, then promote into a Manager / ticket / work session. The collection lives in the shared `store.json` (the same `JSONStore` sessions use) and is **not** visited by the session retention reaper: a parked idea persists until someone acts on it.
+Scratch items (CROW-1231) — the Scratch sidebar. Capture in Crow, then promote into a Manager / ticket / work session. The collection lives in the shared `store.json` (the same `JSONStore` sessions use) and is **not** visited by the session retention reaper: a parked item persists until someone acts on it.
 
 Every subcommand goes through the running daemon's RPC socket. Items are addressed by UUID (`--id`), which `crow todo list` prints.
 
@@ -657,7 +657,7 @@ crow todo add "native scratch list" --tag crow,cli --priority p2 --note "explore
 
 | Flag         | Required | Description                         |
 | ------------ | -------- | ----------------------------------- |
-| `<text>`     | yes      | Idea text (positional)             |
+| `<text>`     | yes      | Item text (positional)             |
 | `--tag`     | no       | Comma-separated tags                 |
 | `--priority`| no       | `p1`, `p2`, `p3`, or `p4`           |
 | `--note`    | no       | Longer note                         |
@@ -722,7 +722,7 @@ crow todo link --id <todo-uuid> --type session --session <session-uuid> --label 
 
 ### `crow todo explore`
 
-Create a Manager, seed the item as a pre-ticket explore brief, attach the session, and move state to `exploring`. Needs tmux.
+Create a Manager, seed the item as a Scratch explore brief, attach the session, and move state to `exploring`. Needs tmux.
 
 ```bash
 crow todo explore --id <todo-uuid>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,8 +133,8 @@ Every subcommand and flag the `crow` binary accepts, generated from the commands
 | [`crow terminal`](#crow-terminal) | View or change terminal wheel-scroll speed |
 | [`crow terminal get`](#crow-terminal-get) | Show the current terminal wheel-scroll settings |
 | [`crow terminal set`](#crow-terminal-set) | Change terminal wheel-scroll speed |
-| [`crow todo`](#crow-todo) | Capture and promote pre-ticket ideas |
-| [`crow todo add`](#crow-todo-add) | Capture a pre-ticket idea |
+| [`crow todo`](#crow-todo) | Capture and promote Scratch items |
+| [`crow todo add`](#crow-todo-add) | Capture a Scratch item |
 | [`crow todo delete`](#crow-todo-delete) | Delete a Scratch item |
 | [`crow todo done`](#crow-todo-done) | Mark a Scratch item done |
 | [`crow todo drop`](#crow-todo-drop) | Drop a Scratch item without filing a ticket |
@@ -2080,7 +2080,7 @@ Only the flags you pass change; at least one is required. Connected browsers pic
 
 ## `crow todo`
 
-Capture and promote pre-ticket ideas.
+Capture and promote Scratch items.
 
 ```
 crow todo <add|list|get|edit|done|reopen|park|drop|delete|link|explore|ticket|work|talk>
@@ -2092,7 +2092,7 @@ Subcommands: [`add`](#crow-todo-add), [`list`](#crow-todo-list), [`get`](#crow-t
 
 ## `crow todo add`
 
-Capture a pre-ticket idea.
+Capture a Scratch item.
 
 ```
 crow todo add <text> [--tag <tag>] [--priority <priority>] [--note <note>]
@@ -2100,7 +2100,7 @@ crow todo add <text> [--tag <tag>] [--priority <priority>] [--note <note>]
 
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
-| _(positional)_ | `<text>` | yes | Idea text |
+| _(positional)_ | `<text>` | yes | Item text |
 | `--tag` | `<tag>` | no | Comma-separated tags |
 | `--priority` | `<priority>` | no | Priority: p1, p2, p3, or p4 |
 | `--note` | `<note>` | no | Longer note |
@@ -2162,7 +2162,7 @@ Only the provided flags change. --add-tag / --remove-tag compose; they do not re
 | Flag | Value | Required | Description |
 | --- | --- | --- | --- |
 | `--id` | `<id>` | yes | Todo UUID |
-| `--text` | `<text>` | no | Replacement idea text |
+| `--text` | `<text>` | no | Replacement item text |
 | `--note` | `<note>` | no | Replacement note |
 | `--priority` | `<priority>` | no | Priority: p1, p2, p3, or p4 |
 | `--add-tag` | `<add-tag>` _(repeatable)_ | no | Tag to add (repeatable) |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -60,7 +60,7 @@ deny-after-call would still teach the model that they do.
 | `list_stuck_sessions` | `sessions:read` | What needs a human, and why |
 | `list_tickets` | `board:read` | The ticket board (issue bodies omitted) |
 | `list_reviews` | `board:read` | The reviews board, by group |
-| `list_todos` | `todos:read` | Pre-ticket Scratch items, with their provenance trail |
+| `list_todos` | `todos:read` | Scratch items, with their provenance trail |
 | `get_todo` | `todos:read` | One Scratch item in full, by UUID |
 
 `list_stuck_sessions` is the one worth knowing about. It joins two payloads that are


### PR DESCRIPTION
Closes #1233

## Summary
- Call the list **Scratch** in UI copy, empty states, the explore brief, and CLI/MCP abstracts — not "ideas" / "pre-ticket ideas"
- Move Scratch onto the Grid · Reviews · Scorecard nav-pill row (open-count badge stays on the pill); `#/scratch` is unchanged
- Explore / Talk wait for the Manager's SessionStart (then retry a bare Enter if the agent stayed idle) so the composer actually submits instead of leaving unsubmitted text

## Test plan
- [ ] Scratch UI, empty states, explore brief, and `crow todo` / MCP abstracts do not say "idea" / "pre-ticket ideas"
- [ ] Sidebar: Scratch is a pill on the Grid · Reviews · Scorecard row, not a card under Tickets; `#/scratch` still opens the board
- [ ] Scratch Explore: the Manager's agent actually starts on the brief (not sitting on unsubmitted composer text). Same for Talk after Explore.


Made with [Cursor](https://cursor.com)