### PR TITLE
Raise the corveil auto-update asset cap to 256 MiB

### DIFF
--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilAutoUpdateServiceTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/CorveilAutoUpdateServiceTests.swift
@@ -32,7 +32,8 @@ import FoundationNetworking
 
     private func assetName() -> String { CorveilAutoUpdate.assetName() }
 
-    private func transport(binary: Data, checksums: String, tag: String = "v0.4.32")
+    private func transport(binary: Data, checksums: String, tag: String = "v0.4.32",
+                           announcedSize: Int? = nil)
         -> @Sendable (URLRequest) async throws -> (Data, URLResponse)
     {
         let release: [String: Any] = [
@@ -41,7 +42,7 @@ import FoundationNetworking
                 [
                     "name": assetName(),
                     "browser_download_url": "https://example.test/\(assetName())",
-                    "size": binary.count,
+                    "size": announcedSize ?? binary.count,
                 ],
                 [
                     "name": "checksums.txt",
@@ -224,5 +225,160 @@ import FoundationNetworking
         let status = await service.runCheck()
         #expect(status.state == .disabled)
         #expect(hits.value == 0)
+    }
+
+    @Test func publishedAssetSizeIsAccepted() async throws {
+        let devRoot = try tempDir("crowd-corveil-dev")
+        let managed = try tempDir("crowd-corveil-bin")
+        defer {
+            try? FileManager.default.removeItem(at: devRoot)
+            try? FileManager.default.removeItem(at: managed)
+        }
+        var config = AppConfig()
+        config.defaults.corveilAutoUpdate = true
+        try ConfigStore.saveConfig(config, devRoot: devRoot.path)
+
+        // v0.4.41 darwin-arm64 — the 80 MiB cap rejected this before download.
+        let publishedSize = 105_344_594
+        let binary = Data("corveil-fixture".utf8)
+        let checksums = "\(fakeHash)  \(assetName())\n"
+        let service = CorveilAutoUpdateService(
+            devRoot: devRoot.path,
+            managedRoot: managed,
+            userAgent: "Crow/test",
+            transport: transport(binary: binary, checksums: checksums, announcedSize: publishedSize),
+            hooks: hooks())
+        let status = await service.runCheck()
+        #expect(status.state == .updated)
+        #expect(status.version == "v0.4.32")
+    }
+
+    @Test func announcedSizeOverCapFailsWithoutDownloadingBinary() async throws {
+        let devRoot = try tempDir("crowd-corveil-dev")
+        let managed = try tempDir("crowd-corveil-bin")
+        defer {
+            try? FileManager.default.removeItem(at: devRoot)
+            try? FileManager.default.removeItem(at: managed)
+        }
+        var config = AppConfig()
+        config.defaults.corveilAutoUpdate = true
+        try ConfigStore.saveConfig(config, devRoot: devRoot.path)
+
+        let lastGood = CorveilAutoUpdate.binaryURL(tag: "v0.4.31", managedRoot: managed)
+        try FileManager.default.createDirectory(
+            at: lastGood.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: lastGood)
+
+        let over = CorveilAutoUpdate.maxAssetBytes + 1
+        let checksums = "\(fakeHash)  \(assetName())\n"
+        let release: [String: Any] = [
+            "tag_name": "v0.4.32",
+            "assets": [
+                [
+                    "name": assetName(),
+                    "browser_download_url": "https://example.test/\(assetName())",
+                    "size": over,
+                ],
+                [
+                    "name": "checksums.txt",
+                    "browser_download_url": "https://example.test/checksums.txt",
+                    "size": checksums.utf8.count,
+                ],
+            ],
+        ]
+        let releaseData = try JSONSerialization.data(withJSONObject: release)
+        let downloadHits = HitCount()
+        let transport: @Sendable (URLRequest) async throws -> (Data, URLResponse) = { request in
+            let url = request.url?.absoluteString ?? ""
+            let body: Data
+            if url.contains("/releases/") {
+                body = releaseData
+            } else {
+                downloadHits.value += 1
+                body = Data("should-not-download".utf8)
+            }
+            return (body, HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let service = CorveilAutoUpdateService(
+            devRoot: devRoot.path,
+            managedRoot: managed,
+            userAgent: "Crow/test",
+            transport: transport,
+            hooks: hooks())
+        let status = await service.runCheck()
+        #expect(status.state == .failed)
+        #expect(status.message?.contains("over the") == true)
+        #expect(downloadHits.value == 0)
+        #expect(FileManager.default.fileExists(atPath: lastGood.path))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot.path)?.defaults.binaries["corveil"] == nil)
+    }
+
+    @Test func offlineFetchKeepsLastGood() async throws {
+        let devRoot = try tempDir("crowd-corveil-dev")
+        let managed = try tempDir("crowd-corveil-bin")
+        defer {
+            try? FileManager.default.removeItem(at: devRoot)
+            try? FileManager.default.removeItem(at: managed)
+        }
+        let lastGood = CorveilAutoUpdate.binaryURL(tag: "v0.4.31", managedRoot: managed)
+        try FileManager.default.createDirectory(
+            at: lastGood.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: lastGood)
+
+        var config = AppConfig()
+        config.defaults.corveilAutoUpdate = true
+        config.defaults.binaries["corveil"] = lastGood.path
+        try ConfigStore.saveConfig(config, devRoot: devRoot.path)
+
+        let transport: @Sendable (URLRequest) async throws -> (Data, URLResponse) = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        let service = CorveilAutoUpdateService(
+            devRoot: devRoot.path,
+            managedRoot: managed,
+            userAgent: "Crow/test",
+            transport: transport,
+            hooks: hooks())
+        let status = await service.runCheck()
+        #expect(status.state == .failed)
+        #expect(status.message?.contains("Could not fetch") == true)
+        #expect(FileManager.default.fileExists(atPath: lastGood.path))
+        #expect(try Data(contentsOf: lastGood) == Data("old".utf8))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot.path)?.defaults.binaries["corveil"]
+                == lastGood.path)
+    }
+
+    /// Hits the public `corveil/corveil-releases` repo over the live network.
+    /// Off in CI. Run with:
+    /// `CROW_LIVE_CORVEIL_UPDATE=1 swift test --package-path Packages/CrowDaemon --filter liveGitHubDownloadInstallsHostBinary`
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["CROW_LIVE_CORVEIL_UPDATE"] == "1"))
+    func liveGitHubDownloadInstallsHostBinary() async throws {
+        let devRoot = try tempDir("crowd-corveil-live-dev")
+        let managed = try tempDir("crowd-corveil-live-bin")
+        defer {
+            try? FileManager.default.removeItem(at: devRoot)
+            try? FileManager.default.removeItem(at: managed)
+        }
+        var config = AppConfig()
+        config.defaults.corveilAutoUpdate = true
+        try ConfigStore.saveConfig(config, devRoot: devRoot.path)
+
+        let service = CorveilAutoUpdateService(
+            devRoot: devRoot.path,
+            managedRoot: managed,
+            userAgent: "Crow/live-test")
+        let status = await service.runCheck()
+        #expect(status.state == .updated, "live update failed: \(status.message ?? "no message")")
+        let version = try #require(status.version)
+        let path = try #require(status.path)
+        #expect(FileManager.default.isExecutableFile(atPath: path))
+        #expect(CorveilAutoUpdate.isManagedPath(path, managedRoot: managed))
+        let outcome = CorveilCLI.verify(path: path)
+        #expect(outcome.ok, "verify: \(outcome.message)")
+        #expect(CorveilAutoUpdate.verifyMessage(outcome.message, matchesTag: version))
+        #expect(ConfigStore.loadConfig(devRoot: devRoot.path)?.defaults.binaries["corveil"] == path)
+        let link = (devRoot.path as NSString).appendingPathComponent(".claude/bin/corveil")
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: link) == path)
     }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/CorveilAutoUpdate.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/CorveilAutoUpdate.swift
