### PR TITLE
Split Scratch nav 2×2 and seed Explore at Manager launch

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -990,10 +990,10 @@ button.scratch-link:hover { border-color: var(--blue); }
 .tk-dot { width: 7px; height: 7px; border-radius: 50%; }
 .tk-n { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-/* Left-column nav rows (CROW-917 / CROW-1233): row 1 Grid/Reviews/Scorecard/Scratch,
-   row 2 the full-width Manager pill. Each .nav-pills-row is its own non-wrapping
-   flex line so groups never reflow; the "+" and Select buttons live in the right
-   icon column. */
+/* Left-column nav rows (CROW-917 / CROW-1237): Grid · Scorecard, then
+   Reviews · Scratch, then the full-width Manager pill. Each .nav-pills-row is
+   its own non-wrapping flex line so groups never reflow; the "+" and Select
+   buttons live in the right icon column. Four pills on one row ellipsized. */
 .nav-pills-row { display: flex; gap: 6px; }
 .nav-pill {
   flex: 1 1 auto; min-width: 0; display: flex; align-items: center; justify-content: center; gap: 5px;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar-chrome.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar-chrome.js
@@ -197,41 +197,46 @@ function sidebarIconColumn() {
   return col;
 }
 
-// Left sidebar-top stack (CROW-917 / CROW-1233): the Tickets card over two
-// nav-pill rows — row 1 Grid · Reviews · Scorecard · Scratch, row 2 the
-// full-width Manager pill.
+// Left sidebar-top stack (CROW-917 / CROW-1237): the Tickets card over three
+// nav-pill rows — Grid · Scorecard, Reviews · Scratch, then the full-width
+// Manager pill. Four pills on one row ellipsize at the default sidebar width.
 function sidebarLeftStack() {
   const wrap = el('div', 'sidebar-left');
   wrap.appendChild(ticketsCard());
 
-  // Row 1: Grid · Reviews · Scorecard · Scratch (each its own non-wrapping flex line).
+  // Row 1: Grid · Scorecard (each .nav-pills-row is its own non-wrapping flex line).
   const row1 = el('div', 'nav-pills-row');
   row1.appendChild(navPill('Grid', selectedBoard === 'grid', () => selectBoard('grid')));
+  row1.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
+  wrap.appendChild(row1);
+
+  // Row 2: Reviews · Scratch. Open-count badge stays on Scratch — two labels
+  // still fit the left column where four did not (CROW-1237).
+  const row2 = el('div', 'nav-pills-row');
   const rev = navPill('Reviews', selectedBoard === 'reviews', () => selectBoard('reviews'));
   const unseen = (boardData.reviews && boardData.reviews.unseen) || 0;
   if (unseen) rev.appendChild(el('span', 'pill-badge', String(unseen)));
-  row1.appendChild(rev);
-  row1.appendChild(navPill('Scorecard', selectedBoard === 'scorecard', () => selectBoard('scorecard')));
-  row1.appendChild(scratchPill());
-  wrap.appendChild(row1);
+  row2.appendChild(rev);
+  row2.appendChild(scratchPill());
+  wrap.appendChild(row2);
 
-  // Row 2: the primary Manager pill, spanning the full left-column width. Only
+  // Row 3: the primary Manager pill, spanning the full left-column width. Only
   // appended when a primary manager exists — an empty .nav-pills-row still consumes
-  // a flex-gap slot, so appending one would leave a stray 6px gap below row 1. (The
+  // a flex-gap slot, so appending one would leave a stray 6px gap below row 2. (The
   // right icon column no longer divides the left column's height — its buttons are a
   // fixed-size centered stack since CROW-922 — so a Manager-less render can't shrink
   // them below the WCAG floor.)
   const primaryManager = sessions.find((s) => s.kind === 'manager');
   if (primaryManager) {
-    const row2 = el('div', 'nav-pills-row');
+    const row3 = el('div', 'nav-pills-row');
     const mgr = navPill('Manager', selectedId === primaryManager.id, () => selectSession(primaryManager.id));
     const ind = activityIndicator(primaryManager);
     const dot = el('span', 'pill-dot' + (ind.pulse ? ' pulse' : ''));
     dot.style.background = ind.color;
     mgr.insertBefore(dot, mgr.firstChild);
     if (liveFor(primaryManager.id).remote_control_active) mgr.appendChild(rcGlyph());
-    row2.appendChild(mgr);
-    wrap.appendChild(row2);
+    row3.appendChild(mgr);
+    wrap.appendChild(row3);
   }
 
   return wrap;

--- a/Packages/CrowDaemon/Sources/CrowDaemon/TodoRPCHandlers.swift
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/TodoRPCHandlers.swift
@@ -193,19 +193,20 @@ private func exploreTodo(
         }
     }
 
+    let brief = TodoRPC.exploreBrief(for: item)
     let (sessionID, name) = await MainActor.run { () -> (UUID, String) in
-        let existing = Set(appState.managerSessions.map(\.name))
-        var n = 2
-        while existing.contains("Manager \(n)") { n += 1 }
-        let id = sessionService.createManagerSession(
-            name: "Manager \(n)", cwd: devRoot, agentKind: requestedAgentKind)
+        // Name the session after the item at create time. A follow-up
+        // `renameSession` would paste `/rename` into the pane before the
+        // agent TUI owns stdin and offset/eat the explore brief (CROW-1237).
         let display = TodoRPC.managerName(from: item.text)
-        _ = sessionService.renameSession(sessionID: id, name: display)
+        let id = sessionService.createManagerSession(
+            name: display, cwd: devRoot, agentKind: requestedAgentKind,
+            initialPrompt: brief)
         return (id, display)
     }
 
     let seeded = await sendToManager(
-        sessionID: sessionID, text: TodoRPC.exploreBrief(for: item),
+        sessionID: sessionID, text: brief,
         appState: appState, waitForAgent: true)
     item.links.append(TodoLink(type: .session, sessionID: sessionID, label: name))
     item.state = .exploring
@@ -226,13 +227,17 @@ private func exploreTodo(
 }
 
 /// Wait for the Manager pane (and, on a fresh launch, for the agent to
-/// announce via SessionStart), paste `text`, then retry a bare Enter if
-/// the agent stayed idle. Managers do not track `TerminalReadiness` the
-/// way work sessions do, so SessionStart + a composer settle is the
-/// "ready to submit" signal (#1233 / #264 / #272). `seeded`/`sent`
-/// still mean "we delivered to a live pane", not "the agent started
-/// working" — the retry is what closes the "words in the box, agent
-/// idle" gap.
+/// announce via SessionStart or to own the pane), then deliver `text`.
+///
+/// Fresh Explore Managers seed the brief as argv on launch (job-style,
+/// CROW-1237) so this returns without pasting when UserPromptSubmit /
+/// `.working` already prove the agent started. Paste is the fallback for
+/// Talk, re-Explore, and harnesses that ignore a positional prompt.
+///
+/// After a paste: wait for acceptance, retry a bare Enter if the agent
+/// stayed idle ("words in the box"), then re-paste the full brief if
+/// Enter was not enough (paste eaten/offset). `seeded`/`sent` still mean
+/// "we delivered to a live pane" when no acceptance hook arrives.
 private func sendToManager(
     sessionID: UUID,
     text: String,
@@ -252,21 +257,47 @@ private func sendToManager(
             appState.hookState(for: sessionID).hookEvents.map(\.eventName)
         }
     }
+    func activity() async -> AgentActivityState {
+        await MainActor.run {
+            appState.hookState(for: sessionID).activityState
+        }
+    }
+    func promptAccepted() async -> Bool {
+        TodoRPC.promptWasAccepted(
+            hookEventNames: await hookEventNames(), activity: await activity())
+    }
+    func paneCommand() async -> String? {
+        await MainActor.run { TerminalRouter.paneCurrentCommand(terminal) }
+    }
+
     var announced = TodoRPC.agentHasAnnounced(hookEventNames: await hookEventNames())
+    var agentInPane = TodoRPC.paneLooksLikeAgent(await paneCommand() ?? "")
     let alreadyAnnounced = announced
-    if !announced {
+    if !announced && !agentInPane {
         let polls = waitForAgent
             ? TodoRPC.agentAnnouncePolls
             : TodoRPC.existingAgentAnnouncePolls
         for _ in 0..<polls {
             announced = TodoRPC.agentHasAnnounced(hookEventNames: await hookEventNames())
-            if announced { break }
+            agentInPane = TodoRPC.paneLooksLikeAgent(await paneCommand() ?? "")
+            if announced || agentInPane { break }
             try? await Task.sleep(nanoseconds: TodoRPC.agentAnnouncePollNanos)
         }
     }
+    let composerReady = announced || agentInPane
     try? await Task.sleep(nanoseconds: alreadyAnnounced
         ? TodoRPC.alreadyUpSettleNanos
         : TodoRPC.composerSettleNanos)
+
+    // Seed-at-launch already running — don't paste a second copy.
+    if await promptAccepted() { return true }
+    if waitForAgent && composerReady {
+        for _ in 0..<4 {
+            if await promptAccepted() { return true }
+            try? await Task.sleep(nanoseconds: TodoRPC.agentAnnouncePollNanos)
+        }
+        if await promptAccepted() { return true }
+    }
 
     var payload = text
     if !payload.hasSuffix("\n") { payload += "\n" }
@@ -275,12 +306,27 @@ private func sendToManager(
     }
 
     try? await Task.sleep(nanoseconds: TodoRPC.submitConfirmNanos)
-    let activity = await MainActor.run {
-        appState.hookState(for: sessionID).activityState
-    }
-    if TodoRPC.shouldRetryEnter(activity: activity, agentAnnounced: announced) {
+    if await promptAccepted() { return true }
+    if TodoRPC.shouldRetryEnter(
+        activity: await activity(),
+        agentAnnounced: composerReady,
+        promptAccepted: false
+    ) {
         await MainActor.run {
             TerminalRouter.send(terminal, text: "\n")
+        }
+        try? await Task.sleep(nanoseconds: TodoRPC.submitConfirmNanos)
+        if await promptAccepted() { return true }
+        // Paste was eaten or offset — Enter on leftover composer text is
+        // not enough. Re-send the whole brief (CROW-1237).
+        if TodoRPC.shouldRetryEnter(
+            activity: await activity(),
+            agentAnnounced: composerReady,
+            promptAccepted: false
+        ) {
+            await MainActor.run {
+                TerminalRouter.send(terminal, text: payload)
+            }
         }
     }
     return true

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -628,8 +628,9 @@ import Testing
             "the relocated Select toggle needs its .nav-select styles")
     }
 
-    /// CROW-1233: Scratch is a fourth nav pill on the Grid/Reviews/Scorecard
-    /// row, not a Tickets-style card stacked under Tickets.
+    /// CROW-1237: Scratch is a nav pill on its own two-pill row with Reviews
+    /// (Grid · Scorecard above), not a fourth pill on one line and not a
+    /// Tickets-style card stacked under Tickets.
     @Test func scratchIsANavPillNotACardUnderTickets() throws {
         let js = try Self.webClientJS()
         let stack = try Self.stripComments(String(Self.functionBody("sidebarLeftStack", in: js)))
@@ -639,6 +640,12 @@ import Testing
         #expect(
             try Self.functionBody("scratchPill", in: js).contains("'Scratch'"),
             "scratchPill must label the pill Scratch")
+        #expect(
+            stack.contains("navPill('Grid'") && stack.contains("navPill('Scorecard'"),
+            "row 1 is Grid · Scorecard (CROW-1237)")
+        #expect(
+            stack.contains("navPill('Reviews'") && stack.contains("scratchPill()"),
+            "row 2 is Reviews · Scratch (CROW-1237)")
         let css = try Self.webAsset("app.css")
         #expect(
             !css.contains(".scratch-card") && !css.contains(".scratch-sub"),

