### PR TITLE
Make the sidebar 2×2 nav pills equal size

### DIFF
--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/app.css
@@ -990,21 +990,26 @@ button.scratch-link:hover { border-color: var(--blue); }
 .tk-dot { width: 7px; height: 7px; border-radius: 50%; }
 .tk-n { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-/* Left-column nav rows (CROW-917 / CROW-1237): Grid · Scorecard, then
+/* Left-column nav rows (CROW-917 / CROW-1237 / CROW-1241): Grid · Scorecard, then
    Reviews · Scratch, then the full-width Manager pill. Each .nav-pills-row is
    its own non-wrapping flex line so groups never reflow; the "+" and Select
-   buttons live in the right icon column. Four pills on one row ellipsized. */
+   buttons live in the right icon column. Four pills on one row ellipsized.
+   Equal boxes: `flex: 1 1 0` shares leftover width (not content-sized `auto`,
+   which let Scorecard outgrow Grid and a Reviews/Scratch badge steal from its
+   neighbor). Shared `min-height` keeps both 2×2 rows the same height so a badge
+   sits inside without changing the box. */
 .nav-pills-row { display: flex; gap: 6px; }
+.nav-pills-row > .nav-pill { flex: 1 1 0; min-width: 0; min-height: 32px; }
 .nav-pill {
-  flex: 1 1 auto; min-width: 0; display: flex; align-items: center; justify-content: center; gap: 5px;
+  display: flex; align-items: center; justify-content: center; gap: 5px;
   padding: 6px 8px; border-radius: 6px; cursor: pointer;
   background: var(--bg-surface); border: 1px solid rgba(179, 142, 70, 0.3);
 }
 .nav-pill:hover { border-color: var(--border-strong); }
 .nav-pill.active { background: var(--bg-card); border-color: rgba(179, 142, 70, 0.6); }
-.pill-label { color: var(--gold-dark); font-size: 12px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pill-label { color: var(--gold-dark); font-size: 12px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .nav-pill.active .pill-label { color: var(--gold); }
-.pill-badge { padding: 0 6px; border-radius: 8px; font-size: 10px; font-weight: 700; background: rgba(221, 196, 130, 0.2); color: var(--gold); }
+.pill-badge { flex: 0 0 auto; padding: 0 6px; border-radius: 8px; font-size: 10px; font-weight: 700; line-height: 1.2; background: rgba(221, 196, 130, 0.2); color: var(--gold); }
 .pill-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 .pill-dot.pulse { animation: crow-pulse 1.5s ease-in-out infinite; }
 .nav-plus {

--- a/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar-chrome.js
+++ b/Packages/CrowDaemon/Sources/CrowDaemon/Resources/web/sidebar-chrome.js
@@ -197,9 +197,11 @@ function sidebarIconColumn() {
   return col;
 }
 
-// Left sidebar-top stack (CROW-917 / CROW-1237): the Tickets card over three
+// Left sidebar-top stack (CROW-917 / CROW-1237 / CROW-1241): the Tickets card over three
 // nav-pill rows — Grid · Scorecard, Reviews · Scratch, then the full-width
 // Manager pill. Four pills on one row ellipsize at the default sidebar width.
+// Equal-size 2×2 is CSS (`.nav-pills-row > .nav-pill`); badges append here without
+// a layout branch.
 function sidebarLeftStack() {
   const wrap = el('div', 'sidebar-left');
   wrap.appendChild(ticketsCard());

--- a/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
+++ b/Packages/CrowDaemon/Tests/CrowDaemonTests/WebTerminalAssetTests.swift
@@ -652,6 +652,25 @@ import Testing
             "the Scratch-as-card CSS is dead once Scratch is a nav pill")
     }
 
+    /// CROW-1241: the 2×2 nav pills must share width and height. `flex: 1 1 auto`
+    /// sizes each button from its label (and Reviews/Scratch badges), so Scorecard
+    /// outgrows Grid and a badge steals width from its neighbor. Pin `flex: 1 1 0`
+    /// + a shared min-height on the row's pills so content no longer drives the box.
+    @Test func navPillsInARowAreEqualSize() throws {
+        // stripComments: the flex/min-height values are also named in the rule's
+        // doc comment, so a whole-file `contains` would false-pass off the prose
+        // once the declaration is deleted.
+        let css = Self.stripComments(try Self.webAsset("app.css"))
+        #expect(
+            css.contains(".nav-pills-row > .nav-pill { flex: 1 1 0; min-width: 0; min-height: 32px; }"),
+            "nav pills in a row must share leftover width (flex: 1 1 0, not auto) and a min-height so badges can't resize them (CROW-1241)")
+        // `\n.nav-pill {` skips the `.nav-pills-row > .nav-pill` rule above it.
+        let pill = try Self.ruleBody(openedBy: "\n.nav-pill {", in: css)
+        #expect(
+            !pill.contains("flex: 1 1 auto"),
+            "content-sized flex-basis on .nav-pill is the CROW-1241 regression")
+    }
+
     /// CROW-917/922: layout decisions with no other pin, verified to regress silently
     /// (reverting any leaves every suite green). CROW-922 made the right column's icon
     /// buttons natural-size (`flex: 0 0 auto`) with a `min-height` floor above the WCAG


### PR DESCRIPTION
Closes #1241

## Summary
- Size each `.nav-pills-row > .nav-pill` with `flex: 1 1 0` and a shared `min-height` so Grid, Scorecard, Reviews, and Scratch are the same box.
- `flex: 1 1 auto` grew from the label (and Reviews/Scratch badges), so Scorecard outgrew Grid and a badge stole width from its neighbor.
- Badges stay `flex: 0 0 auto` inside the pill and no longer change its size.

## Test plan
- [x] `swift test --package-path Packages/CrowDaemon --filter navPillsInARowAreEqualSize`
- [x] `node grid.test.js` and `node scratch.test.js` (2×2 row structure)
- [ ] Default sidebar width: Grid, Scorecard, Reviews, and Scratch are the same size
- [ ] Reviews unseen badge and Scratch open-count badge do not widen or shorten their pill vs Grid/Scorecard
- [ ] Labels still fully readable (no return to the four-on-one-line ellipsis)


Made with [Cursor](https://cursor.com)