@@ -14,9 +14,10 @@ import Darwin
 public enum CorveilAutoUpdate {
     public static let checksumsAssetName = "checksums.txt"
     public static let binaryFileName = "corveil"
-    /// Upper bound on a downloaded asset. The published CLIs are tens of MB;
-    /// anything larger is treated as a bad/malicious payload rather than written.
-    public static let maxAssetBytes = 80 * 1024 * 1024
+    /// Upper bound on a downloaded asset. Published CLIs are ~100–110 MiB
+    /// (v0.4.41 darwin-amd64 is 111_143_664 bytes); anything larger is treated
+    /// as a bad/malicious payload rather than written.
+    public static let maxAssetBytes = 256 * 1024 * 1024
 
     public static var hostOperatingSystem: String {
         #if os(macOS)

--- a/Packages/CrowEngine/Tests/CrowEngineTests/CorveilAutoUpdateTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/CorveilAutoUpdateTests.swift
@@ -4,6 +4,12 @@ import Testing
 
 @Suite("Corveil auto-update helpers")
 struct CorveilAutoUpdateTests {
+    @Test func maxAssetBytesFitsPublishedCLIs() {
+        // v0.4.41 darwin-amd64 is 111_143_664 bytes; all four platform binaries
+        // sit just over 100 MiB. An 80 MiB cap rejected every published asset.
+        #expect(CorveilAutoUpdate.maxAssetBytes >= 200 * 1024 * 1024)
+    }
+
     @Test func assetNameMapsX86ToAmd64() {
         #expect(CorveilAutoUpdate.assetName(os: "darwin", arch: "arm64") == "corveil-darwin-arm64")
         #expect(CorveilAutoUpdate.assetName(os: "linux", arch: "x86_64") == "corveil-linux-amd64")


### PR DESCRIPTION
Closes #1235

## Summary
- Raise `CorveilAutoUpdate.maxAssetBytes` from 80 MiB to 256 MiB so published `corveil/corveil-releases` CLIs (~100–110 MiB; v0.4.41 darwin-amd64 is 111_143_664) pass the pre-download guard.
- Keep the pre-download (`binaryAsset.size`) and post-download (`payload.count`) caps. Checksum mismatch and offline still fail closed and leave last-good linked.
- Pin `maxAssetBytes >= 200 MiB` so an 80 MiB cap cannot come back. Gated live test (`CROW_LIVE_CORVEIL_UPDATE=1`) downloads and verifies the host-platform asset from `-releases`.

## Test plan
- [x] `swift test --package-path Packages/CrowEngine --filter CorveilAutoUpdate` — includes `maxAssetBytesFitsPublishedCLIs`
- [x] `swift test --package-path Packages/CrowDaemon --filter CorveilAutoUpdateService` — published 105 MiB announced size is accepted; over-cap fails without download; checksum mismatch / offline keep last-good
- [x] `CROW_LIVE_CORVEIL_UPDATE=1 swift test --package-path Packages/CrowDaemon --filter liveGitHubDownloadInstallsHostBinary` — linked **v0.4.41**
- [ ] `crowd` with auto-update on and no source-build override downloads the host-platform asset instead of `… is N bytes, over the 83886080 cap`
- [ ] Checksum mismatch / offline leave the last-good binary linked; `crowd` still starts


Made with [Cursor](https://cursor.com)