--- a/Packages/CrowDaemon/web-tests/grid.test.js
+++ b/Packages/CrowDaemon/web-tests/grid.test.js
@@ -242,6 +242,10 @@ console.log('\nnav pill:');
   check('Grid sits before Reviews', pills.indexOf('Grid') < pills.indexOf('Reviews'));
   check('Scratch is a nav pill', pills.indexOf('Scratch') !== -1);
   check('Scratch sits after Scorecard', pills.indexOf('Scorecard') < pills.indexOf('Scratch'));
+  const rows = [...stack.querySelectorAll('.nav-pills-row')].map((row) =>
+    [...row.querySelectorAll('.nav-pill .pill-label')].map((n) => n.textContent));
+  check('row 1 is Grid · Scorecard', rows[0] && rows[0].join(' · ') === 'Grid · Scorecard');
+  check('row 2 is Reviews · Scratch', rows[1] && rows[1].join(' · ') === 'Reviews · Scratch');
 }
 
 console.log('\ncontext menu Pin to grid:');

--- a/Packages/CrowDaemon/web-tests/scratch.test.js
+++ b/Packages/CrowDaemon/web-tests/scratch.test.js
@@ -93,6 +93,10 @@ const stack = T.sidebarLeftStack();
 const pills = [...stack.querySelectorAll('.nav-pill .pill-label')].map((n) => n.textContent);
 check('Scratch is a nav pill', pills.indexOf('Scratch') !== -1);
 check('Scratch sits after Scorecard', pills.indexOf('Scorecard') < pills.indexOf('Scratch'));
+const rows = [...stack.querySelectorAll('.nav-pills-row')].map((row) =>
+  [...row.querySelectorAll('.nav-pill .pill-label')].map((n) => n.textContent));
+check('row 1 is Grid · Scorecard', rows[0] && rows[0][0] === 'Grid' && rows[0][1] === 'Scorecard' && rows[0].length === 2);
+check('row 2 is Reviews · Scratch', rows[1] && rows[1][0] === 'Reviews' && rows[1][1] === 'Scratch' && rows[1].length === 2);
 check('Scratch is not a Tickets-style card', !stack.querySelector('.scratch-card'));
 check('open count', T.scratchOpenCount() === 1);
 const scratchPill = [...stack.querySelectorAll('.nav-pill')].find((p) => p.querySelector('.pill-label')?.textContent === 'Scratch');

--- a/Packages/CrowEngine/Sources/CrowEngine/ManagerSessionController.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/ManagerSessionController.swift
@@ -562,9 +562,13 @@ final class ManagerSessionController {
     /// (#314): on tmux this registers a window and pastes the agent command
     /// into it via the shared xterm.js cockpit surface.
     /// `trackReadiness: false` matches the Manager's command-launches-agent
-    /// model — no readiness/launchClaude flow.
+    /// model — no readiness/launchClaude flow. Explore (CROW-1237) is the
+    /// exception: an `initialPrompt` is deferred like a job (`#408`) so the
+    /// brief is argv once the shell is live, not a composer paste race.
     @discardableResult
-    private func createManagerTerminal(session: Session, cwd: String) -> SessionTerminal {
+    private func createManagerTerminal(
+        session: Session, cwd: String, initialPrompt: String? = nil
+    ) -> SessionTerminal {
         let command = managerCommand(for: session)
         // CROW-539: install hook config so `crow hook-event` fires for the
         // Manager, driving the same activity indicators worker cards get. The
@@ -605,14 +609,31 @@ final class ManagerSessionController {
         } else if SessionService.readsClaudeCompatSettings(session.agentKind) {
             ClaudeHookConfigWriter.writeGatewayEnv(dirPath: cwd, resolved: nil)
         }
-        let rawTerminal = SessionTerminal(
+
+        // Persist the bare Manager command so recreate/hydrate still launches
+        // the TUI. The explore brief is a one-shot pending launch (#408) —
+        // stuffing it into `SessionTerminal.command` would re-fire on Recreate.
+        let seedCommand = Self.exploreSeedLaunchCommand(
+            session: session, baseCommand: command, prompt: initialPrompt)
+        var rawTerminal = SessionTerminal(
             sessionID: session.id,
             name: session.name,
             cwd: cwd,
             command: command
         )
+        let deferSeed = seedCommand != nil
+        if let seedCommand {
+            // Seed readiness + pending-launch BEFORE register so a sentinel
+            // that fires on a later main-actor turn always finds them (#408).
+            appState.terminalReadiness[rawTerminal.id] = .uninitialized
+            appState.pendingLaunchCommands[rawTerminal.id] = seedCommand
+            appState.autoLaunchTerminals.insert(rawTerminal.id)
+        }
+        var toRegister = rawTerminal
+        if deferSeed { toRegister.command = nil }
+        var terminal = owner.prepareTerminal(toRegister, trackReadiness: deferSeed)
+        terminal.command = command
 
-        let terminal = owner.prepareTerminal(rawTerminal, trackReadiness: false)
         appState.terminals[session.id] = [terminal]
 
         store.mutate { data in
@@ -630,6 +651,30 @@ final class ManagerSessionController {
         return terminal
     }
 
+    /// Write the explore brief and wrap `baseCommand` so the agent starts
+    /// with it as argv. Nil when there is no prompt or the write failed —
+    /// the caller then falls back to a composer paste.
+    nonisolated static func exploreSeedLaunchCommand(
+        session: Session, baseCommand: String, prompt: String?
+    ) -> String? {
+        guard let prompt, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        let path = TodoRPC.explorePromptPath(sessionID: session.id)
+        do {
+            try prompt.write(toFile: path, atomically: true, encoding: .utf8)
+        } catch {
+            CrowLog.info("[Manager] failed to write explore prompt \(path): \(error.localizedDescription)")
+            return nil
+        }
+        guard FileManager.default.fileExists(atPath: path) else {
+            CrowLog.info("[Manager] explore prompt missing at \(path) after write")
+            return nil
+        }
+        return TodoRPC.seedLaunchCommand(
+            baseCommand: baseCommand, promptPath: path, agentKind: session.agentKind)
+    }
+
     /// Create an additional (non-primary) Manager session in `cwd`. Returns the
     /// new session's id. The terminal is set up by `createManagerTerminal`.
     ///
@@ -637,13 +682,19 @@ final class ManagerSessionController {
     /// (#582): when supplied it wins over the configured default for this
     /// session only, without mutating `agentsByKind` / `defaultAgentKind`.
     /// `nil` falls back to the configured Manager agent.
+    ///
+    /// `initialPrompt` (Explore, CROW-1237) is fed as argv on first launch
+    /// the way jobs feed `.crow-job-prompt.md` — not pasted into the composer.
     @discardableResult
-    public func createManagerSession(name: String, cwd: String, agentKind override: AgentKind? = nil) -> UUID {
+    public func createManagerSession(
+        name: String, cwd: String, agentKind override: AgentKind? = nil,
+        initialPrompt: String? = nil
+    ) -> UUID {
         let agentKind = resolvedManagerAgentKind(override)
         let session = Session(name: name, status: .active, kind: .manager, agentKind: agentKind)
         appState.sessions.append(session)
         store.mutate { $0.sessions.append(session) }
-        createManagerTerminal(session: session, cwd: cwd)
+        createManagerTerminal(session: session, cwd: cwd, initialPrompt: initialPrompt)
         return session.id
     }
 
@@ -740,8 +791,12 @@ extension SessionService {
     }
 
     @discardableResult
-    public func createManagerSession(name: String, cwd: String, agentKind override: AgentKind? = nil) -> UUID {
-        manager.createManagerSession(name: name, cwd: cwd, agentKind: override)
+    public func createManagerSession(
+        name: String, cwd: String, agentKind override: AgentKind? = nil,
+        initialPrompt: String? = nil
+    ) -> UUID {
+        manager.createManagerSession(
+            name: name, cwd: cwd, agentKind: override, initialPrompt: initialPrompt)
     }
     func resolvedManagerAgentKind(_ explicit: AgentKind?) -> AgentKind {
         manager.resolvedManagerAgentKind(explicit)

--- a/Packages/CrowEngine/Sources/CrowEngine/TerminalRouter.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/TerminalRouter.swift
@@ -39,4 +39,11 @@ public enum TerminalRouter {
     public static func canSend(_ terminal: SessionTerminal) -> Bool {
         TmuxBackend.shared.isRegistered(id: terminal.id)
     }
+
+    /// Live foreground command in `terminal`'s pane, or nil if the window
+    /// is not bound / tmux failed. Explore uses this to wait for the agent
+    /// TUI before pasting (CROW-1237).
+    public static func paneCurrentCommand(_ terminal: SessionTerminal) -> String? {
+        TmuxBackend.shared.paneCurrentCommand(id: terminal.id)
+    }
 }

--- a/Packages/CrowEngine/Sources/CrowEngine/TodoRPCSupport.swift
+++ b/Packages/CrowEngine/Sources/CrowEngine/TodoRPCSupport.swift
@@ -141,13 +141,16 @@ public enum TodoRPC {
         return fallback.isEmpty ? "Scratch" : fallback
     }
 
-    /// The prompt pasted into the exploring Manager. Read/explain only — this
-    /// is the Scratch sibling of `/crow-workspace --explore`.
+    /// The prompt seeded into the exploring Manager. Read/explain only — this
+    /// is the Scratch sibling of `/crow-workspace --explore`. Tells the agent
+    /// what to start looking at (the item, this cwd, a recommended next step)
+    /// so a submitted brief actually kicks off work (CROW-1237).
     public static func exploreBrief(for item: TodoItem) -> String {
         var lines = [
-            "This is from Crow Scratch. Explore it. Do not file a ticket, create a worktree, or start a work session unless I ask.",
+            "You are exploring a Crow Scratch item in this Manager session. Start now: read the item below, inspect related code in this working directory, and report what it means, what already exists, and a recommended next step.",
+            "Do not file a ticket, create a worktree, or start a work session unless I ask.",
             "",
-            "## Item",
+            "## Scratch item",
             item.text,
         ]
         if !item.note.isEmpty {
@@ -161,6 +164,68 @@ public enum TodoRPC {
         }
         lines.append("")
         return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Temp file the Explore Manager launch reads as its initial prompt.
+    /// Unique per session so two concurrent Explores cannot clobber each other.
+    public static func explorePromptPath(sessionID: UUID) -> String {
+        (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crow-explore-\(sessionID.uuidString).md")
+    }
+
+    /// Wrap a Manager launch command so the explore brief is argv (job-style
+    /// `evalPromptLaunch`), not a TUI paste. Cursor/Grok need `--` so a brief
+    /// whose first character is `-` is not parsed as a flag.
+    public static func seedLaunchCommand(
+        baseCommand: String, promptPath: String, agentKind: AgentKind
+    ) -> String {
+        ShellLaunchArgs.evalPromptLaunch(
+            prefix: baseCommand,
+            promptPath: promptPath,
+            endOfOptions: seedsExplorePromptWithEndOfOptions(agentKind)
+        )
+    }
+
+    public static func seedsExplorePromptWithEndOfOptions(_ agentKind: AgentKind) -> Bool {
+        agentKind == .cursor || agentKind == .grok
+    }
+
+    /// `#{pane_current_command}` looks like a coding-agent TUI, not the
+    /// wrapper/shell the Manager window is born as. SessionStart can fire
+    /// before the composer owns stdin (Cursor especially); pasting into
+    /// zsh is the "first characters go to the shell" failure (CROW-1237).
+    public static func paneLooksLikeAgent(_ command: String) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let token = (trimmed as NSString).lastPathComponent.lowercased()
+        let shells: Set<String> = [
+            "zsh", "bash", "sh", "fish", "dash", "login", "tmux",
+            "crow-shell-wrapper.sh",
+        ]
+        if shells.contains(token) { return false }
+        let agents = [
+            "claude", "cursor-agent", "codex", "grok", "opencode",
+            "muse", "agy", "antigravity",
+        ]
+        if agents.contains(where: { token == $0 || token.hasPrefix($0) }) {
+            return true
+        }
+        // Cursor's unambiguous name is `cursor-agent`; the colliding `agent`
+        // token is accepted only as an exact basename (not `ssh-agent`).
+        return token == "agent"
+    }
+
+    /// Hook name that means the TUI accepted a prompt (argv or paste).
+    public static let userPromptSubmitEventName = "UserPromptSubmit"
+
+    public static func promptWasAccepted(
+        hookEventNames: [String], activity: AgentActivityState
+    ) -> Bool {
+        if hookEventNames.contains(userPromptSubmitEventName) { return true }
+        switch activity {
+        case .working, .waiting: return true
+        case .idle, .done: return false
+        }
     }
 
     /// Body filed with `todo ticket` — the item plus its note, tagged as
@@ -211,14 +276,17 @@ public enum TodoRPC {
         hookEventNames.contains(sessionStartEventName)
     }
 
-    /// Retry a bare Enter only when the agent announced itself and then
-    /// stayed idle after the paste — "words in the box, agent idle".
-    /// Skip the retry when hooks never fired (don't double-submit an
-    /// agent that accepted Enter but has no hook pipeline).
+    /// Retry a bare Enter only when the agent is up and then stayed idle
+    /// after the paste — "words in the box, agent idle". Skip when hooks
+    /// never fired (don't double-submit an agent that accepted Enter but
+    /// has no hook pipeline) and when UserPromptSubmit / working already
+    /// proved the brief landed (CROW-1237).
     public static func shouldRetryEnter(
-        activity: AgentActivityState, agentAnnounced: Bool
+        activity: AgentActivityState,
+        agentAnnounced: Bool,
+        promptAccepted: Bool = false
     ) -> Bool {
-        guard agentAnnounced else { return false }
+        guard agentAnnounced, !promptAccepted else { return false }
         switch activity {
         case .working, .waiting: return false
         case .idle, .done: return true

--- a/Packages/CrowEngine/Tests/CrowEngineTests/TodoRPCSupportTests.swift
+++ b/Packages/CrowEngine/Tests/CrowEngineTests/TodoRPCSupportTests.swift
@@ -85,14 +85,55 @@ struct TodoRPCSupportTests {
         let item = TodoItem(text: "try this", tags: ["ios"], priority: "p2")
         let brief = TodoRPC.exploreBrief(for: item)
         #expect(brief.hasSuffix("\n"))
-        #expect(brief.contains("## Item"))
+        #expect(brief.contains("## Scratch item"))
         #expect(!brief.contains("## Idea"))
         #expect(!brief.localizedCaseInsensitiveContains("idea"))
         #expect(brief.contains("try this"))
+        #expect(brief.contains("Start now"))
+        #expect(brief.contains("inspect related code"))
         #expect(!brief.contains("## Notes"))
         #expect(brief.contains("Tags: ios"))
         #expect(brief.contains("Priority: p2"))
         #expect(brief.contains("Do not file a ticket"))
+    }
+
+    @Test func seedLaunchCommandIsJobStyleEvalAndEndOfOptionsForCursor() {
+        let path = "/tmp/crow-explore.md"
+        let cursor = TodoRPC.seedLaunchCommand(
+            baseCommand: "'/opt/homebrew/bin/cursor-agent' --trust",
+            promptPath: path, agentKind: .cursor)
+        #expect(cursor.contains("_CROW_P=$(< '/tmp/crow-explore.md')"))
+        #expect(cursor.contains("-- "))
+        #expect(TodoRPC.seedsExplorePromptWithEndOfOptions(.cursor))
+        #expect(TodoRPC.seedsExplorePromptWithEndOfOptions(.grok))
+        #expect(!TodoRPC.seedsExplorePromptWithEndOfOptions(.claudeCode))
+        let claude = TodoRPC.seedLaunchCommand(
+            baseCommand: "claude --permission-mode auto",
+            promptPath: path, agentKind: .claudeCode)
+        #expect(claude.contains("_CROW_P=$(< '/tmp/crow-explore.md')"))
+        #expect(!claude.contains("-- $(printf"))
+    }
+
+    @Test func paneLooksLikeAgentRejectsShellsAndAcceptsHarnessTokens() {
+        #expect(!TodoRPC.paneLooksLikeAgent(""))
+        #expect(!TodoRPC.paneLooksLikeAgent("zsh"))
+        #expect(!TodoRPC.paneLooksLikeAgent("/bin/bash"))
+        #expect(!TodoRPC.paneLooksLikeAgent("crow-shell-wrapper.sh"))
+        #expect(!TodoRPC.paneLooksLikeAgent("ssh-agent"))
+        #expect(TodoRPC.paneLooksLikeAgent("cursor-agent"))
+        #expect(TodoRPC.paneLooksLikeAgent("/Users/x/.local/bin/cursor-agent"))
+        #expect(TodoRPC.paneLooksLikeAgent("claude"))
+        #expect(TodoRPC.paneLooksLikeAgent("agent"))
+        #expect(TodoRPC.paneLooksLikeAgent("codex"))
+    }
+
+    @Test func promptWasAcceptedOnSubmitOrWorking() {
+        #expect(TodoRPC.promptWasAccepted(
+            hookEventNames: ["SessionStart", "UserPromptSubmit"], activity: .idle))
+        #expect(TodoRPC.promptWasAccepted(hookEventNames: ["SessionStart"], activity: .working))
+        #expect(TodoRPC.promptWasAccepted(hookEventNames: [], activity: .waiting))
+        #expect(!TodoRPC.promptWasAccepted(hookEventNames: ["SessionStart"], activity: .idle))
+        #expect(!TodoRPC.promptWasAccepted(hookEventNames: [], activity: .done))
     }
 
     @Test func ticketBodyIncludesNoteAndScratchAttribution() {
@@ -109,9 +150,28 @@ struct TodoRPCSupportTests {
         #expect(!TodoRPC.shouldRetryEnter(activity: .working, agentAnnounced: true))
         #expect(!TodoRPC.shouldRetryEnter(activity: .waiting, agentAnnounced: true))
         #expect(!TodoRPC.shouldRetryEnter(activity: .idle, agentAnnounced: false))
+        #expect(!TodoRPC.shouldRetryEnter(
+            activity: .idle, agentAnnounced: true, promptAccepted: true))
         #expect(TodoRPC.agentHasAnnounced(hookEventNames: ["SessionStart"]))
         #expect(TodoRPC.agentHasAnnounced(hookEventNames: ["UserPromptSubmit", "SessionStart"]))
         #expect(!TodoRPC.agentHasAnnounced(hookEventNames: []))
         #expect(!TodoRPC.agentHasAnnounced(hookEventNames: ["UserPromptSubmit"]))
+    }
+
+    @Test func exploreSeedLaunchCommandWritesPromptAndWrapsLaunch() throws {
+        let session = Session(name: "Scratch item", kind: .manager, agentKind: .cursor)
+        let cmd = try #require(ManagerSessionController.exploreSeedLaunchCommand(
+            session: session,
+            baseCommand: "'/opt/homebrew/bin/cursor-agent' --trust",
+            prompt: "Start now.\n"))
+        #expect(cmd.contains("_CROW_P=$(<"))
+        #expect(cmd.contains("-- "))
+        let path = TodoRPC.explorePromptPath(sessionID: session.id)
+        let body = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(body.contains("Start now."))
+        #expect(ManagerSessionController.exploreSeedLaunchCommand(
+            session: session, baseCommand: "claude", prompt: nil) == nil)
+        #expect(ManagerSessionController.exploreSeedLaunchCommand(
+            session: session, baseCommand: "claude", prompt: "   ") == nil)
     }
 }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxInput.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxInput.swift
@@ -147,6 +147,24 @@ extension TmuxBackend {
         }
     }
 
+    /// Live `#{pane_current_command}` for terminal `id`'s pane. Used by
+    /// Explore/Talk so a paste waits until the agent TUI owns stdin, not
+    /// the wrapper/shell the window is born as (CROW-1237). Nil on any
+    /// error so the caller can fall through to SessionStart.
+    public func paneCurrentCommand(id: UUID) -> String? {
+        guard let windowIndex = bindings[id] else { return nil }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            let raw = try ctrl.displayMessage(target: target, format: "#{pane_current_command}")
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } catch {
+            reportIfTimeout(error)
+            return nil
+        }
+    }
+
     /// Direction for `searchInScrollback`. `backward` walks toward older
     /// output (the common case for Cmd+F on terminal history); `forward`
     /// walks toward newer output.

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -202,6 +202,12 @@ struct TmuxBackendTests {
         }
     }
 
+    @Test func paneCurrentCommandUnknownTerminalIsNil() {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+        #expect(backend.paneCurrentCommand(id: UUID()) == nil)
+    }
+
     @Test func sendTextRoundTripsThroughBuffer() throws {
         let backend = makeBackend()
         defer { backend.shutdown() }


### PR DESCRIPTION
Closes #1237

## Summary
- Split the sidebar nav pills into two rows of two (`Grid · Scorecard`, then `Reviews · Scratch`) so labels no longer ellipsize at the default sidebar width. Route stays `#/scratch`; Scratch is still a pill, not a Tickets-style card.
- Explore now seeds the brief as argv on Manager launch (the job-style `evalPromptLaunch` path, deferred until the shell is ready) instead of racing a composer paste. The session is named after the item at create time so a follow-up `/rename` cannot eat the brief.
- The explore brief tells the agent what to start looking at. `sendToManager` only pastes if the agent stayed idle after seed; it waits for the agent TUI (SessionStart or pane command), retries Enter, then re-pastes the whole brief if Enter was not enough.

## Test plan
- [ ] Sidebar: Grid · Scorecard on one pill row, Reviews · Scratch on the next; no truncated labels at the default sidebar width
- [ ] `#/scratch` still opens the board; Scratch is not a card under Tickets
- [ ] Explore: the spawned Manager's agent actually starts on the Scratch item (not idle with unsubmitted/garbled composer text)


Made with [Cursor](https://cursor.com)